### PR TITLE
docs: add CLAUDE.md + classify root policy files (DCN-CHG-20260429-02)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# CLAUDE.md — dcNess 프로젝트 작업 지침
+
+> 본 파일은 메인 Claude (Claude Code) 가 dcNess 저장소에서 작업할 때의 지침이다.
+> 거버넌스 규칙은 [`docs/process/governance.md`](docs/process/governance.md) (SSOT) 에 있다 — 본 파일은 *재기술하지 않고 절차·링크만 박는다*.
+
+## 0. 프로젝트 정체성
+
+- **목적**: RWHarness fork-and-refactor — status-JSON-mutate 결정론 + 4 기둥 정합 + 함정 회피 5원칙 (`docs/status-json-mutate-pattern.md` §1~§2.5).
+- **모드**: **메인 Claude 직접 작업** (`status-json-mutate-pattern.md` §10 / §11.4 정합).
+  - architect / validator / engineer 위임 강제 **없음**.
+  - RWHarness 가드 미적용 환경. **단** Document Sync 거버넌스만 강제.
+  - 글로벌 `~/.claude/CLAUDE.md` 의 RWHarness 위임 룰(에이전트 분기 / 인프라 프로젝트 분기)은 본 프로젝트에 **미적용**. 본 파일이 우선한다.
+
+## 1. 작업 절차 (모든 변경 공통)
+
+> SSOT: [`docs/process/governance.md`](docs/process/governance.md) §2.3.
+
+1. **Task-ID 발급**: `DCN-CHG-YYYYMMDD-NN` (governance §2.1).
+2. **변경 분류**: governance §2.2 표에서 Change-Type 토큰 결정.
+3. **수정 작업**.
+4. **완료 직전 동반 갱신**:
+   - `docs/process/document_update_record.md` (모든 변경)
+   - `docs/process/change_rationale_history.md` (spec / agent / harness / hooks / ci 변경 시)
+   - `PROGRESS.md` (harness / hooks / ci 변경 시)
+   - 카테고리별 deliverable (governance §2.6)
+5. **commit 직전**: `node scripts/check_document_sync.mjs` 통과 확인.
+   - 자동: Claude Code PreToolUse hook (`scripts/hooks/cc-pre-commit.sh`) + git pre-commit hook 이 동시 차단.
+6. **branch → PR → squash merge** (직접 `main` push 금지).
+
+## 2. 거버넌스 핵심 (전체 룰은 SSOT 참조)
+
+- **Task-ID 형식**: `DCN-CHG-YYYYMMDD-NN` (governance §2.1)
+- **Change-Type 7종**: `spec` / `agent` / `harness` / `hooks` / `ci` / `test` / `docs-only` (governance §2.2)
+- **예외**: `Document-Exception:` 토큰 (governance §2.4 — *현재 diff 추가 라인만 유효*, 과거 누적 무효)
+- **3중 강제**: git pre-commit hook + Claude Code PreToolUse hook + AGENTS.md (governance §2.7)
+
+> ⚠️ **금지**: `--no-verify` 등 hook 우회. 룰 재기술. Task-ID 없는 commit. 과거 머지된 Exception 으로 현재 위반 회피.
+
+## 3. 문서 지도
+
+| 파일 | 역할 |
+|---|---|
+| [`docs/process/governance.md`](docs/process/governance.md) | **SSOT** — 모든 거버넌스 룰의 단일 출처 |
+| [`docs/process/document_update_record.md`](docs/process/document_update_record.md) | WHAT 로그 (Task-ID 별 변경 파일) |
+| [`docs/process/change_rationale_history.md`](docs/process/change_rationale_history.md) | WHY 로그 (Task-ID 별 동기·대안·결정·후속) |
+| [`docs/process/document_impact_matrix.md`](docs/process/document_impact_matrix.md) | 변경 → 검토 문서 빠른 참조 |
+| [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) | RWHarness fork-and-refactor proposal (정체성·Phase·원칙) |
+| [`PROGRESS.md`](PROGRESS.md) | 현재 상태 / TODO / Blockers |
+| [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 |
+| [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) | PR 체크리스트 |
+| [`scripts/check_document_sync.mjs`](scripts/check_document_sync.mjs) | Document Sync 게이트 구현 |
+| [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook |
+| [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook |
+
+## 4. 개발 명령어
+
+```sh
+# Document Sync 게이트 수동 실행 (commit 전 자동 호출됨)
+node scripts/check_document_sync.mjs
+
+# git hook 설치 (clone 후 1회)
+cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+```
+
+> 빌드 / 테스트 / 런타임 명령어는 코드 도입 시 본 섹션에 추가 (별도 Task-ID).
+
+## 5. 커밋 / PR 절차
+
+> 상세: 글로벌 `~/.claude/CLAUDE.md` "커밋 절차" 섹션 + 본 프로젝트 거버넌스 추가 강제.
+
+```
+1. git checkout -b {type}/{설명} main      # type: chore | feat | fix | docs
+2. (변경 + 거버넌스 동반 파일 갱신)
+3. git add {파일}
+4. node scripts/check_document_sync.mjs    # 게이트 수동 확인 (선택)
+5. git commit -m "..."                      # hook 자동 게이트
+6. git push -u origin {branch}
+7. gh pr create --title "..." --body "..."  # PULL_REQUEST_TEMPLATE 채움
+8. gh pr merge --squash
+9. git checkout main && git pull
+```
+
+- **main 직접 commit/push 금지**. 항상 branch → PR → squash merge.
+- **branch 는 merge 후에도 삭제하지 않는다** (글로벌 룰 정합).
+- PR title = commit message subject. PR body = 거버넌스 체크리스트 + 변경 요약.
+
+## 6. 환경변수
+
+현재 없음. 도입 시 본 섹션에 (이름·용도·기본값·필수 여부) 추가.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,15 +1,14 @@
 # PROGRESS
 
 ## 현재 상태
-- 거버넌스 시스템 부트스트랩 완료 (`DCN-CHG-20260429-01`)
+- 거버넌스 시스템 부트스트랩 완료 (`DCN-CHG-20260429-01`, PR #1 머지)
+- 프로젝트 루트 `CLAUDE.md` + 루트 정책 파일 게이트 분류 추가 (`DCN-CHG-20260429-02`)
 - `docs/status-json-mutate-pattern.md` proposal 검토 중 (RWHarness fork-and-refactor 입력)
 
 ## TODO
-- [ ] git 저장소 초기화 + 첫 commit (bootstrap)
-- [ ] git pre-commit hook 설치: `cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`
-- [ ] `chmod +x scripts/check_document_sync.mjs scripts/hooks/pre-commit scripts/hooks/cc-pre-commit.sh`
 - [ ] `.github/workflows/document-sync.yml` 추가 (CI 게이트, 별도 Task-ID)
 - [ ] RWHarness fork 분류 작업 (`status-json-mutate-pattern.md` §11.2)
+- [ ] CLAUDE.md §4 개발 명령어 / §6 환경변수 — 빌드 도입 시 갱신
 
 ## Blockers
 - 없음

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -31,3 +31,18 @@
   - GitHub Actions workflow (`.github/workflows/document-sync.yml`) 추가는 별도 Task-ID
   - 30일 후 carry-over: 게이트가 차단한 위반 카탈로그 → `governance.md` §2.6 룰 정정 input
   - git 저장소 초기화 + 첫 commit (별도 작업)
+
+### DCN-CHG-20260429-02
+- **Date**: 2026-04-29
+- **Rationale**:
+  - dcNess 는 글로벌 `~/.claude/CLAUDE.md` 의 RWHarness 위임 룰(에이전트 분기 / 인프라 분기)이 미적용되는 신규 프로젝트(`status-json-mutate-pattern.md` §10/§11.4). 메인 Claude 가 본 저장소 작업 시 *어떤 절차·문서·금지사항*을 따라야 하는지 단일 진입점이 부재.
+  - 부수 문제: `CLAUDE.md` / `AGENTS.md` 같은 루트 정책 파일이 게이트의 Change-Type 분류에서 어떤 패턴에도 매칭되지 않아 *분류 비대상* → 정책 변경이 record/rationale 동반 없이 통과되는 구멍.
+- **Alternatives**:
+  1. *글로벌 `~/.claude/CLAUDE.md` 만 의존* — RWHarness 위임 룰이 dcNess 모드와 충돌 (architect/engineer 강제 vs §11.4 메인 직접 작업). 기각.
+  2. *루트 정책 파일을 `docs-only` 로 분류* — 정책 변경에 WHY 로그 동반 강제가 안 됨. 기각.
+  3. *(채택)* **루트 CLAUDE.md 신규 + 게이트 `agent` 카테고리에 `^CLAUDE\.md$` / `^AGENTS\.md$` 추가** — 프로젝트 모드 명시 + 정책 변경에 record + rationale 동반 강제.
+- **Decision**: 옵션 3. CLAUDE.md 는 SSOT 재기술 금지 — 절차·링크·문서지도만 박는다. 게이트 룰은 governance.md §2.2 와 `check_document_sync.mjs` 양쪽 동시 갱신 (코드 = 명세 구현).
+- **Follow-Up**:
+  - 후속 정책 파일(예: `SECURITY.md`, `CONTRIBUTING.md`) 도입 시 동일 카테고리 검토.
+  - 빌드/테스트 도입 시 CLAUDE.md §4 개발 명령어 / §6 환경변수 갱신 (별도 Task-ID).
+  - `.github/workflows/document-sync.yml` 추가 (CI 게이트, 별도 Task-ID).

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -37,3 +37,15 @@
   - `PROGRESS.md` (신규)
 - **Summary**: 거버넌스 시스템 초기 구축 — Document Sync 게이트(`check_document_sync.mjs`) + 3중 pre-commit 강제(git hook + Claude Code hook + AGENTS 지침) + SSOT(`governance.md`).
 - **Document-Exception**: bootstrap commit — 거버넌스 자체 도입이라 이전 산출물 없음. 본 항목 자체가 self-record.
+
+### DCN-CHG-20260429-02
+- **Date**: 2026-04-29
+- **Change-Type**: agent, ci, docs-only
+- **Files Changed**:
+  - `CLAUDE.md` (신규 — 메인 Claude 작업 지침)
+  - `docs/process/governance.md` (§2.2 agent 패턴에 `^CLAUDE\.md$`, `^AGENTS\.md$` 추가)
+  - `scripts/check_document_sync.mjs` (CATEGORY_RULES agent 토큰에 동일 패턴 추가)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 프로젝트 루트 CLAUDE.md 신규 + 게이트 룰에 루트 정책 파일(`CLAUDE.md` / `AGENTS.md`) `agent` 카테고리 분류 추가.

--- a/docs/process/governance.md
+++ b/docs/process/governance.md
@@ -33,7 +33,7 @@
 | 토큰 | 감시 경로 (regex) | 의미 |
 |---|---|---|
 | `spec` | `^docs/spec/`, `^docs/proposals/`, `^prd\.md$`, `^trd\.md$` | 헌법 / 사양 문서 |
-| `agent` | `^agents/`, `^\.claude/agent-config/` | agent prompt / 정책 |
+| `agent` | `^agents/`, `^\.claude/agent-config/`, `^CLAUDE\.md$`, `^AGENTS\.md$` | agent prompt / 정책 (메인·외부 에이전트 지침 포함) |
 | `harness` | `^harness/`, `^src/` | 하네스 코어 / 소스 코드 |
 | `hooks` | `^hooks/`, `^\.claude/hooks/` | 차단·검증 hook |
 | `ci` | `^\.github/workflows/`, `^scripts/` | CI / 빌드 / 게이트 스크립트 |

--- a/scripts/check_document_sync.mjs
+++ b/scripts/check_document_sync.mjs
@@ -16,7 +16,7 @@ import { execSync } from 'node:child_process';
 // 분류 우선순위: 위에서 아래로. 한 파일이 여러 패턴에 매칭되면 *상위* 토큰 채택.
 const CATEGORY_RULES = [
   { token: 'spec',      patterns: [/^docs\/spec\//, /^docs\/proposals\//, /^prd\.md$/, /^trd\.md$/] },
-  { token: 'agent',     patterns: [/^agents\//, /^\.claude\/agent-config\//] },
+  { token: 'agent',     patterns: [/^agents\//, /^\.claude\/agent-config\//, /^CLAUDE\.md$/, /^AGENTS\.md$/] },
   { token: 'harness',   patterns: [/^harness\//, /^src\//] },
   { token: 'hooks',     patterns: [/^hooks\//, /^\.claude\/hooks\//] },
   { token: 'ci',        patterns: [/^\.github\/workflows\//, /^scripts\//] },


### PR DESCRIPTION
## Summary
- 프로젝트 루트 `CLAUDE.md` 신규 — 메인 Claude 작업 지침 (SSOT 재기술 금지, 절차·링크·문서지도만)
- 게이트 룰 보강: `agent` 카테고리에 `^CLAUDE\.md$` / `^AGENTS\.md$` 패턴 추가
  - `docs/process/governance.md` §2.2 표 + `scripts/check_document_sync.mjs` `CATEGORY_RULES` 동시 갱신 (코드 = 명세 구현)

## Task-ID
`DCN-CHG-20260429-02`

## Change-Type
- [x] `agent` (CLAUDE.md)
- [x] `ci` (scripts/check_document_sync.mjs)
- [x] `docs-only` (governance.md, record, rationale)

## Document Sync Checklist
- [x] `docs/process/document_update_record.md` 갱신 (WHAT)
- [x] `docs/process/change_rationale_history.md` 갱신 (WHY — agent + ci heavy)
- [x] `PROGRESS.md` 갱신 (ci)
- [x] `node scripts/check_document_sync.mjs` 통과 (`PASS — files: 6, categories: agent, docs-only, ci`)

## Rationale (요약)
글로벌 `~/.claude/CLAUDE.md` 의 RWHarness 위임 룰은 dcNess 모드(`status-json-mutate-pattern.md` §10/§11.4 — 메인 Claude 직접 작업)와 충돌. 본 프로젝트 전용 CLAUDE.md 가 단일 진입점. 부수로 `CLAUDE.md` / `AGENTS.md` 가 게이트 분류 비대상이던 구멍을 `agent` 카테고리로 메움 (정책 변경에 record + rationale 동반 강제).

## Test Plan
- [x] git pre-commit hook 자동 실행 (이 PR commit 시점) → PASS
- [ ] 루트 정책 파일만 변경한 commit → agent 카테고리로 분류되어 record/rationale 동반 강제 (post-merge 검증)
