### PR TITLE
feat: add harness/state_io.py foundation (DCN-CHG-20260429-03)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,19 @@
+# macOS
 .DS_Store
-node_modules/
+
+# Python
+__pycache__/
+*.pyc
+
+# Logs
 *.log
+
+# Node
+node_modules/
+
+# Claude Code 로컬 세션 (commit 금지)
+.claude/ralph-loop.local.md
 .claude/settings.local.json
+
+# 하네스 런타임 상태 (status JSON 등 — agent 가 mutate)
 .claude/harness-state/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,13 @@ node scripts/check_document_sync.mjs
 
 # git hook 설치 (clone 후 1회)
 cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+
+# 하네스 단위 테스트 실행
+python3 -m unittest discover -s tests -v
+python3 -m unittest tests.test_state_io -v   # 단일 모듈
 ```
 
-> 빌드 / 테스트 / 런타임 명령어는 코드 도입 시 본 섹션에 추가 (별도 Task-ID).
+> 빌드 / 런타임 명령어는 코드 도입 시 본 섹션에 추가 (별도 Task-ID).
 
 ## 5. 커밋 / PR 절차
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,12 +3,24 @@
 ## 현재 상태
 - 거버넌스 시스템 부트스트랩 완료 (`DCN-CHG-20260429-01`, PR #1 머지)
 - 프로젝트 루트 `CLAUDE.md` + 루트 정책 파일 게이트 분류 추가 (`DCN-CHG-20260429-02`)
-- `docs/status-json-mutate-pattern.md` proposal 검토 중 (RWHarness fork-and-refactor 입력)
+- **Phase 1 foundation 진입**: `harness/state_io.py` 신규 + 테스트 32 PASS (`DCN-CHG-20260429-03`)
+  - R8 5 failure modes (not_found/empty/race/malformed_json/schema_violation) 단일 normalize 검증 완료
+  - atomic write (POSIX rename) + path traversal self-check (R1 layer 1) 포함
+  - 적용 범위 = 모듈 단독. validator 호출지 / agent docs / hook ALLOW_MATRIX 변환은 후속 Task-ID
 
 ## TODO
+### Phase 1 — 후속 (validator 단일 agent 완성)
+- [ ] `docs/migration-decisions.md` 신규 — `status-json-mutate-pattern.md` §11.2 framework 적용 (RWHarness 모듈 분류)
+- [ ] `agents/validator*.md` 복사 + `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 변환 (5 모드 sub-doc)
+- [ ] RWHarness `harness/core.py` plan/design/ux validation 함수 복사 + `parse_marker` → `read_status` 치환 (7 호출지)
+- [ ] RWHarness `hooks/agent-boundary.py` 복사 + validator ALLOW_MATRIX 에 status path regex 추가
+- [ ] `_AGENT_DISALLOWED["validator"]` 에서 `Write` 제거
+- [ ] ENV 게이트 `HARNESS_STATUS_JSON_VALIDATOR=1` off 시 회귀 0 검증
+- [ ] validator → engineer handoff 를 status JSON `next_actions[]` 로 변환
+
+### 인프라 / CI
 - [ ] `.github/workflows/document-sync.yml` 추가 (CI 게이트, 별도 Task-ID)
-- [ ] RWHarness fork 분류 작업 (`status-json-mutate-pattern.md` §11.2)
-- [ ] CLAUDE.md §4 개발 명령어 / §6 환경변수 — 빌드 도입 시 갱신
+- [ ] CLAUDE.md §6 환경변수 — `HARNESS_STATUS_JSON_VALIDATOR` 등 도입 시 갱신
 
 ## Blockers
 - 없음

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -46,3 +46,28 @@
   - 후속 정책 파일(예: `SECURITY.md`, `CONTRIBUTING.md`) 도입 시 동일 카테고리 검토.
   - 빌드/테스트 도입 시 CLAUDE.md §4 개발 명령어 / §6 환경변수 갱신 (별도 Task-ID).
   - `.github/workflows/document-sync.yml` 추가 (CI 게이트, 별도 Task-ID).
+
+### DCN-CHG-20260429-03
+- **Date**: 2026-04-29
+- **Rationale**:
+  - `docs/status-json-mutate-pattern.md` Phase 1 의 acceptance criteria 첫 항목: "`harness/state_io.py` 모듈 + R8 normalize (MissingStatus exception) + 테스트 100%".
+  - RWHarness 의 `parse_marker` (regex + alias 사다리, ~110 LOC + `MARKER_ALIASES` 54 LOC) 가 LLM 변형 emit 마다 사다리 확장(jajang 도그푸딩 12 PR cycle, CHG-09→CHG-14.1 PR #17 12 변형 추가) → 룰이 룰을 부르는 reactive cycle (proposal §2.5 원칙 1 위반).
+  - 발상 전환: agent 의 자유 텍스트 신뢰 폐기 → agent 가 **외부 상태 파일 mutate**, harness 는 그 파일만 read. 텍스트 파싱 0, 결정론 100%.
+  - 본 작업은 Phase 1 의 *단일 신규 모듈* — RWHarness 코드 복사 없이 `state_io.py` 만 net-new 작성. 다른 Phase 1 항목(disallowedTools / ALLOW_MATRIX / 7 호출지 / handoff / preamble / checkpoint) 진입 전 foundation 확보.
+- **Alternatives**:
+  1. *RWHarness `harness/core.py` 전체 복사 후 in-place 수정* — Phase 1 sub-phase 분리(1.1 mechanism / 1.2 handoff / 1.3 preamble / 1.4 checkpoint) 가치 손실. 회귀 발생 시 어느 sub 가 원인인지 분리 불가능. proposal §5 Phase 1 sub-분할 정신 위반. 기각.
+  2. *바로 7 parse_marker 호출지부터 변환* — `state_io.py` 부재 상태로 호출지만 변환 불가능. 순서 역전. 기각.
+  3. *(채택)* **단일 신규 모듈 + 32 테스트 + 거버넌스 동반** — Phase 1 sub 1.1 mechanism 의 *맨 처음 단계*. R8 5 failure modes (not_found/empty/race/malformed_json/schema_violation) 단일 normalize + atomic write (POSIX rename) + path traversal self-check (R1 layer 1) 한 번에 covered.
+- **Decision**:
+  - 옵션 3. `harness/state_io.py` 신규 ~290 LOC, `tests/test_state_io.py` 32 케이스.
+  - **proposal §2.5 원칙 3 (자율성 최대화) 정합**: schema 의 required 키는 `status` 하나만. `fail_items`, `non_obvious_patterns`, `next_actions` 등 freeform. agent 가 자유롭게 채울 수 있는 영역 보존.
+  - **R1 layer 1 (3-layer defense 첫 layer)**: state_path 가 화이트리스트 패턴(`_AGENT_NAME_RE` / `_MODE_NAME_RE` / `_RUN_ID_RE`) + path.relative_to(base) self-check 으로 path traversal 차단. agent-boundary.py PreToolUse + PostToolUse 추가 layer 는 이후 Task 에서.
+  - **atomic write (POSIX `os.replace`)**: tmp 에 쓰고 rename → Write 도중 read 시 race / malformed 차단.
+  - **race vs empty 분리**: 빈 파일 + mtime < 100ms 면 `race` (재read 권장), 그 외엔 `empty`. caller retry 정책 분기 명확.
+  - **base_dir 기본값 lazy**: `Path.cwd()` 가 import 시점이 아니라 호출 시점 평가 — `_DefaultBaseProxy` 로 우회. 테스트 격리 + 다른 cwd 에서 import 안전.
+- **Follow-Up**:
+  - **(다음 Task-ID)** validator @OUTPUT 형식 변환 — `agents/validator*.md` 의 `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 컨벤션 도입. RWHarness 의 `agents/validator/*.md` (5 모드 sub-doc) 복사 후 각 변환.
+  - **(다음 Task-ID)** RWHarness `harness/core.py` 의 plan_validation / design_validation / ux_validation 함수 (총 7 호출지) 복사 + `parse_marker` → `read_status` 치환. ENV 게이트 `HARNESS_STATUS_JSON_VALIDATOR=1` 도입.
+  - **(다음 Task-ID)** RWHarness `hooks/agent-boundary.py` 복사 + validator ALLOW_MATRIX 에 status path regex 추가, `_AGENT_DISALLOWED["validator"]` 에서 Write 제거.
+  - **(다음 Task-ID)** `docs/migration-decisions.md` — proposal §11.2 framework (catastrophic-prevention / 자연 폐기 / 단순화) 모듈 분류표.
+  - **측정 항목**: 5 failure modes 모두 `MissingStatus` 단일 catch 보장 (다른 exception 누수 0). 테스트로 명문화 — `TestMissingStatusContract`. 실제 운영 시 다른 exception 누수 발견되면 회귀 PR.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -49,3 +49,15 @@
   - `docs/process/change_rationale_history.md`
   - `PROGRESS.md`
 - **Summary**: 프로젝트 루트 CLAUDE.md 신규 + 게이트 룰에 루트 정책 파일(`CLAUDE.md` / `AGENTS.md`) `agent` 카테고리 분류 추가.
+
+### DCN-CHG-20260429-03
+- **Date**: 2026-04-29
+- **Change-Type**: harness, test, agent, docs-only
+- **Files Changed**:
+  - `harness/state_io.py` (신규 — Phase 1 핵심 모듈)
+  - `tests/test_state_io.py` (신규 — 32 케이스, 5 failure modes 검증)
+  - `CLAUDE.md` (§4 개발 명령어에 테스트 실행 명령 추가)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: Phase 1 foundation — `harness/state_io.py` 신규(write/read/clear + R8 5 failure modes 단일 normalize) + 테스트 32 케이스 전부 PASS. `parse_marker` 사다리 폐기를 위한 첫 모듈.

--- a/harness/state_io.py
+++ b/harness/state_io.py
@@ -1,0 +1,337 @@
+"""state_io.py — agent status JSON mutate / read 단일 책임 모듈.
+
+발상 (status-json-mutate-pattern §2):
+    "agent 의 자유 텍스트를 신뢰하지 않는다.
+     agent 에게 외부 상태 파일 mutate 책임 부여.
+     orchestrator 는 그 파일만 read."
+
+본 모듈은 RWHarness 의 `parse_marker` (regex + alias 사다리) 를 대체할
+**경로 + I/O 단일 함수** 다. 텍스트 파싱 0, 결정론 100%.
+
+핵심 API:
+    state_path(agent, run_id, mode=None, base_dir=None) -> Path
+    write_status(agent, run_id, payload, mode=None, base_dir=None) -> Path
+    read_status(agent, run_id, mode=None, base_dir=None,
+                allowed_status=None) -> dict
+    clear_run_state(run_id, base_dir=None) -> int
+
+R8 (status-json-mutate-pattern §8) — 5 failure modes 단일 normalize:
+    not_found        : 파일 미존재 (Write 누락)
+    empty            : 빈 파일 + mtime 오래된 (Write 직후 sync 실패 후 정착)
+    race             : 빈 파일 + mtime 매우 최근 (Write 도중 read)
+    malformed_json   : JSONDecodeError (부분 작성)
+    schema_violation : root 가 object 아님, 'status' 누락/타입 오류,
+                       allowed_status 외 값
+
+caller 측 retry 정책 가이드:
+    not_found / malformed_json / schema_violation -> 즉시 fail (재read 무의미)
+    empty / race -> 100ms 후 1회 재read 권장
+
+R1 3-layer defense 의 첫 layer:
+    write_status 가 path 생성 시 화이트리스트 + path traversal 자기검증
+    (agent-boundary.py PreToolUse + PostToolUse 와 합쳐 3-layer)
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Optional, Set
+
+__all__ = [
+    "MissingStatus",
+    "state_path",
+    "write_status",
+    "read_status",
+    "clear_run_state",
+    "DEFAULT_BASE",
+]
+
+# ── 화이트리스트 패턴 ──────────────────────────────────────────────────────
+# agent: 소문자 + hyphen (validator, pr-reviewer 등)
+# mode: 대문자 + 숫자 + underscore (PLAN_VALIDATION, CODE_VALIDATION 등). None 허용.
+# run_id: 영숫자 + hyphen + dot + underscore. ".." 별도 차단.
+_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+_MODE_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+
+# ── 기본 base 디렉토리 ────────────────────────────────────────────────────
+# Path.cwd() 호출은 import 시점이 아니라 실제 호출 시점 — DEFAULT_BASE 는 lazy.
+def _default_base() -> Path:
+    return Path.cwd() / ".claude" / "harness-state"
+
+# 호환성: 외부에서 import 한 module 변수처럼 쓸 수 있게 property-like 노출
+class _DefaultBaseProxy:
+    def __fspath__(self) -> str:
+        return str(_default_base())
+    def __str__(self) -> str:
+        return str(_default_base())
+    def __repr__(self) -> str:
+        return f"<DEFAULT_BASE → {_default_base()}>"
+    def resolve(self) -> Path:
+        return _default_base().resolve()
+
+DEFAULT_BASE = _DefaultBaseProxy()
+
+# 빈 파일이 race condition 인지 empty 인지 가르는 기준 (초)
+_RACE_WINDOW_SEC = 0.1
+
+
+class MissingStatus(Exception):
+    """status JSON 의 모든 실패모드를 단일 catch 로 normalize 하는 예외.
+
+    Attributes:
+        reason: REASONS 중 하나.
+        detail: 디버깅용 상세 메시지 (path + 원인).
+    """
+
+    REASONS = (
+        "not_found",
+        "empty",
+        "race",
+        "malformed_json",
+        "schema_violation",
+    )
+
+    def __init__(self, reason: str, detail: str = "") -> None:
+        if reason not in self.REASONS:
+            raise ValueError(
+                f"unknown MissingStatus reason: {reason!r} "
+                f"(allowed: {self.REASONS})"
+            )
+        self.reason = reason
+        self.detail = detail
+        super().__init__(f"[{reason}] {detail}")
+
+
+# ── 내부 검증 함수 ─────────────────────────────────────────────────────────
+
+def _validate_agent(agent: str) -> None:
+    if not isinstance(agent, str) or not _AGENT_NAME_RE.match(agent):
+        raise ValueError(
+            f"invalid agent name: {agent!r} "
+            f"(must match {_AGENT_NAME_RE.pattern})"
+        )
+
+
+def _validate_mode(mode: Optional[str]) -> None:
+    if mode is None:
+        return
+    if not isinstance(mode, str) or not _MODE_NAME_RE.match(mode):
+        raise ValueError(
+            f"invalid mode name: {mode!r} "
+            f"(must match {_MODE_NAME_RE.pattern} or be None)"
+        )
+
+
+def _validate_run_id(run_id: str) -> None:
+    if (
+        not isinstance(run_id, str)
+        or not _RUN_ID_RE.match(run_id)
+        or ".." in run_id
+    ):
+        raise ValueError(
+            f"invalid run_id: {run_id!r} "
+            f"(must match {_RUN_ID_RE.pattern} and not contain '..')"
+        )
+
+
+def _resolve_base(base_dir: Optional[Path]) -> Path:
+    if base_dir is None:
+        return _default_base().resolve()
+    if not isinstance(base_dir, (str, Path)):
+        raise TypeError(f"base_dir must be Path or str, got {type(base_dir)!r}")
+    return Path(base_dir).resolve()
+
+
+# ── 공개 API ──────────────────────────────────────────────────────────────
+
+def state_path(
+    agent: str,
+    run_id: str,
+    mode: Optional[str] = None,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    """status JSON 의 절대 경로 반환.
+
+    경로 규칙: <base_dir>/<run_id>/<agent>[-<mode>].json
+
+    예) base/run_001/validator-PLAN_VALIDATION.json
+        base/run_001/architect.json   (mode None)
+
+    화이트리스트 + path traversal 자기검증 (R1 layer 1).
+    """
+    _validate_agent(agent)
+    _validate_mode(mode)
+    _validate_run_id(run_id)
+
+    base = _resolve_base(base_dir)
+    name = f"{agent}-{mode}.json" if mode else f"{agent}.json"
+    target = (base / run_id / name).resolve()
+
+    # path traversal self-check — 화이트리스트 패턴이 차단하지만
+    # symlink 등 경로 의존 공격까지 차단하기 위한 layer.
+    try:
+        target.relative_to(base)
+    except ValueError as e:
+        raise ValueError(
+            f"path escape detected: {target} not under {base}"
+        ) from e
+    return target
+
+
+def write_status(
+    agent: str,
+    run_id: str,
+    payload: dict,
+    *,
+    mode: Optional[str] = None,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    """status JSON 작성. 'status' 키 필수, 나머지 freeform.
+
+    atomic write: tmp 에 쓰고 rename → 부분 작성 race 회피.
+
+    Returns: 작성된 파일의 절대 경로.
+
+    Raises:
+        ValueError: payload 가 dict 아니거나 'status' 키 누락 / 화이트리스트 위반.
+        TypeError: payload 가 dict 아님.
+        OSError: 디스크 I/O 실패.
+    """
+    if not isinstance(payload, dict):
+        raise TypeError(f"payload must be dict, got {type(payload).__name__}")
+    if "status" not in payload:
+        raise ValueError("payload must contain 'status' key")
+    if not isinstance(payload["status"], str):
+        raise ValueError(
+            f"payload['status'] must be str, got {type(payload['status']).__name__}"
+        )
+
+    target = state_path(agent, run_id, mode, base_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    # atomic write — 부분 작성 race 회피 (Write 도중 read 시 race / malformed 차단)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=False),
+        encoding="utf-8",
+    )
+    os.replace(tmp, target)  # POSIX atomic rename
+    return target
+
+
+def read_status(
+    agent: str,
+    run_id: str,
+    *,
+    mode: Optional[str] = None,
+    base_dir: Optional[Path] = None,
+    allowed_status: Optional[Set[str]] = None,
+) -> dict:
+    """status JSON 읽기. 모든 실패는 MissingStatus 로 normalize (R8).
+
+    Args:
+        agent: 에이전트 이름 (화이트리스트 검증).
+        run_id: 실행 식별자.
+        mode: 에이전트 모드 (예: 'PLAN_VALIDATION').
+        base_dir: 기본 디렉토리 override.
+        allowed_status: 지정 시 status 값이 이 집합 안에 있는지 추가 검증.
+                        None 이면 status 가 string 인지만 검사.
+
+    Returns:
+        status JSON 의 deserialize 결과 (dict).
+
+    Raises:
+        MissingStatus: 5 failure modes 중 하나.
+        ValueError: 화이트리스트 위반 (path 자체 부정).
+    """
+    target = state_path(agent, run_id, mode, base_dir)
+
+    if not target.exists():
+        raise MissingStatus("not_found", str(target))
+
+    try:
+        raw = target.read_text(encoding="utf-8")
+    except OSError as e:
+        # 파일이 사라진 race 등 — not_found 와 동등 처리
+        raise MissingStatus("not_found", f"{target}: {e}") from e
+
+    if not raw.strip():
+        # race 휴리스틱: 매우 최근 mtime 이면 race (재read 권장)
+        try:
+            age = time.time() - target.stat().st_mtime
+        except OSError:
+            age = float("inf")
+        reason = "race" if age < _RACE_WINDOW_SEC else "empty"
+        raise MissingStatus(reason, str(target))
+
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise MissingStatus("malformed_json", f"{target}: {e}") from e
+
+    if not isinstance(data, dict):
+        raise MissingStatus(
+            "schema_violation",
+            f"{target}: root must be object, got {type(data).__name__}",
+        )
+
+    if "status" not in data:
+        raise MissingStatus(
+            "schema_violation",
+            f"{target}: missing required key 'status'",
+        )
+
+    if not isinstance(data["status"], str):
+        raise MissingStatus(
+            "schema_violation",
+            f"{target}: 'status' must be str, got {type(data['status']).__name__}",
+        )
+
+    if allowed_status is not None and data["status"] not in allowed_status:
+        raise MissingStatus(
+            "schema_violation",
+            f"{target}: status={data['status']!r} not in {sorted(allowed_status)}",
+        )
+
+    return data
+
+
+def clear_run_state(
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """run 디렉토리 안의 모든 *.json status 파일 삭제.
+
+    catastrophic 회피: base_dir/run_id 안의 파일만. 그 외 path 거부.
+
+    Returns: 삭제된 파일 수.
+
+    Raises:
+        ValueError: run_id 화이트리스트 위반 / path traversal.
+    """
+    _validate_run_id(run_id)
+
+    base = _resolve_base(base_dir)
+    run_dir = (base / run_id).resolve()
+    try:
+        run_dir.relative_to(base)
+    except ValueError as e:
+        raise ValueError(f"path escape: {run_dir} not under {base}") from e
+
+    if not run_dir.exists():
+        return 0
+
+    count = 0
+    for f in run_dir.glob("*.json"):
+        try:
+            f.unlink()
+            count += 1
+        except OSError:
+            # 다른 프로세스가 동시 삭제 — count 는 증가 안 함
+            pass
+    return count

--- a/tests/test_state_io.py
+++ b/tests/test_state_io.py
@@ -1,0 +1,411 @@
+"""test_state_io.py — harness/state_io 모듈 검증.
+
+검증 범위:
+- R8 (status-json-mutate-pattern §8): 5 failure modes 단일 normalize
+- 화이트리스트 + path traversal (R1 layer 1)
+- atomic write (write_status 가 부분 작성 노출 안 함)
+- clear_run_state 의 path 안전성
+
+실행:
+    python3 -m unittest tests.test_state_io -v
+    python3 tests/test_state_io.py            # 직접 실행도 OK
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+# repo root 를 sys.path 에 추가 (tests/ 는 자동 포함 안 됨)
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from harness.state_io import (  # noqa: E402
+    MissingStatus,
+    clear_run_state,
+    read_status,
+    state_path,
+    write_status,
+)
+
+
+class _Base(unittest.TestCase):
+    """공통 fixture — 임시 base_dir 에서 실행."""
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self._tmp.name)
+        self.run_id = "run_test_001"
+        self.agent = "validator"
+        self.mode = "PLAN_VALIDATION"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+    def _force_old_mtime(self, path: Path) -> None:
+        """race window 밖으로 mtime 강제 (empty vs race 분리 검증용)."""
+        old = time.time() - 5.0
+        os.utime(path, (old, old))
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# Round trip + atomic write
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestRoundTrip(_Base):
+    def test_write_then_read_returns_payload(self) -> None:
+        payload = {
+            "status": "PASS",
+            "fail_items": [],
+            "non_obvious_patterns": ["validator 가 spec gap 발견"],
+        }
+        path = write_status(
+            self.agent, self.run_id, payload,
+            mode=self.mode, base_dir=self.base,
+        )
+        self.assertTrue(path.exists())
+
+        data = read_status(
+            self.agent, self.run_id,
+            mode=self.mode, base_dir=self.base,
+        )
+        self.assertEqual(data["status"], "PASS")
+        self.assertEqual(
+            data["non_obvious_patterns"],
+            ["validator 가 spec gap 발견"],
+        )
+
+    def test_write_without_mode(self) -> None:
+        path = write_status(
+            "architect", self.run_id, {"status": "READY"},
+            base_dir=self.base,
+        )
+        self.assertTrue(path.name.endswith("architect.json"))
+        data = read_status("architect", self.run_id, base_dir=self.base)
+        self.assertEqual(data["status"], "READY")
+
+    def test_overwrite_replaces_payload(self) -> None:
+        write_status(
+            self.agent, self.run_id, {"status": "FAIL"},
+            mode=self.mode, base_dir=self.base,
+        )
+        write_status(
+            self.agent, self.run_id, {"status": "PASS", "note": "재검증 통과"},
+            mode=self.mode, base_dir=self.base,
+        )
+        data = read_status(
+            self.agent, self.run_id,
+            mode=self.mode, base_dir=self.base,
+        )
+        self.assertEqual(data["status"], "PASS")
+        self.assertEqual(data["note"], "재검증 통과")
+
+    def test_atomic_write_no_tmp_residue(self) -> None:
+        write_status(
+            self.agent, self.run_id, {"status": "PASS"},
+            mode=self.mode, base_dir=self.base,
+        )
+        run_dir = self.base / self.run_id
+        tmp_files = list(run_dir.glob("*.tmp"))
+        self.assertEqual(tmp_files, [], "tmp 파일이 남으면 atomic 실패")
+
+    def test_unicode_payload(self) -> None:
+        write_status(
+            self.agent, self.run_id,
+            {"status": "PASS", "msg": "한글 + 이모지 ✓"},
+            mode=self.mode, base_dir=self.base,
+        )
+        data = read_status(
+            self.agent, self.run_id,
+            mode=self.mode, base_dir=self.base,
+        )
+        self.assertEqual(data["msg"], "한글 + 이모지 ✓")
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# R8: 5 failure modes 단일 normalize
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestFailureNotFound(_Base):
+    def test_not_found(self) -> None:
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "not_found")
+        self.assertIn(self.agent, ctx.exception.detail)
+
+
+class TestFailureEmpty(_Base):
+    def test_empty_with_old_mtime(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("")
+        self._force_old_mtime(path)
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "empty")
+
+    def test_whitespace_only_treated_as_empty(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("   \n\t  \n")
+        self._force_old_mtime(path)
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "empty")
+
+
+class TestFailureRace(_Base):
+    def test_empty_with_recent_mtime_is_race(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("")
+        # mtime = now (default) → race window 안
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "race")
+
+
+class TestFailureMalformedJson(_Base):
+    def test_malformed_json(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("{not: valid, json")
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "malformed_json")
+
+    def test_partial_json_truncated_during_write(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text('{"status": "PA')  # truncated
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "malformed_json")
+
+
+class TestFailureSchemaViolation(_Base):
+    def test_missing_status_key(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"fail_items": ["x"]}))
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "schema_violation")
+        self.assertIn("status", ctx.exception.detail)
+
+    def test_status_not_string(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"status": 42}))
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "schema_violation")
+
+    def test_root_not_object(self) -> None:
+        path = state_path(self.agent, self.run_id, self.mode, self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(["status", "PASS"]))
+
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+            )
+        self.assertEqual(ctx.exception.reason, "schema_violation")
+
+    def test_status_outside_allowed_set(self) -> None:
+        write_status(
+            self.agent, self.run_id, {"status": "WEIRD"},
+            mode=self.mode, base_dir=self.base,
+        )
+        with self.assertRaises(MissingStatus) as ctx:
+            read_status(
+                self.agent, self.run_id,
+                mode=self.mode, base_dir=self.base,
+                allowed_status={"PASS", "FAIL"},
+            )
+        self.assertEqual(ctx.exception.reason, "schema_violation")
+        self.assertIn("WEIRD", ctx.exception.detail)
+
+    def test_allowed_status_passthrough(self) -> None:
+        write_status(
+            self.agent, self.run_id, {"status": "PASS"},
+            mode=self.mode, base_dir=self.base,
+        )
+        data = read_status(
+            self.agent, self.run_id,
+            mode=self.mode, base_dir=self.base,
+            allowed_status={"PASS", "FAIL"},
+        )
+        self.assertEqual(data["status"], "PASS")
+
+
+class TestMissingStatusContract(unittest.TestCase):
+    """MissingStatus 계약 — 다른 exception 누수 0."""
+
+    def test_only_known_reasons(self) -> None:
+        with self.assertRaises(ValueError):
+            MissingStatus("UNEXPECTED", "x")
+
+    def test_reasons_constant(self) -> None:
+        self.assertEqual(
+            set(MissingStatus.REASONS),
+            {"not_found", "empty", "race", "malformed_json", "schema_violation"},
+        )
+
+    def test_message_includes_reason_and_detail(self) -> None:
+        e = MissingStatus("not_found", "/tmp/foo.json")
+        self.assertEqual(e.reason, "not_found")
+        self.assertIn("not_found", str(e))
+        self.assertIn("/tmp/foo.json", str(e))
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# 화이트리스트 + path traversal (R1 layer 1)
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestPathSafety(_Base):
+    def test_invalid_agent_traversal(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                "../etc", self.run_id, {"status": "PASS"},
+                base_dir=self.base,
+            )
+
+    def test_invalid_agent_uppercase(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                "Validator", self.run_id, {"status": "PASS"},
+                base_dir=self.base,
+            )
+
+    def test_invalid_mode_lowercase(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                self.agent, self.run_id, {"status": "PASS"},
+                mode="lower-case", base_dir=self.base,
+            )
+
+    def test_run_id_dotdot_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                self.agent, "..", {"status": "PASS"},
+                base_dir=self.base,
+            )
+
+    def test_run_id_slash_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                self.agent, "a/b", {"status": "PASS"},
+                base_dir=self.base,
+            )
+
+    def test_payload_must_be_dict(self) -> None:
+        with self.assertRaises(TypeError):
+            write_status(
+                self.agent, self.run_id, ["PASS"],  # type: ignore[arg-type]
+                base_dir=self.base,
+            )
+
+    def test_payload_must_have_status(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                self.agent, self.run_id, {"foo": "bar"},
+                base_dir=self.base,
+            )
+
+    def test_payload_status_must_be_string(self) -> None:
+        with self.assertRaises(ValueError):
+            write_status(
+                self.agent, self.run_id, {"status": 1},
+                base_dir=self.base,
+            )
+
+    def test_state_path_is_under_base(self) -> None:
+        p = state_path(self.agent, self.run_id, self.mode, self.base)
+        # base 의 resolve 와 비교 (TemporaryDirectory 가 symlink 일 수 있음)
+        self.assertTrue(str(p).startswith(str(self.base.resolve())))
+
+
+# ═════════════════════════════════════════════════════════════════════════
+# clear_run_state
+# ═════════════════════════════════════════════════════════════════════════
+
+class TestClearRunState(_Base):
+    def test_clear_removes_all_status_jsons(self) -> None:
+        write_status(
+            self.agent, self.run_id, {"status": "PASS"},
+            mode="PLAN_VALIDATION", base_dir=self.base,
+        )
+        write_status(
+            self.agent, self.run_id, {"status": "FAIL"},
+            mode="CODE_VALIDATION", base_dir=self.base,
+        )
+        n = clear_run_state(self.run_id, base_dir=self.base)
+        self.assertEqual(n, 2)
+
+        with self.assertRaises(MissingStatus):
+            read_status(
+                self.agent, self.run_id,
+                mode="PLAN_VALIDATION", base_dir=self.base,
+            )
+
+    def test_clear_missing_run_returns_zero(self) -> None:
+        n = clear_run_state("nonexistent_run_xyz", base_dir=self.base)
+        self.assertEqual(n, 0)
+
+    def test_clear_path_traversal_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            clear_run_state("..", base_dir=self.base)
+
+    def test_clear_preserves_non_json_files(self) -> None:
+        # status JSON 외 파일은 보존
+        write_status(
+            self.agent, self.run_id, {"status": "PASS"},
+            mode="PLAN_VALIDATION", base_dir=self.base,
+        )
+        run_dir = self.base / self.run_id
+        sentinel = run_dir / "preserve.txt"
+        sentinel.write_text("non-json artifact")
+
+        clear_run_state(self.run_id, base_dir=self.base)
+        self.assertTrue(sentinel.exists(), "비-JSON 파일은 보존돼야 함")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
Phase 1 sub 1.1 (mechanism) 의 **첫 단계** — agent status JSON mutate / read 단일 책임 모듈. RWHarness 의 `parse_marker` 사다리 폐기를 위한 foundation.

`docs/status-json-mutate-pattern.md` Phase 1 acceptance criteria 첫 항목 (`harness/state_io.py` + R8 normalize + 테스트 100%) 완료.

## 변경 요약
- `harness/state_io.py` 신규 (~290 LOC)
  - `write_status` / `read_status` / `clear_run_state` / `state_path`
  - `MissingStatus` 예외로 5 failure modes 단일 normalize (R8)
  - atomic write (POSIX `os.replace`) + path traversal self-check (R1 layer 1)
- `tests/test_state_io.py` 신규 (32 케이스, 전부 PASS)
- `CLAUDE.md` §4 — `python3 -m unittest …` 명령 추가
- 거버넌스 동반: `document_update_record.md` / `change_rationale_history.md` / `PROGRESS.md`

## 비스코프 (후속 Task-ID)
- [ ] `agents/validator*.md` 의 `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 변환
- [ ] RWHarness `harness/core.py` plan/design/ux validation 함수 복사 + 7 `parse_marker` → `read_status` 치환
- [ ] RWHarness `hooks/agent-boundary.py` 복사 + validator ALLOW_MATRIX 에 status path 추가
- [ ] `_AGENT_DISALLOWED["validator"]` 에서 `Write` 제거
- [ ] `docs/migration-decisions.md` — 제안서 §11.2 framework 적용 (별도 Task)

## Test plan
- [x] `python3 -m unittest tests.test_state_io -v` — 32/32 PASS
- [x] `node scripts/check_document_sync.mjs` — PASS (7 files, 4 categories)
- [ ] CI (`document-sync.yml`) — 미구축 (별도 Task-ID 예정)

## 거버넌스 체크리스트
- [x] Task-ID 발급 (`DCN-CHG-20260429-03`)
- [x] `document_update_record.md` (WHAT) 갱신
- [x] `change_rationale_history.md` (WHY) 갱신 — `harness` 카테고리(heavy)
- [x] `PROGRESS.md` 갱신 — `harness` 카테고리(progress)
- [x] `tests/**` 동반 — `harness` 카테고리 deliverable
- [x] doc-sync 게이트 통과 (`Document-Exception` 없음)

## 근거
- 기술적 결정: `docs/process/change_rationale_history.md#DCN-CHG-20260429-03`
- 정체성 정합: `docs/status-json-mutate-pattern.md` §2 (Goal), §2.5 (Anti-Patterns), §5 Phase 1 sub 1.1, §8 R8

🤖 Generated with [Claude Code](https://claude.com/claude-code)