### PR TITLE
feat: add dcness plugin manifest + register in governance (DCN-CHG-20260429-04)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "dcness",
+  "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness. RWHarness fork-and-refactor.",
+  "owner": {
+    "name": "alruminum",
+    "email": "alruminum@gmail.com"
+  },
+  "metadata": {
+    "description": "dcNess 첫 알파 — status JSON mutate 결정론 + 함정 회피 5원칙 + Document Sync 거버넌스. RWHarness 와 공존 가능 설계 (proposal §12).",
+    "version": "0.1.0-alpha"
+  },
+  "plugins": [
+    {
+      "name": "dcness",
+      "source": "./",
+      "description": "Status-JSON-mutate harness — agent 가 외부 상태 파일 mutate, harness 는 그 파일만 read. parse_marker 사다리 폐기.",
+      "category": "development",
+      "tags": [
+        "agent",
+        "workflow",
+        "orchestration",
+        "harness",
+        "status-json-mutate",
+        "governance"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "dcness",
+  "version": "0.1.0-alpha",
+  "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). RWHarness fork-and-refactor with parse_marker ladder eliminated.",
+  "author": {
+    "name": "alruminum",
+    "email": "alruminum@gmail.com"
+  },
+  "license": "MIT",
+  "keywords": [
+    "agent",
+    "workflow",
+    "orchestration",
+    "claude-code",
+    "harness",
+    "status-json-mutate",
+    "lightharness"
+  ],
+  "homepage": "https://github.com/alruminum/dcNess",
+  "repository": "https://github.com/alruminum/dcNess"
+}

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -3,10 +3,13 @@
 ## 현재 상태
 - 거버넌스 시스템 부트스트랩 완료 (`DCN-CHG-20260429-01`, PR #1 머지)
 - 프로젝트 루트 `CLAUDE.md` + 루트 정책 파일 게이트 분류 추가 (`DCN-CHG-20260429-02`)
-- **Phase 1 foundation 진입**: `harness/state_io.py` 신규 + 테스트 32 PASS (`DCN-CHG-20260429-03`)
+- **Phase 1 foundation 진입**: `harness/state_io.py` 신규 + 테스트 32 PASS (`DCN-CHG-20260429-03`, PR #3 머지)
   - R8 5 failure modes (not_found/empty/race/malformed_json/schema_violation) 단일 normalize 검증 완료
   - atomic write (POSIX rename) + path traversal self-check (R1 layer 1) 포함
   - 적용 범위 = 모듈 단독. validator 호출지 / agent docs / hook ALLOW_MATRIX 변환은 후속 Task-ID
+- **Plugin 배포 인프라**: `.claude-plugin/{plugin,marketplace}.json` 신규 (`DCN-CHG-20260429-04`)
+  - 이름 = `dcness`, 버전 = `0.1.0-alpha`. RWHarness 와 공존 가능 설계 (proposal §12.3.2).
+  - governance §2.2 의 `agent` 카테고리에 `^\.claude-plugin/` 패턴 추가하여 plugin manifest 변경도 heavy 카테고리 강제.
 
 ## TODO
 ### Phase 1 — 후속 (validator 단일 agent 완성)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -71,3 +71,26 @@
   - **(다음 Task-ID)** RWHarness `hooks/agent-boundary.py` 복사 + validator ALLOW_MATRIX 에 status path regex 추가, `_AGENT_DISALLOWED["validator"]` 에서 Write 제거.
   - **(다음 Task-ID)** `docs/migration-decisions.md` — proposal §11.2 framework (catastrophic-prevention / 자연 폐기 / 단순화) 모듈 분류표.
   - **측정 항목**: 5 failure modes 모두 `MissingStatus` 단일 catch 보장 (다른 exception 누수 0). 테스트로 명문화 — `TestMissingStatusContract`. 실제 운영 시 다른 exception 누수 발견되면 회귀 PR.
+
+### DCN-CHG-20260429-04
+- **Date**: 2026-04-29
+- **Rationale**:
+  - dcNess 의 정체성: `status-json-mutate-pattern.md` §11.1 — "RWHarness 코어 보존 + 본 proposal 정합 최소 레이어" + §12 — "신규 plugin 1차 완성 후 RWHarness 대체 테스트". 즉 dcNess 는 **Claude Code plugin** 으로 배포돼 RWHarness 와 공존 가능해야 한다.
+  - `.claude-plugin/plugin.json` + `marketplace.json` 부재 시: plugin 매니저(`claude plugin install`) 가 dcNess 를 인식 못 함 → 도그푸딩 / 단계적 전환 / 롤백 시나리오(§12.3.2 ~ §12.3.5) 진입 불가.
+  - 부수 문제: 본 manifest 변경이 governance §2.2 의 어떤 카테고리에도 매칭 안 됨 → record/rationale 동반 없이 통과되는 구멍. plugin 메타는 정책급 (잘못 배포 시 사용자 환경 파괴 catastrophic) → heavy 카테고리 매칭 강제 필요.
+- **Alternatives**:
+  1. *plugin manifest 만 추가, 게이트 룰 변경 없음* — 정책 변경에 record/rationale 동반 강제가 안 됨. CHG-02 와 동일 함정. 기각.
+  2. *`hooks` 카테고리에 추가* — plugin manifest 는 hook 정의가 아니라 plugin 정체성. 의미 mismatch. 기각.
+  3. *`ci` 카테고리에 추가* — build/deploy 메타로 보면 후보. 단 plugin manifest = "패키지 정체성 + agent/hook/skill 묶음" 로 정책 성격 강함. 기각.
+  4. *(채택)* **`agent` 카테고리에 `^\.claude-plugin/` 추가** — agent prompt / 정책 / plugin 메타가 모두 정책급 정합. CLAUDE.md / AGENTS.md / agents/ 와 같은 line-up. heavy 카테고리(rationale 동반 강제) 자동 적용.
+- **Decision**:
+  - 옵션 4 채택. `governance.md` §2.2 agent 패턴 + `check_document_sync.mjs` CATEGORY_RULES 동시 갱신 (코드 = 명세 구현, CHG-02 룰 정합).
+  - plugin 이름 = `dcness`, 마켓플레이스 이름 = `dcness` (소문자 통일). proposal §11.1 후보(`lightharness`, `microharness`, `rwh-lite`, `harness-v2`) 대신 저장소 이름 그대로 채택 — 사용자 결정 + 저장소-plugin 1:1 매핑 명시성.
+  - **RWHarness 와 공존 가능 설계**: plugin 이름이 `realworld-harness` 와 다름 → `claude plugin install` 시 충돌 0. proposal §12.3.2 의 "공존 가능 검증" 시나리오 실현 가능.
+  - **버전**: `0.1.0-alpha` — RWHarness 와 동일 alpha 대역. 첫 plugin 도입.
+  - **hook/agent prefix**: 본 Task 에선 미정. 후속 Task (RWHarness `hooks/` / `agents/` 복사 시) 에서 `dcness-` prefix 또는 별도 디렉토리 결정. 현재는 manifest 만.
+- **Follow-Up**:
+  - **(다음 Task-ID)** `docs/migration-decisions.md` — proposal §11.2 framework 적용 (RWHarness 모듈 분류). plugin layout 결정 (hook/agent 어디 위치할지) 동시 박기.
+  - **(다음 Task-ID)** `agents/validator*.md` 복사 + `@OUTPUT_FILE/SCHEMA/RULE` 변환. plugin manifest 의 hook/agent 매핑 추가.
+  - **(별도 Task)** `claude plugin validate .claude-plugin/` 자동 실행 CI workflow — plugin manifest 형식 검증.
+  - **측정**: plugin 설치/제거 1회 dry-run 후 RWHarness 와 충돌 0 검증 (proposal §12.3.2). 단 plugin 매니저 실측은 후속 — 현 Task 는 manifest 정의 단독.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -61,3 +61,16 @@
   - `docs/process/change_rationale_history.md`
   - `PROGRESS.md`
 - **Summary**: Phase 1 foundation — `harness/state_io.py` 신규(write/read/clear + R8 5 failure modes 단일 normalize) + 테스트 32 케이스 전부 PASS. `parse_marker` 사다리 폐기를 위한 첫 모듈.
+
+### DCN-CHG-20260429-04
+- **Date**: 2026-04-29
+- **Change-Type**: agent, ci, docs-only
+- **Files Changed**:
+  - `.claude-plugin/plugin.json` (신규 — plugin 메타)
+  - `.claude-plugin/marketplace.json` (신규 — marketplace 정의)
+  - `docs/process/governance.md` (§2.2 agent 패턴에 `^\.claude-plugin/` 추가)
+  - `scripts/check_document_sync.mjs` (CATEGORY_RULES agent 토큰 동기 갱신)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: Plugin 배포 인프라 — `dcness@dcness` plugin/marketplace manifest 신규. `status-json-mutate-pattern.md` §12 (RWHarness → 신규 Plugin 전환 절차) 정합. governance §2.2 의 `agent` 카테고리에 `.claude-plugin/` 패턴 추가하여 plugin manifest 변경에도 record/rationale 동반 강제.

--- a/docs/process/governance.md
+++ b/docs/process/governance.md
@@ -33,7 +33,7 @@
 | 토큰 | 감시 경로 (regex) | 의미 |
 |---|---|---|
 | `spec` | `^docs/spec/`, `^docs/proposals/`, `^prd\.md$`, `^trd\.md$` | 헌법 / 사양 문서 |
-| `agent` | `^agents/`, `^\.claude/agent-config/`, `^CLAUDE\.md$`, `^AGENTS\.md$` | agent prompt / 정책 (메인·외부 에이전트 지침 포함) |
+| `agent` | `^agents/`, `^\.claude/agent-config/`, `^\.claude-plugin/`, `^CLAUDE\.md$`, `^AGENTS\.md$` | agent prompt / plugin 메타 / 정책 (메인·외부 에이전트 지침 + plugin manifest 포함) |
 | `harness` | `^harness/`, `^src/` | 하네스 코어 / 소스 코드 |
 | `hooks` | `^hooks/`, `^\.claude/hooks/` | 차단·검증 hook |
 | `ci` | `^\.github/workflows/`, `^scripts/` | CI / 빌드 / 게이트 스크립트 |

--- a/scripts/check_document_sync.mjs
+++ b/scripts/check_document_sync.mjs
@@ -16,7 +16,7 @@ import { execSync } from 'node:child_process';
 // 분류 우선순위: 위에서 아래로. 한 파일이 여러 패턴에 매칭되면 *상위* 토큰 채택.
 const CATEGORY_RULES = [
   { token: 'spec',      patterns: [/^docs\/spec\//, /^docs\/proposals\//, /^prd\.md$/, /^trd\.md$/] },
-  { token: 'agent',     patterns: [/^agents\//, /^\.claude\/agent-config\//, /^CLAUDE\.md$/, /^AGENTS\.md$/] },
+  { token: 'agent',     patterns: [/^agents\//, /^\.claude\/agent-config\//, /^\.claude-plugin\//, /^CLAUDE\.md$/, /^AGENTS\.md$/] },
   { token: 'harness',   patterns: [/^harness\//, /^src\//] },
   { token: 'hooks',     patterns: [/^hooks\//, /^\.claude\/hooks\//] },
   { token: 'ci',        patterns: [/^\.github\/workflows\//, /^scripts\//] },


### PR DESCRIPTION
## Summary
Plugin 배포 인프라 — \`dcness@dcness\` plugin/marketplace manifest 신규. \`status-json-mutate-pattern.md\` §12 (RWHarness → 신규 Plugin 전환 절차) 정합. RWHarness(\`realworld-harness\`) 와 plugin name 충돌 0 → 공존 가능.

## 변경 요약
- \`.claude-plugin/plugin.json\` 신규 — \`name=dcness\`, \`version=0.1.0-alpha\`
- \`.claude-plugin/marketplace.json\` 신규 — 단일 plugin entry (\`category: development\`)
- \`docs/process/governance.md\` §2.2 — \`agent\` 패턴에 \`^\\.claude-plugin/\` 추가
- \`scripts/check_document_sync.mjs\` — CATEGORY_RULES 동기 갱신 → plugin manifest 변경도 heavy 카테고리 강제

## 비스코프 (후속 Task-ID)
- [ ] hook/agent prefix 결정 (RWHarness \`hooks/\` / \`agents/\` 복사 시 \`dcness-\` prefix 또는 별도 디렉토리)
- [ ] \`claude plugin validate .claude-plugin/\` 자동 실행 CI workflow
- [ ] plugin 설치 dry-run 으로 RWHarness 충돌 0 실측 검증 (proposal §12.3.2)

## Test plan
- [x] \`node scripts/check_document_sync.mjs\` → PASS (7 files, 3 categories)
- [x] \`python3 -m unittest tests.test_state_io -v\` → 32/32 PASS (회귀 0)
- [ ] \`claude plugin validate\` 실측 — 후속 Task

## 거버넌스 체크리스트
- [x] Task-ID \`DCN-CHG-20260429-04\`
- [x] WHAT 로그 (\`document_update_record.md\`)
- [x] WHY 로그 (\`change_rationale_history.md\`) — \`agent\`/\`ci\` heavy
- [x] PROGRESS.md 갱신 — \`ci\` progress
- [x] doc-sync 게이트 통과

## 근거
- 정체성: \`status-json-mutate-pattern.md\` §11.1 (lightharness 정체성), §12 (전환 절차)
- 거버넌스: \`docs/process/change_rationale_history.md#DCN-CHG-20260429-04\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)