### PR TITLE
docs: classify RWHarness modules per proposal §11.2 (DCN-CHG-20260429-05)

### DIFF
--- a/docs/migration-decisions.md
+++ b/docs/migration-decisions.md
@@ -1,0 +1,171 @@
+# Migration Decisions — RWHarness → dcNess
+
+> **Status**: ACTIVE
+> **Origin**: `docs/status-json-mutate-pattern.md` §11.2 framework 적용
+> **Bootstrap**: DCN-CHG-20260429-05
+> **Scope**: RWHarness 의 어느 모듈을 dcNess 로 가져올지 / 폐기할지 / 리팩터할지 module-level 결정 기록
+
+## 0. 목적
+
+`status-json-mutate-pattern.md` §11.2 framework 를 RWHarness 모듈 카탈로그에 적용한 결과를 단일 문서로 박는다. 모듈마다 다음 3 질문 중 하나로 분류:
+
+1. **Catastrophic-prevention 인가?** — 돌이킬 수 없는 사고를 막는가? → **PRESERVE**
+2. **발상 변경으로 자연 폐기되는가?** — status JSON mutate / dcNess 메인 직접 작업 모드 적용 시 의미 잃는가? → **DISCARD**
+3. **단순화 가능한가?** — 룰 누적·중복 패턴인가? → **REFACTOR**
+
+본 문서는 **결정 기록** 이지 *재작성 금지의 헌법* 이 아니다. 분류가 잘못된 것으로 판명되면 별도 Task-ID 로 정정.
+
+---
+
+## 1. dcNess 정체성 정합 (분류 전 전제)
+
+dcNess 는 RWHarness 와 다른 *모드* 다. 분류 전 다음 전제 박는다 (proposal §10 / §11.4):
+
+- **메인 Claude 직접 작업 모드** — architect/validator/engineer 위임 강제 *없음*
+- **RWHarness 가드 미적용** — agent-boundary / commit-gate hook 자체가 본 환경엔 동작 안 함 (사용자 프로젝트 가드 ≠ 본 저장소 가드)
+- **Document Sync 거버넌스만 강제** — Task-ID + record/rationale/PROGRESS 동반
+- **Plugin 배포 고려** (`DCN-CHG-20260429-04`) — RWHarness 와 공존 가능 설계
+
+따라서 RWHarness 의 *위임 사이클 강제* 모듈군은 dcNess 환경에선 **자연 폐기** (proposal §11.4).
+
+---
+
+## 2. 분류 결과
+
+> 출처: `~/project/RWHarness` (alruminum/realworld-harness@0.1.0-alpha)
+> 본 분류는 *현 시점 결정*. RWHarness 가 변하면 본 표도 갱신 필요.
+
+### 2.1 `harness/` (Python 코어)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| `core.py:551-680` `MARKER_ALIASES` + `parse_marker` + `diagnose_marker_miss` | **DISCARD** | 발상 변경으로 자연 폐기. `state_io.read_status` 가 대체. proposal §3 |
+| `core.py:2040-2200` `generate_handoff` + `write_handoff` | **DISCARD** | handoff prose → status JSON `next_actions[]`. proposal §4.4 |
+| `core.py:175-210` `class Flag` (enum) | **REFACTOR (Phase 3.2)** | Phase 1~2 보존 후 `workflow-state.json` 합본. proposal §4.5 옵션 B |
+| `core.py:1024-1043` `_AGENT_DISALLOWED` 매트릭스 | **DISCARD (dcNess 한정)** | `agent_call` subprocess 의 일부. dcNess 메인 직접 작업 모드엔 의미 없음 |
+| `core.py` `agent_call` subprocess (claude CLI 격리) | **DISCARD (dcNess 한정)** | 메인 직접 작업 모드라 subagent 호출은 메인 Claude 의 `Agent` 도구 또는 `Task` 도구가 담당. RWHarness 의 별도 subprocess 격리는 ceremony |
+| `core.py` `RunLogger` (JSONL 이벤트 로그) | **PRESERVE (검토)** | 도그푸딩 측정에 유용. dcNess 가 도그푸딩 환경 도입 시 같은 형식 채택. 단 Phase 1 진입 전엔 *보류* (불필요한 LOC) |
+| `core.py` `StateDir` (path 추상) | **PARTIAL** | path 추상은 `state_io.py` 에 이미 흡수. RWHarness `StateDir` 자체는 폐기, 신규 `state_io.state_path` 가 대체 |
+| `core.py` `kill_check` / `HARNESS_KILL` | **PRESERVE (검토)** | 무한 루프 차단 catastrophic-prevention. 단 dcNess 가 subprocess 루프 안 돌리면 의미 없음. 후속 Task 검토 |
+| `executor.py` (agent subprocess executor) | **DISCARD (dcNess 한정)** | `agent_call` 폐기와 동반 |
+| `path_resolver.py` (claude CLI 경로 결정) | **DISCARD (dcNess 한정)** | 메인 작업 모드엔 메인 Claude 가 자기 CLI 안에서 동작 → 외부 CLI path 결정 불필요 |
+| `providers.py` (provider config) | **DISCARD (dcNess 한정)** | 위 동일 |
+| `config.py` `HarnessConfig` | **DISCARD (dcNess 한정)** | 위 동일. dcNess 는 환경변수 + plugin manifest 로 충분 |
+| `notify.py` (알림 send) | **DISCARD (dcNess 한정)** | 메인 작업 모드라 사용자가 직접 인지 |
+| `tracker.py` (Issue tracker integration) | **DISCARD (dcNess 한정)** | 본 저장소 거버넌스가 GitHub Issue 직접 사용 (`gh` CLI) — 별도 추상 불필요 |
+| `helpers.py` (utility) | **검토** | 일부 함수 (`format_ref` 등) 는 유용. 필요 시 cherry-pick |
+| `impl_loop.py` (validator → engineer → pr-reviewer 시퀀스) | **DISCARD (dcNess 한정)** | proposal §11.4 — "impl_loop subprocess 시퀀스 강제" 도입 안 함 |
+| `impl_router.py` (모드 분기) | **DISCARD (dcNess 한정)** | impl_loop 동반 폐기 |
+| `plan_loop.py` (checkpoint hash + planning 시퀀스) | **DISCARD (dcNess 한정)** | 위 동일 |
+| `review_agent.py` (review 분기) | **DISCARD (dcNess 한정)** | 위 동일 |
+
+### 2.2 `hooks/` (Claude Code hook)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| `agent-boundary.py` (ALLOW_MATRIX / READ_DENY_MATRIX / HARNESS_INFRA_PATTERNS) | **DISCARD (dcNess 한정)** | proposal §11.4 — "가드 자체가 신규 프로젝트엔 미적용". 본 저장소가 다른 사용자 프로젝트의 가드가 되려면 *plugin 배포* 후 사용자 프로젝트에서 활성화. 현재 dcNess 자체 작업 시엔 미적용 |
+| `commit-gate.py` (Gate 1/4/5) | **DISCARD (dcNess 한정)** | 위 동일. 본 저장소는 git pre-commit + Claude Code PreToolUse hook (이미 도입) 으로 충분 |
+| `plugin-write-guard.py` (plugin 디렉토리 보호) | **PRESERVE (전역)** | 전역 hook (~/.claude). dcNess 자체는 영향 안 줌. RWHarness 와 공존 시 동시 활성. 본 저장소가 *복사* 할 필요 없음 |
+| `harness-session-start.py` (session bootstrap) | **DISCARD (dcNess 한정)** | RWHarness 활성 화이트리스트 검사 — dcNess 자체엔 무관 |
+| `skill-stop-protect.py` (skill stop 차단) | **PRESERVE (전역)** | 전역 hook. 동일 |
+| `harness_common.py` (hook utility) | **DISCARD (dcNess 한정)** | RWHarness hook 들의 공통 utility. dcNess hook 미도입이라 불필요 |
+| `session_state.py` (live.json SSOT) | **DISCARD (dcNess 한정)** | 위 동일 |
+| 기타 review/router/drift hook | **DISCARD (dcNess 한정)** | 위 동일 |
+
+> **요약**: dcNess 는 *자체 hook 없음*. RWHarness 의 hook 은 *사용자 프로젝트* 보호용으로, dcNess 가 plugin 으로 배포돼 다른 프로젝트에 활성화될 때 의미가 있음. 본 저장소 `hooks/` 디렉토리는 만들지 않는다 (proposal §11.4 정합).
+
+### 2.3 `agents/` (agent prompt + 모드 sub-doc)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| `validator.md` + `validator/*.md` (5 모드) | **REFACTOR (Phase 1)** | `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 변환. `non_obvious_patterns` optional 필드 추가 (proposal §5 Phase 1) |
+| `architect.md` + `architect/*.md` (7 모드) | **REFACTOR (Phase 2)** | 동일 형식 변환 |
+| `engineer.md` | **REFACTOR (Phase 2)** | 동일 |
+| `designer.md` + `designer/*.md` (4 모드) | **REFACTOR (Phase 2)** | 동일 |
+| `design-critic.md` | **REFACTOR (Phase 2)** | 동일 |
+| `qa.md` | **REFACTOR (Phase 2)** | 동일 |
+| `ux-architect.md` | **REFACTOR (Phase 2)** | 동일 |
+| `product-planner.md` | **REFACTOR (Phase 2)** | 동일 |
+| `plan-reviewer.md` | **REFACTOR (Phase 2)** | 동일 |
+| `pr-reviewer.md` | **REFACTOR (Phase 2)** | 동일 |
+| `security-reviewer.md` | **REFACTOR (Phase 2)** | 동일 |
+| `test-engineer.md` | **REFACTOR (Phase 2)** | 동일 |
+| `preamble.md` (자동 주입 헤더) | **DISCARD** | 점진 공개로 대체 (proposal §5 Phase 1.3 / Phase 2). dcNess 가 plugin 으로 배포될 때도 동일 |
+
+> **dcNess 메인 작업 모드 vs Plugin 배포 모드**:
+> - **메인 작업 모드 (본 저장소 내부)**: agent prompt 가 *자료* 일 뿐 의무 호출 없음. 메인 Claude 가 `Task` 도구로 호출 시에만 활성화.
+> - **Plugin 배포 모드 (사용자 프로젝트에서 활성화)**: agent prompt 가 *실 호출 대상*. status JSON mutate 형식 강제.
+>
+> 두 모드 다 같은 agent docs 형식 사용 → 변환은 한 번만.
+
+### 2.4 `agent-config/` (프로젝트별 agent 컨텍스트)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| `agent-config/*.md` (project context) | **DISCARD** | proposal §5 Phase 1: "별 layer 폐기, agents/*.md 통합". dcNess 에 도입 안 함 |
+
+### 2.5 `scripts/` (build/test/governance)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| RWHarness `setup-harness.sh` / `setup-agents.sh` | **DISCARD (dcNess 한정)** | RWHarness 부트스트랩 — dcNess 는 이미 거버넌스 부트스트랩 완료 (`DCN-CHG-20260429-01`) |
+| RWHarness 기타 운영 script | **검토** | cherry-pick 후보. 필요 시 별도 Task |
+
+### 2.6 `orchestration/` (changelog + rationale)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| `orchestration/changelog.md` 형식 + Task-ID 패턴 | **PRESERVE → 이미 흡수** | dcNess 의 `docs/process/document_update_record.md` + `change_rationale_history.md` 가 동일 역할. Task-ID 형식 (`DCN-CHG-YYYYMMDD-NN`) 도 RWHarness `HARNESS-CHG-*` 패턴 정합 |
+| Document-Exception 토큰 룰 | **PRESERVE → 이미 흡수** | governance §2.4 |
+
+### 2.7 `.claude-plugin/` (plugin manifest)
+
+| 모듈 | 결정 | 사유 |
+|---|---|---|
+| `plugin.json` + `marketplace.json` 형식 | **PRESERVE → 이미 흡수** | dcNess 는 자체 manifest (`name=dcness`) 작성 (`DCN-CHG-20260429-04`). RWHarness 와 plugin name 충돌 0 |
+
+---
+
+## 3. 신규 net-new (RWHarness 에 없음)
+
+| 모듈 | 상태 | 위치 |
+|---|---|---|
+| `harness/state_io.py` (R8 normalize 포함) | **DONE** | `DCN-CHG-20260429-03`, PR #3 머지 |
+| `tests/test_state_io.py` (32 케이스) | **DONE** | 위 동일 |
+| `agents/*.md` 의 `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 | **TODO** | 후속 Task |
+| `.github/workflows/document-sync.yml` (CI 게이트) | **TODO** | 후속 Task |
+| `.github/workflows/plugin-validate.yml` | **TODO** | 후속 Task |
+
+---
+
+## 4. 보류 / 미정 (decision pending)
+
+다음 항목은 *후속 Task* 에서 결정:
+
+- **dcNess 가 메인 Claude 의 `Task` 도구로 agent 호출 시 status JSON mutate 형식 강제 여부** — 현 모드(메인 직접 작업) 에선 의무 아님. plugin 배포 후 사용자 프로젝트에서만 강제.
+- **`harness/core.py` 의 `RunLogger` / `kill_check` 도입 여부** — 도그푸딩 측정 또는 무한루프 차단 필요 시 cherry-pick.
+- **`harness/helpers.py` 의 utility 함수 cherry-pick** — 사용 시점에 필요한 함수만 가져옴.
+- **`MARKER_ALIASES` 폴백 layer 의 dcNess 도입 여부** — 사용자 프로젝트 plugin 배포 시 LLM 변형 흡수 가교가 필요할 수 있음. 단 proposal §2.5 원칙 1 (룰 순감소) 정합으로 *기본 미도입*. 측정 데이터 기반 결정.
+
+---
+
+## 5. 분류 변경 절차
+
+분류 결정이 잘못된 것으로 판명 시:
+
+1. 별도 Task-ID 발급 (`DCN-CHG-YYYYMMDD-NN`)
+2. 본 표의 해당 row 갱신
+3. `change_rationale_history.md` 에 변경 사유·근거·후속 기록
+4. 영향 받는 모듈 동반 작업
+
+> 예: validator.md 변환을 시작했는데 RWHarness 의 mode sub-doc 구조가 dcNess 정체성과 맞지 않다고 판명 → REFACTOR → DISCARD + 신규 작성.
+
+---
+
+## 6. 참조
+
+- `docs/status-json-mutate-pattern.md` §11.2 — framework 출처
+- `docs/status-json-mutate-pattern.md` §11.4 — 도입할 것 / 도입 안 할 것 / 안전망
+- `docs/status-json-mutate-pattern.md` §12 — RWHarness → 신규 Plugin 전환 절차
+- `docs/process/governance.md` — Task-ID + Document Sync 룰
+- `~/project/RWHarness` — 분류 대상 코드베이스

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -62,6 +62,15 @@
   - `PROGRESS.md`
 - **Summary**: Phase 1 foundation — `harness/state_io.py` 신규(write/read/clear + R8 5 failure modes 단일 normalize) + 테스트 32 케이스 전부 PASS. `parse_marker` 사다리 폐기를 위한 첫 모듈.
 
+### DCN-CHG-20260429-05
+- **Date**: 2026-04-29
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/migration-decisions.md` (신규 — RWHarness 모듈 분류표)
+  - `docs/process/document_update_record.md` (본 항목)
+- **Summary**: `status-json-mutate-pattern.md` §11.2 framework 적용 — RWHarness 의 `harness/` / `hooks/` / `agents/` / `scripts/` / `orchestration/` / `.claude-plugin/` 모듈을 PRESERVE / DISCARD / REFACTOR 로 분류. dcNess 메인 작업 모드(§11.4) 정합으로 hook/impl_loop 류는 자연 폐기, agent docs 변환 + state_io.py 만 net-new.
+- **Document-Exception**: 본 변경은 분류 *결정 기록* 이라 추가 deliverable 부재. heavy 카테고리 미해당 — `docs-only` 단독.
+
 ### DCN-CHG-20260429-04
 - **Date**: 2026-04-29
 - **Change-Type**: agent, ci, docs-only


### PR DESCRIPTION
## Summary
\`docs/status-json-mutate-pattern.md\` §11.2 framework 를 RWHarness 모듈 카탈로그에 적용한 결정 기록. 어느 모듈을 가져올지 / 폐기할지 / 리팩터할지 module-level 결정 단일 문서.

## 핵심 결정
- **DISCARD (dcNess 한정)**: \`parse_marker\` / \`MARKER_ALIASES\` / \`generate_handoff\` / \`impl_loop\` 시퀀스 / \`agent_call\` subprocess / \`agent-boundary\` hook / \`commit-gate\` hook / \`preamble.md\` / \`agent-config/\`
  - 근거: proposal §11.4 "도입 안 할 것" (메인 직접 작업 모드 + 가드 미적용 환경)
- **PRESERVE (이미 흡수)**: 거버넌스(record/rationale/Task-ID) / plugin manifest
- **REFACTOR (Phase 1~2)**: \`agents/*.md\` @OUTPUT 형식 변환 / \`class Flag\` → Phase 3.2 (workflow-state.json 합본)
- **DONE (net-new)**: \`harness/state_io.py\` / 32 tests / \`.claude-plugin/\`

## 핵심 결론
> dcNess 는 자체 hook 없음. RWHarness hook 은 사용자 프로젝트 보호용으로, dcNess 가 plugin 으로 배포돼 다른 프로젝트에 활성화될 때만 의미. 본 저장소 \`hooks/\` 디렉토리는 만들지 않는다.

## 비스코프 (보류 / 후속 결정)
- 메인 Claude 의 \`Task\` 도구로 agent 호출 시 status JSON mutate 강제 여부
- \`RunLogger\` / \`kill_check\` 도입 (도그푸딩 측정 필요 시)
- \`MARKER_ALIASES\` 폴백 layer dcNess 도입 (플러그인 배포 시 사용자 프로젝트 가교)

## Test plan
- [x] \`node scripts/check_document_sync.mjs\` → PASS (2 files, docs-only)
- [x] \`python3 -m unittest tests.test_state_io -v\` → 32/32 PASS (회귀 0)

## 거버넌스 체크리스트
- [x] Task-ID \`DCN-CHG-20260429-05\`
- [x] WHAT 로그 (\`document_update_record.md\`)
- [x] heavy 카테고리 미해당 → rationale 동반 면제
- [x] progress 카테고리 미해당 → PROGRESS 면제
- [x] doc-sync 게이트 통과
- [x] Document-Exception 자체 명시 (분류 결정 기록의 self-record 성격)

## 근거
- proposal §11.2 framework + §11.4 도입할 것/안 할 것
- proposal §12 plugin 전환 절차

🤖 Generated with [Claude Code](https://claude.com/claude-code)