### PR TITLE
ci: add document-sync workflow (DCN-CHG-20260429-08)

### DIFF
--- a/.github/workflows/document-sync.yml
+++ b/.github/workflows/document-sync.yml
@@ -1,0 +1,67 @@
+# GitHub Actions — Document Sync gate (CI level)
+#
+# 규칙 정의: docs/process/governance.md §2.5 / §2.6 (SSOT)
+# 본 워크플로우는 PR 단위로 base..head diff 를 검사한다.
+# 로컬 게이트 (git pre-commit + Claude Code PreToolUse) 를 통과한 상태에서도
+# 누군가 hook 우회(--no-verify 등) 했을 가능성을 CI 에서 차단.
+#
+# proposal §11 4-pillar #2 (CI/CD 게이트) 정합 — local 우회 가능 영역을
+# CI 가 *최후 차단*.
+
+name: document-sync
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  document-sync:
+    name: Document Sync gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for base..head diff)
+        uses: actions/checkout@v4
+        with:
+          # CI 게이트는 base..head 를 비교 — shallow clone 으론 부족
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve base / head SHAs
+        id: resolve
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            # push to main: 직전 커밋 ↔ 현재 커밋 비교
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+          echo "[doc-sync] base=$BASE  head=$HEAD"
+
+      - name: Run Document Sync gate
+        run: |
+          set -e
+          BASE="${{ steps.resolve.outputs.base }}"
+          HEAD="${{ steps.resolve.outputs.head }}"
+
+          # 빈 SHA (첫 push 등) 폴백: head 단독 검사 = no-op (게이트 비대상)
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "[doc-sync] base SHA 부재 — 게이트 비대상 (initial push)"
+            exit 0
+          fi
+
+          node scripts/check_document_sync.mjs "$BASE" "$HEAD"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -10,20 +10,40 @@
 - **Plugin 배포 인프라**: `.claude-plugin/{plugin,marketplace}.json` 신규 (`DCN-CHG-20260429-04`)
   - 이름 = `dcness`, 버전 = `0.1.0-alpha`. RWHarness 와 공존 가능 설계 (proposal §12.3.2).
   - governance §2.2 의 `agent` 카테고리에 `^\.claude-plugin/` 패턴 추가하여 plugin manifest 변경도 heavy 카테고리 강제.
+- **모듈 분류 framework 적용**: `docs/migration-decisions.md` (`DCN-CHG-20260429-05`)
+  - DISCARD: parse_marker / generate_handoff / impl_loop / agent_call / agent-boundary hook / preamble.md
+  - PRESERVE: 거버넌스 / plugin manifest
+  - REFACTOR: agents/*.md @OUTPUT 변환 / class Flag → Phase 3.2
+- **validator agent docs 변환 완료**: `agents/validator*.md` 6개 + 9 schema round-trip tests (`DCN-CHG-20260429-06,07`)
+  - `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 + 5 모드 mode-specific status enum
+  - preamble / agent-config 의존 제거
+  - 자동 검증: docs 변경 시 schema 깨지면 fail
+- **CI 게이트 추가**: `.github/workflows/document-sync.yml` (`DCN-CHG-20260429-08`)
+  - PR + push to main 시 base..head diff 검사 → local hook 우회 차단
 
 ## TODO
-### Phase 1 — 후속 (validator 단일 agent 완성)
-- [ ] `docs/migration-decisions.md` 신규 — `status-json-mutate-pattern.md` §11.2 framework 적용 (RWHarness 모듈 분류)
-- [ ] `agents/validator*.md` 복사 + `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 변환 (5 모드 sub-doc)
-- [ ] RWHarness `harness/core.py` plan/design/ux validation 함수 복사 + `parse_marker` → `read_status` 치환 (7 호출지)
-- [ ] RWHarness `hooks/agent-boundary.py` 복사 + validator ALLOW_MATRIX 에 status path regex 추가
-- [ ] `_AGENT_DISALLOWED["validator"]` 에서 `Write` 제거
-- [ ] ENV 게이트 `HARNESS_STATUS_JSON_VALIDATOR=1` off 시 회귀 0 검증
-- [ ] validator → engineer handoff 를 status JSON `next_actions[]` 로 변환
+### Phase 1 — validator 단위 완성 ✅
+모든 acceptance 항목 완료 (state_io / agent docs 변환 / round-trip 검증). dcNess 메인 작업 모드(§11.4) 정합으로 RWHarness `harness/core.py` 의 7 parse_marker 호출지 / agent-boundary hook ALLOW_MATRIX / `_AGENT_DISALLOWED` 변경은 *plugin 배포 시점* 의 사용자 프로젝트 가드용 → 본 저장소엔 미도입.
 
-### 인프라 / CI
-- [ ] `.github/workflows/document-sync.yml` 추가 (CI 게이트, 별도 Task-ID)
-- [ ] CLAUDE.md §6 환경변수 — `HARNESS_STATUS_JSON_VALIDATOR` 등 도입 시 갱신
+### Phase 2 — 다른 12 agent docs 변환 (선택)
+plugin 배포 시 사용자 프로젝트에서 각 agent 가 status JSON Write 하도록.
+- [ ] `agents/architect.md` + 7 mode sub-doc (System Design / Module Plan / SPEC_GAP / Task Decompose / Technical Epic / Light Plan / Docs Sync)
+- [ ] `agents/engineer.md`
+- [ ] `agents/designer.md` + 4 mode sub-doc
+- [ ] `agents/design-critic.md`
+- [ ] `agents/qa.md`
+- [ ] `agents/ux-architect.md`
+- [ ] `agents/product-planner.md`
+- [ ] `agents/plan-reviewer.md`
+- [ ] `agents/pr-reviewer.md`
+- [ ] `agents/security-reviewer.md`
+- [ ] `agents/test-engineer.md`
+
+### 인프라 / CI 보강
+- [ ] `.github/workflows/plugin-validate.yml` (별도 Task)
+- [ ] `.github/workflows/python-tests.yml` — agent docs schema round-trip 자동
+- [ ] branch protection 룰 추가 (사용자 수동, GitHub Settings)
+- [ ] CLAUDE.md §6 환경변수 — 도입 시 갱신
 
 ## Blockers
 - 없음

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -119,3 +119,30 @@
   - **(별도 Task)** plugin 배포 시 hook 도입 — agent-boundary ALLOW_MATRIX 에 validator status path regex 추가. 현재 dcNess 자체엔 hook 미도입 (proposal §11.4).
   - **측정**: validator 호출 시 alias hit (옛 LGTM/OK/APPROVE) 0건. 실제 호출 데이터 누적 (`.claude/harness-state/.metrics/`) 후 측정.
 - **Document-Exception**: agent 카테고리(heavy)지만 코드/CI 변경 없음 → PROGRESS 미해당. 거버넌스 §2.6 룰상 PROGRESS 는 harness/hooks/ci 만 강제이므로 본 변경엔 미적용. 단 후속 갱신 시 본 Task ID 도 명시.
+
+### DCN-CHG-20260429-08
+- **Date**: 2026-04-29
+- **Rationale**:
+  - 거버넌스 부트스트랩(`DCN-CHG-20260429-01`) 시 명시한 follow-up: "GitHub Actions workflow (`.github/workflows/document-sync.yml`) 추가는 별도 Task-ID". 본 Task 가 그 항목.
+  - **Local 우회 가능성**: 현재 3중 강제(git pre-commit + Claude Code PreToolUse + AGENTS.md) 는 `git commit --no-verify` 또는 hook 미설치(`cp scripts/hooks/pre-commit .git/hooks/pre-commit` 미실행) 시 우회 가능. 사용자 실수 또는 외부 에이전트가 `--no-verify` 추가하면 거버넌스 자체가 무력.
+  - **proposal §2.5 원칙 2 (강제 vs 권고 분리)** 정합: Document Sync 게이트는 *catastrophic* 가 아닌 *측정 가능 신호* — 단 거버넌스 시스템 자체의 무결성을 위해 *최후 차단* 만 강제.
+  - **proposal R9 (GitHub 외부화 trade-off)** 인지: PR 후 CI 실패 = 분 단위 피드백 지연. 단 *local hook 이 정상 작동 시* 90%+ catch → CI 는 잔여 10% 만 차단.
+- **Alternatives**:
+  1. *현 상태 유지 (3중 local 강제만)* — `--no-verify` 우회 가능. 외부 에이전트(Codex 등) 로컬 hook 미설치 시 무방비. 기각.
+  2. *모든 변경에 PR 리뷰어 수동 검사 강제* — 인적 오류, CHG-01 에서 이미 기각.
+  3. *(채택)* **CI workflow 추가** — base..head diff 검사. local 통과한 PR 도 CI 가 재검 → 우회 차단.
+- **Decision**:
+  - 옵션 3 채택. `.github/workflows/document-sync.yml` 신규.
+  - **trigger**: `pull_request` (base 검증) + `push: branches: [main]` (직접 push 또는 squash merge 후 main 재검).
+  - **base..head diff**: PR 의 경우 `pull_request.base.sha` ↔ `pull_request.head.sha`. push to main 의 경우 `event.before` ↔ `sha`. 첫 push 등 base 부재 시 *비대상* 처리(no-op) — false fail 방지.
+  - **fetch-depth: 0**: shallow clone 으론 base..head diff 불가. 본 게이트는 history 전체 필요.
+  - **Node 20**: `scripts/check_document_sync.mjs` 의 ESM import 동작 검증된 메이저 버전.
+  - **permissions: contents: read, pull-requests: read**: 최소 권한. 게이트는 *읽기만*, 차단은 exit code 로 표현.
+  - **로컬 게이트와의 인터페이스 (R9 완화)**: 본 CI 는 *최후 차단* 이지 *유일 차단* 아님. local 게이트가 90% catch, CI 가 10% catch 이상적. 사용자 git pre-commit hook 정상 설치 가이드 (`CLAUDE.md` §4) 보존.
+- **Follow-Up**:
+  - **(별도 Task)** `.github/workflows/plugin-validate.yml` — `claude plugin validate .claude-plugin/` 자동 실행. plugin manifest 형식 회귀 차단.
+  - **(별도 Task)** `.github/workflows/python-tests.yml` — `python3 -m unittest discover -s tests` 자동 실행. agent docs schema round-trip 회귀 차단.
+  - **측정 (proposal §2.5 원칙 5 — 30일 데이터 후 결정)**:
+    - 본 CI 가 차단한 위반 카탈로그 → governance §2.6 룰 정정 input
+    - false positive 발생 시 게이트 룰 완화 / Document-Exception 사용 빈도
+  - **branch protection 권장 (사용자 수동)**: GitHub Settings → Branches → main → "Require status checks to pass" → `document-sync` 추가. 본 PR 머지 후 사용자 액션. 본 Task 에선 워크플로우 자체만.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -71,6 +71,16 @@
 - **Summary**: `status-json-mutate-pattern.md` §11.2 framework 적용 — RWHarness 의 `harness/` / `hooks/` / `agents/` / `scripts/` / `orchestration/` / `.claude-plugin/` 모듈을 PRESERVE / DISCARD / REFACTOR 로 분류. dcNess 메인 작업 모드(§11.4) 정합으로 hook/impl_loop 류는 자연 폐기, agent docs 변환 + state_io.py 만 net-new.
 - **Document-Exception**: 본 변경은 분류 *결정 기록* 이라 추가 deliverable 부재. heavy 카테고리 미해당 — `docs-only` 단독.
 
+### DCN-CHG-20260429-08
+- **Date**: 2026-04-29
+- **Change-Type**: ci
+- **Files Changed**:
+  - `.github/workflows/document-sync.yml` (신규 — Document Sync 게이트 CI workflow)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: Document Sync 게이트 CI level 추가 — PR 단위로 base..head diff 를 검사. 로컬 게이트(git pre-commit + Claude Code PreToolUse) 가 우회된 경우(`--no-verify` 등) CI 가 *최후 차단*. proposal 4-pillar #2 (CI 게이트) 정합.
+
 ### DCN-CHG-20260429-07
 - **Date**: 2026-04-29
 - **Change-Type**: test


### PR DESCRIPTION
## Summary
거버넌스 부트스트랩 시 명시한 follow-up — Document Sync 게이트 CI level 추가. local 3중 강제 우회 시(`--no-verify` / hook 미설치) CI 가 최후 차단.

## 변경 (4 files)
- `.github/workflows/document-sync.yml` 신규
- 거버넌스 동반: record / rationale / PROGRESS

## Workflow 동작
- trigger: `pull_request` (base 검증) + `push: branches: [main]` (squash merge 후 재검)
- `fetch-depth: 0` 후 base..head SHA 추출
- `node scripts/check_document_sync.mjs <base> <head>` 실행
- 첫 push 등 base 부재 시 비대상 처리 (false fail 방지)

## Test plan
- [x] `node scripts/check_document_sync.mjs` → PASS (4 files, ci + docs-only)
- [x] tests/test_state_io + test_validator_schemas → 41/41 PASS (회귀 0)
- [ ] 본 PR 머지 후 첫 CI run 실측

## 거버넌스 체크리스트
- [x] Task-ID `DCN-CHG-20260429-08`
- [x] WHAT 로그
- [x] WHY 로그 (`ci` heavy)
- [x] PROGRESS.md 갱신 (`ci` progress)
- [x] doc-sync 게이트 통과

## 근거 / Trade-off (R9)
- 4-pillar #2 (CI 게이트) 정합
- local hook 90%+ catch + CI 10% catch — 분 단위 피드백 지연 수용

🤖 Generated with [Claude Code](https://claude.com/claude-code)