### PR TITLE
ci: add python-tests workflow (DCN-CHG-20260429-09)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,50 @@
+# GitHub Actions — Python unittest 자동 실행
+#
+# 목적:
+# - harness/state_io.py 회귀 차단 (R8 5 failure modes / atomic write / path safety)
+# - agents/validator/*.md schema round-trip 회귀 차단 (DCN-CHG-20260429-07)
+#
+# 트리거:
+# - PR / push to main 시 tests/ 또는 harness/ 또는 agents/ 변경 시
+# - paths 필터로 docs-only PR 에서 불필요 실행 회피
+#
+# proposal §11.4 안전망: "매 sub-phase squash merge 후 측정" 의 자동화 버전
+
+name: python-tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'harness/**'
+      - 'tests/**'
+      - 'agents/**'
+      - '.github/workflows/python-tests.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'harness/**'
+      - 'tests/**'
+      - 'agents/**'
+      - '.github/workflows/python-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  unittest:
+    name: unittest discover
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run unittest
+        run: |
+          set -e
+          python3 -m unittest discover -s tests -v

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -20,6 +20,9 @@
   - 자동 검증: docs 변경 시 schema 깨지면 fail
 - **CI 게이트 추가**: `.github/workflows/document-sync.yml` (`DCN-CHG-20260429-08`)
   - PR + push to main 시 base..head diff 검사 → local hook 우회 차단
+- **Python 테스트 CI**: `.github/workflows/python-tests.yml` (`DCN-CHG-20260429-09`)
+  - paths 필터(`harness/` / `tests/` / `agents/`) 로 docs-only PR 면제
+  - state_io 32 케이스 + validator schemas 9 케이스 자동 회귀 차단
 
 ## TODO
 ### Phase 1 — validator 단위 완성 ✅

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -146,3 +146,25 @@
     - 본 CI 가 차단한 위반 카탈로그 → governance §2.6 룰 정정 input
     - false positive 발생 시 게이트 룰 완화 / Document-Exception 사용 빈도
   - **branch protection 권장 (사용자 수동)**: GitHub Settings → Branches → main → "Require status checks to pass" → `document-sync` 추가. 본 PR 머지 후 사용자 액션. 본 Task 에선 워크플로우 자체만.
+
+### DCN-CHG-20260429-09
+- **Date**: 2026-04-29
+- **Rationale**:
+  - 현재 41 단위 테스트 (`tests/test_state_io.py` 32 + `tests/test_validator_schemas.py` 9) 가 로컬 실행만 가능 — PR 에서 회귀가 들어와도 CI 가 자동 실행 안 함.
+  - **schema round-trip 회귀 위험**: `agents/validator/*.md` 의 status enum / required 필드가 변경되면 `state_io.read_status` 와 어긋날 수 있는데, 본 docs 변경 PR 에서 *테스트 자동 실행* 안 되면 머지 후 발견.
+  - proposal §11.4 안전망: "매 sub-phase squash merge 후 smoke test 강제" — 본 워크플로우가 그 *자동화 버전*.
+  - DCN-CHG-20260429-08 (document-sync workflow) 와 보완 관계: 그쪽은 *거버넌스 구조*, 본 Task 는 *코드/스키마 정합* 강제.
+- **Alternatives**:
+  1. *전 PR 에 unittest 무조건 실행* — docs-only PR 도 발동 → 불필요 CI 시간 + 큐 점유. 기각.
+  2. *local pre-push hook 만 추가* — `--no-verify` 우회 가능. CHG-08 와 동일 함정. 기각.
+  3. *(채택)* **paths 필터 + GitHub Actions** — `harness/` / `tests/` / `agents/` / 본 workflow 자체 변경 시만 발동. docs-only PR 면제. CI 우회 차단.
+- **Decision**:
+  - 옵션 3 채택. trigger paths 필터 명시.
+  - **Python 3.11**: `unittest`, `pathlib`, `tempfile` 등 표준 라이브러리만 사용 — 의존성 install 단계 없음. 런타임 ~5초 예상.
+  - **dev dependency 부재**: 현재 외부 패키지 미사용 (json/re/time/os/pathlib 모두 표준). `requirements.txt` 미도입. 도입 시점에 본 workflow 도 갱신.
+  - **agents/ 도 trigger paths**: validator agent docs 변경 시 schema round-trip 테스트가 자동 실행 → docs 변경의 *acceptance 검증* 자동.
+  - **permissions: contents: read** 단독: 테스트는 코드 *읽고 실행* 만 — 쓰기·외부 호출 없음.
+- **Follow-Up**:
+  - **(별도 Task)** `.github/workflows/plugin-validate.yml` — `claude plugin validate` 자동.
+  - **(별도 Task)** branch protection 룰에 `python-tests / unittest discover` required 등록 (사용자 수동).
+  - **측정**: 본 workflow 가 차단한 회귀 카탈로그 → 30일 후 운영 데이터로 false positive / 평균 실행 시간 / 회귀 발견율 분석.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -71,6 +71,16 @@
 - **Summary**: `status-json-mutate-pattern.md` §11.2 framework 적용 — RWHarness 의 `harness/` / `hooks/` / `agents/` / `scripts/` / `orchestration/` / `.claude-plugin/` 모듈을 PRESERVE / DISCARD / REFACTOR 로 분류. dcNess 메인 작업 모드(§11.4) 정합으로 hook/impl_loop 류는 자연 폐기, agent docs 변환 + state_io.py 만 net-new.
 - **Document-Exception**: 본 변경은 분류 *결정 기록* 이라 추가 deliverable 부재. heavy 카테고리 미해당 — `docs-only` 단독.
 
+### DCN-CHG-20260429-09
+- **Date**: 2026-04-29
+- **Change-Type**: ci
+- **Files Changed**:
+  - `.github/workflows/python-tests.yml` (신규)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: Python unittest 자동 회귀 차단 — `tests/test_state_io.py` (32) + `tests/test_validator_schemas.py` (9) 자동 실행. paths 필터로 `harness/` / `tests/` / `agents/` 변경 시만 발동(docs-only PR 면제).
+
 ### DCN-CHG-20260429-08
 - **Date**: 2026-04-29
 - **Change-Type**: ci


### PR DESCRIPTION
## Summary
41 단위 테스트(state_io 32 + validator schemas 9) 자동 회귀 차단. DCN-08(document-sync)이 *거버넌스 구조* 강제라면 본 Task 는 *코드/스키마 정합* 강제.

## Workflow
- trigger: `pull_request` + `push: branches: [main]`
- paths 필터: `harness/` / `tests/` / `agents/` / 본 workflow
- docs-only PR 면제
- Python 3.11 + 표준 라이브러리만 (`requirements.txt` 부재 — 의존성 install 단계 없음)
- `python3 -m unittest discover -s tests -v`

## 가치
- **schema round-trip 자동**: `agents/validator/*.md` 변경 시 docs 의 ```json``` 예시가 `state_io` 와 round-trip 안 되면 즉시 fail
- **R8 회귀 차단**: state_io 5 failure modes / atomic write / path safety 회귀 즉시 fail

## Test plan
- [x] `python3 -m unittest discover -s tests -v` (local) → 41/41 PASS
- [x] `node scripts/check_document_sync.mjs` → PASS (4 files, ci + docs-only)
- [ ] 본 PR 머지 후 첫 CI run 실측

## 거버넌스 체크리스트
- [x] Task-ID `DCN-CHG-20260429-09`
- [x] WHAT 로그
- [x] WHY 로그 (`ci` heavy)
- [x] PROGRESS.md 갱신 (`ci` progress)
- [x] doc-sync 게이트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)