### PR TITLE
ci: add plugin manifest validator (DCN-CHG-20260429-10)

### DIFF
--- a/.github/workflows/plugin-manifest.yml
+++ b/.github/workflows/plugin-manifest.yml
@@ -1,0 +1,47 @@
+# GitHub Actions — Plugin manifest 무결성 검증
+#
+# 검증 범위:
+# - .claude-plugin/plugin.json + marketplace.json 파싱 가능
+# - 필수 필드 (name / version / description / plugins[])
+# - name regex (lowercase + hyphen)
+# - plugin.json.name == marketplace.json.plugins[0].name
+#
+# `claude plugin validate` (CLI 의존) 도입 안 한 이유:
+# - claude CLI 가 GitHub Actions 환경에 설치/인증 필요 — 추가 의존성
+# - 본 검증은 *형식 무결성* 만. 의미 검증(hook/agent 매핑 실재 등) 은 plugin install
+#   시점에 매니저가 수행. CI 는 minimum guard.
+
+name: plugin-manifest
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.claude-plugin/**'
+      - 'scripts/check_plugin_manifest.mjs'
+      - '.github/workflows/plugin-manifest.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude-plugin/**'
+      - 'scripts/check_plugin_manifest.mjs'
+      - '.github/workflows/plugin-manifest.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate manifest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run plugin manifest check
+        run: node scripts/check_plugin_manifest.mjs

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -23,6 +23,9 @@
 - **Python 테스트 CI**: `.github/workflows/python-tests.yml` (`DCN-CHG-20260429-09`)
   - paths 필터(`harness/` / `tests/` / `agents/`) 로 docs-only PR 면제
   - state_io 32 케이스 + validator schemas 9 케이스 자동 회귀 차단
+- **Plugin manifest 검증 CI**: `scripts/check_plugin_manifest.mjs` + `plugin-manifest.yml` (`DCN-CHG-20260429-10`)
+  - required 필드 + name regex + cross-reference 검증
+  - claude CLI 의존 회피 — Node-only minimum guard
 
 ## TODO
 ### Phase 1 — validator 단위 완성 ✅

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -168,3 +168,28 @@
   - **(별도 Task)** `.github/workflows/plugin-validate.yml` — `claude plugin validate` 자동.
   - **(별도 Task)** branch protection 룰에 `python-tests / unittest discover` required 등록 (사용자 수동).
   - **측정**: 본 workflow 가 차단한 회귀 카탈로그 → 30일 후 운영 데이터로 false positive / 평균 실행 시간 / 회귀 발견율 분석.
+
+### DCN-CHG-20260429-10
+- **Date**: 2026-04-29
+- **Rationale**:
+  - DCN-CHG-20260429-04 에서 명시한 follow-up: "`claude plugin validate .claude-plugin/` 자동 실행 CI workflow — plugin manifest 형식 검증". 본 Task 가 그 항목.
+  - **`claude plugin validate` 도입 위험**: claude CLI 자체가 GitHub Actions runner 에 설치/인증 필요. 토큰 secret 도입 + maintenance burden + CI 의존성 폭증. proposal §2.5 원칙 1 (룰 순감소) 위반.
+  - **하지만 manifest 형식 자체 검증은 가치**: `plugin.json` 의 `name` 이 regex 위반 (예: 대문자 포함) 또는 `marketplace.json.plugins[0].name` 이 `plugin.json.name` 과 다른 경우 — plugin install 시점에 발견되면 사용자 환경 파괴. 형식 무결성은 *catastrophic-prevention* 성격 (proposal §2.5 원칙 2).
+- **Alternatives**:
+  1. *`claude plugin validate` 도입* — CLI 의존 폭증. 기각.
+  2. *JSON Schema (ajv) 기반 엄밀 검증* — schema 정의 + ajv 의존 추가. 의존성 install 단계 발생. 첫 모듈 단위로 과함. 기각.
+  3. *(채택)* **Node-only minimum guard** — 표준 라이브러리 (fs / path) 만. required 필드 + name regex + cross-reference 만 검증. ~70 LOC.
+- **Decision**:
+  - 옵션 3 채택. `scripts/check_plugin_manifest.mjs` (~70 LOC) + `.github/workflows/plugin-manifest.yml`.
+  - **검증 항목**:
+    - `plugin.json`: name (regex `^[a-z][a-z0-9-]*$`), version (string), description (string)
+    - `marketplace.json`: plugins[] non-empty, plugins[0].name + source 존재
+    - cross-reference: `plugin.json.name === marketplace.json.plugins[0].name`
+  - **검증 외 (의도적 제외)**:
+    - hook/agent 매핑 실재 — plugin install 시점에 매니저가 검증
+    - 의미적 정합 (예: keywords 적합성) — manual review
+  - **paths 필터**: `.claude-plugin/**` + `scripts/check_plugin_manifest.mjs` + 본 workflow. 다른 변경 시엔 발동 안 함.
+- **Follow-Up**:
+  - **(별도 Task — 위험 수용 시)** `claude plugin validate` 도입 검토 — 30일 데이터 + 결정 PR. 본 Task 가 *not yet* 결정.
+  - **(별도 Task)** dcNess plugin 실 설치 dry-run — `claude plugin install /Users/dc.kim/project/dcNess/.claude-plugin` 후 hook/agent 매핑 정합 실측. proposal §12.3.2 검증.
+  - **branch protection 권장**: `plugin-manifest / validate manifest` required 등록 (사용자 수동).

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -71,6 +71,17 @@
 - **Summary**: `status-json-mutate-pattern.md` §11.2 framework 적용 — RWHarness 의 `harness/` / `hooks/` / `agents/` / `scripts/` / `orchestration/` / `.claude-plugin/` 모듈을 PRESERVE / DISCARD / REFACTOR 로 분류. dcNess 메인 작업 모드(§11.4) 정합으로 hook/impl_loop 류는 자연 폐기, agent docs 변환 + state_io.py 만 net-new.
 - **Document-Exception**: 본 변경은 분류 *결정 기록* 이라 추가 deliverable 부재. heavy 카테고리 미해당 — `docs-only` 단독.
 
+### DCN-CHG-20260429-10
+- **Date**: 2026-04-29
+- **Change-Type**: ci
+- **Files Changed**:
+  - `scripts/check_plugin_manifest.mjs` (신규 — manifest 무결성 validator)
+  - `.github/workflows/plugin-manifest.yml` (신규 — CI workflow)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: Plugin manifest 무결성 검증 — `plugin.json` + `marketplace.json` 의 required 필드 + name regex + 두 파일 간 name 정합 검증. `claude plugin validate` (CLI 의존) 대신 Node-only minimum guard.
+
 ### DCN-CHG-20260429-09
 - **Date**: 2026-04-29
 - **Change-Type**: ci

--- a/scripts/check_plugin_manifest.mjs
+++ b/scripts/check_plugin_manifest.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * dcNess plugin manifest validator (CI level).
+ *
+ * 검증:
+ * - .claude-plugin/plugin.json 파싱 가능 + 필수 필드(name, version, description)
+ * - .claude-plugin/marketplace.json 파싱 가능 + plugins[] 의 첫 entry name 이 plugin.json.name 과 일치
+ *
+ * `claude plugin validate` (CLI 의존) 를 도입하지 않은 이유:
+ * - GitHub Actions 환경에서 claude CLI 설치/인증 의존성 발생
+ * - 본 검증은 *형식 무결성* 만 — 의미 검증은 plugin install 시점에 매니저가 수행
+ *
+ * 사용:
+ *   node scripts/check_plugin_manifest.mjs
+ *
+ * exit 0: 통과
+ * exit 1: 위반
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const PLUGIN_PATH = resolve('.claude-plugin/plugin.json');
+const MARKETPLACE_PATH = resolve('.claude-plugin/marketplace.json');
+
+const violations = [];
+
+function parseJsonFile(path, label) {
+  if (!existsSync(path)) {
+    violations.push(`${label}: file not found at ${path}`);
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (e) {
+    violations.push(`${label}: JSON parse error — ${e.message}`);
+    return null;
+  }
+}
+
+const plugin = parseJsonFile(PLUGIN_PATH, 'plugin.json');
+const marketplace = parseJsonFile(MARKETPLACE_PATH, 'marketplace.json');
+
+if (plugin) {
+  for (const key of ['name', 'version', 'description']) {
+    if (!plugin[key] || typeof plugin[key] !== 'string') {
+      violations.push(`plugin.json: missing/invalid required field '${key}'`);
+    }
+  }
+  if (plugin.name && !/^[a-z][a-z0-9-]*$/.test(plugin.name)) {
+    violations.push(
+      `plugin.json: name '${plugin.name}' must match /^[a-z][a-z0-9-]*$/`
+    );
+  }
+}
+
+if (marketplace) {
+  if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+    violations.push('marketplace.json: plugins[] must be non-empty array');
+  } else {
+    const first = marketplace.plugins[0];
+    if (!first.name) {
+      violations.push('marketplace.json: plugins[0].name missing');
+    } else if (plugin && first.name !== plugin.name) {
+      violations.push(
+        `marketplace.json: plugins[0].name '${first.name}' != plugin.json.name '${plugin.name}'`
+      );
+    }
+    if (!first.source) {
+      violations.push('marketplace.json: plugins[0].source missing');
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('[plugin-manifest] FAIL');
+  violations.forEach((v) => console.error(`  - ${v}`));
+  process.exit(1);
+}
+
+console.log(
+  `[plugin-manifest] PASS — ${plugin.name}@${plugin.version}`
+);


### PR DESCRIPTION
## Summary
DCN-04 의 follow-up — plugin manifest 무결성 자동 검증. `claude plugin validate` (CLI 의존) 대신 Node-only minimum guard.

## 검증 항목
- `plugin.json`: name (regex `^[a-z][a-z0-9-]*$`), version, description
- `marketplace.json`: plugins[] non-empty, plugins[0].name + source
- cross-reference: `plugin.json.name === marketplace.json.plugins[0].name`

## 검증 외 (의도적 제외)
- hook/agent 매핑 실재 — plugin install 시 매니저가 검증
- 의미적 정합 — manual review

## CLI 도입 회피 사유
- GitHub Actions runner 에 claude CLI 설치/인증 필요 → 의존성 폭증
- proposal §2.5 원칙 1 (룰 순감소) 위반
- 형식 무결성은 *catastrophic-prevention* (원칙 2 정합) — Node-only 충분

## Test plan
- [x] local: `node scripts/check_plugin_manifest.mjs` → PASS (`dcness@0.1.0-alpha`)
- [x] doc-sync: PASS (5 files, ci + docs-only)
- [ ] 본 PR 머지 후 첫 CI run 실측

## 거버넌스 체크리스트
- [x] Task-ID `DCN-CHG-20260429-10`
- [x] WHAT/WHY 로그
- [x] PROGRESS.md 갱신 (`ci` progress)
- [x] doc-sync 게이트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)