### PR TITLE
docs: overhaul README with Phase 1 status (DCN-CHG-20260429-11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,138 @@
 # dcNess
 
-RWHarness fork-and-refactor — lightweight harness with status-JSON-mutate determinism + Document Sync governance.
+> **Status**: `0.1.0-alpha` — Phase 1 (validator 단위) 완료
+> **Origin**: [`alruminum/realworld-harness`](https://github.com/alruminum/realworld-harness) fork-and-refactor
+> **Spec**: [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md)
 
-See [`docs/process/governance.md`](docs/process/governance.md) (SSOT).
+Lightweight harness — **status JSON mutate 결정론** + **4 기둥 정합** + **함정 회피 5원칙** 기반의 RWHarness 후속.
+
+## 무엇이 다른가
+
+| 항목 | RWHarness | dcNess |
+|---|---|---|
+| 결정론 메커니즘 | `parse_marker` regex + `MARKER_ALIASES` 사다리 (~180 LOC) | `state_io.read_status` (~290 LOC) — agent 가 외부 status JSON 을 *mutate*, harness 는 그 파일만 *read* |
+| 컨텍스트 layer | 5 layer (CLAUDE.md + agents + agent-config + preamble + sub-doc) | 2 layer (CLAUDE.md + agents) — preamble / agent-config 자동 주입 폐기 |
+| 게이트 | hook 7+ (agent-boundary / commit-gate / etc.) | 거버넌스 + 3 CI workflow (Document Sync + Python tests + Plugin manifest) |
+| LOC 목표 | 5000 | 2500 ~ 3000 |
+
+핵심 발상 (proposal §2):
+
+> "agent 의 자유 텍스트를 신뢰하지 않는다.
+>  agent 에게 외부 상태 파일 mutate 책임 부여.
+>  orchestrator 는 그 파일만 read."
+
+## 1차 구현 (Phase 1) 현황
+
+✅ **완료** — validator 단일 agent 단위로 status-JSON-mutate 패턴 검증.
+
+| 컴포넌트 | 위치 | 상태 |
+|---|---|---|
+| Status I/O 모듈 | [`harness/state_io.py`](harness/state_io.py) | 32 단위 테스트 통과 (R8 5 failure modes 단일 normalize) |
+| Validator agent docs | [`agents/validator.md`](agents/validator.md) + [`agents/validator/*.md`](agents/validator) (5 모드) | `@OUTPUT_FILE` / `@OUTPUT_SCHEMA` / `@OUTPUT_RULE` 형식 |
+| Schema round-trip 검증 | [`tests/test_validator_schemas.py`](tests/test_validator_schemas.py) | 9 단위 테스트 통과 |
+| Plugin manifest | [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) + [marketplace.json](.claude-plugin/marketplace.json) | RWHarness 와 공존 가능 (`name=dcness`) |
+| Governance | [`docs/process/governance.md`](docs/process/governance.md) | Document Sync 게이트 SSOT |
+| CI workflows | [`.github/workflows/`](.github/workflows) | 3 종 (document-sync / python-tests / plugin-manifest) |
+
+자세한 현황: [`PROGRESS.md`](PROGRESS.md)
+
+## Quick Start (개발자)
+
+### 의존성
+
+- Python 3.11+ (테스트 실행)
+- Node.js 20+ (governance 게이트)
+- 외부 패키지 0 (표준 라이브러리만)
+
+### 셋업
+
+```sh
+git clone https://github.com/alruminum/dcNess.git
+cd dcNess
+
+# git pre-commit hook 설치 (1회)
+cp scripts/hooks/pre-commit .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+```
+
+### 검증
+
+```sh
+# 단위 테스트 (state_io + validator schemas)
+python3 -m unittest discover -s tests -v
+
+# Document Sync 게이트 (수동 실행 — commit 시 자동 호출)
+node scripts/check_document_sync.mjs
+
+# Plugin manifest 검증
+node scripts/check_plugin_manifest.mjs
+```
+
+### 코드 사용 예 (`state_io`)
+
+```python
+from harness.state_io import write_status, read_status, MissingStatus
+
+# Agent 측 — status JSON Write
+write_status(
+    "validator", "run_001",
+    {
+        "status": "PLAN_VALIDATION_PASS",
+        "fail_items": [],
+        "non_obvious_patterns": ["impl 6.2 의 retry 횟수 명세 일치"],
+    },
+    mode="PLAN_VALIDATION",
+)
+
+# Orchestrator 측 — 결정론 read
+try:
+    result = read_status(
+        "validator", "run_001",
+        mode="PLAN_VALIDATION",
+        allowed_status={"PLAN_VALIDATION_PASS", "PLAN_VALIDATION_FAIL"},
+    )
+    if result["status"] == "PLAN_VALIDATION_PASS":
+        # 다음 단계 진입
+        ...
+except MissingStatus as e:
+    # 5 failure modes 단일 catch — e.reason 으로 retry 정책 분기
+    if e.reason in ("empty", "race"):
+        ...  # 100ms 후 1회 재read
+    else:
+        ...  # 즉시 fail (not_found / malformed_json / schema_violation)
+```
+
+## 거버넌스 (필수)
+
+본 저장소의 모든 변경은 [`docs/process/governance.md`](docs/process/governance.md) 에 따른다 (SSOT).
+
+- **Task-ID**: `DCN-CHG-YYYYMMDD-NN` 형식. 모든 작업은 단 하나의 ID.
+- **3중 강제**: git pre-commit hook + Claude Code PreToolUse hook + AGENTS.md (외부 에이전트 지침)
+- **CI 게이트**: PR 단위로 base..head diff 검사 — local 우회 차단
+
+PR 절차: [`CLAUDE.md`](CLAUDE.md) §5.
+
+## 다음 단계 (Phase 2 ~ )
+
+[`PROGRESS.md`](PROGRESS.md) §TODO 참조. 핵심 후보:
+
+- 다른 12 agent docs 변환 (architect / engineer / designer / ...)
+- branch protection 룰 추가 (사용자 수동, GitHub Settings)
+- 실 plugin 설치 dry-run — RWHarness 와 공존 검증 (proposal §12.3.2)
+
+## 참조 문서
+
+| 문서 | 역할 |
+|---|---|
+| [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) | proposal — Goal / Mechanism / Phase / Risks / Plugin 전환 절차 |
+| [`docs/migration-decisions.md`](docs/migration-decisions.md) | RWHarness 모듈 PRESERVE / DISCARD / REFACTOR 분류 |
+| [`docs/process/governance.md`](docs/process/governance.md) | Document Sync SSOT |
+| [`docs/process/document_update_record.md`](docs/process/document_update_record.md) | WHAT 로그 (Task-ID 별 변경 파일) |
+| [`docs/process/change_rationale_history.md`](docs/process/change_rationale_history.md) | WHY 로그 (Task-ID 별 동기·대안·결정·후속) |
+| [`PROGRESS.md`](PROGRESS.md) | 현재 상태 / TODO / Blockers |
+| [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 |
+| [`CLAUDE.md`](CLAUDE.md) | 메인 Claude 작업 지침 |
+
+## License
+
+MIT — see [`LICENSE`](LICENSE) (TBD).

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -71,6 +71,14 @@
 - **Summary**: `status-json-mutate-pattern.md` §11.2 framework 적용 — RWHarness 의 `harness/` / `hooks/` / `agents/` / `scripts/` / `orchestration/` / `.claude-plugin/` 모듈을 PRESERVE / DISCARD / REFACTOR 로 분류. dcNess 메인 작업 모드(§11.4) 정합으로 hook/impl_loop 류는 자연 폐기, agent docs 변환 + state_io.py 만 net-new.
 - **Document-Exception**: 본 변경은 분류 *결정 기록* 이라 추가 deliverable 부재. heavy 카테고리 미해당 — `docs-only` 단독.
 
+### DCN-CHG-20260429-11
+- **Date**: 2026-04-29
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `README.md` (대폭 보강 — 정체성·차이점·Phase 1 현황·Quick Start·코드 예·거버넌스·후속)
+  - `docs/process/document_update_record.md` (본 항목)
+- **Summary**: README.md 보강 — Phase 1 완료 외부 공개. RWHarness vs dcNess 차이 표 + 1차 구현 컴포넌트 매핑 + Quick Start (의존성 / 셋업 / 검증 / 코드 사용 예) + 거버넌스 / 다음 단계 / 참조 문서 지도.
+
 ### DCN-CHG-20260429-10
 - **Date**: 2026-04-29
 - **Change-Type**: ci


### PR DESCRIPTION
## Summary
8 PR 머지로 Phase 1 (validator 단위) 완료 — 외부 공개를 위한 README 대폭 보강.

## 추가 섹션
- **무엇이 다른가**: RWHarness vs dcNess 비교 표 (parse_marker → state_io / 5 layer → 2 layer / hook 7+ → 3 CI / LOC 5000 → 2500-3000)
- **1차 구현 현황**: state_io / validator agent docs / schema round-trip / plugin manifest / governance / 3 CI workflows 매핑
- **Quick Start**: 의존성 (Python 3.11 + Node 20, 외부 패키지 0) / 셋업 / 검증 / 코드 사용 예 (write_status / read_status / MissingStatus retry 정책)
- **거버넌스 절차**: Task-ID + 3중 강제 + CI 게이트
- **다음 단계**: Phase 2 후보 + branch protection / plugin dry-run
- **참조 문서 지도**: 8 문서 한눈에

## Test plan
- [x] doc-sync: PASS (2 files, docs-only)
- [x] tests 회귀: 41/41 PASS

## 거버넌스 체크리스트
- [x] Task-ID `DCN-CHG-20260429-11`
- [x] WHAT 로그
- [x] heavy 미해당(`docs-only` 단독) → rationale 면제
- [x] doc-sync 게이트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)