### PR TITLE
docs: status JSON pattern guidance to AGENTS.md (DCN-CHG-20260429-12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,8 +47,23 @@ Document-Exception-Task: DCN-CHG-YYYYMMDD-NN
 
 `document_update_record.md` 의 해당 Task 항목에도 사유 명시 필수.
 
+## Status JSON Mutate 패턴 (validator 등 검증 에이전트)
+
+본 저장소는 [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) 의 발상에 따라 검증 결과를 **자유 텍스트 마커가 아닌 status JSON 파일** 로 전달한다. 검증 에이전트(validator, plan-reviewer, pr-reviewer, security-reviewer 등) 호출 시:
+
+1. **결과 파일 경로**: `.claude/harness-state/<run_id>/<agent>-<MODE>.json` (`agents/<agent>.md` 의 `@OUTPUT_FILE` 참조)
+2. **schema 필수**: `status` 키 (mode-specific enum) + (FAIL 시) `fail_items[]`. 나머지 freeform.
+3. **Write 도구**: 마지막 액션으로 위 파일 작성. 미작성 시 호출 측은 워크플로우 즉시 종료.
+4. **폐기된 컨벤션**: `---MARKER:X---` 마지막 줄 정형 + `MARKER_ALIASES` 폴백 + `preamble.md` 자동 주입 의존 — 모두 사용 금지. 자유 텍스트(prose) 는 *진단/감사 용* 으로만 stdout 에 잔존.
+
+자세한 형식 + 모드별 enum: [`agents/validator.md`](agents/validator.md), [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) §3 / §4.7.
+
+orchestrator 측 read 는 [`harness/state_io.py`](harness/state_io.py) 의 `read_status` 사용 — 5 failure modes (`MissingStatus`) 단일 normalize.
+
 ## 참조
 
-- [`docs/process/governance.md`](docs/process/governance.md) — SSOT (모든 규칙)
+- [`docs/process/governance.md`](docs/process/governance.md) — SSOT (모든 거버넌스 규칙)
+- [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) — 결정론 메커니즘 SSOT
 - [`docs/process/document_impact_matrix.md`](docs/process/document_impact_matrix.md) — 변경 → 검토 문서 빠른 참조
 - [`PROGRESS.md`](PROGRESS.md) — 현재 상태 / TODO / Blockers
+- [`README.md`](README.md) — 프로젝트 개요 + Quick Start

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -193,3 +193,19 @@
   - **(별도 Task — 위험 수용 시)** `claude plugin validate` 도입 검토 — 30일 데이터 + 결정 PR. 본 Task 가 *not yet* 결정.
   - **(별도 Task)** dcNess plugin 실 설치 dry-run — `claude plugin install /Users/dc.kim/project/dcNess/.claude-plugin` 후 hook/agent 매핑 정합 실측. proposal §12.3.2 검증.
   - **branch protection 권장**: `plugin-manifest / validate manifest` required 등록 (사용자 수동).
+
+### DCN-CHG-20260429-12
+- **Date**: 2026-04-29
+- **Rationale**:
+  - DCN-06 (validator agent docs 변환) + DCN-11 (README 보강) 으로 status JSON 패턴이 *내부 컨벤션* 으로 박혔음. 단 외부 에이전트(Codex 등) 가 본 저장소에 PR 작성 시 *기존 RWHarness 컨벤션* (`---MARKER:X---`, `MARKER_ALIASES` 변형) 으로 작성할 우려 — AGENTS.md 가 그 진입점인데 status JSON 패턴 언급 부재.
+  - proposal §2.5 원칙 1 (룰 순감소) 정합으로 *재기술 금지* 지키며, AGENTS.md 는 짧은 *지침 + SSOT 링크* 만 박는다.
+- **Alternatives**:
+  1. *AGENTS.md 변경 없음* — 외부 에이전트가 폐기된 컨벤션 사용 위험. 기각.
+  2. *AGENTS.md 에 schema 전체 박기* — `governance.md` SSOT 룰 위반(재기술). 기각.
+  3. *(채택)* **5줄 짜리 안내 + SSOT 링크**: 결과 파일 경로 / schema 필수 / Write 도구 / 폐기된 컨벤션 명시 / 자세한 건 `agents/validator.md` + `docs/status-json-mutate-pattern.md` 참조.
+- **Decision**:
+  - 옵션 3 채택. AGENTS.md 에 "Status JSON Mutate 패턴" 섹션 한 단락 + 참조 5 링크.
+  - **재기술 금지 정합**: 본 추가는 *어디 가서 보면 되는지* 만. 룰 자체는 SSOT(`agents/validator.md` + proposal) 가 정의.
+- **Follow-Up**:
+  - **(별도 Task)** Phase 2 다른 12 agent docs 변환 시 본 섹션의 "validator 등" 표현이 자연스럽게 일반화 (각 검증 에이전트마다 동일 패턴).
+  - **(측정)** 외부 에이전트가 본 저장소에 보낸 PR 의 status JSON 사용 빈도. 30일 후 운영 데이터로 본 안내가 효과적인지 평가.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -71,6 +71,15 @@
 - **Summary**: `status-json-mutate-pattern.md` §11.2 framework 적용 — RWHarness 의 `harness/` / `hooks/` / `agents/` / `scripts/` / `orchestration/` / `.claude-plugin/` 모듈을 PRESERVE / DISCARD / REFACTOR 로 분류. dcNess 메인 작업 모드(§11.4) 정합으로 hook/impl_loop 류는 자연 폐기, agent docs 변환 + state_io.py 만 net-new.
 - **Document-Exception**: 본 변경은 분류 *결정 기록* 이라 추가 deliverable 부재. heavy 카테고리 미해당 — `docs-only` 단독.
 
+### DCN-CHG-20260429-12
+- **Date**: 2026-04-29
+- **Change-Type**: agent
+- **Files Changed**:
+  - `AGENTS.md` (Status JSON Mutate 패턴 섹션 추가 + 참조 보강)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: AGENTS.md 보강 — 외부 에이전트(Codex 등) 가 본 저장소에 PR 보낼 때 status JSON Write 패턴을 인지하도록 명시. 폐기된 `---MARKER:X---` 컨벤션 사용 금지 + 결과 파일 경로 + schema 필수 필드 + read_status 가이드.
+
 ### DCN-CHG-20260429-11
 - **Date**: 2026-04-29
 - **Change-Type**: docs-only


### PR DESCRIPTION
## Summary
외부 에이전트(Codex 등) 가 본 저장소에 PR 보낼 때 status JSON Write 패턴을 인지하도록 `AGENTS.md` 보강. 재기술 금지 정합으로 SSOT 링크만 박음.

## 추가 섹션 (Status JSON Mutate 패턴)
- 결과 파일 경로: `.claude/harness-state/<run_id>/<agent>-<MODE>.json`
- schema 필수: `status` (mode-specific enum) + (FAIL 시) `fail_items[]`
- Write 도구로 마지막 액션. 미작성 시 워크플로우 종료.
- 폐기된 컨벤션 명시 (`---MARKER:X---` / `MARKER_ALIASES` / preamble 자동 주입)

## 재기술 금지 정합
본 추가는 *어디 가서 보면 되는지* 만. 룰 자체는 SSOT 가 정의:
- `agents/validator.md` — 형식 + 모드별 enum
- `docs/status-json-mutate-pattern.md` — 발상 + 메커니즘
- `harness/state_io.py` — read 측 단일 normalize

## Test plan
- [x] doc-sync: PASS (`agent` heavy + docs-only)
- [x] tests 회귀: 41/41 PASS

## 거버넌스 체크리스트
- [x] Task-ID `DCN-CHG-20260429-12`
- [x] WHAT/WHY 로그
- [x] heavy(`agent`) → rationale 동반
- [x] doc-sync 게이트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)