### PR TITLE
chore: sweep stale status-json references (DCN-CHG-20260429-14)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,27 +1,27 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "dcness",
-  "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness. RWHarness fork-and-refactor.",
+  "description": "Lightweight harness — prose-only determinism + meta-LLM interpretation. RWHarness fork-and-refactor.",
   "owner": {
     "name": "alruminum",
     "email": "alruminum@gmail.com"
   },
   "metadata": {
-    "description": "dcNess 첫 알파 — status JSON mutate 결정론 + 함정 회피 5원칙 + Document Sync 거버넌스. RWHarness 와 공존 가능 설계 (proposal §12).",
+    "description": "dcNess 첫 알파 — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙 + Document Sync 거버넌스. RWHarness 와 공존 가능 설계 (proposal §12).",
     "version": "0.1.0-alpha"
   },
   "plugins": [
     {
       "name": "dcness",
       "source": "./",
-      "description": "Status-JSON-mutate harness — agent 가 외부 상태 파일 mutate, harness 는 그 파일만 read. parse_marker 사다리 폐기.",
+      "description": "Prose-only harness — agent 자유 prose emit, harness 가 메타 LLM 으로 결론 해석. 형식 강제 사다리 폐기.",
       "category": "development",
       "tags": [
         "agent",
         "workflow",
         "orchestration",
         "harness",
-        "status-json-mutate",
+        "prose-only",
         "governance"
       ]
     }

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,8 +1,8 @@
 # GitHub Actions — Python unittest 자동 실행
 #
 # 목적:
-# - harness/state_io.py 회귀 차단 (R8 5 failure modes / atomic write / path safety)
-# - agents/validator/*.md schema round-trip 회귀 차단 (DCN-CHG-20260429-07)
+# - harness/signal_io.py 회귀 차단 (prose I/O / interpret_signal 휴리스틱 / path safety)
+# - DCN-CHG-20260429-13 prose-only 패턴 회귀 차단
 #
 # 트리거:
 # - PR / push to main 시 tests/ 또는 harness/ 또는 agents/ 변경 시

--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,5 @@ node_modules/
 .claude/ralph-loop.local.md
 .claude/settings.local.json
 
-# 하네스 런타임 상태 (status JSON 등 — agent 가 mutate)
+# 하네스 런타임 상태 (agent prose 파일 등)
 .claude/harness-state/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-com
 
 # 하네스 단위 테스트 실행
 python3 -m unittest discover -s tests -v
-python3 -m unittest tests.test_state_io -v   # 단일 모듈
+python3 -m unittest tests.test_signal_io -v   # 단일 모듈
 ```
 
 > 빌드 / 런타임 명령어는 코드 도입 시 본 섹션에 추가 (별도 Task-ID).

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,6 +9,7 @@
 - **모듈 분류 framework 적용**: `docs/migration-decisions.md` (`DCN-CHG-20260429-05`)
 - **CI 게이트 3종**: Document Sync (`-08`) / Python tests (`-09`) / Plugin manifest (`-10`)
 - **README + AGENTS 보강**: `-11`, `-12`
+- **🧹 stale 참조 sweep** (`DCN-CHG-20260429-14`): CLAUDE.md test 명령어 + python-tests.yml 헤더 + marketplace.json description/tags + .gitignore 코멘트 + migration-decisions framework 표현을 prose-only 로 정정. history record 항목은 governance §2.4 스코핑 정합으로 미수정.
 - **🔄 Phase 1 재정렬 — Prose-Only Pattern** (`DCN-CHG-20260429-13`):
   - **proposal 갱신**: `docs/status-json-mutate-pattern.md` 가 *Prose-Only Pattern* 으로 정정. 형식 강제 자체가 사다리를 부른다는 자각 — JSON schema 도 형식 사다리의 한 형태. harness 강제 = 작업 순서 + 접근 영역만, 그 외는 agent 자율.
   - **폐기**: `harness/state_io.py` (~290 LOC) + `tests/test_state_io.py` (32) + `tests/test_validator_schemas.py` (9). JSON schema 강제 자체가 형식 사다리 잠재.

--- a/docs/migration-decisions.md
+++ b/docs/migration-decisions.md
@@ -10,7 +10,7 @@
 `status-json-mutate-pattern.md` §11.2 framework 를 RWHarness 모듈 카탈로그에 적용한 결과를 단일 문서로 박는다. 모듈마다 다음 3 질문 중 하나로 분류:
 
 1. **Catastrophic-prevention 인가?** — 돌이킬 수 없는 사고를 막는가? → **PRESERVE**
-2. **발상 변경으로 자연 폐기되는가?** — status JSON mutate / dcNess 메인 직접 작업 모드 적용 시 의미 잃는가? → **DISCARD**
+2. **발상 변경으로 자연 폐기되는가?** — Prose-Only Pattern / dcNess 메인 직접 작업 모드 적용 시 의미 잃는가? → **DISCARD**
 3. **단순화 가능한가?** — 룰 누적·중복 패턴인가? → **REFACTOR**
 
 본 문서는 **결정 기록** 이지 *재작성 금지의 헌법* 이 아니다. 분류가 잘못된 것으로 판명되면 별도 Task-ID 로 정정.
@@ -94,7 +94,7 @@ dcNess 는 RWHarness 와 다른 *모드* 다. 분류 전 다음 전제 박는다
 
 > **dcNess 메인 작업 모드 vs Plugin 배포 모드**:
 > - **메인 작업 모드 (본 저장소 내부)**: agent prompt 가 *자료* 일 뿐 의무 호출 없음. 메인 Claude 가 `Task` 도구로 호출 시에만 활성화.
-> - **Plugin 배포 모드 (사용자 프로젝트에서 활성화)**: agent prompt 가 *실 호출 대상*. status JSON mutate 형식 강제.
+> - **Plugin 배포 모드 (사용자 프로젝트에서 활성화)**: agent prompt 가 *실 호출 대상*. prose 자유 emit + 메타 LLM 해석 (형식 강제 X).
 >
 > 두 모드 다 같은 agent docs 형식 사용 → 변환은 한 번만.
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,22 @@
 
 ## Records
 
+### DCN-CHG-20260429-14
+- **Date**: 2026-04-29
+- **Rationale**:
+  - DCN-CHG-20260429-13 가 prose-only 로 패턴 전환했으나 forward-looking 문서/메타 (CLAUDE.md test 명령어 / python-tests.yml 헤더 / marketplace.json description / .gitignore 코멘트 / migration-decisions framework 질문) 에 stale `status JSON` / `state_io` 표현이 잔존.
+  - Plugin manifest 의 `tags: ["status-json-mutate"]` 는 marketplace 검색 인덱스에 노출되는 *공개 메타* 라 정정 우선 순위 높음. CLAUDE.md §4 의 stale 단일 모듈 테스트 명령은 실행 시 `ModuleNotFoundError` (이미 삭제된 모듈) — 신규 기여자 onboarding 함정.
+- **Alternatives**:
+  1. *과거 record/rationale 항목까지 일괄 정정* — governance §2.4 "현재 diff 추가 라인만 유효" 정합 위반. 과거 사실 (당시 status JSON 도입했음) 을 사후에 prose-only 로 위장하면 history 신뢰성 손상. 기각.
+  2. *Phase 2 시점에 일괄* — Phase 2 는 메타 LLM 통합 + 12 agent docs 변환이라 *별도 책임*. stale 표현은 onboarding 비용을 매일 발생시키므로 즉시 cleanup 이 옳음. 기각.
+  3. *(채택)* **forward-looking 문서만 sweep + history 항목 보존 + Document-Exception 명시**.
+- **Decision**:
+  - 옵션 3. 5 파일 cleanup. history record 본문은 governance §2.4 정합으로 *명시적 미수정*. record 의 "본 변경" 자체는 새 Task-ID 의 추가 라인이라 게이트 통과.
+  - tags 변경: `status-json-mutate` → `prose-only`. marketplace 사용자가 본 plugin 의 결정론 메커니즘을 정확히 식별 가능.
+- **Follow-Up**:
+  - **(별도 Task-ID)** RWHarness 와 plugin name 충돌 시나리오 dry-run — plugin 메타 변경이 install/disable 동작에 영향 주는지 확인.
+  - **측정**: marketplace 검색 키워드 분석 시 `prose-only` 매칭 횟수 추적 (해당 메트릭 도입 시).
+
 ### DCN-CHG-20260429-13
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,20 @@
 
 ## Records
 
+### DCN-CHG-20260429-14
+- **Date**: 2026-04-29
+- **Change-Type**: agent, ci, docs-only
+- **Files Changed**:
+  - `CLAUDE.md` (§4 단일 모듈 테스트 명령어 → `tests.test_signal_io`)
+  - `.github/workflows/python-tests.yml` (헤더 코멘트 — state_io → signal_io)
+  - `.gitignore` (.claude/harness-state 코멘트 — status JSON → prose)
+  - `.claude-plugin/marketplace.json` (description / metadata / plugin tags — status-json-mutate → prose-only)
+  - `docs/migration-decisions.md` (§0 framework 질문 + §2.3 Plugin 배포 모드 — prose-only 표현으로 정정)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: DCN-CHG-20260429-13 후 잔존하는 stale `status JSON` / `state_io` 표현 sweep — 현재/forward-looking 문서 + plugin manifest + CI workflow 코멘트만 정정. 과거 이력 record 항목은 governance §2.4 스코핑 정합으로 미수정 (당시 사실 보존).
+- **Document-Exception**: history 보존 — 이전 Task-ID 의 record/rationale 항목 본문은 *그 시점 사실* 이라 수정하지 않는다. governance §2.4 의 "현재 diff 추가 라인만 유효" 정합.
+
 ### DCN-CHG-20260429-13
 - **Date**: 2026-04-29
 - **Change-Type**: spec, harness, agent, test, docs-only


### PR DESCRIPTION
## Summary

DCN-CHG-20260429-13 prose-only 전환 후 잔존하는 forward-looking 문서/메타의 stale `status JSON` / `state_io` 표현 정리.

### 변경
- `CLAUDE.md` §4 단일 모듈 테스트 명령어 → `tests.test_signal_io` (이전 명령은 `ModuleNotFoundError` 유발)
- `.github/workflows/python-tests.yml` 헤더 코멘트
- `.gitignore` `.claude/harness-state` 코멘트
- `.claude-plugin/marketplace.json` description / metadata / plugin tags (`status-json-mutate` → `prose-only`)
- `docs/migration-decisions.md` §0 framework 질문 + §2.3 Plugin 배포 모드

### 미수정 (의도)
- 과거 `document_update_record` / `change_rationale_history` 의 record 본문 — governance §2.4 "현재 diff 추가 라인만 유효" 정합. 당시 사실 (status JSON 도입) 보존이 history 신뢰성.

## Test plan

- [x] `node scripts/check_document_sync.mjs` → PASS (8 files, agent/ci/docs-only)
- [x] `node scripts/check_plugin_manifest.mjs` → PASS (dcness@0.1.0-alpha)
- [x] `python3 -m unittest discover -s tests` → 29 PASS

## Governance

- **Task-ID**: `DCN-CHG-20260429-14`
- **Change-Type**: agent, ci, docs-only
- **Document-Exception**: history 보존 (record 항목 본문 미수정)

🤖 Generated with [Claude Code](https://claude.com/claude-code)