### PR TITLE
ci: add task-id validation workflow + script (DCN-CHG-20260429-20)

### DIFF
--- a/.github/workflows/task-id-validation.yml
+++ b/.github/workflows/task-id-validation.yml
@@ -1,0 +1,72 @@
+# GitHub Actions — Task-ID 형식 검증 게이트 (CI level)
+#
+# 규칙 정의: docs/process/governance.md §2.1 (SSOT)
+# 본 워크플로우는 PR 단위로 base..head 범위의 모든 비-머지 커밋이
+# DCN-CHG-YYYYMMDD-NN 토큰을 정확히 1개 포함하는지 검사한다.
+#
+# proposal §5 Phase 3 — "Task-ID 형식 검증 → workflow regex" 정합.
+# proposal §11 4-pillar #2 (CI/CD 게이트) — local 우회 가능 영역의 *최후 차단*.
+#
+# 머지 커밋 면제: squash merge / 자동 생성 합본 메시지에 Task-ID 누락 가능.
+
+name: task-id-validation
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  task-id:
+    name: Task-ID format gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history for base..head diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Resolve base / head SHAs
+        id: resolve
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+          fi
+          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD" >> "$GITHUB_OUTPUT"
+          echo "[task-id] base=$BASE  head=$HEAD"
+
+      - name: Run Task-ID validation gate
+        run: |
+          set -e
+          BASE="${{ steps.resolve.outputs.base }}"
+          HEAD="${{ steps.resolve.outputs.head }}"
+
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "[task-id] base SHA 부재 — initial push, skip"
+            exit 0
+          fi
+
+          node scripts/check_task_id.mjs "$BASE" "$HEAD"
+
+      - name: Validate PR title (PR mode only)
+        if: github.event_name == 'pull_request'
+        run: |
+          set -e
+          TITLE="${{ github.event.pull_request.title }}"
+          node scripts/check_task_id.mjs --pr-title "$TITLE"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -62,10 +62,20 @@
   - [x] **iter 4 완료** (DCN-CHG-20260429-18): `agents/designer.md` (4 모드 inline) + `agents/design-critic.md`
   - [x] **iter 5 완료** (DCN-CHG-20260429-19): `agents/ux-architect.md` + `agents/product-planner.md` — Phase 2 13 agents 종결 🎉
 
-### Phase 3 — Plugin 배포 dry-run (선택)
+### Phase 3 — GitHub 외부화 + Sweep (진행 중)
+
+> proposal §5 Phase 3 정합 — RWHarness `commit-gate.py` Gate 1/4/5 → GitHub Actions 외부화.
+> dcNess 는 commit-gate.py 미도입(migration-decisions §2.2 DISCARD)이라 *자연 외부화* — 신규 워크플로우만 추가.
+
+- [x] **iter 1 완료** (DCN-CHG-20260429-20): Task-ID 형식 검증 워크플로 + 스크립트 — `scripts/check_task_id.mjs` + `.github/workflows/task-id-validation.yml`. 모든 비-머지 커밋이 `DCN-CHG-YYYYMMDD-NN` 토큰 정확히 1개 포함하는지 PR/push 단위로 차단. PR title 도 동시 검증. 머지 커밋 면제(squash 합본). proposal §11 4-pillar #2 (CI 최후 차단) 정합.
+- [ ] iter 2 후보 — 브랜치 보호 룰 + LGTM 게이트 문서화 (proposal §5 Phase 3 "Gate 5 → branch protection required reviewers")
+- [ ] iter 3 후보 — Anthropic SDK haiku interpreter 통합 (`interpret_signal(..., interpreter=anthropic_haiku_call)` swap point 채움)
+- [ ] iter 4 후보 — ambiguous prose 카탈로그 + 휴리스틱 hit rate 측정 스크립트
+- [ ] iter 5 후보 — Phase 3 종결 + plugin 배포 dry-run 가이드 정리
+
+### Phase 3 (확장) — Plugin 배포 dry-run (선택)
 - [ ] RWHarness 와 공존 시나리오 검증 (proposal §12.3.2)
 - [ ] 1 프로젝트 1 cycle 도그푸딩
-- [ ] 휴리스틱 interpreter hit rate 측정 (단어경계 매칭 vs ambiguous 빈도)
 
 ### 인프라 / CI 보강
 - [ ] branch protection 룰 추가 (사용자 수동, GitHub Settings)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,32 @@
 
 ## Records
 
+### DCN-CHG-20260429-20
+- **Date**: 2026-04-29
+- **Rationale**:
+  - Phase 2 종결(13 agent docs prose-only) 직후 Phase 3 진입. proposal §5 Phase 3 = "GitHub 외부화 + Sweep". RWHarness 의 commit-gate Gate 1/4/5 → GitHub Actions.
+  - dcNess 는 commit-gate.py 자체를 도입하지 않음 (migration-decisions §2.2 DISCARD) → 자연 외부화 상태. Gate 4(doc-sync) 는 이미 `.github/workflows/document-sync.yml` 로 외부화 완료 (`DCN-CHG-20260429-08`).
+  - 남은 즉시 가능 항목 = **Task-ID 형식 검증**. governance §2.1 의 `DCN-CHG-YYYYMMDD-NN` 룰은 PR template + AGENTS.md 에 *문서화* 만 돼 있고 *기계적 강제* 가 없었다. PR #1~#19 19개 모두 수동 준수했지만, 외부 에이전트(Codex 등) 또는 미래 자동 PR 시 누락 위험.
+  - 분류 우선순위: Task-ID 누락은 다른 모든 거버넌스 룰(record/rationale/PROGRESS 동반)의 *anchor* — 누락 시 두 로그가 묶일 anchor 자체가 없음. 따라서 Phase 3 first-class 항목.
+- **Alternatives**:
+  1. *PR template 강조 + 수동 검증* — 현재 상태. 외부 에이전트/자동 PR 누락 위험. 기각.
+  2. *commit-msg git hook 으로 로컬 차단* — 로컬 우회(`--no-verify`) 가능. proposal §11 4-pillar #2 정합 안 함. CI 게이트가 본질. 단 *추가* 옵션으로 도입 가능 — 본 Task 에선 CI 만 도입, 로컬 hook 은 후속.
+  3. *(채택)* **CI 워크플로우 + 로컬 스크립트 듀얼 모드**. 로컬은 수동 호출(`node scripts/check_task_id.mjs`), CI 는 PR/push 자동. PR title 검증도 부가.
+  4. *PR template-only 검증* — title 만 검사. body 안 Task-ID 누락 가능. commit 별 검사가 정확. 기각.
+- **Decision**:
+  - 옵션 3. CI(필수) + 로컬 스크립트(선택). PR title 추가 검증.
+  - **머지 커밋 면제**: 2개+ parent 커밋은 squash merge 합본 등 자동 생성 메시지 케이스. 이미 squash 된 commit subject 안에 Task-ID 가 있으므로 머지 합본 검사 면제는 안전.
+  - **다중 Task-ID 차단**: governance §2.1 "단 하나의 Task-ID" 명문 — `unique.length > 1` 도 FAIL. PR 한번에 두 Task 를 합치는 패턴 차단.
+  - **Document-Exception-Task 자연 인정**: 같은 정규식이라 별도 처리 불필요.
+  - **proposal §2.5 원칙 정합**: (원칙 1) 기존 룰(governance §2.1) 강제 *정밀화* — 신규 룰 추가 X. (원칙 2) catastrophic 차단(Task-ID 0 = anchor 부재 = governance 시스템 무효화). 강제(deny) 정당화.
+- **Follow-Up**:
+  - **iter 2 (Phase 3)**: 브랜치 보호 룰 + LGTM 게이트 — `gh api` CLI 또는 README 운영 가이드 추가 (proposal §5 Phase 3 "Gate 5 → branch protection required reviewers").
+  - **iter 3**: Anthropic SDK haiku interpreter 통합 — `harness/signal_io.py` 의 `interpret_signal(..., interpreter=)` swap point 채움. proposal §3 비용 측정 ($0.001/cycle).
+  - **iter 4**: ambiguous prose 카탈로그 + 휴리스틱 hit rate 측정 (proposal R1 / R8).
+  - **iter 5**: Phase 3 종결 + plugin 배포 dry-run 가이드 정리.
+  - **(별도 Task)** 로컬 git commit-msg hook (`scripts/hooks/commit-msg`) 추가 가능 — opt-in. 사용자가 `.git/hooks/commit-msg` 설치하면 push 전 차단.
+  - **(측정)** 본 게이트 도입 후 1주 내 false-positive 빈도 측정. 0 이면 안정. > 0 이면 정규식 정정.
+
 ### DCN-CHG-20260429-19
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,7 +20,17 @@
 
 ## Records
 
-### DCN-CHG-20260429-19
+### DCN-CHG-20260429-20
+- **Date**: 2026-04-29
+- **Change-Type**: ci
+- **Files Changed**:
+  - `scripts/check_task_id.mjs` (신규 — Task-ID 형식 검증 스크립트, 로컬/CI/PR-title 3 모드)
+  - `.github/workflows/task-id-validation.yml` (신규 — CI 게이트, base..head 범위 + PR title 동시 검사)
+  - `PROGRESS.md` (Phase 3 시작 + iter 1 완료 표시)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: Phase 3 iter 1 — Task-ID 형식 검증 게이트(`DCN-CHG-YYYYMMDD-NN`)를 GitHub Actions + 로컬 스크립트로 도입. proposal §5 Phase 3 의 "Task-ID 형식 검증 → workflow regex" 이행. 모든 비-머지 커밋의 메시지(subject+body) 가 정확히 1개 토큰 포함하는지 검사하고 PR title 도 추가 검증. 머지 커밋(2개+ parent)은 squash 합본 자동 메시지 케이스로 면제. 다중 Task-ID(governance §2.1 "단 하나" 위반) 도 차단. Document-Exception-Task 토큰도 동일 패턴이라 자연 인정.
+- **Document-Exception**: 없음 (ci 단일 카테고리, deliverable 동반 의무 없음)
 - **Date**: 2026-04-29
 - **Change-Type**: agent, docs-only
 - **Files Changed**:

--- a/scripts/check_task_id.mjs
+++ b/scripts/check_task_id.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * dcNess Task-ID 형식 검증 게이트
+ * 규칙 정의: docs/process/governance.md §2.1 (SSOT)
+ *
+ * 사용:
+ *   node scripts/check_task_id.mjs                 # 로컬: HEAD 커밋 1개 검사
+ *   node scripts/check_task_id.mjs <base> <head>   # CI: base..head 범위 검사
+ *   node scripts/check_task_id.mjs --pr-title "<title>"  # CI: PR title 검사 (옵션)
+ *
+ * 규칙:
+ *   - 모든 비-머지 커밋은 메시지(subject 또는 body) 안에 정확히 1개의
+ *     DCN-CHG-YYYYMMDD-NN 토큰을 포함해야 한다.
+ *   - 토큰 패턴: ^DCN-CHG-\d{8}-\d{2}$ (zero-pad 일별 순번)
+ *   - 머지 커밋(2개 이상 parent)은 검사 면제 — squash merge 합본 등 자동 생성 케이스.
+ *   - Document-Exception-Task: DCN-CHG-... 도 동일 토큰으로 인정.
+ *   - PR title 옵션 사용 시 title 안에 1개 이상 매칭이면 PASS.
+ *
+ * exit 0: 통과
+ * exit 1: 위반 (Task-ID 누락 / 형식 위반 / 다중 ID)
+ *
+ * proposal §5 Phase 3 — "Task-ID 형식 검증 → workflow regex" 정합.
+ * proposal §11 4-pillar #2 — local 우회 가능 영역 CI 최후 차단.
+ */
+import { execSync } from 'node:child_process';
+
+const TASK_ID_RE = /\bDCN-CHG-\d{8}-\d{2}\b/g;
+const TASK_ID_STRICT_RE = /^DCN-CHG-\d{8}-\d{2}$/;
+
+function git(cmd) {
+  try {
+    return execSync(cmd, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  } catch {
+    return '';
+  }
+}
+
+function isGitRepo() {
+  try {
+    execSync('git rev-parse --is-inside-work-tree', { stdio: ['ignore', 'pipe', 'pipe'] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getCommitsInRange(base, head) {
+  const raw = git(`git log --format=%H ${base}..${head}`);
+  return raw.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+function isMergeCommit(sha) {
+  const parents = git(`git log -1 --format=%P ${sha}`).trim().split(/\s+/).filter(Boolean);
+  return parents.length >= 2;
+}
+
+function getCommitMessage(sha) {
+  return git(`git log -1 --format=%B ${sha}`);
+}
+
+function getCommitSubject(sha) {
+  return git(`git log -1 --format=%s ${sha}`).trim();
+}
+
+/**
+ * 단일 메시지 검증.
+ * @returns {{ok: boolean, error?: string, taskIds: string[]}}
+ */
+function validateMessage(message) {
+  const matches = message.match(TASK_ID_RE) || [];
+  const unique = [...new Set(matches)];
+
+  if (unique.length === 0) {
+    return { ok: false, error: 'Task-ID 누락 — DCN-CHG-YYYYMMDD-NN 토큰 필요', taskIds: [] };
+  }
+
+  // 다중 Task-ID 는 governance §2.1 위반 — "단 하나의 Task-ID"
+  if (unique.length > 1) {
+    return {
+      ok: false,
+      error: `다중 Task-ID 발견 (${unique.length}개): ${unique.join(', ')} — governance §2.1 위반`,
+      taskIds: unique,
+    };
+  }
+
+  // 엄격 매칭 검증 (이미 regex 가 보장하지만 방어적으로 재확인)
+  for (const id of unique) {
+    if (!TASK_ID_STRICT_RE.test(id)) {
+      return { ok: false, error: `형식 위반: ${id}`, taskIds: unique };
+    }
+  }
+
+  return { ok: true, taskIds: unique };
+}
+
+// === 메인 ===
+const args = process.argv.slice(2);
+
+if (!isGitRepo() && !args.includes('--pr-title')) {
+  console.log('[task-id] not a git repo — skip');
+  process.exit(0);
+}
+
+// PR title 모드
+const prTitleIdx = args.indexOf('--pr-title');
+if (prTitleIdx !== -1) {
+  const title = args[prTitleIdx + 1];
+  if (!title) {
+    console.error('[task-id] --pr-title 인자 누락');
+    process.exit(1);
+  }
+  const result = validateMessage(title);
+  if (!result.ok) {
+    console.error(`[task-id] FAIL — PR title 검증: ${result.error}`);
+    console.error(`  title: ${title}`);
+    process.exit(1);
+  }
+  console.log(`[task-id] PASS — PR title Task-ID: ${result.taskIds[0]}`);
+  process.exit(0);
+}
+
+// commit 범위 모드 (CI)
+let commits = [];
+if (args.length === 2) {
+  const [base, head] = args;
+  // 빈 SHA 폴백
+  if (!base || base === '0000000000000000000000000000000000000000') {
+    console.log('[task-id] base SHA 부재 — initial push, skip');
+    process.exit(0);
+  }
+  commits = getCommitsInRange(base, head);
+} else if (args.length === 0) {
+  // 로컬: HEAD 1개
+  const head = git('git rev-parse HEAD').trim();
+  if (head) commits = [head];
+} else {
+  console.error('[task-id] 사용법:');
+  console.error('  node scripts/check_task_id.mjs                 # 로컬 HEAD');
+  console.error('  node scripts/check_task_id.mjs <base> <head>   # CI 범위');
+  console.error('  node scripts/check_task_id.mjs --pr-title "<title>"');
+  process.exit(1);
+}
+
+if (commits.length === 0) {
+  console.log('[task-id] 검사 대상 커밋 0 — skip');
+  process.exit(0);
+}
+
+const violations = [];
+let passed = 0;
+let skippedMerges = 0;
+
+for (const sha of commits) {
+  if (isMergeCommit(sha)) {
+    skippedMerges++;
+    continue;
+  }
+  const msg = getCommitMessage(sha);
+  const subject = getCommitSubject(sha);
+  const result = validateMessage(msg);
+  if (!result.ok) {
+    violations.push({
+      sha: sha.substring(0, 7),
+      subject,
+      error: result.error,
+    });
+  } else {
+    passed++;
+  }
+}
+
+if (violations.length > 0) {
+  console.error('[task-id] FAIL — 위반 커밋:');
+  for (const v of violations) {
+    console.error(`  ${v.sha} "${v.subject}"`);
+    console.error(`    → ${v.error}`);
+  }
+  console.error('');
+  console.error('규칙: docs/process/governance.md §2.1 (Task-ID = DCN-CHG-YYYYMMDD-NN, 커밋당 1개)');
+  process.exit(1);
+}
+
+console.log(`[task-id] PASS`);
+console.log(`  검사: ${commits.length}, 통과: ${passed}, 머지 면제: ${skippedMerges}`);


### PR DESCRIPTION
## Summary
- Phase 3 iter 1 — Task-ID 형식 검증 게이트(`DCN-CHG-YYYYMMDD-NN`) GitHub Actions + 로컬 스크립트로 도입.
- proposal §5 Phase 3 "Task-ID 형식 검증 → workflow regex" 이행.
- governance §2.1 의 "단 하나의 Task-ID" 룰을 PR/push 단위로 기계적 차단.

## Task-ID
\`DCN-CHG-20260429-20\`

## Change-Type
- [x] \`ci\`
- [x] \`docs-only\`

## Document Sync Checklist
- [x] \`docs/process/document_update_record.md\` 갱신
- [x] \`docs/process/change_rationale_history.md\` 갱신 (ci 카테고리)
- [x] \`PROGRESS.md\` 갱신 (ci 카테고리)
- [x] 카테고리별 deliverable: ci 카테고리는 동반 의무 없음
- [x] \`node scripts/check_document_sync.mjs\` 통과

## Test Plan
- [x] 긍정 케이스 로컬 smoke (PASS)
- [x] PR title 음성 케이스 (FAIL exit 1)
- [x] Document Sync 게이트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)