### PR TITLE
feat: anthropic haiku interpreter for signal_io (DCN-CHG-20260429-22)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ node_modules/
 
 # 하네스 런타임 상태 (agent prose 파일 등)
 .claude/harness-state/
+
+# 메타 LLM (haiku) 호출 telemetry — 주간 비용 리포트 입력
+.metrics/

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -69,7 +69,7 @@
 
 - [x] **iter 1 완료** (DCN-CHG-20260429-20): Task-ID 형식 검증 워크플로 + 스크립트 — `scripts/check_task_id.mjs` + `.github/workflows/task-id-validation.yml`. 모든 비-머지 커밋이 `DCN-CHG-YYYYMMDD-NN` 토큰 정확히 1개 포함하는지 PR/push 단위로 차단. PR title 도 동시 검증. 머지 커밋 면제(squash 합본). proposal §11 4-pillar #2 (CI 최후 차단) 정합.
 - [x] **iter 2 완료** (DCN-CHG-20260429-21): branch protection 적용 스크립트 + 가이드 — `scripts/setup_branch_protection.mjs` (멱등 PUT, dry-run 지원) + `docs/process/branch-protection-setup.md` (자동/수동/검증) + `governance.md` §2.8 신설. proposal §5 Phase 3 "Gate 5 (LGTM flag) → branch protection required reviewers" 외부화. RWHarness `class Flag` LGTM in-process 메커니즘은 dcNess 자연 폐기 (migration-decisions §2.2 DISCARD), GitHub branch protection 이 동일 역할 외부 강제. 4 status check (`Document Sync gate` / `unittest discover` / `validate manifest` / `Task-ID format gate`) + 1 approving review + force-push/삭제 차단 + linear history.
-- [ ] iter 3 후보 — Anthropic SDK haiku interpreter 통합 (`interpret_signal(..., interpreter=anthropic_haiku_call)` swap point 채움)
+- [x] **iter 3 완료** (DCN-CHG-20260429-22): Anthropic SDK haiku interpreter 통합 — `harness/llm_interpreter.py` (신규, `make_haiku_interpreter()` 팩토리, mock client DI 지원, telemetry `.metrics/meta-llm-calls.jsonl`, ambiguous fallback) + `tests/test_llm_interpreter.py` (16 케이스, 실 SDK 호출 0). `harness/signal_io.py` 의 `interpret_signal(..., interpreter=)` swap point 가 프로덕션 가능 상태. proposal §3 비용 (~$0.0001/호출) + R8 telemetry 누적.
 - [ ] iter 4 후보 — ambiguous prose 카탈로그 + 휴리스틱 hit rate 측정 스크립트
 - [ ] iter 5 후보 — Phase 3 종결 + plugin 배포 dry-run 가이드 정리
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,40 @@
 
 ## Records
 
+### DCN-CHG-20260429-22
+- **Date**: 2026-04-29
+- **Rationale**:
+  - Phase 3 iter 3. `harness/signal_io.py` (DCN-CHG-20260429-13) 의 `interpret_signal(..., interpreter=)` 는 휴리스틱 fallback 만 가능했음. 프로덕션 swap 함수가 부재 → proposal §3 의 "메타 LLM (haiku) 1 호출" 메커니즘이 비어있는 상태.
+  - migration-decisions §3 의 "메타 LLM (haiku) interpreter 통합" TODO 와 PROGRESS.md Phase 2 미완 항목 정합. Phase 3 의 외부화 + sweep 의 일환.
+  - 휴리스틱이 ambiguous (단어경계 0 hit / 다중 hit) 일 때만 LLM 호출 = 비용 minimization (proposal §3 cycle 당 $0.001 미만 목표).
+- **Alternatives**:
+  1. *signal_io.py 안에 직접 SDK import* — anthropic 패키지 미설치 환경 (CI / 외부 컨트리뷰터) 에서 import error. 분리 모듈 + 지연 import 가 안전.
+  2. *별도 모듈 + 즉시 import* — anthropic 미설치 시 모듈 import 자체 실패. 지연 import (factory 안에서 import) 가 적절.
+  3. *(채택)* **별도 `harness/llm_interpreter.py` + factory 안 지연 import + DI client**. 테스트는 mock client 주입으로 실 API 호출 0.
+  4. *prompt caching 도입* — system prompt ~50 토큰. haiku 의 cache minimum (~1024 토큰) 미달. 매 호출 prose 다름 → cache hit 0. 손익 negative. 기각 (claude-api skill 의 trigger 정합 검토했지만 본 use case 엔 N/A).
+  5. *다중 retry / exponential backoff* — proposal §3 / R1 의 "ambiguous → 사용자 prompt" fallback. 본 Task 에선 기본 단일 호출 + ambiguous propagate 만 구현. 재시도 정책은 호출 측 결정.
+- **Decision**:
+  - 옵션 3. 분리 모듈 + factory + DI + ambiguous fallback.
+  - **모델**: `claude-haiku-4-5-20251001` (시스템 cutoff 정합, 가장 저렴 + classifier 용도 충분).
+  - **prompt 설계**:
+    - system: allowed enum + "한 단어, 대문자, UNKNOWN if 모호" 룰. 50~100 토큰.
+    - user: prose 마지막 4000 chars (~1000 tokens, proposal R2 정합).
+    - max_tokens=10 (한 단어 충분).
+  - **응답 파싱**: 첫 단어 → uppercase → 구두점 strip → allowed 매칭. 매칭 실패 = `MissingSignal('ambiguous')`. raw response 200 chars 까지 telemetry 기록 (디버깅용).
+  - **Telemetry SSOT**: `.metrics/meta-llm-calls.jsonl` (proposal R8 정합). 항목: ts/model/allowed/raw_response[:200]/parsed/input_tokens/output_tokens/cost_usd/elapsed_ms.
+  - **비용 모델**: haiku 4.5 input $1/1M, output $5/1M. 평균 호출 = 80 in + 5 out ≈ $0.000105. cycle 당 65 호출 = ~$0.007 (proposal §3 의 $0.065 추정보다 9× 저렴 — haiku 가격 인하 반영).
+  - **proposal §2.5 원칙 정합**:
+    - 원칙 1 (룰 순감소): 신규 LOC ~180 (interpreter + tests). signal_io 의 swap point 활용 — 추가 함수형 강제 0.
+    - 원칙 2 (강제 vs 권고): LLM 응답 형식은 prompt *권고* (system 안에 ALL CAPS 단일 단어 출력 룰). 형식 강제 X — 모호 시 ambiguous propagate.
+    - 원칙 3 (agent 자율성): agent prose emit 형식은 그대로 자유. interpreter 가 결론을 추출.
+- **Follow-Up**:
+  - **(검증)** ANTHROPIC_API_KEY 환경에서 실 호출 1회 — 본 Task 에선 미실시 (auto mode + secrets 정책). 운영자 수동.
+  - **iter 4 (Phase 3)**: ambiguous prose 카탈로그 + 휴리스틱 hit rate 측정 — telemetry JSONL 분석 스크립트.
+  - **iter 5 (Phase 3)**: Phase 3 종결 + plugin 배포 dry-run 가이드.
+  - **(별도 Task)** ambiguous 누적 패턴 발견 시 agent prose writing guide 정정 (proposal R1 카탈로그 → 작성 가이드 강화 사이클).
+  - **(별도 Task)** prompt caching 재검토 — agent prose 가 표준화돼 system prompt 가 ≥1024 토큰 되면 도입 가능.
+  - **(별도 Task)** 비용 폭증 시 retry/backoff/cache 정책 — 주간 cost 리포트 첫 1주 데이터 후 결정.
+
 ### DCN-CHG-20260429-21
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,7 +20,18 @@
 
 ## Records
 
-### DCN-CHG-20260429-21
+### DCN-CHG-20260429-22
+- **Date**: 2026-04-29
+- **Change-Type**: harness, test, docs-only
+- **Files Changed**:
+  - `harness/llm_interpreter.py` (신규 — Anthropic haiku interpreter 팩토리, telemetry, prompt 구성, ambiguous fallback)
+  - `tests/test_llm_interpreter.py` (신규 — 16 케이스, mock client DI, telemetry on/off, signal_io 통합)
+  - `.gitignore` (`.metrics/` 추가 — telemetry 디렉토리)
+  - `PROGRESS.md` (Phase 3 iter 3 완료 표시)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: Phase 3 iter 3 — `harness/signal_io.py` 의 `interpret_signal(..., interpreter=)` swap point 에 주입할 Anthropic Claude haiku interpreter 구현. `make_haiku_interpreter(client=None, model='claude-haiku-4-5-20251001')` 팩토리. system prompt 가 allowed enum + UNKNOWN 출력 강제. 응답 파싱: 첫 단어 → 대문자 → allowed 매칭 안 되면 `MissingSignal('ambiguous')`. telemetry: 호출별 (model/allowed/parsed/input_tokens/output_tokens/cost_usd/elapsed_ms) `.metrics/meta-llm-calls.jsonl` append (proposal R8). `DCNESS_LLM_TELEMETRY=0` 으로 비활성. 비용 추정 모델 ~$0.0001/호출 (haiku 4.5 가격 기준). 16 테스트 PASS — 실 API 호출 0 (mock client DI 만).
+- **Document-Exception**: 없음 (harness 카테고리 deliverable = `tests/**` 동반 ✅)
 - **Date**: 2026-04-29
 - **Change-Type**: ci, agent, docs-only
 - **Files Changed**:

--- a/harness/llm_interpreter.py
+++ b/harness/llm_interpreter.py
@@ -1,0 +1,205 @@
+"""llm_interpreter.py — Anthropic Claude haiku 기반 prose 결론 해석기.
+
+발상 (status-json-mutate-pattern.md §3):
+    "harness 가 stdout 캡처 → 메타 LLM (haiku) 1 호출:
+     '다음 prose 의 결론은 PASS/FAIL/SPEC_MISSING 중 무엇? 한 단어.'"
+
+본 모듈은 `harness/signal_io.py` 의 `interpret_signal(prose, allowed, interpreter=)` 의
+프로덕션 swap 함수 = `make_haiku_interpreter()` 를 제공한다.
+
+사용:
+    from harness.signal_io import interpret_signal
+    from harness.llm_interpreter import make_haiku_interpreter
+
+    fn = make_haiku_interpreter()  # ANTHROPIC_API_KEY 환경변수
+    result = interpret_signal(prose, ["PASS", "FAIL"], interpreter=fn)
+
+설계 결정:
+    1. **휴리스틱 우선** — `signal_io._heuristic_interpret` 가 단어경계 단일 매칭에
+       성공하면 LLM 호출 0. haiku 는 *fallback* 으로 ambiguous 케이스만 처리.
+       비용 minimization (proposal §3 cycle 당 $0.001 미만 목표).
+    2. **Caching 미적용** — 시스템 prompt ~50 토큰. haiku 의 caching 최소(~1024 토큰)
+       미달 + 매 호출마다 prose 다름 → cache hit 0. 비용/지연 손익 negative.
+    3. **결과 단어 1개 강제** — system prompt 가 "한 단어. allowed 외 출력 시 unknown"
+       지시. parse 시 strip + uppercase + allowed 매칭. 매칭 실패 = ambiguous.
+    4. **DI 우선** — `make_haiku_interpreter(client=...)` 로 mocked client 주입 가능.
+       테스트는 이 경로로 실 SDK 호출 회피.
+    5. **모델 ID** — `claude-haiku-4-5-20251001` (시스템 안내 cutoff 정합).
+
+Cost telemetry:
+    각 호출의 input_tokens / output_tokens / total_cost_usd 를
+    `.metrics/meta-llm-calls.jsonl` 에 append (proposal R8 정합).
+    환경변수 `DCNESS_LLM_TELEMETRY=0` 이면 비활성.
+
+비용 모델 (claude-haiku-4-5, 2026-04 기준 추정):
+    input: $1 / 1M tokens
+    output: $5 / 1M tokens
+    평균 호출 = 80 in + 5 out = $0.000105 (~$0.0001/호출)
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from harness.signal_io import MissingSignal
+
+__all__ = [
+    "make_haiku_interpreter",
+    "DEFAULT_MODEL",
+    "MAX_PROSE_TAIL_CHARS",
+]
+
+DEFAULT_MODEL = "claude-haiku-4-5-20251001"
+MAX_PROSE_TAIL_CHARS = 4000  # ~ 1000 tokens; proposal R2 (마지막 500 토큰만 전달) 정합
+
+_PRICE_PER_M_INPUT_USD = 1.0
+_PRICE_PER_M_OUTPUT_USD = 5.0
+
+
+def _build_system_prompt(allowed: list[str]) -> str:
+    """system prompt 단일 책임 — allowed enum + 출력 규약."""
+    enum_str = " / ".join(allowed)
+    return (
+        "You classify a verification report into exactly one of these labels: "
+        f"{enum_str}.\n"
+        "Rules:\n"
+        "- Output ONLY the label, in upper case, no other text.\n"
+        "- If the report does not clearly indicate any label, output: UNKNOWN.\n"
+        "- Do not explain. Do not apologize. Do not output multiple labels."
+    )
+
+
+def _build_user_prompt(prose: str) -> str:
+    tail = prose[-MAX_PROSE_TAIL_CHARS:]
+    return (
+        "Classify this report's conclusion. Output one label only.\n\n"
+        "---\n"
+        f"{tail}\n"
+        "---"
+    )
+
+
+def _telemetry_path(base_dir: Optional[Path] = None) -> Path:
+    base = base_dir or (Path.cwd() / ".metrics")
+    return base / "meta-llm-calls.jsonl"
+
+
+def _record_telemetry(
+    event: dict[str, Any],
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    if os.environ.get("DCNESS_LLM_TELEMETRY", "1") == "0":
+        return
+    path = _telemetry_path(base_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+
+def _estimate_cost_usd(input_tokens: int, output_tokens: int) -> float:
+    return (
+        input_tokens * _PRICE_PER_M_INPUT_USD / 1_000_000
+        + output_tokens * _PRICE_PER_M_OUTPUT_USD / 1_000_000
+    )
+
+
+def make_haiku_interpreter(
+    *,
+    client: Any = None,
+    model: str = DEFAULT_MODEL,
+    telemetry_dir: Optional[Path] = None,
+) -> Callable[[str, list[str]], str]:
+    """Anthropic Claude haiku 호출 interpreter 팩토리.
+
+    Args:
+        client: Anthropic SDK client. None 이면 `anthropic.Anthropic()` 자동 생성
+                (ANTHROPIC_API_KEY 환경변수 필수). 테스트는 mock 주입.
+        model: 모델 ID. 기본 = claude-haiku-4-5-20251001.
+        telemetry_dir: 호출 로그 디렉토리. None = `.metrics/`.
+
+    Returns:
+        `(prose: str, allowed: list[str]) -> str` 형식 callable.
+        signal_io.interpret_signal 의 interpreter= 인자에 그대로 전달.
+
+    Raises:
+        ImportError: client=None 인데 anthropic 패키지 미설치.
+        RuntimeError: API 호출 실패.
+        MissingSignal('ambiguous'): 모델이 UNKNOWN 또는 allowed 외 값 반환.
+    """
+    if client is None:
+        try:
+            import anthropic  # noqa: WPS433 — 지연 import 가 의도 (SDK 미설치 환경 허용)
+        except ImportError as e:
+            raise ImportError(
+                "anthropic 패키지 미설치. `pip install anthropic` 후 재시도. "
+                "또는 client= 인자로 mock 주입."
+            ) from e
+        client = anthropic.Anthropic()
+
+    def _call(prose: str, allowed: list[str]) -> str:
+        if not allowed:
+            raise ValueError("allowed must be non-empty")
+
+        system = _build_system_prompt(allowed)
+        user = _build_user_prompt(prose)
+
+        started = time.time()
+        try:
+            response = client.messages.create(
+                model=model,
+                max_tokens=10,
+                system=system,
+                messages=[{"role": "user", "content": user}],
+            )
+        except Exception as e:
+            raise RuntimeError(f"Anthropic API 호출 실패: {e}") from e
+        elapsed_ms = int((time.time() - started) * 1000)
+
+        # response.content 는 ContentBlock 리스트. 첫 번째 text block 추출.
+        raw_text = ""
+        for block in getattr(response, "content", []):
+            if getattr(block, "type", None) == "text":
+                raw_text = getattr(block, "text", "")
+                break
+        if not raw_text:
+            raise MissingSignal(
+                "ambiguous", f"empty model response (model={model})"
+            )
+
+        # 첫 단어만 추출 + 정규화
+        first_word = raw_text.strip().split()[0] if raw_text.strip() else ""
+        normalized = first_word.upper().rstrip(".,;:!?")
+
+        usage = getattr(response, "usage", None)
+        input_tokens = getattr(usage, "input_tokens", 0) if usage else 0
+        output_tokens = getattr(usage, "output_tokens", 0) if usage else 0
+        cost = _estimate_cost_usd(input_tokens, output_tokens)
+
+        _record_telemetry(
+            {
+                "ts": datetime.now(timezone.utc).isoformat(),
+                "model": model,
+                "allowed": allowed,
+                "raw_response": raw_text[:200],
+                "parsed": normalized,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cost_usd": round(cost, 6),
+                "elapsed_ms": elapsed_ms,
+            },
+            base_dir=telemetry_dir,
+        )
+
+        if normalized == "UNKNOWN" or normalized not in allowed:
+            raise MissingSignal(
+                "ambiguous",
+                f"model returned {normalized!r} not in allowed {allowed}",
+            )
+        return normalized
+
+    return _call

--- a/tests/test_llm_interpreter.py
+++ b/tests/test_llm_interpreter.py
@@ -1,0 +1,234 @@
+"""test_llm_interpreter — Anthropic haiku interpreter 검증.
+
+테스트 전략:
+    실제 SDK 호출은 절대 안 함. mock client 주입으로 round-trip 검증.
+    - 정상 응답 → allowed enum 매칭
+    - UNKNOWN 응답 → MissingSignal('ambiguous')
+    - allowed 외 응답 → MissingSignal('ambiguous')
+    - empty content → MissingSignal('ambiguous')
+    - API 예외 → RuntimeError
+    - telemetry 기록 검증 (DCNESS_LLM_TELEMETRY=1)
+    - telemetry 비활성 검증 (DCNESS_LLM_TELEMETRY=0)
+    - signal_io.interpret_signal 통합 (interpreter= 주입)
+
+대 원칙 정합:
+    - 형식 강제 0: 시스템 prompt 가 *권고* 형식 (allowed enum) — agent prose 자유 emit
+    - 작업 영역: 외부 API 호출. 실 호출 안 하고 mock 검증.
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+from harness.llm_interpreter import (
+    DEFAULT_MODEL,
+    MAX_PROSE_TAIL_CHARS,
+    make_haiku_interpreter,
+)
+from harness.signal_io import MissingSignal, interpret_signal
+
+
+def _make_mock_response(text: str, input_tokens: int = 80, output_tokens: int = 5):
+    """Anthropic SDK 응답 객체 흉내."""
+    block = MagicMock()
+    block.type = "text"
+    block.text = text
+
+    response = MagicMock()
+    response.content = [block]
+
+    usage = MagicMock()
+    usage.input_tokens = input_tokens
+    usage.output_tokens = output_tokens
+    response.usage = usage
+
+    return response
+
+
+def _make_mock_client(text: str, **usage_kwargs):
+    client = MagicMock()
+    client.messages.create.return_value = _make_mock_response(text, **usage_kwargs)
+    return client
+
+
+class HappyPathTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.tele = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_returns_matched_label(self) -> None:
+        client = _make_mock_client("PASS")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        result = fn("검증 결과 모두 통과", ["PASS", "FAIL", "SPEC_MISSING"])
+        self.assertEqual(result, "PASS")
+
+    def test_lowercase_response_normalized(self) -> None:
+        client = _make_mock_client("fail")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        result = fn("스펙 위반", ["PASS", "FAIL"])
+        self.assertEqual(result, "FAIL")
+
+    def test_extra_punctuation_stripped(self) -> None:
+        client = _make_mock_client("PASS.")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        result = fn("ok", ["PASS", "FAIL"])
+        self.assertEqual(result, "PASS")
+
+    def test_first_word_only(self) -> None:
+        client = _make_mock_client("PASS — verification complete")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        result = fn("ok", ["PASS", "FAIL"])
+        self.assertEqual(result, "PASS")
+
+
+class AmbiguousResponseTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.tele = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_unknown_raises_ambiguous(self) -> None:
+        client = _make_mock_client("UNKNOWN")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        with self.assertRaises(MissingSignal) as ctx:
+            fn("모호한 prose", ["PASS", "FAIL"])
+        self.assertEqual(ctx.exception.reason, "ambiguous")
+
+    def test_out_of_allowed_raises_ambiguous(self) -> None:
+        client = _make_mock_client("MAYBE")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        with self.assertRaises(MissingSignal) as ctx:
+            fn("?", ["PASS", "FAIL"])
+        self.assertEqual(ctx.exception.reason, "ambiguous")
+        self.assertIn("MAYBE", str(ctx.exception))
+
+    def test_empty_content_raises_ambiguous(self) -> None:
+        client = _make_mock_client("")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        with self.assertRaises(MissingSignal) as ctx:
+            fn("?", ["PASS"])
+        self.assertEqual(ctx.exception.reason, "ambiguous")
+
+
+class ApiFailureTests(unittest.TestCase):
+    def test_api_exception_wrapped_runtime_error(self) -> None:
+        client = MagicMock()
+        client.messages.create.side_effect = RuntimeError("rate limit")
+        fn = make_haiku_interpreter(client=client)
+        with self.assertRaises(RuntimeError) as ctx:
+            fn("text", ["PASS"])
+        self.assertIn("Anthropic API 호출 실패", str(ctx.exception))
+
+
+class ValidationTests(unittest.TestCase):
+    def test_empty_allowed_raises(self) -> None:
+        client = _make_mock_client("PASS")
+        fn = make_haiku_interpreter(client=client)
+        with self.assertRaises(ValueError):
+            fn("text", [])
+
+
+class TelemetryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.tele = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+        os.environ.pop("DCNESS_LLM_TELEMETRY", None)
+
+    def test_records_jsonl_event(self) -> None:
+        client = _make_mock_client("PASS", input_tokens=120, output_tokens=2)
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        fn("text", ["PASS", "FAIL"])
+
+        log_path = self.tele / "meta-llm-calls.jsonl"
+        self.assertTrue(log_path.exists())
+
+        lines = log_path.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(len(lines), 1)
+        event = json.loads(lines[0])
+
+        self.assertEqual(event["model"], DEFAULT_MODEL)
+        self.assertEqual(event["allowed"], ["PASS", "FAIL"])
+        self.assertEqual(event["parsed"], "PASS")
+        self.assertEqual(event["input_tokens"], 120)
+        self.assertEqual(event["output_tokens"], 2)
+        # 비용 = 120 * 1e-6 + 2 * 5e-6 = 1.3e-4
+        self.assertAlmostEqual(event["cost_usd"], 0.00013, places=6)
+
+    def test_telemetry_disabled_via_env(self) -> None:
+        os.environ["DCNESS_LLM_TELEMETRY"] = "0"
+        client = _make_mock_client("PASS")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        fn("text", ["PASS"])
+        log_path = self.tele / "meta-llm-calls.jsonl"
+        self.assertFalse(log_path.exists())
+
+    def test_records_cost_for_ambiguous_too(self) -> None:
+        # ambiguous 도 호출은 발생 → 비용 기록은 남아야 (proposal R8)
+        client = _make_mock_client("UNKNOWN", input_tokens=80, output_tokens=2)
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        with self.assertRaises(MissingSignal):
+            fn("text", ["PASS"])
+        log_path = self.tele / "meta-llm-calls.jsonl"
+        self.assertTrue(log_path.exists())
+
+
+class SignalIoIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.tele = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_interpret_signal_uses_haiku_interpreter(self) -> None:
+        client = _make_mock_client("PASS")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        result = interpret_signal("자유 prose", ["PASS", "FAIL"], interpreter=fn)
+        self.assertEqual(result, "PASS")
+
+    def test_interpret_signal_propagates_ambiguous(self) -> None:
+        client = _make_mock_client("UNKNOWN")
+        fn = make_haiku_interpreter(client=client, telemetry_dir=self.tele)
+        with self.assertRaises(MissingSignal):
+            interpret_signal("자유 prose", ["PASS", "FAIL"], interpreter=fn)
+
+
+class PromptConstructionTests(unittest.TestCase):
+    def test_long_prose_truncated_to_tail(self) -> None:
+        client = _make_mock_client("PASS")
+        fn = make_haiku_interpreter(client=client)
+        long_prose = "X" * 50_000 + " conclusion: PASS"
+        fn(long_prose, ["PASS"])
+
+        # mock client.messages.create 호출 시 user content 검사
+        call = client.messages.create.call_args
+        user_content = call.kwargs["messages"][0]["content"]
+        self.assertLessEqual(len(user_content), MAX_PROSE_TAIL_CHARS + 200)
+        self.assertIn("conclusion: PASS", user_content)
+
+    def test_system_prompt_lists_allowed(self) -> None:
+        client = _make_mock_client("PASS")
+        fn = make_haiku_interpreter(client=client)
+        fn("text", ["PASS", "FAIL", "SPEC_MISSING"])
+        call = client.messages.create.call_args
+        system = call.kwargs["system"]
+        self.assertIn("PASS", system)
+        self.assertIn("FAIL", system)
+        self.assertIn("SPEC_MISSING", system)
+        self.assertIn("UNKNOWN", system)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Phase 3 iter 3 — \`harness/signal_io.py\` 의 \`interpret_signal(..., interpreter=)\` swap point 에 주입할 Anthropic Claude haiku interpreter 구현.
- proposal §3 메커니즘 (메타 LLM 1 호출) + R8 telemetry 누적 시작.
- 16 신규 테스트 모두 PASS, 실 SDK 호출 0 (mock client DI).

## Task-ID
\`DCN-CHG-20260429-22\`

## Change-Type
- [x] \`harness\` (harness/llm_interpreter.py)
- [x] \`test\` (tests/test_llm_interpreter.py)
- [x] \`docs-only\` (.gitignore, PROGRESS, record/rationale)

## Document Sync Checklist
- [x] \`document_update_record.md\` 갱신
- [x] \`change_rationale_history.md\` 갱신 (harness 카테고리)
- [x] \`PROGRESS.md\` 갱신 (harness 카테고리)
- [x] harness deliverable: \`tests/test_llm_interpreter.py\` 동반 ✅
- [x] \`node scripts/check_document_sync.mjs\` PASS

## Test Plan
- [x] 16 신규 테스트 PASS (Happy / Ambiguous / API failure / Validation / Telemetry / signal_io 통합 / Prompt construction)
- [x] 전체 45/45 PASS (회귀 0)
- [x] mock client DI — 실 ANTHROPIC_API_KEY 불필요
- [ ] (운영자 수동) 실 API 1회 호출 검증 — secrets 정책으로 자동화 미실시

🤖 Generated with [Claude Code](https://claude.com/claude-code)