### PR TITLE
feat: harness/session_state.py 신규 — 멀티세션 격리 API (DCN-CHG-20260429-30)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,14 @@
 
 ## 현재 상태
 
+- **🚀 Conveyor 인프라 Step 1 — `harness/session_state.py` 신규** (`DCN-CHG-20260429-30`):
+  - OMC `SkillActiveStateV2` (active_runs map, soft tombstone, heartbeat) + RWH `_meta` envelope + 3-tier resolution (글로벌 폴백 제외) + atomic write (O_EXCL+fsync+rename+dir fsync, 0o600) 차용.
+  - 14 함수 export — session_id 검증/추출/resolution, session pointer R/W, run_id 생성, atomic_write, session_dir/run_dir/live_path, read_live/update_live, start_run/update_current_step/complete_run, cleanup_stale_runs.
+  - 49 신규 테스트 (전체 101/101 PASS).
+  - **컨베이어 spec** (`docs/conveyor-design.md` PR #29) 의 첫 코드 구현. 후속 Task 들 (-31 impl_driver / -32 SessionStart hook / -33 catastrophic-gate hook) 의 인프라 기반.
+- **🎯 Conveyor 디자인 spec — `docs/conveyor-design.md`** (`DCN-CHG-20260429-29`, PR #29 머지):
+  - 메인 클로드 = 시퀀스 결정자, 컨베이어 = 멍청한 순회기, catastrophic = PreToolUse 훅. 12 절 660 줄.
+  - PR #28 (옵션 c JSON 결정자) close 후 새 spec. proposal §2.5 (prose-only) 정합.
 - 거버넌스 시스템 부트스트랩 완료 (`DCN-CHG-20260429-01`, PR #1 머지)
 - 프로젝트 루트 `CLAUDE.md` + 루트 정책 파일 게이트 분류 추가 (`DCN-CHG-20260429-02`)
 - **Plugin 배포 인프라**: `.claude-plugin/{plugin,marketplace}.json` (`DCN-CHG-20260429-04`)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,32 @@
 
 ## Records
 
+### DCN-CHG-20260429-30
+- **Date**: 2026-04-29
+- **Rationale**:
+  - `docs/conveyor-design.md` (DCN-CHG-20260429-29 PR #29 머지) spec 의 첫 코드 구현 단계. 컨베이어 / 훅 / impl_driver 모두 본 모듈의 session_id / run_id / live.json API 에 의존 → **인프라 우선 박음**.
+  - 멀티세션 기본 가정 (사용자가 동시 다중 세션 띄움) → 격리 메커니즘 필수. OMC `SkillActiveStateV2` (active_runs map 다중 슬롯 + soft tombstone + heartbeat) + RWH `_meta` envelope (자기참조 sessionId 검증) + 3-tier resolution (env > pointer, 글로벌 폴백 제외) 차용.
+  - atomic write 는 `signal_io.write_prose` 의 단순 `os.replace` 대비 강화 — POSIX O_EXCL+fsync+rename+dir fsync 4 단계로 race 0 + 디스크 fault tolerance + 0o600 권한 (다중 사용자 머신 보호).
+- **Alternatives**:
+  1. *RWH 단일 active_state + 자기참조* — 동시 다중 run 미지원. 한 세션에 백그라운드 ralph + foreground quick 띄우는 시나리오 막힘. 기각.
+  2. *OMC active_skills map 만 + RWH 차용 0* — `_meta` envelope + atomic write 누락 → leftover 방어 약화. 기각.
+  3. *글로벌 ~/.claude pointer 폴백 도입 (RWH issue #19)* — dcNess 자체 도그푸딩 시 SessionStart 훅 미적용 환경 대응. 4-가드 복잡도 vs 도그푸딩 가치 trade-off 검토 후 미채택. dcNess 자체 SessionStart 훅 작성으로 우회 가능. 기각.
+  4. *(채택)* **OMC active_runs + RWH `_meta` envelope + atomic write + 2-tier resolution (글로벌 폴백 제외)**. conveyor-design.md §6 차용 표 정합.
+- **Decision**:
+  - 모듈 export 14 함수 + 4 상수.
+  - **session_id**: OMC regex `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$`, OMC 3 변형 stdin (sessionId/session_id/sessionid), 2-tier resolution (env > pointer).
+  - **run_id**: `run-{token_hex(4)}` 8 hex chars 정형 (RUN_ID_RE 검증). 16M 조합 → sid 안 충돌 사실상 0. 1000회 충돌 테스트 PASS.
+  - **atomic_write**: O_EXCL (충돌 시 raise) + tmp 파일명 `{name}.tmp.{pid}.{uuid8}` (race-safe) + fsync + rename + dir fsync. 0o600 기본. 일부 파일시스템 (tmpfs) 의 dir fsync 미지원은 silent ignore.
+  - **live.json envelope**: `_meta.sessionId/writtenAt/version` + top-level `session_id` 자기참조. read 시 sessionId 불일치면 leftover 로 거부 (빈 dict). update 시 `_meta` 항상 갱신 (옛 envelope 신뢰 0).
+  - **active_runs slot 필드**: run_id, entry_point, started_at, last_confirmed_at, completed_at, run_dir, current_step, issue_num.
+  - **cleanup**: completed+24h 또는 heartbeat dead+24h 슬롯 삭제. ttl_sec 인자로 조정 가능.
+- **Follow-Up**:
+  - **Task -31**: `harness/orchestration_agent.py` 폐기 + `harness/impl_driver.py` 새로 작성 (~50 줄). 본 모듈의 start_run / update_current_step / complete_run 사용.
+  - **Task -32**: `hooks/session-start.sh` (stdin → sid 추출 → write_session_pointer + update_live 초기화) 신규. 본 모듈 함수 호출.
+  - **Task -33**: `hooks/catastrophic-gate.sh` PreToolUse Agent 훅 신규. current_session_id + run_dir 으로 prose 종이 검사.
+  - **Task -34** (선택): `signal_io.write_prose` 의 atomic write 를 본 모듈의 atomic_write 로 교체.
+  - **회귀 위험**: 본 API 가 후속 모듈/훅의 인터페이스 spec 이 됨. signature 변경 시 cascade 영향 — major version 변경 또는 backward-compat alias 필수.
+
 ### DCN-CHG-20260429-29
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,18 @@
 
 ## Records
 
+### DCN-CHG-20260429-30
+- **Date**: 2026-04-29
+- **Change-Type**: harness, test, docs-only
+- **Files Changed**:
+  - `harness/session_state.py` (신규, ~370 LOC) — OMC+RWH 차용 세션/run 격리 API
+  - `tests/test_session_state.py` (신규, 49 케이스) — session_id / pointer / atomic write / live.json envelope / active_runs / cleanup
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: `docs/conveyor-design.md` §4/§6/§9 spec 의 첫 코드 구현. session_id resolution 2-tier (env > project pointer, 글로벌 폴백 제외) + regex 검증 (OMC) + run_id `run-{token_hex(4)}` + atomic write (O_EXCL+fsync+rename+dir fsync, 0o600 RWH 패턴) + live.json with `_meta` envelope (RWH 자기참조 sessionId 검증) + active_runs map (OMC SkillActiveStateV2 차용, soft tombstone, heartbeat) + cleanup_stale_runs (24h TTL). 101/101 tests PASS (52 기존 + 49 신규). 회귀 0.
+- **Document-Exception**: 없음 (harness 카테고리 deliverable = `tests/**` 동반 ✅)
+
 ### DCN-CHG-20260429-29
 - **Date**: 2026-04-29
 - **Change-Type**: docs-only

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1,0 +1,503 @@
+"""session_state.py — 세션/run 격리 상태 API (멀티세션 기본 가정).
+
+발상 (`docs/conveyor-design.md` §4 / §6 / §9):
+    Claude Code 가 세션 단위 동작 → 한 사용자가 동시 다중 세션 띄울 수 있음.
+    각 세션 안에서 컨베이어가 다중 run 가능 (예: 백그라운드 ralph + foreground quick).
+    sid × run_id 별 격리된 디렉토리 구조 + `_meta` envelope 으로 leftover 방어.
+
+본 모듈은 다음을 단일 책임으로 묶는다:
+    1. session_id 검증 + resolution (3-tier: env → project pointer; 글로벌 폴백 제외)
+    2. session pointer 파일 (`.session-id`) 읽기/쓰기
+    3. run_id 생성 (`run-{token_hex(4)}`)
+    4. atomic write (O_EXCL+fsync+rename+dir fsync, 0o600 — RWH 패턴)
+    5. live.json 스키마 + active_runs map 조작 (OMC `SkillActiveStateV2` 차용)
+
+OMC + RWH 차용 매핑:
+    - regex `^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$`           ← OMC SESSION_ID_ALLOWLIST
+    - stdin 3 변형 fallback (sessionId/session_id/sessionid) ← OMC
+    - 3-tier resolution (env > pointer)                    ← RWH (글로벌 폴백 제외)
+    - `_meta` envelope + 자기참조 sessionId 검증            ← RWH
+    - atomic write O_EXCL+fsync+rename+dir fsync           ← RWH
+    - active_runs map + soft tombstone                     ← OMC SkillActiveStateV2
+
+핵심 상수:
+    SESSION_ID_RE       : path traversal 방어
+    DEFAULT_RUN_TTL_SEC : run 슬롯 stale 기준 (24h)
+    LIVE_JSON_VERSION   : 스키마 진화 추적
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import select
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+__all__ = [
+    "SESSION_ID_RE",
+    "DEFAULT_RUN_TTL_SEC",
+    "LIVE_JSON_VERSION",
+    "STDIN_TIMEOUT_SEC",
+    "valid_session_id",
+    "session_id_from_stdin",
+    "current_session_id",
+    "read_session_pointer",
+    "write_session_pointer",
+    "generate_run_id",
+    "atomic_write",
+    "session_dir",
+    "run_dir",
+    "live_path",
+    "read_live",
+    "update_live",
+    "start_run",
+    "update_current_step",
+    "complete_run",
+    "cleanup_stale_runs",
+]
+
+# ── 상수 ─────────────────────────────────────────────────────────────
+SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$")
+RUN_ID_RE = re.compile(r"^run-[a-z0-9]{8}$")
+
+DEFAULT_RUN_TTL_SEC = 24 * 60 * 60        # 24h — completed slot 보관 후 cleanup
+LIVE_JSON_VERSION = 1                      # 스키마 진화 추적
+STDIN_TIMEOUT_SEC = 2.0                    # 훅 stdin 읽기 hang 방지
+_ATOMIC_FILE_MODE = 0o600
+
+
+# ── 경로 유틸 ───────────────────────────────────────────────────────
+
+
+def _default_base() -> Path:
+    return Path.cwd() / ".claude" / "harness-state"
+
+
+def _resolve_base(base_dir: Optional[Path]) -> Path:
+    if base_dir is None:
+        return _default_base().resolve()
+    if not isinstance(base_dir, (str, Path)):
+        raise TypeError(f"base_dir must be Path or str, got {type(base_dir).__name__}")
+    return Path(base_dir).resolve()
+
+
+def session_dir(
+    session_id: str, *, base_dir: Optional[Path] = None, create: bool = False
+) -> Path:
+    """`.sessions/{sid}/` 절대 경로."""
+    if not valid_session_id(session_id):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+    base = _resolve_base(base_dir)
+    target = (base / ".sessions" / session_id).resolve()
+    # path traversal 방어
+    try:
+        target.relative_to(base)
+    except ValueError as e:
+        raise ValueError(f"path escape: {target} not under {base}") from e
+    if create:
+        target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def run_dir(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+    create: bool = False,
+) -> Path:
+    """`.sessions/{sid}/runs/{run_id}/` 절대 경로."""
+    if not RUN_ID_RE.match(run_id):
+        raise ValueError(
+            f"invalid run_id: {run_id!r} (expected format: run-{{8 hex chars}})"
+        )
+    target = (session_dir(session_id, base_dir=base_dir) / "runs" / run_id).resolve()
+    if create:
+        target.mkdir(parents=True, exist_ok=True)
+    return target
+
+
+def live_path(session_id: str, *, base_dir: Optional[Path] = None) -> Path:
+    """`.sessions/{sid}/live.json` 경로 — 읽기 전용 (디렉토리 미생성)."""
+    return session_dir(session_id, base_dir=base_dir) / "live.json"
+
+
+def _pointer_path(base_dir: Optional[Path] = None) -> Path:
+    return _resolve_base(base_dir) / ".session-id"
+
+
+# ── session_id 검증 ─────────────────────────────────────────────────
+
+
+def valid_session_id(sid: Any) -> bool:
+    """OMC 패턴 — path traversal 방어."""
+    if not isinstance(sid, str):
+        return False
+    return bool(SESSION_ID_RE.match(sid))
+
+
+def session_id_from_stdin(
+    data: Optional[Dict[str, Any]] = None,
+    timeout_sec: float = STDIN_TIMEOUT_SEC,
+) -> str:
+    """훅 stdin 또는 파싱된 dict 에서 session_id 추출.
+
+    OMC 패턴 — 3 변형 fallback (sessionId / session_id / sessionid).
+    검증 실패 시 빈 문자열.
+
+    Args:
+        data: 이미 파싱된 dict. None 이면 stdin 직접 read.
+        timeout_sec: stdin 읽기 타임아웃 (hang 방지).
+    """
+    d: Optional[Dict[str, Any]] = data
+    if d is None:
+        try:
+            if sys.stdin.isatty():
+                return ""
+            if timeout_sec > 0:
+                ready, _, _ = select.select([sys.stdin], [], [], timeout_sec)
+                if not ready:
+                    return ""
+            raw = sys.stdin.read()
+            d = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError, ValueError):
+            return ""
+    if not isinstance(d, dict):
+        return ""
+    sid = d.get("session_id") or d.get("sessionId") or d.get("sessionid") or ""
+    return sid if valid_session_id(sid) else ""
+
+
+def current_session_id(*, base_dir: Optional[Path] = None) -> str:
+    """현재 세션 ID resolution — 2-tier (RWH 3-tier 의 글로벌 폴백 제외).
+
+    1. `DCNESS_SESSION_ID` env (subprocess 전파, 가장 권위)
+    2. `.claude/harness-state/.session-id` pointer (SessionStart 훅이 작성)
+
+    실패 시 빈 문자열. 호출자가 빈 문자열 처리 책임.
+    """
+    sid = os.environ.get("DCNESS_SESSION_ID", "")
+    if valid_session_id(sid):
+        return sid
+    return read_session_pointer(base_dir=base_dir)
+
+
+def read_session_pointer(*, base_dir: Optional[Path] = None) -> str:
+    """`.session-id` pointer 파일 읽기. 검증 실패 시 빈 문자열."""
+    path = _pointer_path(base_dir)
+    try:
+        if not path.exists():
+            return ""
+        sid = path.read_text(encoding="utf-8").strip()
+        return sid if valid_session_id(sid) else ""
+    except OSError:
+        return ""
+
+
+def write_session_pointer(
+    session_id: str, *, base_dir: Optional[Path] = None
+) -> Path:
+    """`.session-id` pointer atomic 작성."""
+    if not valid_session_id(session_id):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+    target = _pointer_path(base_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(target, session_id.encode("utf-8"))
+    return target
+
+
+# ── run_id 생성 ──────────────────────────────────────────────────────
+
+
+def generate_run_id() -> str:
+    """`run-{token_hex(4)}` — 16M 조합, sid 안 충돌 사실상 0."""
+    return f"run-{secrets.token_hex(4)}"
+
+
+# ── atomic write (O_EXCL+fsync+rename+dir fsync, 0o600) ─────────────
+
+
+def atomic_write(
+    target: Path, content: bytes, *, mode: int = _ATOMIC_FILE_MODE
+) -> None:
+    """RWH 패턴 — POSIX atomic 보장.
+
+    1. tmp 파일 (O_EXCL — 같은 이름 충돌 시 raise)
+    2. write + fsync
+    3. close
+    4. rename (atomic)
+    5. dir fsync (POSIX 강제)
+
+    Args:
+        target: 최종 파일 경로.
+        content: bytes.
+        mode: 0o600 기본 (소유자만).
+    """
+    if not isinstance(content, (bytes, bytearray)):
+        raise TypeError(f"content must be bytes, got {type(content).__name__}")
+    target = Path(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    # unique tmp 이름 — O_EXCL 충돌 회피 + race-safe
+    tmp_name = f"{target.name}.tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}"
+    tmp = target.parent / tmp_name
+
+    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
+    try:
+        os.write(fd, bytes(content))
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+    try:
+        os.replace(tmp, target)  # POSIX atomic rename
+    except OSError:
+        # 정리: tmp 가 남았으면 제거
+        try:
+            tmp.unlink()
+        except OSError:
+            pass
+        raise
+
+    # dir fsync — 새 entry 가 디스크에 박히도록 (POSIX 권장)
+    try:
+        dir_fd = os.open(str(target.parent), os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        # 일부 파일시스템 (tmpfs 등) 은 dir fsync 미지원 — 무시
+        pass
+
+
+# ── live.json read / update ──────────────────────────────────────────
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _make_meta(session_id: str) -> Dict[str, Any]:
+    return {
+        "sessionId": session_id,
+        "writtenAt": _now_iso(),
+        "version": LIVE_JSON_VERSION,
+    }
+
+
+def read_live(
+    session_id: str, *, base_dir: Optional[Path] = None
+) -> Dict[str, Any]:
+    """live.json 읽기 + `_meta.sessionId` 자기참조 검증.
+
+    소유자 불일치 (`_meta.sessionId` ≠ session_id) 면 빈 dict 반환 — leftover 방어.
+    파일 미존재 / 파싱 실패 시 빈 dict.
+    """
+    if not valid_session_id(session_id):
+        return {}
+    path = live_path(session_id, base_dir=base_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    meta = data.get("_meta", {})
+    if not isinstance(meta, dict):
+        return {}
+    meta_sid = meta.get("sessionId", "")
+    if meta_sid and meta_sid != session_id:
+        # 다른 세션이 같은 경로에 덮어쓰기 시도 → 거부
+        return {}
+    return data
+
+
+def update_live(
+    session_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+    **fields: Any,
+) -> None:
+    """live.json 의 top-level 필드 read-merge-atomic-write.
+
+    `_meta` 와 `session_id` 자기참조는 항상 갱신.
+    값이 None 이면 필드 삭제 (단 `active_runs` 같은 dict 는 그대로 유지 — `**fields` 가 None 일 때만 pop).
+    """
+    if not valid_session_id(session_id):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+
+    current = read_live(session_id, base_dir=base_dir) or {}
+    # `_meta` 는 항상 새로 작성. 옛 envelope 신뢰 안 함.
+    current.pop("_meta", None)
+
+    for k, v in fields.items():
+        if v is None:
+            current.pop(k, None)
+        else:
+            current[k] = v
+
+    current["session_id"] = session_id
+    current["_meta"] = _make_meta(session_id)
+    if "active_runs" not in current:
+        current["active_runs"] = {}
+
+    payload = json.dumps(current, ensure_ascii=False, indent=2, sort_keys=True)
+    target = live_path(session_id, base_dir=base_dir)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(target, payload.encode("utf-8"))
+
+
+# ── active_runs map 조작 ────────────────────────────────────────────
+
+
+def _resolve_run_dir_str(
+    session_id: str, run_id: str, base_dir: Optional[Path]
+) -> str:
+    """run_dir 의 문자열 표현 — base_dir 가 cwd 안이면 상대경로, 아니면 절대."""
+    rd = run_dir(session_id, run_id, base_dir=base_dir)
+    try:
+        return str(rd.relative_to(Path.cwd()))
+    except ValueError:
+        return str(rd)
+
+
+def start_run(
+    session_id: str,
+    run_id: str,
+    entry_point: str,
+    *,
+    base_dir: Optional[Path] = None,
+    issue_num: Optional[int] = None,
+) -> None:
+    """`active_runs[run_id]` 슬롯 추가 + run 디렉토리 생성.
+
+    이미 존재하면 ValueError (중복 run_id 방어).
+    """
+    if not valid_session_id(session_id):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+    if not RUN_ID_RE.match(run_id):
+        raise ValueError(f"invalid run_id: {run_id!r}")
+    if not isinstance(entry_point, str) or not entry_point:
+        raise ValueError("entry_point must be non-empty str")
+
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict):
+        active = {}
+    if run_id in active:
+        raise ValueError(f"run_id already active: {run_id}")
+
+    now = _now_iso()
+    active[run_id] = {
+        "run_id": run_id,
+        "entry_point": entry_point,
+        "started_at": now,
+        "last_confirmed_at": now,
+        "completed_at": None,
+        "run_dir": _resolve_run_dir_str(session_id, run_id, base_dir),
+        "current_step": None,
+        "issue_num": issue_num,
+    }
+    update_live(session_id, base_dir=base_dir, active_runs=active)
+    # run 디렉토리 생성
+    run_dir(session_id, run_id, base_dir=base_dir, create=True)
+
+
+def update_current_step(
+    session_id: str,
+    run_id: str,
+    agent: str,
+    mode: Optional[str],
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """`active_runs[run_id].current_step` 갱신 + heartbeat (`last_confirmed_at`)."""
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict) or run_id not in active:
+        raise ValueError(f"run_id not active: {run_id}")
+    slot = dict(active[run_id])
+    now = _now_iso()
+    slot["current_step"] = {
+        "agent": agent,
+        "mode": mode,
+        "started_at": now,
+    }
+    slot["last_confirmed_at"] = now
+    active[run_id] = slot
+    update_live(session_id, base_dir=base_dir, active_runs=active)
+
+
+def complete_run(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """`active_runs[run_id].completed_at` 채움 (soft tombstone — 즉시 삭제 X)."""
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict) or run_id not in active:
+        return  # idempotent — 이미 없으면 noop
+    slot = dict(active[run_id])
+    now = _now_iso()
+    slot["completed_at"] = now
+    slot["last_confirmed_at"] = now
+    slot["current_step"] = None
+    active[run_id] = slot
+    update_live(session_id, base_dir=base_dir, active_runs=active)
+
+
+def cleanup_stale_runs(
+    session_id: str,
+    *,
+    ttl_sec: int = DEFAULT_RUN_TTL_SEC,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """다음 슬롯 삭제:
+        1. `completed_at` 채워진 + ttl_sec 초과한 슬롯
+        2. `last_confirmed_at` 이 ttl_sec 초과한 슬롯 (heartbeat dead)
+
+    Returns: 삭제된 슬롯 수.
+    """
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict):
+        return 0
+
+    now = datetime.now(timezone.utc)
+    removed = 0
+    survivors: Dict[str, Any] = {}
+
+    for rid, slot in active.items():
+        if not isinstance(slot, dict):
+            continue
+        completed_at = slot.get("completed_at")
+        last_confirmed = slot.get("last_confirmed_at")
+
+        candidate_iso = completed_at or last_confirmed
+        if not candidate_iso:
+            survivors[rid] = slot
+            continue
+        try:
+            ts = datetime.fromisoformat(str(candidate_iso))
+        except ValueError:
+            survivors[rid] = slot
+            continue
+        age_sec = (now - ts).total_seconds()
+        if age_sec > ttl_sec:
+            removed += 1
+        else:
+            survivors[rid] = slot
+
+    if removed:
+        update_live(session_id, base_dir=base_dir, active_runs=survivors)
+    return removed

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1,0 +1,547 @@
+"""test_session_state — 세션/run 격리 상태 API 검증.
+
+Coverage matrix:
+    valid_session_id:
+        - valid (영숫자 / 하이픈 / 언더스코어 with leading alphanumeric)
+        - invalid (empty / leading underscore / space / dot / non-str / 256+ chars)
+
+    session_id_from_stdin:
+        - 3 변형 (sessionId / session_id / sessionid)
+        - 빈 dict / 잘못된 타입 / 잘못된 sid 형식
+        - data= 전달 시 stdin read 스킵
+
+    current_session_id (env > pointer):
+        - env 있음 → env
+        - env 빈 + pointer 있음 → pointer
+        - 둘 다 빈 → ""
+        - env 잘못된 → pointer
+
+    read_session_pointer:
+        - 정상 / 미존재 / 잘못된 sid
+
+    write_session_pointer:
+        - 작성 + 0o600 권한
+        - 잘못된 sid → ValueError
+
+    generate_run_id:
+        - 형식 (run-{8 hex})
+        - 충돌 없음 (1000회)
+
+    atomic_write:
+        - 파일 생성 + 권한 + 내용
+        - tmp residue 없음
+        - bytes 외 타입 → TypeError
+
+    session_dir / run_dir / live_path:
+        - 정상 경로
+        - path traversal 차단
+        - run_id 형식 검증
+
+    read_live:
+        - envelope 자기참조 일치 → 데이터 반환
+        - sessionId 불일치 → 빈 dict (leftover 방어)
+        - 미존재 / 잘못된 JSON → 빈 dict
+
+    update_live:
+        - _meta 항상 갱신
+        - session_id 자기참조 박힘
+        - 필드 None 시 삭제
+        - active_runs 디폴트 빈 dict
+
+    start_run / update_current_step / complete_run:
+        - 슬롯 lifecycle
+        - 중복 run_id → ValueError
+        - 미활성 run_id update → ValueError
+        - complete idempotent
+
+    cleanup_stale_runs:
+        - completed+ttl 초과 삭제
+        - heartbeat ttl 초과 삭제
+        - 신선 슬롯 보존
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from harness.session_state import (
+    DEFAULT_RUN_TTL_SEC,
+    LIVE_JSON_VERSION,
+    SESSION_ID_RE,
+    atomic_write,
+    cleanup_stale_runs,
+    complete_run,
+    current_session_id,
+    generate_run_id,
+    live_path,
+    read_live,
+    read_session_pointer,
+    run_dir,
+    session_dir,
+    session_id_from_stdin,
+    start_run,
+    update_current_step,
+    update_live,
+    valid_session_id,
+    write_session_pointer,
+)
+
+
+# ---------------------------------------------------------------------------
+# valid_session_id
+# ---------------------------------------------------------------------------
+
+
+class ValidSessionIdTests(unittest.TestCase):
+    def test_valid_examples(self) -> None:
+        for sid in ["abc-def-123", "A1", "x", "abcDEF_123-xyz", "z" * 256]:
+            self.assertTrue(valid_session_id(sid), f"should accept: {sid!r}")
+
+    def test_invalid_examples(self) -> None:
+        invalids = [
+            "",
+            "_starts_underscore",
+            "-starts-hyphen",
+            "with space",
+            "with.dot",
+            "../path",
+            "x" * 257,
+            None,
+            42,
+            ["list"],
+        ]
+        for sid in invalids:
+            self.assertFalse(valid_session_id(sid), f"should reject: {sid!r}")
+
+
+# ---------------------------------------------------------------------------
+# session_id_from_stdin (data= 인자만 — stdin read 는 별도)
+# ---------------------------------------------------------------------------
+
+
+class SessionIdFromStdinTests(unittest.TestCase):
+    def test_session_id_variant(self) -> None:
+        self.assertEqual(
+            session_id_from_stdin(data={"session_id": "abc-123"}),
+            "abc-123",
+        )
+
+    def test_sessionId_variant(self) -> None:
+        self.assertEqual(
+            session_id_from_stdin(data={"sessionId": "abc-123"}),
+            "abc-123",
+        )
+
+    def test_sessionid_variant(self) -> None:
+        self.assertEqual(
+            session_id_from_stdin(data={"sessionid": "abc-123"}),
+            "abc-123",
+        )
+
+    def test_priority_session_id_over_sessionId(self) -> None:
+        # session_id 가 첫 우선
+        result = session_id_from_stdin(
+            data={"session_id": "first", "sessionId": "second"}
+        )
+        self.assertEqual(result, "first")
+
+    def test_invalid_sid_returns_empty(self) -> None:
+        self.assertEqual(
+            session_id_from_stdin(data={"session_id": "../bad"}), ""
+        )
+
+    def test_empty_dict_returns_empty(self) -> None:
+        self.assertEqual(session_id_from_stdin(data={}), "")
+
+    def test_non_dict_data_returns_empty(self) -> None:
+        self.assertEqual(session_id_from_stdin(data="string"), "")
+        self.assertEqual(session_id_from_stdin(data=[]), "")
+
+
+# ---------------------------------------------------------------------------
+# current_session_id (env > pointer)
+# ---------------------------------------------------------------------------
+
+
+class CurrentSessionIdTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+        os.environ.pop("DCNESS_SESSION_ID", None)
+
+    def test_env_var_takes_priority(self) -> None:
+        os.environ["DCNESS_SESSION_ID"] = "env-sid"
+        write_session_pointer("pointer-sid", base_dir=self.base)
+        self.assertEqual(
+            current_session_id(base_dir=self.base), "env-sid"
+        )
+
+    def test_pointer_used_when_env_empty(self) -> None:
+        write_session_pointer("pointer-sid", base_dir=self.base)
+        self.assertEqual(
+            current_session_id(base_dir=self.base), "pointer-sid"
+        )
+
+    def test_returns_empty_when_both_missing(self) -> None:
+        self.assertEqual(current_session_id(base_dir=self.base), "")
+
+    def test_invalid_env_falls_to_pointer(self) -> None:
+        os.environ["DCNESS_SESSION_ID"] = "../bad"
+        write_session_pointer("pointer-sid", base_dir=self.base)
+        self.assertEqual(
+            current_session_id(base_dir=self.base), "pointer-sid"
+        )
+
+
+# ---------------------------------------------------------------------------
+# session pointer read/write
+# ---------------------------------------------------------------------------
+
+
+class SessionPointerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_write_then_read(self) -> None:
+        write_session_pointer("abc-sid", base_dir=self.base)
+        self.assertEqual(read_session_pointer(base_dir=self.base), "abc-sid")
+
+    def test_read_missing_returns_empty(self) -> None:
+        self.assertEqual(read_session_pointer(base_dir=self.base), "")
+
+    def test_write_invalid_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            write_session_pointer("../bad", base_dir=self.base)
+
+    def test_pointer_file_permissions(self) -> None:
+        write_session_pointer("abc-sid", base_dir=self.base)
+        path = self.base / ".session-id"
+        # POSIX 만 — Windows 는 0o600 매핑이 다름
+        if os.name == "posix":
+            mode = path.stat().st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+
+
+# ---------------------------------------------------------------------------
+# generate_run_id
+# ---------------------------------------------------------------------------
+
+
+class GenerateRunIdTests(unittest.TestCase):
+    def test_format(self) -> None:
+        rid = generate_run_id()
+        self.assertTrue(rid.startswith("run-"))
+        suffix = rid[4:]
+        self.assertEqual(len(suffix), 8)
+        # all lowercase hex
+        int(suffix, 16)  # would raise if not valid hex
+        self.assertEqual(suffix, suffix.lower())
+
+    def test_uniqueness_in_1000_calls(self) -> None:
+        ids = {generate_run_id() for _ in range(1000)}
+        self.assertEqual(len(ids), 1000)
+
+
+# ---------------------------------------------------------------------------
+# atomic_write
+# ---------------------------------------------------------------------------
+
+
+class AtomicWriteTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_creates_file_with_content(self) -> None:
+        target = self.base / "x.json"
+        atomic_write(target, b'{"a": 1}')
+        self.assertEqual(target.read_bytes(), b'{"a": 1}')
+
+    def test_no_tmp_residue(self) -> None:
+        target = self.base / "x.json"
+        atomic_write(target, b"data")
+        residue = list(self.base.glob("*.tmp.*"))
+        self.assertEqual(residue, [])
+
+    def test_overwrites_existing(self) -> None:
+        target = self.base / "x.json"
+        atomic_write(target, b"v1")
+        atomic_write(target, b"v2")
+        self.assertEqual(target.read_bytes(), b"v2")
+
+    def test_default_permissions_0o600(self) -> None:
+        if os.name != "posix":
+            self.skipTest("0o600 검증은 POSIX 만")
+        target = self.base / "x.json"
+        atomic_write(target, b"data")
+        mode = target.stat().st_mode & 0o777
+        self.assertEqual(mode, 0o600)
+
+    def test_rejects_non_bytes(self) -> None:
+        target = self.base / "x.json"
+        with self.assertRaises(TypeError):
+            atomic_write(target, "string")  # type: ignore[arg-type]
+
+    def test_creates_parent_dir(self) -> None:
+        target = self.base / "deep" / "nested" / "x.json"
+        atomic_write(target, b"data")
+        self.assertTrue(target.exists())
+
+
+# ---------------------------------------------------------------------------
+# session_dir / run_dir / live_path
+# ---------------------------------------------------------------------------
+
+
+class PathHelperTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_session_dir_format(self) -> None:
+        path = session_dir("abc-sid", base_dir=self.base)
+        self.assertEqual(path, (self.base / ".sessions" / "abc-sid").resolve())
+
+    def test_run_dir_format(self) -> None:
+        rid = "run-a3f81b29"
+        path = run_dir("abc", rid, base_dir=self.base)
+        self.assertEqual(
+            path,
+            (self.base / ".sessions" / "abc" / "runs" / rid).resolve(),
+        )
+
+    def test_run_dir_create(self) -> None:
+        path = run_dir("abc", "run-12345678", base_dir=self.base, create=True)
+        self.assertTrue(path.exists())
+
+    def test_session_dir_invalid_sid_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            session_dir("../bad", base_dir=self.base)
+
+    def test_run_dir_invalid_run_id_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            run_dir("abc", "not-a-run-id", base_dir=self.base)
+
+    def test_live_path(self) -> None:
+        path = live_path("abc", base_dir=self.base)
+        self.assertEqual(path.name, "live.json")
+        self.assertEqual(path.parent.name, "abc")
+
+
+# ---------------------------------------------------------------------------
+# read_live / update_live (envelope)
+# ---------------------------------------------------------------------------
+
+
+class LiveJsonTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self.sid = "abc-sid"
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_read_missing_returns_empty(self) -> None:
+        self.assertEqual(read_live(self.sid, base_dir=self.base), {})
+
+    def test_update_then_read_roundtrip(self) -> None:
+        update_live(self.sid, base_dir=self.base, custom_field="hello")
+        data = read_live(self.sid, base_dir=self.base)
+        self.assertEqual(data["custom_field"], "hello")
+        self.assertEqual(data["_meta"]["sessionId"], self.sid)
+        self.assertEqual(data["_meta"]["version"], LIVE_JSON_VERSION)
+        self.assertIn("writtenAt", data["_meta"])
+
+    def test_active_runs_default_empty_dict(self) -> None:
+        update_live(self.sid, base_dir=self.base, foo="bar")
+        data = read_live(self.sid, base_dir=self.base)
+        self.assertEqual(data["active_runs"], {})
+
+    def test_field_none_deletes(self) -> None:
+        update_live(self.sid, base_dir=self.base, x=1, y=2)
+        update_live(self.sid, base_dir=self.base, x=None)
+        data = read_live(self.sid, base_dir=self.base)
+        self.assertNotIn("x", data)
+        self.assertEqual(data["y"], 2)
+
+    def test_cross_session_envelope_rejected(self) -> None:
+        # 다른 세션이 같은 경로에 leftover 남긴 상황 시뮬
+        path = live_path(self.sid, base_dir=self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps({
+                "_meta": {"sessionId": "OTHER-SID", "writtenAt": "x", "version": 1},
+                "session_id": "OTHER-SID",
+                "active_runs": {"run-aaaaaaaa": {"foo": 1}},
+            }),
+            encoding="utf-8",
+        )
+        # read_live 가 다른 sid 의 데이터 거부
+        self.assertEqual(read_live(self.sid, base_dir=self.base), {})
+
+    def test_invalid_json_returns_empty(self) -> None:
+        path = live_path(self.sid, base_dir=self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("not valid json", encoding="utf-8")
+        self.assertEqual(read_live(self.sid, base_dir=self.base), {})
+
+    def test_session_id_self_reference(self) -> None:
+        update_live(self.sid, base_dir=self.base, x=1)
+        data = read_live(self.sid, base_dir=self.base)
+        self.assertEqual(data["session_id"], self.sid)
+
+
+# ---------------------------------------------------------------------------
+# active_runs operations
+# ---------------------------------------------------------------------------
+
+
+class ActiveRunsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self.sid = "abc-sid"
+        self.run_id = "run-12345678"
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_start_run_adds_slot(self) -> None:
+        start_run(
+            self.sid, self.run_id, "quick",
+            base_dir=self.base, issue_num=42,
+        )
+        data = read_live(self.sid, base_dir=self.base)
+        slot = data["active_runs"][self.run_id]
+        self.assertEqual(slot["run_id"], self.run_id)
+        self.assertEqual(slot["entry_point"], "quick")
+        self.assertEqual(slot["issue_num"], 42)
+        self.assertIsNone(slot["completed_at"])
+        self.assertIsNone(slot["current_step"])
+        self.assertIn("started_at", slot)
+        self.assertIn("last_confirmed_at", slot)
+        self.assertIn("run_dir", slot)
+
+    def test_start_run_creates_dir(self) -> None:
+        start_run(self.sid, self.run_id, "quick", base_dir=self.base)
+        rd = run_dir(self.sid, self.run_id, base_dir=self.base)
+        self.assertTrue(rd.exists())
+
+    def test_start_run_duplicate_raises(self) -> None:
+        start_run(self.sid, self.run_id, "quick", base_dir=self.base)
+        with self.assertRaises(ValueError):
+            start_run(self.sid, self.run_id, "quick", base_dir=self.base)
+
+    def test_update_current_step(self) -> None:
+        start_run(self.sid, self.run_id, "quick", base_dir=self.base)
+        update_current_step(
+            self.sid, self.run_id, "engineer", "IMPL",
+            base_dir=self.base,
+        )
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertEqual(slot["current_step"]["agent"], "engineer")
+        self.assertEqual(slot["current_step"]["mode"], "IMPL")
+
+    def test_update_step_unknown_run_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            update_current_step(
+                self.sid, self.run_id, "engineer", "IMPL",
+                base_dir=self.base,
+            )
+
+    def test_complete_run(self) -> None:
+        start_run(self.sid, self.run_id, "quick", base_dir=self.base)
+        complete_run(self.sid, self.run_id, base_dir=self.base)
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertIsNotNone(slot["completed_at"])
+        self.assertIsNone(slot["current_step"])
+
+    def test_complete_run_idempotent_on_missing(self) -> None:
+        # raise 안 함 — noop
+        complete_run(self.sid, self.run_id, base_dir=self.base)
+
+    def test_multiple_active_runs(self) -> None:
+        # 동시 다중 run 지원 검증 (OMC 차용 핵심)
+        start_run(self.sid, "run-aaaaaaaa", "quick", base_dir=self.base)
+        start_run(self.sid, "run-bbbbbbbb", "product-plan", base_dir=self.base)
+        data = read_live(self.sid, base_dir=self.base)
+        self.assertEqual(len(data["active_runs"]), 2)
+
+
+# ---------------------------------------------------------------------------
+# cleanup_stale_runs
+# ---------------------------------------------------------------------------
+
+
+class CleanupStaleRunsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self.sid = "abc-sid"
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _set_slot(self, run_id: str, **overrides) -> None:
+        live = read_live(self.sid, base_dir=self.base) or {}
+        active = live.get("active_runs", {}) or {}
+        active[run_id] = {
+            "run_id": run_id,
+            "entry_point": "quick",
+            "started_at": "2026-04-29T00:00:00+00:00",
+            "last_confirmed_at": "2026-04-29T00:00:00+00:00",
+            "completed_at": None,
+            "run_dir": "x",
+            "current_step": None,
+            "issue_num": None,
+        }
+        active[run_id].update(overrides)
+        update_live(self.sid, base_dir=self.base, active_runs=active)
+
+    def test_removes_completed_old_slot(self) -> None:
+        # 25h 전 완료된 슬롯
+        old = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat(timespec="seconds")
+        self._set_slot("run-aaaaaaaa", completed_at=old, last_confirmed_at=old)
+        self._set_slot("run-bbbbbbbb")  # 신선
+        removed = cleanup_stale_runs(self.sid, base_dir=self.base)
+        self.assertEqual(removed, 1)
+        active = read_live(self.sid, base_dir=self.base)["active_runs"]
+        self.assertNotIn("run-aaaaaaaa", active)
+        self.assertIn("run-bbbbbbbb", active)
+
+    def test_removes_heartbeat_dead_slot(self) -> None:
+        # 25h heartbeat 안 갱신된 슬롯 (completed 아닌데 stale)
+        old = (datetime.now(timezone.utc) - timedelta(hours=25)).isoformat(timespec="seconds")
+        self._set_slot("run-cccccccc", last_confirmed_at=old)
+        removed = cleanup_stale_runs(self.sid, base_dir=self.base)
+        self.assertEqual(removed, 1)
+
+    def test_keeps_fresh_slot(self) -> None:
+        self._set_slot("run-dddddddd")
+        removed = cleanup_stale_runs(self.sid, base_dir=self.base)
+        self.assertEqual(removed, 0)
+        active = read_live(self.sid, base_dir=self.base)["active_runs"]
+        self.assertIn("run-dddddddd", active)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

\`docs/conveyor-design.md\` (PR #29) §4/§6/§9 spec 의 첫 코드 구현. 컨베이어 / 훅 / impl_driver 후속 Task 들의 인프라 기반.

### 변경
- \`harness/session_state.py\` (신규, ~370 LOC, 14 함수)
- \`tests/test_session_state.py\` (49 케이스, 모두 PASS)
- 거버넌스 동반 갱신 (document_update_record / change_rationale_history / PROGRESS.md)

### 차용 매핑
| 패턴 | 출처 |
|---|---|
| regex \`^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$\` | OMC SESSION_ID_ALLOWLIST |
| stdin 3 변형 (sessionId/session_id/sessionid) | OMC |
| 3-tier resolution (env > pointer; 글로벌 폴백 제외) | RWH |
| \`_meta\` envelope + 자기참조 sessionId 검증 | RWH |
| atomic write (O_EXCL+fsync+rename+dir fsync, 0o600) | RWH |
| active_runs map + soft tombstone + heartbeat | OMC SkillActiveStateV2 |

## Why

멀티세션 기본 가정. 각 세션 격리 + run_id 별 격리 + leftover 방어 메커니즘 코드화. 후속 Task 들은 이 모듈의 API 만 사용.

## Governance checklist
- [x] Task-ID \`DCN-CHG-20260429-30\` (governance §2.1)
- [x] Change-Type: harness, test, docs-only (§2.2)
- [x] document_update_record / change_rationale_history / PROGRESS.md 갱신 (§2.3)
- [x] \`node scripts/check_document_sync.mjs\` PASS
- [x] 101/101 tests PASS (52 기존 + 49 신규)
- [x] No hook bypass

## Test plan
- [x] \`python3 -m unittest discover -s tests\` → 101/101 OK
- [x] regex / resolution / atomic write / envelope / active_runs 회귀 커버

## Follow-up Tasks
- Task -31: \`harness/orchestration_agent.py\` 폐기 + \`impl_driver.py\` 새로 작성
- Task -32: \`hooks/session-start.sh\`
- Task -33: \`hooks/catastrophic-gate.sh\`
- Task -34 (선택): \`signal_io.write_prose\` atomic write 강화

🤖 Generated with [Claude Code](https://claude.com/claude-code)