### PR TITLE
docs: conveyor-design.md rewrite — Task tool 패턴 (DCN-CHG-20260429-32)

### DIFF
--- a/docs/conveyor-design.md
+++ b/docs/conveyor-design.md
@@ -1,9 +1,9 @@
 # Conveyor Design — dcNess plugin runtime
 
 > **Status**: ACTIVE
-> **Origin**: `DCN-CHG-20260429-29`
+> **Origin**: `DCN-CHG-20260429-29` (초안) / `DCN-CHG-20260429-32` (Task tool 패턴으로 rewrite)
 > **Scope**: dcNess 가 plugin (`dcness@dcness`) 으로 사용자 프로젝트에 활성화될 때의 *runtime 인프라* 설계.
-> **Relation**: [`orchestration.md`](orchestration.md) = WHAT 룰 (시퀀스 / 권한 / catastrophic). 본 문서 = HOW 인프라 (컨베이어 / 세션 / 디렉토리 / 훅).
+> **Relation**: [`orchestration.md`](orchestration.md) = WHAT 룰 (시퀀스 / 권한 / catastrophic). 본 문서 = HOW 인프라 (메인 + Task tool + helpers + 훅).
 
 ---
 
@@ -11,19 +11,17 @@
 
 ### 0.1 본 문서가 정의하는 것
 
-dcNess 가 plugin 으로 사용자 프로젝트에 활성화됐을 때 동작하는 **runtime 인프라**:
-- 컨베이어 (Python driver) — 시퀀스 순회
-- 세션/run 식별 — 멀티세션 격리
-- 디렉토리 layout — prose 종이 + state 파일
+dcNess plugin 활성 환경의 **runtime 인프라**:
+- 메인 클로드 + Claude Code 의 Task tool 기반 시퀀스 진행
+- helper 모듈 (`harness/session_state.py`) — sid/rid 관리, prose 저장, enum 추출
+- 훅 (`hooks/session-start.sh`, `hooks/catastrophic-gate.sh`)
+- 디렉토리 layout — sid 별 격리 + by-pid 레지스트리 (멀티세션 정합)
 - `live.json` 스키마 — 활성 run 메타
-- 훅 책임 분담 — SessionStart / PreToolUse / PostToolUse
-- catastrophic backbone 강제 메커니즘
-- atomic write 정책
 
 ### 0.2 본 문서가 정의하지 *않는* 것
 
 - agent prose 형식 / preamble — agent 자율 (proposal §2.5)
-- 시퀀스 결정 룰 — `orchestration.md` §4 결정표가 SSOT, 메인 클로드가 그것 보고 결정
+- 시퀀스 결정 룰 — `orchestration.md` §4 결정표가 SSOT, 메인이 그것 보고 결정
 - agent prompt 구조 — `agents/*.md` SSOT
 
 ### 0.3 proposal §2.5 정합
@@ -31,9 +29,23 @@ dcNess 가 plugin 으로 사용자 프로젝트에 활성화됐을 때 동작하
 > **harness 가 강제하는 것은 단 2가지 — (1) 작업 순서, (2) 접근 영역. 그 외 모두 agent 자율.**
 
 본 문서는:
-- **작업 순서** = catastrophic backbone (orchestration.md §2.3 4 룰) → PreToolUse 훅 강제
-- **접근 영역** = HARNESS_ONLY_AGENTS (DCNESS_RUN_ID 없으면 engineer 차단) → 동일 훅
-- 그 외 = 메인 클로드의 자율 결정 (시퀀스 짜기, 재계획, 사용자 위임)
+- **작업 순서** = catastrophic backbone (orchestration.md §2.3 4 룰) → PreToolUse Agent 훅 강제
+- **접근 영역** = HARNESS_ONLY_AGENTS (run 컨텍스트 없으면 engineer 차단) → 동일 훅
+- 그 외 = 메인 클로드 자율 결정 (시퀀스 짜기, 재계획, 사용자 위임)
+
+### 0.4 Task tool 패턴 채택 이유 (Python 컨베이어 폐기)
+
+이전 Iteration (`DCN-CHG-20260429-29` 초안) 은 Python `run_conveyor` 함수를 단일 진입점으로 설계. 검토 결과 폐기:
+
+1. **Subagent 호출 분리 문제** — Python 안에서 Agent 호출 시 subprocess `claude --agent` 또는 SDK 직접 호출 필요. 메인 세션의 PreToolUse 훅이 발화 안 하거나 다른 settings 적용. catastrophic 보호 깨짐.
+2. **사용자 가시성 0** — Python batch 호출 종료까지 사용자는 "실행 중…" 만 봄.
+3. **메인 자율도 0** — 매 step 사이에 메인이 prose 보고 판단할 수 없음 (Python 안 갇힘).
+
+새 모델 = Task tool + Agent + helper + 훅:
+- 메인이 매 step 직접 Agent 도구 호출 → PreToolUse 훅 자동 발화
+- Agent 도구 자체가 subagent 컨텍스트 격리 (메인 transcript leak 0)
+- helper 호출로 ID/prose 관리 일관성 보장
+- Task tool 로 진행 가시화 + 메인 매 step 자율 판단
 
 ---
 
@@ -41,240 +53,188 @@ dcNess 가 plugin 으로 사용자 프로젝트에 활성화됐을 때 동작하
 
 ### 1.1 책임 매트릭스
 
-| 역할 | 무엇 | 코드 위치 | 똑똑함 정도 |
+| 역할 | 무엇 | 위치 | 똑똑함 정도 |
 |---|---|---|---|
-| **메인 클로드** | 시퀀스 설계, ConveyorPause 받고 재계획, 사용자 의도 파악 | (사용자 세션) | 매우 똑똑 (전체 맥락) |
-| **컨베이어** | 시퀀스 순회, Agent 호출, prose 수집, 결과 반환 | `harness/impl_driver.py` (~50줄) | 멍청 (loop 만) |
-| **서브에이전트** | 자기 칸 작업 + prose 종이 작성 | `agents/*.md` | 똑똑 (자기 도메인) |
-| **해석 하이쿠** | prose → enum 1단어 추출 | `harness/signal_io.interpret_signal` (기존) | 작게 똑똑 (단일 enum) |
-| **세션 인프라** | session_id / run_id 추적, live.json 갱신 | `harness/session_state.py` (신규, OMC+RWH 차용) | 도구 |
-| **catastrophic 훅** | Agent 호출 직전 §2.3 4룰 검사 | `hooks/catastrophic-gate.sh` (신규) | 도구 |
-| **PM 오케스트레이터** | (옵션) 시퀀스 짜기 위임 받음 | `agents/orchestrator.md` (Phase follow-up) | — |
+| **메인 클로드** | 시퀀스 설계, Task lifecycle 운영, Agent 호출, 매 step 결과 보고 advance/pause/pivot | (사용자 세션) | 매우 똑똑 (전체 맥락) |
+| **서브에이전트** | 자기 칸 작업 + prose 종이 작성 (자유 형식) | `agents/*.md` (frontmatter system prompt + 자체 도구 권한) | 똑똑 (자기 도메인) |
+| **Claude Code Task tool** | 메인의 todo list 관리 — 진행 가시화 + 사용자 개입 지점 | CC 내장 | 도구 |
+| **Claude Code Agent tool** | 서브에이전트 호출 + 컨텍스트 격리 | CC 내장 | 도구 |
+| **해석 하이쿠** | prose → enum 1단어 추출 | `harness/signal_io.interpret_signal` (기존) | 작게 똑똑 |
+| **session_state 모듈** | sid/rid 관리, by-pid 레지스트리, atomic write, prose 저장, enum 추출 | `harness/session_state.py` (신규 + 확장) | 도구 |
+| **SessionStart 훅** | sid 추출 + `.by-pid/{cc_pid}` 작성 + live.json 초기화 | `hooks/session-start.sh` | 도구 |
+| **catastrophic-gate 훅** | PreToolUse Agent 직전 §2.3 4룰 + HARNESS_ONLY_AGENTS 검사 | `hooks/catastrophic-gate.sh` | 도구 |
+| **PM 오케스트레이터** | (옵션, 향후) 메인의 시퀀스 짜기 위임 받음 | `agents/orchestrator.md` (Phase follow-up) | — |
 
 ### 1.2 안 하는 것 (= 폐기 결정 명시)
 
+- ❌ Python `run_conveyor` 함수 (= 옛 옵션 c JSON 결정자 / 옛 v1 멍청한 순회기) — Agent 호출 격리 + 사용자 가시성 + 메인 자율도 모두 손실
 - ❌ JSON 출력 강제 LLM (옛 옵션 c "결정 하이쿠")
 - ❌ 별도 관문 하이쿠 (`ADVANCE/ESCALATE` 1-bit) — 해석 하이쿠 + advance_when 비교로 충분
-- ❌ 컨베이어 코드 안 catastrophic / retry hardcode (모두 훅으로 이전)
 - ❌ 시퀀스 분기 룰 Python dict (옛 옵션 b)
-- ❌ 글로벌 `~/.claude/harness-state/.session-id` 폴백 (RWH issue #19 패턴 — 도그푸딩 가치 < 복잡도)
+- ❌ 글로벌 `~/.claude/harness-state/.session-id` 폴백 (RWH issue #19 패턴 — 도그푸딩 가치 < 4-가드 복잡도)
+- ❌ 환경변수 `DCNESS_RUN_ID` 전파 (Bash subprocess 가 휘발성 — 메인 다음 호출 시 사라짐) → by-pid 레지스트리로 대체
+- ❌ 단일 공유 pointer (`.session-id`, `.current-run-id`) — 멀티세션 충돌 → 디렉토리 격리 + by-pid 로 대체
 
 ---
 
-## 2. 컨베이어 흐름
+## 2. 컨베이어 흐름 (Task lifecycle)
 
-### 2.1 정상 흐름 (시퀀스 완주)
+### 2.1 메인의 한 사이클
 
 ```mermaid
 flowchart TD
-    main["메인 클로드<br/>(시퀀스 짜기)"]
-    conv["run_conveyor(seq)"]
-    step["next_step = seq[0]<br/>(catastrophic 훅이 1차 검사)"]
-    invoke["Agent(step.agent, step.mode) 호출"]
-    prose["prose 종이 작성<br/>.sessions/{sid}/runs/{run_id}/agent-mode.md"]
-    interp["interpret_signal(prose, allowed_enums)<br/>→ enum"]
-    check{"enum ∈ step.advance_when?"}
-    pop["sequence.pop(0)<br/>다음 step"]
-    pause["ConveyorPause<br/>(메인한테 반환)"]
-    done["ConveyorComplete<br/>(시퀀스 소진)"]
+    skill["사용자: /quick (skill 트리거)"]
+    plan["메인이 orchestration.md §4 보고 시퀀스 짜기"]
+    create["TaskCreate × N (각 step 1 task)"]
+    loop["매 task:"]
+    step1["TaskUpdate(in_progress)"]
+    step2["Bash: begin-step helper<br/>(live.json.current_step + heartbeat)"]
+    step3["Agent(subagent_type, mode, prompt)<br/>← PreToolUse 훅 발화 (catastrophic)"]
+    step4["Bash: end-step helper<br/>(prose 저장 + enum 추출)"]
+    step5["메인이 enum 보고:<br/>advance / pause / pivot"]
+    step6["TaskUpdate(completed)"]
+    end_run["전 task 완료 → end-run helper<br/>(live.json.completed_at)"]
 
-    main --> conv
-    conv --> step
-    step --> invoke
-    invoke --> prose
-    prose --> interp
-    interp --> check
-    check -->|YES| pop
-    pop --> step
-    check -->|NO| pause
-    pop -->|seq 비었음| done
-    pause --> main
+    skill --> plan --> create --> loop
+    loop --> step1 --> step2 --> step3 --> step4 --> step5
+    step5 -->|advance| step6 --> loop
+    step5 -->|pause| user["사용자에게 prose 보여주고 결정 위임"]
+    step5 -->|pivot| plan
+    step6 -->|마지막 task| end_run
 ```
 
-### 2.2 멈춤 트리거 3종
+### 2.2 멈춤 (pause) 조건 — 메인 자율 판단
 
-| reason | 의미 | 메인이 받는 정보 |
-|---|---|---|
-| `judge_escalate` | enum ∉ advance_when (예: validator FAIL) | 직전 step + prose + enum |
-| `agent_emit_escalate` | enum 자체가 ESCALATE 계열 (orchestration.md §6) | 동일 + escalate 종류 |
-| `interpret_failed` | interpret_signal 이 ambiguous (휴리스틱 + LLM fallback 모두 실패) | step + prose + ambiguous reason |
-| `hook_blocked` | PreToolUse 훅이 catastrophic 위반 차단 | step + 위반 룰 (예: §2.3.3) |
+매 task 끝에 메인이 enum 보고 판단:
+- enum ∈ `Step.advance_when` → TaskUpdate(completed) + 다음 task
+- enum 이 escalate 계열 (orchestration.md §6) → 사용자 위임
+- enum 이 ambiguous (interpret 실패) → 사용자 위임
+- 메인의 추가 판단 (예: 사용자 의도 변경) → pivot 또는 pause
 
-### 2.3 메인의 자율 처리
+**핵심**: pause 가 *예외* 가 아니라 *정상 동작*. 메인이 매 step 통제 가능.
 
-ConveyorPause 받은 메인이 할 수 있는 것 — 무제한:
-- 새 시퀀스로 `run_conveyor` 재호출 (같은 run_id 또는 새 run_id)
-- 컨베이어 안 쓰고 다른 agent 직접 호출
-- 사용자한테 prose 보여주고 결정 위임
-- 작업 종료
+### 2.3 protocol 위반 시 보호
 
-컨베이어는 메인의 결정에 강제 0. 멈춤 = 정상 동작.
+메인이 protocol 안 따르고 Agent 직접 호출하면:
+- helper 안 부름 → live.json `current_step` 안 갱신
+- prose 종이 안 만들어짐
+- **PreToolUse Agent 훅이 차단**:
+  - HARNESS_ONLY_AGENTS (engineer / validator-PLAN/CODE/BUGFIX_VALIDATION) 호출 시 → run_dir 안 prose 검사 → 없으면 차단
+  - run_dir 자체가 없으면 → DCNESS_RUN_ID env 또는 by-pid 레지스트리 검사 → 없으면 HARNESS_ONLY_AGENTS 차단
+
+→ 메인이 도지덜 해도 catastrophic 룰은 훅이 잡음.
 
 ---
 
 ## 3. 데이터 모델
 
-> Python dataclass / type 시그니처 수준. 실 구현은 `harness/impl_driver.py` 별도 Task.
+> Python signature 수준. 실 구현은 `harness/session_state.py` 모듈.
 
-### 3.1 Step
+### 3.1 Step (참고용 — 메인이 마음속으로 짜는 시퀀스)
+
+메인이 시퀀스 짤 때 *개념적* 으로 사용:
 
 ```python
-@dataclass(frozen=True)
+@dataclass
 class Step:
-    agent: str                    # 13 agent 중 하나 (validator/engineer/...)
-    mode: Optional[str]           # 모드 (PLAN_VALIDATION/IMPL/...) 또는 None
-    allowed_enums: tuple[str]     # interpret_signal 에 전달 (모든 가능 결론)
-    advance_when: tuple[str]      # 이 enum 들 중 하나면 컨베이어가 다음 step 진행
-                                  # advance_when ⊆ allowed_enums
+    agent: str           # 13 agent 중 하나
+    mode: Optional[str]  # PLAN_VALIDATION 등 또는 None
+    allowed_enums: tuple # interpret_signal 후보 (예: ("PASS", "FAIL", "SPEC_MISSING"))
+    advance_when: tuple  # 성공 enum (예: ("PASS",))
 ```
 
-**왜 둘로 나뉘는가**:
-- `allowed_enums` = 해석 하이쿠한테 "이 중 하나로 답해" 라고 알려주는 후보 집합 (PASS/FAIL/SPEC_MISSING/IMPL_DONE/SPEC_GAP_FOUND/...)
-- `advance_when` = 그 중 "성공으로 간주할 enum" 부분집합. 나머지는 ConveyorPause 트리거.
+실제 시퀀스는 메인의 머리 속 또는 Task list 의 task 들로 표현. Python 코드 상 객체로 영속될 필요 없음.
 
-예시:
-```python
-Step(
-    agent="validator",
-    mode="PLAN_VALIDATION",
-    allowed_enums=("PASS", "FAIL", "SPEC_MISSING"),
-    advance_when=("PASS",),
-)
-Step(
-    agent="engineer",
-    mode="IMPL",
-    allowed_enums=("IMPL_DONE", "SPEC_GAP_FOUND", "TESTS_FAIL", "IMPLEMENTATION_ESCALATE"),
-    advance_when=("IMPL_DONE",),
-)
+### 3.2 helper 호출 인터페이스 (Bash)
+
+메인이 매 step 호출:
+
+```bash
+# step 시작
+$ python3 -m harness.session_state begin-step <agent> [<mode>]
+ok
+
+# step 끝 (prose 저장 + enum 추출)
+$ python3 -m harness.session_state end-step <agent> [<mode>] \
+    --allowed-enums "PASS,FAIL,SPEC_MISSING" \
+    --prose-file /tmp/prose.md
+PASS
+# stdout: 추출된 enum 1단어 (또는 "AMBIGUOUS")
 ```
 
-### 3.2 StepResult
+### 3.3 run lifecycle helper
 
-```python
-@dataclass
-class StepResult:
-    step: Step
-    prose: str                    # agent 가 emit 한 자유 텍스트
-    prose_path: Path              # .sessions/{sid}/runs/{run_id}/agent-mode.md
-    parsed_enum: str              # interpret_signal 결과
-    started_at: str               # ISO8601
-    finished_at: str              # ISO8601
-```
+```bash
+# run 시작
+$ python3 -m harness.session_state begin-run <entry_point>
+run-a3f81b29
+# stdout: 새 run_id
 
-### 3.3 ConveyorPause / ConveyorComplete
+# run 종료 (성공)
+$ python3 -m harness.session_state end-run
 
-```python
-@dataclass
-class ConveyorPause:
-    reason: str                   # judge_escalate / agent_emit_escalate / interpret_failed / hook_blocked
-    last_step: Step
-    last_prose: str
-    last_prose_path: Path
-    parsed_enum: Optional[str]    # interpret 실패 시 None
-    history: list[StepResult]
-    remaining_sequence: list[Step]
-    run_id: str
-    state_dir: Path
-    detail: Optional[str]         # 훅 차단 reason / interpret ambiguous detail
-
-@dataclass
-class ConveyorComplete:
-    history: list[StepResult]
-    run_id: str
-    state_dir: Path
-
-ConveyorResult = ConveyorPause | ConveyorComplete
-```
-
-`run_conveyor()` 가 둘 중 하나 반환. 예외 raise 안 함 (메인이 isinstance 로 분기).
-
-### 3.4 DriverContext (내부)
-
-컨베이어가 한 사이클 동안 들고 다니는 상태:
-
-```python
-@dataclass
-class DriverContext:
-    run_id: str
-    session_id: str
-    base_dir: Path                # .claude/harness-state/.sessions/{sid}/runs/{run_id}/
-    history: list[StepResult] = field(default_factory=list)
-    attempts: dict[str, int] = field(default_factory=dict)  # `.attempts.json` 영속화
+# (멈춤은 별도 처리 안 함 — live.json 의 슬롯이 미완료로 남음, 24h 후 cleanup)
 ```
 
 ---
 
-## 4. 멀티세션 — session_id 와 run_id
+## 4. 멀티세션 — session_id / run_id 관리
 
-### 4.1 session_id resolution (3-tier, RWH 차용)
+### 4.1 멀티세션 = 기본 가정
 
-```python
-def current_session_id() -> str:
-    # 1. env var (subprocess 전파 — 가장 권위)
-    sid = os.environ.get("DCNESS_SESSION_ID", "")
-    if valid_session_id(sid):
-        return sid
-    # 2. 프로젝트 .session-id pointer (SessionStart 훅이 작성)
-    sid = read_pointer(Path.cwd() / ".claude" / "harness-state" / ".session-id")
-    if valid_session_id(sid):
-        return sid
-    # 3. 글로벌 폴백 — 채택 안 함 (도그푸딩 복잡도 회피)
-    return ""
-```
+사용자가 같은 프로젝트에 동시 두 CC 세션 띄우는 건 흔함. 모든 자원 격리 필수.
 
-### 4.2 session_id 형식
+### 4.2 session_id 출처 (3 경로)
 
-OMC 차용 — Claude Code 가 자체 발급:
+| 경로 | 누가 사용 |
+|---|---|
+| **CC stdin payload** (`sessionId` / `session_id` / `sessionid` 3 변형) | 모든 훅 (SessionStart, PreToolUse, PostToolUse, Stop) |
+| **`.by-pid/{cc_pid}` 파일** (SessionStart 훅이 작성) | helper (Bash subprocess) — `$PPID = CC main pid` 로 lookup |
+| **메인 세션 자체 알고 있음** | (메인 LLM 이 sid 명시 처리는 어려움 — 위 두 경로로 충분) |
+
+### 4.3 session_id 검증 (OMC 차용)
+
 ```python
 SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$")
 ```
 
-훅 stdin payload 의 3 변형 fallback (OMC 패턴):
-```python
-sid = data.get("session_id") or data.get("sessionId") or data.get("sessionid") or ""
-```
-
-### 4.3 run_id 형식
+### 4.4 run_id 형식
 
 ```python
 import secrets
-run_id = f"run-{secrets.token_hex(4)}"   # 예: run-a3f81b29
+run_id = f"run-{secrets.token_hex(4)}"   # run-a3f81b29
 ```
 
-- 16M 조합 → 한 세션 안 충돌 사실상 0
+- 16M 조합 → sid 안 충돌 사실상 0
 - 짧고 가독성 OK
-- session_id 안에서만 unique 보장 필요 (디렉토리가 sid 별 격리됨)
 
-### 4.4 환경변수 전파
+### 4.5 by-pid 레지스트리 (env 변수 대체)
 
-컨베이어가 시작/종료 시 set/unset:
+env 전파 안 통하는 이유:
+- 메인 → Bash subprocess (env set)
+- Bash 끝나면 메인 process 의 env 변경 0
+- 다음 Bash 호출 시 메인의 env 그대로
 
-```python
-def run_conveyor(...) -> ConveyorResult:
-    sid = current_session_id()
-    run_id = f"run-{secrets.token_hex(4)}"
-    os.environ["DCNESS_SESSION_ID"] = sid
-    os.environ["DCNESS_RUN_ID"] = run_id
-    try:
-        ... loop ...
-    finally:
-        os.environ.pop("DCNESS_RUN_ID", None)
-        # DCNESS_SESSION_ID 는 그대로 (다른 컨베이어가 또 돌 수 있음)
+해결 = **PID-keyed 파일**:
+- `.by-pid/{cc_pid}` ← sid (SessionStart 훅이 작성)
+- `.by-pid-current-run/{cc_pid}` ← rid (begin-run helper 가 작성)
+- helper / 훅 모두 `$PPID` (Bash) 또는 hook 의 `$PPID` (CC main pid) 로 lookup
+
+```bash
+# helper 안에서
+CC_PID=$PPID  # Bash subprocess 의 부모 = CC main
+SID=$(cat .claude/harness-state/.by-pid/$CC_PID)
+RID=$(cat .claude/harness-state/.by-pid-current-run/$CC_PID 2>/dev/null)
 ```
 
-훅은 `os.environ.get("DCNESS_RUN_ID")` 로 읽음. subprocess Agent 호출은 부모 env 상속.
+### 4.6 PID 재사용 보호
 
-### 4.5 멀티세션 안전성 보장
+OS 가 PID 재할당 가능 (CC 12345 종료 후 다른 프로세스가 12345 받음).
 
-| 자원 | 충돌 가능성 | 격리 메커니즘 |
-|---|---|---|
-| session_id | 0 (CC 자체 발급) | — |
-| run_id (한 세션 안) | ~0 (token_hex(4)) | secrets.token_hex |
-| `.sessions/{sid}/` 디렉토리 | 0 (sid 격리) | filesystem |
-| `live.json` | 0 (sid 별 1개) | — |
-| `DCNESS_RUN_ID` env | 0 (프로세스별) | OS env vars |
-| `.attempts.json` | 0 (run_id 별) | — |
-| `.metrics/*.jsonl` | 가능 | append-only + atomic line write |
+완화책:
+- `.by-pid/{cc_pid}` 안에 `sid` + `start_ts` 같이 저장 → 검증 시 timestamp 체크
+- Stop 훅 (선택) 으로 종료 시 cleanup
+- `cleanup_stale_runs` 가 6h 이상 stale 한 by-pid 도 정리
 
 ---
 
@@ -282,33 +242,39 @@ def run_conveyor(...) -> ConveyorResult:
 
 ```
 .claude/harness-state/
-├── .session-id                                  # 현재 세션 pointer (SessionStart 훅 작성)
-├── .global.json                                  # 전역 신호 (lenient — 세션 무관 상태)
-├── .sessions/
-│   └── {sid}/                                    # 세션 스코프 (멀티세션 격리)
-│       ├── live.json                             # 활성 run 메타 (§6 스키마)
-│       └── runs/
-│           ├── {run_id}/                         # 컨베이어 사이클 스코프
-│           │   ├── architect-MODULE_PLAN.md      # prose 종이 (덮어쓰기, attempt 별 X)
-│           │   ├── validator-PLAN_VALIDATION.md
-│           │   ├── test-engineer.md              # mode 없는 agent 는 agent.md
-│           │   ├── engineer-IMPL.md
-│           │   ├── validator-CODE_VALIDATION.md
-│           │   ├── pr-reviewer.md
-│           │   └── .attempts.json                # 카운터 (덮어쓰기 방어)
-│           └── {run_id-2}/...
+├── .sessions/                                  # sid 별 격리 (멀티세션 핵심)
+│   ├── {sid-A}/
+│   │   ├── live.json                           # 세션 A 의 active_runs (§6 스키마)
+│   │   └── runs/
+│   │       ├── {run_id-A1}/                    # 세션 A 의 첫 번째 run
+│   │       │   ├── architect-MODULE_PLAN.md    # prose 종이
+│   │       │   ├── validator-PLAN_VALIDATION.md
+│   │       │   ├── test-engineer.md            # mode 없는 agent 는 agent.md
+│   │       │   ├── engineer-IMPL.md
+│   │       │   ├── validator-CODE_VALIDATION.md
+│   │       │   └── pr-reviewer.md
+│   │       └── {run_id-A2}/...
+│   └── {sid-B}/...
+├── .by-pid/                                    # cc_pid → sid 매핑
+│   ├── {cc_pid_A}                              # 세션 A 의 CC main pid
+│   └── {cc_pid_B}
+├── .by-pid-current-run/                        # cc_pid → 현재 활성 rid
+│   ├── {cc_pid_A}
+│   └── {cc_pid_B}
+├── .global.json                                # 전역 신호 (lenient — 세션 무관)
 └── .logs/
 ```
 
-**디렉토리 격리 자체가 멀티세션 leftover 방어**. 다른 세션이 같은 파일 만질 경로 없음.
-
-**attempt 별 prose 보존 X (옵션 D)**: 같은 (agent, mode) 가 여러 번 돌아도 마지막만 디스크에 남음. `.attempts.json` 이 카운트만 유지. 옛 prose 손실 인정 — 디버깅은 git history 또는 최신 prose 로 충분.
+**격리 보증**:
+- sid 별 디렉토리 → 세션 간 충돌 0
+- by-pid 별 파일 → 세션 간 pointer 충돌 0
+- attempt 별 prose 보존 X (= 옵션 D, 덮어쓰기) — 마지막 시도만 디스크에 남음
 
 ---
 
-## 6. live.json 스키마 (OMC active_runs 패턴)
+## 6. live.json 스키마
 
-### 6.1 스키마
+### 6.1 스키마 (OMC active_runs 패턴)
 
 ```json
 {
@@ -344,47 +310,24 @@ def run_conveyor(...) -> ConveyorResult:
 |---|---|---|
 | `_meta.sessionId/writtenAt/version` | RWH | leftover 방어 + 스키마 진화 |
 | `session_id` 자기참조 | RWH | envelope 검증 (다른 세션 덮어쓰기 거부) |
-| `active_runs` map | OMC SkillActiveStateV2 | 동시 다중 run 지원 (한 세션 안 백그라운드 + foreground) |
-| `started_at` / `completed_at` | OMC | soft tombstone (디버깅 / 감사) |
-| `last_confirmed_at` | OMC | heartbeat — stale run 탐지 (PostToolUse 훅이 갱신) |
-| `current_step` | dcNess 신규 | 컨베이어가 어느 칸 진행 중 (훅이 prose 위치 추론) |
-| `entry_point` | dcNess 신규 | quick / product-plan / qa 등 진입점 trigger 추적 |
-| `run_dir` | dcNess 신규 | 훅이 prose 디렉토리 직접 찾는 폴백 (env 없을 때) |
-| `issue_num` | RWH | GitHub 연동 시 (선택) |
+| `active_runs` map | OMC SkillActiveStateV2 | 동시 다중 run 지원 |
+| `started_at` / `completed_at` | OMC | soft tombstone (디버깅/감사) |
+| `last_confirmed_at` | OMC | heartbeat — stale run 탐지 |
+| `current_step` | dcNess 신규 | 컨베이어가 어느 칸 진행 중 |
+| `entry_point` | dcNess 신규 | quick / product-plan / qa 등 진입점 |
+| `run_dir` | dcNess 신규 | 훅이 prose 디렉토리 직접 찾는 폴백 |
+| `issue_num` | RWH | GitHub 연동 시 |
 
-### 6.3 폐기한 필드
-
-OMC `SkillActiveStateV2`:
-- `parent_skill` (nested lineage) — dcNess 컨베이어는 1차원 시퀀스
-- `mode_state_path` / `initialized_*_path` — `run_dir` + 디렉토리 스캔으로 충분
-- `support_skill` — OMC 특화 개념
-- dual-copy (root + session) — dcNess 는 sid 격리만
-- `source` — `entry_point` 흡수
-
-RWH `live.json`:
-- `harness_active: bool` — `active_runs` 비었으면 inactive (별도 플래그 불요)
-- `prefix`, `mode` (executor mode) — RWHarness executor 특화
-- `_harness_canary` — 디버깅 잔재
-- top-level `agent` 단일 — `active_runs.{run_id}.current_step.agent` 흡수
-
-### 6.4 lifecycle
+### 6.3 lifecycle
 
 | 시점 | 동작 |
 |---|---|
-| SessionStart | `live.json` 초기 (`active_runs: {}`) |
-| 컨베이어 시작 | `active_runs[run_id] = {...}` 추가 |
-| 매 step 시작 | `active_runs[run_id].current_step` 갱신 + `last_confirmed_at` |
-| 매 step 끝 | `last_confirmed_at` 갱신 (PostToolUse 훅 또는 컨베이어) |
-| ConveyorComplete | `active_runs[run_id].completed_at` 채움 |
-| ConveyorPause | `active_runs[run_id]` 그대로 (재진입 가능) |
-| 24h 후 cleanup | `completed_at` 채워진 슬롯 + 6h 이상 stale `last_confirmed_at` 슬롯 삭제 |
-
-### 6.5 version 마이그레이션 정책
-
-- v1 시작
-- v2 변경 시 `_meta.version` 비교 후 마이그레이션 함수 호출
-- backward compat: read 시 모름 version 만나면 lenient (필드 무시)
-- write 시 항상 최신 version
+| SessionStart 훅 | `live.json` 초기 (`active_runs: {}`) |
+| begin-run helper | `active_runs[run_id] = {...}` 추가 + `.by-pid-current-run/{cc_pid}` 작성 |
+| begin-step helper | `current_step` 갱신 + `last_confirmed_at` |
+| end-step helper | (선택) `last_confirmed_at` 갱신만 |
+| end-run helper | `completed_at` 채움 + `current_step = null` + `.by-pid-current-run/{cc_pid}` 삭제 |
+| 24h cleanup | completed 이거나 heartbeat dead 슬롯 삭제 |
 
 ---
 
@@ -392,167 +335,157 @@ RWH `live.json`:
 
 ### 7.1 SessionStart 훅 (신규)
 
-**파일**: `hooks/session-start.sh` (또는 `.py`)
-**트리거**: Claude Code SessionStart event
+**파일**: `hooks/session-start.sh`
+**트리거**: CC 세션 시작
 **책임**:
-1. stdin payload 에서 session_id 추출 (3 변형 fallback)
+1. stdin payload 에서 sessionId 추출 (3 변형 fallback)
 2. regex 검증
-3. `.claude/harness-state/.session-id` pointer atomic write
-4. `.claude/harness-state/.sessions/{sid}/live.json` 초기화 (없으면)
+3. `$PPID` 로 CC main pid 추출
+4. `.by-pid/{cc_pid}` ← sid 작성 (atomic, 0o600)
+5. `.sessions/{sid}/live.json` 초기화 (이미 있으면 envelope 검증 후 보존)
 
 ### 7.2 PreToolUse Agent 훅 (`catastrophic-gate`, 신규)
 
 **파일**: `hooks/catastrophic-gate.sh`
 **트리거**: PreToolUse, tool=Agent
-**책임**: orchestration.md §2.3 4룰 강제 (§8 참조)
-**차단 시**: stderr 메시지 + exit 1 → Claude Code 가 Agent 호출 거부
+**책임**: orchestration.md §2.3 4룰 + HARNESS_ONLY_AGENTS 강제 (§8 참조)
+**차단 시**: stderr 메시지 + exit 1 → CC 가 Agent 호출 거부
 
-### 7.3 PostToolUse Agent 훅 (선택, 후속 Task)
+### 7.3 PostToolUse Agent 훅 (선택, 후속)
 
 **파일**: `hooks/post-agent.sh`
-**트리거**: PostToolUse, tool=Agent
-**책임**:
-- `live.json.active_runs[run_id].last_confirmed_at` 갱신 (heartbeat)
-- 필요 시 `current_step` 정리
-
-선택 사항 — 컨베이어가 직접 `live.json` 갱신해도 됨. 훅으로 빼면 컨베이어 외부 호출 (메인 직접 Agent 호출) 도 추적 가능.
+**책임**: `last_confirmed_at` 자동 갱신 (메인이 end-step 안 불러도 heartbeat 보장)
 
 ### 7.4 git pre-commit 훅 (기존)
 
-**파일**: `scripts/hooks/pre-commit` + `scripts/hooks/cc-pre-commit.sh`
-**책임**: Document Sync 게이트 (governance §2.5)
-**무관**: 컨베이어 / catastrophic 검사와 직교
+**책임**: Document Sync (governance §2.5). 컨베이어 / catastrophic 검사와 직교.
 
 ---
 
 ## 8. catastrophic backbone — 훅 강제
 
-### 8.1 4룰 (orchestration.md §2.3) 매핑
+### 8.1 4룰 매핑
 
-| 룰 | 검사 위치 | 검사 방법 |
-|---|---|---|
-| §2.3.1 src/ 변경 후 CODE_VALIDATION 없이 pr-reviewer 금지 | PreToolUse Agent (subagent=pr-reviewer) | 가장 최근 `engineer-IMPL.md` 후 `validator-CODE_VALIDATION.md` PASS 확인 |
-| §2.3.2 LGTM 없이 merge 금지 | branch protection (governance §2.8) | GitHub UI/API |
-| §2.3.3 architect.module-plan READY_FOR_IMPL 없이 engineer 금지 | PreToolUse Agent (subagent=engineer, mode≠POLISH) | `architect-MODULE_PLAN.md` 안 READY_FOR_IMPL 확인 |
-| §2.3.4 PRD 변경 후 plan-reviewer + ux-architect 없이 architect SD 금지 | PreToolUse Agent (subagent=architect, mode∈{SYSTEM_DESIGN,TASK_DECOMPOSE}) | 가장 최근 product-planner 후 plan-reviewer PASS + ux-architect READY 확인 |
+| 룰 | 훅 검사 |
+|---|---|
+| §2.3.1 src/ 변경 후 CODE_VALIDATION 없이 pr-reviewer 금지 | PreToolUse(Agent), subagent=pr-reviewer → run_dir 안 `validator-CODE_VALIDATION.md` 또는 `validator-BUGFIX_VALIDATION.md` 안 PASS 확인 |
+| §2.3.2 LGTM 없이 merge 금지 | branch protection (governance §2.8) — 외부화 |
+| §2.3.3 architect plan READY 없이 engineer 금지 | PreToolUse(Agent), subagent=engineer, mode≠POLISH → run_dir 안 `architect-MODULE_PLAN.md` (READY_FOR_IMPL) 또는 `architect-LIGHT_PLAN.md` (LIGHT_PLAN_READY) 확인 |
+| §2.3.4 PRD 변경 후 plan-reviewer + ux-architect 없이 architect SD/TD 금지 | PreToolUse(Agent), subagent=architect, mode∈{SYSTEM_DESIGN,TASK_DECOMPOSE} → 가장 최근 product-planner 후 plan-reviewer PASS + ux-architect READY 확인 |
 
-### 8.2 훅 동작 (pseudo-bash)
+### 8.2 HARNESS_ONLY_AGENTS
+
+```
+HARNESS_ONLY_AGENTS = {
+    ("engineer", "*"),
+    ("validator", "PLAN_VALIDATION"),
+    ("validator", "CODE_VALIDATION"),
+    ("validator", "BUGFIX_VALIDATION"),
+}
+```
+
+이 agent/mode 조합은 *컨베이어 컨텍스트 (run_dir + by-pid 레지스트리)* 가 있어야 호출 가능. 없으면 차단.
+
+### 8.3 훅 동작 (pseudo-bash)
 
 ```bash
 #!/usr/bin/env bash
-# hooks/catastrophic-gate.sh
-# PreToolUse Agent 훅 — orchestration.md §2.3 + HARNESS_ONLY_AGENTS 강제
+INPUT=$(cat)
+SID=$(jq -r '.sessionId // .session_id // .sessionid' <<< "$INPUT")
+[[ "$SID" =~ ^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$ ]] || exit 0  # invalid → silent skip
 
-set -euo pipefail
-INPUT=$(cat)   # stdin = Claude Code 가 주는 hook payload (JSON)
+CC_PID=$PPID  # 훅 실행 컨텍스트 — CC main 의 자식
+RID=$(cat .claude/harness-state/.by-pid-current-run/$CC_PID 2>/dev/null)
 
-# subagent_type / mode 추출 (jq 또는 python -c)
-SUBAGENT=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // empty')
-MODE=$(echo "$INPUT" | jq -r '.tool_input.mode // empty')
+SUBAGENT=$(jq -r '.tool_input.subagent_type // empty' <<< "$INPUT")
+MODE=$(jq -r '.tool_input.mode // empty' <<< "$INPUT")
 
-# 1. session_id / run_id 결정
-SID="${DCNESS_SESSION_ID:-}"
-[ -z "$SID" ] && SID=$(echo "$INPUT" | jq -r '.session_id // empty')
-[ -z "$SID" ] && SID=$(cat .claude/harness-state/.session-id 2>/dev/null || echo "")
-
-RUN_ID="${DCNESS_RUN_ID:-}"
-
-# 2. HARNESS_ONLY_AGENTS — RUN_ID 없으면 engineer / validator(plan/code/bugfix) 차단
-if [ -z "$RUN_ID" ]; then
-    case "$SUBAGENT:$MODE" in
-        engineer:*|validator:PLAN_VALIDATION|validator:CODE_VALIDATION|validator:BUGFIX_VALIDATION)
-            echo "[catastrophic-gate] HARNESS_ONLY_AGENTS — $SUBAGENT$([ -n "$MODE" ] && echo ":$MODE") 는 컨베이어 경유 필수 (DCNESS_RUN_ID 미설정)" >&2
+# 1. HARNESS_ONLY_AGENTS — RID 없으면 차단
+case "$SUBAGENT:$MODE" in
+    engineer:*|validator:PLAN_VALIDATION|validator:CODE_VALIDATION|validator:BUGFIX_VALIDATION)
+        if [ -z "$RID" ]; then
+            echo "[catastrophic] $SUBAGENT$([ -n "$MODE" ] && echo ":$MODE") 는 컨베이어 경유 필수 (run 미시작)" >&2
             exit 1
-            ;;
-    esac
-    exit 0   # 그 외 agent 는 컨베이어 밖 호출 허용
-fi
+        fi
+        ;;
+esac
 
-PROSE_DIR=".claude/harness-state/.sessions/$SID/runs/$RUN_ID"
+[ -z "$RID" ] && exit 0  # run 외부 호출 — 그 외 agent 는 통과
 
-# 3. §2.3.3 — engineer 직전 검사
+RUN_DIR=".claude/harness-state/.sessions/$SID/runs/$RID"
+
+# 2. §2.3.3 — engineer 직전 검사
 if [ "$SUBAGENT" = "engineer" ] && [ "$MODE" != "POLISH" ]; then
-    if ! grep -q "READY_FOR_IMPL" "$PROSE_DIR/architect-MODULE_PLAN.md" 2>/dev/null \
-       && ! grep -q "LIGHT_PLAN_READY" "$PROSE_DIR/architect-LIGHT_PLAN.md" 2>/dev/null; then
-        echo "[catastrophic §2.3.3] engineer 호출은 architect.module-plan READY_FOR_IMPL 또는 LIGHT_PLAN_READY 후에만 가능" >&2
+    if grep -q "READY_FOR_IMPL" "$RUN_DIR/architect-MODULE_PLAN.md" 2>/dev/null \
+       || grep -q "LIGHT_PLAN_READY" "$RUN_DIR/architect-LIGHT_PLAN.md" 2>/dev/null; then
+        :
+    else
+        echo "[catastrophic §2.3.3] engineer 호출은 architect plan READY 후만" >&2
         exit 1
     fi
 fi
 
-# 4. §2.3.1 — pr-reviewer 직전 검사
+# 3. §2.3.1 — pr-reviewer 직전 검사
 if [ "$SUBAGENT" = "pr-reviewer" ]; then
-    # 가장 최근 engineer 가 IMPL_DONE/POLISH_DONE 인 경우, 그 후 CODE/BUGFIX VALIDATION PASS 필수
-    if [ -f "$PROSE_DIR/engineer-IMPL.md" ] || [ -f "$PROSE_DIR/engineer-POLISH.md" ]; then
-        if ! grep -q "PASS" "$PROSE_DIR/validator-CODE_VALIDATION.md" 2>/dev/null \
-           && ! grep -q "PASS" "$PROSE_DIR/validator-BUGFIX_VALIDATION.md" 2>/dev/null; then
-            echo "[catastrophic §2.3.1] pr-reviewer 호출은 validator CODE/BUGFIX_VALIDATION PASS 후에만 가능" >&2
+    if [ -f "$RUN_DIR/engineer-IMPL.md" ] || [ -f "$RUN_DIR/engineer-POLISH.md" ]; then
+        if grep -q "PASS" "$RUN_DIR/validator-CODE_VALIDATION.md" 2>/dev/null \
+           || grep -q "PASS" "$RUN_DIR/validator-BUGFIX_VALIDATION.md" 2>/dev/null; then
+            :
+        else
+            echo "[catastrophic §2.3.1] pr-reviewer 호출은 validator CODE/BUGFIX_VALIDATION PASS 후만" >&2
             exit 1
         fi
     fi
 fi
 
-# 5. §2.3.4 — architect SYSTEM_DESIGN/TASK_DECOMPOSE 직전 검사
-if [ "$SUBAGENT" = "architect" ] && [ "$MODE" = "SYSTEM_DESIGN" -o "$MODE" = "TASK_DECOMPOSE" ]; then
-    if [ -f "$PROSE_DIR/product-planner.md" ]; then
-        # PRD 변경됨 → plan-reviewer PASS + ux-architect READY 필수
-        grep -q "PLAN_REVIEW_PASS" "$PROSE_DIR/plan-reviewer.md" 2>/dev/null \
+# 4. §2.3.4 — architect SD/TD 직전 검사
+if [ "$SUBAGENT" = "architect" ] && { [ "$MODE" = "SYSTEM_DESIGN" ] || [ "$MODE" = "TASK_DECOMPOSE" ]; }; then
+    if [ -f "$RUN_DIR/product-planner.md" ]; then
+        grep -q "PLAN_REVIEW_PASS" "$RUN_DIR/plan-reviewer.md" 2>/dev/null \
             || { echo "[catastrophic §2.3.4] PRD 변경 후 plan-reviewer PLAN_REVIEW_PASS 필수" >&2; exit 1; }
-        grep -qE "UX_FLOW_READY|UX_FLOW_PATCHED" "$PROSE_DIR/ux-architect.md" 2>/dev/null \
-            || { echo "[catastrophic §2.3.4] PRD 변경 후 ux-architect UX_FLOW_READY/PATCHED 필수" >&2; exit 1; }
+        grep -qE "UX_FLOW_READY|UX_FLOW_PATCHED" "$RUN_DIR/ux-architect.md" 2>/dev/null \
+            || { echo "[catastrophic §2.3.4] PRD 변경 후 ux-architect UX_FLOW_READY 필수" >&2; exit 1; }
     fi
 fi
 
 exit 0
 ```
 
-### 8.3 보호막 다중화
+### 8.4 보호 다중화
 
 | 위치 | 무엇 막나 | 룰 |
 |---|---|---|
-| **PreToolUse 훅** (catastrophic-gate) | engineer / pr-reviewer / architect 잘못된 호출 | §2.3.1, §2.3.3, §2.3.4 |
+| **PreToolUse Agent 훅** (catastrophic-gate) | engineer / pr-reviewer / architect 잘못된 호출 | §2.3.1 / §2.3.3 / §2.3.4 |
 | **branch protection** (이미 있음) | merge (LGTM 없이) | §2.3.2 |
 | **git pre-commit** (이미 있음) | docs 미동반 commit | governance |
 
-훅 1곳만 있어도 막힘. 메인이 의도적 우회 시 3 단계 모두 우회는 불가.
+훅 1곳만 막혀도 차단. 메인 의도적 우회 시 3 단계 모두 우회는 불가.
 
 ---
 
 ## 9. atomic write 정책
 
-### 9.1 RWH 패턴 차용
+### 9.1 RWH 패턴 차용 (이미 `session_state.atomic_write` 구현)
 
 ```python
-def atomic_write(target: Path, content: bytes, mode: int = 0o600) -> None:
+def atomic_write(target: Path, content: bytes, *, mode: int = 0o600) -> None:
     """O_EXCL+fsync+rename+dir fsync — POSIX atomic 보장."""
-    tmp = target.with_suffix(target.suffix + f".tmp.{os.getpid()}.{uuid.uuid4().hex[:8]}")
-    fd = os.open(str(tmp), os.O_WRONLY | os.O_CREAT | os.O_EXCL, mode)
-    try:
-        os.write(fd, content)
-        os.fsync(fd)
-    finally:
-        os.close(fd)
-    os.replace(tmp, target)
-    # dir fsync (POSIX 강제)
-    dir_fd = os.open(str(target.parent), os.O_RDONLY)
-    try:
-        os.fsync(dir_fd)
-    finally:
-        os.close(dir_fd)
 ```
 
 ### 9.2 적용 대상
 
 | 파일 | 적용 |
 |---|---|
-| `live.json` | ✅ atomic_write (read-modify-write 패턴) |
-| `.attempts.json` | ✅ atomic_write |
-| prose `.md` (signal_io.write_prose) | ✅ atomic_write 로 강화 (현재 `os.replace` 만) |
-| `.session-id` pointer | ✅ atomic_write |
-| `.metrics/*.jsonl` | ❌ append-only, line < 4KB → POSIX atomic 보장 (별도 lock 불요) |
+| `live.json` | ✅ |
+| `.by-pid/{cc_pid}` | ✅ |
+| `.by-pid-current-run/{cc_pid}` | ✅ |
+| prose `.md` (signal_io.write_prose) | ⚠️ 현재 `os.replace` — 강화 필요 (별도 Task) |
+| `.attempts.json` | ✅ |
+| `.metrics/*.jsonl` | ❌ append-only, line < 4KB → POSIX atomic 자연 |
 
 ### 9.3 권한
 
-모든 atomic write 파일 `0o600` (소유자만 읽기/쓰기). prose 종이도 동일 — 다른 사용자가 같은 머신에서 cat 못 하게.
+모든 atomic write 파일 `0o600` (소유자 전용).
 
 ---
 
@@ -562,29 +495,19 @@ def atomic_write(target: Path, content: bytes, mode: int = 0o600) -> None:
 
 현재 디자인: **메인 클로드가 시퀀스 결정**. PM 별도 agent 도입 안 함.
 
-향후 plugin Phase 에서 도입 검토:
-- 사용자 메인 클로드의 결정 품질 분산 (haiku 메인 사용자 vs opus 메인 사용자)
-- skills/* prompt 에 결정 로직 분산 → 일관성 약화
-- skill 진입점 (quick / product-plan / qa) 마다 결정 prompt 중복
-
 ### 10.2 도입 시 design
 
 `agents/orchestrator.md` (frontmatter prose-only):
-- 입력 (prompt 으로 전달):
-  - 작업 목표 (예: impl docs/impl/00-foo.md)
-  - 최근 prose 종이 경로들 (있으면)
-  - 멈춘 이유 (있으면)
-- 출력 (자유 prose):
-  - 권장 시퀀스를 번호 매겨 prose 로 작성
-  - 각 step: agent 이름 / mode / advance_when (= 성공 enum)
-- 결론 enum: `SEQUENCE_READY` / `NO_SEQUENCE_POSSIBLE` / `NEED_USER_INPUT`
+- 입력 (prompt 으로): 작업 목표 / 최근 prose 종이 경로 / 멈춘 이유
+- 출력 (자유 prose): 권장 시퀀스 prose 권장 + 결론 enum (`SEQUENCE_READY` 등)
+- 메인이 PM prose 읽고 자체 LLM 두뇌로 task list 구성 — JSON 파싱 0
 
 ### 10.3 메인 직접 vs PM 위임 트레이드오프
 
 | 측면 | 메인 직접 | PM 위임 |
 |---|---|---|
 | 추가 호출 | 0 | +1 / 결정 |
-| 사용자 의도 누적 | ✅ 자동 | ⚠️ 호출자가 매번 prompt 로 전달 |
+| 사용자 의도 누적 | ✅ 자동 | ⚠️ 호출자가 매번 prompt |
 | 메인 컨텍스트 청소 | ❌ 결정표 prose 누적 | ✅ 분리 |
 | 결정 일관성 | 메인 모델 의존 | PM system prompt 통일 |
 | 재사용 (다중 진입점) | skill 마다 중복 | ✅ 한 PM |
@@ -597,32 +520,35 @@ def atomic_write(target: Path, content: bytes, mode: int = 0o600) -> None:
 
 ## 11. 폐기한 것들
 
-### 11.1 PR #28 (DCN-CHG-20260429-28) retraction
+### 11.1 PR #28 (`DCN-CHG-20260429-28`) — 옵션 c JSON 결정자 모델
 
-PR #28 이 채택했던 옵션 (c) JSON 결정자 모델은 **본 문서로 대체**:
+폐기 이유: LLM JSON 출력 강제 = proposal §2.5 (prose-only) 충돌. 도그푸딩 결과 LLM JSON 형식 미준수 빈발 → 휴리스틱 파싱 추가는 dcNess 정신 위반.
 
-| 폐기 | 이유 |
-|---|---|
-| `harness/orchestration_agent.py` (`decide_next_sequence`) | LLM JSON 출력 강제가 proposal §2.5 (prose-only) 충돌 |
-| `parse_sequence_json` (JSON 파싱 로직) | LLM 응답 형식 휴리스틱 = dcNess 정신 위반 |
-| 결정 하이쿠 system prompt | 결정 자체를 메인이 함, 별도 LLM 불요 |
-| `harness/impl_driver.py` 의 catastrophic / retry hardcode | 훅으로 이전 |
-| ESCALATE_ENUMS hardcode | 메인이 prose 보고 판단 |
+폐기 대상:
+- `harness/orchestration_agent.py` (`decide_next_sequence`, `parse_sequence_json`, system prompt)
+- `harness/impl_driver.py` v1 의 catastrophic / retry hardcode
+- ESCALATE_ENUMS hardcode
 
-PR #28 의 ~95% 코드 폐기. 살아남는 것:
-- `Step` dataclass (단, `advance_when` 추가)
-- `StepResult` / `DriverContext` 껍데기
-- atomic write 패턴 (단, RWH O_EXCL+fsync 로 강화)
-- 테스트 헬퍼 패턴 (drain decider, mock invoker)
+### 11.2 PR #29 (`DCN-CHG-20260429-29`) 의 v1 design — Python 멍청한 컨베이어
 
-### 11.2 토론 중 검토 후 폐기한 옵션
+이전 conveyor-design.md 가 정의한 `run_conveyor` 함수 모델. 폐기 이유:
+
+1. **Subagent 호출 격리 부족** — Python 안에서 Agent 호출 시 subprocess `claude --agent` 또는 SDK 직접 호출. 메인 세션의 PreToolUse 훅 미발화 또는 다른 settings 적용. catastrophic 보호 깨짐.
+2. **사용자 가시성 0** — Python batch 종료까지 진행 안 보임.
+3. **메인 자율도 0** — 매 step 사이 메인 개입 불가.
+
+대체: 본 문서 (Task tool + Agent + helper + 훅 패턴).
+
+### 11.3 토론 중 검토 후 폐기한 옵션
 
 | 옵션 | 이유 |
 |---|---|
-| (α) 단일 라벨 결정 하이쿠 (`ADVANCE/RETRY/INSERT_SPEC_GAP/ESCALATE` 1단어) | 라벨 수 늘면 driver 코드 hardcode 부담. 결국 메인 결정 + 훅이 더 단순 |
-| (β) 정적 dict 라우팅 (옵션 b 부활) | 분기 룰 코드 박힘 — proposal §2.5 원칙 1 (룰 순감소) 약화 |
-| 글로벌 `~/.claude/harness-state/.session-id` 폴백 (RWH issue #19) | 도그푸딩 가치 < 4-가드 복잡도. dcNess 자체 도그푸딩 시 로컬 SessionStart 훅이 작성되도록 만들면 됨 |
-| 관문 하이쿠 별도 LLM 호출 (`ADVANCE/ESCALATE` 1-bit) | 해석 하이쿠가 이미 enum 추출 + advance_when 비교로 충분. 추가 호출 불요 |
+| (α) 단일 라벨 결정 하이쿠 (`ADVANCE/RETRY/INSERT_SPEC_GAP/ESCALATE`) | 라벨 늘면 driver hardcode 부담. 메인 결정 + 훅이 더 단순 |
+| (β) 정적 dict 라우팅 (옵션 b 부활) | 분기 룰 코드 박힘 — proposal §2.5 원칙 1 약화 |
+| 글로벌 `~/.claude` 폴백 (RWH issue #19) | 도그푸딩 가치 < 4-가드 복잡도 |
+| 관문 하이쿠 별도 LLM 호출 | 해석 하이쿠 + advance_when 비교로 충분 |
+| 환경변수 `DCNESS_RUN_ID` 전파 | Bash subprocess 휘발성 — 메인 다음 호출 시 사라짐 |
+| 단일 `.session-id` / `.current-run-id` pointer | 멀티세션 충돌 — by-pid 레지스트리로 대체 |
 
 ---
 
@@ -637,24 +563,27 @@ PR #28 의 ~95% 코드 폐기. 살아남는 것:
 - **RWHarness** — 진화된 패턴
   - `hooks/session_state.py` — 3-tier resolution + `_meta` envelope + atomic write
   - `harness/executor.py` — `update_live(harness_active=True, ...)` 패턴
-  - `docs/impl/19-session-id-fallback.md` — 글로벌 폴백 도입 동기 (dcNess 는 미채택)
+  - `docs/impl/19-session-id-fallback.md` — 글로벌 폴백 동기 (dcNess 미채택)
 
 ### 12.2 내부
 
 - [`orchestration.md`](orchestration.md) — 시퀀스 / 권한 / catastrophic 룰 SSOT
 - [`process/governance.md`](process/governance.md) — Task-ID / doc-sync / branch protection
-- [`status-json-mutate-pattern.md`](status-json-mutate-pattern.md) — proposal §2.5 대 원칙 (prose-only)
+- [`status-json-mutate-pattern.md`](status-json-mutate-pattern.md) — proposal §2.5 대 원칙
 - [`process/branch-protection-setup.md`](process/branch-protection-setup.md) — §2.3.2 외부화
 - `harness/signal_io.py` — interpret_signal 단일 호출
 - `harness/interpret_strategy.py` — heuristic-first + LLM-fallback
 - `harness/llm_interpreter.py` — Anthropic haiku interpreter
-- `agents/*.md` — 13 agent prose writing guide (결론 enum 출처)
+- `harness/session_state.py` — sid/rid 관리, atomic write, live.json (`DCN-CHG-20260429-30` 머지)
+- `agents/*.md` — 13 agent prose writing guide
 
 ### 12.3 향후 작업 (별도 Task-ID)
 
-- `harness/session_state.py` 신규 작성 (OMC+RWH 차용, 글로벌 폴백 제외)
+- `harness/session_state.py` 확장 — by-pid 레지스트리 함수 + CLI subcommands (`init-session/begin-run/end-run/begin-step/end-step`)
 - `hooks/session-start.sh` 신규
 - `hooks/catastrophic-gate.sh` 신규
-- `harness/impl_driver.py` 새로 작성 (~50줄 컨베이어)
-- `harness/orchestration_agent.py` 폐기 (PR #28 코드)
-- `agents/orchestrator.md` (PM 도입 시, plugin Phase follow-up)
+- `hooks/post-agent.sh` (선택, heartbeat 자동화)
+- `.claude/settings.json` 템플릿 — plugin 활성 시 hook 자동 등록
+- `signal_io.write_prose` atomic write 강화
+- `agents/orchestrator.md` PM 도입 검토 (plugin Phase)
+- skill prompt 템플릿 — `/quick`, `/product-plan`, `/qa` 등이 helper protocol 따르도록

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,55 @@
 
 ## Records
 
+### DCN-CHG-20260429-32
+- **Date**: 2026-04-29
+- **Rationale**:
+  - PR #29 (`docs/conveyor-design.md` 초안) 의 Python `run_conveyor` 모델이 실 구현 단계 (Task -31) 검토 중 본질적 결함 발견:
+    1. **Subagent 호출 격리 문제** — Python 안에서 Agent 호출 시 subprocess `claude --agent` 또는 SDK 직접 호출 필요. 메인 세션의 PreToolUse 훅 미발화 또는 다른 settings 적용. catastrophic 보호 깨짐.
+    2. **사용자 가시성 0** — Python batch 종료까지 진행 안 보임.
+    3. **메인 자율도 0** — 매 step 사이 메인 개입 불가.
+  - 대안 검토:
+    - α) 단일 라벨 결정 하이쿠 — 라벨 늘면 driver hardcode 부담
+    - β) 정적 dict 라우팅 (옵션 b 부활) — 분기 룰 코드 박힘 (§2.5 원칙 1 약화)
+    - 글로벌 ~/.claude 폴백 — 도그푸딩 가치 < 4-가드 복잡도
+    - 관문 하이쿠 별도 LLM — 해석 하이쿠 + advance_when 로 충분
+    - **Task tool + Agent + helper + 훅** ← 채택
+  - 추가 발견 — 멀티세션 정합:
+    - `.session-id` / `.current-run-id` 단일 pointer = 동시 두 세션 띄우면 덮어쓰기 충돌
+    - env `DCNESS_RUN_ID` 전파 = Bash subprocess 휘발성 (메인 다음 호출 시 사라짐)
+    - 해결 = sid 별 디렉토리 격리 + by-pid 레지스트리 (`{cc_pid}` → sid/rid 매핑)
+- **Alternatives**:
+  1. *PR #29 그대로 머지하고 v1 design 으로 구현* — PreToolUse 훅 우회, 멀티세션 충돌 등 본질적 결함 그대로. 기각.
+  2. *PR #29 force-push 갈아엎기* — 리뷰 어려움. 기각.
+  3. *(채택)* **별도 PR (DCN-CHG-20260429-32) 로 conveyor-design.md rewrite + governance retraction notice** — 머지 이력 보존 + 전환 사유 명시.
+- **Decision**:
+  - 옵션 3. 동일 파일 (`docs/conveyor-design.md`) 의 12 절 내용 대폭 갱신:
+    - §0.4 신규 — Task tool 패턴 채택 이유
+    - §1 등장인물 — Python 컨베이어 폐기, helper module + 훅 명시
+    - §2 흐름 — Task lifecycle mermaid (TaskCreate → Update → Agent → end-step → Update)
+    - §3 데이터 모델 — Step (참고용), helper 호출 인터페이스 (Bash subcommand)
+    - §4 멀티세션 — by-pid 레지스트리, env 폐기 사유, PID 재사용 보호
+    - §5 디렉토리 — `.by-pid/` `.by-pid-current-run/` 추가
+    - §6 live.json — 그대로 (이미 OMC active_runs 패턴)
+    - §7 훅 — SessionStart + PreToolUse Agent 명시
+    - §8 catastrophic — pseudo-bash 풀 코드 박음
+    - §11 폐기 — PR #28 + v1 (Python 컨베이어) + 토론 검토 옵션 모두 명시
+  - **멀티세션 정합 핵심**:
+    - 모든 자원 sid 별 격리 (`.sessions/{sid}/`)
+    - by-pid 레지스트리 (`.by-pid/{cc_pid}` → sid, `.by-pid-current-run/{cc_pid}` → rid)
+    - 훅은 stdin payload sid 사용, helper 는 PPID 로 by-pid lookup
+    - PID 재사용 보호 = TTL + (선택) 시작 timestamp hash
+  - **HARNESS_ONLY_AGENTS 강제 mechanism**:
+    - PreToolUse Agent 훅이 by-pid-current-run 검사
+    - 없으면 engineer / validator-PLAN/CODE/BUGFIX_VALIDATION 차단
+    - "메인이 컨베이어 protocol 안 따르고 Agent 직접 호출" 시나리오 자동 차단
+- **Follow-Up**:
+  - **Task -33**: `harness/session_state.py` 확장 — by-pid 함수 (`write_pid_session/read_session_by_pid/...`) + CLI argparse subcommand (`init-session/begin-run/end-run/begin-step/end-step`). 기존 49 테스트 + 추가 ~20.
+  - **Task -34**: `hooks/session-start.sh` + `hooks/catastrophic-gate.sh` 신규. `.claude/settings.json` 템플릿 갱신 (plugin 활성 시 hook 자동 등록 패턴). shell test 또는 python pytest 로 회귀.
+  - **Task 후속**: `signal_io.write_prose` 의 atomic write 강화 (현재 `os.replace` → `session_state.atomic_write`).
+  - **plugin Phase follow-up**: skill prompt 템플릿 갱신 (`/quick` 등이 helper protocol 박음), `agents/orchestrator.md` PM 도입 검토.
+  - **회귀 위험**: 본 spec 박힌 후 Task -33/-34 가 spec 어긋나면 재PR. PR review 시 conveyor-design.md 정합 확인 필수.
+
 ### DCN-CHG-20260429-30
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260429-32
+- **Date**: 2026-04-29
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/conveyor-design.md` — 대폭 rewrite (Python `run_conveyor` 모델 → Task tool + Agent + helper + 훅 패턴). 멀티세션 by-pid 레지스트리 layout 추가.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: PR #29 의 v1 design (Python 컨베이어) 폐기 후 Task tool 패턴으로 대체. 폐기 이유 = subagent 호출이 Python 안에서 일어나면 PreToolUse 훅 미발화 + 사용자 가시성 0 + 메인 자율도 0. 새 모델 = 메인이 매 step Task lifecycle 운영하며 Agent 도구 직접 호출 → CC 가 자동으로 컨텍스트 격리 + 훅 발화. helper (`begin-run/begin-step/end-step/end-run`) 가 Bash 로 호출되며 by-pid 레지스트리 (`DCNESS_RUN_ID` env 폐기 — Bash subprocess 휘발성 회피) 로 멀티세션 정합. 코드 변경 0 — 후속 Task -33 (session_state.py 확장) / -34 (hooks 신규) 가 실 구현.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260429-30
 - **Date**: 2026-04-29
 - **Change-Type**: harness, test, docs-only


### PR DESCRIPTION
## Summary
PR #29 의 v1 design (Python \`run_conveyor\` 컨베이어) 폐기 후 Task tool + Agent + helper + 훅 패턴으로 갈아엎음.

### 폐기 이유
- Python 안에서 Agent 호출 시 PreToolUse 훅 미발화 → catastrophic 보호 본질적 결함
- Python batch 호출은 사용자 가시성 0
- 매 step 사이 메인 개입 불가 → 메인 자율도 0

### 새 모델
- 메인이 매 step Task lifecycle 운영 + Agent 도구 직접 호출
  - CC 가 자동 컨텍스트 격리 (Agent tool 자체)
  - PreToolUse 훅 자동 발화
- helper (begin-run/begin-step/end-step/end-run) Bash 호출 → live.json/prose 갱신
- 멀티세션 정합 = by-pid 레지스트리 (\`{cc_pid}\` → sid/rid 매핑)
  - env \`DCNESS_RUN_ID\` 전파 폐기 (Bash subprocess 휘발성)
  - 단일 \`.session-id\` pointer 폐기 (멀티세션 충돌)

### 12 절 변경 매트릭스
| 절 | 주요 변경 |
|---|---|
| §0.4 | Task tool 패턴 채택 이유 신규 |
| §1 | Python 컨베이어 폐기, helper module + Task tool + 훅 추가 |
| §2 | Task lifecycle mermaid |
| §3 | Step 참고용 + Bash subcommand 인터페이스 |
| §4 | by-pid 레지스트리 + PID 재사용 보호 |
| §5 | \`.by-pid/\` \`.by-pid-current-run/\` 추가 |
| §7 | SessionStart + PreToolUse Agent 책임 명시 |
| §8 | pseudo-bash 풀 코드 |
| §11 | PR #28 + v1 + 토론 검토 옵션 모두 폐기 명시 |

## Why
구현 단계 시작 전 spec 정확히 박음. v1 으로 구현하면 catastrophic 보호 깨짐 + 멀티세션 충돌 → 시작 전에 디자인 재정렬.

## Governance
- [x] Task-ID \`DCN-CHG-20260429-32\`
- [x] Change-Type: docs-only
- [x] document_update_record / change_rationale_history 갱신
- [x] doc-sync gate PASS
- [x] 코드 변경 0 → 회귀 0 (101/101 tests 그대로)

## Follow-up
- Task -33: \`harness/session_state.py\` 확장 (by-pid 함수 + CLI subcommand)
- Task -34: \`hooks/session-start.sh\` + \`hooks/catastrophic-gate.sh\` 신규

🤖 Generated with [Claude Code](https://claude.com/claude-code)