### PR TITLE
feat: session_state.py 확장 — by-pid 레지스트리 + CLI (DCN-CHG-20260429-33)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,15 @@
 
 ## 현재 상태
 
+- **🚀 Conveyor 인프라 Step 2 — `session_state.py` 확장 (by-pid 레지스트리 + CLI)** (`DCN-CHG-20260429-33`):
+  - by-pid 레지스트리 함수 8개 (`.by-pid/{cc_pid}` sid 매핑 + `.by-pid-current-run/{cc_pid}` rid 매핑) — 멀티세션 정합 핵심.
+  - PPID chain walker (`os.getppid()` → bash → `ps` → CC main pid) — 환경변수 휘발성 우회.
+  - CLI subcommand 5개 (`init-session/begin-run/end-run/begin-step/end-step`) — argparse 진입점.
+  - 신규 20 테스트 (전체 121/121 PASS).
+- **📐 Conveyor 디자인 v2 — `docs/conveyor-design.md` rewrite** (`DCN-CHG-20260429-32`, PR #31 머지):
+  - PR #29 v1 (Python `run_conveyor`) 폐기 후 Task tool + Agent + helper + 훅 패턴 채택.
+  - 12 절 모두 갱신. 멀티세션 by-pid 레지스트리 layout 명시.
+  - 폐기 사유 = subagent 호출이 Python 안에서 일어나면 PreToolUse 훅 미발화 + 사용자 가시성 0 + 메인 자율도 0.
 - **🚀 Conveyor 인프라 Step 1 — `harness/session_state.py` 신규** (`DCN-CHG-20260429-30`):
   - OMC `SkillActiveStateV2` (active_runs map, soft tombstone, heartbeat) + RWH `_meta` envelope + 3-tier resolution (글로벌 폴백 제외) + atomic write (O_EXCL+fsync+rename+dir fsync, 0o600) 차용.
   - 14 함수 export — session_id 검증/추출/resolution, session pointer R/W, run_id 생성, atomic_write, session_dir/run_dir/live_path, read_live/update_live, start_run/update_current_step/complete_run, cleanup_stale_runs.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,45 @@
 
 ## Records
 
+### DCN-CHG-20260429-33
+- **Date**: 2026-04-29
+- **Rationale**:
+  - `docs/conveyor-design.md` v2 (DCN-CHG-20260429-32) 의 §4/§5 멀티세션 인프라 코드 구현. helper protocol 의 진입점 (`begin-run/begin-step/end-step/end-run`) 도 동시 도입.
+  - 멀티세션 정합 = 환경변수 `DCNESS_RUN_ID` 전파가 Bash subprocess 휘발성으로 작동 안 함을 발견. 대체 = **PID-keyed 레지스트리** (RWH issue #19 패턴 부분 차용 + 글로벌 폴백 제외).
+  - PPID chain walker — python helper 가 자기 grandparent (CC main) PID 추출. `os.getppid()` 는 bash pid (직접 부모), `ps -o ppid=` 명령으로 한 단계 더 위 = CC main pid 획득. macOS / Linux 모두 동작.
+- **Alternatives**:
+  1. *환경변수 `DCNESS_RUN_ID` 메인이 export* — Bash subprocess 가 메인 process env 변경 못 함. 동작 안 함. 기각.
+  2. *메인이 helper 호출 시 sid/rid 직접 인자로 전달* — 사용자가 매번 `--sid abc --rid run-xxx` 박아야 → skill prompt 복잡 + 실수 위험. 기각.
+  3. *Skill prompt template 안에서 ps 로 CC pid 추출 후 인자로 전달* — 가능하나 매 helper 호출마다 boilerplate. 기각.
+  4. *(채택)* **CLI 안에서 PPID chain walker 가 자동 추출** + auto_detect_session_id / auto_detect_run_id helper. 메인이 인자 안 박아도 됨.
+- **Decision**:
+  - **by-pid 레지스트리 함수 8개**:
+    - `pid_session_path` / `pid_run_path` — 경로 helper
+    - `write_pid_session` / `read_pid_session` — sid 매핑
+    - `write_pid_current_run` / `read_pid_current_run` / `clear_pid_current_run` — rid 매핑
+    - `cleanup_stale_pid_files` — TTL (24h) 기반 정리 (PID 재사용 보호)
+  - **PPID chain walker** — `get_cc_pid_via_ppid_chain()`:
+    - `os.getppid()` = bash pid
+    - `subprocess.run(["ps", "-o", "ppid=", "-p", str(bash_pid)])` = CC main pid
+    - 실패 시 None 반환 (fallback to env/pointer in auto_detect)
+  - **auto-detect 함수**:
+    - `auto_detect_session_id` — by-pid 우선, current_session_id() 폴백
+    - `auto_detect_run_id` — by-pid-current-run lookup
+  - **CLI subcommand 5개**:
+    - `init-session <sid> <cc_pid>` — SessionStart 훅 보조 (write_pid_session + update_live 초기화)
+    - `begin-run <entry_point>` — sid auto-detect → generate rid → start_run + write_pid_current_run → stdout: rid
+    - `end-run` — sid+rid auto-detect → complete_run + clear_pid_current_run
+    - `begin-step <agent> [<mode>]` — sid+rid auto-detect → update_current_step
+    - `end-step <agent> [<mode>] --allowed-enums <csv> --prose-file <path>` — sid+rid auto-detect → write_prose + interpret_with_fallback → stdout: enum 1단어 (또는 "AMBIGUOUS")
+  - **end-step 의 ambiguous 처리** — interpret_with_fallback 실패 시 stdout="AMBIGUOUS" + stderr 에 detail. exit 0 (정상 결과 — 메인이 이 신호 보고 자율 처리).
+  - **PID 재사용 보호** — `cleanup_stale_pid_files(ttl_sec=24h)` 가 mtime 기준 stale by-pid 파일 정리. (start_ts hash 박는 옵션은 보류 — 24h TTL 충분).
+- **Follow-Up**:
+  - **Task -34**: `hooks/session-start.sh` (CLI 의 init-session 호출) + `hooks/catastrophic-gate.sh` (PreToolUse Agent 검사) 신규.
+  - **Task 후속**: `signal_io.write_prose` 의 `os.replace` → `session_state.atomic_write` 로 강화.
+  - **plugin Phase**: skill prompt 템플릿 (`/quick`, `/product-plan` 등) 가 helper protocol 박음.
+  - **회귀 위험**: PPID chain walker 가 macOS / Linux 동작 가정. Windows 미지원. tmux/screen 같은 환경에서 ppid 가 비표준일 수 있음 — auto_detect 가 폴백 (current_session_id) 으로 우회.
+  - **측정 (proposal §2.5 원칙 5)**: end-step 의 stdout 이 "AMBIGUOUS" 빈도 telemetry 누적 → agent prose writing guide 정확도 측정 데이터.
+
 ### DCN-CHG-20260429-32
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,18 @@
 
 ## Records
 
+### DCN-CHG-20260429-33
+- **Date**: 2026-04-29
+- **Change-Type**: harness, test, docs-only
+- **Files Changed**:
+  - `harness/session_state.py` — by-pid 레지스트리 함수 8개 + PPID chain walker + auto-detect 함수 2개 + CLI argparse subcommands 5개 (init-session/begin-run/end-run/begin-step/end-step) 추가. 약 +280 LOC.
+  - `tests/test_session_state.py` — by-pid 레지스트리 테스트 12 + cleanup 1 + CLI 테스트 7 = 신규 20 케이스. 49 → 69 케이스.
+  - `PROGRESS.md`
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+- **Summary**: `docs/conveyor-design.md` v2 (`DCN-CHG-20260429-32`) 의 §4/§5 multi-session 인프라 코드화. by-pid 레지스트리 = `.by-pid/{cc_pid}` (sid 매핑) + `.by-pid-current-run/{cc_pid}` (rid 매핑) — 멀티세션 정합 핵심. CLI subcommands = SessionStart 훅 (`init-session`) + helper protocol (`begin-run`/`end-run`/`begin-step`/`end-step`) 진입점. PPID chain walker = python helper 가 grandparent CC main pid 추출 (`os.getppid()` = bash → `ps -o ppid=` = CC main). auto_detect_session_id / auto_detect_run_id = by-pid 우선 + env/pointer 폴백. 121/121 tests PASS (101 기존 + 20 신규).
+- **Document-Exception**: 없음 (harness 카테고리 deliverable = `tests/**` 동반 ✅)
+
 ### DCN-CHG-20260429-32
 - **Date**: 2026-04-29
 - **Change-Type**: docs-only

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -32,6 +32,7 @@ import os
 import re
 import secrets
 import select
+import subprocess
 import sys
 import uuid
 from datetime import datetime, timezone
@@ -41,8 +42,21 @@ from typing import Any, Dict, Optional
 __all__ = [
     "SESSION_ID_RE",
     "DEFAULT_RUN_TTL_SEC",
+    "DEFAULT_PID_TTL_SEC",
     "LIVE_JSON_VERSION",
     "STDIN_TIMEOUT_SEC",
+    "valid_cc_pid",
+    "pid_session_path",
+    "pid_run_path",
+    "write_pid_session",
+    "read_pid_session",
+    "write_pid_current_run",
+    "read_pid_current_run",
+    "clear_pid_current_run",
+    "cleanup_stale_pid_files",
+    "get_cc_pid_via_ppid_chain",
+    "auto_detect_session_id",
+    "auto_detect_run_id",
     "valid_session_id",
     "session_id_from_stdin",
     "current_session_id",
@@ -66,9 +80,11 @@ SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,255}$")
 RUN_ID_RE = re.compile(r"^run-[a-z0-9]{8}$")
 
 DEFAULT_RUN_TTL_SEC = 24 * 60 * 60        # 24h — completed slot 보관 후 cleanup
+DEFAULT_PID_TTL_SEC = 24 * 60 * 60        # 24h — by-pid 파일 stale 기준 (PID 재사용 보호)
 LIVE_JSON_VERSION = 1                      # 스키마 진화 추적
 STDIN_TIMEOUT_SEC = 2.0                    # 훅 stdin 읽기 hang 방지
 _ATOMIC_FILE_MODE = 0o600
+_PPID_LOOKUP_TIMEOUT_SEC = 2.0
 
 
 # ── 경로 유틸 ───────────────────────────────────────────────────────
@@ -501,3 +517,319 @@ def cleanup_stale_runs(
     if removed:
         update_live(session_id, base_dir=base_dir, active_runs=survivors)
     return removed
+
+
+# ── by-pid 레지스트리 (멀티세션 정합 핵심) ─────────────────────────
+
+
+def valid_cc_pid(cc_pid: Any) -> bool:
+    """양수 정수만 유효."""
+    return isinstance(cc_pid, int) and cc_pid > 0
+
+
+def pid_session_path(cc_pid: int, *, base_dir: Optional[Path] = None) -> Path:
+    """`.by-pid/{cc_pid}` 절대 경로."""
+    if not valid_cc_pid(cc_pid):
+        raise ValueError(f"invalid cc_pid: {cc_pid!r}")
+    return _resolve_base(base_dir) / ".by-pid" / str(cc_pid)
+
+
+def pid_run_path(cc_pid: int, *, base_dir: Optional[Path] = None) -> Path:
+    """`.by-pid-current-run/{cc_pid}` 절대 경로."""
+    if not valid_cc_pid(cc_pid):
+        raise ValueError(f"invalid cc_pid: {cc_pid!r}")
+    return _resolve_base(base_dir) / ".by-pid-current-run" / str(cc_pid)
+
+
+def write_pid_session(
+    cc_pid: int, session_id: str, *, base_dir: Optional[Path] = None
+) -> Path:
+    """`.by-pid/{cc_pid}` ← session_id atomic 작성."""
+    if not valid_session_id(session_id):
+        raise ValueError(f"invalid session_id: {session_id!r}")
+    target = pid_session_path(cc_pid, base_dir=base_dir)
+    atomic_write(target, session_id.encode("utf-8"))
+    return target
+
+
+def read_pid_session(cc_pid: int, *, base_dir: Optional[Path] = None) -> str:
+    """`.by-pid/{cc_pid}` 읽기. 미존재 / 잘못된 sid → 빈 문자열."""
+    try:
+        path = pid_session_path(cc_pid, base_dir=base_dir)
+    except ValueError:
+        return ""
+    try:
+        if not path.exists():
+            return ""
+        sid = path.read_text(encoding="utf-8").strip()
+        return sid if valid_session_id(sid) else ""
+    except OSError:
+        return ""
+
+
+def write_pid_current_run(
+    cc_pid: int, run_id: str, *, base_dir: Optional[Path] = None
+) -> Path:
+    """`.by-pid-current-run/{cc_pid}` ← run_id atomic 작성."""
+    if not RUN_ID_RE.match(run_id):
+        raise ValueError(f"invalid run_id: {run_id!r}")
+    target = pid_run_path(cc_pid, base_dir=base_dir)
+    atomic_write(target, run_id.encode("utf-8"))
+    return target
+
+
+def read_pid_current_run(cc_pid: int, *, base_dir: Optional[Path] = None) -> str:
+    """`.by-pid-current-run/{cc_pid}` 읽기. 미존재 → 빈 문자열."""
+    try:
+        path = pid_run_path(cc_pid, base_dir=base_dir)
+    except ValueError:
+        return ""
+    try:
+        if not path.exists():
+            return ""
+        rid = path.read_text(encoding="utf-8").strip()
+        return rid if RUN_ID_RE.match(rid) else ""
+    except OSError:
+        return ""
+
+
+def clear_pid_current_run(
+    cc_pid: int, *, base_dir: Optional[Path] = None
+) -> bool:
+    """`.by-pid-current-run/{cc_pid}` 삭제. 성공 여부 반환."""
+    try:
+        path = pid_run_path(cc_pid, base_dir=base_dir)
+    except ValueError:
+        return False
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+
+def cleanup_stale_pid_files(
+    *,
+    ttl_sec: int = DEFAULT_PID_TTL_SEC,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """오래된 by-pid 파일 삭제 (PID 재사용 보호).
+
+    `.by-pid/*` 와 `.by-pid-current-run/*` 의 mtime 기준 ttl_sec 초과 파일 제거.
+    Returns: 삭제된 파일 수.
+    """
+    base = _resolve_base(base_dir)
+    now = datetime.now(timezone.utc).timestamp()
+    removed = 0
+    for sub in (".by-pid", ".by-pid-current-run"):
+        d = base / sub
+        if not d.exists():
+            continue
+        for f in d.iterdir():
+            try:
+                age = now - f.stat().st_mtime
+                if age > ttl_sec:
+                    f.unlink()
+                    removed += 1
+            except OSError:
+                pass
+    return removed
+
+
+# ── PPID chain — Bash 에서 호출된 helper 의 cc_pid 추출 ───────────
+
+
+def get_cc_pid_via_ppid_chain() -> Optional[int]:
+    """python helper 가 자신의 grandparent (CC main) PID 추출.
+
+    호출 chain: CC main → Bash subprocess → python helper.
+    `os.getppid()` = Bash pid. `ps -o ppid= -p <bash_pid>` = CC main pid.
+
+    Returns None if can't determine (e.g. ps 실패, 단독 실행).
+    """
+    try:
+        bash_pid = os.getppid()
+        result = subprocess.run(
+            ["ps", "-o", "ppid=", "-p", str(bash_pid)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=_PPID_LOOKUP_TIMEOUT_SEC,
+        )
+        cc_pid = int(result.stdout.strip())
+        if cc_pid > 0:
+            return cc_pid
+    except (
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        FileNotFoundError,
+        ValueError,
+    ):
+        pass
+    return None
+
+
+def auto_detect_session_id(*, base_dir: Optional[Path] = None) -> str:
+    """helper 컨텍스트 — by-pid (멀티세션 정합) 우선, env/pointer 폴백."""
+    cc_pid = get_cc_pid_via_ppid_chain()
+    if cc_pid is not None:
+        sid = read_pid_session(cc_pid, base_dir=base_dir)
+        if sid:
+            return sid
+    return current_session_id(base_dir=base_dir)
+
+
+def auto_detect_run_id(*, base_dir: Optional[Path] = None) -> str:
+    """helper 컨텍스트 — by-pid-current-run 에서 rid 추출."""
+    cc_pid = get_cc_pid_via_ppid_chain()
+    if cc_pid is None:
+        return ""
+    return read_pid_current_run(cc_pid, base_dir=base_dir)
+
+
+# ── CLI (python3 -m harness.session_state <subcommand>) ─────────────
+
+
+def _cli_init_session(args: Any) -> int:
+    """SessionStart 훅이 호출. by-pid 작성 + live.json 초기화."""
+    if not valid_session_id(args.sid):
+        print(f"[session_state] invalid sid: {args.sid!r}", file=sys.stderr)
+        return 1
+    if not valid_cc_pid(args.cc_pid):
+        print(f"[session_state] invalid cc_pid: {args.cc_pid!r}", file=sys.stderr)
+        return 1
+    write_pid_session(args.cc_pid, args.sid)
+    if not read_live(args.sid):
+        update_live(args.sid)  # 빈 active_runs 로 초기화
+    return 0
+
+
+def _cli_begin_run(args: Any) -> int:
+    """sid auto-detect → rid 생성 → start_run + by-pid-current-run."""
+    sid = auto_detect_session_id()
+    if not sid:
+        print("[session_state] sid 미해결 — SessionStart 훅 미실행?", file=sys.stderr)
+        return 1
+    rid = generate_run_id()
+    issue_num = args.issue_num if args.issue_num is not None else None
+    start_run(sid, rid, args.entry_point, issue_num=issue_num)
+    cc_pid = get_cc_pid_via_ppid_chain()
+    if cc_pid is not None:
+        write_pid_current_run(cc_pid, rid)
+    print(rid)
+    return 0
+
+
+def _cli_end_run(args: Any) -> int:
+    """sid+rid auto-detect → complete_run + clear by-pid-current-run."""
+    sid = auto_detect_session_id()
+    rid = auto_detect_run_id()
+    if not sid or not rid:
+        print("[session_state] sid/rid 미해결", file=sys.stderr)
+        return 1
+    complete_run(sid, rid)
+    cc_pid = get_cc_pid_via_ppid_chain()
+    if cc_pid is not None:
+        clear_pid_current_run(cc_pid)
+    return 0
+
+
+def _cli_begin_step(args: Any) -> int:
+    """sid+rid auto-detect → update_current_step."""
+    sid = auto_detect_session_id()
+    rid = auto_detect_run_id()
+    if not sid or not rid:
+        print("[session_state] sid/rid 미해결", file=sys.stderr)
+        return 1
+    mode = args.mode if args.mode else None
+    update_current_step(sid, rid, args.agent, mode)
+    print("ok")
+    return 0
+
+
+def _cli_end_step(args: Any) -> int:
+    """sid+rid auto-detect → write_prose + interpret_with_fallback."""
+    # 지연 import — interpret_strategy 는 telemetry 등 무거움
+    from harness.signal_io import write_prose
+    from harness.interpret_strategy import interpret_with_fallback
+    from harness.signal_io import MissingSignal
+
+    sid = auto_detect_session_id()
+    rid = auto_detect_run_id()
+    if not sid or not rid:
+        print("[session_state] sid/rid 미해결", file=sys.stderr)
+        return 1
+
+    prose = Path(args.prose_file).read_text(encoding="utf-8")
+    if not prose.strip():
+        print("[session_state] empty prose", file=sys.stderr)
+        return 1
+
+    mode = args.mode if args.mode else None
+    # prose 저장 — base_dir 은 .sessions/{sid}/runs/ (signal_io 가 그 아래 rid 디렉토리 생성)
+    base = session_dir(sid) / "runs"
+    write_prose(args.agent, rid, prose, mode=mode, base_dir=base)
+
+    allowed = [s.strip() for s in args.allowed_enums.split(",") if s.strip()]
+    if not allowed:
+        print("[session_state] empty --allowed-enums", file=sys.stderr)
+        return 1
+
+    try:
+        enum = interpret_with_fallback(prose, allowed)
+    except MissingSignal as e:
+        print("AMBIGUOUS", file=sys.stdout)
+        print(f"[session_state] interpret 실패: {e.detail[:200]}", file=sys.stderr)
+        return 0  # ambiguous 자체는 정상 결과 — 메인이 이 신호 보고 pause 결정
+
+    print(enum)
+    return 0
+
+
+def _build_arg_parser() -> Any:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="python3 -m harness.session_state",
+        description="dcNess 세션/run 격리 helper CLI",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_init = sub.add_parser("init-session", help="SessionStart 훅 보조")
+    p_init.add_argument("sid")
+    p_init.add_argument("cc_pid", type=int)
+    p_init.set_defaults(func=_cli_init_session)
+
+    p_br = sub.add_parser("begin-run", help="run_id 발급 + start_run")
+    p_br.add_argument("entry_point")
+    p_br.add_argument("--issue-num", type=int, default=None)
+    p_br.set_defaults(func=_cli_begin_run)
+
+    p_er = sub.add_parser("end-run", help="complete_run + clear by-pid-current-run")
+    p_er.set_defaults(func=_cli_end_run)
+
+    p_bs = sub.add_parser("begin-step", help="current_step + heartbeat 갱신")
+    p_bs.add_argument("agent")
+    p_bs.add_argument("mode", nargs="?", default="")
+    p_bs.set_defaults(func=_cli_begin_step)
+
+    p_es = sub.add_parser("end-step", help="prose 저장 + enum 추출 (stdout)")
+    p_es.add_argument("agent")
+    p_es.add_argument("mode", nargs="?", default="")
+    p_es.add_argument("--allowed-enums", required=True, help="comma-separated")
+    p_es.add_argument("--prose-file", required=True, help="prose 본문 파일 경로")
+    p_es.set_defaults(func=_cli_end_step)
+
+    return parser
+
+
+def _main(argv: Optional[list] = None) -> int:
+    parser = _build_arg_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -543,5 +543,290 @@ class CleanupStaleRunsTests(unittest.TestCase):
         self.assertIn("run-dddddddd", active)
 
 
+# ---------------------------------------------------------------------------
+# by-pid 레지스트리 (멀티세션 정합)
+# ---------------------------------------------------------------------------
+
+
+class ByPidRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        from harness.session_state import (
+            valid_cc_pid, pid_session_path, pid_run_path,
+            write_pid_session, read_pid_session,
+            write_pid_current_run, read_pid_current_run,
+            clear_pid_current_run,
+        )
+        self.valid_cc_pid = valid_cc_pid
+        self.pid_session_path = pid_session_path
+        self.pid_run_path = pid_run_path
+        self.write_pid_session = write_pid_session
+        self.read_pid_session = read_pid_session
+        self.write_pid_current_run = write_pid_current_run
+        self.read_pid_current_run = read_pid_current_run
+        self.clear_pid_current_run = clear_pid_current_run
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_valid_cc_pid(self) -> None:
+        self.assertTrue(self.valid_cc_pid(12345))
+        self.assertFalse(self.valid_cc_pid(0))
+        self.assertFalse(self.valid_cc_pid(-1))
+        self.assertFalse(self.valid_cc_pid("12345"))
+        self.assertFalse(self.valid_cc_pid(None))
+
+    def test_pid_session_path_format(self) -> None:
+        path = self.pid_session_path(12345, base_dir=self.base)
+        self.assertEqual(path, (self.base / ".by-pid" / "12345").resolve())
+
+    def test_pid_run_path_format(self) -> None:
+        path = self.pid_run_path(12345, base_dir=self.base)
+        self.assertEqual(
+            path,
+            (self.base / ".by-pid-current-run" / "12345").resolve(),
+        )
+
+    def test_write_then_read_pid_session(self) -> None:
+        self.write_pid_session(12345, "abc-sid", base_dir=self.base)
+        self.assertEqual(
+            self.read_pid_session(12345, base_dir=self.base), "abc-sid"
+        )
+
+    def test_read_pid_session_missing(self) -> None:
+        self.assertEqual(self.read_pid_session(99999, base_dir=self.base), "")
+
+    def test_read_pid_session_invalid_returns_empty(self) -> None:
+        # Force write invalid sid bypassing validator
+        path = self.pid_session_path(12345, base_dir=self.base)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("../bad", encoding="utf-8")
+        self.assertEqual(self.read_pid_session(12345, base_dir=self.base), "")
+
+    def test_write_then_read_pid_current_run(self) -> None:
+        self.write_pid_current_run(12345, "run-12345678", base_dir=self.base)
+        self.assertEqual(
+            self.read_pid_current_run(12345, base_dir=self.base),
+            "run-12345678",
+        )
+
+    def test_clear_pid_current_run(self) -> None:
+        self.write_pid_current_run(12345, "run-12345678", base_dir=self.base)
+        ok = self.clear_pid_current_run(12345, base_dir=self.base)
+        self.assertTrue(ok)
+        self.assertEqual(self.read_pid_current_run(12345, base_dir=self.base), "")
+
+    def test_clear_pid_current_run_idempotent(self) -> None:
+        self.assertFalse(self.clear_pid_current_run(99999, base_dir=self.base))
+
+    def test_invalid_sid_write_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            self.write_pid_session(12345, "../bad", base_dir=self.base)
+
+    def test_invalid_run_id_write_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            self.write_pid_current_run(12345, "not-a-run", base_dir=self.base)
+
+    def test_invalid_cc_pid_path_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            self.pid_session_path(-1, base_dir=self.base)
+
+    def test_multi_session_isolation(self) -> None:
+        # 두 세션 동시 by-pid 작성 — 서로 영향 0
+        self.write_pid_session(12345, "ses-A", base_dir=self.base)
+        self.write_pid_session(23456, "ses-B", base_dir=self.base)
+        self.write_pid_current_run(12345, "run-aaaaaaaa", base_dir=self.base)
+        self.write_pid_current_run(23456, "run-bbbbbbbb", base_dir=self.base)
+        self.assertEqual(
+            self.read_pid_session(12345, base_dir=self.base), "ses-A"
+        )
+        self.assertEqual(
+            self.read_pid_session(23456, base_dir=self.base), "ses-B"
+        )
+        self.assertEqual(
+            self.read_pid_current_run(12345, base_dir=self.base), "run-aaaaaaaa"
+        )
+        self.assertEqual(
+            self.read_pid_current_run(23456, base_dir=self.base), "run-bbbbbbbb"
+        )
+
+
+class CleanupStalePidTests(unittest.TestCase):
+    def setUp(self) -> None:
+        from harness.session_state import (
+            cleanup_stale_pid_files, write_pid_session, write_pid_current_run,
+        )
+        self.cleanup_stale_pid_files = cleanup_stale_pid_files
+        self.write_pid_session = write_pid_session
+        self.write_pid_current_run = write_pid_current_run
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_removes_old_pid_files(self) -> None:
+        import time
+        self.write_pid_session(12345, "old-sid", base_dir=self.base)
+        # mtime 25h 전으로 조작
+        path = self.base / ".by-pid" / "12345"
+        old = time.time() - (25 * 3600)
+        os.utime(path, (old, old))
+
+        # 신선한 파일
+        self.write_pid_session(23456, "fresh-sid", base_dir=self.base)
+
+        removed = self.cleanup_stale_pid_files(base_dir=self.base)
+        self.assertEqual(removed, 1)
+        self.assertFalse((self.base / ".by-pid" / "12345").exists())
+        self.assertTrue((self.base / ".by-pid" / "23456").exists())
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommands (subprocess 통해 호출 — 회귀 검증)
+# ---------------------------------------------------------------------------
+
+
+class CliInitSessionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        from harness.session_state import _cli_init_session, read_pid_session, read_live
+        self._cli_init_session = _cli_init_session
+        self.read_pid_session = read_pid_session
+        self.read_live = read_live
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self._cwd = os.getcwd()
+        os.chdir(self.base)
+
+    def tearDown(self) -> None:
+        os.chdir(self._cwd)
+        self._td.cleanup()
+
+    def test_init_session_writes_by_pid_and_live(self) -> None:
+        from types import SimpleNamespace
+        rc = self._cli_init_session(
+            SimpleNamespace(sid="abc-sid", cc_pid=12345)
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(self.read_pid_session(12345), "abc-sid")
+        live = self.read_live("abc-sid")
+        self.assertEqual(live["session_id"], "abc-sid")
+        self.assertEqual(live["active_runs"], {})
+
+    def test_init_session_invalid_sid(self) -> None:
+        from types import SimpleNamespace
+        rc = self._cli_init_session(
+            SimpleNamespace(sid="../bad", cc_pid=12345)
+        )
+        self.assertEqual(rc, 1)
+
+    def test_init_session_invalid_cc_pid(self) -> None:
+        from types import SimpleNamespace
+        rc = self._cli_init_session(
+            SimpleNamespace(sid="abc-sid", cc_pid=0)
+        )
+        self.assertEqual(rc, 1)
+
+
+class CliBeginStepEndStepTests(unittest.TestCase):
+    """auto_detect_* 를 mock 하고 CLI subcommand 동작 검증."""
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self._cwd = os.getcwd()
+        os.chdir(self.base)
+        # init session
+        from harness.session_state import (
+            write_pid_session, write_pid_current_run,
+            start_run, generate_run_id,
+        )
+        self.sid = "test-sid"
+        self.rid = "run-12345678"
+        self.cc_pid = 99999  # 임의
+        write_pid_session(self.cc_pid, self.sid)
+        from harness.session_state import update_live
+        update_live(self.sid)
+        start_run(self.sid, self.rid, "test-entry")
+        write_pid_current_run(self.cc_pid, self.rid)
+        # auto_detect 가 self.cc_pid 반환하도록 mock
+        from unittest.mock import patch
+        self._patcher = patch(
+            "harness.session_state.get_cc_pid_via_ppid_chain",
+            return_value=self.cc_pid,
+        )
+        self._patcher.start()
+        # interpret 텔레메트리 off
+        self._prev_telemetry = os.environ.get("DCNESS_LLM_TELEMETRY")
+        os.environ["DCNESS_LLM_TELEMETRY"] = "0"
+
+    def tearDown(self) -> None:
+        self._patcher.stop()
+        os.chdir(self._cwd)
+        self._td.cleanup()
+        if self._prev_telemetry is None:
+            os.environ.pop("DCNESS_LLM_TELEMETRY", None)
+        else:
+            os.environ["DCNESS_LLM_TELEMETRY"] = self._prev_telemetry
+
+    def test_begin_step_updates_current_step(self) -> None:
+        from harness.session_state import _cli_begin_step, read_live
+        from types import SimpleNamespace
+        rc = _cli_begin_step(SimpleNamespace(agent="validator", mode="PLAN_VALIDATION"))
+        self.assertEqual(rc, 0)
+        live = read_live(self.sid)
+        slot = live["active_runs"][self.rid]
+        self.assertEqual(slot["current_step"]["agent"], "validator")
+        self.assertEqual(slot["current_step"]["mode"], "PLAN_VALIDATION")
+
+    def test_end_step_writes_prose_and_extracts_enum(self) -> None:
+        from harness.session_state import _cli_end_step, session_dir
+        from types import SimpleNamespace
+        prose_path = self.base / "tmp_prose.md"
+        prose_path.write_text("## 결과\n검증.\n## 결론\nPASS\n", encoding="utf-8")
+
+        # capture stdout
+        from io import StringIO
+        from contextlib import redirect_stdout
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="validator",
+                mode="PLAN_VALIDATION",
+                allowed_enums="PASS,FAIL,SPEC_MISSING",
+                prose_file=str(prose_path),
+            ))
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "PASS")
+
+        # prose 종이 저장 확인
+        prose_md = (
+            session_dir(self.sid) / "runs" / self.rid /
+            "validator-PLAN_VALIDATION.md"
+        )
+        self.assertTrue(prose_md.exists())
+
+    def test_end_step_ambiguous_returns_AMBIGUOUS(self) -> None:
+        from harness.session_state import _cli_end_step
+        from types import SimpleNamespace
+        prose_path = self.base / "tmp_prose.md"
+        prose_path.write_text("no enum here at all", encoding="utf-8")
+
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="validator",
+                mode="PLAN_VALIDATION",
+                allowed_enums="PASS,FAIL",
+                prose_file=str(prose_path),
+            ))
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "AMBIGUOUS")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
\`docs/conveyor-design.md\` v2 (PR #31) §4/§5 멀티세션 인프라 코드 구현.

### 추가
- **by-pid 레지스트리 함수 8개**:
  - \`.by-pid/{cc_pid}\` (sid 매핑) + \`.by-pid-current-run/{cc_pid}\` (rid 매핑)
  - cleanup_stale_pid_files (24h TTL — PID 재사용 보호)
- **PPID chain walker**: \`os.getppid()\` (bash) → \`ps -o ppid=\` → CC main pid
- **auto-detect 함수 2개**: by-pid 우선 + env/pointer 폴백
- **CLI argparse subcommand 5개**: init-session / begin-run / end-run / begin-step / end-step

### CLI 사용 예
\`\`\`bash
# SessionStart 훅이 호출
$ python3 -m harness.session_state init-session abc-sid 12345

# 메인이 호출 (sid/rid auto-detect)
$ python3 -m harness.session_state begin-run quick
run-a3f81b29

$ python3 -m harness.session_state begin-step engineer IMPL
ok

$ python3 -m harness.session_state end-step engineer IMPL --allowed-enums "IMPL_DONE,TESTS_FAIL" --prose-file /tmp/p.md
IMPL_DONE
\`\`\`

### 멀티세션 정합
환경변수 \`DCNESS_RUN_ID\` 전파는 Bash subprocess 휘발성으로 작동 안 함 → PID-keyed 파일로 대체.

각 helper Bash 호출 시:
- bash 의 PPID = CC main pid
- python (helper) 의 grandparent = CC main
- \`ps -o ppid=\` 로 1 단계 더 위 추출 → CC main pid 획득
- by-pid 레지스트리에서 sid/rid lookup

세션 격리:
- 각 CC 세션 = 다른 CC main pid → 다른 .by-pid/ 파일 → 충돌 0
- sid 별 디렉토리 (\`.sessions/{sid}/\`) 와 결합 → 완전 격리

## Why
Multi-session safe helpers without env var propagation issues.

## Governance
- [x] Task-ID \`DCN-CHG-20260429-33\`
- [x] Change-Type: harness, test, docs-only
- [x] PROGRESS.md / document_update_record / change_rationale_history 갱신
- [x] doc-sync gate PASS
- [x] 121/121 tests PASS (101 기존 + 20 신규)

## Test plan
- [x] python3 -m unittest discover -s tests → 121/121 OK
- [x] CLI smoke (\`python3 -m harness.session_state --help\`)
- [ ] PPID chain walker 가 tmux/screen 같은 환경에서도 동작 — 후속 e2e 테스트

## Follow-up
- Task -34: \`hooks/session-start.sh\` (CLI init-session 호출) + \`hooks/catastrophic-gate.sh\` (PreToolUse Agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)