### PR TITLE
feat: hooks 인프라 — SessionStart + catastrophic-gate (DCN-CHG-20260429-34)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🚀 Conveyor 인프라 Step 3 — 훅 인프라** (`DCN-CHG-20260429-34`):
+  - `harness/hooks.py` (~280 LOC) — Python 훅 핸들러 (SessionStart + PreToolUse Agent)
+  - `hooks/session-start.sh` + `hooks/catastrophic-gate.sh` — bash 래퍼 (PPID 캡처 + python 호출)
+  - `hooks/hooks.json` — plugin 활성 시 자동 등록 (RWHarness 패턴 정합)
+  - HARNESS_ONLY_AGENTS (engineer / validator-PLAN/CODE/BUGFIX_VALIDATION) + §2.3 4룰 (1/3/4) 강제
+  - 신규 28 테스트 (전체 149/149 PASS).
 - **🚀 Conveyor 인프라 Step 2 — `session_state.py` 확장 (by-pid 레지스트리 + CLI)** (`DCN-CHG-20260429-33`):
   - by-pid 레지스트리 함수 8개 (`.by-pid/{cc_pid}` sid 매핑 + `.by-pid-current-run/{cc_pid}` rid 매핑) — 멀티세션 정합 핵심.
   - PPID chain walker (`os.getppid()` → bash → `ps` → CC main pid) — 환경변수 휘발성 우회.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,50 @@
 
 ## Records
 
+### DCN-CHG-20260429-34
+- **Date**: 2026-04-29
+- **Rationale**:
+  - `docs/conveyor-design.md` v2 (DCN-CHG-20260429-32) §7/§8 의 훅 인프라 코드 구현. catastrophic 보호의 *물리 강제선* — 메인이 protocol 따르든 안 따르든 Agent 호출 시 자동 발화.
+  - 훅 스크립트는 bash 래퍼 + Python 핸들러 분리. 이유:
+    1. bash 가 PPID 캡처 + python 인자로 전달 — Python 의 `os.getppid()` 가 shell 인지 CC 인지 모호한 케이스 회피
+    2. 모든 로직은 Python (테스트 가능) — bash 는 1줄 wrapper
+    3. RWHarness 패턴 정합 (`hooks/hooks.json` 으로 plugin 활성 시 자동 등록)
+- **Alternatives**:
+  1. *Python 직접 invoke (bash wrapper 없이)* — `python3 -m harness.hooks ...` 로 hooks.json 박음. 단점: PPID 가 shell 인지 CC 인지 모호. 기각 (bash 래퍼가 PPID 명시 캡처).
+  2. *훅 안에 catastrophic 검사 직접 구현 (Python 모듈 없이)* — 테스트 어려움 + 코드 분산. 기각.
+  3. *Settings.json 의 hooks 직접 박기 (plugin 자동 등록 안 함)* — plugin 사용자가 수동 설정 필요. 기각.
+  4. *(채택)* **bash 래퍼 + Python 핸들러 + hooks.json plugin 자동 등록** (RWHarness 패턴).
+- **Decision**:
+  - **`harness/hooks.py` 모듈** (~280 LOC):
+    - `HARNESS_ONLY_AGENTS` 상수 — orchestration.md §7.1 정합
+    - `handle_session_start(stdin_data, cc_pid)` — sid 추출 + write_pid_session + update_live 초기화
+    - `handle_pretooluse_agent(stdin_data, cc_pid)` — HARNESS_ONLY_AGENTS + §2.3.1/3/4 검사
+    - `_resolve_rid(sid, cc_pid)` — by-pid-current-run 우선, live.json 가장 최근 미완료 슬롯 폴백
+    - 헬퍼 4개 (`_has_plan_ready`, `_has_engineer_write`, `_has_validator_pass`, `_has_plan_review_pass`, `_has_ux_flow_ready`)
+    - CLI `python3 -m harness.hooks {session-start, pretooluse-agent}`
+  - **bash 래퍼**:
+    - `hooks/session-start.sh` — `CC_PID=$PPID; python3 -m harness.hooks session-start --cc-pid $CC_PID; exit 0` (silent skip on error)
+    - `hooks/catastrophic-gate.sh` — `CC_PID=$PPID; python3 -m harness.hooks pretooluse-agent --cc-pid $CC_PID; exit $?` (block 시 exit 1)
+  - **`hooks/hooks.json`** — plugin 자동 등록:
+    - `SessionStart` → session-start.sh (timeout 5s)
+    - `PreToolUse` matcher=Agent → catastrophic-gate.sh (timeout 10s)
+  - **silent skip 정책**:
+    - 모든 비-catastrophic 실패 (sid 없음 / cc_pid 없음 / parse 실패 / OS 에러) → exit 0 + skip
+    - 진짜 위반만 exit 1 + stderr 메시지
+    - 이유: CC 동작 방해 안 함 + plugin 환경 차이 (jq 없음 등) 견딤
+  - **테스트**:
+    - 28 케이스. mock stdin payload + base_dir 격리.
+    - HARNESS_ONLY_AGENTS 차단 / 통과 매트릭스
+    - §2.3.1/3/4 4룰 모두 happy/blocked path
+    - rid 폴백 (by-pid 없을 때 live.json 미완료 슬롯 픽업)
+- **Follow-Up**:
+  - **e2e 테스트** — 실 plugin 환경에서 `claude` 띄워 hook 발화 검증 (수동, 별도 PR)
+  - **multi-session 한계 명시** — Phase 1 은 단일 working directory 단일 세션 가정. 멀티세션 도그푸딩은 plugin Phase follow-up.
+  - **PostToolUse(Agent) heartbeat 갱신 훅** (선택) — last_confirmed_at 자동화
+  - **skill prompt 템플릿 갱신** — `/quick`, `/product-plan` 등이 helper protocol (begin-run/begin-step/end-step) 박음
+  - **`signal_io.write_prose` atomic write 강화** — 현재 `os.replace` → `session_state.atomic_write`
+  - **plugin smoke test** — `.claude-plugin/plugin.json` 의 hooks 등록 자동화 검증
+
 ### DCN-CHG-20260429-33
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,21 @@
 
 ## Records
 
+### DCN-CHG-20260429-34
+- **Date**: 2026-04-29
+- **Change-Type**: harness, hooks, test, docs-only
+- **Files Changed**:
+  - `harness/hooks.py` (신규, ~280 LOC) — Claude Code 훅 핸들러 (SessionStart + PreToolUse Agent). 순수 Python.
+  - `hooks/session-start.sh` (신규) — bash 래퍼, python 핸들러 호출 + cc_pid 전달
+  - `hooks/catastrophic-gate.sh` (신규) — 동일 패턴
+  - `hooks/hooks.json` (신규) — plugin 활성 시 hook 자동 등록 (RWHarness 패턴 정합)
+  - `tests/test_hooks.py` (신규, 28 케이스) — handle_session_start (7) + HARNESS_ONLY_AGENTS (3) + §2.3.3 engineer (4) + §2.3.1 pr-reviewer (4) + §2.3.4 architect (5) + rid 폴백 (1) + silent allow (3) + (1)
+  - `PROGRESS.md`
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+- **Summary**: `docs/conveyor-design.md` v2 (`DCN-CHG-20260429-32`) §7/§8 의 훅 스크립트 + 핸들러 구현. SessionStart = stdin sid 추출 + by-pid 작성 + live.json 초기화. PreToolUse Agent = HARNESS_ONLY_AGENTS (engineer / validator-PLAN/CODE/BUGFIX_VALIDATION) + §2.3 4룰 (1/3/4) 검사. rid 결정 = by-pid-current-run 우선 + live.json active_runs 가장 최근 미완료 슬롯 폴백. 모든 비-catastrophic 실패는 silent (CC 동작 방해 X). 149/149 tests PASS (121 기존 + 28 신규).
+- **Document-Exception**: 없음 (harness/hooks 카테고리 deliverable = `tests/**` 동반 ✅)
+
 ### DCN-CHG-20260429-33
 - **Date**: 2026-04-29
 - **Change-Type**: harness, test, docs-only

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -1,0 +1,296 @@
+"""hooks.py — Claude Code 훅 핸들러 (`docs/conveyor-design.md` §7).
+
+bash 훅 (`hooks/*.sh`) 이 stdin payload + cc_pid 를 본 모듈의 핸들러로 전달.
+순수 Python 으로 catastrophic 검사 + by-pid 레지스트리 갱신을 처리.
+
+핸들러:
+    handle_session_start(stdin_data, cc_pid) -> exit_code
+        SessionStart event. sid 추출 + by-pid 작성 + live.json 초기화.
+
+    handle_pretooluse_agent(stdin_data, cc_pid) -> exit_code
+        PreToolUse, tool=Agent. HARNESS_ONLY_AGENTS + §2.3 4 룰 검사.
+        exit 0 = allow, exit 1 = block (stderr 메시지 + CC 가 호출 거부).
+
+규약:
+    - 모든 실패 케이스 silent (exit 0) — CC 동작 방해 최소화
+    - 단, catastrophic 위반은 exit 1 + stderr 메시지 (CC 사용자에게 가시)
+    - stdin payload 파싱 실패 / sid 없음 / 잘못된 sid 등은 exit 0 (skip)
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from harness.session_state import (
+    read_live,
+    read_pid_current_run,
+    run_dir,
+    update_live,
+    valid_cc_pid,
+    valid_session_id,
+    write_pid_session,
+)
+
+
+__all__ = [
+    "HARNESS_ONLY_AGENTS",
+    "handle_session_start",
+    "handle_pretooluse_agent",
+]
+
+
+# orchestration.md §7.1 — 컨베이어 경유 필수 agent
+# (agent_name, mode_or_None) — None = 모든 mode 적용
+HARNESS_ONLY_AGENTS: tuple = (
+    ("engineer", None),
+    ("validator", "PLAN_VALIDATION"),
+    ("validator", "CODE_VALIDATION"),
+    ("validator", "BUGFIX_VALIDATION"),
+)
+
+
+def _extract_sid(payload: Dict[str, Any]) -> str:
+    """OMC 3 변형 fallback."""
+    return (
+        payload.get("session_id")
+        or payload.get("sessionId")
+        or payload.get("sessionid")
+        or ""
+    )
+
+
+def _is_harness_only(subagent: str, mode: str) -> bool:
+    for agent, m in HARNESS_ONLY_AGENTS:
+        if subagent == agent and (m is None or mode == m):
+            return True
+    return False
+
+
+def _resolve_rid(
+    sid: str,
+    cc_pid: Optional[int],
+    *,
+    base_dir: Optional[Path] = None,
+) -> str:
+    """rid 결정 — by-pid-current-run 우선, live.json 의 가장 최근 미완료 슬롯 폴백."""
+    if cc_pid is not None and valid_cc_pid(cc_pid):
+        rid = read_pid_current_run(cc_pid, base_dir=base_dir)
+        if rid:
+            return rid
+
+    live = read_live(sid, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict):
+        return ""
+    candidates = [
+        (rid_, slot) for rid_, slot in active.items()
+        if isinstance(slot, dict) and slot.get("completed_at") is None
+    ]
+    if not candidates:
+        return ""
+    candidates.sort(key=lambda x: x[1].get("started_at", ""), reverse=True)
+    return candidates[0][0]
+
+
+def handle_session_start(
+    stdin_data: Optional[Dict[str, Any]] = None,
+    cc_pid: Optional[int] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """SessionStart 훅 처리.
+
+    1. stdin 의 sessionId 추출
+    2. regex 검증
+    3. `.by-pid/{cc_pid}` ← sid 작성
+    4. `.sessions/{sid}/live.json` 초기화 (없으면)
+
+    실패 시 silent (exit 0).
+    """
+    if stdin_data is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_data = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError):
+            return 0
+
+    if not isinstance(stdin_data, dict):
+        return 0
+
+    sid = _extract_sid(stdin_data)
+    if not valid_session_id(sid):
+        return 0
+
+    if cc_pid is None or not valid_cc_pid(cc_pid):
+        return 0
+
+    try:
+        write_pid_session(cc_pid, sid, base_dir=base_dir)
+        if not read_live(sid, base_dir=base_dir):
+            update_live(sid, base_dir=base_dir)
+    except (OSError, ValueError):
+        return 0
+    return 0
+
+
+def handle_pretooluse_agent(
+    stdin_data: Optional[Dict[str, Any]] = None,
+    cc_pid: Optional[int] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """PreToolUse Agent 훅 처리 — HARNESS_ONLY_AGENTS + orchestration.md §2.3 4룰.
+
+    Returns:
+        0: allow
+        1: block (stderr 메시지 동반 — CC 가 호출 거부)
+    """
+    if stdin_data is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_data = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError):
+            return 0  # parse 실패 → silent allow
+
+    if not isinstance(stdin_data, dict):
+        return 0
+
+    sid = _extract_sid(stdin_data)
+    if not valid_session_id(sid):
+        return 0  # sid 없음 → 검사 불가, allow
+
+    tool_input = stdin_data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+    subagent = tool_input.get("subagent_type", "") or ""
+    mode = tool_input.get("mode", "") or ""
+
+    rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
+
+    # 1. HARNESS_ONLY_AGENTS — run 컨텍스트 없으면 차단
+    if _is_harness_only(subagent, mode):
+        if not rid:
+            label = subagent + (f":{mode}" if mode else "")
+            print(
+                f"[catastrophic] {label} 는 컨베이어 경유 필수 (run 미시작)",
+                file=sys.stderr,
+            )
+            return 1
+
+    if not rid:
+        return 0  # 컨베이어 외부 — 그 외 agent 는 통과
+
+    rd = run_dir(sid, rid, base_dir=base_dir)
+
+    # 2. §2.3.3 — engineer 직전 architect plan READY 필수 (mode != POLISH)
+    if subagent == "engineer" and mode != "POLISH":
+        if not _has_plan_ready(rd):
+            print(
+                "[catastrophic §2.3.3] engineer 호출은 architect plan READY 후만 "
+                "(MODULE_PLAN.md 안 READY_FOR_IMPL 또는 LIGHT_PLAN.md 안 LIGHT_PLAN_READY)",
+                file=sys.stderr,
+            )
+            return 1
+
+    # 3. §2.3.1 — pr-reviewer 직전 validator (CODE/BUGFIX) PASS 필수
+    if subagent == "pr-reviewer":
+        if _has_engineer_write(rd) and not _has_validator_pass(rd):
+            print(
+                "[catastrophic §2.3.1] pr-reviewer 호출은 validator "
+                "CODE_VALIDATION 또는 BUGFIX_VALIDATION PASS 후만",
+                file=sys.stderr,
+            )
+            return 1
+
+    # 4. §2.3.4 — architect SD/TD 직전 plan-reviewer + ux-architect 검토 필수
+    if subagent == "architect" and mode in ("SYSTEM_DESIGN", "TASK_DECOMPOSE"):
+        if (rd / "product-planner.md").exists():
+            if not _has_plan_review_pass(rd):
+                print(
+                    "[catastrophic §2.3.4] PRD 변경 후 plan-reviewer "
+                    "PLAN_REVIEW_PASS 필수",
+                    file=sys.stderr,
+                )
+                return 1
+            if not _has_ux_flow_ready(rd):
+                print(
+                    "[catastrophic §2.3.4] PRD 변경 후 ux-architect "
+                    "UX_FLOW_READY/PATCHED 필수",
+                    file=sys.stderr,
+                )
+                return 1
+
+    return 0
+
+
+def _read_or_empty(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+    except OSError:
+        return ""
+
+
+def _has_plan_ready(rd: Path) -> bool:
+    mp = _read_or_empty(rd / "architect-MODULE_PLAN.md")
+    if "READY_FOR_IMPL" in mp:
+        return True
+    lp = _read_or_empty(rd / "architect-LIGHT_PLAN.md")
+    return "LIGHT_PLAN_READY" in lp
+
+
+def _has_engineer_write(rd: Path) -> bool:
+    return (rd / "engineer-IMPL.md").exists() or (rd / "engineer-POLISH.md").exists()
+
+
+def _has_validator_pass(rd: Path) -> bool:
+    cv = _read_or_empty(rd / "validator-CODE_VALIDATION.md")
+    if "PASS" in cv:
+        return True
+    bv = _read_or_empty(rd / "validator-BUGFIX_VALIDATION.md")
+    return "PASS" in bv
+
+
+def _has_plan_review_pass(rd: Path) -> bool:
+    return "PLAN_REVIEW_PASS" in _read_or_empty(rd / "plan-reviewer.md")
+
+
+def _has_ux_flow_ready(rd: Path) -> bool:
+    text = _read_or_empty(rd / "ux-architect.md")
+    return "UX_FLOW_READY" in text or "UX_FLOW_PATCHED" in text
+
+
+# ── CLI 진입점 (bash 훅 → python -m harness.hooks <subcommand>) ─────
+
+
+def _main(argv: Optional[list] = None) -> int:
+    import argparse
+    import os
+
+    parser = argparse.ArgumentParser(
+        prog="python3 -m harness.hooks",
+        description="dcNess Claude Code 훅 진입점",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_ss = sub.add_parser("session-start", help="SessionStart 훅 처리")
+    p_ss.add_argument("--cc-pid", type=int, default=None)
+
+    p_ag = sub.add_parser("pretooluse-agent", help="PreToolUse Agent 훅 처리")
+    p_ag.add_argument("--cc-pid", type=int, default=None)
+
+    args = parser.parse_args(argv)
+
+    # cc_pid 미명시 시 PPID 사용 (bash 훅 의 PPID = CC main)
+    cc_pid = args.cc_pid if args.cc_pid is not None else os.getppid()
+
+    if args.cmd == "session-start":
+        return handle_session_start(cc_pid=cc_pid)
+    elif args.cmd == "pretooluse-agent":
+        return handle_pretooluse_agent(cc_pid=cc_pid)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/hooks/catastrophic-gate.sh
+++ b/hooks/catastrophic-gate.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# dcNess catastrophic-gate 훅 — PreToolUse Agent 직전 §2.3 4룰 검사
+#
+# 트리거: Claude Code PreToolUse event, tool=Agent
+# stdin: CC payload (sessionId + tool_input.{subagent_type, mode})
+# 동작: harness/hooks.py 의 handle_pretooluse_agent 호출
+#
+# 반환:
+#   exit 0: allow (CC 가 Agent 호출 진행)
+#   exit 1: block (stderr 메시지 + CC 가 호출 거부)
+#
+# 강제 룰:
+#   - HARNESS_ONLY_AGENTS (engineer, validator-PLAN/CODE/BUGFIX_VALIDATION) — run 미시작 시 차단
+#   - §2.3.1 — pr-reviewer 직전 validator (CODE/BUGFIX) PASS 확인
+#   - §2.3.3 — engineer 직전 architect plan READY 확인
+#   - §2.3.4 — architect SD/TD 직전 plan-reviewer + ux-architect 검토 확인
+
+set -uo pipefail
+
+# bash 의 PPID = CC main process
+CC_PID=$PPID
+
+python3 -m harness.hooks pretooluse-agent --cc-pid "$CC_PID"
+exit $?

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,28 @@
+{
+  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid 추출 + PreToolUse Agent catastrophic-gate)",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/catastrophic-gate.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# dcNess SessionStart 훅 — sid 추출 + by-pid 작성 + live.json 초기화
+#
+# 트리거: Claude Code SessionStart event
+# stdin: CC payload (sessionId 포함)
+# 동작: harness/hooks.py 의 handle_session_start 호출
+#
+# 실패 시 silent (exit 0) — CC 동작 방해 안 함.
+#
+# 등록: .claude/settings.json 의 hooks.SessionStart 에 본 스크립트 경로 박음.
+#       plugin 활성 시 자동 등록되도록 .claude-plugin/plugin.json 에서도 명시.
+
+set -uo pipefail
+
+# bash 의 PPID = CC main process
+CC_PID=$PPID
+
+# Python 으로 stdin 처리 + 핸들러 호출
+python3 -m harness.hooks session-start --cc-pid "$CC_PID"
+
+# 모든 실패는 silent
+exit 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,470 @@
+"""test_hooks — Claude Code 훅 핸들러 검증 (`harness/hooks.py`).
+
+Coverage matrix:
+    handle_session_start:
+        - 정상 sid 추출 + by-pid 작성 + live.json 초기화
+        - 잘못된 sid → silent skip (return 0)
+        - cc_pid invalid → silent skip
+        - 빈 stdin → silent skip
+        - 기존 live.json 보존 (재호출 안전)
+
+    handle_pretooluse_agent:
+        - HARNESS_ONLY_AGENTS — run 없으면 차단
+        - HARNESS_ONLY_AGENTS — run 있으면 추가 검사
+        - §2.3.1 — pr-reviewer 직전 CODE_VALIDATION 없으면 차단
+        - §2.3.1 — engineer 변경 후 CODE_VALIDATION PASS 있으면 통과
+        - §2.3.1 — BUGFIX_VALIDATION PASS 도 인정
+        - §2.3.3 — engineer 직전 plan READY 없으면 차단
+        - §2.3.3 — MODULE_PLAN READY_FOR_IMPL 있으면 통과
+        - §2.3.3 — LIGHT_PLAN_READY 있으면 통과 (light path)
+        - §2.3.3 — engineer POLISH 모드는 plan 검사 skip
+        - §2.3.4 — PRD 변경 후 plan-reviewer 없으면 차단
+        - §2.3.4 — ux-architect READY 없으면 차단
+        - §2.3.4 — 둘 다 있으면 통과
+        - 그 외 agent (architect MODULE_PLAN, qa 등) — run 외부에서도 통과
+        - sid 없음 → silent allow
+        - tool_input 비정상 → silent allow
+
+    rid 결정:
+        - by-pid-current-run 우선
+        - 폴백: live.json 의 가장 최근 미완료 슬롯
+        - 둘 다 없음 → ""
+"""
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.hooks import (
+    HARNESS_ONLY_AGENTS,
+    handle_pretooluse_agent,
+    handle_session_start,
+)
+from harness.session_state import (
+    read_live,
+    read_pid_session,
+    run_dir,
+    session_dir,
+    start_run,
+    update_live,
+    write_pid_current_run,
+    write_pid_session,
+)
+
+
+# ---------------------------------------------------------------------------
+# handle_session_start
+# ---------------------------------------------------------------------------
+
+
+class HandleSessionStartTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_happy_creates_by_pid_and_live(self) -> None:
+        rc = handle_session_start(
+            stdin_data={"sessionId": "abc-sid"},
+            cc_pid=12345,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(read_pid_session(12345, base_dir=self.base), "abc-sid")
+        live = read_live("abc-sid", base_dir=self.base)
+        self.assertEqual(live["session_id"], "abc-sid")
+        self.assertEqual(live["active_runs"], {})
+
+    def test_session_id_3_variants(self) -> None:
+        for key in ("session_id", "sessionId", "sessionid"):
+            with TemporaryDirectory() as td:
+                base = Path(td)
+                rc = handle_session_start(
+                    stdin_data={key: "test-sid"},
+                    cc_pid=12345,
+                    base_dir=base,
+                )
+                self.assertEqual(rc, 0)
+                self.assertEqual(read_pid_session(12345, base_dir=base), "test-sid")
+
+    def test_invalid_sid_silent(self) -> None:
+        rc = handle_session_start(
+            stdin_data={"sessionId": "../bad"},
+            cc_pid=12345,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        # 아무것도 안 만들어짐
+        self.assertFalse((self.base / ".by-pid" / "12345").exists())
+
+    def test_missing_cc_pid_silent(self) -> None:
+        rc = handle_session_start(
+            stdin_data={"sessionId": "abc-sid"},
+            cc_pid=None,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        self.assertFalse((self.base / ".by-pid").exists())
+
+    def test_invalid_cc_pid_silent(self) -> None:
+        rc = handle_session_start(
+            stdin_data={"sessionId": "abc-sid"},
+            cc_pid=0,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_empty_payload_silent(self) -> None:
+        rc = handle_session_start(stdin_data={}, cc_pid=12345, base_dir=self.base)
+        self.assertEqual(rc, 0)
+
+    def test_idempotent_preserves_live(self) -> None:
+        # 1차 호출 + start_run
+        handle_session_start(
+            stdin_data={"sessionId": "abc-sid"},
+            cc_pid=12345,
+            base_dir=self.base,
+        )
+        start_run("abc-sid", "run-aaaaaaaa", "test", base_dir=self.base)
+        # 2차 호출 — 기존 active_runs 보존되어야 함
+        handle_session_start(
+            stdin_data={"sessionId": "abc-sid"},
+            cc_pid=12345,
+            base_dir=self.base,
+        )
+        live = read_live("abc-sid", base_dir=self.base)
+        self.assertIn("run-aaaaaaaa", live.get("active_runs", {}))
+
+
+# ---------------------------------------------------------------------------
+# handle_pretooluse_agent — base setup
+# ---------------------------------------------------------------------------
+
+
+class _PreToolBase(unittest.TestCase):
+    sid = "test-sid"
+    rid = "run-12345678"
+    cc_pid = 99999
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        # 기본 setup — session + run 활성
+        write_pid_session(self.cc_pid, self.sid, base_dir=self.base)
+        update_live(self.sid, base_dir=self.base)
+        start_run(self.sid, self.rid, "test", base_dir=self.base)
+        write_pid_current_run(self.cc_pid, self.rid, base_dir=self.base)
+        self.run_path = run_dir(self.sid, self.rid, base_dir=self.base)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _payload(self, subagent: str, mode: str = "") -> dict:
+        return {
+            "sessionId": self.sid,
+            "tool_input": {
+                "subagent_type": subagent,
+                "mode": mode,
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# HARNESS_ONLY_AGENTS
+# ---------------------------------------------------------------------------
+
+
+class HarnessOnlyAgentsTests(_PreToolBase):
+    def test_constant_matches_spec(self) -> None:
+        # orchestration.md §7.1 정합 확인
+        self.assertIn(("engineer", None), HARNESS_ONLY_AGENTS)
+        self.assertIn(("validator", "PLAN_VALIDATION"), HARNESS_ONLY_AGENTS)
+        self.assertIn(("validator", "CODE_VALIDATION"), HARNESS_ONLY_AGENTS)
+        self.assertIn(("validator", "BUGFIX_VALIDATION"), HARNESS_ONLY_AGENTS)
+
+    def test_engineer_blocked_without_run(self) -> None:
+        # 새 base — run 없음
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            update_live(self.sid, base_dir=base)  # live 만 있고 run 없음
+            rc = handle_pretooluse_agent(
+                stdin_data=self._payload("engineer", "IMPL"),
+                cc_pid=88888,  # run 없는 cc_pid
+                base_dir=base,
+            )
+            self.assertEqual(rc, 1)
+
+    def test_validator_plan_blocked_without_run(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            update_live(self.sid, base_dir=base)
+            rc = handle_pretooluse_agent(
+                stdin_data=self._payload("validator", "PLAN_VALIDATION"),
+                cc_pid=88888,
+                base_dir=base,
+            )
+            self.assertEqual(rc, 1)
+
+    def test_non_harness_only_agent_allowed_without_run(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            update_live(self.sid, base_dir=base)
+            rc = handle_pretooluse_agent(
+                stdin_data=self._payload("qa", ""),
+                cc_pid=88888,
+                base_dir=base,
+            )
+            self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# §2.3.3 — engineer 직전 plan READY 검사
+# ---------------------------------------------------------------------------
+
+
+class CatastrophicEngineerTests(_PreToolBase):
+    def test_blocked_without_plan(self) -> None:
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_allowed_with_module_plan_ready(self) -> None:
+        (self.run_path / "architect-MODULE_PLAN.md").write_text(
+            "## 계획\n...\n## 결론\nREADY_FOR_IMPL\n", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_allowed_with_light_plan_ready(self) -> None:
+        (self.run_path / "architect-LIGHT_PLAN.md").write_text(
+            "LIGHT_PLAN_READY", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_polish_mode_skips_plan_check(self) -> None:
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "POLISH"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# §2.3.1 — pr-reviewer 직전 validator PASS 검사
+# ---------------------------------------------------------------------------
+
+
+class CatastrophicPrReviewerTests(_PreToolBase):
+    def test_no_engineer_write_allows(self) -> None:
+        # engineer 호출 흔적 없으면 통과
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("pr-reviewer", ""),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_engineer_write_without_validator_blocks(self) -> None:
+        (self.run_path / "engineer-IMPL.md").write_text("IMPL_DONE", encoding="utf-8")
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("pr-reviewer", ""),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_engineer_write_with_code_validation_pass_allows(self) -> None:
+        (self.run_path / "engineer-IMPL.md").write_text("IMPL_DONE", encoding="utf-8")
+        (self.run_path / "validator-CODE_VALIDATION.md").write_text(
+            "PASS", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("pr-reviewer", ""),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_engineer_write_with_bugfix_validation_pass_allows(self) -> None:
+        (self.run_path / "engineer-IMPL.md").write_text("IMPL_DONE", encoding="utf-8")
+        (self.run_path / "validator-BUGFIX_VALIDATION.md").write_text(
+            "PASS", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("pr-reviewer", ""),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# §2.3.4 — architect SD/TD 직전 PRD 변경 후 검토 검사
+# ---------------------------------------------------------------------------
+
+
+class CatastrophicArchitectTests(_PreToolBase):
+    def test_no_prd_change_allows(self) -> None:
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "SYSTEM_DESIGN"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_prd_change_without_review_blocks(self) -> None:
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "SYSTEM_DESIGN"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_prd_change_with_plan_review_no_ux_blocks(self) -> None:
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        (self.run_path / "plan-reviewer.md").write_text(
+            "PLAN_REVIEW_PASS", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "SYSTEM_DESIGN"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_prd_change_full_review_allows(self) -> None:
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        (self.run_path / "plan-reviewer.md").write_text(
+            "PLAN_REVIEW_PASS", encoding="utf-8",
+        )
+        (self.run_path / "ux-architect.md").write_text(
+            "UX_FLOW_READY", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "SYSTEM_DESIGN"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_architect_module_plan_skips_prd_check(self) -> None:
+        # MODULE_PLAN 은 §2.3.4 미적용
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "MODULE_PLAN"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# rid 폴백 (by-pid-current-run 없을 때 live.json 에서 추정)
+# ---------------------------------------------------------------------------
+
+
+class RidResolutionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        self.sid = "test-sid"
+        update_live(self.sid, base_dir=self.base)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_falls_back_to_most_recent_uncompleted(self) -> None:
+        # 두 run 존재. by-pid-current-run 없음.
+        start_run(self.sid, "run-aaaaaaaa", "older", base_dir=self.base)
+        # 약간 기다리지 않아도 ISO 같은 sec 단위 — 둘 다 같은 ts 가능
+        # 강제로 서로 다른 ts 박기
+        from harness.session_state import read_live as _rl
+        live = _rl(self.sid, base_dir=self.base) or {}
+        active = live.get("active_runs", {}) or {}
+        if "run-aaaaaaaa" in active:
+            active["run-aaaaaaaa"]["started_at"] = "2026-04-29T11:00:00+00:00"
+        update_live(self.sid, base_dir=self.base, active_runs=active)
+        start_run(self.sid, "run-bbbbbbbb", "newer", base_dir=self.base)
+        live = _rl(self.sid, base_dir=self.base) or {}
+        active = live.get("active_runs", {}) or {}
+        active["run-bbbbbbbb"]["started_at"] = "2026-04-29T12:00:00+00:00"
+        update_live(self.sid, base_dir=self.base, active_runs=active)
+
+        rd_b = run_dir(self.sid, "run-bbbbbbbb", base_dir=self.base)
+        # newer 의 run_dir 에 plan READY 박음
+        rd_b.mkdir(parents=True, exist_ok=True)
+        (rd_b / "architect-MODULE_PLAN.md").write_text(
+            "READY_FOR_IMPL", encoding="utf-8",
+        )
+
+        # by-pid 없이 호출 → live.json 의 newer 슬롯 선택 → READY 있어 통과
+        rc = handle_pretooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_input": {"subagent_type": "engineer", "mode": "IMPL"},
+            },
+            cc_pid=None,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# 비정상 입력 — silent allow
+# ---------------------------------------------------------------------------
+
+
+class SilentAllowTests(_PreToolBase):
+    def test_no_session_id_silent(self) -> None:
+        rc = handle_pretooluse_agent(
+            stdin_data={"tool_input": {"subagent_type": "engineer", "mode": "IMPL"}},
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_no_tool_input_silent(self) -> None:
+        rc = handle_pretooluse_agent(
+            stdin_data={"sessionId": self.sid},
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_non_dict_stdin_silent(self) -> None:
+        rc = handle_pretooluse_agent(
+            stdin_data="invalid",  # type: ignore[arg-type]
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
\`docs/conveyor-design.md\` v2 §7/§8 의 훅 인프라 구현. catastrophic 보호의 *물리 강제선*.

### 추가 (5 신규 파일, +905 LOC)
- \`harness/hooks.py\` — Python 핸들러 (~280 LOC)
- \`hooks/session-start.sh\` — bash 래퍼
- \`hooks/catastrophic-gate.sh\` — bash 래퍼
- \`hooks/hooks.json\` — plugin 자동 등록 (RWH 패턴)
- \`tests/test_hooks.py\` — 28 케이스

### 강제 룰
- **HARNESS_ONLY_AGENTS** — engineer / validator-PLAN/CODE/BUGFIX_VALIDATION 은 컨베이어 (run 컨텍스트) 경유 필수
- **§2.3.1** — pr-reviewer 직전 validator (CODE/BUGFIX) PASS 확인
- **§2.3.3** — engineer 직전 architect plan READY 확인
- **§2.3.4** — architect SD/TD 직전 PRD 변경 후 plan-reviewer + ux-architect 확인

### 보호의 본질
메인이 컨베이어 protocol 따르든 안 따르든, Agent 도구 호출 시 PreToolUse 훅 자동 발화 → catastrophic 위반 시 차단.

### Silent skip 정책
모든 비-catastrophic 실패 (sid/cc_pid/parse 에러 등) → exit 0 + skip. 진짜 위반만 exit 1 + stderr 메시지. CC 동작 방해 안 함.

## Why
plugin 사용자 환경에서 메인 도지덜 (LLM rebellion) 시에도 catastrophic 보장.

## Governance
- [x] Task-ID DCN-CHG-20260429-34
- [x] Change-Type: harness, hooks, test, docs-only
- [x] PROGRESS.md / document_update_record / change_rationale_history 갱신
- [x] doc-sync gate PASS
- [x] 149/149 tests PASS (121 기존 + 28 신규)

## Test plan
- [x] python3 -m unittest discover -s tests → 149/149 OK
- [x] Bash hook scripts 실행 권한 (chmod +x)
- [x] python3 -m harness.hooks --help 동작
- [ ] 실 plugin 환경 e2e 테스트 (별도 PR — manual smoke)

## Follow-up
- e2e 테스트 (실 \`claude\` 세션에서 hook 발화)
- skill prompt 템플릿 갱신 (helper protocol 박음)
- multi-session 한계 명시 (Phase 1 = 단일 working dir 단일 세션 가정)
- PostToolUse(Agent) heartbeat 자동화 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)