### PR TITLE
feat: commands/qa.md — /qa skill (DCN-CHG-20260429-36)

### DIFF
--- a/commands/qa.md
+++ b/commands/qa.md
@@ -1,0 +1,193 @@
+---
+name: qa
+description: 버그/이슈를 자연어로 받아 qa 에이전트로 분류하고 다음 액션을 추천하는 스킬. 사용자가 "버그 있다", "이슈", "이상해", "안 돼", "오류", "@qa", "QA", "큐에이" 등의 표현을 쓸 때 반드시 이 스킬을 사용한다. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 분류 결과 (FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 에 따라 후속 skill 추천.
+---
+
+# QA Skill — 버그/이슈 분류 + 라우팅 추천
+
+> 본 skill 은 dcNess `docs/conveyor-design.md` 의 Task tool + helper protocol 으로 동작한다.
+> qa agent 호출 → prose 종이 저장 → enum 추출 → 결과 보고. 분류 결과만 사용자에게 보여주고 후속 skill 은 사용자가 결정.
+
+## 언제 사용하는가
+
+- 사용자 발화에 다음 keyword 포함 — "버그", "이슈", "이상해", "안 돼", "안 맞아", "오류", "깨져", "@qa", "QA", "큐에이", "에러"
+- 또는 사용자가 어떤 동작/결과가 잘못됐다고 보고
+- 분류·라우팅 추천이 목적
+
+## 언제 사용하지 않음
+
+- "간단히 고쳐줘" / "한 줄 수정" → `/quick` (구현 후)
+- "새 기능", "피쳐 추가", "기획" → `/product-plan` (구현 후)
+- "디자인 바꿔", "레이아웃" → `/ux` (구현 후)
+- 코드 변경 의도 명확하고 분류 불필요 → `/quick` 또는 직접 architect 호출
+
+## 절차 (Task tool + helper protocol)
+
+### Step 0 — run 시작
+
+```bash
+RUN_ID=$(python3 -m harness.session_state begin-run qa)
+echo "[qa] run started: $RUN_ID"
+```
+
+`begin-run` 내부 동작:
+- sid auto-detect (PPID chain + by-pid lookup)
+- run_id 생성 (`run-{token_hex(4)}`)
+- `live.json.active_runs[run_id]` 슬롯 추가
+- `.by-pid-current-run/{cc_pid}` ← run_id
+
+### Step 1 — Task 생성
+
+```
+TaskCreate("qa: 이슈 분류")
+```
+
+(단일 task 만. 추가 단계는 사용자 결정 후.)
+
+### Step 2 — 사용자 입력 명확화 (필요 시)
+
+agent 호출 전, 다음 중 하나라도 모호하면 사용자에게 역질문:
+- 재현 조건
+- 화면/기능/컴포넌트
+- 예상/실제 동작 차이
+- 에러 메시지/로그
+- 발생 범위 (항상 vs 특정 조건)
+
+이미 명확하면 skip. 명확화 안 되면 분석 시작 X (사용자 응답 대기).
+
+### Step 3 — qa Agent 호출
+
+```
+TaskUpdate("qa: 이슈 분류", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step qa
+```
+
+`Agent` 도구 호출:
+```
+Agent(
+  subagent_type="qa",
+  description="<사용자 발화 및 명확화된 컨텍스트>"
+)
+```
+
+agent prose 가 메인 transcript 에 자동 박힘.
+
+### Step 4 — prose 저장 + enum 추출
+
+메인 transcript 의 prose 본문을 임시 파일에 저장 후 helper 호출:
+
+```bash
+# prose 를 here-doc 으로 임시 파일 작성 (메인이 transcript 에서 가져옴)
+cat > /tmp/dcness-qa-prose.md << 'PROSE_EOF'
+<agent prose 본문 그대로>
+PROSE_EOF
+
+# end-step
+ENUM=$(python3 -m harness.session_state end-step qa \
+    --allowed-enums "FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE" \
+    --prose-file /tmp/dcness-qa-prose.md)
+echo "[qa] classification: $ENUM"
+```
+
+`end-step` 내부 동작:
+- prose 를 `.sessions/{sid}/runs/{rid}/qa.md` 로 atomic write
+- `interpret_with_fallback` (heuristic only — no haiku)
+- 휴리스틱이 prose 마지막 영역에서 enum 단어 매칭
+- stdout: 추출된 enum 1단어, 또는 `"AMBIGUOUS"` (실패 시)
+
+### Step 5 — AMBIGUOUS 처리 (실패 시 cascade)
+
+`end-step` stdout 이 `"AMBIGUOUS"` 면 다음 순서로 처리:
+
+#### 5-1. agent 재호출 (1회)
+
+```
+Agent(
+  subagent_type="qa",
+  description="직전 응답에서 결론 enum 미명시. FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE 중 하나로 prose 마지막 단락에 명시해서 다시 분석해줘. 원본 이슈: <사용자 발화>"
+)
+```
+
+재호출 prose 받으면 Step 4 반복. enum 추출되면 Step 6 진행.
+
+#### 5-2. 재호출도 AMBIGUOUS 면 사용자 위임
+
+```
+사용자에게:
+"qa 가 결론을 명확히 안 적었습니다. 본문 발췌:
+   <prose tail 발췌>
+
+다음 중 어느 분류로 진행할까요?
+1) FUNCTIONAL_BUG  (기능 버그 — impl 루프)
+2) CLEANUP         (코드 정리 — impl 루프 light)
+3) DESIGN_ISSUE    (디자인 이슈 — designer)
+4) KNOWN_ISSUE     (이미 알려진 — 종료)
+5) SCOPE_ESCALATE  (분류 모호 — 사용자 결정)
+6) 종료"
+```
+
+사용자 응답 받으면 그 enum 으로 진행.
+
+### Step 6 — 결과 보고 + 후속 skill 추천
+
+```
+TaskUpdate("qa: 이슈 분류", completed)
+```
+
+분류 결과 + 라우팅 추천 출력:
+
+```
+[qa 분류 결과] $ENUM
+
+prose 종이: .claude/harness-state/.sessions/{sid}/runs/{rid}/qa.md
+
+다음 추천:
+- FUNCTIONAL_BUG → /quick (구현 후) 또는 architect LIGHT_PLAN 직접 호출
+- CLEANUP        → /quick (구현 후) 또는 engineer 직접 호출
+- DESIGN_ISSUE   → /ux (구현 후) 또는 designer 직접 호출
+- KNOWN_ISSUE    → 종료 (이미 알려진 이슈)
+- SCOPE_ESCALATE → 사용자 결정 필요 (분류 모호)
+
+진행할까요? 사용자 결정 대기.
+```
+
+후속 skill 자동 진입 안 함 (사용자가 결정). FUNCTIONAL_BUG / CLEANUP 의 경우 `/quick` 미구현 시 architect 직접 호출 가이드 제공.
+
+### Step 7 — run 종료
+
+사용자 응답에 따라:
+- 후속 진행 → run 유지 (다음 step 시작 — 다른 skill 진입)
+- 종료 → `python3 -m harness.session_state end-run`
+
+```bash
+python3 -m harness.session_state end-run
+```
+
+`end-run` 내부:
+- `live.json.active_runs[rid].completed_at` 채움 (soft tombstone)
+- `.by-pid-current-run/{cc_pid}` 삭제
+
+## Catastrophic 룰 정합
+
+본 skill 은 catastrophic 위반 없음:
+- qa agent 는 HARNESS_ONLY_AGENTS 미해당 — run 컨텍스트 없어도 호출 가능 (단 본 skill 은 begin-run 으로 컨텍스트 만듦 — prose 저장 / live.json 갱신 위해)
+- §2.3 4룰 모두 qa 무관
+
+`docs/conveyor-design.md` §8 의 catastrophic-gate.sh 가 자동 통과.
+
+## 한계 / 후속
+
+- **`/quick`, `/ux` 미구현** — 본 skill 은 분류만 하고 다음 skill 자동 진입 안 함. 별도 Task 에서 후속 skill 추가 시 자동 라우팅 활성.
+- **재현 검증 안 함** — qa agent 가 분류 + 추적 ID 발급. 실제 재현은 다음 단계 (engineer/designer) 책임.
+- **휴리스틱 fail rate 측정** — `.metrics/heuristic-calls.jsonl` 누적. fail rate 30%+ 면 haiku fallback 검토 (별도 Task).
+
+## 참조
+
+- `agents/qa.md` — qa 에이전트 system prompt (5 결론 enum 출처)
+- `docs/orchestration.md` §3.6 — qa 라우팅 시퀀스
+- `docs/orchestration.md` §4.11 — qa 결론 enum → 다음 trigger 결정표
+- `docs/conveyor-design.md` §2 / §3 / §7 — Task tool + helper protocol + 훅 책임
+- `harness/session_state.py` — begin-run / begin-step / end-step / end-run helpers

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,42 @@
 
 ## Records
 
+### DCN-CHG-20260429-36
+- **Date**: 2026-04-29
+- **Rationale**:
+  - dcNess plugin 의 첫 skill 도입. 사용자 진입점 = "버그 있다" 류 자연어 발화 → 분류 + 라우팅 추천.
+  - 사용자 결정 — heuristic only (haiku 안 켬). 이유:
+    1. **메인 단독 판단 vs catastrophic 훅 일관성** 트레이드오프 검토 결과 heuristic 유지가 안전 (메인이 prose 본문 본 의미 vs 훅 grep 결과 어긋날 위험)
+    2. **API 키 의존 회피** — dcNess 자체 도그푸딩 환경 (subscription only) 호환
+    3. **비용 0** — heuristic 은 Python regex (cycle 당 LLM 호출 0)
+    4. **dcNess 정신 정합** — heuristic 은 가벼운 enum 추출 (단어경계 매칭 1개), 형식 강제 사다리 아님
+  - AMBIGUOUS 처리 = cascade 패턴 — agent 재호출 (1회) → 사용자 위임. 메인 단독 판단으로 진행 시 다음 step 의 catastrophic 훅 grep 과 어긋날 risk 회피.
+- **Alternatives**:
+  1. *heuristic + haiku fallback 동시 켬* — robustness ↑, but API 키 의존 + dcNess 도그푸딩 호환성 ↓. 기각.
+  2. *heuristic + haiku 둘 다 폐기, 메인이 prose 본문 보고 직접 판단* — 메인 vs 훅 일관성 깨짐 risk. 기각.
+  3. *(채택)* **heuristic only + AMBIGUOUS cascade (재호출 → 사용자)** — 결정론 + plugin 환경 호환 + dcNess 정신 정합.
+- **Decision**:
+  - `commands/qa.md` 신규. CC 가 `commands/*.md` 자동 디스커버 (RWHarness 패턴 정합).
+  - **8 step protocol**:
+    - Step 0 — `begin-run qa` 로 run_id 발급
+    - Step 1 — `TaskCreate("qa: 이슈 분류")` (단일 task)
+    - Step 2 — 사용자 입력 명확화 (재현·범위·예상 동작 등 모호 시 역질문)
+    - Step 3 — `TaskUpdate(in_progress)` + `begin-step qa` + `Agent(qa, ...)`
+    - Step 4 — prose 임시 파일 저장 + `end-step qa --allowed-enums "..." --prose-file ...` → enum 또는 AMBIGUOUS
+    - Step 5 — AMBIGUOUS 시 cascade (5-1 재호출 / 5-2 사용자 위임)
+    - Step 6 — `TaskUpdate(completed)` + 분류 결과 보고 + 후속 skill 추천 (자동 진입 X)
+    - Step 7 — 종료 시 `end-run`
+  - **agents/qa.md 정합**: 5 결론 enum (FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 그대로 사용.
+  - **catastrophic 룰 무관**: qa agent 는 HARNESS_ONLY_AGENTS 미해당, §2.3 4룰 모두 비대상.
+  - **후속 skill 미구현 명시**: `/quick`, `/ux` 가 없으므로 분류 결과만 보여주고 자동 라우팅 X. 사용자 결정 받고 architect 직접 호출 또는 종료.
+- **Follow-Up**:
+  - **Task -37**: `/quick` skill (FUNCTIONAL_BUG / CLEANUP 분류 후 light path 자동 진입)
+  - **Task -38**: `/init-dcness` (enable / disable 헬퍼)
+  - **Task -39**: `/harness-monitor` `/harness-list` `/harness-kill` (디버깅/운영)
+  - **manual smoke**: 실 `claude` 세션에서 `/qa <bug 보고>` 발화 → SessionStart 훅 → run_dir + prose 종이 + end-run 검증
+  - **measurement**: `.metrics/heuristic-calls.jsonl` 누적 → AMBIGUOUS 빈도 측정. 30%+ 면 haiku fallback 검토.
+  - **회귀 위험**: skill prompt 가 helper CLI 시그니처에 묶임. `harness/session_state.py` 변경 시 skill prompt 도 동기화 필요. governance §2.6 의 doc-sync 가 자동 catch (commands/ 는 docs-only category, 매 변경 시 doc-sync 발화).
+
 ### DCN-CHG-20260429-35
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260429-36
+- **Date**: 2026-04-29
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `commands/qa.md` (신규) — `/qa` skill (버그/이슈 분류 + 라우팅 추천)
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+- **Summary**: dcNess plugin 의 첫 skill 신규. `/qa` = 사용자가 "버그 있다 / 이슈 / 이상해 / 오류" 등 발화 시 진입. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 절차: begin-run → TaskCreate → 명확화 (필요 시) → begin-step + Agent(qa) + end-step → AMBIGUOUS cascade (재호출 → 사용자 위임) → 결과 보고 + 후속 skill 추천 → end-run. heuristic only (haiku 미사용 — API 키 의존 회피, 비용 0). `/quick`, `/ux` 미구현이라 후속 자동 라우팅 X — 사용자 결정 받음. agents/qa.md 의 5 결론 enum (FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 정합. 코드 변경 0 (prompt-only).
+- **Document-Exception**: 없음 (docs-only 카테고리)
+
 ### DCN-CHG-20260429-35
 - **Date**: 2026-04-29
 - **Change-Type**: test, docs-only


### PR DESCRIPTION
## Summary
dcNess plugin 의 첫 skill. \`/qa\` = 사용자가 "버그 / 이슈 / 이상해 / 오류" 등 발화 시 진입.

### 동작
qa agent 호출 → 분류 (5 enum) → 후속 skill 추천. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅).

### 8-step protocol
0. \`begin-run qa\` — run 컨텍스트 설정
1. \`TaskCreate("qa: 이슈 분류")\` — UI 가시성
2. 사용자 입력 명확화 (모호 시 역질문)
3. \`TaskUpdate(in_progress)\` + \`begin-step\` + \`Agent(qa, ...)\`
4. prose 저장 + \`end-step --allowed-enums "..."\` → enum / AMBIGUOUS
5. AMBIGUOUS cascade (재호출 → 사용자 위임)
6. \`TaskUpdate(completed)\` + 분류 결과 + 후속 skill 추천
7. 종료 시 \`end-run\`

### 설계 결정 (change_rationale 발췌)
- **heuristic only (haiku 미사용)** — API 키 의존 회피 + 비용 0 + dcNess 자체 도그푸딩 호환
- **AMBIGUOUS = 메인 단독 판단 X** — 재호출 → 사용자 위임 cascade
  - 이유: 메인 단독 판단 시 prose 본문 grep 하는 catastrophic 훅 결과와 어긋날 risk
- **후속 skill 자동 진입 X** — \`/quick\`, \`/ux\` 미구현 → 사용자 결정 대기

### 정합
- \`agents/qa.md\` 의 5 결론 enum (FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 그대로 사용
- \`docs/conveyor-design.md\` 의 Task tool + helper protocol 정합
- \`docs/orchestration.md\` §3.6 / §4.11 정합
- catastrophic 룰 무관 (qa 는 HARNESS_ONLY_AGENTS 미해당)

## Why
사용자 진입점 첫 skill. 컨베이어 인프라 (PR #30/#31/#32/#33/#34) 가 실제 사용 가능 단계로 이행.

## Governance
- [x] Task-ID DCN-CHG-20260429-36
- [x] Change-Type: docs-only
- [x] document_update_record / change_rationale_history 갱신
- [x] doc-sync gate PASS
- [x] 160/160 tests PASS (변경 없음 — prompt-only)

## Follow-up
- Task -37: \`/quick\` skill (FUNCTIONAL_BUG / CLEANUP 자동 진입)
- Task -38: \`/init-dcness\` (enable/disable)
- Task -39: \`/harness-monitor\` / \`/harness-list\` / \`/harness-kill\`
- governance §2.2 에 \`commands/\` 카테고리 추가 검토 (현재 null 분류)
- manual smoke (실 \`claude\` 에서 \`/qa\` 발화 → 전체 흐름)

🤖 Generated with [Claude Code](https://claude.com/claude-code)