### PR TITLE
feat: /quick + /product-plan skills (DCN-CHG-20260429-37)

### DIFF
--- a/commands/product-plan.md
+++ b/commands/product-plan.md
@@ -1,0 +1,316 @@
+---
+name: product-plan
+description: 새 기능 / PRD 변경 / 큰 기획을 받아 product-planner → plan-reviewer → ux-architect → validator UX_VALIDATION → architect SYSTEM_DESIGN → architect TASK_DECOMPOSE 시퀀스로 spec/design 단계까지 진행하는 스킬. 사용자가 "기획자야", "새 기능", "피쳐 추가", "이런 기능이 필요할 것 같아", "기획해줘", "프로덕트 플랜", "/product-plan" 등을 말할 때 반드시 이 스킬을 사용한다. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 구현 진입은 별도 (`/quick` 또는 정식 impl 루프).
+---
+
+# Product Plan Skill — 새 기능 spec/design 흐름
+
+> dcNess 컨베이어 패턴. PRD → 검토 → UX → 검증 → 시스템 설계 → 태스크 분해까지 *spec 단계만* 자동 진행. 구현은 사용자 결정 (다음 진입점).
+
+## 언제 사용하는가
+
+- 사용자 발화에 다음 keyword — "새 기능", "피쳐", "기획", "기획자", "기능 추가", "프로덕트 플랜", "이런 기능이 필요"
+- 또는 PRD 변경이 동반된 작업
+- 단순 버그픽스 / 코드 정리 → `/quick` 으로 라우팅
+
+## 언제 사용하지 않음
+
+- "버그", "오류", "이상해" → `/qa`
+- "간단한 수정", "오타" → `/quick`
+- "디자인", "레이아웃" 만의 변경 → `/ux` (구현 후) 또는 designer 직접 호출
+- 기능 정의 명확 + 구현만 필요 → `/quick` 또는 architect MODULE_PLAN 직접
+
+## 시퀀스 (orchestration.md §3.1)
+
+```
+product-planner → plan-reviewer → ux-architect → validator (UX_VALIDATION) →
+architect (SYSTEM_DESIGN) → architect (TASK_DECOMPOSE) → 구현 진입 (별도)
+```
+
+각 단계마다 결론 enum:
+- product-planner → `PRODUCT_PLAN_READY` (또는 `CLARITY_INSUFFICIENT` / `PRODUCT_PLAN_CHANGE_DIFF` / `PRODUCT_PLAN_UPDATED` / `ISSUES_SYNCED`)
+- plan-reviewer → `PLAN_REVIEW_PASS` (또는 `PLAN_REVIEW_CHANGES_REQUESTED`)
+- ux-architect → `UX_FLOW_READY` (또는 `UX_FLOW_PATCHED` / `UX_REFINE_READY` / `UX_FLOW_ESCALATE`)
+- validator UX_VALIDATION → `PASS` (또는 `FAIL`)
+- architect SYSTEM_DESIGN → `SYSTEM_DESIGN_READY`
+- architect TASK_DECOMPOSE → `READY_FOR_IMPL`
+
+## 절차 (Task tool + helper protocol)
+
+### Step 0 — run 시작 + 사용자 확인
+
+```bash
+RUN_ID=$(python3 -m harness.session_state begin-run product-plan)
+echo "[product-plan] run started: $RUN_ID"
+```
+
+사용자에게 한 번 확인:
+```
+[product-plan] 실행 설정
+- 요청: <유저 원문>
+- 작업 유형: <신규 기능 / PRD 변경 / 기존 기능 확장 중 추정>
+- 시퀀스: product-planner → plan-reviewer → ux-architect → validator UX → architect SYSTEM_DESIGN → architect TASK_DECOMPOSE
+- 후속: 구현은 별도 진입 (사용자 결정)
+
+진행할까요?
+```
+
+확인 못 받으면 대기.
+
+### Step 1 — 6 task 생성
+
+```
+TaskCreate("product-planner: PRD 작성")
+TaskCreate("plan-reviewer: PRD 심사")
+TaskCreate("ux-architect: UX_FLOW")
+TaskCreate("validator: UX_VALIDATION")
+TaskCreate("architect: SYSTEM_DESIGN")
+TaskCreate("architect: TASK_DECOMPOSE")
+```
+
+### Step 2 — product-planner
+
+```
+TaskUpdate("product-planner: PRD 작성", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step product-planner
+```
+
+```
+Agent(
+  subagent_type="product-planner",
+  description="<유저 원문>. PRD 작성해줘. 결론 enum: PRODUCT_PLAN_READY / CLARITY_INSUFFICIENT / PRODUCT_PLAN_CHANGE_DIFF / PRODUCT_PLAN_UPDATED / ISSUES_SYNCED."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step product-planner \
+    --allowed-enums "PRODUCT_PLAN_READY,CLARITY_INSUFFICIENT,PRODUCT_PLAN_CHANGE_DIFF,PRODUCT_PLAN_UPDATED,ISSUES_SYNCED" \
+    --prose-file /tmp/dcness-pp-pp.md)
+```
+
+분기:
+- `PRODUCT_PLAN_READY` → 다음 step (plan-reviewer)
+- `PRODUCT_PLAN_UPDATED` → ux-architect 로 직행 (변경 반영, plan-reviewer skip 가능 — 기존 PASS 활용)
+- `PRODUCT_PLAN_CHANGE_DIFF` → plan-reviewer 변경분만 재심사
+- `CLARITY_INSUFFICIENT` → 사용자 역질문 후 재호출 (대기)
+- `ISSUES_SYNCED` → 동기화 완료, 추가 진행 없음 (종료)
+- `AMBIGUOUS` → cascade
+
+advance:
+```
+TaskUpdate("product-planner: PRD 작성", completed)
+```
+
+### Step 3 — plan-reviewer
+
+```
+TaskUpdate("plan-reviewer: PRD 심사", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step plan-reviewer
+```
+
+```
+Agent(
+  subagent_type="plan-reviewer",
+  description="product-planner 의 PRD 심사해줘. 8 차원 (현실성·MVP·제약·UX 저니·숨은 가정·경쟁 맥락·과금 설계·기술 실현성). 결론 enum: PLAN_REVIEW_PASS / PLAN_REVIEW_CHANGES_REQUESTED."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step plan-reviewer \
+    --allowed-enums "PLAN_REVIEW_PASS,PLAN_REVIEW_CHANGES_REQUESTED" \
+    --prose-file /tmp/dcness-pp-pr.md)
+```
+
+분기:
+- `PLAN_REVIEW_PASS` → 다음 step (ux-architect)
+- `PLAN_REVIEW_CHANGES_REQUESTED` → product-planner 재진입 (Step 2) — 1~2회 cycle, 무한 루프 방지
+- `AMBIGUOUS` → cascade
+
+### Step 4 — ux-architect (UX_FLOW)
+
+```
+TaskUpdate("ux-architect: UX_FLOW", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step ux-architect UX_FLOW
+```
+
+```
+Agent(
+  subagent_type="ux-architect",
+  mode="UX_FLOW",
+  description="plan-reviewer PASS 받음. PRD 기반 UX Flow 작성. 결론 enum: UX_FLOW_READY / UX_FLOW_PATCHED / UX_REFINE_READY / UX_FLOW_ESCALATE."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step ux-architect UX_FLOW \
+    --allowed-enums "UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE" \
+    --prose-file /tmp/dcness-pp-ux.md)
+```
+
+분기:
+- `UX_FLOW_READY` / `UX_FLOW_PATCHED` → 다음 step (validator UX_VALIDATION)
+- `UX_REFINE_READY` → designer SCREEN 호출 흐름 (별도 — `/ux` 권장)
+- `UX_FLOW_ESCALATE` → 사용자 위임
+- `AMBIGUOUS` → cascade
+
+### Step 5 — validator UX_VALIDATION
+
+```
+TaskUpdate("validator: UX_VALIDATION", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step validator UX_VALIDATION
+```
+
+```
+Agent(
+  subagent_type="validator",
+  mode="UX_VALIDATION",
+  description="ux-architect 의 UX Flow 검증해줘. 결론 enum: PASS / FAIL."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step validator UX_VALIDATION \
+    --allowed-enums "PASS,FAIL" \
+    --prose-file /tmp/dcness-pp-uxv.md)
+```
+
+분기:
+- `PASS` → 다음 step (architect SYSTEM_DESIGN)
+- `FAIL` → ux-architect 재진입 (Step 4)
+- `AMBIGUOUS` → cascade
+
+### Step 6 — architect SYSTEM_DESIGN
+
+```
+TaskUpdate("architect: SYSTEM_DESIGN", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step architect SYSTEM_DESIGN
+```
+
+PreToolUse 훅 검사 (catastrophic-gate.sh):
+- §2.3.4 — `product-planner.md` 존재 확인 → `plan-reviewer.md` 안 `PLAN_REVIEW_PASS` + `ux-architect.md` 안 `UX_FLOW_READY/PATCHED` 둘 다 필수. 시퀀스 정합 시 자동 통과.
+
+```
+Agent(
+  subagent_type="architect",
+  mode="SYSTEM_DESIGN",
+  description="UX_VALIDATION PASS 받음. PRD + UX Flow 기반 시스템 설계. 결론 enum: SYSTEM_DESIGN_READY."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step architect SYSTEM_DESIGN \
+    --allowed-enums "SYSTEM_DESIGN_READY" \
+    --prose-file /tmp/dcness-pp-sd.md)
+```
+
+advance: `SYSTEM_DESIGN_READY`.
+
+### Step 7 — architect TASK_DECOMPOSE
+
+```
+TaskUpdate("architect: TASK_DECOMPOSE", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step architect TASK_DECOMPOSE
+```
+
+PreToolUse 훅:
+- §2.3.4 — Step 6 와 동일 검사. SYSTEM_DESIGN 통과 후라 자연 정합.
+
+```
+Agent(
+  subagent_type="architect",
+  mode="TASK_DECOMPOSE",
+  description="SYSTEM_DESIGN 완료. epic stories → 기술 태스크 분해 + impl batch 작성. 결론 enum: READY_FOR_IMPL."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step architect TASK_DECOMPOSE \
+    --allowed-enums "READY_FOR_IMPL" \
+    --prose-file /tmp/dcness-pp-td.md)
+```
+
+advance: `READY_FOR_IMPL`.
+
+```
+TaskUpdate("architect: TASK_DECOMPOSE", completed)
+```
+
+### Step 8 — run 종료 + 다음 단계 추천
+
+```bash
+python3 -m harness.session_state end-run
+```
+
+사용자에게:
+```
+[product-plan] spec/design 단계 완료
+- run_id: $RUN_ID
+- 산출물:
+  - PRD: .claude/harness-state/.sessions/{sid}/runs/$RUN_ID/product-planner.md
+  - UX Flow: .../ux-architect-UX_FLOW.md
+  - 시스템 설계: .../architect-SYSTEM_DESIGN.md
+  - 태스크 분해: .../architect-TASK_DECOMPOSE.md (impl batch 들 prose 안에)
+
+다음 단계 (구현):
+- 작은 단위 한 번에 → `/quick` (light path)
+- impl batch 별 정식 루프 → architect MODULE_PLAN 직접 호출 또는 별도 진입점
+
+진행할까요?
+```
+
+구현은 본 skill 범위 밖. 사용자 결정 받아 별도 skill / Agent 호출.
+
+## AMBIGUOUS 처리 — 매 step 동일
+
+`end-step` stdout `AMBIGUOUS` 면:
+1. 재호출 (1회)
+2. 그래도 AMBIGUOUS → 사용자 위임 (`/qa` cascade 정합)
+
+## 재진입 / cycle 한도
+
+- `PLAN_REVIEW_CHANGES_REQUESTED` → product-planner 재진입 — **2 cycle 한도**. 초과 시 사용자 위임.
+- validator UX_VALIDATION FAIL → ux-architect 재진입 — **2 cycle 한도**.
+- 한도 초과 = 사용자 결정 필요 (escalate).
+
+## Catastrophic 룰 — 자동 정합
+
+본 시퀀스는 §2.3 4룰 정합:
+- §2.3.1 (pr-reviewer 직전 validator PASS) — pr-reviewer 본 skill 시퀀스 안 없음. 비대상.
+- §2.3.3 (engineer 직전 plan READY) — engineer 본 skill 시퀀스 안 없음. 비대상.
+- §2.3.4 (architect SD/TD 직전 PRD 검토) — Step 3 plan-reviewer + Step 4-5 ux-architect 가 자연 충족.
+
+PreToolUse 훅이 매 Agent 직전 자동 검사. 시퀀스 정합 시 통과.
+
+## 한계 / 후속
+
+- **구현 자동 진입 X** — Step 8 에서 종료. 구현은 사용자 결정 (별도 진입).
+- **architect TASK_DECOMPOSE 의 impl batch 들** — 각 batch 별 architect MODULE_PLAN 호출 자동화 X. v1 은 사용자가 batch 1개씩 처리.
+- **UX_REFINE_READY 분기 미구현** — designer SCREEN 호출 자동화는 `/ux` 후속 도입.
+
+## 참조
+
+- `agents/product-planner.md` / `agents/plan-reviewer.md` / `agents/ux-architect.md`
+- `agents/validator/ux-validation.md`
+- `agents/architect.md` + `agents/architect/{system-design,task-decompose}.md`
+- `docs/orchestration.md` §3.1 — 신규 기능 / PRD 변경 시퀀스
+- `docs/orchestration.md` §4.1 / §4.2 / §4.3 / §4.4 — 결론 enum 결정표
+- `docs/conveyor-design.md` §2 / §3 / §7 / §8 — Task tool + helper + 훅
+- `commands/qa.md` / `commands/quick.md` — 다른 진입점

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -1,0 +1,285 @@
+---
+name: quick
+description: 작은 버그픽스·코드 정리를 한 줄로 받아 light path 시퀀스 (qa → architect LIGHT_PLAN → engineer simple → validator BUGFIX_VALIDATION → pr-reviewer) 자동 진행하는 스킬. 사용자가 "간단히 해줘", "작은 수정", "한 줄 버그", "/quick", "퀵", "바로 고쳐줘", "오타 고쳐", "간단한 수정" 등을 말할 때 반드시 이 스킬을 사용한다. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 분류 결과가 FUNCTIONAL_BUG / CLEANUP 면 자동 진행, 그 외 (DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 면 사용자 결정.
+---
+
+# Quick Skill — 작은 버그픽스 light path 자동화
+
+> dcNess 컨베이어 패턴. qa 분류 후 FUNCTIONAL_BUG / CLEANUP 만 light path 자동 진행. 다른 분류는 사용자 결정.
+> light path = depth=simple, test-engineer 단계 생략, BUGFIX_VALIDATION 사용 (`docs/orchestration.md` §3.5).
+
+## 언제 사용하는가
+
+- 사용자 발화에 다음 keyword — "간단히", "작은 수정", "퀵", "바로 고쳐", "오타", "한 줄"
+- 또는 수정 범위가 한 줄 / 한 함수 내부로 명백
+- 분류·라우팅 ping-pong 최소화하고 싶을 때
+
+## 언제 사용하지 않음
+
+- "새 기능" / "피쳐 추가" → `/product-plan`
+- "리디자인" / "레이아웃" / "시안" → `/ux` (구현 후) 또는 designer 직접 호출
+- 코드 변경 범위가 여러 모듈 / 아키텍처 영향 → `/qa` 정석 분류
+
+## 시퀀스 (orchestration.md §3.5 light path)
+
+```
+qa (분류) → architect LIGHT_PLAN → engineer IMPL → validator BUGFIX_VALIDATION → pr-reviewer
+```
+
+자동 진행 조건: qa 결론이 `FUNCTIONAL_BUG` 또는 `CLEANUP`. 그 외 분류는 fallback.
+
+## 절차 (Task tool + helper protocol)
+
+### Step 0 — run 시작 + 사용자 확인
+
+```bash
+RUN_ID=$(python3 -m harness.session_state begin-run quick)
+echo "[quick] run started: $RUN_ID"
+```
+
+사용자에게 한 번 확인:
+```
+[quick] 실행 설정
+- 요청: <유저 원문>
+- 이슈 제목 (한 줄, 70자 이내): <뽑은 제목>
+- depth: simple (light path 고정)
+
+진행할까요?
+```
+
+확인 못 받으면 대기. 자동 진행 금지.
+
+### Step 1 — 5 task 생성
+
+```
+TaskCreate("qa: 이슈 분류")
+TaskCreate("architect: LIGHT_PLAN")
+TaskCreate("engineer: IMPL (simple)")
+TaskCreate("validator: BUGFIX_VALIDATION")
+TaskCreate("pr-reviewer: 검토")
+```
+
+(commit/PR 은 사용자 결정 — Task 에 안 넣음)
+
+### Step 2 — qa 분류
+
+```
+TaskUpdate("qa: 이슈 분류", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step qa
+```
+
+```
+Agent(
+  subagent_type="qa",
+  description="<유저 원문>. [Quick 모드] depth=simple 고정, architect LIGHT_PLAN 진입 예정. 5 결론 enum 중 하나로 분류해줘."
+)
+```
+
+prose 받으면:
+```bash
+cat > /tmp/dcness-quick-qa.md << 'PROSE_EOF'
+<agent prose>
+PROSE_EOF
+
+ENUM=$(python3 -m harness.session_state end-step qa \
+    --allowed-enums "FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE" \
+    --prose-file /tmp/dcness-quick-qa.md)
+```
+
+분기:
+- **FUNCTIONAL_BUG / CLEANUP** → 다음 step 진행
+- **DESIGN_ISSUE** → 종료 + `/ux` (구현 후) 또는 designer 직접 호출 추천
+- **KNOWN_ISSUE** → 종료 (이미 알려진 이슈)
+- **SCOPE_ESCALATE** → 사용자 위임 (분류 모호)
+- **AMBIGUOUS** → /qa 의 cascade 패턴 (재호출 → 사용자) 적용
+
+advance 시:
+```
+TaskUpdate("qa: 이슈 분류", completed)
+```
+
+### Step 3 — architect LIGHT_PLAN
+
+```
+TaskUpdate("architect: LIGHT_PLAN", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step architect LIGHT_PLAN
+```
+
+```
+Agent(
+  subagent_type="architect",
+  mode="LIGHT_PLAN",
+  description="qa 분류 = $ENUM. 이슈: <원문>. light path. depth=simple. impl 계획 prose 로 짜줘. 결론 enum: LIGHT_PLAN_READY / SPEC_GAP_FOUND / TECH_CONSTRAINT_CONFLICT 중 하나."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step architect LIGHT_PLAN \
+    --allowed-enums "LIGHT_PLAN_READY,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT" \
+    --prose-file /tmp/dcness-quick-light-plan.md)
+```
+
+advance 조건: `LIGHT_PLAN_READY`. 그 외:
+- `SPEC_GAP_FOUND` → architect SPEC_GAP 끼우거나 사용자 위임
+- `TECH_CONSTRAINT_CONFLICT` → 사용자 위임 (escalate)
+- `AMBIGUOUS` → cascade
+
+```
+TaskUpdate("architect: LIGHT_PLAN", completed)
+```
+
+### Step 4 — engineer IMPL
+
+```
+TaskUpdate("engineer: IMPL (simple)", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step engineer IMPL
+```
+
+PreToolUse 훅 검사 (catastrophic-gate.sh):
+- §2.3.3 — `architect-LIGHT_PLAN.md` 안 `LIGHT_PLAN_READY` 확인 → 통과 (Step 3 에서 박힘)
+
+```
+Agent(
+  subagent_type="engineer",
+  mode="IMPL",
+  description="architect LIGHT_PLAN 완료. 계획 prose: <agent transcript 의 직전 architect prose>. 구현해줘. 결론 enum: IMPL_DONE / SPEC_GAP_FOUND / TESTS_FAIL / IMPLEMENTATION_ESCALATE."
+)
+```
+
+engineer 가 src/ 수정. PreToolUse Write 훅 (있다면) 이 ALLOW path 검증.
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step engineer IMPL \
+    --allowed-enums "IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE" \
+    --prose-file /tmp/dcness-quick-impl.md)
+```
+
+advance 조건: `IMPL_DONE`. 그 외:
+- `SPEC_GAP_FOUND` → architect SPEC_GAP 진입 (별도 cycle)
+- `TESTS_FAIL` → engineer 재호출 (depth=simple 이라 보통 안 발생)
+- `IMPLEMENTATION_ESCALATE` → 사용자 위임
+- `AMBIGUOUS` → cascade
+
+### Step 5 — validator BUGFIX_VALIDATION
+
+```
+TaskUpdate("validator: BUGFIX_VALIDATION", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step validator BUGFIX_VALIDATION
+```
+
+```
+Agent(
+  subagent_type="validator",
+  mode="BUGFIX_VALIDATION",
+  description="engineer IMPL 완료. 변경: <transcript 의 engineer prose>. 검증해줘. 결론 enum: PASS / FAIL."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step validator BUGFIX_VALIDATION \
+    --allowed-enums "PASS,FAIL" \
+    --prose-file /tmp/dcness-quick-bugfix.md)
+```
+
+advance 조건: `PASS`. `FAIL` 면 engineer 재호출 또는 사용자 위임.
+
+### Step 6 — pr-reviewer
+
+```
+TaskUpdate("pr-reviewer: 검토", in_progress)
+```
+
+```bash
+python3 -m harness.session_state begin-step pr-reviewer
+```
+
+PreToolUse 훅 검사:
+- §2.3.1 — `validator-BUGFIX_VALIDATION.md` 안 `PASS` 확인 → 통과
+
+```
+Agent(
+  subagent_type="pr-reviewer",
+  description="engineer IMPL + validator BUGFIX_VALIDATION PASS. 검토해줘. 결론 enum: LGTM / CHANGES_REQUESTED."
+)
+```
+
+```bash
+ENUM=$(python3 -m harness.session_state end-step pr-reviewer \
+    --allowed-enums "LGTM,CHANGES_REQUESTED" \
+    --prose-file /tmp/dcness-quick-pr.md)
+```
+
+advance 조건: `LGTM`. `CHANGES_REQUESTED` 면 engineer POLISH 호출 또는 사용자 위임.
+
+```
+TaskUpdate("pr-reviewer: 검토", completed)
+```
+
+### Step 7 — run 종료 + commit/PR 안내
+
+```bash
+python3 -m harness.session_state end-run
+```
+
+사용자에게:
+```
+[quick] 완료
+- run_id: $RUN_ID
+- 변경: <src/ 변경 파일 요약>
+- prose 종이: .claude/harness-state/.sessions/{sid}/runs/$RUN_ID/
+
+커밋/PR 진행할까요?
+
+(글로벌 CLAUDE.md 의 커밋 절차 참조 — branch → PR → squash merge)
+```
+
+사용자 응답 받으면 git commit / push / gh pr create 등.
+
+## AMBIGUOUS 처리 — 매 step 동일
+
+`end-step` stdout 이 `AMBIGUOUS` 면:
+
+1. **재호출 (1회)** — agent 한테 결론 enum 명시 요청 후 재실행
+2. 재호출도 AMBIGUOUS → **사용자 위임** (현재 step 의 enum 후보 + prose 발췌 보여주고 결정 받음)
+3. 사용자 응답 → 그 enum 으로 진행 또는 종료
+
+`/qa` 의 cascade 패턴 정합.
+
+## Catastrophic 룰 — 자동 정합
+
+본 시퀀스는 §2.3 4룰 모두 정합:
+- §2.3.1 (pr-reviewer 직전 validator PASS) — Step 5 BUGFIX_VALIDATION PASS 가 충족
+- §2.3.3 (engineer 직전 plan READY) — Step 3 LIGHT_PLAN_READY 가 충족
+- §2.3.4 (architect SD/TD 직전 PRD 검토) — light path 는 architect SD/TD 안 써서 비대상
+
+PreToolUse 훅이 매 Agent 호출 직전 자동 검사. 시퀀스 정합 시 자동 통과.
+
+## 한계 / 후속
+
+- **depth=simple 고정** — 한 줄 / 한 함수 수정 외엔 부적합. test-engineer 단계 없어 회귀 위험. 큰 변경은 `/product-plan` 또는 정식 impl 루프.
+- **SPEC_GAP_FOUND 자동 처리 미구현** — 별도 cycle 진입 X. v1 은 사용자 위임.
+- **commit/PR 자동화 X** — Step 7 에서 사용자 결정. 자동 commit 은 위험 (governance §2.5 doc-sync gate 위배 가능).
+
+## 참조
+
+- `agents/qa.md` — qa system prompt
+- `agents/architect/light-plan.md` — LIGHT_PLAN system prompt
+- `agents/engineer.md` — engineer (IMPL / POLISH)
+- `agents/validator/bugfix-validation.md` — BUGFIX_VALIDATION system prompt
+- `agents/pr-reviewer.md` — pr-reviewer
+- `docs/orchestration.md` §3.5 — light path 시퀀스
+- `docs/orchestration.md` §4 — agent 별 결론 enum 결정표
+- `docs/conveyor-design.md` §2 / §3 / §7 / §8 — Task tool + helper + 훅
+- `commands/qa.md` — `/qa` skill (분류만 하는 진입점)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,41 @@
 
 ## Records
 
+### DCN-CHG-20260429-37
+- **Date**: 2026-04-29
+- **Rationale**:
+  - `/qa` (DCN-CHG-20260429-36) 다음으로 핵심 진입점 2개 추가:
+    - `/quick` = `/qa` 분류 결과가 FUNCTIONAL_BUG/CLEANUP 시 *자동 진행* — light path. 사용자가 일일이 다음 step 결정 안 해도 됨.
+    - `/product-plan` = 큰 기획 / 새 기능 / PRD 변경 진입점 — spec/design 단계까지 자동 진행, 구현은 별도.
+  - 둘 다 `/qa` skill 의 8-step protocol 패턴 확장. 시퀀스 길이만 다름 (qa 1 task / quick 5 task / product-plan 6 task).
+  - 재진입 cycle 한도 명시 — PRD 심사 / UX 검증 fail 시 무한 루프 방지.
+- **Alternatives**:
+  1. *quick + product-plan 분리 PR* — 작은 PR 단위 OK 하지만 둘 다 prompt-only + 동일 패턴이라 같이 묶는 게 review 효율 ↑. 기각.
+  2. *quick 안에 product-plan 자동 라우팅* — quick 이 분류 결과 SCOPE 가 크면 product-plan 호출. 복잡도 ↑. 기각 (사용자가 진입점 선택).
+  3. *product-plan 에 구현 자동 진입 (architect MODULE_PLAN 부터 impl 루프 N회)* — spec 단계 + 구현 단계 분리가 사용자 결정에 자연스러움. 자동 진입은 큰 작업 통제 어려움. 기각.
+  4. *(채택)* **`/quick` + `/product-plan` 동일 PR + 구현 자동 진입 X** — 사용자 결정 layer 보존.
+- **Decision**:
+  - **`/quick` 시퀀스** (orchestration.md §3.5 light path):
+    - qa (분류) → architect LIGHT_PLAN → engineer IMPL → validator BUGFIX_VALIDATION → pr-reviewer
+    - 5 task 자동 진행. depth=simple 고정. test-engineer 단계 생략.
+    - qa 분류 결과 FUNCTIONAL_BUG / CLEANUP 만 자동 진행. 그 외 (DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) → 종료 + 사용자 결정.
+  - **`/product-plan` 시퀀스** (orchestration.md §3.1):
+    - product-planner → plan-reviewer → ux-architect → validator UX_VALIDATION → architect SYSTEM_DESIGN → architect TASK_DECOMPOSE
+    - 6 task. spec 단계까지만. 구현 진입은 별도 (사용자 결정).
+    - PLAN_REVIEW_CHANGES_REQUESTED → product-planner 재진입 (2 cycle 한도)
+    - UX_VALIDATION FAIL → ux-architect 재진입 (2 cycle 한도)
+  - **공통 — AMBIGUOUS cascade**: `/qa` 정합. 재호출 (1회) → 사용자 위임.
+  - **공통 — catastrophic 자동 정합**: skill 시퀀스가 §2.3 4룰 충족하도록 짜여서 PreToolUse 훅이 자연 통과.
+    - `/quick` Step 3 (architect LIGHT_PLAN_READY) → Step 4 engineer (§2.3.3 충족)
+    - `/quick` Step 5 (validator BUGFIX_VALIDATION PASS) → Step 6 pr-reviewer (§2.3.1 충족)
+    - `/product-plan` Step 3 (plan-reviewer PASS) + Step 4-5 (ux-architect READY) → Step 6 architect SYSTEM_DESIGN (§2.3.4 충족)
+- **Follow-Up**:
+  - **Task -38**: `/init-dcness` skill (enable/disable 부트스트랩)
+  - **Task -39**: `/ux` skill (designer + design-critic THREE_WAY)
+  - **manual smoke**: 실 `claude` 에서 `/quick`, `/product-plan` 발화 → 전체 흐름 검증
+  - **architect TASK_DECOMPOSE 의 impl batch 자동 처리** — v2 follow-up
+  - **회귀 위험**: skill prompt 가 helper CLI 시그니처에 묶임. `harness/session_state.py` CLI 변경 시 3개 skill 모두 동기화 필요. governance §2.6 docs-only sync 가 catch.
+
 ### DCN-CHG-20260429-36
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260429-37
+- **Date**: 2026-04-29
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `commands/quick.md` (신규) — `/quick` skill (light path 자동화: qa → architect LIGHT_PLAN → engineer IMPL → validator BUGFIX_VALIDATION → pr-reviewer)
+  - `commands/product-plan.md` (신규) — `/product-plan` skill (새 기능 spec/design: product-planner → plan-reviewer → ux-architect → validator UX → architect SYSTEM_DESIGN → architect TASK_DECOMPOSE)
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+- **Summary**: dcNess plugin 의 2번째 + 3번째 skill 동시 신규. `/quick` = 작은 버그픽스 light path 자동 진행 (qa 분류가 FUNCTIONAL_BUG/CLEANUP 시), 5 task. `/product-plan` = 새 기능 spec/design 흐름 6 task (구현 진입은 별도). 둘 다 dcNess 컨베이어 패턴 (Task tool + helper + Agent + 훅) 정합. AMBIGUOUS cascade (`/qa` 와 동일 — 재호출 → 사용자 위임). 재진입 cycle 한도 (PLAN_REVIEW_CHANGES_REQUESTED / UX_VALIDATION FAIL = 각 2 cycle). catastrophic 룰 자동 정합 (§2.3.3 / §2.3.4 시퀀스가 자연 충족). 코드 변경 0 (prompt-only).
+- **Document-Exception**: 없음 (docs-only)
+
 ### DCN-CHG-20260429-36
 - **Date**: 2026-04-29
 - **Change-Type**: docs-only


### PR DESCRIPTION
## Summary
dcNess plugin 의 2번째 + 3번째 skill 동시 신규. \`/qa\` 의 8-step protocol 패턴을 더 긴 시퀀스로 확장.

### \`/quick\` — light path 자동화
- 시퀀스: qa → architect LIGHT_PLAN → engineer IMPL → validator BUGFIX_VALIDATION → pr-reviewer (5 task)
- depth=simple 고정. test-engineer 생략.
- 분류 결과 FUNCTIONAL_BUG / CLEANUP 만 자동 진행. 그 외는 종료 + 사용자 결정.

### \`/product-plan\` — 새 기능 spec/design
- 시퀀스: product-planner → plan-reviewer → ux-architect → validator UX → architect SYSTEM_DESIGN → architect TASK_DECOMPOSE (6 task)
- spec 단계까지만 — 구현 진입은 별도 (사용자 결정).
- 재진입 cycle 한도: PLAN_REVIEW_CHANGES_REQUESTED / UX_VALIDATION FAIL 각 2 cycle.

### 공통 패턴
- AMBIGUOUS cascade (재호출 → 사용자 위임) — \`/qa\` 정합
- catastrophic 자동 정합 — 시퀀스가 §2.3.3 / §2.3.4 자연 충족
- Task tool + helper protocol (begin-run / begin-step / end-step / end-run)

## Why
\`/qa\` 만으론 분류만 가능. \`/quick\` 으로 작은 수정 자동 진행 + \`/product-plan\` 으로 큰 기획 진입점. dcNess plugin 사용 가치 ↑.

## Governance
- [x] Task-ID DCN-CHG-20260429-37
- [x] Change-Type: docs-only
- [x] document_update_record / change_rationale_history 갱신
- [x] doc-sync gate PASS
- [x] 160/160 tests PASS (변경 없음 — prompt-only)

## Follow-up
- Task -38: \`/init-dcness\` (enable/disable)
- Task -39: \`/ux\` (designer + critic) — Pencil MCP 의존
- manual smoke (실 claude 에서 /quick, /product-plan 발화 검증)
- architect TASK_DECOMPOSE 의 impl batch 자동 처리 (v2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)