### PR TITLE
feat: plugin 활성화 게이트 + cross-project PYTHONPATH (DCN-CHG-20260429-40)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🚪 Plugin 활성화 게이트 + cross-project PYTHONPATH** (`DCN-CHG-20260429-40`):
+  - `harness/session_state.py` — `is_project_active` / `enable_project` / `disable_project` + 4 CLI subcommand. plugin-scoped whitelist (`~/.claude/plugins/data/dcness-dcness/projects.json`) — CC `data/` 컨벤션 정합 + 글로벌 `~/.claude/` 오염 0.
+  - hook 양쪽 (`hooks/session-start.sh` `hooks/catastrophic-gate.sh`) — PYTHONPATH=$CLAUDE_PLUGIN_ROOT prepend + `is-active` 게이트 (inactive 프로젝트 즉시 exit 0). hook 자체는 모든 프로젝트에서 호출되지만 dcness 미활성 프로젝트는 import 비용도 0.
+  - `commands/init-dcness.md` 신규 — `/init-dcness` skill (현재 cwd 활성화 + 안내).
+  - 신규 10 테스트 (`ProjectActivationTests`). 175/175 PASS.
+  - manual smoke 사용자 발견에서 출발 — dcness install 후 hook 미발화 + cross-project ModuleNotFoundError. 두 문제 동반 해결.
 - **🌲 Worktree 격리 옵션 C** (`DCN-CHG-20260429-39`):
   - `harness/session_state.py` `_default_base()` γ 설계 — `git rev-parse --git-common-dir` 로 main repo `.claude/harness-state/` 를 단일 source. cwd 별 캐시. 비-git 폴백 보존.
   - `commands/quick.md` / `commands/product-plan.md` Step 0a — keyword (`worktree` / `wt` / `격리` / `isolate`) 트리거 시 EnterWorktree, 종료 step 에 ExitWorktree 옵션.

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -1,0 +1,103 @@
+---
+name: init-dcness
+description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하는 부트스트랩 스킬. dcNess 는 디폴트로 모든 프로젝트에서 비활성 (hook pass-through). 본 스킬 호출 시 현재 cwd 의 main repo 를 plugin-scoped whitelist (`~/.claude/plugins/data/dcness-dcness/projects.json`) 에 추가해 SessionStart / PreToolUse Agent 훅이 발화하기 시작한다. 사용자가 "init-dcness", "dcness 활성화", "이 프로젝트에 dcness 켜", "dcness 시작", "/init-dcness" 등을 말할 때 사용. 비활성화는 `/disable-dcness` (또는 본 스킬에서 status 확인 후 안내).
+---
+
+# Init dcNess Skill — 프로젝트 활성화
+
+> dcNess plugin 은 디폴트 disabled. RWHarness 처럼 명시 활성화 필요. plugin install 만으로는 hook 발화 0 (pass-through).
+
+## 언제 사용
+
+- 사용자 발화: "init-dcness", "dcness 활성화", "/init-dcness", "이 프로젝트에 dcness 켜"
+- 새 프로젝트에 dcness plugin 사용 시작 시
+- 비활성 → 활성 전환 시
+
+## 핵심 동작
+
+```bash
+python3 -m harness.session_state enable
+```
+
+- 현재 cwd 의 main repo root 추출 (γ resolution — `git rev-parse --git-common-dir`)
+- `~/.claude/plugins/data/dcness-dcness/projects.json` 의 `projects` 배열에 추가 (중복 자동 제거)
+- 다음 세션부터 SessionStart / PreToolUse Agent 훅 발화 시작
+
+## 절차
+
+### Step 1 — 현재 상태 확인
+
+```bash
+python3 -m harness.session_state status
+```
+
+출력 예시:
+```
+[dcness] cwd project root: /Users/dc.kim/project/foo
+[dcness] active: NO
+[dcness] whitelist file: /Users/dc.kim/.claude/plugins/data/dcness-dcness/projects.json
+[dcness] no active projects (whitelist empty)
+```
+
+이미 활성 (`active: YES`) 이면 step 2 skip → step 3.
+
+### Step 2 — 활성화
+
+```bash
+python3 -m harness.session_state enable
+```
+
+출력 예시:
+```
+[dcness] enabled: /Users/dc.kim/project/foo
+[dcness] whitelist: /Users/dc.kim/.claude/plugins/data/dcness-dcness/projects.json
+```
+
+### Step 3 — 사용자 안내
+
+```
+[dcness] 활성화 완료
+- 프로젝트: <main repo root>
+- whitelist: ~/.claude/plugins/data/dcness-dcness/projects.json
+
+다음 세션부터 발화하는 것:
+- SessionStart 훅 — by-pid / live.json 자동 생성
+- PreToolUse Agent 훅 — catastrophic 룰 (orchestration.md §2.3) 검사
+
+사용 가능한 skill:
+- /qa  — 이슈 분류
+- /quick — 작은 버그픽스 light path
+- /product-plan — 새 기능 spec/design
+- /smart-compact — 컨텍스트 압축 + resume prompt
+
+비활성화 — `/disable-dcness` 또는 `python3 -m harness.session_state disable`.
+
+** Claude Code 세션 재시작 권장** — SessionStart 훅은 현재 세션엔 적용 안 됨.
+```
+
+### Step 4 (선택) — `harness/` 모듈 import 검증
+
+cross-project 시나리오에선 plugin hook 이 `${CLAUDE_PLUGIN_ROOT}` 를 PYTHONPATH 에 추가해
+`harness.session_state` import 가능. dcNess repo 안에서 직접 활성화하는 경우 cwd 가 plugin
+root 가 아니라도 `harness/` 가 cwd 에 있으니 정상 동작.
+
+문제 발생 시:
+```bash
+python3 -c "import harness.session_state; print('OK')"
+```
+
+`ModuleNotFoundError` 면 plugin 설치 누락 → `claude plugin install dcness@dcness` 재실행.
+
+## 한계 / 후속
+
+- **세션 재시작 필요** — SessionStart 훅은 *세션 시작 시점* 에 한 번 발화. 활성화 직후 현재 세션에는 by-pid 미생성. 새 `claude` 세션 띄워야 hook 발화 시작.
+- **`/disable-dcness` skill 미구현 (v1)** — 본 skill 의 cousin. 명시 비활성화 진입점. v2 후속.
+- **whitelist 파일 직접 편집 가능** — 관리/감사 시 `cat ~/.claude/plugins/data/dcness-dcness/projects.json` 으로 확인. 손편집 권장 X (atomic write 컨벤션 우회).
+- **plugin uninstall 시 자동 cleanup** — CC 가 `data/` 디렉토리 자동 정리 (CC 공식 컨벤션). dcness 만 제거하면 whitelist 도 함께 소실.
+
+## 참조
+
+- `harness/session_state.py` — `is_project_active` / `enable_project` / `disable_project` / CLI subcommands
+- `hooks/session-start.sh` / `hooks/catastrophic-gate.sh` — 첫 줄에 `is-active` 게이트
+- `docs/conveyor-design.md` §13 — worktree γ resolution (활성화도 main repo 기준)
+- RWHarness `init-rwh` — 패턴 참조 (whitelist 위치는 글로벌 `~/.claude/harness-projects.json` 대신 plugin-scoped `~/.claude/plugins/data/dcness-dcness/projects.json`)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,33 @@
 
 ## Records
 
+### DCN-CHG-20260429-40
+- **Date**: 2026-04-29
+- **Rationale**:
+  - Manual smoke 도중 사용자 발견: dcNess plugin 설치만 했는데도 RWHarness 처럼 자동 활성 안 되면서 hook 미발화. 그 외 cross-project 시나리오 (dcNess repo 밖 cwd 에서 claude 실행) 에선 helper 가 `harness/` import 실패로 ModuleNotFoundError → silent exit. 두 문제 동반 해결 필요.
+  - 더 큰 문제: dcNess plugin 이 모든 프로젝트에 자동 활성되면 부작용 폭증 — RWHarness 와 hook race + 사용자가 의도하지 않은 카테고리 자동 검사 + cross-project 사용자 경험 surprise.
+  - RWHarness 는 `~/.claude/harness-projects.json` 글로벌 whitelist 로 해결. 단 글로벌 파일 = 다른 plugin 도 보일 수 있음 + plugin 제거해도 잔재. 사용자는 plugin-scoped 저장 명시 요구.
+- **Alternatives** (활성화 메커니즘):
+  1. *항상 활성* (현재 디폴트). 부작용 폭증. 기각.
+  2. *RWHarness 와 동일 글로벌 whitelist* (`~/.claude/harness-projects.json`). 명시 거부 (사용자 발화).
+  3. *프로젝트 별 마커 파일* (`<project>/.claude/harness-state/.dcness-enabled`). 자기선언 명확 + 글로벌 0. 단점: plugin 단에서 활성 프로젝트 목록 한눈에 못 봄 + 마커 파일 별도 관리 부담. 차순위.
+  4. **(채택) plugin-scoped whitelist** (`~/.claude/plugins/data/dcness-dcness/projects.json`). CC 공식 plugin-data 컨벤션 정합 — plugin namespace + reinstall 보존 + plugin 제거 시 자동 cleanup. 사용자 발화 정합.
+- **Alternatives** (PYTHONPATH 해법):
+  1. *plugin install 시 PYTHONPATH 환경변수 자동 추가* — 사용자 shell init 변경 부담. 기각.
+  2. **(채택) hook 스크립트가 `${CLAUDE_PLUGIN_ROOT}` 를 PYTHONPATH 에 prepend** — 1줄 추가, plugin install 위치 자동 추적, 사용자 환경 영향 0.
+- **Decision**:
+  - 활성화 = 옵션 4 (plugin-scoped whitelist). PYTHONPATH = 옵션 2 (hook 스크립트 prepend). 같은 PR 에 묶음 — 둘 다 cross-project 인프라.
+  - **게이트 위치**: hook 스크립트 첫 줄 (`is-active` exit 1 시 즉시 `exit 0`). Python 진입 전이라 inactive 프로젝트는 import 비용도 0.
+  - **`/init-dcness` skill**: `python3 -m harness.session_state enable` 호출 + 사용자 안내 (다음 세션 재시작 권장).
+  - **`/disable-dcness`**: v1 미구현 — 명시 비활성화는 CLI 직접 호출 (`python3 -m harness.session_state disable`). v2 follow-up.
+  - **테스트 환경 우회**: `DCNESS_FORCE_ENABLE=1` env 로 whitelist 무시 + 무조건 active. multisession smoke 11 테스트가 의존.
+  - **γ resolution 정합**: `is_project_active` 가 `_resolve_project_root` (worktree → main repo) 사용 → worktree cwd 도 main repo whitelist 상속.
+- **Follow-Up**:
+  - **(별도 Task — v1.1)** `/disable-dcness` skill 신규 (cousin to /init-dcness).
+  - **(별도 Task — v2)** plugin uninstall hook — `data/dcness-dcness/` 자동 cleanup 검증.
+  - **(별도 Task — v2)** `/init-dcness` 가 첫 호출 시 plugin uninstall reminder + 추천 후속 skill 안내.
+  - **측정**: 첫 manual smoke 결과 — hook 게이트가 inactive 프로젝트에서 100% no-op 인지.
+
 ### DCN-CHG-20260429-39
 - **Date**: 2026-04-29
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,22 @@
 
 ## Records
 
+### DCN-CHG-20260429-40
+- **Date**: 2026-04-29
+- **Change-Type**: harness, hooks, spec, docs-only
+- **Files Changed**:
+  - `harness/session_state.py` — `is_project_active` / `enable_project` / `disable_project` / `list_active_projects` / `whitelist_path` 함수 + 5 CLI subcommand (`enable` / `disable` / `is-active` / `status`). plugin-scoped whitelist (`~/.claude/plugins/data/dcness-dcness/projects.json`) + `DCNESS_WHITELIST_PATH` env override + `DCNESS_FORCE_ENABLE` 디버깅 env.
+  - `hooks/session-start.sh` — PYTHONPATH=$CLAUDE_PLUGIN_ROOT prepend + 활성화 게이트 (`is-active` 실패 시 exit 0).
+  - `hooks/catastrophic-gate.sh` — 동일 패턴.
+  - `commands/init-dcness.md` (신규) — `/init-dcness` skill (현재 cwd main repo 활성화).
+  - `tests/test_session_state.py` — `ProjectActivationTests` 10 케이스 추가.
+  - `tests/test_multisession_smoke.py` — bash hook 호출 env 에 `DCNESS_FORCE_ENABLE=1` 추가 (게이트 우회).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: dcNess plugin 활성화 게이트 도입. 기본 disabled — plugin install 만으로는 hook 발화 0 (다른 프로젝트에 영향 0). `/init-dcness` 으로 명시 활성화 시만 SessionStart / PreToolUse Agent 훅 발화. whitelist 는 plugin-scoped (CC `data/` 컨벤션) → 글로벌 `~/.claude/` 폴더 오염 0, plugin 제거 시 자동 정리. RWHarness `harness-projects.json` 패턴 정합 + γ resolution 으로 worktree 도 main repo whitelist 상속.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260429-39
 - **Date**: 2026-04-29
 - **Change-Type**: harness, spec, docs-only

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -73,6 +73,11 @@ __all__ = [
     "update_current_step",
     "complete_run",
     "cleanup_stale_runs",
+    "is_project_active",
+    "enable_project",
+    "disable_project",
+    "list_active_projects",
+    "whitelist_path",
 ]
 
 # ── 상수 ─────────────────────────────────────────────────────────────
@@ -741,6 +746,124 @@ def auto_detect_run_id(*, base_dir: Optional[Path] = None) -> str:
     return read_pid_current_run(cc_pid, base_dir=base_dir)
 
 
+# ── 프로젝트 활성화 (whitelist) ─────────────────────────────────────
+
+
+_DEFAULT_WHITELIST_PATH = (
+    Path.home() / ".claude" / "plugins" / "data" / "dcness-dcness" / "projects.json"
+)
+
+
+def whitelist_path() -> Path:
+    """Plugin-scoped whitelist 경로.
+
+    기본: `~/.claude/plugins/data/dcness-dcness/projects.json` (CC 공식 plugin-state
+    컨벤션 — plugin install 시 자동 생성, plugin 제거 시 자동 정리).
+    `DCNESS_WHITELIST_PATH` env 로 override (테스트 / 도그푸딩).
+    """
+    override = os.environ.get("DCNESS_WHITELIST_PATH")
+    if override:
+        return Path(override)
+    return _DEFAULT_WHITELIST_PATH
+
+
+def _load_whitelist() -> list:
+    """projects.json 의 `projects` 배열 → resolved real path 리스트."""
+    path = whitelist_path()
+    try:
+        if not path.exists():
+            return []
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict):
+        return []
+    raw = data.get("projects", [])
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for p in raw:
+        if not isinstance(p, str):
+            continue
+        try:
+            out.append(str(Path(p).expanduser().resolve()))
+        except (OSError, ValueError):
+            continue
+    return out
+
+
+def _save_whitelist(paths: list) -> None:
+    """projects.json atomic 작성. 중복 제거 + 정렬."""
+    deduped = sorted(set(str(p) for p in paths))
+    payload = json.dumps(
+        {"version": 1, "projects": deduped},
+        ensure_ascii=False,
+        indent=2,
+        sort_keys=True,
+    )
+    target = whitelist_path()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(target, payload.encode("utf-8"))
+
+
+def _resolve_project_root(cwd: Optional[Path] = None) -> Path:
+    """cwd 의 main repo root (γ resolution).
+
+    `_resolve_state_root_for_cwd` 가 `<main_root>/.claude/harness-state` 반환 →
+    parent.parent = main_root. git 미사용 환경 폴백 시 cwd 자체 반환.
+    """
+    cwd_str = str((cwd or Path.cwd()).resolve())
+    base = _resolve_state_root_for_cwd(cwd_str)
+    return base.parent.parent
+
+
+def is_project_active(cwd: Optional[Path] = None) -> bool:
+    """현재 cwd (또는 인자) 가 dcNess whitelist 에 등록됐는지 판정.
+
+    - 기본 disabled — whitelist 없거나 cwd 가 목록 밖이면 False
+    - whitelist 경로의 서브디렉토리 (worktree 포함) 도 True (γ resolution 으로 main repo 추출)
+    - `DCNESS_FORCE_ENABLE=1` env 로 임시 활성 (디버깅)
+    """
+    if os.environ.get("DCNESS_FORCE_ENABLE") == "1":
+        return True
+    try:
+        project_root = _resolve_project_root(cwd).resolve()
+    except OSError:
+        return False
+    project_root_str = str(project_root)
+    for entry in _load_whitelist():
+        if project_root_str == entry or project_root_str.startswith(entry + os.sep):
+            return True
+    return False
+
+
+def enable_project(cwd: Optional[Path] = None) -> Path:
+    """cwd 의 main repo root 를 whitelist 에 추가. 이미 있으면 noop."""
+    project_root = _resolve_project_root(cwd).resolve()
+    project_root_str = str(project_root)
+    paths = _load_whitelist()
+    if project_root_str not in paths:
+        paths.append(project_root_str)
+        _save_whitelist(paths)
+    return project_root
+
+
+def disable_project(cwd: Optional[Path] = None) -> Path:
+    """cwd 의 main repo root 를 whitelist 에서 제거. 없으면 noop."""
+    project_root = _resolve_project_root(cwd).resolve()
+    project_root_str = str(project_root)
+    paths = _load_whitelist()
+    if project_root_str in paths:
+        paths = [p for p in paths if p != project_root_str]
+        _save_whitelist(paths)
+    return project_root
+
+
+def list_active_projects() -> list:
+    """현재 whitelist 의 projects 배열 (resolved path 들)."""
+    return _load_whitelist()
+
+
 # ── CLI (python3 -m harness.session_state <subcommand>) ─────────────
 
 
@@ -840,6 +963,44 @@ def _cli_end_step(args: Any) -> int:
     return 0
 
 
+def _cli_enable(args: Any) -> int:
+    """현재 cwd 의 main repo 를 whitelist 에 추가."""
+    root = enable_project()
+    print(f"[dcness] enabled: {root}")
+    print(f"[dcness] whitelist: {whitelist_path()}")
+    return 0
+
+
+def _cli_disable(args: Any) -> int:
+    """현재 cwd 의 main repo 를 whitelist 에서 제거."""
+    root = disable_project()
+    print(f"[dcness] disabled: {root}")
+    return 0
+
+
+def _cli_is_active(args: Any) -> int:
+    """현재 cwd 활성 여부 — 활성=exit 0, 비활성=exit 1 (silent, hook 게이트용)."""
+    return 0 if is_project_active() else 1
+
+
+def _cli_status(args: Any) -> int:
+    """whitelist + 현재 cwd 활성 상태 출력."""
+    active = is_project_active()
+    cwd_root = _resolve_project_root().resolve()
+    print(f"[dcness] cwd project root: {cwd_root}")
+    print(f"[dcness] active: {'YES' if active else 'NO'}")
+    print(f"[dcness] whitelist file: {whitelist_path()}")
+    projects = list_active_projects()
+    if projects:
+        print(f"[dcness] {len(projects)} active project(s):")
+        for p in projects:
+            mark = "*" if p == str(cwd_root) else " "
+            print(f"  {mark} {p}")
+    else:
+        print("[dcness] no active projects (whitelist empty)")
+    return 0
+
+
 def _build_arg_parser() -> Any:
     import argparse
 
@@ -873,6 +1034,18 @@ def _build_arg_parser() -> Any:
     p_es.add_argument("--allowed-enums", required=True, help="comma-separated")
     p_es.add_argument("--prose-file", required=True, help="prose 본문 파일 경로")
     p_es.set_defaults(func=_cli_end_step)
+
+    p_en = sub.add_parser("enable", help="현재 cwd 의 main repo 활성화 (whitelist 추가)")
+    p_en.set_defaults(func=_cli_enable)
+
+    p_di = sub.add_parser("disable", help="현재 cwd 비활성화 (whitelist 제거)")
+    p_di.set_defaults(func=_cli_disable)
+
+    p_ia = sub.add_parser("is-active", help="활성 여부 (silent, exit 0/1) — hook 게이트용")
+    p_ia.set_defaults(func=_cli_is_active)
+
+    p_st = sub.add_parser("status", help="whitelist + 현재 cwd 상태")
+    p_st.set_defaults(func=_cli_status)
 
     return parser
 

--- a/hooks/catastrophic-gate.sh
+++ b/hooks/catastrophic-gate.sh
@@ -17,6 +17,12 @@
 
 set -uo pipefail
 
+# plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응.
+export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+
+# 활성화 게이트 — 미활성 프로젝트는 즉시 통과 (Agent 호출 차단 0).
+python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+
 # bash 의 PPID = CC main process
 CC_PID=$PPID
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -12,6 +12,14 @@
 
 set -uo pipefail
 
+# plugin root 를 PYTHONPATH 에 prepend — cwd 에 harness/ 없는 cross-project 시나리오 대응.
+# CLAUDE_PLUGIN_ROOT 는 CC 가 plugin hook 실행 시 자동 설정.
+export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+
+# 활성화 게이트 — 현재 프로젝트가 dcness whitelist 에 없으면 즉시 pass-through.
+# /init-dcness 로 활성화. 미활성 프로젝트에선 hook 자체가 no-op.
+python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+
 # bash 의 PPID = CC main process
 CC_PID=$PPID
 

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -42,7 +42,12 @@ def _run_bash_hook(
         text=True,
         capture_output=True,
         cwd=str(cwd),
-        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            # smoke 테스트는 임시 cwd 라 whitelist 미등록 → 게이트 우회 강제 활성화
+            "DCNESS_FORCE_ENABLE": "1",
+        },
         timeout=10,
     )
 
@@ -64,7 +69,12 @@ def _run_python_hook(
         text=True,
         capture_output=True,
         cwd=str(cwd),
-        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            # smoke 테스트는 임시 cwd 라 whitelist 미등록 → 게이트 우회 강제 활성화
+            "DCNESS_FORCE_ENABLE": "1",
+        },
         timeout=10,
     )
 
@@ -80,7 +90,12 @@ def _run_python_cli(
         capture_output=True,
         text=True,
         cwd=str(cwd),
-        env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+        env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            # smoke 테스트는 임시 cwd 라 whitelist 미등록 → 게이트 우회 강제 활성화
+            "DCNESS_FORCE_ENABLE": "1",
+        },
         timeout=10,
     )
 
@@ -214,7 +229,12 @@ class MultiSessionIsolationTests(unittest.TestCase):
             ],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             cwd=str(self.cwd),
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+            env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            # smoke 테스트는 임시 cwd 라 whitelist 미등록 → 게이트 우회 강제 활성화
+            "DCNESS_FORCE_ENABLE": "1",
+        },
         )
         p_b = subprocess.Popen(
             [
@@ -223,7 +243,12 @@ class MultiSessionIsolationTests(unittest.TestCase):
             ],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             cwd=str(self.cwd),
-            env={**os.environ, "PYTHONPATH": str(REPO_ROOT)},
+            env={
+            **os.environ,
+            "PYTHONPATH": str(REPO_ROOT),
+            # smoke 테스트는 임시 cwd 라 whitelist 미등록 → 게이트 우회 강제 활성화
+            "DCNESS_FORCE_ENABLE": "1",
+        },
         )
 
         out_a, _ = p_a.communicate(json.dumps({"sessionId": self.sid_a}).encode(), timeout=10)

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -956,5 +956,167 @@ class DefaultBaseWorktreeTests(unittest.TestCase):
             )
 
 
+class ProjectActivationTests(unittest.TestCase):
+    """프로젝트 활성화 (whitelist) — `is_project_active` / `enable_project` / `disable_project`.
+
+    plugin-scoped whitelist 경로는 `~/.claude/plugins/data/dcness-dcness/projects.json`.
+    테스트는 `DCNESS_WHITELIST_PATH` env 로 임시 경로 override.
+    """
+
+    def setUp(self) -> None:
+        from harness.session_state import _clear_default_base_cache
+        self._orig_cwd = os.getcwd()
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(lambda: os.chdir(self._orig_cwd))
+        # DCNESS_WHITELIST_PATH override
+        self._whitelist_file = Path(self._tmp.name) / "projects.json"
+        self._env_patch = patch.dict(
+            os.environ,
+            {"DCNESS_WHITELIST_PATH": str(self._whitelist_file)},
+            clear=False,
+        )
+        self._env_patch.start()
+        self.addCleanup(self._env_patch.stop)
+        # DCNESS_FORCE_ENABLE env 가 외부에서 1로 set 되면 테스트 깨짐 — 보호
+        if "DCNESS_FORCE_ENABLE" in os.environ:
+            self._force_patch = patch.dict(
+                os.environ, {"DCNESS_FORCE_ENABLE": ""}, clear=False
+            )
+            self._force_patch.start()
+            self.addCleanup(self._force_patch.stop)
+        _clear_default_base_cache()
+        self.addCleanup(_clear_default_base_cache)
+
+    def _init_git_repo(self, path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True)
+        for cmd in (
+            ["git", "init", "-q"],
+            ["git", "config", "user.email", "test@example.com"],
+            ["git", "config", "user.name", "test"],
+            ["git", "commit", "-q", "--allow-empty", "-m", "init"],
+        ):
+            subprocess.run(cmd, cwd=path, check=True, capture_output=True)
+
+    def test_inactive_when_whitelist_empty(self) -> None:
+        from harness.session_state import is_project_active
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        os.chdir(repo)
+        self.assertFalse(is_project_active())
+
+    def test_enable_then_active(self) -> None:
+        from harness.session_state import is_project_active, enable_project
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        os.chdir(repo)
+        root = enable_project()
+        self.assertEqual(root, repo.resolve())
+        self.assertTrue(is_project_active())
+        # 파일이 작성됐는지
+        self.assertTrue(self._whitelist_file.exists())
+
+    def test_disable_then_inactive(self) -> None:
+        from harness.session_state import (
+            is_project_active, enable_project, disable_project
+        )
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        os.chdir(repo)
+        enable_project()
+        self.assertTrue(is_project_active())
+        disable_project()
+        self.assertFalse(is_project_active())
+
+    def test_enable_idempotent(self) -> None:
+        from harness.session_state import enable_project, list_active_projects
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        os.chdir(repo)
+        enable_project()
+        enable_project()
+        enable_project()
+        self.assertEqual(len(list_active_projects()), 1)
+
+    def test_subdirectory_inherits_active(self) -> None:
+        """activated 프로젝트의 subdir 도 active 로 판정."""
+        from harness.session_state import is_project_active, enable_project
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        sub = repo / "subdir" / "deep"
+        sub.mkdir(parents=True)
+        os.chdir(repo)
+        enable_project()
+        os.chdir(sub)
+        self.assertTrue(is_project_active())
+
+    def test_worktree_inherits_active_via_gamma(self) -> None:
+        """worktree cwd 에서 is_project_active = True (γ resolution → main repo whitelist hit)."""
+        from harness.session_state import (
+            is_project_active, enable_project, _clear_default_base_cache,
+        )
+        repo = Path(self._tmp.name) / "main"
+        self._init_git_repo(repo)
+        wt = Path(self._tmp.name) / "wt"
+        subprocess.run(
+            ["git", "worktree", "add", "-q", str(wt), "-b", "wt"],
+            cwd=repo, check=True, capture_output=True,
+        )
+        try:
+            os.chdir(repo)
+            _clear_default_base_cache()
+            enable_project()
+            os.chdir(wt)
+            _clear_default_base_cache()
+            self.assertTrue(is_project_active())
+        finally:
+            os.chdir(self._orig_cwd)
+            subprocess.run(
+                ["git", "worktree", "remove", str(wt), "--force"],
+                cwd=repo, check=False, capture_output=True,
+            )
+
+    def test_force_enable_env_override(self) -> None:
+        """DCNESS_FORCE_ENABLE=1 → whitelist 무시 + 무조건 active."""
+        from harness.session_state import is_project_active
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        os.chdir(repo)
+        with patch.dict(os.environ, {"DCNESS_FORCE_ENABLE": "1"}, clear=False):
+            self.assertTrue(is_project_active())
+
+    def test_other_project_remains_inactive(self) -> None:
+        """A 만 enable 했을 때 B 는 inactive."""
+        from harness.session_state import is_project_active, enable_project
+        repo_a = Path(self._tmp.name) / "a"
+        repo_b = Path(self._tmp.name) / "b"
+        self._init_git_repo(repo_a)
+        self._init_git_repo(repo_b)
+        os.chdir(repo_a)
+        enable_project()
+        os.chdir(repo_b)
+        self.assertFalse(is_project_active())
+
+    def test_whitelist_corrupt_returns_empty(self) -> None:
+        """projects.json 파일 깨졌을 때 빈 리스트 반환 (silent)."""
+        from harness.session_state import list_active_projects
+        self._whitelist_file.parent.mkdir(parents=True, exist_ok=True)
+        self._whitelist_file.write_text("not valid json", encoding="utf-8")
+        self.assertEqual(list_active_projects(), [])
+
+    def test_cli_is_active_exit_code(self) -> None:
+        """`is-active` subcommand exit 0=active, 1=inactive."""
+        from harness.session_state import _cli_is_active, enable_project
+        from types import SimpleNamespace
+        repo = Path(self._tmp.name) / "repo"
+        self._init_git_repo(repo)
+        os.chdir(repo)
+        # 비활성
+        self.assertEqual(_cli_is_active(SimpleNamespace()), 1)
+        # 활성화 후
+        enable_project()
+        self.assertEqual(_cli_is_active(SimpleNamespace()), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- dcNess plugin 활성화 게이트 도입 — 디폴트 disabled. plugin install 만으로는 hook 발화 0 (다른 프로젝트 영향 0).
- `/init-dcness` skill — 현재 cwd 의 main repo 를 plugin-scoped whitelist 에 추가.
- whitelist 위치 = `~/.claude/plugins/data/dcness-dcness/projects.json` (CC 공식 plugin-data 컨벤션 — 글로벌 `~/.claude/` 폴더 오염 0).
- Cross-project hook 호출 시 `PYTHONPATH=$CLAUDE_PLUGIN_ROOT` prepend 으로 `harness/` import 가능.
- 신규 10 테스트 (`ProjectActivationTests`). 175/175 PASS.

## Background
Manual smoke 도중 발견 — dcNess plugin 설치만 했는데 hook 미발화 (cross-project ModuleNotFoundError). 동시에 모든 프로젝트 자동 활성은 부작용 폭증 (RWHarness hook race + 사용자 의도하지 않은 검사).

해법:
1. 활성화 = 프로젝트별 명시 opt-in (`/init-dcness`)
2. whitelist 저장 = plugin-scoped (CC `data/` 컨벤션 — RWHarness 의 글로벌 `~/.claude/harness-projects.json` 패턴 거부, 사용자 명시 요구 정합)
3. hook 게이트 = `is-active` exit 1 시 즉시 `exit 0` (Python import 비용 0)
4. PYTHONPATH = hook 스크립트 첫 줄 `${CLAUDE_PLUGIN_ROOT}` prepend (사용자 shell 영향 0)

γ resolution 정합 — `is_project_active` 가 worktree cwd 도 main repo whitelist 상속.

## 거버넌스 체크리스트
- [x] Task-ID `DCN-CHG-20260429-40`
- [x] document_update_record + change_rationale_history 갱신
- [x] PROGRESS.md 갱신
- [x] doc-sync PASS
- [x] tests 175/175 PASS

## 후속 (v2)
- `/disable-dcness` skill 신규
- plugin uninstall hook 검증 (data/ 자동 cleanup)
- `/init-dcness` 첫 호출 시 후속 skill 안내 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)