### PR TITLE
docs: branch-surface-tracking + RWH 사다리 카탈로그 (DCN-CHG-20260430-03)

### DIFF
--- a/docs/migration-decisions.md
+++ b/docs/migration-decisions.md
@@ -174,3 +174,71 @@ dcNess 는 RWHarness 와 다른 *모드* 다. 분류 전 다음 전제 박는다
 - `docs/status-json-mutate-pattern.md` §12 — RWHarness → 신규 Plugin 전환 절차
 - `docs/process/governance.md` — Task-ID + Document Sync 룰
 - `~/project/RWHarness` — 분류 대상 코드베이스
+
+---
+
+## 7. RWH 사다리 카탈로그 + dcness 한계 (2026-04-30)
+
+> **출처**: 2026-04-30 RWH 에이전트 진단 + dcness 응답. self-check 메커니즘은 [`process/branch-surface-tracking.md`](process/branch-surface-tracking.md) 참조.
+
+### 7.1 RWH 가 누적 patch 한 사다리 3종
+
+RWH 깃 로그 (3일 / 82 commit / [1.1]~[46.1]) 분석:
+
+#### 사다리 #1 — 형식 (alias) 사다리
+
+- **패턴**: 형식 강제 → LLM 변형 발생 → alias 추가 흡수 → 새 변형 → ...
+- **RWH 사례**: `MARKER_ALIASES ×12`, `parse_marker alias map`, bare LGTM alias, plan-reviewer 마커 alias 보강.
+- **dcness 차단**: `prose-only + 메타 LLM 의미 해석` 발상으로 발생 자리 제거. alias #13 부재가 정조준 타격 증거.
+- **후속 hole 가능성**: **자연 부재** — dcness 가 형식 강제 도입 안 하는 한 발생 안 함.
+
+#### 사다리 #2 — state hole 사다리
+
+- **패턴**: 분기 추가 → 분기 안 상태 보존 의무 자리 누락 → 통과 시 상태 손실 → 사후 발견 → patch → 다음 분기 추가 시 재발.
+- **RWH 사례**:
+  - plan_loop checkpoint hole: PASS → ux-architect FAIL 분기에서 `(A) early exit` / `(B) full save` 둘 다 안 거침 → metadata 부재 → planner 재실행. patch 사다리: `[41.1]` `[43.1]` `[44.1]` 3 단.
+  - worktree plan 파일 hole: `[14.2]` 진입 시 untracked 복사 → `[26]` 재사용 케이스 또 누락. patch 의 patch.
+  - autocheck no_changes 오판 (`[34.1]`): test-only commit 분류 누락 → orphan commit 양산.
+- **dcness 회피 (해결 아님)**: plan_loop / impl_loop / review_agent / impl_router 폐기 (§2.1). 분기 0 → hole 0 = 동어반복. 공학 해결 X, 운영적 절제 ⚪.
+- **후속 hole 가능성**: **현재 시작 안 함, 미래 위험 인정**. by-pid 레지스트리가 첫 분기 케이스 — sweep / orphan patch 0회. dcness 가 RWH 가 다루던 복잡도 (멀티세션 + 도그푸딩 sync + 마켓플레이스 + plugin 활성화 + worktree 격리) 를 *동일 비중* 흡수하면 분기 수 RWH 수렴 → 동일 사다리 시작.
+
+#### 사다리 #2.5 — 외부 환경 사다리 (신규 분류)
+
+- **패턴**: 외부 시스템 (CC plugin install / marketplace 컨벤션 / OS) 미공식 동작 → 우리 폴백 / wrapper 깨짐 → patch → 외부 시스템 다른 미공식 동작 만남 → patch 의 patch.
+- **RWH 사례**: PLUGIN_ROOT self-detect (file 기반 폴백) — 일부.
+- **dcness 사례 (이미 진입)**:
+  - DCN-CHG-41 (PYTHONPATH wrapper, slash command bash 환경 PYTHONPATH 미설정 발견)
+  - DCN-CHG-42 (cache glob fallback, local marketplace add 시 `marketplaces/` 미생성 발견).
+  - 3 commit / 2 단 patch.
+- **layer 구분 (RWH 진단 정정 인용)**: 사다리 #2 와 형식 같지만 *layer 다름* — #2 는 dcness 자체 코드 안 분기, #2.5 는 외부 시스템과의 인터페이스. 형식 강제 정조준 타격 (#1) 도, 분기 폐기 (#2 회피) 도 둘 다 #2.5 에 무력.
+- **후속 hole 가능성**: **양쪽 공통 부담**, dcness 가 더 유리하지도 불리하지도 않음.
+
+### 7.2 dcness 의 한계 명시
+
+RWH 에이전트의 한 줄 (인용):
+
+> ▎ State hole 은 발상 전환으로 안 사라짐. 분기가 있는 한 자리는 있음. dcness 의 답 = 분기 자체를 줄임. 분기를 줄일 수 있는 동안만 유효한 답.
+
+dcness 의 베팅 (2026-04-30 시점):
+1. **사다리 #1 차단 = 확정** — prose-only 발상이 영구 해결.
+2. **사다리 #2 회피 = 작은 표면적 유지로만 유효** — 분기 늘면 동일 사다리 진입. *측정 지속 필요*.
+3. **사다리 #2.5 = 공통 부담** — 양쪽 외부 시스템 미공식 동작에 노출.
+
+### 7.3 sticky 룰 — dcness 의 self-discipline
+
+governance 영구 자리에 박는다:
+
+1. **분기 늘리지 않기 = 1차 룰**. 신규 분기 / 진입경로 추가 PR 은 `process/branch-surface-tracking.md` §2 self-check 의무.
+2. **사다리 임계 신호 모니터링**: 동일 모듈 hole patch 30일 3회 = warning, 5회 = critical. critical 시 spec 발상 전환 협의.
+3. **layer 구분 보수적**: 사다리 #2 vs #2.5 회색지대 시 #2 분류 (더 엄격).
+
+### 7.4 inverse fallacy 회피 — outside view 부재 양쪽 동일
+
+RWH 에이전트 정정 인용:
+
+> ▎ 곡선은 양쪽 다 못 그림. 측정만이 답. ... 측정 데이터가 쌓이면 그땐 진짜 곡선이 보일 거.
+
+따라서:
+- "RWH 임계 도달 / 더 이상 진화 못 함" 단정 = inverse fallacy. 양쪽 미래 곡선 측정 없이 추정 못 함.
+- "dcness 가 사다리 #2 자유" 도 동일 단정 못 함. *현 시점 미진입* 만 사실.
+- **측정 데이터 누적이 1차** — `branch-surface-tracking.md` 가 그 회로.

--- a/docs/process/branch-surface-tracking.md
+++ b/docs/process/branch-surface-tracking.md
@@ -1,0 +1,137 @@
+# Branch Surface Tracking — 사다리 진입 조기 감지
+
+> **출처**: 2026-04-30 RWH 에이전트 진단 + 본 저장소 응답 (`docs/process/change_rationale_history.md` `DCN-CHG-20260430-03`).
+>
+> **목적**: dcNess 가 RWH 가 빠진 *patch-of-patch 사다리* (특히 사다리 #2 = 내부 state hole) 에 진입하는 시점을 가능한 한 조기에 자각.
+>
+> **본 문서가 정의하는 것**: 신규 분기 / 진입경로 추가 PR 의 self-check + 사다리 시그널 분류 + 임계 도달 시 대응.
+>
+> **본 문서가 정의하지 *않는* 것**: 사다리 자체를 *방지* 하는 메커니즘 (그건 운영적 절제 — `migration-decisions.md` §7 참조).
+
+---
+
+## 1. 사다리 분류 (3 종)
+
+RWH 깃 로그 분석 + dcness 자기 점검 결과 3 가지 구분:
+
+| # | 이름 | 원인 layer | RWH 사례 | dcness 상태 |
+|---|---|---|---|---|
+| 1 | **형식 사다리** | LLM 출력 형식 강제 | `MARKER_ALIASES ×12`, parse_marker alias map | **자연 부재** — prose-only 가 발생 자리를 없앰 |
+| 2 | **state hole 사다리** | 내부 상태기계 분기 × 진입경로 | plan_loop checkpoint hole, worktree 재사용 untracked plan 미복사 | **아직 시작 X** — by-pid 가 첫 분기 케이스, sweep/orphan patch 0회 |
+| 2.5 | **외부 환경 사다리** | 외부 시스템 (CC plugin install / marketplace 컨벤션) 미공식 | RWH PLUGIN_ROOT self-detect | DCN-CHG-41/42 (PYTHONPATH wrapper / cache glob fallback) |
+
+**핵심 구분**:
+- 사다리 #2 와 #2.5 는 *형식 같지만 layer 다름*. 사다리 #2 는 dcness 자체 코드 안 분기, 사다리 #2.5 는 외부 시스템과의 인터페이스.
+- 형식 강제 정조준 타격 (#1) 은 #2/#2.5 에 무력.
+- 분기 폐기 (#2 회피 전략) 는 #2.5 에 무력.
+
+---
+
+## 2. 신규 분기 추가 PR 의 self-check
+
+다음 변경을 포함하는 PR 작성자는 본 절 체크리스트를 PR body 에 붙인다 (governance §2.6 의 `harness` / `hooks` / `spec` 카테고리 PR 한정 — `docs-only` / `test` 면제):
+
+```markdown
+## Branch Surface Self-Check
+
+- 이 PR 이 추가하는 분기 / 진입경로 수: <N>
+- 추가된 분기 종류:
+  - [ ] 새 함수 분기 (if/else / match)
+  - [ ] 새 진입점 (CLI subcommand / hook 새 trigger / skill 새 step)
+  - [ ] 폴백 분기 (예: env 미설정 시 default path)
+  - [ ] 외부 시스템 인터페이스 분기 (plugin / git / CC / OS 등)
+- hole 후보 자리 (분기 안 *상태 보존 의무* 자리):
+  - <list — 또는 "없음 (분기가 stateless)">
+- 직전 30 일 동일 패턴 PR:
+  - <Task-ID 들 + 짧은 설명, 또는 "없음">
+- 사다리 진입 자가 판정:
+  - [ ] 사다리 #1 (형식) — 해당 없음 (prose-only)
+  - [ ] 사다리 #2 (state hole) — <yes/no + 이유>
+  - [ ] 사다리 #2.5 (외부 환경) — <yes/no + 이유>
+```
+
+작성 가이드:
+
+- **분기 / 진입경로 수**: `if` / `match` / `try` / 새 CLI subcommand / hook trigger 등 사람 눈으로 추가된 분지점. 한 줄 1점.
+- **hole 후보 자리**: 그 분기 안에서 상태 (파일 / live.json / by-pid / .steps.jsonl 등) 가 갱신/저장되는 자리. 분기 추가 시 자주 누락.
+- **30 일 동일 패턴 PR**: `git log --since='30 days ago' --grep='<keyword>'` 으로 검색. 동일 모듈에 같은 종류의 분기 patch 가 3 회 이상 누적이면 사다리 시그널.
+
+---
+
+## 3. 사다리 임계 신호 (warning / critical)
+
+| 신호 | 임계 (warning) | 임계 (critical) |
+|---|---|---|
+| 동일 모듈에 같은 종류 hole patch | 30 일 안 3 회 | 30 일 안 5 회 |
+| 한 함수의 분기 수 | 7 이상 | 12 이상 |
+| 한 PR 에서 추가되는 분기 수 | 5 이상 | 10 이상 |
+| 폴백 분기 (env 미설정 / 파일 미존재 등) 의 케이스 다중화 | 3 단 이상 | 4 단 이상 |
+| `harness/` 단일 파일 LOC | 1500 이상 | 2500 이상 |
+
+### 3.1 warning 도달 시
+
+PR body 에 명시:
+```
+⚠️ Branch Surface Warning — <임계 항목 + 수치>
+완화안: <분기 통합 / 진입점 단일화 / 폐기 검토 등>
+```
+
+다음 PR 부터 분기 추가 신중. 리뷰어 (현재는 사용자 / 메인 Claude 자가 점검) 가 폐기 가능 분기 적극 탐색.
+
+### 3.2 critical 도달 시
+
+다음 작업 중단 + spec 발상 전환 협의:
+
+1. 신규 Task-ID 발급 (`docs/process/document_update_record.md` 안 별도 entry)
+2. 회의 — 현재 사다리 진입 사실 명시 + RWH 사례 비교 + 발상 전환 후보
+3. `migration-decisions.md` 갱신 — 임계 도달 패턴 + 결정
+
+발상 전환 후보 (참고):
+- 분기 자체 폐기 (가능하면)
+- 진입점 단일화 (여러 hook → 단일 dispatcher)
+- 외부 시스템 의존 격리 (예: CC plugin path 검색을 helper 1곳에 집중)
+- spec 자체 변경 (예: state 위치 통합)
+
+---
+
+## 4. dcness 의 한계 (RWH 진단 인용)
+
+RWH 에이전트 (2026-04-30):
+
+> ▎ State hole 은 발상 전환으로 안 사라짐. 분기가 있는 한 자리는 있음. dcness 의 답 = 분기 자체를 줄임. 분기를 줄일 수 있는 동안만 유효한 답.
+
+dcness 의 베팅:
+- 사다리 #1 차단 = 발상 (prose-only) 으로 영구 해결
+- 사다리 #2 회피 = *작은 표면적 유지* — 분기 늘면 동일 사다리 진입 가능
+- 사다리 #2.5 = 양쪽 공통 부담, dcness 가 더 유리하지도 불리하지도 않음
+
+**즉, dcness 의 self-discipline 은 "분기 늘리지 않기" 가 1차 룰**. 본 추적 문서가 그 자가 점검 회로.
+
+---
+
+## 5. 본 문서 자체의 한계
+
+- **추적 대상 ≠ 사다리 방지**: 신호 보고 자가 멈출지 결정은 사람의 판단. 자동 차단 메커니즘 없음.
+- **임계 수치는 추정**: 30/3, 30/5, 1500/2500 LOC 등은 RWH 데이터를 1-time snapshot 본 추정. 30 회 이상 dcness 자가 데이터 쌓이면 보정 필요.
+- **layer 구분 회색지대**: 사다리 #2 vs #2.5 가 명확히 구분 안 되는 케이스 존재 (예: hook 의 PYTHONPATH 처리는 외부 환경이지만 hook 코드의 분기이기도). 자가 판정 시 보수적으로 (#2 분류 — 더 엄격) 처리.
+
+---
+
+## 6. 운영 절차
+
+1. 매 `harness` / `hooks` / `spec` PR 작성 시 §2 self-check 첨부
+2. warning 도달 시 §3.1 절차
+3. critical 도달 시 §3.2 절차
+4. 30 일 단위 회고 — `docs/process/branch-surface-tracking-log.md` (별도, 본 PR 에선 생성 안 함) 에 누적 기록 → 임계 수치 보정
+
+본 문서는 sticky — RWH 가 dcness 에 던진 가장 가치 있는 외부 시각이라 dcness governance 의 영구 자리에 박는다.
+
+---
+
+## 7. 참조
+
+- `docs/process/governance.md` — PR 일반 절차
+- `docs/process/document_update_record.md` `DCN-CHG-20260430-03` — 본 문서 신규 entry
+- `docs/process/change_rationale_history.md` `DCN-CHG-20260430-03` — 채택 동기 + RWH 진단 인용 + 행동 결정
+- `docs/migration-decisions.md` §7 (보강 후) — RWH 사다리 카탈로그 + dcness 한계 명시
+- `docs/status-json-mutate-pattern.md` §2.5 — proposal 5 원칙 (룰 순감소 / catastrophic-prevention 등)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,35 @@
 
 ## Records
 
+### DCN-CHG-20260430-03
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 2026-04-30 RWH 에이전트가 dcness 의 git log (3일 / 82 commit) 분석 + 진단 제출. 핵심 4 메시지:
+    1. dcness 의 prose-only 가 사다리 #1 (alias) 정조준 끊음 = 확정.
+    2. 사다리 #2 (state hole) 와 #3 (sweep) 는 dcness 가 *분기 자체 폐기* 로 회피 (해결 아님).
+    3. DCN-CHG-41/42 가 사다리 시그널 (PYTHONPATH wrapper → cache glob fallback patch).
+    4. RWH 가 더 이상 진화 못 하는 임계 / [200.1] 도달 단정.
+  - dcness 응답 검토 — 4개 정확 / 1개 over-claim / 1개 부분 정정 결과:
+    - 수용: prose-only 의 정조준 평가, 사다리 #2 회피 = 운영적 절제, DCN-41/42 시그널, RWH = baseline 카탈로그.
+    - 반박: "[200.1] / 더 이상 진화 못 함" 단정 = inverse fallacy. commit 빈도 → 가치 곡선 추론은 outside view 부재 (양쪽 동일).
+    - 부분 정정: DCN-41/42 vs RWH alias 사다리 layer 구분 — 형식 같지만 #2.5 (외부 환경) 신규 분류로 분리. 사다리 #2 (내부 state hole) 는 dcness 안 아직 시작 안 함.
+  - RWH 에이전트가 정정 두 건 (inverse fallacy 철회 + layer 혼동 정정 → #2.5 분류 수용) 응답.
+  - 외부 진단을 dcness governance 안 영구 자리로 흡수해야 — 분석이 외부 코멘트로 흐르지 않고 self-discipline 문서로 작동.
+- **Alternatives**:
+  1. *RWH 진단 무시* (dcness 가 우월 가정). over-claim. 기각.
+  2. *dcness 코드 안에 자동 사다리 차단 메커니즘* — 어떤 분기를 자동 차단할지 spec 부재 + 자동 차단이 새 사다리. 기각.
+  3. **(채택) governance 문서에 진단 흡수 + self-check 회로** — 신규 분기 PR self-check (`branch-surface-tracking.md`) + 사다리 카탈로그 sticky 명시 (`migration-decisions.md` §7). 자동 차단 X, 자가 점검 ⚪. 사람의 판단 (사용자 / 메인 Claude) 이 신호 보고 결정.
+- **Decision**:
+  - 옵션 3. 두 문서 신규/보강 docs-only PR.
+  - **사다리 #2.5 (외부 환경) 신규 분류** — RWH 진단 layer 혼동 정정 결과. 사다리 #2 와 #2.5 layer 차이 (내부 코드 vs 외부 시스템 인터페이스) 박음. 양쪽 회피 전략 다름.
+  - **임계 수치 (30일/3 warning, 30일/5 critical)** — RWH 데이터 1-time snapshot 기반 추정. 30 회 dcness 자가 데이터 후 보정 (별도 Task).
+  - **layer 회색지대 보수적**: 사다리 #2 vs #2.5 모호 시 #2 분류 (더 엄격).
+  - **inverse fallacy 양쪽 동일**: "RWH 임계 도달 / dcness 사다리 자유" 둘 다 단정 못 함. 측정 데이터 누적이 1차.
+- **Follow-Up**:
+  - **(별도 Task — 측정)** branch-surface-tracking.md 의 임계 수치 30일 누적 데이터 수집 후 보정.
+  - **(별도 Task — 측정)** 매 `harness` / `hooks` / `spec` PR 의 self-check 첨부 강제 — 현재는 권장 (governance §2.6 카테고리 PR 한정). 30일 후 강제 vs 권장 결정.
+  - **(별도 Task — 가능성)** dcness 가 critical 임계 도달 시 자동 alert 메커니즘 (`scripts/check_branch_surface.mjs` 같은 형식). 단 자동 차단 X — 사람 판단 우선.
+
 ### DCN-CHG-20260430-02
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260430-03
+- **Date**: 2026-04-30
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/process/branch-surface-tracking.md` (신규) — 사다리 분류 (#1 형식 / #2 state hole / #2.5 외부 환경) + 신규 분기 추가 PR self-check + 임계 신호 (warning/critical) + dcness 한계 명시.
+  - `docs/migration-decisions.md` — §7 RWH 사다리 카탈로그 + dcness 한계 + sticky 룰 + inverse fallacy 회피 추가.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 2026-04-30 RWH 에이전트 진단 (3일/82커밋 git log 분석) 의 정확한 부분 4건 + 정정 부분 2건 (inverse fallacy 철회 + layer 혼동 정정 → 사다리 #2.5 신규 분류) governance 영구 자리에 흡수. RWH 의 외부 시각이 dcness self-discipline 문서로 변환. branch-surface-tracking.md = 매 PR self-check 회로, migration-decisions.md §7 = 사다리 카탈로그 + dcness 한계 sticky 명시. 코드 변경 0.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-02
 - **Date**: 2026-04-30
 - **Change-Type**: harness, spec, docs-only, test


### PR DESCRIPTION
## Summary
2026-04-30 RWH 에이전트 진단 (3일/82커밋 dcness git log 분석) governance 영구 자리 흡수.

## 변경
- `docs/process/branch-surface-tracking.md` 신규 — 사다리 분류 (#1/#2/#2.5), 신규 분기 PR self-check, 임계 신호 (warning/critical), dcness 한계.
- `docs/migration-decisions.md` §7 추가 — RWH 사다리 카탈로그, sticky 룰, inverse fallacy 회피.

## 수용 4 / 반박 1 / 정정 1
- 수용: prose-only 정조준 평가, 사다리 #2 회피 = 운영적 절제, DCN-41/42 시그널, RWH = baseline.
- 반박: "[200.1] / 더 이상 진화 못 함" inverse fallacy (RWH 도 동의).
- 정정: DCN-41/42 vs alias 사다리 layer 구분 → 사다리 #2.5 (외부 환경) 신규 분류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)