### PR TITLE
feat: validator DESIGN_VALIDATION step 추가 (DCN-CHG-20260430-05)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🔍 DESIGN_VALIDATION step 추가** (`DCN-CHG-20260430-05`):
+  - orchestration §3.1 mermaid + §2.3.5 catastrophic 룰 + §4.9 결정표 갱신.
+  - /product-plan Step 6.5 신규 (validator DESIGN_VALIDATION) + cycle 한도 2.
+  - hooks.py §2.3.5 검사 (architect TASK_DECOMPOSE + SYSTEM_DESIGN.md 존재 시 DESIGN_REVIEW_PASS 필수).
+  - 신규 5 테스트 (`CatastrophicDesignValidationTests`). 171/171 PASS.
+  - 사용자 manual smoke 발견 — validator/design-validation.md agent 정의는 있는데 orchestration 시퀀스에서 호출 자리 빠져있던 갭 메움.
 - **🧹 heuristic-only 정착 + dead code 제거** (`DCN-CHG-20260430-04`):
   - `harness/llm_interpreter.py` + `tests/test_llm_interpreter.py` 삭제 (dead code, 호출 경로 0).
   - `interpret_with_fallback` 의 `llm_interpreter=` 인자 제거 — heuristic-only.

--- a/commands/product-plan.md
+++ b/commands/product-plan.md
@@ -93,7 +93,7 @@ echo "[product-plan] run started: $RUN_ID"
 
 확인 못 받으면 대기.
 
-### Step 1 — 6 task 생성
+### Step 1 — 7 task 생성
 
 ```
 TaskCreate("product-planner: PRD 작성")
@@ -101,6 +101,7 @@ TaskCreate("plan-reviewer: PRD 심사")
 TaskCreate("ux-architect: UX_FLOW")
 TaskCreate("validator: UX_VALIDATION")
 TaskCreate("architect: SYSTEM_DESIGN")
+TaskCreate("validator: DESIGN_VALIDATION")
 TaskCreate("architect: TASK_DECOMPOSE")
 ```
 
@@ -256,6 +257,43 @@ ENUM=$("$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/
 
 advance: `SYSTEM_DESIGN_READY`.
 
+### Step 6.5 — validator DESIGN_VALIDATION (DCN-CHG-20260430-05)
+
+설계 루프의 검증 단계 — TASK_DECOMPOSE 진입 전 시스템 설계 구현 가능성 + 스펙 완결성 + 리스크 검증.
+
+```
+TaskUpdate("validator: DESIGN_VALIDATION", in_progress)
+```
+
+```bash
+"$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper" begin-step validator DESIGN_VALIDATION
+```
+
+```
+Agent(
+  subagent_type="validator",
+  mode="DESIGN_VALIDATION",
+  description="architect SYSTEM_DESIGN 완료. 시스템 설계 검증해줘. 3 계층 체크리스트 (구현 가능성·스펙 완결성·리스크). 결론 enum: DESIGN_REVIEW_PASS / DESIGN_REVIEW_FAIL / DESIGN_REVIEW_ESCALATE."
+)
+```
+
+```bash
+ENUM=$("$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper" end-step validator DESIGN_VALIDATION \
+    --allowed-enums "DESIGN_REVIEW_PASS,DESIGN_REVIEW_FAIL,DESIGN_REVIEW_ESCALATE" \
+    --prose-file /tmp/dcness-pp-dv.md)
+```
+
+분기:
+- `DESIGN_REVIEW_PASS` → 다음 step (architect TASK_DECOMPOSE)
+- `DESIGN_REVIEW_FAIL` → architect SYSTEM_DESIGN 재진입 (Step 6) — **cycle 한도 2**, 초과 시 사용자 위임
+- `DESIGN_REVIEW_ESCALATE` → 사용자 위임 (escalate)
+- `AMBIGUOUS` → cascade
+
+advance:
+```
+TaskUpdate("validator: DESIGN_VALIDATION", completed)
+```
+
 ### Step 7 — architect TASK_DECOMPOSE
 
 ```
@@ -267,7 +305,8 @@ TaskUpdate("architect: TASK_DECOMPOSE", in_progress)
 ```
 
 PreToolUse 훅:
-- §2.3.4 — Step 6 와 동일 검사. SYSTEM_DESIGN 통과 후라 자연 정합.
+- §2.3.4 — Step 6 와 동일 검사 (PRD + UX 검토 정합).
+- §2.3.5 (DCN-CHG-20260430-05) — `validator-DESIGN_VALIDATION.md` 안 `DESIGN_REVIEW_PASS` 확인 → 통과 (Step 6.5 에서 박힘).
 
 ```
 Agent(
@@ -333,6 +372,7 @@ ExitWorktree(action="<keep|remove>")
 
 - `PLAN_REVIEW_CHANGES_REQUESTED` → product-planner 재진입 — **2 cycle 한도**. 초과 시 사용자 위임.
 - validator UX_VALIDATION FAIL → ux-architect 재진입 — **2 cycle 한도**.
+- validator DESIGN_VALIDATION DESIGN_REVIEW_FAIL → architect SYSTEM_DESIGN 재진입 — **2 cycle 한도** (DCN-CHG-20260430-05).
 - 한도 초과 = 사용자 결정 필요 (escalate).
 
 ## Catastrophic 룰 — 자동 정합

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -117,6 +117,7 @@ flowchart TD
 2. **pr-reviewer LGTM 없이 merge 금지**
 3. **engineer 가 architect.module-plan 통과 (READY_FOR_IMPL) 없이 src/ 작성 금지**
 4. **PRD 변경 후 plan-reviewer + ux-architect 검토 없이 architect 진입 금지**
+5. **architect TASK_DECOMPOSE 직전 validator DESIGN_VALIDATION (DESIGN_REVIEW_PASS) 없이 진입 금지** (DCN-CHG-20260430-05) — 시스템 설계가 구현 가능성 검증 통과 안 했으면 impl batch 분해 무의미.
 
 이는 proposal §2.5 원칙 4 ("흐름 강제는 catastrophic 시퀀스만") 의 catastrophic 백본. 코드 driver 도입 시 hook 으로 강제.
 
@@ -138,9 +139,14 @@ flowchart LR
     ux -->|UX_FLOW_READY| uv[validator UX_VALIDATION]
     uv -->|PASS| sd[architect SYSTEM_DESIGN]
     uv -->|FAIL| ux
-    sd -->|SYSTEM_DESIGN_READY| td[architect TASK_DECOMPOSE]
+    sd -->|SYSTEM_DESIGN_READY| dv[validator DESIGN_VALIDATION]
+    dv -->|DESIGN_REVIEW_PASS| td[architect TASK_DECOMPOSE]
+    dv -->|DESIGN_REVIEW_FAIL| sd
+    dv -->|DESIGN_REVIEW_ESCALATE| esc((escalate))
     td -->|READY_FOR_IMPL| impl[구현 루프 §2.1]
 ```
+
+DESIGN_VALIDATION cycle 한도 = 2 (DCN-CHG-20260430-05). 초과 시 사용자 위임. catastrophic 룰 §2.3.5 — TASK_DECOMPOSE 직전 DESIGN_REVIEW_PASS 필수.
 
 진입: `product-plan` 스킬 호출 또는 사용자가 "기능 추가" 발화.
 
@@ -288,8 +294,9 @@ flowchart LR
 | CODE_VALIDATION | `PASS` | pr-reviewer |
 | CODE_VALIDATION | `FAIL` | engineer 재시도 (attempt < 3) |
 | CODE_VALIDATION | `SPEC_MISSING` | architect SPEC_GAP |
-| DESIGN_VALIDATION | `PASS` | (system design 통과) impl 진입 |
-| DESIGN_VALIDATION | `FAIL` | architect SYSTEM_DESIGN 재진입 |
+| DESIGN_VALIDATION | `DESIGN_REVIEW_PASS` | architect TASK_DECOMPOSE (DCN-CHG-20260430-05) |
+| DESIGN_VALIDATION | `DESIGN_REVIEW_FAIL` | architect SYSTEM_DESIGN 재진입 (cycle 한도 2) |
+| DESIGN_VALIDATION | `DESIGN_REVIEW_ESCALATE` | 사용자 위임 |
 | UX_VALIDATION | `PASS` | architect SYSTEM_DESIGN |
 | UX_VALIDATION | `FAIL` | ux-architect 재진입 |
 | BUGFIX_VALIDATION | `PASS` | pr-reviewer |

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,27 @@
 
 ## Records
 
+### DCN-CHG-20260430-05
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 manual smoke 도중 (`/product-plan` 실행) 발견 — 설계 루프가 SYSTEM_DESIGN_READY 후 곧바로 TASK_DECOMPOSE 진입. 사용자 지적: "아키텍트 루프의 최종은 벨리데이터가 검증하고 필요하면 다시 아키텍트가 재설계해서 최종 설계 리뷰 완료까지" — 검증 step 누락.
+  - 검증 결과: `agents/validator/design-validation.md` 가 *이미 존재* (enum: DESIGN_REVIEW_PASS / FAIL / ESCALATE) — agent 정의는 있는데 *orchestration §3.1 + /product-plan skill 시퀀스에 호출 자리 없음*. 갭.
+  - 결과: SYSTEM_DESIGN 후 검증 없이 TASK_DECOMPOSE → 구현 가능성 / 스펙 완결성 / 리스크 검증 안 된 채 impl batch 분해. 잘못된 설계가 batch 단계로 흐르면 후속 impl loop 에서야 발견 → 비싼 rollback.
+- **Alternatives**:
+  1. *DESIGN_VALIDATION step 도입 안 함* — 사용자 지적 무시. 기각.
+  2. *DESIGN_VALIDATION 을 architect 자체에 inline* (architect SD 가 자가 검증). 동일 LLM 의 자가 검증은 검증 가치 ↓. 기각.
+  3. **(채택) validator DESIGN_VALIDATION step 신규** — orchestration §3.1 mermaid 에 노드 + FAIL 루프 추가, /product-plan skill Step 6.5 신규, catastrophic §2.3.5 (TD 직전 DESIGN_REVIEW_PASS 필수) hooks.py 강제. cycle 한도 2 (FAIL → SD 재진입).
+- **Decision**:
+  - 옵션 3. 시퀀스 위치 = SD 와 TD 사이.
+  - **catastrophic §2.3.5 강제 조건**: `architect-SYSTEM_DESIGN.md` 가 존재할 때만 발동 — 단순 `MODULE_PLAN` 후 TASK_DECOMPOSE 직접 호출 등 다른 진입 경로엔 미적용 (그 케이스는 §3.4 직접 호출 시퀀스).
+  - **cycle 한도 2 일관성**: PLAN_REVIEW_CHANGES_REQUESTED (2) / UX_VALIDATION FAIL (2) 와 동일. 초과 시 사용자 위임.
+  - **enum 매트릭스**: DESIGN_REVIEW_PASS / DESIGN_REVIEW_FAIL / DESIGN_REVIEW_ESCALATE — 기존 agent 정의 그대로.
+  - **task 등록 6 → 7**: /product-plan Step 1 갱신.
+- **Follow-Up**:
+  - **(별도 Task — PR 후속)** `/impl` skill 신규 — TASK_DECOMPOSE 의 impl batch 1개 받아 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer).
+  - **(별도 Task — PR 후속)** `/impl-loop` skill — impl batch list sequential /impl chain.
+  - **(별도 Task — 측정)** 30 회 /product-plan run 후 DESIGN_REVIEW_FAIL 비율. 30%+ 면 architect SYSTEM_DESIGN 의 prompt 또는 input 형식 정정 (FAIL 잦으면 SD 자가 검증 강화 후보 — cycle 비용 vs 검증 정확도 트레이드오프).
+
 ### DCN-CHG-20260430-04
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,20 @@
 
 ## Records
 
+### DCN-CHG-20260430-05
+- **Date**: 2026-04-30
+- **Change-Type**: spec, harness, hooks, docs-only, test
+- **Files Changed**:
+  - `docs/orchestration.md` — §3.1 mermaid 에 validator DESIGN_VALIDATION 노드 + FAIL 루프 추가. §2.3 catastrophic 룰 §2.3.5 신규 (TD 직전 DESIGN_REVIEW_PASS 필수). §4.9 결정표에 DESIGN_VALIDATION 3 enum 추가.
+  - `commands/product-plan.md` — Step 6.5 (validator DESIGN_VALIDATION) 신규. Step 1 의 task 등록 6 → 7. cycle 한도 (DESIGN_REVIEW_FAIL → SD 재진입 2 cycle) 명시. Step 7 의 PreToolUse 훅 §2.3.5 인용.
+  - `harness/hooks.py` — `_has_design_review_pass()` 함수 + `handle_pretooluse_agent` 에 §2.3.5 검사 (architect TASK_DECOMPOSE + SYSTEM_DESIGN.md 존재 시 DESIGN_VALIDATION PASS grep).
+  - `tests/test_hooks.py` — `CatastrophicDesignValidationTests` 5 케이스 추가.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: orchestration §3.1 에 validator DESIGN_VALIDATION step 추가 — 사용자 manual smoke 도중 발견한 갭 (validator/design-validation.md agent 존재하지만 spec/skill 시퀀스에 빠져있음). architect SYSTEM_DESIGN 후 TASK_DECOMPOSE 직전 검증 cycle 추가, FAIL 시 SD 재진입 (cycle 한도 2). catastrophic §2.3.5 = TD 직전 DESIGN_REVIEW_PASS 필수 — 시스템 설계 검증 안 한 채 impl batch 분해 = 무의미. /product-plan skill Step 6.5 + hooks.py 검사 로직 + 5 테스트.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-04
 - **Date**: 2026-04-30
 - **Change-Type**: harness, spec, docs-only, test

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -222,6 +222,20 @@ def handle_pretooluse_agent(
                 )
                 return 1
 
+    # 5. §2.3.5 (DCN-CHG-20260430-05) — architect TASK_DECOMPOSE 직전 validator
+    #    DESIGN_VALIDATION (DESIGN_REVIEW_PASS) 필수. 시스템 설계 검증 안 한 채
+    #    impl batch 분해 = 무의미.
+    if subagent == "architect" and mode == "TASK_DECOMPOSE":
+        # SYSTEM_DESIGN 단계가 있었다는 사실 확인 — design-validation 검사 발동 조건
+        if (rd / "architect-SYSTEM_DESIGN.md").exists():
+            if not _has_design_review_pass(rd):
+                print(
+                    "[catastrophic §2.3.5] architect TASK_DECOMPOSE 직전 "
+                    "validator DESIGN_VALIDATION DESIGN_REVIEW_PASS 필수",
+                    file=sys.stderr,
+                )
+                return 1
+
     return 0
 
 
@@ -259,6 +273,11 @@ def _has_plan_review_pass(rd: Path) -> bool:
 def _has_ux_flow_ready(rd: Path) -> bool:
     text = _read_or_empty(rd / "ux-architect.md")
     return "UX_FLOW_READY" in text or "UX_FLOW_PATCHED" in text
+
+
+def _has_design_review_pass(rd: Path) -> bool:
+    """validator-DESIGN_VALIDATION.md 안 DESIGN_REVIEW_PASS 확인 (DCN-CHG-20260430-05)."""
+    return "DESIGN_REVIEW_PASS" in _read_or_empty(rd / "validator-DESIGN_VALIDATION.md")
 
 
 # ── CLI 진입점 (bash 훅 → python -m harness.hooks <subcommand>) ─────

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -385,6 +385,105 @@ class CatastrophicArchitectTests(_PreToolBase):
 
 
 # ---------------------------------------------------------------------------
+# §2.3.5 — architect TASK_DECOMPOSE 직전 DESIGN_VALIDATION PASS (DCN-CHG-20260430-05)
+# ---------------------------------------------------------------------------
+
+
+class CatastrophicDesignValidationTests(_PreToolBase):
+    """architect TASK_DECOMPOSE 직전 validator DESIGN_VALIDATION DESIGN_REVIEW_PASS 필수.
+
+    조건: SYSTEM_DESIGN.md 가 존재할 때만 발동 (시스템 설계 단계가 있었음). 단순
+    MODULE_PLAN 진입은 미적용.
+    """
+
+    def _setup_full_review(self) -> None:
+        """SD 까지의 정합 prose 들 박기 (§2.3.4 통과 + §2.3.5 검사 발동 조건)."""
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        (self.run_path / "plan-reviewer.md").write_text(
+            "PLAN_REVIEW_PASS", encoding="utf-8",
+        )
+        (self.run_path / "ux-architect.md").write_text(
+            "UX_FLOW_READY", encoding="utf-8",
+        )
+        (self.run_path / "architect-SYSTEM_DESIGN.md").write_text(
+            "SYSTEM_DESIGN_READY", encoding="utf-8",
+        )
+
+    def test_td_blocked_without_design_review_pass(self) -> None:
+        self._setup_full_review()
+        # validator-DESIGN_VALIDATION.md 부재 → 차단
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "TASK_DECOMPOSE"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_td_blocked_with_design_review_fail(self) -> None:
+        self._setup_full_review()
+        (self.run_path / "validator-DESIGN_VALIDATION.md").write_text(
+            "DESIGN_REVIEW_FAIL — 인터페이스 미정의", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "TASK_DECOMPOSE"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_td_passes_with_design_review_pass(self) -> None:
+        self._setup_full_review()
+        (self.run_path / "validator-DESIGN_VALIDATION.md").write_text(
+            "DESIGN_REVIEW_PASS — 3 계층 모두 통과", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "TASK_DECOMPOSE"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_sd_passes_without_design_review(self) -> None:
+        """architect SYSTEM_DESIGN 호출 자체는 §2.3.5 미적용 (TD 만 검사)."""
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        (self.run_path / "plan-reviewer.md").write_text(
+            "PLAN_REVIEW_PASS", encoding="utf-8",
+        )
+        (self.run_path / "ux-architect.md").write_text(
+            "UX_FLOW_READY", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "SYSTEM_DESIGN"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_td_skipped_when_no_system_design(self) -> None:
+        """SYSTEM_DESIGN.md 부재 시 §2.3.5 발동 X — 단순 TASK_DECOMPOSE 직접 호출 케이스."""
+        (self.run_path / "product-planner.md").write_text(
+            "PRODUCT_PLAN_READY", encoding="utf-8",
+        )
+        (self.run_path / "plan-reviewer.md").write_text(
+            "PLAN_REVIEW_PASS", encoding="utf-8",
+        )
+        (self.run_path / "ux-architect.md").write_text(
+            "UX_FLOW_READY", encoding="utf-8",
+        )
+        # SYSTEM_DESIGN 없으면 §2.3.5 검사 skip — §2.3.4 만 적용 (이미 통과)
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("architect", "TASK_DECOMPOSE"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
 # rid 폴백 (by-pid-current-run 없을 때 live.json 에서 추정)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
사용자 manual smoke 도중 발견 — `agents/validator/design-validation.md` agent 는 정의됐는데 orchestration §3.1 + /product-plan skill 시퀀스에 호출 자리 누락. SD 후 검증 없이 TASK_DECOMPOSE → 잘못된 설계가 impl batch 단계로 흘러감.

## 변경
- orchestration §3.1 mermaid + §2.3.5 catastrophic 룰 + §4.9 결정표
- /product-plan Step 6.5 + cycle 한도 2
- hooks.py §2.3.5 검사 (TD 직전 DESIGN_REVIEW_PASS 필수, SYSTEM_DESIGN.md 존재 시만 발동)
- 신규 5 테스트 (CatastrophicDesignValidationTests)

171/171 PASS.

## 후속 (별도 PR)
- /impl skill (per-batch 정식 impl 루프)
- /impl-loop skill (sequential auto chain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)