### PR TITLE
feat: /impl + /impl-loop skill 신규 (DCN-CHG-20260430-06)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,11 @@
 
 ## 현재 상태
 
+- **🔁 /impl + /impl-loop skill 신규** (`DCN-CHG-20260430-06`):
+  - `/impl` — per-batch 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer + clean 자동 commit/PR + yolo + worktree).
+  - `/impl-loop` — multi-batch sequential auto chain (각 batch 마다 /impl 호출 + clean 자동 진행 + caveat 멈춤).
+  - /product-plan TASK_DECOMPOSE 산출 batch list 의 후속 진입점. 5 sub-task per batch 가시화 — 사용자 manual smoke 지적 정합.
+  - dcNess plugin skill 7개 됨: /qa /quick /product-plan /smart-compact /init-dcness /impl /impl-loop.
 - **🔍 DESIGN_VALIDATION step 추가** (`DCN-CHG-20260430-05`):
   - orchestration §3.1 mermaid + §2.3.5 catastrophic 룰 + §4.9 결정표 갱신.
   - /product-plan Step 6.5 신규 (validator DESIGN_VALIDATION) + cycle 한도 2.

--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -1,0 +1,144 @@
+---
+name: impl-loop
+description: impl batch list (architect TASK_DECOMPOSE 산출물) 를 순차 자동 chain 으로 처리하는 스킬. 사용자가 "전부 구현", "/impl-loop", "batch 다 돌려", "epic 전체 구현", "/product-plan 후 자동", "끝까지 구현" 등을 말할 때 반드시 이 스킬을 사용한다. 각 batch 마다 /impl skill 의 정식 루프를 실행 + clean run 만 자동 진행 + caveat 시 사용자 위임. /product-plan 종료 후 N 개 batch 한 번에 처리하고 싶을 때.
+---
+
+# Impl Loop Skill — multi-batch sequential auto chain
+
+> dcNess 컨베이어 패턴. `/impl` 의 multi-batch 래퍼 — batch list 1~N 개 순차 처리. clean 시 자동 진행 + caveat 시 멈춤.
+
+## 언제 사용
+
+- 사용자 발화: "/impl-loop", "전부 구현", "다 돌려", "epic 전체", "끝까지 구현", "/product-plan 후 자동"
+- /product-plan TASK_DECOMPOSE 산출 batch N 개 한 번에 처리할 때
+- yolo 모드 + 사용자가 잠시 자리 비울 때 (각 batch clean 진행 시 무인)
+
+## 언제 사용하지 않음
+
+- batch 1 개만 처리 → `/impl` (단일 batch)
+- batch 별로 사용자가 검토하고 싶음 → `/impl` 1개씩 수동 호출
+- 한 줄 / 한 함수 수정 → `/quick`
+- 새 기능 spec/design 단계 → `/product-plan`
+
+## 핵심 동작
+
+각 batch 에 대해 `/impl` skill 의 시퀀스 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer) 실행. clean 시 자동 commit/PR + 다음 batch 진행. caveat (FAIL / AMBIGUOUS / MUST FIX) 시 멈춤 + 사용자 위임.
+
+## 절차
+
+### Step 0 — batch list 추출 + 사용자 확인
+
+사용자 발화 또는 architect TASK_DECOMPOSE 산출물에서 batch 파일 list 추출:
+
+```bash
+# 예시 — TASK_DECOMPOSE prose 가 박은 임프로젝트 디렉토리 패턴
+BATCH_LIST=$(ls docs/milestones/v*/epics/epic-*/impl/*.md 2>/dev/null | sort)
+echo "발견된 batch:"
+echo "$BATCH_LIST"
+```
+
+또는 사용자가 직접 list 명시 (예: `/impl-loop epic-01/01.md epic-01/02.md`).
+
+```bash
+HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
+RUN_ID=$("$HELPER" begin-run impl-loop)
+echo "[impl-loop] run started: $RUN_ID"
+```
+
+사용자에게:
+```
+[impl-loop] 실행 설정
+- 처리할 batch (N 개):
+  1. <batch 1 경로>
+  2. <batch 2 경로>
+  ...
+- 시퀀스: 각 batch 마다 /impl 의 정식 루프 (architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer)
+- 분기 정책:
+  - clean → 자동 commit/PR + 다음 batch 진행
+  - caveat → 멈춤 + 사용자 위임
+- yolo 모드: <yes/no — 사용자 발화 keyword 검출 결과>
+
+진행할까요?
+```
+
+### Step 1 — task 등록 (batch 별 1개)
+
+```
+for i in 1..N:
+  TaskCreate(f"impl-{i}: <batch 파일명 + 짧은 제목>")
+```
+
+각 batch = 1 외부 task. 각 batch 안의 5 sub-task 는 batch 진행 시 `/impl` 가 만듦 — 외부 시각엔 배 N 개 task progress 보임.
+
+### Step 2 — 각 batch 순차 처리 (1 부터 N 까지)
+
+```
+for batch in BATCH_LIST:
+  TaskUpdate(f"impl-{i}: ...", in_progress)
+  → /impl skill 의 Step 1~7 시퀀스 호출 (인자 = batch path, 단 begin-run 은 본 outer run 안 별도 inner run 으로):
+
+      INNER_RUN=$("$HELPER" begin-run "impl-batch-$i")
+      → /impl 의 Step 1~7 (batch 1개 처리)
+      → /impl Step 7 의 finalize-run 으로 status 받음
+      → clean 판정:
+          - clean → 자동 commit/PR (graceful degrade) → INNER_RUN end
+          - caveat → 사용자 위임 → 본 loop 멈춤
+
+  TaskUpdate(f"impl-{i}: ...", completed) # clean 만
+```
+
+### Step 2.5 — caveat 발생 시 멈춤
+
+clean 아닌 batch 만나면:
+
+```
+[impl-loop] batch <i> 에서 멈춤 — caveat 발생
+- batch: <batch 경로>
+- caveat: <FAIL / AMBIGUOUS / MUST FIX 등>
+- 처리한 batch: <i-1>/<N>
+- 남은 batch: <list>
+
+옵션:
+1. 사용자가 batch <i> 수동 처리 후 `/impl-loop` 재호출 (남은 batch 만 인자로)
+2. yolo + cycle 한도 내 재시도 (yolo ON 일 때만)
+3. 종료
+```
+
+사용자 응답 받으면 그에 따라.
+
+### Step 3 — 모든 batch 완료 시 보고
+
+```
+[impl-loop] 전체 완료 ✅
+- run_id: $RUN_ID
+- 처리한 batch: <N>/<N>
+- 각 batch 의 inner run_id + 변경 파일 + PR URL (생성된 경우)
+
+prose 종이 트리: <main repo>/.claude/harness-state/.sessions/{sid}/runs/$RUN_ID/
+                 + 각 inner run dir 들
+
+다음 단계 (선택):
+- 추가 batch 가 발생하면 /impl-loop 재호출
+- 또는 epic 전체 완료 시 /product-plan 다음 epic 진입
+```
+
+## yolo 모드
+
+`/impl` 의 yolo 와 동일 + multi-batch 한정 추가 동작:
+- 각 batch 의 caveat 도 yolo 매트릭스 적용 — `auto-resolve` 권장 액션 자동 적용
+- 단 매 3 batch 마다 또는 1 시간마다 사용자에게 progress 보고 (장시간 무인 운영 시 안전)
+
+## 한계 / 후속
+
+- **batch 간 의존성 처리 X (v1)** — batch 들이 병렬 가능한지, 직렬 의존인지 자동 판단 X. v1 = 무조건 직렬. 사용자가 list 순서로 의존 표현.
+- **재시도 시 cycle 누적** — batch B 에서 재시도 5회 후 실패 → 그 시점까지의 commit 들은 보존. rollback X (안전 가드).
+- **inner run 의 .steps.jsonl 분리** — 각 batch 가 자기 inner run dir 사용. outer run dir 엔 batch 진행 메타만 (별도 jsonl).
+- **multi-batch resume 미구현 (v1)** — caveat 멈춤 후 재실행 시 처음부터 다시. 단 이미 commit 된 batch 는 architect MODULE_PLAN 단계 자가 검출 (SPEC_GAP_FOUND 분기) 로 skip 가능.
+
+## 참조
+
+- `commands/impl.md` — 단일 batch 처리 (본 skill 의 inner)
+- `commands/product-plan.md` — TASK_DECOMPOSE 산출 batch list 출처
+- `docs/orchestration.md` §2.1 — 정식 impl 루프
+- `docs/orchestration.md` §3.1 — /product-plan → /impl-loop 진입 흐름
+- `commands/quick.md` — 한 줄 수정 (light path, multi-batch 무관)

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -1,0 +1,319 @@
+---
+name: impl
+description: impl batch (architect TASK_DECOMPOSE 산출물) 1개를 받아 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer) 자동 진행하는 스킬. 사용자가 "구현해줘", "/impl <batch>", "이 batch 구현", "module plan 부터 진행", "impl 루프" 등을 말할 때 반드시 이 스킬을 사용한다. /product-plan 의 후속 — TASK_DECOMPOSE 의 batch list 1개씩 처리. /quick 보다 무거움 (test-engineer + CODE_VALIDATION 포함). dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작.
+---
+
+# Impl Skill — per-batch 정식 impl 루프
+
+> dcNess 컨베이어 패턴. /product-plan TASK_DECOMPOSE 산출 batch 1개를 정식 impl 루프로 처리. orchestration §2.1 정합.
+
+## 언제 사용
+
+- 사용자 발화: "구현해줘", "/impl", "이 batch 구현", "module plan", "정식 루프", "impl 루프"
+- /product-plan 종료 후 batch list 1개씩 진행할 때
+- 단순 한 줄 수정 (`/quick` 영역) 보다 *모듈 단위 + 테스트* 가 필요한 경우
+
+## 언제 사용하지 않음
+
+- 한 줄 / 한 함수 수정 → `/quick` (light path, test-engineer 생략)
+- 새 기능 spec/design 단계 → `/product-plan`
+- 다중 batch 자동 chain → `/impl-loop`
+- impl batch 가 부재 (TASK_DECOMPOSE 안 거침) → `/quick` 또는 architect MODULE_PLAN 직접 호출
+
+## 시퀀스 (orchestration.md §2.1)
+
+```
+architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer
+```
+
+각 단계 결론 enum:
+- architect MODULE_PLAN → `READY_FOR_IMPL` (또는 `SPEC_GAP_FOUND` / `TECH_CONSTRAINT_CONFLICT`)
+- test-engineer → `TESTS_WRITTEN` (또는 `SPEC_GAP_FOUND`)
+- engineer IMPL → `IMPL_DONE` (또는 `SPEC_GAP_FOUND` / `TESTS_FAIL` / `IMPLEMENTATION_ESCALATE`)
+- validator CODE_VALIDATION → `PASS` (또는 `FAIL` / `SPEC_MISSING`)
+- pr-reviewer → `LGTM` (또는 `CHANGES_REQUESTED`)
+
+## yolo 모드 — keyword 트리거
+
+`/quick` `/product-plan` 과 동일. 사용자 발화에 `yolo` / `auto` / `끝까지` / `막힘 없이` / `다 알아서` 시 yolo ON.
+
+yolo 시:
+- `SPEC_GAP_FOUND` → architect SPEC_GAP cycle 자동 진입 (단 cycle 한도 2 — 초과 시 사용자 위임)
+- `TESTS_FAIL` → engineer 재시도 (attempt < 3)
+- `CODE_VALIDATION FAIL` → engineer 재시도
+- `CHANGES_REQUESTED` → engineer POLISH 자동 호출 (cycle 한도 2)
+- `*_ESCALATE` / `AMBIGUOUS` → `auto-resolve` 매핑 적용 후 fallback (사용자 위임)
+
+catastrophic 룰 (PreToolUse 훅 §2.3) hard safety 보존.
+
+## 절차 (Task tool + helper protocol)
+
+### Step 0a — worktree 격리 진입 (선택, keyword 트리거)
+
+`/quick` 동일 — `worktree` / `wt` / `격리` / `isolate` keyword 시:
+
+```
+EnterWorktree(name="impl-{ts_short}")
+```
+
+batch 단위 작업이라 worktree 격리 권장. 사용자 발화에 keyword 없어도 batch 작업 = src/ 다중 파일 수정 → conflict 위험 있을 시 메인이 자체 판단으로 권유 가능.
+
+### Step 0b — run 시작 + 사용자 확인
+
+사용자 발화에서 impl batch 경로 추출 (예: `docs/milestones/v0.2/epics/epic-01-greet-i18n/impl/01-greetings-data.md`).
+
+```bash
+HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
+RUN_ID=$("$HELPER" begin-run impl)
+echo "[impl] run started: $RUN_ID"
+```
+
+사용자에게 한 번 확인:
+```
+[impl] 실행 설정
+- batch: <batch 파일 경로>
+- 이슈 제목 (한 줄, 70자 이내): <impl batch 의 ## 제목 줄 추출>
+- 시퀀스: architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer
+- attempt 한도: engineer 3 / POLISH 2 / SPEC_GAP cycle 2
+
+진행할까요?
+```
+
+### Step 1 — 5 task 생성
+
+```
+TaskCreate("architect: MODULE_PLAN")
+TaskCreate("test-engineer: TDD attempt 0")
+TaskCreate("engineer: IMPL")
+TaskCreate("validator: CODE_VALIDATION")
+TaskCreate("pr-reviewer: 검토")
+```
+
+### Step 2 — architect MODULE_PLAN
+
+```
+TaskUpdate("architect: MODULE_PLAN", in_progress)
+```
+
+```bash
+"$HELPER" begin-step architect MODULE_PLAN
+```
+
+```
+Agent(
+  subagent_type="architect",
+  mode="MODULE_PLAN",
+  description="impl batch 파일: <batch path>. 모듈 plan 작성 — 생성/수정 파일 + 인터페이스 + 의사코드 + 결정 근거. 결론 enum: READY_FOR_IMPL / SPEC_GAP_FOUND / TECH_CONSTRAINT_CONFLICT."
+)
+```
+
+```bash
+ENUM=$("$HELPER" end-step architect MODULE_PLAN \
+    --allowed-enums "READY_FOR_IMPL,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT" \
+    --prose-file /tmp/dcness-impl-mp.md)
+```
+
+advance: `READY_FOR_IMPL`. 그 외:
+- `SPEC_GAP_FOUND` → architect SPEC_GAP 진입 (cycle < 2) 또는 사용자 위임
+- `TECH_CONSTRAINT_CONFLICT` → 사용자 위임
+- `AMBIGUOUS` → cascade
+
+### Step 3 — test-engineer (TDD attempt 0)
+
+```
+TaskUpdate("test-engineer: TDD attempt 0", in_progress)
+```
+
+```bash
+"$HELPER" begin-step test-engineer
+```
+
+PreToolUse 훅:
+- §2.3.3 — `architect-MODULE_PLAN.md` 안 `READY_FOR_IMPL` 확인 → 통과.
+
+```
+Agent(
+  subagent_type="test-engineer",
+  description="MODULE_PLAN 완료. impl 의 ## 생성/수정 파일 경로만 사용 (src/ 읽기 금지 — catastrophic-prevention). 테스트 코드 작성. 결론 enum: TESTS_WRITTEN / SPEC_GAP_FOUND."
+)
+```
+
+```bash
+ENUM=$("$HELPER" end-step test-engineer \
+    --allowed-enums "TESTS_WRITTEN,SPEC_GAP_FOUND" \
+    --prose-file /tmp/dcness-impl-test.md)
+```
+
+advance: `TESTS_WRITTEN`. `SPEC_GAP_FOUND` 면 architect SPEC_GAP 또는 사용자 위임.
+
+### Step 4 — engineer IMPL (attempt 0..3)
+
+```
+TaskUpdate("engineer: IMPL", in_progress)
+```
+
+```bash
+"$HELPER" begin-step engineer IMPL
+```
+
+PreToolUse 훅:
+- §2.3.3 — `architect-MODULE_PLAN.md` 안 `READY_FOR_IMPL` 확인 → 통과.
+
+```
+Agent(
+  subagent_type="engineer",
+  mode="IMPL",
+  description="MODULE_PLAN + TESTS_WRITTEN 완료. 구현해줘. 결론 enum: IMPL_DONE / SPEC_GAP_FOUND / TESTS_FAIL / IMPLEMENTATION_ESCALATE."
+)
+```
+
+```bash
+ENUM=$("$HELPER" end-step engineer IMPL \
+    --allowed-enums "IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE" \
+    --prose-file /tmp/dcness-impl-impl.md)
+```
+
+advance: `IMPL_DONE`. 그 외:
+- `SPEC_GAP_FOUND` → architect SPEC_GAP cycle (한도 2) 또는 사용자 위임
+- `TESTS_FAIL` → engineer 재시도 (attempt < 3, 재호출 시 attempt 카운터 ↑)
+- `IMPLEMENTATION_ESCALATE` → 사용자 위임
+- `AMBIGUOUS` → cascade
+
+### Step 5 — validator CODE_VALIDATION
+
+```
+TaskUpdate("validator: CODE_VALIDATION", in_progress)
+```
+
+```bash
+"$HELPER" begin-step validator CODE_VALIDATION
+```
+
+```
+Agent(
+  subagent_type="validator",
+  mode="CODE_VALIDATION",
+  description="engineer IMPL 완료. 코드 검증해줘. 결론 enum: PASS / FAIL / SPEC_MISSING."
+)
+```
+
+```bash
+ENUM=$("$HELPER" end-step validator CODE_VALIDATION \
+    --allowed-enums "PASS,FAIL,SPEC_MISSING" \
+    --prose-file /tmp/dcness-impl-cv.md)
+```
+
+advance: `PASS`. 그 외:
+- `FAIL` → engineer 재시도 (attempt < 3)
+- `SPEC_MISSING` → architect SPEC_GAP
+
+### Step 6 — pr-reviewer
+
+```
+TaskUpdate("pr-reviewer: 검토", in_progress)
+```
+
+```bash
+"$HELPER" begin-step pr-reviewer
+```
+
+PreToolUse 훅:
+- §2.3.1 — `validator-CODE_VALIDATION.md` 안 `PASS` 확인 → 통과.
+
+```
+Agent(
+  subagent_type="pr-reviewer",
+  description="engineer IMPL + validator CODE_VALIDATION PASS. 검토. 결론 enum: LGTM / CHANGES_REQUESTED."
+)
+```
+
+```bash
+ENUM=$("$HELPER" end-step pr-reviewer \
+    --allowed-enums "LGTM,CHANGES_REQUESTED" \
+    --prose-file /tmp/dcness-impl-pr.md)
+```
+
+advance: `LGTM`. `CHANGES_REQUESTED` 면 engineer POLISH 호출 (cycle 한도 2) 또는 사용자 위임.
+
+#### POLISH 사이드 사이클 (CHANGES_REQUESTED)
+
+```
+Agent(
+  subagent_type="engineer",
+  mode="POLISH",
+  description="pr-reviewer CHANGES_REQUESTED. 지적 사항 반영. 결론 enum: POLISH_DONE / IMPLEMENTATION_ESCALATE."
+)
+```
+
+POLISH_DONE 후 pr-reviewer 재호출. cycle 한도 2.
+
+### Step 7 — finalize-run + clean 자동 commit/PR (또는 caveat 확인)
+
+`/quick` 의 Step 7 와 동일 패턴. 차이점은 enum 매트릭스만:
+
+#### 7.1 helper 로 status 집계
+
+```bash
+STATUS=$("$HELPER" finalize-run)
+"$HELPER" end-run
+echo "$STATUS"
+```
+
+#### 7.2 clean 판정
+
+다음 모두 충족 → **clean**:
+- `has_ambiguous == false`
+- `has_must_fix == false`
+- step enum 매트릭스:
+  - `architect:MODULE_PLAN.enum == READY_FOR_IMPL`
+  - `test-engineer.enum == TESTS_WRITTEN`
+  - `engineer:IMPL.enum == IMPL_DONE`
+  - `validator:CODE_VALIDATION.enum == PASS`
+  - `pr-reviewer.enum == LGTM`
+- git 안전 가드 (`/quick` Step 7.2 동일)
+
+#### 7a — Clean 자동 commit/PR
+
+`/quick` Step 7a 와 동일. branch prefix = `feat/<batch-slug>` 또는 `chore/<batch-slug>` (impl 분류에 따라).
+
+#### 7b — Caveat 확인
+
+`/quick` Step 7b 와 동일.
+
+worktree 처리도 동일 — squash 흡수 검사 자동.
+
+## AMBIGUOUS 처리 — 매 step 동일
+
+`/quick` 의 cascade 패턴 정합:
+1. 재호출 1회
+2. 재호출도 AMBIGUOUS → 사용자 위임 (yolo 시 auto-resolve fallback)
+
+## Catastrophic 룰 — 자동 정합
+
+본 시퀀스는 §2.3 4룰 + §2.3.5 정합:
+- §2.3.1 (pr-reviewer 직전 validator PASS) — Step 5 CODE_VALIDATION PASS 충족
+- §2.3.3 (engineer/test-engineer 직전 plan READY) — Step 2 MODULE_PLAN READY_FOR_IMPL 충족
+- §2.3.4 (architect SD/TD 직전 PRD 검토) — MODULE_PLAN 은 SD/TD 아님 → 비대상
+- §2.3.5 (TD 직전 DESIGN_REVIEW_PASS) — TD 본 시퀀스 안 없음 → 비대상
+
+PreToolUse 훅이 매 Agent 직전 자동 검사. 시퀀스 정합 시 통과.
+
+## 한계 / 후속
+
+- **batch list 자동 chain X** — 본 skill 은 batch 1개 처리. multi-batch 자동 chain 은 `/impl-loop` (별도 skill).
+- **attempt counter 메인 추적** — engineer 재시도 횟수 메인이 자체 카운팅 (현재 helper 미지원, 향후 follow-up 가능).
+- **POLISH cycle 한도 2** — 초과 시 사용자 위임.
+
+## 참조
+
+- `agents/architect/module-plan.md` — MODULE_PLAN system prompt
+- `agents/test-engineer.md` — test-engineer system prompt
+- `agents/engineer.md` — engineer (IMPL / POLISH)
+- `agents/validator/code-validation.md` — CODE_VALIDATION
+- `agents/pr-reviewer.md` — pr-reviewer
+- `docs/orchestration.md` §2.1 — 정식 impl 루프
+- `docs/orchestration.md` §4 — agent 별 결론 enum 결정표
+- `docs/conveyor-design.md` — Task tool + helper + 훅
+- `commands/quick.md` — light path (test-engineer 생략, BUGFIX_VALIDATION 사용)
+- `commands/product-plan.md` — spec/design (TASK_DECOMPOSE 산출 = 본 skill 입력)
+- `commands/impl-loop.md` — multi-batch sequential auto chain (별도 skill)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,30 @@
 
 ## Records
 
+### DCN-CHG-20260430-06
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 manual smoke (/product-plan v0.2 → "하나씩 순차로 구현해") 도중 발견 — /product-plan 종료 시 architect TASK_DECOMPOSE 산출 = 5 impl batch list. 그러나 후속 정식 impl 루프 (orchestration §2.1) 호출 진입점 부재 → 메인이 즉흥 처리. 외부 task 5 개만 등록 (batch 별), 각 batch 안 5 sub-task (plan/test/impl/validate/review) 누락 → 진행 가시성 ↓.
+  - 사용자 지적: "근데 이게 맞냐 impl마다 단계를 task로 잡아야지". 정확.
+  - 갭 = orchestration §3.1 의 "→ 구현 루프 §2.1 (별도)" 가 *concrete entry skill* 부재.
+- **Alternatives**:
+  1. */product-plan 자체에 impl 루프 chain 박기* — /product-plan 의 spec/design 책임이 폭증. 단발 impl batch 만 처리하고 싶을 때 과한 작업. 기각.
+  2. */quick 으로 batch 처리* — /quick 은 light path (test-engineer 생략, BUGFIX_VALIDATION 사용). batch 처리엔 부족 (test 없음 + 회귀 위험). 기각.
+  3. **(채택) 신규 skill 2 개**: /impl (per-batch 정식 루프) + /impl-loop (multi-batch wrapper). /impl 은 orchestration §2.1 그대로 5 단계. /impl-loop 은 batch list 받아 각 batch 마다 /impl chain + clean 자동 진행.
+- **Decision**:
+  - 옵션 3. 두 skill 신규.
+  - **/impl 시퀀스** = orchestration §2.1 정합. PreToolUse 훅 §2.3.1 / §2.3.3 자연 정합.
+  - **5 sub-task per batch** — 각 batch 안 architect MODULE_PLAN / test-engineer / engineer / validator / pr-reviewer 가 task list 로 보임. 사용자 지적 정합.
+  - **clean 자동 commit/PR**: /quick Step 7a 패턴 정합 — finalize-run JSON 집계 + clean 판정 + graceful degrade.
+  - **yolo 모드**: /quick / /product-plan 동일 keyword + auto-resolve 매핑.
+  - **/impl-loop wrapper**: 각 batch 마다 /impl 의 inner run 별도 (begin-run impl-batch-N). outer run 은 batch list 진행 메타만 추적.
+  - **caveat 멈춤**: clean 아니면 멈춤 + 사용자 위임. yolo 도 has_must_fix true 시 멈춤 (hard safety).
+- **Follow-Up**:
+  - **(별도 Task)** /impl-loop 의 multi-batch resume — caveat 멈춤 후 재실행 시 처음부터 다시 도는 거 정정 (이미 commit 된 batch skip).
+  - **(별도 Task)** batch 간 의존성 처리 (병렬 가능 / 직렬 강제 자동 판단). 현재 v1 = 무조건 직렬.
+  - **(별도 Task)** /product-plan 종료 시 "/impl-loop 진입" 옵션 자동 제안 (현재는 사용자 명시 발화 필요).
+  - **(측정)** /impl-loop 의 N batch 자동 진행률 + 멈춤 횟수. 30 회 후 yolo 매트릭스 보강.
+
 ### DCN-CHG-20260430-05
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,18 @@
 
 ## Records
 
+### DCN-CHG-20260430-06
+- **Date**: 2026-04-30
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `commands/impl.md` (신규) — `/impl` skill (per-batch 정식 impl 루프 — architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer + clean 자동 commit/PR + yolo + worktree).
+  - `commands/impl-loop.md` (신규) — `/impl-loop` skill (multi-batch sequential auto chain — 각 batch 마다 /impl 호출 + clean 자동 진행 + caveat 시 멈춤).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: dcNess plugin 의 6+7 번째 skill. /quick 과 /product-plan 사이 갭 (정식 impl 루프 호출 진입점) 메움. /impl = per-batch (5 단계 task), /impl-loop = multi-batch wrapper (각 batch 의 /impl 자동 chain + clean 시 자동 진행). 사용자 manual smoke 발견 — /product-plan TASK_DECOMPOSE 산출 batch N 개를 메인이 즉흥 처리 (sub-task 등록 누락) 한 거 정정. 코드 변경 0 (prompt-only).
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-05
 - **Date**: 2026-04-30
 - **Change-Type**: spec, harness, hooks, docs-only, test


### PR DESCRIPTION
## Summary
사용자 manual smoke 도중 발견 — /product-plan TASK_DECOMPOSE 산출 batch list 의 후속 정식 impl 루프 진입점 부재.

- /impl = per-batch 정식 루프 (5 sub-task)
- /impl-loop = multi-batch sequential auto chain

dcNess plugin skill 7개 완성.

🤖 Generated with [Claude Code](https://claude.com/claude-code)