### PR TITLE
feat: /efficiency skill — jha0313/skills_repo 흡수 (DCN-CHG-20260430-08)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **💰 /efficiency skill — jha0313/skills_repo 흡수** (`DCN-CHG-20260430-08`):
+  - `harness/efficiency/` 패키지 (4 script fork from `improve-token-efficiency`) + `scripts/dcness-efficiency` wrapper + `commands/efficiency.md` skill prompt.
+  - dcness fix 2건: encode_repo_path 의 `.` → `-` (CC 실 인코딩 룰 정합), price_for prefix 매칭 (dated suffix / variant tag 흡수).
+  - 4 지표 점수화 (Cache utilization 40% + Output density 20% + Read redundancy 20% + Tool economy 20%) + Pareto + 6 절감 휴리스틱.
+  - 신규 10 테스트 (`test_efficiency.py`). 181/181 PASS.
+  - dcness skill 8 개: /init-dcness /qa /quick /product-plan /impl /impl-loop /smart-compact /efficiency.
 - **🔁 /impl + /impl-loop skill 신규** (`DCN-CHG-20260430-06`):
   - `/impl` — per-batch 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer + clean 자동 commit/PR + yolo + worktree).
   - `/impl-loop` — multi-batch sequential auto chain (각 batch 마다 /impl 호출 + clean 자동 진행 + caveat 멈춤).

--- a/commands/efficiency.md
+++ b/commands/efficiency.md
@@ -1,0 +1,148 @@
+---
+name: efficiency
+description: Claude Code 세션 JSONL 로그 (`~/.claude/projects/<encoded-repo>/*.jsonl`) 를 파싱해서 토큰 / 캐시 효율 / 비용 리포트 (HTML 대시보드 + ROI 절감안) 를 생성하는 분석 스킬. 사용자가 "토큰 효율", "비용 분석", "Claude 비용", "session report", "/efficiency", "효율 리포트", "캐시 히트율", "내 Claude 얼마 썼나", "absorb" 등을 말할 때 사용. 단발 세션 X — 레포 전체 N 세션 집계 + 4 지표 점수화 + Pareto 분석 + 6 절감 휴리스틱.
+---
+
+# Efficiency Skill — Claude Code 세션 토큰/비용 분석
+
+> **출처 (attribution)**: `jha0313/skills_repo` 의 `improve-token-efficiency` skill (DCN-CHG-20260430-08 흡수). 4 script 보존, dcness 패턴 (helper protocol + skill prompt) 으로 wrap.
+
+## 언제 사용
+
+- "토큰 효율 분석", "세션 효율", "비용 분석"
+- "Claude Code usage report", "show session cost"
+- "효율 리포트", "캐시 히트율", "내 Claude 얼마 썼나"
+- 레포 단위 (현 cwd 또는 명시 path) Claude Code 사용 패턴 / 비용 / 점수 알고 싶을 때
+- 단발 세션 X — *여러 세션 집계 + 점수화 + 시각화* 가 필요한 모든 경우
+
+## 언제 사용하지 않음
+
+- 코드 작성 / 버그픽스 / 기획 → `/quick` `/product-plan` `/impl` 등 다른 skill
+- 단일 prose 결론 추출 (단발) → `harness.signal_io.interpret_signal` 직접 호출 (skill 불필요)
+- AI-readiness 평가 (코드베이스 자체) → 본 skill 비대상 (별도 ai-readiness 도구 후보)
+
+## 시퀀스
+
+본 skill 은 **read-only 분석 도구** — agent 호출 X, prose 종이 X, catastrophic 룰 비대상. 단순 helper wrapper 호출 chain.
+
+```
+analyze_sessions (Python) → JSON 리포트
+  → build_dashboard (Python) → HTML 대시보드
+  → 사용자 보고 (Korean, 2~3줄 요약 + 상위 절감안 3가지)
+```
+
+## 절차
+
+### Step 0 — run 시작 (선택)
+
+본 skill 은 분석 도구라 *run 등록 의무 없음*. 단 `.steps.jsonl` 추적 원하면:
+
+```bash
+HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
+RUN_ID=$("$HELPER" begin-run efficiency)
+echo "[efficiency] run started: $RUN_ID"
+```
+
+skip 해도 무방.
+
+### Step 1 — 분석 + 대시보드 (단일 명령)
+
+```bash
+DCEFF="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-efficiency"
+"$DCEFF" full --repo "$(pwd)" --out-dir /tmp/dcness-efficiency
+```
+
+`full` subcommand = `analyze` → `dashboard` 자동 chain.
+
+출력:
+- `/tmp/dcness-efficiency/session_analysis.json` — raw 데이터 (다른 도구가 소비 가능)
+- `/tmp/dcness-efficiency/efficiency_report.html` — 단일 HTML 대시보드 (Chart.js CDN)
+
+### Step 2 — 사용자 보고 (Korean, 2~3줄)
+
+JSON 의 `totals` + `top_sessions` + 개선안 list 에서 핵심 추출:
+
+```
+[efficiency] <session count> 세션 / $<total cost> / 평균 등급 <grade>
+- 캐시 히트율: <ratio>%
+- 상위 N 세션이 전체 비용의 <%> 차지
+- 가장 큰 절감 후보 (3개):
+  1. <개선안 1> — 예상 절감 $<amount>
+  2. <개선안 2> — ...
+  3. <개선안 3> — ...
+
+대시보드: open /tmp/dcness-efficiency/efficiency_report.html
+JSON: /tmp/dcness-efficiency/session_analysis.json
+```
+
+### Step 3 — run 종료 (Step 0 했으면)
+
+```bash
+"$HELPER" end-run
+```
+
+## 추가 명령 (advanced)
+
+본 skill 의 wrapper (`scripts/dcness-efficiency`) 5 subcommand:
+
+| subcommand | 역할 |
+|---|---|
+| `analyze` | JSON 리포트만 (dashboard X) |
+| `dashboard` | analyze JSON → HTML 대시보드 |
+| `patterns` | 패턴 분석 (`detect_patterns.py`) — 토큰 thrash / 반복 read 등 |
+| `patterns-dashboard` | patterns JSON → HTML |
+| `full` | analyze + dashboard chain (가장 흔한 사용) |
+
+특정 user 가 이미 JSON 만 원하면 `analyze`, 패턴 탐지 (반복 read 등) 추가 원하면 `patterns` chain.
+
+## 점수화 rubric (4 지표 가중)
+
+`scripts/analyze_sessions.py` 가 각 세션을 0–100 점화:
+
+| 지표 | 가중치 | 측정 |
+|---|---|---|
+| **Cache utilization** | 40% | `cache_read / total_input`. 0.85 이상 만점. |
+| **Output density** | 20% | `output / total_input`. ~2% sweet spot. |
+| **Read redundancy** | 20% | `redundant_reads / total_reads`. 같은 파일 반복 read = 감점. |
+| **Tool economy** | 20% | 출력 1k 토큰당 툴 호출 수. 2–10 건강. |
+
+등급: A+ ≥90, A ≥85, ..., D ≥40, F <40.
+
+## 가격 기준 (per 1M tokens, USD)
+
+`harness/efficiency/analyze_sessions.py` 의 `PRICING` dict:
+
+| Model | Input | Output | Cache 5m | Cache 1h | Cache read |
+|---|---|---|---|---|---|
+| Opus 4.x | 15.0 | 75.0 | 18.75 | 30.0 | 1.50 |
+| Sonnet 4.x | 3.0 | 15.0 | 3.75 | 6.0 | 0.30 |
+| Haiku 4.x | 0.80 | 4.0 | 1.0 | 1.6 | 0.08 |
+
+prefix 매칭 — `claude-haiku-4-5-20251001`, `claude-opus-4-7[1m]` 같은 variant suffix 자동 흡수. 새 모델은 PRICING dict 한 줄 추가.
+
+## 6 절감 휴리스틱 (`build_dashboard.py`)
+
+1. **Opus → Sonnet 라우팅** — 30% Sonnet 이관 가정. 5배 비용비.
+2. **장시간 세션 `/compact`** — 상위 14 세션 cache_read 30% 감소 가정.
+3. **이미지 세션 관리** — 이미지 포함 세션 컴팩션 50% 절감.
+4. **Cache TTL 1h → 5m** — 1h 캐시의 40% 가 5m 충분 가정.
+5. **세션 scope 축소** — 상위 외 세션 cache_read 15% 감소.
+6. **중복 Read 제거** — `redundant_reads × 3000토큰 × (cache write + 10 re-read)` 비용 차단.
+
+추정치 — 사용자 "실제 절감?" 물으면 "휴리스틱, 실행 후 재측정" 답.
+
+## 한계 / 후속
+
+- **세션 디렉터리 부재**: 레포가 Claude Code 로 한 번도 열린 적 없으면 "분석할 세션 없음" 안내 + 종료.
+- **모든 세션 빈 usage**: 오래된 CLI 버전. 자동 제외 후 남은 게 없으면 종료.
+- **가격 미등록 모델**: prefix 매칭 + Opus default fallback. `PRICING` 갱신 권장.
+- **dcness telemetry 와 분리**: `.metrics/heuristic-calls.jsonl` (heuristic enum 추출 telemetry, DCN-CHG-20260430-04) ≠ 본 skill 의 CC 세션 비용 분석. 두 영역 별도.
+
+## 참조
+
+- `harness/efficiency/analyze_sessions.py` — 세션 JSONL 파싱 + 점수화
+- `harness/efficiency/build_dashboard.py` — Chart.js HTML 대시보드
+- `harness/efficiency/detect_patterns.py` — 토큰 thrash 패턴 탐지
+- `harness/efficiency/build_patterns_dashboard.py` — 패턴 HTML
+- `scripts/dcness-efficiency` — wrapper (analyze / dashboard / patterns / full)
+- `jha0313/skills_repo/improve-token-efficiency` — 출처 skill (DCN-CHG-20260430-08 흡수)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,33 @@
 
 ## Records
 
+### DCN-CHG-20260430-08
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 요청 — `https://github.com/jha0313/skills_repo` 검토 + 흡수 가치 평가.
+  - 3 skills 평가:
+    1. `improve-token-efficiency` ⭐⭐⭐ — proposal §5 Phase 4 fitness (도그푸딩 비용 측정) 와 자연 정합. dcness 의 `.metrics/heuristic-calls.jsonl` (heuristic enum 추출 telemetry) 와 별개로 *CC 세션 단위 비용 분석* 보강. 가치 ↑.
+    2. `ai-readiness-cartography` ⭐⭐ — governance 자가 점검 도구. 단 score.py 룰이 dcness 자체 룰 (branch-surface-tracking / Document Sync) 과 일부 중첩 + dcness 정체성 (RWHarness fork) 과 layer 다름. 외부 plugin 추천이 적합.
+    3. `presentation_slides` ⭐ — YouTube 발표용 HTML. dcness 무관.
+  - `improve-token-efficiency` 1개만 흡수. as-is fork + dcness 패턴 wrapper.
+- **Alternatives**:
+  1. *모두 무시* — 기존 dcness 8 skill 로 충분. 단 비용 측정은 proposal §5 핵심 fitness 항목, 누락이 흠. 기각.
+  2. *전체 3 skill 흡수* — presentation_slides 가 정체성 무관, ai-readiness 도 정합 검토 비용 ↑. 기각.
+  3. **(채택) 1개 (improve-token-efficiency) 만 흡수**. 4 script as-is fork (검증된 stdlib only) + dcness 패턴 (wrapper script + skill prompt + helper 진입 옵션). 출처 attribution 명시.
+- **Decision**:
+  - 옵션 3.
+  - **as-is fork (rewrite X)**: 4 script (analyze_sessions / build_dashboard / detect_patterns / build_patterns_dashboard) 그대로 `harness/efficiency/` 패키지에 복사. 출처 = `harness/efficiency/__init__.py` docstring + `commands/efficiency.md` 첫 줄 명시.
+  - **dcness fix 2건**:
+    1. `encode_repo_path` 의 `.` → `-` 추가 — CC 실 인코딩 룰 (예: `/Users/dc.kim/project/dcNess` → `-Users-dc-kim-project-dcNess`) 정합. 원본은 `/` 만 변환 → 사용자 `dc.kim` 같은 dotted username 환경에서 `[error] sessions dir not found` 발생. 사용자 환경 검증으로 발견.
+    2. `price_for` prefix 매칭 — `claude-haiku-4-5-20251001` (dated suffix), `claude-opus-4-7[1m]` (variant tag) 같은 신모델 ID 자동 흡수. 원본은 exact 매칭 후 Opus default fallback → haiku 사용량이 Opus 가격으로 과추정.
+  - **read-only 분석 도구라 catastrophic 룰 비대상**: agent 호출 X, prose 종이 X, PreToolUse 훅 §2.3 검사 비대상. helper protocol (begin-run / end-run) 은 *선택* (.steps.jsonl 추적 원할 때).
+  - **wrapper subcommand 5개**: analyze / dashboard / patterns / patterns-dashboard / full. `full` = analyze → dashboard chain 편의.
+- **Follow-Up**:
+  - **(별도 Task — 측정)** 30일 dcness 도그푸딩 후 `/efficiency` 자가 사용 빈도. 최소 5회/주 사용 안 되면 skill prompt description 정정.
+  - **(별도 Task — 가격 갱신)** Anthropic 신모델 출시 시 `PRICING` dict 한 줄 추가.
+  - **(별도 Task — 후속 흡수 검토)** 30일 후 `ai-readiness-cartography` 재평가 — dcness governance 와 정합 가능한지 정량 검토.
+  - **(별도 Task — upstream 기여)** dcness fix 2건 (encode_repo_path + price_for) 을 jha0313 upstream 에 PR 제안 (선택).
+
 ### DCN-CHG-20260430-07
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,24 @@
 
 ## Records
 
+### DCN-CHG-20260430-08
+- **Date**: 2026-04-30
+- **Change-Type**: harness, spec, docs-only, test
+- **Files Changed**:
+  - `harness/efficiency/__init__.py` (신규) — 패키지 docstring + attribution.
+  - `harness/efficiency/analyze_sessions.py` (신규, fork) — CC 세션 JSONL 파싱 + 4 지표 점수화. dcness fix: encode_repo_path 가 `/` + `.` 둘 다 → `-` 변환 (CC 실 인코딩 룰 정합), price_for prefix 매칭 (dated suffix `claude-haiku-4-5-20251001` / variant tag `[1m]` 흡수).
+  - `harness/efficiency/build_dashboard.py` (신규, fork) — Chart.js 단일 HTML 대시보드.
+  - `harness/efficiency/detect_patterns.py` (신규, fork) — 토큰 thrash 패턴 탐지.
+  - `harness/efficiency/build_patterns_dashboard.py` (신규, fork) — 패턴 HTML.
+  - `scripts/dcness-efficiency` (신규, 0755) — wrapper (analyze / dashboard / patterns / patterns-dashboard / full subcommand).
+  - `commands/efficiency.md` (신규) — `/efficiency` skill prompt (출처 attribution + dcness 패턴 정합 + 4 지표 rubric + 6 절감 휴리스틱).
+  - `tests/test_efficiency.py` (신규, 10 케이스) — encode_repo_path / price_for prefix 매칭 / wrapper smoke / fixture session 통합.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: `jha0313/skills_repo` 의 `improve-token-efficiency` skill 흡수. Claude Code 세션 JSONL 토큰/캐시/비용 분석 + HTML 대시보드. dcness fix 2건 (CC 인코딩 룰 정합, prefix 매칭). dcness skill 8 개 됨. read-only 분석 도구라 catastrophic 룰 비대상. 181/181 PASS.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-07
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only

--- a/harness/efficiency/__init__.py
+++ b/harness/efficiency/__init__.py
@@ -1,0 +1,17 @@
+"""harness.efficiency — Claude Code 세션 JSONL 토큰 효율 분석 + 대시보드 생성.
+
+출처 (attribution):
+    jha0313/skills_repo `improve-token-efficiency` (MIT 가정 — public repo,
+    license 파일 부재). 2026-04-30 dcness 가 fork 흡수 (DCN-CHG-20260430-08).
+
+dcness 통합:
+    - 4 script (analyze_sessions / build_dashboard / detect_patterns /
+      build_patterns_dashboard) 본 패키지에 보존.
+    - skill prompt = `commands/efficiency.md`.
+    - wrapper script = `scripts/dcness-efficiency` (PYTHONPATH 자동 + analyze →
+      build_dashboard chain).
+    - skill 진입 = dcness conveyor 패턴 (begin-run / end-run, finalize-run 미사용
+      — read-only 분석 도구라 catastrophic 룰 비대상).
+
+가격 update 시 `analyze_sessions.PRICING` dict 수정.
+"""

--- a/harness/efficiency/analyze_sessions.py
+++ b/harness/efficiency/analyze_sessions.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Analyze Claude Code session JSONL files for token/context efficiency.
+
+Usage:
+  python3 analyze_sessions.py --repo /path/to/repo [--out /tmp/session_analysis.json]
+  python3 analyze_sessions.py --sessions-dir ~/.claude/projects/-Users-x-Projects-Foo
+
+The script finds the encoded session directory under ~/.claude/projects/,
+parses every .jsonl file, extracts per-session token usage from each
+assistant message's `usage` field, applies per-model pricing, and
+computes a 4-axis efficiency score.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+from collections import defaultdict
+
+# Anthropic pricing (USD per 1M tokens). Keys match the exact model string the
+# CLI records in `message.model`. Add new rows when new models ship.
+PRICING = {
+    "claude-opus-4-6":   {"in": 15.00, "out": 75.00, "cw5": 18.75, "cw1h": 30.00, "cr": 1.50},
+    "claude-opus-4-7":   {"in": 15.00, "out": 75.00, "cw5": 18.75, "cw1h": 30.00, "cr": 1.50},
+    "claude-sonnet-4-6": {"in":  3.00, "out": 15.00, "cw5":  3.75, "cw1h":  6.00, "cr": 0.30},
+    "claude-sonnet-4-5": {"in":  3.00, "out": 15.00, "cw5":  3.75, "cw1h":  6.00, "cr": 0.30},
+    "claude-haiku-4-5":  {"in":  0.80, "out":  4.00, "cw5":  1.00, "cw1h":  1.60, "cr": 0.08},
+    "<synthetic>":       {"in":  0.00, "out":  0.00, "cw5":  0.00, "cw1h":  0.00, "cr": 0.00},
+}
+# Opus default for unknown models (conservative = higher estimate, so the
+# report doesn't silently under-report cost).
+DEFAULT_PRICE = PRICING["claude-opus-4-6"]
+
+
+def encode_repo_path(repo_path):
+    """Turn /Users/x/Projects/Foo into -Users-x-Projects-Foo."""
+    abs_path = os.path.abspath(os.path.expanduser(repo_path))
+    # CC 인코딩 룰: `/` 와 `.` 모두 `-` 로 변환 (dotted username 처리).
+    return abs_path.replace("/", "-").replace(".", "-")
+
+
+def resolve_sessions_dir(args):
+    if args.sessions_dir:
+        return os.path.expanduser(args.sessions_dir)
+    repo = args.repo or os.getcwd()
+    encoded = encode_repo_path(repo)
+    return os.path.expanduser(f"~/.claude/projects/{encoded}")
+
+
+def price_for(model):
+    if model in PRICING:
+        return PRICING[model]
+    # Prefix 매칭 — `claude-haiku-4-5-20251001` 같은 dated suffix 흡수.
+    # Opus 4.7 의 `[1m]` 같은 variant 도 처리.
+    if model:
+        # `[1m]` 같은 variant tag 떼기
+        base = model.split("[")[0]
+        for known in PRICING:
+            if base == known or base.startswith(known + "-"):
+                return PRICING[known]
+    if model and model not in price_for._warned:
+        print(f"[warn] unknown model: {model}, applying Opus default pricing", file=sys.stderr)
+        price_for._warned.add(model)
+    return DEFAULT_PRICE
+price_for._warned = set()
+
+
+def analyze_session(path):
+    stats = {
+        "session_id": os.path.basename(path).replace(".jsonl", ""),
+        "file_size": os.path.getsize(path),
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_create_5m": 0,
+        "cache_create_1h": 0,
+        "cache_read": 0,
+        "num_assistant_msgs": 0,
+        "num_user_msgs": 0,
+        "num_tool_calls": 0,
+        "tool_use_counter": defaultdict(int),
+        "file_read_counter": defaultdict(int),
+        "first_ts": None,
+        "last_ts": None,
+        "models": set(),
+        "cost_usd": 0.0,
+        "image_count": 0,
+        "compact_count": 0,
+    }
+
+    try:
+        with open(path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except Exception:
+                    continue
+
+                ts = rec.get("timestamp")
+                if ts:
+                    if stats["first_ts"] is None:
+                        stats["first_ts"] = ts
+                    stats["last_ts"] = ts
+
+                rtype = rec.get("type")
+
+                if rtype == "user":
+                    stats["num_user_msgs"] += 1
+                    msg = rec.get("message", {})
+                    content = msg.get("content", [])
+                    if isinstance(content, list):
+                        for c in content:
+                            if isinstance(c, dict) and c.get("type") == "image":
+                                stats["image_count"] += 1
+
+                elif rtype == "assistant":
+                    stats["num_assistant_msgs"] += 1
+                    msg = rec.get("message", {})
+                    model = msg.get("model", "") or ""
+                    if model:
+                        stats["models"].add(model)
+                    usage = msg.get("usage", {})
+                    price = price_for(model)
+
+                    inp = usage.get("input_tokens", 0)
+                    out = usage.get("output_tokens", 0)
+                    cw = usage.get("cache_creation_input_tokens", 0)
+                    cr = usage.get("cache_read_input_tokens", 0)
+
+                    cw_detail = usage.get("cache_creation", {}) or {}
+                    cw5 = cw_detail.get("ephemeral_5m_input_tokens", 0)
+                    cw1h = cw_detail.get("ephemeral_1h_input_tokens", 0)
+                    if cw5 + cw1h == 0 and cw > 0:
+                        # Older CLI: no breakdown. Assume 5m (cheaper default).
+                        cw5 = cw
+
+                    stats["input_tokens"] += inp
+                    stats["output_tokens"] += out
+                    stats["cache_create_5m"] += cw5
+                    stats["cache_create_1h"] += cw1h
+                    stats["cache_read"] += cr
+
+                    stats["cost_usd"] += (
+                        inp * price["in"] / 1e6
+                        + out * price["out"] / 1e6
+                        + cw5 * price["cw5"] / 1e6
+                        + cw1h * price["cw1h"] / 1e6
+                        + cr * price["cr"] / 1e6
+                    )
+
+                    content = msg.get("content", [])
+                    if isinstance(content, list):
+                        for c in content:
+                            if isinstance(c, dict) and c.get("type") == "tool_use":
+                                stats["num_tool_calls"] += 1
+                                tname = c.get("name", "unknown")
+                                stats["tool_use_counter"][tname] += 1
+                                if tname == "Read":
+                                    fp = c.get("input", {}).get("file_path", "")
+                                    if fp:
+                                        stats["file_read_counter"][fp] += 1
+
+                elif rtype == "compact-summary":
+                    stats["compact_count"] += 1
+    except Exception as e:
+        stats["error"] = str(e)
+
+    total_input_any = (
+        stats["input_tokens"]
+        + stats["cache_create_5m"]
+        + stats["cache_create_1h"]
+        + stats["cache_read"]
+    )
+    stats["total_input_tokens"] = total_input_any
+    stats["cache_hit_ratio"] = (stats["cache_read"] / total_input_any) if total_input_any else 0.0
+    stats["uncached_ratio"] = (stats["input_tokens"] / total_input_any) if total_input_any else 0.0
+    stats["output_ratio"] = (stats["output_tokens"] / total_input_any) if total_input_any else 0.0
+
+    stats["redundant_reads"] = sum((c - 1) for c in stats["file_read_counter"].values() if c > 1)
+    stats["unique_files_read"] = len(stats["file_read_counter"])
+    stats["total_file_reads"] = sum(stats["file_read_counter"].values())
+    stats["had_image"] = stats["image_count"] > 0
+
+    stats["models"] = sorted(list(stats["models"]))
+    stats["tool_use_counter"] = dict(stats["tool_use_counter"])
+    stats.pop("file_read_counter", None)
+    return stats
+
+
+def score_session(s):
+    """4-axis 0–100 scoring. Weighted: cache 40 / density 20 / redundancy 20 / tool 20."""
+    tot = s["total_input_tokens"] or 1
+
+    # Cache utilization: cache_read / total_input, 85% = full marks.
+    cache_score = min(100, s["cache_hit_ratio"] / 0.85 * 100)
+
+    # Output density: sweet spot ~2%. Penalize too low (churn) and too high (monologue).
+    od = s["output_ratio"]
+    if od < 0.005:
+        density_score = od / 0.005 * 60
+    elif od < 0.02:
+        density_score = 60 + (od - 0.005) / 0.015 * 40
+    elif od < 0.05:
+        density_score = 100 - (od - 0.02) / 0.03 * 20
+    else:
+        density_score = max(40, 80 - (od - 0.05) * 200)
+
+    # Read redundancy: penalize per redundant read as share of total reads.
+    total_reads = s["total_file_reads"] or 1
+    redundancy_ratio = s["redundant_reads"] / total_reads
+    redundancy_score = max(0, 100 - redundancy_ratio * 200)
+
+    # Tool economy: healthy 2–10 tool calls per 1k output tokens. >20 = thrash.
+    out_k = max(1, s["output_tokens"] / 1000)
+    tpk = s["num_tool_calls"] / out_k
+    if tpk < 2:
+        tool_score = 70 + tpk * 15
+    elif tpk < 10:
+        tool_score = 100 - (tpk - 2) * 2
+    elif tpk < 20:
+        tool_score = 84 - (tpk - 10) * 4
+    else:
+        tool_score = max(0, 44 - (tpk - 20) * 2)
+
+    composite = (
+        cache_score * 0.40
+        + density_score * 0.20
+        + redundancy_score * 0.20
+        + tool_score * 0.20
+    )
+
+    return {
+        "cache_score": round(cache_score, 1),
+        "density_score": round(density_score, 1),
+        "redundancy_score": round(redundancy_score, 1),
+        "tool_score": round(tool_score, 1),
+        "composite": round(composite, 1),
+        "grade": grade_of(composite),
+    }
+
+
+def grade_of(score):
+    for threshold, grade in [
+        (90, "A+"), (85, "A"), (80, "A-"), (75, "B+"), (70, "B"),
+        (65, "B-"), (60, "C+"), (55, "C"), (50, "C-"), (40, "D"),
+    ]:
+        if score >= threshold:
+            return grade
+    return "F"
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", help="Repository path (default: cwd)")
+    ap.add_argument("--sessions-dir", help="Direct path to ~/.claude/projects/<encoded>/")
+    ap.add_argument("--out", default="/tmp/session_analysis.json", help="Output JSON path")
+    args = ap.parse_args()
+
+    sessions_dir = resolve_sessions_dir(args)
+
+    if not os.path.isdir(sessions_dir):
+        print(f"[error] sessions dir not found: {sessions_dir}", file=sys.stderr)
+        print("        This repo may have never been opened with Claude Code.", file=sys.stderr)
+        sys.exit(2)
+
+    files = sorted(glob.glob(os.path.join(sessions_dir, "*.jsonl")))
+    if not files:
+        print(f"[error] no .jsonl files in {sessions_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"[info] sessions dir: {sessions_dir}")
+    print(f"[info] found {len(files)} session files")
+
+    results = []
+    for fp in files:
+        s = analyze_session(fp)
+        if s["total_input_tokens"] == 0 and s["output_tokens"] == 0:
+            continue
+        s["scores"] = score_session(s)
+        results.append(s)
+
+    if not results:
+        print("[error] all sessions have empty usage (old CLI?), nothing to report", file=sys.stderr)
+        sys.exit(2)
+
+    totals = {
+        "sessions_dir": sessions_dir,
+        "sessions": len(results),
+        "input_tokens": sum(r["input_tokens"] for r in results),
+        "output_tokens": sum(r["output_tokens"] for r in results),
+        "cache_create_5m": sum(r["cache_create_5m"] for r in results),
+        "cache_create_1h": sum(r["cache_create_1h"] for r in results),
+        "cache_read": sum(r["cache_read"] for r in results),
+        "cost_usd": sum(r["cost_usd"] for r in results),
+        "total_input_tokens": sum(r["total_input_tokens"] for r in results),
+        "num_tool_calls": sum(r["num_tool_calls"] for r in results),
+        "redundant_reads": sum(r["redundant_reads"] for r in results),
+        "image_count": sum(r["image_count"] for r in results),
+        "compact_count": sum(r["compact_count"] for r in results),
+    }
+    totals["cache_hit_ratio"] = (
+        totals["cache_read"] / totals["total_input_tokens"] if totals["total_input_tokens"] else 0
+    )
+
+    results.sort(key=lambda r: r["cost_usd"], reverse=True)
+
+    with open(args.out, "w") as f:
+        json.dump({"totals": totals, "sessions": results}, f, default=str, indent=2)
+
+    print(f"[ok] wrote {args.out}")
+    print(f"     {len(results)} sessions, ${totals['cost_usd']:.2f}, cache hit {totals['cache_hit_ratio']*100:.1f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/efficiency/build_dashboard.py
+++ b/harness/efficiency/build_dashboard.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Build an HTML efficiency dashboard from analyze_sessions.py output.
+
+Usage:
+  python3 build_dashboard.py --input /tmp/session_analysis.json --out /tmp/efficiency_report.html
+"""
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+
+# Must mirror analyze_sessions.py. Only used here for dollar-value estimates in
+# the improvement cards (not for primary cost calculation, which already lives
+# in the per-session `cost_usd`).
+OPUS_IN = 15.0
+OPUS_OUT = 75.0
+OPUS_W5 = 18.75
+OPUS_W1H = 30.0
+OPUS_READ = 1.50
+SONNET_RATIO = 5.0  # Opus / Sonnet blended multiplier
+
+
+def compute_savings(totals, sessions):
+    """Return a dict of {label: dollar_amount} for improvement suggestions.
+
+    Every heuristic below is conservative and documented. Sum may exceed
+    actual achievable savings because items partially overlap (e.g. compaction
+    and image management both reduce cache_read).
+    """
+    # 1. Opus → Sonnet: assume 30% of total spend could run on Sonnet
+    save_model = totals["cost_usd"] * 0.30 * (1 - 1 / SONNET_RATIO)
+
+    # 2. /compact on top-14 sessions: cut cache_read by 30%
+    top14 = sessions[:14]
+    top14_cache_read = sum(s["cache_read"] for s in top14)
+    save_compact = top14_cache_read * 0.3 * OPUS_READ / 1e6
+
+    # 3. Image sessions: each image adds ~40k tokens to cache. Reclaiming 50%.
+    img_sessions = [s for s in sessions if s["had_image"]]
+    img_count = sum(s["image_count"] for s in img_sessions)
+    save_images = img_count * 40000 * 0.5 * OPUS_READ / 1e6
+
+    # 4. Cache TTL 1h → 5m for 40% of writes
+    save_ttl = totals["cache_create_1h"] * 0.4 * (OPUS_W1H - OPUS_W5) / 1e6
+
+    # 5. Session scope reduction: 15% cache_read cut on non-top14 sessions
+    other_cache_read = totals["cache_read"] - top14_cache_read
+    save_scope = other_cache_read * 0.15 * OPUS_READ / 1e6
+
+    # 6. Redundant reads: each redundant read ≈ 3k tokens × (write + 10 reads later)
+    save_redundant = totals["redundant_reads"] * 3000 * (OPUS_W1H + OPUS_READ * 10) / 1e6
+
+    return {
+        "model_routing": save_model,
+        "compact": save_compact,
+        "images": save_images,
+        "ttl": save_ttl,
+        "scope": save_scope,
+        "redundant": save_redundant,
+    }
+
+
+def build_html(data, repo_name):
+    totals = data["totals"]
+    sessions = data["sessions"]
+    n = len(sessions)
+
+    # cost category breakdown
+    cost_cache_write = (
+        totals["cache_create_1h"] * OPUS_W1H / 1e6
+        + totals["cache_create_5m"] * OPUS_W5 / 1e6
+    )
+    cost_cache_read = totals["cache_read"] * OPUS_READ / 1e6
+    cost_output = totals["output_tokens"] * OPUS_OUT / 1e6
+    cost_input = totals["input_tokens"] * OPUS_IN / 1e6
+
+    savings = compute_savings(totals, sessions)
+    total_savings = sum(savings.values())
+    save_pct = total_savings / totals["cost_usd"] * 100 if totals["cost_usd"] else 0
+
+    # score component averages
+    score_comp_avg = {
+        "cache": sum(s["scores"]["cache_score"] for s in sessions) / n,
+        "density": sum(s["scores"]["density_score"] for s in sessions) / n,
+        "redundancy": sum(s["scores"]["redundancy_score"] for s in sessions) / n,
+        "tool": sum(s["scores"]["tool_score"] for s in sessions) / n,
+    }
+
+    # grade distribution
+    grade_order = ["A+", "A", "A-", "B+", "B", "B-", "C+", "C", "C-", "D", "F"]
+    grades = Counter(s["scores"]["grade"] for s in sessions)
+    grade_counts = [grades.get(g, 0) for g in grade_order]
+
+    # scatter data
+    scatter_data = [
+        {
+            "x": round(s["cost_usd"], 2),
+            "y": s["scores"]["composite"],
+            "r": min(20, 3 + s["num_tool_calls"] / 20),
+        }
+        for s in sessions
+    ]
+
+    # pareto
+    sorted_by_cost = sessions  # already sorted desc by cost
+    cum, running = [], 0
+    for s in sorted_by_cost:
+        running += s["cost_usd"]
+        cum.append(round(running / totals["cost_usd"] * 100, 1) if totals["cost_usd"] else 0)
+
+    # top 20 rows
+    def short(sid): return sid[:8]
+    top_rows = "\n".join(
+        f"""<tr>
+            <td class="mono">{short(s['session_id'])}</td>
+            <td class="num">${s['cost_usd']:.2f}</td>
+            <td class="num">{s['num_tool_calls']}</td>
+            <td class="num">{s['total_input_tokens']/1e6:.1f}M</td>
+            <td class="num">{s['output_tokens']/1e3:.1f}k</td>
+            <td class="num">{s['cache_hit_ratio']*100:.1f}%</td>
+            <td class="num">{s['redundant_reads']}</td>
+            <td class="num">{s['scores']['composite']}</td>
+            <td><span class="grade g-{s['scores']['grade'][0].lower()}">{s['scores']['grade']}</span></td>
+        </tr>"""
+        for s in sessions[:20]
+    )
+
+    avg_composite = sum(s["scores"]["composite"] for s in sessions) / n
+
+    html = f"""<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>{repo_name} — Claude Code 세션 효율 리포트</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  :root {{
+    --bg: #0b0f17; --panel: #131924; --panel-2: #1a2230;
+    --border: #232d3d; --text: #e6edf3; --muted: #8b98a9;
+    --accent: #7ad1ff; --good: #4ade80; --warn: #fbbf24; --bad: #ef4444;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ font-family: -apple-system, BlinkMacSystemFont, 'Inter', 'SF Pro', Segoe UI, sans-serif;
+         background: var(--bg); color: var(--text); margin: 0; padding: 32px; line-height: 1.5; }}
+  h1 {{ font-size: 28px; margin: 0 0 6px; }}
+  h2 {{ font-size: 20px; margin: 40px 0 16px; color: var(--accent); letter-spacing: -0.01em; }}
+  h3 {{ font-size: 15px; margin: 0 0 12px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }}
+  .sub {{ color: var(--muted); font-size: 14px; margin-bottom: 32px; }}
+  .grid {{ display: grid; gap: 16px; }}
+  .kpis {{ grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }}
+  .kpi {{ background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }}
+  .kpi .v {{ font-size: 28px; font-weight: 700; letter-spacing: -0.02em; }}
+  .kpi .l {{ color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }}
+  .kpi .s {{ color: var(--muted); font-size: 12px; margin-top: 4px; }}
+  .card {{ background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }}
+  .row2 {{ grid-template-columns: 1fr 1fr; }}
+  canvas {{ max-height: 320px; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
+  th, td {{ padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }}
+  th {{ color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 11px; letter-spacing: 0.06em; }}
+  .num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  .mono {{ font-family: 'SF Mono', Menlo, monospace; font-size: 12px; color: var(--muted); }}
+  .grade {{ padding: 2px 8px; border-radius: 4px; font-weight: 700; font-size: 12px; }}
+  .grade.g-a {{ background: #14532d; color: #86efac; }}
+  .grade.g-b {{ background: #1e3a5f; color: #93c5fd; }}
+  .grade.g-c {{ background: #633a19; color: #fbbf24; }}
+  .grade.g-d, .grade.g-f {{ background: #4b1515; color: #fca5a5; }}
+  .rubric td:first-child {{ font-weight: 600; }}
+  .rubric .bar {{ height: 8px; background: var(--panel-2); border-radius: 4px; overflow: hidden; margin-top: 6px; }}
+  .rubric .bar > div {{ height: 100%; background: linear-gradient(90deg, #4ade80, #60a5fa); }}
+  .imp {{ border-left: 3px solid var(--accent); padding: 12px 18px; background: var(--panel-2); border-radius: 0 8px 8px 0; margin-bottom: 12px; }}
+  .imp .h {{ display: flex; justify-content: space-between; align-items: center; margin-bottom: 6px; }}
+  .imp .h .t {{ font-weight: 600; font-size: 15px; }}
+  .imp .h .s {{ color: var(--good); font-weight: 700; font-variant-numeric: tabular-nums; }}
+  .imp p {{ margin: 4px 0; color: var(--muted); font-size: 13px; }}
+  .footer {{ margin-top: 48px; color: var(--muted); font-size: 12px; text-align: center; }}
+  .good {{ color: var(--good); }} .warn {{ color: var(--warn); }} .bad {{ color: var(--bad); }}
+</style>
+</head>
+<body>
+  <h1>Claude Code 세션 효율 리포트</h1>
+  <div class="sub">{repo_name} · 활성 세션 {n}개 · 세션 디렉터리: <code>{totals.get('sessions_dir', '')}</code></div>
+
+  <div class="grid kpis">
+    <div class="kpi"><div class="l">누적 비용</div><div class="v">${totals['cost_usd']:.2f}</div><div class="s">세션당 평균 ${totals['cost_usd']/n:.2f}</div></div>
+    <div class="kpi"><div class="l">총 토큰 처리</div><div class="v">{totals['total_input_tokens']/1e6:.0f}M</div><div class="s">입력(캐시 포함) 기준</div></div>
+    <div class="kpi"><div class="l">캐시 적중률</div><div class="v good">{totals['cache_hit_ratio']*100:.1f}%</div><div class="s">cache_read ÷ 총 입력</div></div>
+    <div class="kpi"><div class="l">출력 토큰</div><div class="v">{totals['output_tokens']/1e6:.2f}M</div><div class="s">실제 assistant 산출</div></div>
+    <div class="kpi"><div class="l">도구 호출 수</div><div class="v">{totals['num_tool_calls']:,}</div><div class="s">세션당 평균 {totals['num_tool_calls']/n:.0f}회</div></div>
+    <div class="kpi"><div class="l">평균 종합 점수</div><div class="v">{avg_composite:.1f}</div><div class="s">100점 만점 (composite)</div></div>
+  </div>
+
+  <h2>비용 구조 분석</h2>
+  <div class="grid row2">
+    <div class="card"><h3>비용 내역 (카테고리별)</h3><canvas id="costPie"></canvas></div>
+    <div class="card"><h3>세션별 비용 (Pareto)</h3><canvas id="pareto"></canvas></div>
+  </div>
+
+  <h2>점수 분포</h2>
+  <div class="grid row2">
+    <div class="card"><h3>등급 히스토그램</h3><canvas id="gradeBar"></canvas></div>
+    <div class="card"><h3>비용 vs 점수 (버블 크기 = 도구 호출 수)</h3><canvas id="scatter"></canvas></div>
+  </div>
+
+  <h2>평가 기준 (Rubric)</h2>
+  <div class="card">
+    <table class="rubric">
+      <thead><tr><th style="width:240px;">평가 항목</th><th>측정 방식</th><th style="width:110px;">가중치</th><th style="width:160px;">레포 평균</th></tr></thead>
+      <tbody>
+        <tr>
+          <td>캐시 활용도</td>
+          <td>cache_read ÷ 총 입력. 0.85 이상이 만점. 재사용률이 높을수록 매 turn 마다 같은 토큰을 다시 보내는 비용이 줄어든다.
+            <div class="bar"><div style="width:{score_comp_avg['cache']}%;"></div></div>
+          </td>
+          <td class="num">40%</td>
+          <td class="num good">{score_comp_avg['cache']:.1f} / 100</td>
+        </tr>
+        <tr>
+          <td>산출 밀도</td>
+          <td>출력 ÷ 입력. ~2%가 적정 구간. 낮으면 읽기만 많고 산출이 부족, 높으면 긴 독백.
+            <div class="bar"><div style="width:{score_comp_avg['density']}%;"></div></div>
+          </td>
+          <td class="num">20%</td>
+          <td class="num warn">{score_comp_avg['density']:.1f} / 100</td>
+        </tr>
+        <tr>
+          <td>중복 Read 비율</td>
+          <td>같은 파일을 반복 Read 한 비중. Grep/Glob 으로 위치를 좁히지 않고 Read 를 남발하면 감점.
+            <div class="bar"><div style="width:{score_comp_avg['redundancy']}%;"></div></div>
+          </td>
+          <td class="num">20%</td>
+          <td class="num warn">{score_comp_avg['redundancy']:.1f} / 100</td>
+        </tr>
+        <tr>
+          <td>도구 사용 효율</td>
+          <td>출력 1k 토큰당 도구 호출 수. 2–10 이 건강한 범위, 20 초과는 탐색 thrash 신호.
+            <div class="bar"><div style="width:{score_comp_avg['tool']}%;"></div></div>
+          </td>
+          <td class="num">20%</td>
+          <td class="num good">{score_comp_avg['tool']:.1f} / 100</td>
+        </tr>
+      </tbody>
+    </table>
+    <div style="margin-top:16px; padding:12px; background:var(--panel-2); border-radius:6px; font-size:13px; color:var(--muted);">
+      종합 점수 = 0.4 · 캐시 + 0.2 · 산출밀도 + 0.2 · 중복read + 0.2 · 도구효율. 등급: A+ ≥ 90, A ≥ 85, A- ≥ 80, B+ ≥ 75, B ≥ 70, B- ≥ 65, C+ ≥ 60, C ≥ 55, C- ≥ 50, D ≥ 40, F &lt; 40.
+    </div>
+  </div>
+
+  <h2>비용 상위 세션 Top 20</h2>
+  <div class="card">
+    <table>
+      <thead><tr>
+        <th>세션</th><th class="num">비용</th><th class="num">도구</th>
+        <th class="num">총 입력</th><th class="num">출력</th>
+        <th class="num">캐시 적중</th><th class="num">중복 Read</th>
+        <th class="num">점수</th><th>등급</th>
+      </tr></thead>
+      <tbody>{top_rows}</tbody>
+    </table>
+  </div>
+
+  <h2>비용 절감 개선안 (예상 $ 기준)</h2>
+  <div class="card">
+    <div class="imp">
+      <div class="h"><div class="t">1. Opus → Sonnet 라우팅 (작업 난이도별)</div><div class="s">~${savings['model_routing']:.0f} (~{savings['model_routing']/totals['cost_usd']*100:.0f}%)</div></div>
+      <p>간단한 리팩터/리드/테스트 실행은 Sonnet으로 이관. <code>/fast</code> 토글 또는 <code>--model sonnet</code> 세션.</p>
+      <p><b>Why:</b> Opus 가격 = Sonnet × 5. 30%만 다운그레이드해도 큰 폭 절감.</p>
+    </div>
+    <div class="imp">
+      <div class="h"><div class="t">2. 장시간 세션 <code>/compact</code> 적극 사용</div><div class="s">~${savings['compact']:.0f}</div></div>
+      <p>상위 14개 세션이 비용의 대부분을 차지. 매 150-200 turn마다 /compact로 절반 이상 cache read 절감 가능.</p>
+      <p><b>Why:</b> 세션 길어질수록 매 turn 누적 컨텍스트를 re-read 과금. 컴팩션이 요약으로 교체.</p>
+    </div>
+    <div class="imp">
+      <div class="h"><div class="t">3. 이미지 첨부 세션 관리</div><div class="s">~${savings['images']:.0f}</div></div>
+      <p>이미지는 장당 ~20-60k 토큰. 확인 후에도 세션 내내 캐시 유지됨. 짧게 보고 즉시 /compact.</p>
+      <p><b>Why:</b> 이미지는 가장 비싼 페이로드. 불필요하게 오래 유지되면 cache_read 누적.</p>
+    </div>
+    <div class="imp">
+      <div class="h"><div class="t">4. Cache TTL 1h → 5m 전환</div><div class="s">~${savings['ttl']:.0f}</div></div>
+      <p>짧은 세션엔 1h 프리미엄($30/M) 불필요. 5m($18.75/M)로 충분. <code>ANTHROPIC_CACHE_TTL=5m</code> env 설정.</p>
+      <p><b>Why:</b> 1h 프리미엄은 30분+ 세션에서만 회수. 단기 세션엔 순수 낭비.</p>
+    </div>
+    <div class="imp">
+      <div class="h"><div class="t">5. 세션 scope 축소 & 재진입</div><div class="s">~${savings['scope']:.0f}</div></div>
+      <p>작업 단위별 세션 분리. <code>--continue</code> 대신 새 세션. CLAUDE.md/MEMORY.md가 컨텍스트 이관.</p>
+      <p><b>Why:</b> 한 세션 내 컨텍스트 누적 → 매 turn cache_read 선형 증가. 짧은 세션이 효율적.</p>
+    </div>
+    <div class="imp">
+      <div class="h"><div class="t">6. 중복 Read 제거</div><div class="s">~${savings['redundant']:.0f}</div></div>
+      <p>{totals['redundant_reads']}건의 redundant read 감지. Grep/Glob → Read 순서. 한 번 읽은 파일은 컨텍스트 내에서 참조.</p>
+      <p><b>Why:</b> 재Read는 cache write + 이후 매 turn cache read로 이중 과금.</p>
+    </div>
+    <div class="imp" style="border-left-color:var(--good); background:#0f2a1a;">
+      <div class="h"><div class="t">예상 누적 절감 (단순 합산)</div><div class="s">~${total_savings:.0f} / ${totals['cost_usd']:.0f} (~{save_pct:.0f}%)</div></div>
+      <p>항목 간 중복 고려 시 실제로는 <b>30–40%</b> 수준 기대. 세션당 평균 ${totals['cost_usd']/n:.2f} → ${(totals['cost_usd']-total_savings)/n:.2f}.</p>
+    </div>
+  </div>
+
+  <h2>즉시 실행 권장</h2>
+  <div class="card" style="font-size:14px; line-height:1.7;">
+    <ol style="margin:0; padding-left:20px;">
+      <li><b>settings.json에 <code>env: {{"ANTHROPIC_CACHE_TTL":"5m"}}</code></b> — 단기 세션 즉시 감소.</li>
+      <li><b>CLAUDE.md에 "200k 토큰 초과 시 /compact" 명시</b> — 상위 세션은 모두 이 규칙 위반.</li>
+      <li><b>Sonnet 기본, Opus는 Plan/복잡 리팩터에 제한</b>.</li>
+      <li><b>이미지 업로드 후 즉시 /compact</b>.</li>
+      <li><b>Grep/Glob 우선 탐색 규율</b>.</li>
+    </ol>
+  </div>
+
+  <div class="footer">
+    가격 기준: 1M 토큰당 (입력 / 출력 / 캐시쓰기 5m / 캐시쓰기 1h / 캐시읽기) · Opus 4.x ($15 / $75 / $18.75 / $30 / $1.50) · Sonnet 4.x ($3 / $15 / $3.75 / $6 / $0.30) · Haiku 4.x ($0.80 / $4 / $1 / $1.60 / $0.08).
+  </div>
+
+<script>
+Chart.defaults.color = '#e6edf3';
+Chart.defaults.borderColor = '#232d3d';
+const chartColors = ['#7ad1ff','#4ade80','#fbbf24','#f472b6','#a78bfa','#fb923c'];
+
+new Chart(document.getElementById('costPie'), {{
+  type: 'doughnut',
+  data: {{
+    labels: ['캐시 쓰기 (1h+5m)', '캐시 읽기', '출력', '입력 (캐시 미스)'],
+    datasets: [{{
+      data: [{cost_cache_write:.2f}, {cost_cache_read:.2f}, {cost_output:.2f}, {cost_input:.2f}],
+      backgroundColor: chartColors, borderWidth: 0,
+    }}]
+  }},
+  options: {{
+    plugins: {{
+      legend: {{ position: 'right' }},
+      tooltip: {{ callbacks: {{ label: (c) => c.label + ': $' + c.parsed.toFixed(2) + ' (' + (c.parsed/{totals['cost_usd'] or 1}*100).toFixed(1) + '%)' }} }}
+    }}
+  }}
+}});
+
+new Chart(document.getElementById('pareto'), {{
+  type: 'bar',
+  data: {{
+    labels: {list(range(1, n+1))},
+    datasets: [
+      {{ type: 'bar', label: '세션별 비용 ($)',
+         data: {[round(s['cost_usd'],2) for s in sorted_by_cost]},
+         backgroundColor: '#7ad1ff', yAxisID: 'y' }},
+      {{ type: 'line', label: '누적 %',
+         data: {cum}, borderColor: '#fbbf24', backgroundColor: 'transparent',
+         yAxisID: 'y1', tension: 0.2, pointRadius: 0 }}
+    ]
+  }},
+  options: {{
+    scales: {{
+      x: {{ ticks: {{ display: false }}, title: {{ display: true, text: '세션 (비용 내림차순)' }} }},
+      y: {{ title: {{ display: true, text: '세션당 USD' }} }},
+      y1: {{ position: 'right', min: 0, max: 100, title: {{ display: true, text: '누적 비용 %' }}, grid: {{ display: false }} }}
+    }}
+  }}
+}});
+
+new Chart(document.getElementById('gradeBar'), {{
+  type: 'bar',
+  data: {{
+    labels: {json.dumps(grade_order)},
+    datasets: [{{
+      data: {grade_counts},
+      backgroundColor: ['#4ade80','#4ade80','#86efac','#60a5fa','#60a5fa','#93c5fd','#fbbf24','#fbbf24','#fcd34d','#fca5a5','#ef4444'],
+    }}]
+  }},
+  options: {{
+    plugins: {{ legend: {{ display: false }} }},
+    scales: {{ y: {{ beginAtZero: true, title: {{ display: true, text: '세션 수' }} }} }}
+  }}
+}});
+
+new Chart(document.getElementById('scatter'), {{
+  type: 'bubble',
+  data: {{
+    datasets: [{{
+      label: '세션', data: {json.dumps(scatter_data)},
+      backgroundColor: 'rgba(122,209,255,0.5)', borderColor: '#7ad1ff',
+    }}]
+  }},
+  options: {{
+    plugins: {{ legend: {{ display: false }} }},
+    scales: {{
+      x: {{ type: 'logarithmic', title: {{ display: true, text: '비용 (USD, 로그 스케일)' }} }},
+      y: {{ min: 50, max: 100, title: {{ display: true, text: '종합 점수' }} }}
+    }}
+  }}
+}});
+</script>
+</body>
+</html>
+"""
+    return html
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", default="/tmp/session_analysis.json")
+    ap.add_argument("--out", default="/tmp/efficiency_report.html")
+    ap.add_argument("--repo-name", default=None, help="Label shown in report header")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"[error] input not found: {args.input}", file=sys.stderr)
+        print(f"        run analyze_sessions.py first", file=sys.stderr)
+        sys.exit(2)
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    if not data.get("sessions"):
+        print("[error] no sessions in analysis output", file=sys.stderr)
+        sys.exit(2)
+
+    repo_name = args.repo_name or os.path.basename(
+        data["totals"].get("sessions_dir", "").rstrip("/")
+    ) or "Claude Code sessions"
+
+    html = build_html(data, repo_name)
+    with open(args.out, "w") as f:
+        f.write(html)
+
+    print(f"[ok] wrote {args.out}")
+    print(f"     open it: open {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/efficiency/build_patterns_dashboard.py
+++ b/harness/efficiency/build_patterns_dashboard.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Render the 5-pattern detector output as an HTML dashboard.
+
+Usage:
+  python3 build_patterns_dashboard.py \
+    --input /tmp/pattern_analysis.json \
+    --out /tmp/patterns_report.html
+"""
+import argparse
+import json
+import os
+import sys
+
+PATTERN_KO_NAME = {
+    "context_bloat": "컨텍스트 부풀림",
+    "giant_tool_outputs": "거대 도구 출력",
+    "poor_cache_util": "캐시 활용 저조",
+    "duplicate_tools": "도구 중복 호출",
+    "subagent_overuse": "서브에이전트 과다",
+}
+
+PATTERN_META = {
+    "context_bloat": {
+        "title": "1. 컨텍스트 창이 무한정 부풀어 오름",
+        "rule": "컨텍스트 100k 토큰 초과가 연속 20+ turn 이어지고, 그 사이 50% 이상 감소(=compact)가 없음.",
+        "formula": "낭비 = Σ max(0, 컨텍스트 − 80k) × cache_read 단가 ($1.50/M).",
+        "fix_code": """# CLAUDE.md 에 명시
+누적 입력이 200k 를 넘으면 진행 전에 /compact 실행.
+주제가 바뀌면 새 세션 시작 — CLAUDE.md 와 MEMORY.md 가
+세션 간 컨텍스트를 유지해 주므로 손실 없음.""",
+        "fix_summary": "200k 도달 시 /compact, 주제 전환 시 새 세션.",
+    },
+    "giant_tool_outputs": {
+        "title": "2. 거대한 도구 출력이 컨텍스트를 부풀림",
+        "rule": "tool_result 가 50k chars(약 12.5k 토큰) 이상 — 이후 모든 turn 의 컨텍스트에 그대로 잔존.",
+        "formula": "낭비 = 결과_토큰 × 세션 남은 turn 수 × cache_read 단가.",
+        "fix_code": """# Bash: 시끄러운 출력 캐핑
+git log --oneline | head -50          # git log 통째로 X
+find . -name '*.ts' | wc -l           # 개수 먼저, 목록은 필요할 때만
+psql -c 'SELECT count(*) FROM x'      # SELECT * 지양
+
+# 큰 출력이 불가피했다면 즉시:
+/compact""",
+        "fix_summary": "읽기 전에 head/grep/wc/limit. 큰 출력 후 즉시 /compact.",
+    },
+    "poor_cache_util": {
+        "title": "3. 프롬프트 캐시 활용 저조",
+        "rule": "한 turn 의 cache 적중률 < 50% 이면서 컨텍스트 > 30k (= prompt prefix 가 흔들리는 중).",
+        "formula": "낭비 = cache_create × (쓰기 단가 − 읽기 단가) = × $28.50/M.",
+        "fix_code": """# prefix 무효화의 흔한 원인
+- 세션 도중 CLAUDE.md 수정 → 그 아래 전부 무효화
+- system reminder 추가/변경 → cache miss
+- 세션 도중 모델 전환 → cache miss
+- 뒤늦게 이미지/스크린샷 첨부 → prefix 흔들림
+
+# 규칙: 긴 작업 시작 전에 prefix 재료를 모두 확정해 둘 것.""",
+        "fix_summary": "긴 세션 전 CLAUDE.md 동결. 도중 prefix 변경 금지.",
+    },
+    "duplicate_tools": {
+        "title": "4. 동일한 도구 호출이 그대로 반복됨",
+        "rule": "SHA-256(tool_name, input) 가 동일한 호출 — 같은 호출을 또 함.",
+        "formula": "낭비 = 결과_토큰 × cache_write 단가 ($30/M, 결과가 컨텍스트에 재진입하므로).",
+        "fix_code": """# Read/Grep/Bash 를 다시 부르기 전에 자문
+- 이 답이 대화 위쪽에 이미 있지 않나?
+- 마지막 Read 이후 파일이 정말 바뀌었나?
+
+# 이 레포에서 흔한 중복
+- 매 turn 마다 `git status` / `git diff` 재호출
+- 인접 파일 편집 후 같은 소스를 또 Read
+- 직전 결과 캐싱 없이 `gh pr view` 폴링""",
+        "fix_summary": "이미 컨텍스트에 있는 결과 참조. 변경 없는 파일 재Read 금지.",
+    },
+    "subagent_overuse": {
+        "title": "5. Task / 서브에이전트 과다 위임",
+        "rule": "Agent 호출 5회 이상 + 평균 결과 ≤ 2k 토큰 (= 각 작업이 ≤3 turn 수준의 사소한 작업).",
+        "formula": "낭비 = 호출 수 × 서브에이전트당 약 3k 오버헤드 × write 단가 ($30/M).",
+        "fix_code": """# 서브에이전트 사용 기준
+- 인라인으로: 단일 파일 조회, 단순 Grep, "package.json 안 보기"
+- 서브에이전트로: 다단계 리서치, 병렬 작업, 대용량 컨텍스트 탐색
+
+# 각 서브에이전트는 system prompt 셋업에 약 3k 오버헤드,
+# 거기에 작업 프롬프트와 결과 래핑이 더해진다. 3 turn 미만 작업은
+# 거의 항상 인라인이 더 저렴하다.""",
+        "fix_summary": "사소한 조회는 인라인. 5+ turn 탐색에만 Agent.",
+    },
+}
+
+
+def fmt_usd(x):
+    return f"${x:,.2f}"
+
+
+def fmt_int(x):
+    return f"{x:,}" if x else "0"
+
+
+def build_html(data):
+    totals = data["totals"]
+    sessions = data["sessions"]
+    pt = totals["patterns"]
+
+    # KPIs
+    kpi_html = f"""
+    <div class="grid kpis">
+      <div class="kpi"><div class="l">분석된 세션</div><div class="v">{totals['sessions_total']}</div><div class="s">{totals['sessions_with_any_pattern']}개에서 1개 이상 패턴 검출</div></div>
+      <div class="kpi"><div class="l">예상 누적 낭비</div><div class="v bad">{fmt_usd(totals['total_waste_usd'])}</div><div class="s">5개 검출기 합산 (Opus 가격 기준)</div></div>
+      <div class="kpi"><div class="l">최대 단일 패턴</div><div class="v warn">{fmt_usd(max(p['total_waste_usd'] for p in pt.values()))}</div><div class="s">{PATTERN_KO_NAME[max(pt, key=lambda k: pt[k]['total_waste_usd'])]}</div></div>
+      <div class="kpi"><div class="l">활성 패턴 수</div><div class="v">{sum(1 for p in pt.values() if p['affected_sessions']>0)} / 5</div><div class="s">검출된 비효율 종류</div></div>
+    </div>
+    """
+
+    # Per-pattern bar chart data
+    chart_labels = []
+    chart_data = []
+    chart_sessions = []
+    for key, meta in PATTERN_META.items():
+        chart_labels.append(PATTERN_KO_NAME[key])
+        chart_data.append(round(pt[key]["total_waste_usd"], 2))
+        chart_sessions.append(pt[key]["affected_sessions"])
+
+    # Pattern detail cards
+    pattern_cards = []
+    for key, meta in PATTERN_META.items():
+        info = pt[key]
+        offenders = info["top_offenders"]
+        offender_rows = "\n".join(
+            f"""<tr>
+                <td class="mono">{o['session_id']}</td>
+                <td>{o['evidence']}</td>
+                <td class="num bad">{fmt_usd(o['waste_usd'])}</td>
+            </tr>"""
+            for o in offenders
+        ) or '<tr><td colspan="3" class="muted">검출된 세션 없음 ✓</td></tr>'
+
+        status = "good" if info["affected_sessions"] == 0 else "warn"
+        status_text = "이상 없음" if info["affected_sessions"] == 0 else f"{info['affected_sessions']}개 세션"
+
+        pattern_cards.append(f"""
+        <div class="card pattern">
+          <div class="phead">
+            <h2 style="margin: 0;">{meta['title']}</h2>
+            <div class="pmetrics">
+              <span class="badge {status}">{status_text}</span>
+              <span class="badge waste">{fmt_usd(info['total_waste_usd'])}</span>
+            </div>
+          </div>
+
+          <div class="rule"><b>탐지 조건:</b> {meta['rule']}</div>
+          <div class="rule"><b>낭비 계산식:</b> <code>{meta['formula']}</code></div>
+
+          <h3>가장 심한 세션</h3>
+          <table>
+            <thead><tr><th>세션</th><th>근거</th><th class="num">낭비액</th></tr></thead>
+            <tbody>{offender_rows}</tbody>
+          </table>
+
+          <h3>해결책</h3>
+          <pre class="code">{meta['fix_code']}</pre>
+          <div class="quick"><b>한 줄 요약:</b> {meta['fix_summary']}</div>
+        </div>
+        """)
+
+    # Per-session waste table (top 15)
+    def waste_of(s):
+        return sum(f["waste_usd"] for f in s["findings"].values())
+
+    top_sessions = [s for s in sessions if waste_of(s) > 0][:15]
+    session_rows = []
+    for s in top_sessions:
+        flags = list(s["findings"].keys())
+        flag_html = "".join(
+            f'<span class="tag t-{k}" title="{PATTERN_KO_NAME[k]}">{PATTERN_KO_NAME[k]}</span>'
+            for k in flags
+        )
+        session_rows.append(f"""<tr>
+            <td class="mono">{s['session_id'][:8]}</td>
+            <td class="num">{s['n_turns']}</td>
+            <td class="num">{s['peak_context']/1000:.0f}k</td>
+            <td>{flag_html}</td>
+            <td class="num bad">{fmt_usd(waste_of(s))}</td>
+        </tr>""")
+    session_rows_html = "\n".join(session_rows) or '<tr><td colspan="5" class="muted">검출된 세션이 없습니다</td></tr>'
+
+    html = f"""<!doctype html>
+<html lang="ko">
+<head>
+<meta charset="utf-8">
+<title>Claude Code — 5대 비효율 패턴 리포트</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<style>
+  :root {{
+    --bg:#0b0f17; --panel:#131924; --panel-2:#1a2230; --border:#232d3d;
+    --text:#e6edf3; --muted:#8b98a9; --accent:#7ad1ff;
+    --good:#4ade80; --warn:#fbbf24; --bad:#ef4444;
+  }}
+  * {{ box-sizing: border-box; }}
+  body {{ font-family: -apple-system, 'Inter', 'SF Pro', Segoe UI, sans-serif;
+         background: var(--bg); color: var(--text); margin: 0; padding: 32px; line-height: 1.5; }}
+  h1 {{ font-size: 28px; margin: 0 0 6px; }}
+  h2 {{ font-size: 18px; margin: 0; letter-spacing: -0.01em; }}
+  h3 {{ font-size: 13px; margin: 20px 0 8px; color: var(--muted); text-transform: uppercase; letter-spacing: 0.08em; font-weight: 600; }}
+  .sub {{ color: var(--muted); font-size: 14px; margin-bottom: 32px; }}
+  .grid {{ display: grid; gap: 16px; }}
+  .kpis {{ grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); margin-bottom: 24px; }}
+  .kpi {{ background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }}
+  .kpi .v {{ font-size: 28px; font-weight: 700; letter-spacing: -0.02em; }}
+  .kpi .l {{ color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }}
+  .kpi .s {{ color: var(--muted); font-size: 12px; margin-top: 4px; }}
+  .card {{ background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 22px; margin-bottom: 16px; }}
+  .pattern .phead {{ display: flex; justify-content: space-between; align-items: center; gap: 12px; margin-bottom: 14px; }}
+  .pmetrics {{ display: flex; gap: 8px; }}
+  .badge {{ padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }}
+  .badge.good {{ background: #14532d; color: #86efac; }}
+  .badge.warn {{ background: #633a19; color: #fbbf24; }}
+  .badge.waste {{ background: #4b1515; color: #fca5a5; font-variant-numeric: tabular-nums; }}
+  .rule {{ font-size: 13px; color: var(--muted); margin: 4px 0; }}
+  .rule code {{ color: var(--text); background: var(--panel-2); padding: 1px 5px; border-radius: 3px; }}
+  .quick {{ margin-top: 12px; padding: 10px 14px; background: var(--panel-2); border-left: 3px solid var(--good); border-radius: 0 6px 6px 0; font-size: 13px; }}
+  pre.code {{ background: #0a0e15; border: 1px solid var(--border); border-radius: 6px;
+              padding: 14px; font-family: 'SF Mono', Menlo, monospace; font-size: 12.5px;
+              line-height: 1.55; overflow-x: auto; white-space: pre; color: #cbd5e1; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 13px; }}
+  th, td {{ padding: 8px 12px; text-align: left; border-bottom: 1px solid var(--border); }}
+  th {{ color: var(--muted); font-weight: 600; text-transform: uppercase; font-size: 11px; letter-spacing: 0.06em; }}
+  td.num, th.num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+  td.muted {{ color: var(--muted); text-align: center; padding: 18px 0; }}
+  .mono {{ font-family: 'SF Mono', Menlo, monospace; font-size: 12px; color: var(--muted); }}
+  .bad {{ color: var(--bad); font-weight: 600; }}
+  .warn {{ color: var(--warn); }}
+  .good {{ color: var(--good); }}
+  .tag {{ display: inline-block; padding: 2px 8px; margin: 1px 3px 1px 0; border-radius: 4px;
+          font-size: 11px; font-weight: 600; letter-spacing: 0; white-space: nowrap; }}
+  .tag.t-context_bloat {{ background: #4b1515; color: #fca5a5; }}
+  .tag.t-giant_tool_outputs {{ background: #633a19; color: #fbbf24; }}
+  .tag.t-poor_cache_util {{ background: #1e3a5f; color: #93c5fd; }}
+  .tag.t-duplicate_tools {{ background: #14532d; color: #86efac; }}
+  .tag.t-subagent_overuse {{ background: #4c1d95; color: #c4b5fd; }}
+  canvas {{ max-height: 260px; }}
+  .footer {{ margin-top: 48px; color: var(--muted); font-size: 12px; text-align: center; }}
+</style>
+</head>
+<body>
+  <h1>Claude Code — 5대 비효율 패턴 리포트</h1>
+  <div class="sub">{totals['sessions_dir']}</div>
+
+  {kpi_html}
+
+  <div class="card">
+    <h3>패턴별 누적 낭비 ($)</h3>
+    <canvas id="patternBar"></canvas>
+  </div>
+
+  {''.join(pattern_cards)}
+
+  <div class="card">
+    <h2 style="margin: 0 0 14px;">개별 세션 — 패턴 검출 결과 (top 15)</h2>
+    <table>
+      <thead><tr>
+        <th>세션</th><th class="num">Turn 수</th><th class="num">최대 컨텍스트</th>
+        <th>검출 패턴</th><th class="num">총 낭비액</th>
+      </tr></thead>
+      <tbody>{session_rows_html}</tbody>
+    </table>
+  </div>
+
+  <div class="card">
+    <h2 style="margin: 0 0 12px;">즉시 적용할 단일 변경</h2>
+    <ol style="font-size: 14px; line-height: 1.8; margin: 0; padding-left: 20px;">
+      <li><b>CLAUDE.md 에 컨텍스트 룰 추가</b> — "200k 토큰 초과 시 /compact, 50k 글자 초과 도구 출력 시 /compact" 명시. (패턴 1 + 2)</li>
+      <li><b>긴 세션 시작 전 prompt prefix 동결</b> — CLAUDE.md, system reminder, 모델 선택을 미리 확정. (패턴 3)</li>
+      <li><b>Bash 출력 캐핑 습관화</b> — <code>| head -50</code>, <code>| wc -l</code> 같은 제한부터 붙이기. (패턴 2)</li>
+      <li><b>Read 직전 자기 확인</b> — "이 파일 이미 읽지 않았나?" → 컨텍스트 위쪽 확인 후 호출. (패턴 4)</li>
+      <li><b>Agent 호출 임계 룰</b> — 단일 grep · 단일 파일 조회는 인라인, 다중 검색 · 병렬 조사만 Agent. (패턴 5)</li>
+    </ol>
+  </div>
+
+  <div class="footer">
+    위 탐지 규칙과 계산식은 결정론적입니다 — 같은 입력에 대해 항상 같은 낭비액이 산출됩니다.<br>
+    가격 기준: Opus 4.x (1M 토큰당 read $1.50 / write 1h $30 / output $75).
+  </div>
+
+<script>
+Chart.defaults.color = '#e6edf3';
+Chart.defaults.borderColor = '#232d3d';
+new Chart(document.getElementById('patternBar'), {{
+  type: 'bar',
+  data: {{
+    labels: {json.dumps(chart_labels)},
+    datasets: [{{
+      label: '낭비액 (USD)',
+      data: {json.dumps(chart_data)},
+      backgroundColor: ['#ef4444','#fbbf24','#60a5fa','#4ade80','#a78bfa'],
+      borderWidth: 0,
+    }}]
+  }},
+  options: {{
+    plugins: {{
+      legend: {{ display: false }},
+      tooltip: {{ callbacks: {{
+        afterLabel: (c) => '검출된 세션: ' + ({json.dumps(chart_sessions)})[c.dataIndex] + '개'
+      }} }}
+    }},
+    scales: {{
+      y: {{ beginAtZero: true, title: {{ display: true, text: '낭비액 (USD)' }} }}
+    }}
+  }}
+}});
+</script>
+</body>
+</html>
+"""
+    return html
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--input", default="/tmp/pattern_analysis.json")
+    ap.add_argument("--out", default="/tmp/patterns_report.html")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"[error] missing {args.input}. Run detect_patterns.py first.", file=sys.stderr)
+        sys.exit(2)
+
+    with open(args.input) as f:
+        data = json.load(f)
+
+    html = build_html(data)
+    with open(args.out, "w") as f:
+        f.write(html)
+    print(f"[ok] wrote {args.out}")
+    print(f"     open: open {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/harness/efficiency/detect_patterns.py
+++ b/harness/efficiency/detect_patterns.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""Detect 5 inefficiency patterns in Claude Code sessions with $ waste estimates.
+
+Each detector follows an exact formula from the spec — no fuzzy heuristics.
+
+Detectors:
+  1. context-bloat       : context > 100k for 20+ consecutive turns without a >50% drop (no compact).
+                           Waste = Σ max(0, context - 80k) per affected turn × cache_read price.
+  2. giant-tool-outputs  : tool_result ≥ 50k chars (~12.5k tokens).
+                           Waste = result_tokens × remaining_turns_in_session × cache_read price.
+  3. poor-cache-util     : per-turn cache_hit < 50% AND context > 30k.
+                           Waste = cache_create × (write_price − read_price).
+  4. duplicate-tools     : SHA-256 of (tool_name, input). Repeats are pure waste.
+                           Waste = result_tokens (re-paid + sitting in context) × cache_write price.
+  5. subagent-overuse    : ≥5 Agent calls AND avg subagent result ≤ 2k tokens (proxy for ≤3 turns).
+                           Waste = num_calls × ~3k overhead per call × cache_write price.
+
+Usage:
+  python3 detect_patterns.py --repo /path/to/repo --out /tmp/pattern_analysis.json
+"""
+import argparse
+import glob
+import hashlib
+import json
+import os
+import sys
+from collections import defaultdict
+
+# Pricing (USD per 1M tokens). We price waste at Opus rates; if the actual
+# session was Sonnet, the dollar number is overstated by ~5x — but Sonnet
+# sessions are also cheap so the overall % impact is roughly right.
+OPUS_READ = 1.50
+OPUS_W1H = 30.00
+OPUS_OUT = 75.00
+
+# Thresholds (from the user's spec)
+CONTEXT_HIGH_TOKENS = 100_000          # P1: "context exceeds 100k"
+CONTEXT_BASELINE = 80_000              # P1: "tokens above 80k per turn"
+CONSEC_TURNS_REQUIRED = 20             # P1: "over 20+ turns"
+COMPACT_DROP_RATIO = 0.50              # P1: ">50% drop signals compact"
+
+GIANT_TOOL_CHARS = 50_000              # P2: ≥ 50k chars
+CHARS_PER_TOKEN = 4                    # ~12.5k tokens for 50k chars
+
+CACHE_HIT_FLOOR = 0.50                 # P3: hit ratio < 50%
+CONTEXT_FLOOR_FOR_CACHE = 30_000       # P3: context > 30k
+
+SUBAGENT_MIN_CALLS = 5                 # P5: ≥ 5 Task calls
+TRIVIAL_RESULT_TOKENS = 2000           # P5: avg result ≤ 2k → ≤3 turns proxy
+SUBAGENT_OVERHEAD_TOKENS = 3000        # P5: per-call system prompt + framing
+
+
+def encode_repo_path(p):
+    return os.path.abspath(os.path.expanduser(p)).replace("/", "-")
+
+
+def stringify(obj):
+    """Stable string for hashing tool inputs."""
+    return json.dumps(obj, sort_keys=True, default=str)
+
+
+def sha256_short(s):
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()[:16]
+
+
+def estimate_tokens_from_content(content):
+    """Approximate token count for arbitrary tool result content (str or list)."""
+    if isinstance(content, str):
+        return len(content) // CHARS_PER_TOKEN
+    if isinstance(content, list):
+        total = 0
+        for item in content:
+            if isinstance(item, dict):
+                if item.get("type") == "text":
+                    total += len(item.get("text", "")) // CHARS_PER_TOKEN
+                elif item.get("type") == "image":
+                    total += 1500  # rough per-image token estimate
+        return total
+    return 0
+
+
+def chars_of_content(content):
+    if isinstance(content, str):
+        return len(content)
+    if isinstance(content, list):
+        return sum(
+            len(item.get("text", "")) if isinstance(item, dict) and item.get("type") == "text" else 0
+            for item in content
+        )
+    return 0
+
+
+def analyze_session(path):
+    """Walk one session JSONL, build per-turn trajectories, run all 5 detectors."""
+    sid = os.path.basename(path).replace(".jsonl", "")
+    try:
+        with open(path) as f:
+            records = [json.loads(line) for line in f if line.strip()]
+    except Exception:
+        return None
+
+    # Index assistant turns and capture per-turn metrics in order.
+    assistant_turns = []           # list of dicts: {idx, input, cache_read, cache_create, output, tool_uses}
+    pending_tool_uses = {}         # tool_use_id → {name, input, turn_idx}
+
+    # Map tool_use_id → result content (chars + token estimate). Walk records
+    # in order; user records come AFTER the corresponding assistant tool_use.
+    tool_results = {}              # tool_use_id → {chars, tokens, content_kind}
+
+    for rec in records:
+        rtype = rec.get("type")
+        if rtype == "assistant":
+            msg = rec.get("message", {})
+            usage = msg.get("usage", {})
+            cw_detail = usage.get("cache_creation", {}) or {}
+            cw_total = (
+                cw_detail.get("ephemeral_5m_input_tokens", 0)
+                + cw_detail.get("ephemeral_1h_input_tokens", 0)
+            )
+            if cw_total == 0:
+                cw_total = usage.get("cache_creation_input_tokens", 0)
+
+            inp = usage.get("input_tokens", 0)
+            cr = usage.get("cache_read_input_tokens", 0)
+            out = usage.get("output_tokens", 0)
+            context_size = inp + cr + cw_total
+
+            tool_uses = []
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "tool_use":
+                        tu = {
+                            "id": c.get("id"),
+                            "name": c.get("name", "unknown"),
+                            "input": c.get("input", {}),
+                        }
+                        tool_uses.append(tu)
+                        pending_tool_uses[tu["id"]] = {
+                            "name": tu["name"],
+                            "input": tu["input"],
+                            "turn_idx": len(assistant_turns),
+                        }
+
+            assistant_turns.append({
+                "idx": len(assistant_turns),
+                "input_tokens": inp,
+                "cache_read": cr,
+                "cache_create": cw_total,
+                "output_tokens": out,
+                "context_size": context_size,
+                "tool_uses": tool_uses,
+            })
+
+        elif rtype == "user":
+            # Tool results come back as user messages with tool_result blocks.
+            msg = rec.get("message", {})
+            content = msg.get("content", [])
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "tool_result":
+                        tu_id = c.get("tool_use_id")
+                        result_content = c.get("content")
+                        chars = chars_of_content(result_content)
+                        tokens = estimate_tokens_from_content(result_content)
+                        tool_results[tu_id] = {"chars": chars, "tokens": tokens}
+
+    n_turns = len(assistant_turns)
+    if n_turns == 0:
+        return None
+
+    # Run each detector.
+    findings = {}
+
+    # --- P1: context-bloat ---
+    p1 = detect_context_bloat(assistant_turns)
+    if p1["triggered"]:
+        findings["context_bloat"] = p1
+
+    # --- P2: giant-tool-outputs ---
+    p2 = detect_giant_tool_outputs(assistant_turns, tool_results, n_turns)
+    if p2["triggered"]:
+        findings["giant_tool_outputs"] = p2
+
+    # --- P3: poor-cache-util ---
+    p3 = detect_poor_cache_util(assistant_turns)
+    if p3["triggered"]:
+        findings["poor_cache_util"] = p3
+
+    # --- P4: duplicate-tools ---
+    p4 = detect_duplicate_tools(assistant_turns, tool_results)
+    if p4["triggered"]:
+        findings["duplicate_tools"] = p4
+
+    # --- P5: subagent-overuse ---
+    p5 = detect_subagent_overuse(assistant_turns, tool_results)
+    if p5["triggered"]:
+        findings["subagent_overuse"] = p5
+
+    return {
+        "session_id": sid,
+        "n_turns": n_turns,
+        "peak_context": max((t["context_size"] for t in assistant_turns), default=0),
+        "findings": findings,
+    }
+
+
+# ----------------- detectors -----------------
+
+def detect_context_bloat(turns):
+    """P1: context > 100k for 20+ consecutive turns, no >50% drop."""
+    n = len(turns)
+    # Find longest run of consecutive turns where context_size > CONTEXT_HIGH_TOKENS
+    # AND no consecutive turn has a > COMPACT_DROP_RATIO drop within that run.
+    best_run = []
+    current_run = []
+    for i, t in enumerate(turns):
+        if t["context_size"] > CONTEXT_HIGH_TOKENS:
+            # Check if previous turn (if any) had a big drop FROM here — actually
+            # "drop by >50%" between consecutive turns signals compact, breaks the run.
+            if current_run:
+                prev_ctx = turns[current_run[-1]]["context_size"]
+                this_ctx = t["context_size"]
+                if prev_ctx > 0 and (prev_ctx - this_ctx) / prev_ctx > COMPACT_DROP_RATIO:
+                    # compact happened — break run
+                    if len(current_run) > len(best_run):
+                        best_run = current_run
+                    current_run = [i]
+                    continue
+            current_run.append(i)
+        else:
+            if len(current_run) > len(best_run):
+                best_run = current_run
+            current_run = []
+    if len(current_run) > len(best_run):
+        best_run = current_run
+
+    if len(best_run) < CONSEC_TURNS_REQUIRED:
+        return {"triggered": False}
+
+    # Waste: sum of (context - 80k) for those turns × cache_read price
+    waste_tokens = sum(max(0, turns[i]["context_size"] - CONTEXT_BASELINE) for i in best_run)
+    waste_usd = waste_tokens * OPUS_READ / 1e6
+
+    return {
+        "triggered": True,
+        "evidence": f"{len(best_run)} consecutive turns above 100k context, no >50% drop",
+        "consec_turns": len(best_run),
+        "peak_context": max(turns[i]["context_size"] for i in best_run),
+        "waste_tokens": int(waste_tokens),
+        "waste_usd": round(waste_usd, 2),
+        "fix": "Run /compact when cumulative input passes 200k. Branch new sessions for unrelated tasks.",
+    }
+
+
+def detect_giant_tool_outputs(turns, tool_results, n_turns):
+    """P2: any tool_result ≥ 50k chars. Waste = tokens × remaining_turns × cache_read."""
+    giants = []
+    for turn in turns:
+        for tu in turn["tool_uses"]:
+            res = tool_results.get(tu["id"])
+            if not res:
+                continue
+            if res["chars"] >= GIANT_TOOL_CHARS:
+                remaining = n_turns - turn["idx"] - 1
+                waste_tokens = res["tokens"] * remaining
+                giants.append({
+                    "tool": tu["name"],
+                    "turn_idx": turn["idx"],
+                    "chars": res["chars"],
+                    "tokens": res["tokens"],
+                    "remaining_turns": remaining,
+                    "waste_tokens": waste_tokens,
+                })
+
+    if not giants:
+        return {"triggered": False}
+
+    total_waste_tokens = sum(g["waste_tokens"] for g in giants)
+    waste_usd = total_waste_tokens * OPUS_READ / 1e6
+
+    return {
+        "triggered": True,
+        "evidence": f"{len(giants)} tool result(s) ≥ 50k chars, persisting in context",
+        "count": len(giants),
+        "biggest_chars": max(g["chars"] for g in giants),
+        "waste_tokens": int(total_waste_tokens),
+        "waste_usd": round(waste_usd, 2),
+        "samples": giants[:3],
+        "fix": "Pipe through head/grep/wc before reading. Truncate Bash dumps. /compact after big reads.",
+    }
+
+
+def detect_poor_cache_util(turns):
+    """P3: per-turn cache_hit < 50% AND context > 30k. Waste = cache_create × (write − read)."""
+    bad_turns = []
+    for t in turns:
+        if t["context_size"] < CONTEXT_FLOOR_FOR_CACHE:
+            continue
+        cr, cw = t["cache_read"], t["cache_create"]
+        if cr + cw == 0:
+            continue
+        hit = cr / (cr + cw + t["input_tokens"])
+        if hit < CACHE_HIT_FLOOR:
+            bad_turns.append({"idx": t["idx"], "hit": round(hit, 3), "cache_create": cw})
+
+    if not bad_turns:
+        return {"triggered": False}
+
+    waste_tokens = sum(b["cache_create"] for b in bad_turns)
+    # Spread between paying for a write vs a read
+    waste_usd = waste_tokens * (OPUS_W1H - OPUS_READ) / 1e6
+
+    return {
+        "triggered": True,
+        "evidence": f"{len(bad_turns)} turns with cache hit < 50% at context > 30k",
+        "bad_turns_count": len(bad_turns),
+        "waste_tokens": int(waste_tokens),
+        "waste_usd": round(waste_usd, 2),
+        "fix": "Stop mutating prompt prefix mid-session. Settle CLAUDE.md before long runs. Avoid late additions.",
+    }
+
+
+def detect_duplicate_tools(turns, tool_results):
+    """P4: SHA-256 of (tool_name, input). Duplicates → entire result is waste."""
+    seen = {}
+    duplicates = []
+    for turn in turns:
+        for tu in turn["tool_uses"]:
+            key = sha256_short(stringify((tu["name"], tu["input"])))
+            if key in seen:
+                first_idx = seen[key]
+                res = tool_results.get(tu["id"], {"tokens": 0, "chars": 0})
+                duplicates.append({
+                    "tool": tu["name"],
+                    "first_turn": first_idx,
+                    "dup_turn": turn["idx"],
+                    "result_tokens": res["tokens"],
+                })
+            else:
+                seen[key] = turn["idx"]
+
+    if not duplicates:
+        return {"triggered": False}
+
+    waste_tokens = sum(d["result_tokens"] for d in duplicates)
+    # The duplicate's result re-enters context and gets cached again.
+    waste_usd = waste_tokens * OPUS_W1H / 1e6
+
+    # Tool breakdown
+    by_tool = defaultdict(int)
+    for d in duplicates:
+        by_tool[d["tool"]] += 1
+
+    return {
+        "triggered": True,
+        "evidence": f"{len(duplicates)} exact-duplicate tool calls (same name+input)",
+        "duplicate_count": len(duplicates),
+        "by_tool": dict(by_tool),
+        "waste_tokens": int(waste_tokens),
+        "waste_usd": round(waste_usd, 2),
+        "samples": duplicates[:3],
+        "fix": "Reference earlier results from context instead of re-calling. Especially for Read/Grep/Bash status.",
+    }
+
+
+def detect_subagent_overuse(turns, tool_results):
+    """P5: ≥5 Agent calls AND avg result ≤ 2k tokens → trivial farming."""
+    agent_calls = []
+    for turn in turns:
+        for tu in turn["tool_uses"]:
+            if tu["name"] in ("Agent", "Task"):
+                res = tool_results.get(tu["id"], {"tokens": 0})
+                agent_calls.append({"turn_idx": turn["idx"], "result_tokens": res["tokens"]})
+
+    if len(agent_calls) < SUBAGENT_MIN_CALLS:
+        return {"triggered": False}
+
+    avg_result = sum(c["result_tokens"] for c in agent_calls) / len(agent_calls)
+    if avg_result > TRIVIAL_RESULT_TOKENS:
+        return {"triggered": False}
+
+    waste_tokens = len(agent_calls) * SUBAGENT_OVERHEAD_TOKENS
+    waste_usd = waste_tokens * OPUS_W1H / 1e6
+
+    return {
+        "triggered": True,
+        "evidence": f"{len(agent_calls)} Agent calls, avg result {avg_result:.0f} tokens (trivial)",
+        "agent_calls": len(agent_calls),
+        "avg_result_tokens": round(avg_result, 0),
+        "waste_tokens": int(waste_tokens),
+        "waste_usd": round(waste_usd, 2),
+        "fix": "Inline trivial lookups. Reserve subagents for >5-turn explorations or long parallel work.",
+    }
+
+
+# ----------------- main -----------------
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", help="Repo path (default cwd)")
+    ap.add_argument("--sessions-dir")
+    ap.add_argument("--out", default="/tmp/pattern_analysis.json")
+    args = ap.parse_args()
+
+    if args.sessions_dir:
+        sessions_dir = os.path.expanduser(args.sessions_dir)
+    else:
+        repo = args.repo or os.getcwd()
+        sessions_dir = os.path.expanduser(f"~/.claude/projects/{encode_repo_path(repo)}")
+
+    if not os.path.isdir(sessions_dir):
+        print(f"[error] sessions dir not found: {sessions_dir}", file=sys.stderr)
+        sys.exit(2)
+
+    files = sorted(glob.glob(os.path.join(sessions_dir, "*.jsonl")))
+    print(f"[info] scanning {len(files)} sessions ...")
+
+    sessions = []
+    for fp in files:
+        s = analyze_session(fp)
+        if s:
+            sessions.append(s)
+
+    # Aggregate per pattern
+    pattern_keys = ["context_bloat", "giant_tool_outputs", "poor_cache_util",
+                    "duplicate_tools", "subagent_overuse"]
+    pattern_totals = {}
+    for key in pattern_keys:
+        affected = [s for s in sessions if key in s["findings"]]
+        affected.sort(key=lambda s: s["findings"][key]["waste_usd"], reverse=True)
+        pattern_totals[key] = {
+            "affected_sessions": len(affected),
+            "total_waste_usd": round(sum(s["findings"][key]["waste_usd"] for s in affected), 2),
+            "total_waste_tokens": sum(s["findings"][key]["waste_tokens"] for s in affected),
+            "top_offenders": [
+                {
+                    "session_id": s["session_id"][:8],
+                    "evidence": s["findings"][key]["evidence"],
+                    "waste_usd": s["findings"][key]["waste_usd"],
+                }
+                for s in affected[:5]
+            ],
+        }
+
+    totals = {
+        "sessions_dir": sessions_dir,
+        "sessions_total": len(sessions),
+        "sessions_with_any_pattern": sum(1 for s in sessions if s["findings"]),
+        "patterns": pattern_totals,
+        "total_waste_usd": round(sum(p["total_waste_usd"] for p in pattern_totals.values()), 2),
+    }
+
+    sessions.sort(
+        key=lambda s: sum(f["waste_usd"] for f in s["findings"].values()),
+        reverse=True,
+    )
+
+    with open(args.out, "w") as f:
+        json.dump({"totals": totals, "sessions": sessions}, f, default=str, indent=2)
+
+    print(f"[ok] wrote {args.out}")
+    print(f"     {totals['sessions_total']} sessions, {totals['sessions_with_any_pattern']} flagged")
+    print(f"     total estimated waste: ${totals['total_waste_usd']:.2f}")
+    for k in pattern_keys:
+        v = pattern_totals[k]
+        print(f"       {k:22s}  {v['affected_sessions']:3d} sessions  ${v['total_waste_usd']:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dcness-efficiency
+++ b/scripts/dcness-efficiency
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# dcNess efficiency wrapper — Claude Code 세션 JSONL 토큰/비용 분석 + HTML 대시보드.
+#
+# 출처 (attribution): jha0313/skills_repo `improve-token-efficiency` (DCN-CHG-20260430-08).
+#
+# 사용:
+#   "${CLAUDE_PLUGIN_ROOT:-...}/scripts/dcness-efficiency" <subcommand> [args]
+#
+# subcommand:
+#   analyze [--repo PATH] [--out PATH]    — JSON 리포트 생성
+#   dashboard [--input PATH] [--out PATH] — analyze 결과 → HTML 대시보드
+#   patterns [--repo PATH] [--out PATH]   — 패턴 분석 (detect_patterns)
+#   patterns-dashboard [--input] [--out]  — 패턴 → HTML
+#   full [--repo PATH] [--out-dir DIR]    — analyze + dashboard chain (편의)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+EFF_DIR="$PLUGIN_ROOT/harness/efficiency"
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: dcness-efficiency <analyze|dashboard|patterns|patterns-dashboard|full> [args]" >&2
+    exit 1
+fi
+
+cmd="$1"
+shift
+
+case "$cmd" in
+    analyze)
+        exec python3 "$EFF_DIR/analyze_sessions.py" "$@"
+        ;;
+    dashboard)
+        exec python3 "$EFF_DIR/build_dashboard.py" "$@"
+        ;;
+    patterns)
+        exec python3 "$EFF_DIR/detect_patterns.py" "$@"
+        ;;
+    patterns-dashboard)
+        exec python3 "$EFF_DIR/build_patterns_dashboard.py" "$@"
+        ;;
+    full)
+        # analyze → dashboard chain (편의 wrapper)
+        repo=""
+        out_dir="/tmp/dcness-efficiency"
+        while [ "$#" -gt 0 ]; do
+            case "$1" in
+                --repo) repo="$2"; shift 2 ;;
+                --out-dir) out_dir="$2"; shift 2 ;;
+                *) shift ;;
+            esac
+        done
+        mkdir -p "$out_dir"
+        json_path="$out_dir/session_analysis.json"
+        html_path="$out_dir/efficiency_report.html"
+
+        analyze_args=("--out" "$json_path")
+        [ -n "$repo" ] && analyze_args+=("--repo" "$repo")
+        python3 "$EFF_DIR/analyze_sessions.py" "${analyze_args[@]}" || exit $?
+        python3 "$EFF_DIR/build_dashboard.py" --input "$json_path" --out "$html_path" || exit $?
+
+        echo ""
+        echo "[dcness-efficiency] 완료"
+        echo "  JSON:  $json_path"
+        echo "  HTML:  $html_path"
+        echo "  open '$html_path' 으로 대시보드 확인"
+        ;;
+    *)
+        echo "unknown subcommand: $cmd" >&2
+        exit 1
+        ;;
+esac

--- a/tests/test_efficiency.py
+++ b/tests/test_efficiency.py
@@ -1,0 +1,168 @@
+"""test_efficiency — Claude Code 세션 분석 스크립트 (jha0313 fork) 검증.
+
+DCN-CHG-20260430-08: improve-token-efficiency skill 흡수. encode_repo_path 가
+CC 인코딩 룰 (`/` + `.` 둘 다 → `-`) 정합 + price_for prefix 매칭 검증.
+
+핵심 동작 (analyze_sessions / build_dashboard) 의 통합 smoke 만 — read-only 분석
+도구라 catastrophic 룰 비대상.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class EncodeRepoPathTests(unittest.TestCase):
+    """CC 인코딩 룰 — `/` + `.` 모두 `-` 로 변환."""
+
+    def test_simple_path(self) -> None:
+        from harness.efficiency.analyze_sessions import encode_repo_path
+        self.assertEqual(
+            encode_repo_path("/Users/foo/projects/bar"),
+            "-Users-foo-projects-bar",
+        )
+
+    def test_dotted_username(self) -> None:
+        """`/Users/dc.kim/...` 의 `.` 도 `-` 로 (CC 실 동작)."""
+        from harness.efficiency.analyze_sessions import encode_repo_path
+        result = encode_repo_path("/Users/dc.kim/project/dcNess")
+        self.assertEqual(result, "-Users-dc-kim-project-dcNess")
+
+    def test_dotted_dirname(self) -> None:
+        from harness.efficiency.analyze_sessions import encode_repo_path
+        self.assertEqual(
+            encode_repo_path("/Users/x/.config/foo"),
+            "-Users-x--config-foo",
+        )
+
+
+class PriceForTests(unittest.TestCase):
+    """prefix 매칭 — dated suffix / variant tag 자동 흡수."""
+
+    def test_exact_match(self) -> None:
+        from harness.efficiency.analyze_sessions import price_for, PRICING
+        self.assertEqual(price_for("claude-opus-4-6"), PRICING["claude-opus-4-6"])
+
+    def test_dated_haiku_suffix(self) -> None:
+        """`claude-haiku-4-5-20251001` → haiku 가격 (prefix 매칭)."""
+        from harness.efficiency.analyze_sessions import price_for, PRICING
+        self.assertEqual(
+            price_for("claude-haiku-4-5-20251001"),
+            PRICING["claude-haiku-4-5"],
+        )
+
+    def test_variant_tag_1m(self) -> None:
+        """`claude-opus-4-7[1m]` → opus 가격 (변형 tag 무시)."""
+        from harness.efficiency.analyze_sessions import price_for, PRICING
+        self.assertEqual(
+            price_for("claude-opus-4-7[1m]"),
+            PRICING["claude-opus-4-7"],
+        )
+
+    def test_unknown_falls_back_default(self) -> None:
+        from harness.efficiency.analyze_sessions import price_for, DEFAULT_PRICE
+        # 새 모델 ID — DEFAULT_PRICE (Opus default) fallback
+        self.assertEqual(price_for("claude-future-99-x-20300101"), DEFAULT_PRICE)
+
+
+class WrapperSmokeTests(unittest.TestCase):
+    """`scripts/dcness-efficiency` wrapper 가 정상 실행 + 빈 디렉토리 처리."""
+
+    def test_no_subcommand_exits_1(self) -> None:
+        result = subprocess.run(
+            [str(REPO_ROOT / "scripts" / "dcness-efficiency")],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("usage", result.stderr.lower())
+
+    def test_analyze_empty_sessions_dir(self) -> None:
+        """빈 sessions dir → analyze 가 graceful exit (FileNotFoundError 방지)."""
+        with TemporaryDirectory() as td:
+            sessions = Path(td) / "sessions"
+            # 디렉토리만 만들고 jsonl 0개
+            sessions.mkdir()
+            result = subprocess.run(
+                [
+                    str(REPO_ROOT / "scripts" / "dcness-efficiency"),
+                    "analyze",
+                    "--sessions-dir", str(sessions),
+                    "--out", str(Path(td) / "out.json"),
+                ],
+                capture_output=True, text=True, timeout=10,
+            )
+            # 빈 sessions → analyze 가 명시 종료 (exit ≠ 0). 구현체 = exit 2.
+            # 핵심 = silent crash X (FileNotFoundError 방지) + 명확한 에러 메시지.
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("no .jsonl files", result.stderr.lower())
+
+
+class IntegrationSmokeTests(unittest.TestCase):
+    """analyze + dashboard chain — 가짜 세션 jsonl 생성 후 실제 동작 검증."""
+
+    def test_full_chain_with_fixture_session(self) -> None:
+        with TemporaryDirectory() as td:
+            sessions = Path(td) / "sessions"
+            sessions.mkdir()
+            # 가짜 세션 jsonl — 1 assistant message with usage
+            fixture = sessions / "session-fixture.jsonl"
+            record = {
+                "type": "assistant",
+                "message": {
+                    "model": "claude-opus-4-7",
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_creation_input_tokens": 200,
+                        "cache_read_input_tokens": 1000,
+                    },
+                },
+            }
+            fixture.write_text(json.dumps(record) + "\n", encoding="utf-8")
+
+            json_out = Path(td) / "analysis.json"
+            result = subprocess.run(
+                [
+                    str(REPO_ROOT / "scripts" / "dcness-efficiency"),
+                    "analyze",
+                    "--sessions-dir", str(sessions),
+                    "--out", str(json_out),
+                ],
+                capture_output=True, text=True, timeout=15,
+            )
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertTrue(json_out.exists())
+
+            data = json.loads(json_out.read_text(encoding="utf-8"))
+            self.assertGreaterEqual(len(data.get("sessions", [])), 1)
+            self.assertGreater(data.get("totals", {}).get("cost_usd", 0), 0)
+
+            # dashboard 도 실행 가능한지
+            html_out = Path(td) / "report.html"
+            result2 = subprocess.run(
+                [
+                    str(REPO_ROOT / "scripts" / "dcness-efficiency"),
+                    "dashboard",
+                    "--input", str(json_out),
+                    "--out", str(html_out),
+                ],
+                capture_output=True, text=True, timeout=15,
+            )
+            self.assertEqual(result2.returncode, 0, msg=result2.stderr)
+            self.assertTrue(html_out.exists())
+            html_text = html_out.read_text(encoding="utf-8")
+            self.assertIn("<html", html_text.lower())
+            self.assertIn("chart", html_text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
사용자 요청 — `https://github.com/jha0313/skills_repo` 검토 + 흡수 가치 평가. 3 skill 중 1개 (`improve-token-efficiency`) 만 fork. 나머지 2개 skip.

## 변경
- `harness/efficiency/` 패키지 (4 script fork) + `scripts/dcness-efficiency` wrapper + `commands/efficiency.md` skill prompt.
- 출처 attribution 명시.
- dcness fix 2건:
  1. encode_repo_path 의 `.` → `-` (CC 실 인코딩 룰)
  2. price_for prefix 매칭 (dated suffix + variant tag)

181/181 PASS. dcness plugin skill 8개.

## 후속
- 30일 도그푸딩 후 자가 사용 빈도 측정
- jha0313 upstream 에 fix 2건 PR 제안 (선택)

🤖 Generated with [Claude Code](https://claude.com/claude-code)