### PR TITLE
feat: MODULE_PLAN_READY 마커 → state-aware skip (DCN-CHG-20260430-13)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🪄 MODULE_PLAN_READY 마커 → state-aware skip** (`DCN-CHG-20260430-13`):
+  - 사용자 통찰 — RWHarness plan_loop 의 원래 의도 (산출물 있으면 통과 / 없으면 다시 호출) 복원.
+  - `agents/architect/task-decompose.md` — 각 batch 산출 시 ## 생성/수정 파일 / ## 인터페이스 / ## 의사코드 / ## 결정 근거 + `MODULE_PLAN_READY` 마커 박는 컨벤션.
+  - `commands/impl.md` Step 2.0 — batch 파일 마커 grep → SKIP_MODULE_PLAN 시 batch 파일을 architect-MODULE_PLAN.md 자리에 cp + test-engineer 직진. catastrophic §2.3.3 정합.
+  - 분기 추가 = 1 (grep 1줄). branch-surface-tracking warning 임계 미달.
+  - 옵션 D — 컨벤션 + 메인 자율. dcness 철학 정합.
 - **🧷 /impl-loop inner sub-task 의무 + `b<i>.<agent>` prefix 컨벤션** (`DCN-CHG-20260430-12`):
   - 사용자 smoke 발견 — 메인이 inner 5 sub-task TaskCreate inline skip → outer 5 batch entry 만 보임.
   - `commands/impl-loop.md` Step 2 에 ⚠️ "skip 금지" 경고 + `b<i>.<agent>` prefix 컨벤션 박음.

--- a/agents/architect/task-decompose.md
+++ b/agents/architect/task-decompose.md
@@ -35,3 +35,39 @@ design-handoff.md 있는 경우 (B 모드 = 디자인 후 구현) 는 스킵.
 - impl 목차 outline (파일명 + 다룰 스토리 + depth + 1 줄 요약 + 의존·순서)
 - 추가된 태스크 (Story → impl 매핑)
 - 생성된 impl 파일 목록 (경로 + depth + 가드레일 표시 — 듀얼 모드 시 `01-theme-tokens.md`)
+
+## 각 impl 파일 형식 의무 (DCN-CHG-20260430-13)
+
+각 impl batch 파일 (`docs/milestones/vNN/epics/epic-NN-*/impl/NN-*.md`) 은 다음 섹션 박는다 — `/impl` skill 의 MODULE_PLAN step skip 판정 근거:
+
+```markdown
+## 생성/수정 파일
+- `src/foo.py` — <변경 요약 1줄>
+- ...
+
+## 인터페이스
+- `foo(a: int, b: int) -> int` — <signature + 반환 의미>
+- ...
+
+## 의사코드
+```python
+def foo(a, b):
+    if b == 0:
+        raise ValueError(...)
+    return a // b
+```
+
+## 결정 근거
+- <왜 이 인터페이스 / 분기 / 에러 처리 채택했는지>
+
+## 다른 모듈과의 경계
+- <다른 impl 과의 의존 / 충돌 / 순서>
+
+## MODULE_PLAN_READY
+```
+
+마지막 줄에 `MODULE_PLAN_READY` 마커 박음 = "이 batch 자체가 MODULE_PLAN 수준 detail 충족". `/impl` 가 이 마커 grep 후 architect MODULE_PLAN step skip → test-engineer 직진 (DCN-CHG-20260430-13).
+
+마커 박지 않으면 (또는 위 섹션 미충족) `/impl` 가 architect MODULE_PLAN 정상 호출 — 본 컨벤션이 *권장* 이지 의무 아님 (메인 자율 + state-aware skip).
+
+근거: RWHarness 의 plan_loop 가 의도했던 "산출물 있으면 통과 + 없으면 다시 호출" 패턴 정합. 분기 0 추가 (skill prompt 의 마커 grep 1줄만 추가).

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -100,7 +100,37 @@ TaskCreate("pr-reviewer: 검토")
 
 **`/impl-loop` 안 inner 호출**: 호출자 (`/impl-loop`) 가 batch index `i` 와 함께 호출 시 prefix 컨벤션 — `b<i>.<agent>` (예: `b1.architect: MODULE_PLAN`). 자세한 컨벤션 = `commands/impl-loop.md` Step 2 참조. 본 skill standalone 시 prefix 없음.
 
-### Step 2 — architect MODULE_PLAN
+### Step 2 — architect MODULE_PLAN (state-aware skip 가능)
+
+#### 2.0 batch 마커 검사 (DCN-CHG-20260430-13)
+
+batch 파일 안 `MODULE_PLAN_READY` 마커 검사:
+
+```bash
+if grep -q "MODULE_PLAN_READY" "<batch path>"; then
+    echo "[impl] batch 자체에 MODULE_PLAN_READY 박힘 — architect MODULE_PLAN step skip"
+    SKIP_MODULE_PLAN=true
+else
+    SKIP_MODULE_PLAN=false
+fi
+```
+
+조건: `architect TASK_DECOMPOSE` (`/product-plan` Step 7) 가 batch 산출 시 ## 생성/수정 파일 / ## 인터페이스 / ## 의사코드 / ## 결정 근거 박고 마지막 줄에 `MODULE_PLAN_READY` 마커 박음 (`agents/architect/task-decompose.md` 컨벤션).
+
+**SKIP_MODULE_PLAN=true 시**:
+- TaskUpdate("architect: MODULE_PLAN", completed) + label 정정 → "skipped (batch 자체 MODULE_PLAN_READY)"
+- batch 파일 자체를 MODULE_PLAN prose 로 사용 (architect-MODULE_PLAN.md 자리에 batch path symlink 또는 cp)
+- catastrophic 훅 §2.3.3 (engineer 직전 plan READY 검사) 통과 위해 prose 종이 필요:
+  ```bash
+  cp "<batch path>" "$RUN_DIR/architect-MODULE_PLAN.md"
+  ```
+- → Step 3 (test-engineer) 직진
+
+**SKIP_MODULE_PLAN=false 시**: 정상 호출 (아래 2.1).
+
+근거: RWHarness 의 plan_loop 가 의도했던 "산출물 있으면 통과 + 없으면 다시 호출". dcness 가 분기 폐기로 일관성 회피하느라 잃었던 효율성 복원. 분기 추가 0 — skill prompt 의 grep 1줄 + 메인 자율.
+
+#### 2.1 architect MODULE_PLAN 정상 호출 (마커 부재 시)
 
 ```
 TaskUpdate("architect: MODULE_PLAN", in_progress)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,34 @@
 
 ## Records
 
+### DCN-CHG-20260430-13
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 통찰 (manual smoke 도중) — "근데 이미 아키텍트가 모듈 나누고 왔는데 왜 B1에서 아키텍트부터 다시 시작해? 원래 루프에 있던 의미는 없으면 다시하고 오라는거였고 패스되는거였을텐데."
+  - RWHarness plan_loop 원래 의도 = state-aware skip:
+    ```
+    impl_loop 진입:
+      if 산출물 (MODULE_PLAN.md) 있음 → 통과 + test-engineer 직진
+      else → architect MODULE_PLAN 호출 ("다시 하고 와")
+    ```
+  - dcness 가 사다리 #2 (state hole — checkpoint 보존 의무 자리) 회피하느라 분기 자체를 없앤 결과 *효율성도 함께 잃음*. 매 batch 마다 무조건 MODULE_PLAN 호출 = LLM 비용 / 시간 N×.
+  - architect TASK_DECOMPOSE 가 이미 batch 산출 시 ## 생성/수정 파일 / ## 인터페이스 / ## 의사코드 / ## 결정 근거 박는 컨벤션 일부 — MODULE_PLAN 수준 detail 충족이면 *재설계* 의미 없음.
+- **Alternatives** (사용자 의문 정합 4 옵션):
+  1. *옵션 A — 현재 유지* (매 batch 마다 MODULE_PLAN 호출). 보수적 / 비효율. 기각.
+  2. *옵션 B — batch 충분 상세 시 skip* (자동 판정). detail 판정 룰이 새 hole 후보 자리. 기각.
+  3. *옵션 C — helper 단 격리* (`dcness-helper batch-status`). 자동화 + skill prompt 의 분기 추가 0. 단 helper 안 분기 추가. 차순위.
+  4. **(채택) 옵션 D — 컨벤션 + 메인 자율** — TASK_DECOMPOSE 가 batch 산출 시 `MODULE_PLAN_READY` 마커 박음. /impl Step 2.0 에서 grep 1줄 — 마커 충족 시 skip / 부재 시 정상 호출. 분기 추가 = 1 (skip vs 호출 / grep 단순 검사). branch-surface-tracking 임계 미달.
+- **Decision**:
+  - 옵션 D. 사용자 발화 ("D 가 맞지 이게 우리 철학이잖아") 정합.
+  - **컨벤션 박는 자리** = `agents/architect/task-decompose.md` 의 "각 impl 파일 형식 의무" 절. architect TASK_DECOMPOSE 가 prose 산출 시 batch 파일 마지막에 `MODULE_PLAN_READY` 마커 박음.
+  - **검사 자리** = `commands/impl.md` Step 2.0. `grep -q "MODULE_PLAN_READY" "<batch>"` 1줄. SKIP_MODULE_PLAN=true 시 batch 파일을 MODULE_PLAN prose 로 cp + Step 3 (test-engineer) 직진.
+  - **catastrophic 훅 §2.3.3 정합**: engineer 직전 architect-MODULE_PLAN.md (or LIGHT_PLAN.md) 안 READY_FOR_IMPL grep 검사. SKIP 케이스도 batch path 를 cp 했으므로 자연 정합 (batch 파일이 architect-MODULE_PLAN.md 위치에 박힘).
+  - **권장 vs 의무**: 본 컨벤션은 *권장*. 마커 안 박힌 batch 도 정상 호출 (옵션 A 동작). dcness 정신 정합 — agent 자율 + 메인 자율.
+- **Follow-Up**:
+  - **(별도 Task)** /impl-loop 의 resume 메커니즘 — 본 마커 + 코드 검사 결합으로 이미 구현된 batch 검출 (사용자 이전 질문 정합).
+  - **(측정)** 30 batch 산출 후 `MODULE_PLAN_READY` 마커 박힘 비율. 80%+ 면 컨벤션 정합. 그 미만이면 task-decompose prompt 강도 추가 보강.
+  - **(branch-surface-tracking 자가 점검)**: 본 PR 이 추가하는 분기 = 1 (impl Step 2.0 의 grep 분기). hole 후보 자리 = batch 파일에 마커 박는 의무 자리 1곳 (TASK_DECOMPOSE prompt 강화). warning 임계 (3 회/30일) 미달.
+
 ### DCN-CHG-20260430-12
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,18 @@
 
 ## Records
 
+### DCN-CHG-20260430-13
+- **Date**: 2026-04-30
+- **Change-Type**: agent, spec, docs-only
+- **Files Changed**:
+  - `agents/architect/task-decompose.md` — "각 impl 파일 형식 의무" 절 추가. 각 batch 산출 시 ## 생성/수정 파일 / ## 인터페이스 / ## 의사코드 / ## 결정 근거 / ## 다른 모듈과의 경계 + `MODULE_PLAN_READY` 마커 컨벤션 박음.
+  - `commands/impl.md` Step 2 — `2.0 batch 마커 검사` 절 신규 (`MODULE_PLAN_READY` 마커 grep → SKIP_MODULE_PLAN 분기). 정상 호출은 2.1 로.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 사용자 통찰 — RWHarness 의 plan_loop 원래 의도 = "산출물 있으면 통과, 없으면 다시 호출". dcness 가 분기 폐기 (사다리 #2 회피) 하면서 *효율성도 함께 잃음* — 매 batch 마다 architect MODULE_PLAN 무조건 호출. 옵션 D (메인 자율 + 컨벤션) 채택 — TASK_DECOMPOSE 가 batch 산출 시 MODULE_PLAN 수준 detail + `MODULE_PLAN_READY` 마커 박음. /impl Step 2 가 마커 grep → 충족 시 skip + test-engineer 직진. 분기 0 추가 (grep 1줄 + 메인 판단). RWHarness 원래 의도 복원.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-12
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only


### PR DESCRIPTION
사용자 통찰 — RWHarness plan_loop 원래 의도 복원. 옵션 D (컨벤션 + 메인 자율).

🤖 Generated with [Claude Code](https://claude.com/claude-code)