### PR TITLE
feat: /impl Step 4.5 — stories.md/backlog.md 자동 sync (DCN-CHG-20260430-14)

### DIFF
--- a/commands/impl.md
+++ b/commands/impl.md
@@ -220,6 +220,55 @@ advance: `IMPL_DONE`. 그 외:
 - `IMPLEMENTATION_ESCALATE` → 사용자 위임
 - `AMBIGUOUS` → cascade
 
+### Step 4.5 — stories.md / backlog.md 체크박스 동기화 (DCN-CHG-20260430-14)
+
+engineer IMPL 의 `IMPL_DONE` 직후, validator 진입 *전* 메인이 직접 mechanical edit 수행. agent 위임 X (engineer 는 `src/**` 만, architect 는 spec doc 만 — stories.md/backlog.md 체크박스는 도메인 외).
+
+근거: 글로벌 `~/.claude/CLAUDE.md` "태스크 완료 → stories.md 체크. 에픽 완료 → backlog.md 체크" 룰의 *완료* 시점 = IMPL 완료 시점. impl.md 시퀀스에 step 으로 박지 않으면 매 batch 마다 누락.
+
+#### 4.5.1 batch → epic 경로 추출
+
+batch 파일 경로에서 epic dir 추출:
+```bash
+# 예: docs/milestones/v0.3/epics/epic-01-greet-lang-apply/impl/01-*.md
+EPIC_DIR=$(dirname $(dirname "<batch path>"))
+STORIES_FILE="$EPIC_DIR/stories.md"
+BACKLOG_FILE="$(dirname $(dirname $EPIC_DIR))/../backlog.md"  # milestone root + ..
+```
+
+(실제 경로는 milestone 구조에 따라 메인이 자체 판단 — `find` / `Glob` 으로 stories.md 위치 확인 후 진행.)
+
+#### 4.5.2 stories.md 체크박스 갱신
+
+batch 가 다룬 Story 의 `[ ]` → `[x]`. batch 파일 안 `## 관련 Story` 또는 `## 적용 범위` 등의 메타로 어느 Story 인지 식별. 없으면 batch 파일명/제목으로 매칭.
+
+```
+Edit(STORIES_FILE, "- [ ] Story X: ...", "- [x] Story X: ...")
+```
+
+batch 가 1 Story 의 일부 task 만 처리한 경우 → 해당 task 만 `[x]`. Story 하위 task 모두 `[x]` 면 Story 자체도 `[x]`.
+
+#### 4.5.3 backlog.md 체크박스 갱신 (epic 완료 시만)
+
+stories.md 의 모든 Story 가 `[x]` 면 backlog.md 의 epic 라인도 `[x]`:
+
+```
+if all stories checked:
+    Edit(BACKLOG_FILE, "- [ ] epic-NN-...", "- [x] epic-NN-...")
+```
+
+부분 진행이면 backlog.md 손대지 않음.
+
+#### 4.5.4 가시성
+
+```
+[impl] step 4.5 — stories.md / backlog.md sync
+- stories.md: Story 1 [ ] → [x] (8 task 모두 완료)
+- backlog.md: epic-01 라인 [ ] → [x] (epic 전체 Story 완료)
+```
+
+다음 step (validator) 은 src/ 만 검증 — stories.md 변경 무시. pr-reviewer 가 코드 + doc 같이 검토 (잘못 체크된 항목 catch).
+
 ### Step 5 — validator CODE_VALIDATION
 
 ```

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,31 @@
 
 ## Records
 
+### DCN-CHG-20260430-14
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 글로벌 `~/.claude/CLAUDE.md` 룰 = "태스크 완료 → stories.md 체크. 에픽 완료 → backlog.md 체크". 룰 자체는 존재하나 `/impl` 시퀀스에 *step 으로* 박혀있지 않음.
+  - 실제 dcTest epic-01 manual smoke 에서 발견 — src/ 반영 (commit 4b185b9 `feat: greet lang 인자 실 적용`) 됐는데 stories.md Story 1 체크박스 8개 `[ ]` 상태 그대로. backlog.md epic-01 라인도 미체크.
+  - 메인 Claude 가 매 batch 마다 stories.md/backlog.md 체크 누락 → 사용자가 별도 명령으로 정리해야 함. 사용자 "하나의 구현루프가 끝나면 이런거 작업하게 해줘" 직접 지시.
+- **Alternatives**:
+  1. *옵션 1 — engineer agent 가 직접 처리*. engineer 룰 (`src/**` 만) 위반 위험 + agent prompt 비대해짐. 기각.
+  2. *옵션 2 — Step 6.5 (pr-reviewer LGTM 후, commit 전)*. 1 PR 에 코드+doc 같이 들어가는 건 동일하나, pr-reviewer 가 doc 변경 검토 못 함 (LGTM 후 추가). 사용자 지정한 잘못 체크 catch 기회 상실. 차순위.
+  3. *옵션 3 — Step 7 후 별도 commit/PR*. doc-only PR 추가 — 노이즈 + governance 오버헤드. 기각.
+  4. **(채택) 옵션 A — Step 4.5 (engineer IMPL 직후, validator 전)** — 메인이 mechanical edit. validator 는 src/ 만 검증 (doc 무시). pr-reviewer 가 코드 + doc 같이 검토 (체크 누락/오류 catch). 1 PR = 1 batch 완성.
+- **Decision**:
+  - 옵션 A. engineer 룰 위반 X (메인 직접 edit), pr-reviewer 검토 범위 포함, 1 PR 단위 보존.
+  - 위치 = `commands/impl.md` Step 4.5 (Step 4 engineer IMPL ↔ Step 5 validator CODE_VALIDATION 사이).
+  - 동작:
+    1. batch 파일 경로에서 epic dir + stories.md 위치 추출
+    2. batch 가 다룬 Story 의 `[ ]` → `[x]` (batch 메타 또는 파일명 매칭)
+    3. 모든 Story `[x]` 면 backlog.md epic 라인도 `[x]`
+    4. 부분 진행이면 backlog.md 손대지 않음
+  - `/impl-loop` 는 inner /impl 이 알아서 처리 — 추가 변경 불필요.
+- **Follow-Up**:
+  - **dcTest epic-01 retro 갱신** — 본 변경 적용 *후* 누적된 미체크 stories.md 를 한번에 sync (별도 Task-ID, 본 변경 범위 외).
+  - **batch 메타 컨벤션** — batch 파일 안 `## 관련 Story: Story 1.3` 명시 컨벤션은 architect TASK_DECOMPOSE 산출 시 박힐지 후속 검토. 현재는 메인이 batch 파일명/제목으로 매칭.
+  - **회귀 검증** — 다음 dcTest /impl-loop 실행 시 매 batch 마다 stories.md 체크 동기화 자동 발화 확인.
+
 ### DCN-CHG-20260430-13
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260430-14
+- **Date**: 2026-04-30
+- **Change-Type**: spec
+- **Files Changed**:
+  - `commands/impl.md` — Step 4.5 신규 (engineer IMPL `IMPL_DONE` 직후, validator 진입 전). batch 가 다룬 stories.md Story 체크박스 `[ ]` → `[x]`. 모든 Story 완료 시 backlog.md epic 라인도 `[x]`. 메인이 직접 mechanical edit (agent 위임 X).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 글로벌 `~/.claude/CLAUDE.md` "태스크 완료 → stories.md 체크. 에픽 완료 → backlog.md 체크" 룰의 *완료* 시점 = engineer IMPL 완료 시점. impl.md 시퀀스에 step 으로 박지 않으면 매 batch 마다 누락 (실제 dcTest epic-01 에서 src 반영 후 stories.md 미체크 건 발견). Step 4.5 로 박아서 매 batch 자동 적용. validator 는 src/ 만 검증 → doc 변경 무시. pr-reviewer 가 코드 + doc 같이 검토.
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-13
 - **Date**: 2026-04-30
 - **Change-Type**: agent, spec, docs-only


### PR DESCRIPTION
## Summary
- `commands/impl.md` 에 **Step 4.5** 신규 — engineer IMPL `IMPL_DONE` 직후, validator 진입 전 메인이 mechanical edit 으로 stories.md 체크박스 `[ ]` → `[x]` + 모든 Story 완료 시 backlog.md epic 라인도 `[x]`
- agent 위임 X — engineer/architect 도메인 외. 메인 직접 처리.
- validator 는 src/ 만 검증 (doc 무시), pr-reviewer 가 코드+doc 같이 검토하여 잘못 체크 catch.
- `/impl-loop` 는 inner `/impl` 이 알아서 처리 — 추가 변경 불필요.

## Why
- 글로벌 `~/.claude/CLAUDE.md` 룰 "태스크 완료 → stories.md 체크. 에픽 완료 → backlog.md 체크" 는 존재하나 `/impl` 시퀀스에 step 으로 박혀있지 않음.
- dcTest epic-01 manual smoke 에서 발견 — src/ 반영 (commit 4b185b9) 됐는데 stories.md Story 1 체크박스 8개 `[ ]` 그대로, backlog.md 미체크.
- 사용자 직접 지시 — "하나의 구현루프가 끝나면 이런거 작업하게 해줘".

## Governance
- Task-ID: `DCN-CHG-20260430-14`
- Change-Type: `spec`
- Files:
  - `commands/impl.md` (Step 4.5 신규)
  - `docs/process/document_update_record.md`
  - `docs/process/change_rationale_history.md`
- Doc-sync gate: PASS (`node scripts/check_document_sync.mjs`)

## Test Plan
- [x] doc-sync gate 통과
- [ ] (post-merge) dcTest 에서 plugin 재설치 후 `/impl-loop` 실행 시 매 batch 마다 Step 4.5 발화 확인
- [ ] (post-merge) dcTest epic-01 retro sync 별도 Task-ID 로 누적 미체크 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)