### PR TITLE
feat: /run-review skill — 메타-하네스 self-improvement Phase 1 (DCN-CHG-20260430-19)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,14 @@
 
 ## 현재 상태
 
+- **🔍 /run-review skill — 메타-하네스 self-improvement Phase 1** (`DCN-CHG-20260430-19`):
+  - RWHarness `harness-review.py` 의 dcness 변환. dcness conveyor run 사후 분석.
+  - `harness/run_review.py` (~370 LOC) — `.steps.jsonl` + per-agent prose 파싱 → 잘한 점 5 패턴 + 잘못한 점 8 패턴 detection + run-level cost (CC session JSONL 합산).
+  - 잘한 점: `ENUM_CLEAN` / `PROSE_ECHO_OK` (DCN-30-15) / `DDD_PHASE_A` (DCN-30-16) / `DEPENDENCY_CAUSAL` / `EXTERNAL_VERIFIED_PRESENT` (DCN-30-18).
+  - 잘못한 점: `RETRY_SAME_FAIL` / `ECHO_VIOLATION` / `PLACEHOLDER_LEAK` / `MUST_FIX_GHOST` / `SPEC_GAP_LOOP` / `INFRA_READ` / `READONLY_BASH` / `EXTERNAL_VERIFIED_MISSING`. 오늘 박은 룰 자동 회귀 검출.
+  - `commands/run-review.md` skill prompt — character-for-character 출력 룰 (RW 패턴 정합).
+  - 신규 15 테스트 PASS. dcness skill 9 개.
+  - Phase 2 후속: per-Agent cost 매칭 (`toolUseResult.totalCost`), finalize-run 자동 트리거, 30일 누적 분석.
 - **🪄 MODULE_PLAN_READY 마커 → state-aware skip** (`DCN-CHG-20260430-13`):
   - 사용자 통찰 — RWHarness plan_loop 의 원래 의도 (산출물 있으면 통과 / 없으면 다시 호출) 복원.
   - `agents/architect/task-decompose.md` — 각 batch 산출 시 ## 생성/수정 파일 / ## 인터페이스 / ## 의사코드 / ## 결정 근거 + `MODULE_PLAN_READY` 마커 박는 컨벤션.

--- a/commands/run-review.md
+++ b/commands/run-review.md
@@ -1,0 +1,102 @@
+---
+name: run-review
+description: dcness conveyor run (begin-run / end-run 사이클) 사후 분석 스킬. 각 step 의 잘한 점·잘못한 점·비용을 추출해서 메타-하네스 self-improvement 루프 시작점 제공. 사용자가 "/run-review", "리뷰", "이번 run 어땠어", "낭비 분석", "잘못한 점 찾아", "사후 분석" 등을 말할 때 사용한다. RWHarness review skill 의 dcness 변환 (DCN-CHG-20260430-19).
+---
+
+# Run Review Skill — 사후 분석 + 메타-하네스 self-improvement
+
+> dcness 컨베이어 run (`/quick`, `/impl`, `/impl-loop`, `/product-plan` 등) 의 산출물을 사후 분석. RWHarness `harness-review.py` 의 dcness 변환.
+
+## 언제 사용
+
+- 사용자 발화: "/run-review", "리뷰", "이번 run 어땠어", "낭비 분석", "잘못한 점 찾아", "사후 분석", "복기"
+- impl-loop / product-plan 등 큰 사이클 종료 후 자동 회고
+- 30일 누적 위반 사례 수집 (별도 후속 — 본 skill 은 단일 run)
+
+## 언제 사용하지 않음
+
+- 진행 중 run 분석 → 끝난 run 만 (`.steps.jsonl` 마감 후)
+- 토큰 / 캐시 효율 전체 측정 → `/efficiency` (세션 단위 집계)
+- 단일 PR 코드 리뷰 → `pr-reviewer` agent
+
+## 핵심 동작
+
+`.sessions/{sid}/runs/{rid}/.steps.jsonl` + 단계별 prose + CC session JSONL 을 cross-correlation 해서:
+
+1. **단계별 비용** — run 시작/종료 timestamp 내 assistant turn cost 합산 (price_for util 재사용)
+2. **잘한 점** (GOOD findings) — ENUM_CLEAN / PROSE_ECHO_OK / DDD_PHASE_A / DEPENDENCY_CAUSAL / EXTERNAL_VERIFIED_PRESENT
+3. **잘못한 점** (WASTE findings) — RETRY_SAME_FAIL / ECHO_VIOLATION / PLACEHOLDER_LEAK / MUST_FIX_GHOST / SPEC_GAP_LOOP / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_MISSING
+
+## 절차
+
+### Step 0 — run 식별
+
+```bash
+HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-review"
+
+# (a) 인자 없음 → 최신 run
+"$HELPER" --latest
+
+# (b) 인자 = run_id → 명시
+"$HELPER" --run-id <RID>
+
+# (c) 인자 = "list" → run 목록만
+"$HELPER" --list --limit 20
+```
+
+사용자 발화에 run_id 가 명시되면 (b), 없으면 (a) 실행. 사용자가 "어떤 run?" 식 모호 질문이면 (c) 로 list 출력 후 선택 받음.
+
+### Step 1 — 리포트 출력 (그대로 character-for-character 복사)
+
+⚠️ **출력 룰 절대 준수 (RWHarness review skill 패턴 정합)**:
+
+Bash stdout 의 마크다운 리포트를 **한 글자도 바꾸지 않고 그대로** Claude 텍스트 응답에 복사. 마크다운 테이블을 ASCII 박스로 변환 X. 섹션 생략 / 축약 / 재배치 X. "핵심은~" / "정리하면~" 같은 자체 해석 삽입 X.
+
+근거: dcness echo 룰 MUST (DCN-30-15) — 압축 본능 차단. 본 skill 도 동일 정신.
+
+### Step 2 — 후속 라우팅 권고 (선택, prose 끝에 1~3 줄)
+
+리포트 출력 *후* 메인 Claude 가 추가 1~3 줄로 후속 액션 권고 가능 (별도 줄 — 리포트 본문에 삽입 X):
+- HIGH waste 1+ → 해당 agent prompt 고치는 PR 권유
+- HIGH waste 0 + GOOD 다수 → "이번 run clean 정합. 다음 batch 진행 가능"
+- MUST_FIX_GHOST 발견 → caveat 멈춤 룰 강화 검토
+
+## 잘한 점 / 잘못한 점 패턴 매트릭스
+
+### 잘한 점 (GOOD)
+
+| 패턴 | 검출 조건 | 정합 룰 |
+|---|---|---|
+| `ENUM_CLEAN` | step enum 이 expected 매트릭스 정합 + must_fix=False | orchestration §4 |
+| `PROSE_ECHO_OK` | prose_excerpt 5~12줄 | DCN-30-15 |
+| `DDD_PHASE_A` | architect SD prose 안 Domain Model / Phase A 섹션 | DCN-30-16 |
+| `DEPENDENCY_CAUSAL` | architect SD prose 의존성 화살표에 인과관계 표기 | DCN-30-16 |
+| `EXTERNAL_VERIFIED_PRESENT` | plan-reviewer prose 에 EXTERNAL_VERIFIED 섹션 | DCN-30-18 |
+
+### 잘못한 점 (WASTE)
+
+| 패턴 | 심각도 | 검출 조건 | 정합 룰 |
+|---|---|---|---|
+| `RETRY_SAME_FAIL` | MEDIUM | 연속 동일 FAIL enum | orchestration §retry |
+| `ECHO_VIOLATION` | MEDIUM | prose_excerpt < 3줄 | DCN-30-15 |
+| `PLACEHOLDER_LEAK` | HIGH (architect) / MEDIUM | prose 안 `[미기록]` / `M0 이후` / `NotImplementedError` | DCN-30-18 |
+| `MUST_FIX_GHOST` | HIGH | must_fix=true 이후 다음 step 진행 | conveyor caveat 룰 |
+| `SPEC_GAP_LOOP` | MEDIUM | architect SPEC_GAP > 2회 | orchestration cycle 한도 |
+| `INFRA_READ` | HIGH | prose 안 인프라 경로 흔적 | catastrophic 권한 경계 |
+| `READONLY_BASH` | HIGH | read-only agent 가 Bash 호출 | catastrophic 권한 경계 |
+| `EXTERNAL_VERIFIED_MISSING` | HIGH | plan-reviewer prose 에 EXTERNAL_VERIFIED 섹션 부재 | DCN-30-18 |
+
+## 한계 / 후속
+
+- **per-Agent 정확 cost X (Phase 1)** — 현재는 run timeframe 합산 (coarse). Phase 2 = `toolUseResult.totalCost` 매칭 (Agent tool call 별).
+- **prose 텍스트 분석 한계** — 한국어/영어 mixed regex 기반. semantic 분석 안 함.
+- **한 run 만** — 30일 누적 / 다른 run 비교는 별도 skill 후속.
+- **자동 트리거 X** — 현재는 사용자 명시 호출. 후속: finalize-run 직후 자동 trigger 옵션.
+
+## 참조
+
+- `harness/run_review.py` — 본 skill 의 실 구현
+- `commands/efficiency.md` — 세션 단위 토큰/캐시 효율 (보완 관계)
+- `agents/architect/system-design.md` §Spike Gate (DCN-30-18) — PLACEHOLDER_LEAK 룰 출처
+- `commands/quick.md` 가시성 룰 (DCN-30-15) — ECHO_VIOLATION 룰 출처
+- RWHarness `commands/harness-review.md` — 본 skill 의 출처 패턴

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,51 @@
 
 ## Records
 
+### DCN-CHG-20260430-19
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 메타-하네스 self-improvement 루프 요청 — RWHarness 의 `/harness-review` 패턴을 dcness 에 도입.
+  - RWHarness review skill 분석 결과:
+    - JSONL log 파싱 → agent 별 cost/elapsed/tools/files_read 추출
+    - 8 waste 패턴 (INFRA_READ / SUB_AGENT / TIMEOUT / NO_OUTPUT / RETRY / CONTEXT_BLOAT / SLOW / DUPLICATE_READ)
+    - 마크다운 리포트 + 수정 제안
+    - HARNESS_DONE / ESCALATE 후 자동 트리거
+  - dcness 데이터 소스 확인 (실측):
+    - `.steps.jsonl` (DCN-30-2 부터 존재) → step 별 (agent, mode, enum, must_fix, prose_excerpt, ts)
+    - per-agent prose files → 전체 결론 + 본문
+    - CC session JSONL → assistant turn 별 cost/usage (이미 `harness/efficiency/` 가 파싱)
+    - Agent tool `toolUseResult` → `totalCost` / `totalDurationMs` / `totalTokens` (Phase 2 후속용)
+  - 가능성 확인: ✅ 잘한 점/잘못한 점 추출 + ⚠️ 단계별 금액 부분 가능 (Phase 1 = run-level, Phase 2 = per-Agent).
+- **Alternatives**:
+  1. *옵션 1 — RW review.py 통째 fork*. 최소 변경. 단 RW JSONL event format 과 dcness `.steps.jsonl` 형식이 다름 → 무의미. 기각.
+  2. *옵션 2 — Phase 1 + Phase 2 동시 구현*. 한 번에 완성. per-Agent cost 매칭은 timestamp + subagent_type 매핑 복잡 — 본 PR 비대 위험. 차순위.
+  3. **(채택) 옵션 3 — Phase 1 (run-level coarse) 우선 + Phase 2 후속** — 빠른 가치 제공 + 추후 정밀화. 사용자 "확인" (feasibility 우선) 발화 정합.
+- **Decision**:
+  - 옵션 3 채택. Phase 1 = `harness/run_review.py` 신규 (~370 LOC).
+  - 잘한 점 (GOOD findings) 5 패턴:
+    - `ENUM_CLEAN` — step enum 이 expected 매트릭스 정합 + must_fix=False
+    - `PROSE_ECHO_OK` — prose_excerpt 5~12줄 (DCN-30-15 룰 회귀 검출)
+    - `DDD_PHASE_A` — architect SD prose 안 Domain Model / Phase A 섹션 (DCN-30-16)
+    - `DEPENDENCY_CAUSAL` — 의존성 화살표에 인과관계 1줄 (DCN-30-16)
+    - `EXTERNAL_VERIFIED_PRESENT` — plan-reviewer EXTERNAL_VERIFIED 섹션 (DCN-30-18)
+  - 잘못한 점 (WASTE findings) 8 패턴:
+    - `RETRY_SAME_FAIL` (MEDIUM) — 연속 동일 FAIL enum
+    - `ECHO_VIOLATION` (MEDIUM) — prose_excerpt < 3줄 (DCN-30-15 회귀)
+    - `PLACEHOLDER_LEAK` (HIGH/MEDIUM) — `[미기록]` / `M0 이후` / `NotImplementedError` 발견 (DCN-30-18 회귀)
+    - `MUST_FIX_GHOST` (HIGH) — must_fix=true 이후 다음 step 진행
+    - `SPEC_GAP_LOOP` (MEDIUM) — architect SPEC_GAP > 2회
+    - `INFRA_READ` (HIGH) — prose 안 인프라 경로 흔적
+    - `READONLY_BASH` (HIGH) — read-only agent 가 Bash 호출 흔적
+    - `EXTERNAL_VERIFIED_MISSING` (HIGH) — plan-reviewer EXTERNAL_VERIFIED 섹션 부재 (DCN-30-18 회귀)
+  - 출력 룰 — Bash stdout 의 마크다운 리포트를 character-for-character 그대로 (RWHarness review 패턴 정합 + DCN-30-15 echo 룰 정합).
+  - dcness skill 9 개 (efficiency 와 보완 관계: efficiency=세션 단위 / run-review=run 단위).
+- **Follow-Up**:
+  - **Phase 2** — per-Agent cost 매칭 (`toolUseResult.totalCost` 추출, Agent tool 호출 timestamp + subagent_type 으로 step 에 매핑)
+  - **자동 트리거** — finalize-run 직후 자동 review trigger 옵션 (RWHarness 의 HARNESS_DONE post-hook 정합)
+  - **누적 분석** — 30일 N runs 비교 + 에이전트 별 위반 빈도 ranking (별도 skill)
+  - **테스트 flaky fix** — `tests/test_session_state.CleanupStaleRunsTests` 2건 pre-existing 별도 Task-ID 로 fix
+  - **prose 텍스트 분석 강화** — 현재 regex 기반. semantic 분석 (key 단어 다양성) 도입 검토.
+
 ### DCN-CHG-20260430-18
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260430-19
+- **Date**: 2026-04-30
+- **Change-Type**: harness, spec, test
+- **Files Changed**:
+  - `harness/run_review.py` (신규, ~370 LOC) — RWHarness `harness-review.py` 의 dcness 변환. `.steps.jsonl` + per-agent prose 파싱 → 잘한 점 (5 패턴) + 잘못한 점 (8 패턴) detection + run-level cost cross-correlation (CC session JSONL `usage` 합산) + markdown 리포트 생성.
+  - `scripts/dcness-review` (신규, 0755) — wrapper (PYTHONPATH 자동 설정 후 `harness.run_review` CLI 실행).
+  - `commands/run-review.md` (신규) — `/run-review` skill prompt. Step 0 (run 식별 — `--latest` / `--run-id` / `--list`) + Step 1 (Bash stdout character-for-character 출력 룰, RWHarness 패턴 정합) + Step 2 (후속 라우팅 권고).
+  - `tests/test_run_review.py` (신규, 15 케이스) — parse_steps / waste detection 6 / good detection 4 / report render / run list.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 사용자 메타-하네스 self-improvement 루프 요청 — RWHarness `/harness-review` 분석 후 dcness 측 가능성 확인 + Phase 1 구현. 데이터 소스 확인: (1) `.steps.jsonl` (agent/mode/enum/must_fix/prose_excerpt) (2) `<run_dir>/<agent>[-<MODE>].md` 전체 prose (3) CC session JSONL `usage` 합산. 잘한 점 5 패턴 (ENUM_CLEAN / PROSE_ECHO_OK / DDD_PHASE_A / DEPENDENCY_CAUSAL / EXTERNAL_VERIFIED_PRESENT) + 잘못한 점 8 패턴 (RETRY_SAME_FAIL / ECHO_VIOLATION / PLACEHOLDER_LEAK / MUST_FIX_GHOST / SPEC_GAP_LOOP / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_MISSING). 오늘 박은 룰 (DCN-30-15/16/18) 회귀 자동 검출 가능. dcness skill 9 개 됨. 200 tests 중 198 PASS (2건은 본 변경 무관 pre-existing flaky).
+- **Document-Exception**: 없음
+
 ### DCN-CHG-20260430-18
 - **Date**: 2026-04-30
 - **Change-Type**: agent

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -1,0 +1,623 @@
+"""run_review.py — dcness conveyor run 사후 분석 (RWHarness review skill 의 dcness 변환).
+
+데이터 소스:
+  1. `.sessions/{sid}/runs/{rid}/.steps.jsonl` — step 시퀀스 (agent/mode/enum/must_fix/prose_excerpt/ts)
+  2. `.sessions/{sid}/runs/{rid}/<agent>[-<MODE>].md` — 각 step 의 전체 prose
+  3. CC session JSONL — run timeframe 내 cost/token (run-level coarse)
+
+산출물:
+  - markdown 리포트 (요약 / 호출 흐름 / 단계별 표 / 잘한 점 / 잘못한 점 / 수정 제안)
+
+사용:
+    python3 -m harness.run_review --run-id RID
+    python3 -m harness.run_review --latest
+    python3 -m harness.run_review --list
+
+DCN-CHG-20260430-19.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+# Reuse existing pricing util.
+try:
+    from harness.efficiency.analyze_sessions import price_for
+except Exception:
+    def price_for(_model: str) -> dict:  # type: ignore
+        return {"in": 15.0, "out": 75.0, "cw5": 18.75, "cw1h": 30.0, "cr": 1.50}
+
+# ── 상수 ───────────────────────────────────────────────────────────────
+
+EXPECTED_FINAL_ENUMS = {
+    "architect": {"MODULE_PLAN": "READY_FOR_IMPL", "SYSTEM_DESIGN": "SYSTEM_DESIGN_READY",
+                   "TASK_DECOMPOSE": "READY_FOR_IMPL", "LIGHT_PLAN": "LIGHT_PLAN_READY",
+                   "SPEC_GAP": "SPEC_GAP_RESOLVED", "DOCS_SYNC": "DOCS_SYNCED"},
+    "test-engineer": {None: "TESTS_WRITTEN"},
+    "engineer": {"IMPL": "IMPL_DONE", "POLISH": "POLISH_DONE"},
+    "validator": {"CODE_VALIDATION": "PASS", "BUGFIX_VALIDATION": "BUGFIX_PASS",
+                   "DESIGN_VALIDATION": "DESIGN_REVIEW_PASS",
+                   "PLAN_VALIDATION": "PLAN_VALIDATION_PASS",
+                   "UX_VALIDATION": "UX_REVIEW_PASS"},
+    "pr-reviewer": {None: "LGTM"},
+    "security-reviewer": {None: "SECURE"},
+    "qa": {None: None},  # qa 다양 (FUNCTIONAL_BUG / CLEANUP / etc.)
+    "plan-reviewer": {None: "PLAN_REVIEW_PASS"},
+    "product-planner": {"PRODUCT_PLAN": "PRODUCT_PLAN_READY"},
+}
+
+PLACEHOLDER_PATTERNS = [
+    r"\[미기록\]", r"\[미결\]", r"M0\s*이후", r"M0\s*에서\s*검증",
+    r"NotImplementedError", r"^\s*#\s*TODO\b", r"후보\s*\d+\s*개\s*비교",
+]
+
+INFRA_PATH_PATTERNS = [
+    "/.claude/harness-state/", "/.claude/harness-logs/",
+    "harness-memory.md", "harness.config.json", "/.claude/harness/",
+]
+
+READONLY_AGENTS = {"qa", "validator", "pr-reviewer", "security-reviewer",
+                    "plan-reviewer", "design-critic"}
+
+
+# ── 데이터 모델 ────────────────────────────────────────────────────────
+
+@dataclass
+class StepRecord:
+    idx: int
+    ts: str
+    agent: str
+    mode: Optional[str]
+    enum: str
+    must_fix: bool
+    prose_excerpt: str
+    prose_full: str = ""
+    elapsed_s: int = 0  # ts diff to next step
+
+
+@dataclass
+class WasteFinding:
+    pattern: str
+    severity: str  # HIGH / MEDIUM / LOW
+    step_idx: int
+    agent: str
+    detail: str
+    fix: str
+
+
+@dataclass
+class GoodFinding:
+    pattern: str
+    step_idx: int
+    agent: str
+    detail: str
+
+
+@dataclass
+class RunReport:
+    run_id: str
+    session_id: str
+    run_dir: Path
+    steps: list[StepRecord] = field(default_factory=list)
+    wastes: list[WasteFinding] = field(default_factory=list)
+    goods: list[GoodFinding] = field(default_factory=list)
+    total_cost_usd: float = 0.0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    elapsed_s: int = 0
+    final_enum: str = ""
+    final_clean: bool = False
+
+
+# ── Run discovery ─────────────────────────────────────────────────────
+
+def list_runs(sessions_root: Path) -> list[Path]:
+    """`.sessions/{sid}/runs/{rid}/` 디렉토리 list (mtime 내림차순)."""
+    if not sessions_root.exists():
+        return []
+    runs = []
+    for sid_dir in sessions_root.iterdir():
+        runs_dir = sid_dir / "runs"
+        if not runs_dir.is_dir():
+            continue
+        for rid_dir in runs_dir.iterdir():
+            if (rid_dir / ".steps.jsonl").exists():
+                runs.append(rid_dir)
+    return sorted(runs, key=lambda p: p.stat().st_mtime, reverse=True)
+
+
+def find_run_dir(sessions_root: Path, run_id: Optional[str], use_latest: bool) -> Optional[Path]:
+    if run_id:
+        for rd in list_runs(sessions_root):
+            if rd.name == run_id:
+                return rd
+        return None
+    if use_latest:
+        runs = list_runs(sessions_root)
+        return runs[0] if runs else None
+    return None
+
+
+# ── Step 파싱 ─────────────────────────────────────────────────────────
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return None
+
+
+def parse_steps(run_dir: Path) -> list[StepRecord]:
+    steps: list[StepRecord] = []
+    jsonl = run_dir / ".steps.jsonl"
+    if not jsonl.exists():
+        return steps
+    raw = []
+    for line in jsonl.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            raw.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+
+    for idx, rec in enumerate(raw):
+        agent = rec.get("agent", "?")
+        mode = rec.get("mode")
+        prose_path = run_dir / (f"{agent}-{mode}.md" if mode else f"{agent}.md")
+        prose_full = ""
+        if prose_path.exists():
+            try:
+                prose_full = prose_path.read_text(encoding="utf-8")
+            except OSError:
+                prose_full = ""
+        steps.append(StepRecord(
+            idx=idx,
+            ts=rec.get("ts", ""),
+            agent=agent,
+            mode=mode,
+            enum=rec.get("enum", ""),
+            must_fix=bool(rec.get("must_fix")),
+            prose_excerpt=rec.get("prose_excerpt", ""),
+            prose_full=prose_full,
+        ))
+
+    # elapsed 계산 — 다음 step ts 와의 차이
+    for i in range(len(steps) - 1):
+        a = _parse_iso(steps[i].ts)
+        b = _parse_iso(steps[i + 1].ts)
+        if a and b:
+            steps[i].elapsed_s = int((b - a).total_seconds())
+    return steps
+
+
+# ── Waste 탐지 ────────────────────────────────────────────────────────
+
+def detect_wastes(steps: list[StepRecord]) -> list[WasteFinding]:
+    findings: list[WasteFinding] = []
+
+    # RETRY_SAME_FAIL — 연속 동일 FAIL enum
+    for i in range(1, len(steps)):
+        prev, cur = steps[i - 1], steps[i]
+        if prev.agent == cur.agent and prev.enum == cur.enum and prev.enum not in (
+            "PASS", "READY_FOR_IMPL", "IMPL_DONE", "TESTS_WRITTEN", "LGTM",
+            "SECURE", "DESIGN_REVIEW_PASS", "BUGFIX_PASS", "PLAN_VALIDATION_PASS",
+            "UX_REVIEW_PASS", "SYSTEM_DESIGN_READY", "DOCS_SYNCED", "POLISH_DONE",
+            "SPEC_GAP_RESOLVED", "LIGHT_PLAN_READY", "PRODUCT_PLAN_READY",
+        ):
+            findings.append(WasteFinding(
+                pattern="RETRY_SAME_FAIL",
+                severity="MEDIUM",
+                step_idx=i,
+                agent=cur.agent,
+                detail=f"step {i-1}→{i} 동일 enum 반복: {cur.enum}",
+                fix=f"agents/{cur.agent}.md fail 전략 강화 또는 impl 보강",
+            ))
+
+    # ECHO_VIOLATION (DCN-30-15) — prose_excerpt 가 너무 짧음
+    for s in steps:
+        line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
+        if line_count < 3 and s.enum != "AMBIGUOUS":
+            findings.append(WasteFinding(
+                pattern="ECHO_VIOLATION",
+                severity="MEDIUM",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail=f"{s.agent} prose 발췌 {line_count}줄 (DCN-30-15 룰 — 5~12줄 의무)",
+                fix="agents/{agent}.md / commands/quick.md 가시성 룰 재인용",
+            ))
+
+    # PLACEHOLDER_LEAK (DCN-30-18) — Must 직결 placeholder 흔적
+    for s in steps:
+        for pat in PLACEHOLDER_PATTERNS:
+            if re.search(pat, s.prose_full, re.IGNORECASE):
+                findings.append(WasteFinding(
+                    pattern="PLACEHOLDER_LEAK",
+                    severity="HIGH" if s.agent == "architect" else "MEDIUM",
+                    step_idx=s.idx,
+                    agent=s.agent,
+                    detail=f"{s.agent} prose 안 placeholder 발견: `{pat}` (DCN-30-18 — Spike Gate 룰)",
+                    fix="agents/architect/system-design.md §Spike Gate 정합 — concrete 구현 + sdk.md 갱신",
+                ))
+                break
+
+    # MUST_FIX_GHOST — must_fix=true 이후 다음 step 진행
+    for i, s in enumerate(steps):
+        if s.must_fix and i + 1 < len(steps):
+            findings.append(WasteFinding(
+                pattern="MUST_FIX_GHOST",
+                severity="HIGH",
+                step_idx=i,
+                agent=s.agent,
+                detail=f"step {i} ({s.agent}) MUST_FIX 발견됐는데 step {i+1} 진행 — 멈춤 위반",
+                fix="commands/{skill}.md caveat 멈춤 룰 강화",
+            ))
+
+    # SPEC_GAP_LOOP — architect SPEC_GAP cycle 한도 초과
+    spec_gap_count = sum(1 for s in steps if s.agent == "architect" and s.mode == "SPEC_GAP")
+    if spec_gap_count > 2:
+        findings.append(WasteFinding(
+            pattern="SPEC_GAP_LOOP",
+            severity="MEDIUM",
+            step_idx=-1,
+            agent="architect",
+            detail=f"architect SPEC_GAP {spec_gap_count}회 — cycle 한도 2 초과",
+            fix="impl batch 자체 보강 또는 product-planner escalate",
+        ))
+
+    # INFRA_READ — prose 안 인프라 경로 흔적
+    for s in steps:
+        for path in INFRA_PATH_PATTERNS:
+            if path in s.prose_full:
+                findings.append(WasteFinding(
+                    pattern="INFRA_READ",
+                    severity="HIGH",
+                    step_idx=s.idx,
+                    agent=s.agent,
+                    detail=f"{s.agent} prose 안 인프라 경로 흔적: `{path}`",
+                    fix=f"agents/{s.agent}.md 권한 경계 인프라 탐색 금지 강화",
+                ))
+                break
+
+    # READONLY_BASH — read-only agent 가 Bash 호출 흔적
+    for s in steps:
+        if s.agent in READONLY_AGENTS and re.search(r"`bash`|Bash tool|```bash", s.prose_full):
+            findings.append(WasteFinding(
+                pattern="READONLY_BASH",
+                severity="HIGH",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail=f"{s.agent} (read-only) prose 안 Bash 흔적",
+                fix=f"agents/{s.agent}.md Bash 사용 금지 명시 강화",
+            ))
+
+    # EXTERNAL_VERIFIED_MISSING (DCN-30-18) — plan-reviewer prose 에 EXTERNAL_VERIFIED 섹션 부재
+    for s in steps:
+        if s.agent == "plan-reviewer" and "EXTERNAL_VERIFIED" not in s.prose_full:
+            findings.append(WasteFinding(
+                pattern="EXTERNAL_VERIFIED_MISSING",
+                severity="HIGH",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail="plan-reviewer prose 에 EXTERNAL_VERIFIED 섹션 부재 (DCN-30-18 산출물 의무)",
+                fix="agents/plan-reviewer.md §산출물 EXTERNAL_VERIFIED 섹션 의무 재강조",
+            ))
+
+    return findings
+
+
+# ── Good 탐지 ─────────────────────────────────────────────────────────
+
+def detect_goods(steps: list[StepRecord]) -> list[GoodFinding]:
+    goods: list[GoodFinding] = []
+
+    # ENUM_CLEAN — 각 step 의 enum 이 expected 정합
+    for s in steps:
+        expected_map = EXPECTED_FINAL_ENUMS.get(s.agent, {})
+        expected = expected_map.get(s.mode) or expected_map.get(None)
+        if expected and s.enum == expected and not s.must_fix:
+            goods.append(GoodFinding(
+                pattern="ENUM_CLEAN",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail=f"{s.agent} enum={s.enum} (expected 정합)",
+            ))
+
+    # PROSE_ECHO_OK — prose_excerpt 5~12줄 + must_fix=False
+    for s in steps:
+        line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
+        if 5 <= line_count <= 12:
+            goods.append(GoodFinding(
+                pattern="PROSE_ECHO_OK",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail=f"{s.agent} prose_excerpt {line_count}줄 (DCN-30-15 룰 정합)",
+            ))
+
+    # DDD_PHASE_A — architect SYSTEM_DESIGN prose 안 Domain Model 섹션 존재
+    for s in steps:
+        if s.agent == "architect" and s.mode == "SYSTEM_DESIGN":
+            if re.search(r"##\s*Domain\s*Model|##\s*도메인\s*모델|Phase\s*A", s.prose_full, re.IGNORECASE):
+                goods.append(GoodFinding(
+                    pattern="DDD_PHASE_A",
+                    step_idx=s.idx,
+                    agent=s.agent,
+                    detail="architect SYSTEM_DESIGN prose 에 Domain Model Phase A 섹션 존재 (DCN-30-16 룰 정합)",
+                ))
+
+    # DEPENDENCY_CAUSAL — system-design prose 의존성에 인과관계 표기
+    for s in steps:
+        if s.agent == "architect" and s.mode == "SYSTEM_DESIGN":
+            if re.search(r"→.*\(.*(필요|의존|구독|입력)", s.prose_full):
+                goods.append(GoodFinding(
+                    pattern="DEPENDENCY_CAUSAL",
+                    step_idx=s.idx,
+                    agent=s.agent,
+                    detail="architect prose 의존성 화살표에 인과관계 1줄 (DCN-30-16 룰 정합)",
+                ))
+
+    # EXTERNAL_VERIFIED_PRESENT — plan-reviewer 산출물 의무 충족
+    for s in steps:
+        if s.agent == "plan-reviewer" and "EXTERNAL_VERIFIED" in s.prose_full:
+            goods.append(GoodFinding(
+                pattern="EXTERNAL_VERIFIED_PRESENT",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail="plan-reviewer EXTERNAL_VERIFIED 섹션 존재 (DCN-30-18 룰 정합)",
+            ))
+
+    return goods
+
+
+# ── Cost cross-correlation (run-level coarse) ────────────────────────
+
+def encode_repo_path_dcness(repo_path: str) -> str:
+    """CC project dir 인코딩 룰 — `/` 와 `.` 모두 `-` 로 (DCN-30-08 fix 정합)."""
+    return repo_path.replace("/", "-").replace(".", "-")
+
+
+def find_session_jsonls(repo_path: Path) -> list[Path]:
+    encoded = encode_repo_path_dcness(str(repo_path))
+    base = Path.home() / ".claude" / "projects" / encoded
+    if not base.exists():
+        return []
+    return list(base.glob("*.jsonl"))
+
+
+def compute_run_cost(run_dir: Path, repo_path: Path) -> tuple[float, int, int]:
+    """Run timeframe 내 assistant turn 의 cost/input/output 합산. Coarse — Agent 별 분리 X."""
+    steps_file = run_dir / ".steps.jsonl"
+    if not steps_file.exists():
+        return (0.0, 0, 0)
+
+    raw = []
+    for line in steps_file.read_text(encoding="utf-8").splitlines():
+        try:
+            raw.append(json.loads(line))
+        except json.JSONDecodeError:
+            continue
+    if not raw:
+        return (0.0, 0, 0)
+
+    first_ts = _parse_iso(raw[0].get("ts", ""))
+    last_ts = _parse_iso(raw[-1].get("ts", ""))
+    if not first_ts or not last_ts:
+        return (0.0, 0, 0)
+
+    total_cost = 0.0
+    total_in = 0
+    total_out = 0
+
+    for jsonl in find_session_jsonls(repo_path):
+        try:
+            for line in jsonl.read_text(encoding="utf-8").splitlines():
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                ts = rec.get("timestamp", "")
+                rec_ts = _parse_iso(ts)
+                if not rec_ts:
+                    continue
+                if rec_ts < first_ts or rec_ts > last_ts:
+                    continue
+                if rec.get("type") != "assistant":
+                    continue
+                msg = rec.get("message", {})
+                model = msg.get("model", "") or ""
+                usage = msg.get("usage", {}) or {}
+                price = price_for(model)
+                inp = usage.get("input_tokens", 0)
+                out = usage.get("output_tokens", 0)
+                cw = usage.get("cache_creation_input_tokens", 0)
+                cr = usage.get("cache_read_input_tokens", 0)
+                total_cost += (
+                    inp * price["in"] / 1e6 + out * price["out"] / 1e6
+                    + cw * price["cw5"] / 1e6 + cr * price["cr"] / 1e6
+                )
+                total_in += inp + cw + cr
+                total_out += out
+        except OSError:
+            continue
+
+    return (total_cost, total_in, total_out)
+
+
+# ── Report 생성 ───────────────────────────────────────────────────────
+
+def render_report(report: RunReport) -> str:
+    lines = []
+    lines.append(f"# Run Review: {report.run_id}")
+    lines.append("")
+    lines.append("## 요약")
+    lines.append("| 항목 | 값 |")
+    lines.append("|---|---|")
+    lines.append(f"| run_id | `{report.run_id}` |")
+    lines.append(f"| session_id | `{report.session_id}` |")
+    lines.append(f"| step 수 | {len(report.steps)} |")
+    lines.append(f"| 소요 | {report.elapsed_s}s |")
+    lines.append(f"| 비용 (run window 내) | ${report.total_cost_usd:.4f} |")
+    lines.append(f"| input tokens | {report.total_input_tokens:,} |")
+    lines.append(f"| output tokens | {report.total_output_tokens:,} |")
+    lines.append(f"| 최종 enum | `{report.final_enum}` |")
+    lines.append(f"| clean 판정 | {'✅' if report.final_clean else '❌'} |")
+    lines.append("")
+
+    # 호출 흐름
+    lines.append("## 호출 흐름")
+    lines.append("```")
+    for i, s in enumerate(report.steps):
+        marker = "└─" if i == len(report.steps) - 1 else "├─"
+        mode_str = f" [{s.mode}]" if s.mode else ""
+        flag = " ⚠️" if s.must_fix else ""
+        lines.append(f"{marker} {s.agent}{mode_str} ({s.elapsed_s}s) → {s.enum}{flag}")
+    lines.append("```")
+    lines.append("")
+
+    # 단계별 표
+    lines.append("## 단계별 상세")
+    lines.append("| # | agent | mode | elapsed(s) | enum | must_fix | prose 줄 |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for s in report.steps:
+        line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
+        lines.append(
+            f"| {s.idx} | {s.agent} | {s.mode or '-'} | {s.elapsed_s} | "
+            f"`{s.enum}` | {'⚠️' if s.must_fix else ''} | {line_count} |"
+        )
+    lines.append("")
+
+    # 잘한 점
+    if report.goods:
+        lines.append("## 잘한 점 (Good Findings)")
+        lines.append("| # | 패턴 | step | agent | 상세 |")
+        lines.append("|---|---|---|---|---|")
+        for i, g in enumerate(report.goods, 1):
+            lines.append(f"| {i} | `{g.pattern}` | {g.step_idx} | {g.agent} | {g.detail} |")
+        lines.append("")
+    else:
+        lines.append("## 잘한 점 — 없음")
+        lines.append("")
+
+    # 잘못한 점
+    if report.wastes:
+        lines.append("## 잘못한 점 (Waste Findings)")
+        lines.append("| # | 심각도 | 패턴 | step | agent | 상세 | 수정 |")
+        lines.append("|---|---|---|---|---|---|---|")
+        sev_order = {"HIGH": 0, "MEDIUM": 1, "LOW": 2}
+        for i, w in enumerate(sorted(report.wastes, key=lambda x: sev_order.get(x.severity, 9)), 1):
+            lines.append(
+                f"| {i} | {w.severity} | `{w.pattern}` | {w.step_idx} | {w.agent} "
+                f"| {w.detail} | {w.fix} |"
+            )
+        lines.append("")
+    else:
+        lines.append("## 잘못한 점 — 없음 ✅")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ── 실행 ──────────────────────────────────────────────────────────────
+
+def build_report(run_dir: Path, repo_path: Path) -> RunReport:
+    steps = parse_steps(run_dir)
+    wastes = detect_wastes(steps)
+    goods = detect_goods(steps)
+    cost, in_tok, out_tok = compute_run_cost(run_dir, repo_path)
+
+    elapsed = 0
+    if len(steps) >= 2:
+        a = _parse_iso(steps[0].ts)
+        b = _parse_iso(steps[-1].ts)
+        if a and b:
+            elapsed = int((b - a).total_seconds())
+
+    final_enum = steps[-1].enum if steps else ""
+    has_must_fix = any(s.must_fix for s in steps)
+    has_ambiguous = any(s.enum == "AMBIGUOUS" for s in steps)
+    final_clean = (final_enum and not has_must_fix and not has_ambiguous
+                   and len([w for w in wastes if w.severity == "HIGH"]) == 0)
+
+    sid = run_dir.parent.parent.name
+    return RunReport(
+        run_id=run_dir.name,
+        session_id=sid,
+        run_dir=run_dir,
+        steps=steps,
+        wastes=wastes,
+        goods=goods,
+        total_cost_usd=cost,
+        total_input_tokens=in_tok,
+        total_output_tokens=out_tok,
+        elapsed_s=elapsed,
+        final_enum=final_enum,
+        final_clean=final_clean,
+    )
+
+
+def _detect_sessions_root(cwd: Path) -> Optional[Path]:
+    """`.claude/harness-state/.sessions/` 위치 자동 탐지 (현재 dir + .git common parent)."""
+    cur = cwd / ".claude" / "harness-state" / ".sessions"
+    if cur.exists():
+        return cur
+    # worktree fallback — git common-dir
+    try:
+        import subprocess
+        r = subprocess.run(["git", "rev-parse", "--git-common-dir"],
+                            cwd=str(cwd), capture_output=True, text=True, check=False)
+        if r.returncode == 0:
+            common = Path(r.stdout.strip())
+            cand = common.parent / ".claude" / "harness-state" / ".sessions"
+            if cand.exists():
+                return cand
+    except Exception:
+        pass
+    return None
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    p = argparse.ArgumentParser(prog="dcness-run-review", description="dcness run 사후 분석")
+    p.add_argument("--run-id", help="명시 run_id")
+    p.add_argument("--latest", action="store_true", help="최신 run 분석")
+    p.add_argument("--list", action="store_true", help="run list 만 출력")
+    p.add_argument("--repo", default=".", help="저장소 cwd (default: cwd)")
+    p.add_argument("--limit", type=int, default=10, help="--list 시 최대 개수")
+    args = p.parse_args(argv)
+
+    repo_path = Path(args.repo).resolve()
+    sessions_root = _detect_sessions_root(repo_path)
+    if not sessions_root:
+        print("[run-review] sessions root 미탐지 — `.claude/harness-state/.sessions/` 부재", file=sys.stderr)
+        return 2
+
+    if args.list:
+        runs = list_runs(sessions_root)[:args.limit]
+        if not runs:
+            print("[run-review] runs 없음")
+            return 0
+        for i, r in enumerate(runs, 1):
+            mtime = datetime.fromtimestamp(r.stat().st_mtime).strftime("%Y-%m-%d %H:%M:%S")
+            print(f"{i}. {r.name}  (sid={r.parent.parent.name}, mtime={mtime})")
+        return 0
+
+    run_dir = find_run_dir(sessions_root, args.run_id, args.latest or not args.run_id)
+    if not run_dir:
+        print(f"[run-review] run_dir 미탐지 (run_id={args.run_id})", file=sys.stderr)
+        return 2
+
+    report = build_report(run_dir, repo_path)
+    print(render_report(report))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dcness-review
+++ b/scripts/dcness-review
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# dcness-review wrapper — PYTHONPATH 자동 설정 후 harness.run_review CLI 실행.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+export PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}"
+
+exec python3 -m harness.run_review "$@"

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -1,0 +1,210 @@
+"""tests/test_run_review.py — DCN-CHG-20260430-19 run_review 단위 테스트."""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from harness.run_review import (  # noqa: E402
+    StepRecord, build_report, detect_goods, detect_wastes,
+    parse_steps, render_report, list_runs, find_run_dir,
+)
+
+
+def _make_run_dir(tmp: Path, sid: str, rid: str, step_records: list[dict],
+                    prose_files: dict[str, str] | None = None) -> Path:
+    run_dir = tmp / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
+    run_dir.mkdir(parents=True, exist_ok=True)
+    jsonl = run_dir / ".steps.jsonl"
+    with open(jsonl, "w", encoding="utf-8") as f:
+        for r in step_records:
+            f.write(json.dumps(r, ensure_ascii=False) + "\n")
+    for filename, content in (prose_files or {}).items():
+        (run_dir / filename).write_text(content, encoding="utf-8")
+    return run_dir
+
+
+class ParseStepsTests(unittest.TestCase):
+    def test_parses_steps_jsonl(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "architect", "mode": "MODULE_PLAN",
+                 "enum": "READY_FOR_IMPL", "must_fix": False,
+                 "prose_excerpt": "## 결론\nMODULE_PLAN 완성\nREADY_FOR_IMPL"},
+                {"ts": "2026-04-30T10:05:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False,
+                 "prose_excerpt": "구현 완료\n## 결론\nIMPL_DONE"},
+            ])
+            steps = parse_steps(rd)
+            self.assertEqual(len(steps), 2)
+            self.assertEqual(steps[0].agent, "architect")
+            self.assertEqual(steps[0].mode, "MODULE_PLAN")
+            self.assertEqual(steps[0].enum, "READY_FOR_IMPL")
+            self.assertEqual(steps[0].elapsed_s, 300)
+            self.assertEqual(steps[1].agent, "engineer")
+
+    def test_returns_empty_when_no_jsonl(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = tmp / "empty"
+            rd.mkdir()
+            self.assertEqual(parse_steps(rd), [])
+
+    def test_loads_full_prose(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "architect", "mode": "SYSTEM_DESIGN",
+                 "enum": "SYSTEM_DESIGN_READY", "must_fix": False, "prose_excerpt": "x"},
+            ], prose_files={"architect-SYSTEM_DESIGN.md": "## Domain Model\nEntity X\n"})
+            steps = parse_steps(rd)
+            self.assertIn("Domain Model", steps[0].prose_full)
+
+
+class WasteDetectionTests(unittest.TestCase):
+    def test_retry_same_fail(self):
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="engineer", mode="IMPL",
+                       enum="TESTS_FAIL", must_fix=False, prose_excerpt="a\nb\nc\nd\ne"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="IMPL",
+                       enum="TESTS_FAIL", must_fix=False, prose_excerpt="a\nb\nc\nd\ne"),
+        ]
+        wastes = detect_wastes(steps)
+        kinds = {w.pattern for w in wastes}
+        self.assertIn("RETRY_SAME_FAIL", kinds)
+
+    def test_echo_violation(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="architect", mode="MODULE_PLAN",
+                       enum="READY_FOR_IMPL", must_fix=False, prose_excerpt="too short"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "ECHO_VIOLATION" for w in wastes))
+
+    def test_placeholder_leak(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="architect", mode="SYSTEM_DESIGN",
+                       enum="SYSTEM_DESIGN_READY", must_fix=False,
+                       prose_excerpt="a\nb\nc\nd\ne",
+                       prose_full="## Voice Cloning\n외부 의존: [미기록] — M0 이후 결정"),
+        ]
+        wastes = detect_wastes(steps)
+        leak = [w for w in wastes if w.pattern == "PLACEHOLDER_LEAK"]
+        self.assertEqual(len(leak), 1)
+        self.assertEqual(leak[0].severity, "HIGH")
+
+    def test_must_fix_ghost(self):
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="validator", mode="CODE_VALIDATION",
+                       enum="FAIL", must_fix=True, prose_excerpt="a\nb\nc\nd\ne"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False, prose_excerpt="a\nb\nc\nd\ne"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
+    def test_spec_gap_loop(self):
+        steps = [
+            StepRecord(idx=i, ts=f"t{i}", agent="architect", mode="SPEC_GAP",
+                       enum="SPEC_GAP_RESOLVED", must_fix=False, prose_excerpt="a\nb\nc\nd\ne")
+            for i in range(3)
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "SPEC_GAP_LOOP" for w in wastes))
+
+    def test_external_verified_missing(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="plan-reviewer", mode=None,
+                       enum="PLAN_REVIEW_PASS", must_fix=False,
+                       prose_excerpt="a\nb\nc\nd\ne",
+                       prose_full="## 8 차원 판정\n모두 PASS"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "EXTERNAL_VERIFIED_MISSING" for w in wastes))
+
+
+class GoodDetectionTests(unittest.TestCase):
+    def test_enum_clean(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="architect", mode="MODULE_PLAN",
+                       enum="READY_FOR_IMPL", must_fix=False, prose_excerpt="a\nb\nc\nd\ne"),
+        ]
+        goods = detect_goods(steps)
+        self.assertTrue(any(g.pattern == "ENUM_CLEAN" for g in goods))
+
+    def test_prose_echo_ok(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False,
+                       prose_excerpt="line1\nline2\nline3\nline4\nline5\nline6"),
+        ]
+        goods = detect_goods(steps)
+        self.assertTrue(any(g.pattern == "PROSE_ECHO_OK" for g in goods))
+
+    def test_ddd_phase_a(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="architect", mode="SYSTEM_DESIGN",
+                       enum="SYSTEM_DESIGN_READY", must_fix=False,
+                       prose_excerpt="a\nb\nc\nd\ne",
+                       prose_full="## Domain Model\nEntity / VO / Aggregate ..."),
+        ]
+        goods = detect_goods(steps)
+        self.assertTrue(any(g.pattern == "DDD_PHASE_A" for g in goods))
+
+    def test_dependency_causal(self):
+        steps = [
+            StepRecord(idx=0, ts="t", agent="architect", mode="SYSTEM_DESIGN",
+                       enum="SYSTEM_DESIGN_READY", must_fix=False,
+                       prose_excerpt="a\nb\nc\nd\ne",
+                       prose_full="A → B (B 의 결과를 입력으로 사용 — 비즈니스 흐름상 필수)"),
+        ]
+        goods = detect_goods(steps)
+        self.assertTrue(any(g.pattern == "DEPENDENCY_CAUSAL" for g in goods))
+
+
+class ReportRenderTests(unittest.TestCase):
+    def test_render_smoke(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "architect", "mode": "MODULE_PLAN",
+                 "enum": "READY_FOR_IMPL", "must_fix": False,
+                 "prose_excerpt": "line1\nline2\nline3\nline4\nline5\nline6"},
+                {"ts": "2026-04-30T10:05:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False,
+                 "prose_excerpt": "line1\nline2\nline3\nline4\nline5\nline6"},
+            ])
+            report = build_report(rd, repo_path=tmp)
+            text = render_report(report)
+            self.assertIn("# Run Review", text)
+            self.assertIn("## 호출 흐름", text)
+            self.assertIn("## 단계별 상세", text)
+            self.assertIn("MODULE_PLAN", text)
+            self.assertIn("IMPL_DONE", text)
+
+
+class RunListTests(unittest.TestCase):
+    def test_list_and_find(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            sessions_root = tmp / ".claude" / "harness-state" / ".sessions"
+            _make_run_dir(tmp, "sid1", "rid_a", [
+                {"ts": "2026-04-30T10:00:00", "agent": "architect", "mode": None,
+                 "enum": "READY_FOR_IMPL", "must_fix": False, "prose_excerpt": "x"}])
+            _make_run_dir(tmp, "sid1", "rid_b", [
+                {"ts": "2026-04-30T11:00:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x"}])
+            runs = list_runs(sessions_root)
+            self.assertEqual(len(runs), 2)
+            self.assertEqual(find_run_dir(sessions_root, "rid_a", False).name, "rid_a")
+            self.assertEqual(find_run_dir(sessions_root, None, True).name, runs[0].name)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
RWHarness \`harness-review.py\` 의 dcness 변환. dcness conveyor run 사후 분석 — 잘한 점·잘못한 점·비용 추출.

### 신규 파일
- \`harness/run_review.py\` (~370 LOC) — \`.steps.jsonl\` + per-agent prose 파싱 + waste/good detection + run-level cost (CC session JSONL 합산)
- \`scripts/dcness-review\` — wrapper
- \`commands/run-review.md\` — skill prompt
- \`tests/test_run_review.py\` (15 케이스 PASS)

### 잘한 점 5 패턴
| 패턴 | 정합 룰 |
|---|---|
| \`ENUM_CLEAN\` | orchestration §4 |
| \`PROSE_ECHO_OK\` | DCN-30-15 |
| \`DDD_PHASE_A\` | DCN-30-16 |
| \`DEPENDENCY_CAUSAL\` | DCN-30-16 |
| \`EXTERNAL_VERIFIED_PRESENT\` | DCN-30-18 |

### 잘못한 점 8 패턴
| 패턴 | 심각도 | 정합 룰 |
|---|---|---|
| \`RETRY_SAME_FAIL\` | MEDIUM | retry 룰 |
| \`ECHO_VIOLATION\` | MEDIUM | DCN-30-15 회귀 |
| \`PLACEHOLDER_LEAK\` | HIGH/MEDIUM | DCN-30-18 회귀 |
| \`MUST_FIX_GHOST\` | HIGH | caveat 멈춤 룰 |
| \`SPEC_GAP_LOOP\` | MEDIUM | cycle 한도 |
| \`INFRA_READ\` | HIGH | catastrophic 권한 |
| \`READONLY_BASH\` | HIGH | catastrophic 권한 |
| \`EXTERNAL_VERIFIED_MISSING\` | HIGH | DCN-30-18 회귀 |

오늘 박은 룰 (DCN-30-15/16/18) 회귀 자동 검출 가능.

## Why
사용자 메타-하네스 self-improvement 루프 요청. RWHarness review skill 분석 후 dcness 데이터 소스 (.steps.jsonl + per-agent prose + CC session JSONL) 가용성 확인 → Phase 1 구현.

## Phase 2 후속
- per-Agent cost 매칭 (\`toolUseResult.totalCost\` Agent tool 호출 별)
- finalize-run 직후 자동 트리거 (RWHarness HARNESS_DONE post-hook 정합)
- 30일 누적 N runs 비교 + 위반 빈도 ranking

## Governance
- Task-ID: \`DCN-CHG-20260430-19\`
- Change-Type: \`harness, spec, test\`
- Doc-sync gate: PASS
- 200 tests 중 198 PASS (2건 pre-existing flaky, 본 변경 무관)
- dcness skill 9 개

## Test Plan
- [x] 단위 테스트 15/15 PASS
- [x] CLI smoke (\`--list\` / \`--latest\`)
- [ ] (post-merge + jajang 실전 푸딩) 첫 run 종료 후 \`/run-review\` 호출 → 잘한 점/잘못한 점 발화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)