### PR TITLE
fix: /run-review 단계별 표에 local time 시각 컬럼 (DCN-CHG-20260430-24)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,8 @@
 
 ## 현재 상태
 
+- **🕐 /run-review 단계별 표에 local time 시각 컬럼** (`DCN-CHG-20260430-24`):
+  - 사용자 디버그 시 UTC `04:xx` 가 헷갈려 보고. `.steps.jsonl` 은 UTC ISO 저장 (시스템 표준), render 측만 `astimezone()` 변환해서 KST 표시.
 - **🩹 /run-review 매칭 fix + skill prompt 의 prose-file 격리** (`DCN-CHG-20260430-23`):
   - jajang 실측 (run-657d86fc, 9 step) 발견 2 결함 동시 fix.
   - **(1) 매칭 cascade 결함**: step 0 invocation 부재 시 후속 step 모두 어긋남 (9 중 2 매칭). timestamp-proximity 기반 매칭 (inv.ts < step.ts AND step.ts - inv.ts ≤ 600s, closest before) 으로 해결 → 9 중 8 매칭 (step 0 정당 미매칭).

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,12 @@
 
 ## Records
 
+### DCN-CHG-20260430-24
+- **Date**: 2026-04-30
+- **Rationale**: 사용자 jajang 분석 디버그 도중 ts 가 `04:xx` 로 보여 헷갈림. `.steps.jsonl` UTC 저장 + 사용자 KST 환경 + Mac mtime local 표시의 timezone mix.
+- **Decision**: render 측 `astimezone()` 변환 (system local). 저장 형식 (UTC ISO) 변경 X — 시스템 간 전송 표준 보존.
+- **Follow-Up**: 후속 debug 도구 작성 시 동일 패턴 적용.
+
 ### DCN-CHG-20260430-23
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,15 @@
 
 ## Records
 
+### DCN-CHG-20260430-24
+- **Date**: 2026-04-30
+- **Change-Type**: harness
+- **Files Changed**:
+  - `harness/run_review.py` `render_report()` — `## 단계별 상세` 표에 `시작(local)` 컬럼 추가. UTC `.steps.jsonl` ts 를 `astimezone()` 로 system local timezone (KST) 변환해서 `HH:MM:SS` 표시.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 사용자 보고 — 디버그 출력에서 step ts 가 `04:xx` UTC 로 표시되어 KST 와 9시간 차이로 헷갈림. dcness `.steps.jsonl` 은 ISO UTC 저장 (시스템 표준), 매칭/계산은 timezone 무관 (delta 기반). 표시 측만 system local timezone 변환. `--list` mtime 은 이미 local — 일관성 확보.
+
 ### DCN-CHG-20260430-23
 - **Date**: 2026-04-30
 - **Change-Type**: harness, spec, test

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -683,18 +683,23 @@ def render_report(report: RunReport) -> str:
     lines.append("```")
     lines.append("")
 
-    # 단계별 표 (DCN-30-20: per-Agent metrics 컬럼)
+    # 단계별 표 (DCN-30-20: per-Agent metrics + DCN-30-24: local time 시작 컬럼)
     lines.append("## 단계별 상세")
-    lines.append("| # | agent | mode | elapsed(s) | duration(s) | out_tok | total_tok | cost($) | enum | must_fix | prose줄 |")
-    lines.append("|---|---|---|---|---|---|---|---|---|---|---|")
+    lines.append("| # | 시작(local) | agent | mode | elapsed(s) | duration(s) | out_tok | total_tok | cost($) | enum | must_fix | prose줄 |")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|")
     for s in report.steps:
         line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
         dur_s = f"{s.duration_ms / 1000:.0f}" if s.matched_invocation else "-"
         out_tok = f"{s.output_tokens:,}" if s.matched_invocation else "-"
         tot_tok = f"{s.total_tokens:,}" if s.matched_invocation else "-"
         cost = f"{s.cost_usd:.4f}" if s.matched_invocation else "-"
+        ts_local = "-"
+        ts_dt = _parse_iso(s.ts)
+        if ts_dt:
+            # UTC ISO → system local time (Mac 기본: 한국 KST)
+            ts_local = ts_dt.astimezone().strftime("%H:%M:%S")
         lines.append(
-            f"| {s.idx} | {s.agent} | {s.mode or '-'} | {s.elapsed_s} | "
+            f"| {s.idx} | {ts_local} | {s.agent} | {s.mode or '-'} | {s.elapsed_s} | "
             f"{dur_s} | {out_tok} | {tot_tok} | {cost} | "
             f"`{s.enum}` | {'⚠️' if s.must_fix else ''} | {line_count} |"
         )

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -170,6 +170,23 @@ class GoodDetectionTests(unittest.TestCase):
         self.assertTrue(any(g.pattern == "DEPENDENCY_CAUSAL" for g in goods))
 
 
+class LocalTimeRenderTests(unittest.TestCase):
+    def test_step_table_shows_local_time(self):
+        # DCN-30-24: UTC ts → system local time (e.g. KST = UTC+9)
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T02:46:47+00:00", "agent": "architect", "mode": "MODULE_PLAN",
+                 "enum": "READY_FOR_IMPL", "must_fix": False,
+                 "prose_excerpt": "a\nb\nc\nd\ne\nf"},
+            ])
+            report = build_report(rd, repo_path=tmp)
+            text = render_report(report)
+            self.assertIn("시작(local)", text)
+            # `:46:47` 부분만 확인 — 시스템 timezone 무관 (분/초는 동일)
+            self.assertIn(":46:47", text)
+
+
 class ReportRenderTests(unittest.TestCase):
     def test_render_smoke(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
사용자 디버그 시 \`.steps.jsonl\` UTC ts 가 KST 와 9시간 차이로 헷갈림. render 측만 \`astimezone()\` 변환.

- \`harness/run_review.py\` \`render_report()\` — 단계별 상세 표에 \`시작(local)\` 컬럼 추가
- \`.steps.jsonl\` 저장 형식 (UTC ISO) 변경 X
- 신규 1 테스트

## Governance
- Task-ID: DCN-CHG-20260430-24
- Doc-sync PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)