### PR TITLE
docs: loop-procedure.md SSOT 신설 + cross-ref (DCN-CHG-20260430-27)

### DIFF
--- a/docs/loop-procedure.md
+++ b/docs/loop-procedure.md
@@ -1,0 +1,252 @@
+# Loop Execution Procedure (메인 Claude 컨베이어 mechanics)
+
+> **Status**: ACTIVE
+> **Origin**: `DCN-CHG-20260430-27`
+> **Scope**: dcness 8 loop 의 *공통 실행 절차* SSOT. 메인 Claude 가 skill 트리거 또는 직접 발화로 루프 시작 시 본 문서를 컨베이어 매뉴얼처럼 따른다.
+> **Cross-ref**: [`orchestration.md`](orchestration.md) §2~§7 (시퀀스 카탈로그 / 결정표 / 권한 매트릭스), [`process/dcness-guidelines.md`](process/dcness-guidelines.md) (echo / yolo / worktree / AMBIGUOUS 등 cross-cutting 룰).
+
+---
+
+## 0. 진입 모델
+
+skill 트리거 또는 직접 발화 → 메인 Claude 가 **§7 매트릭스** 보고 task 리스트 동적 구성 → §1~§6 mechanics 따름.
+
+- **skill 경유**: `commands/<skill>.md` 의 `Loop` 필드가 §7 행 가리킴. skill 은 input 정형화 + 라우팅 추천만 — 절차는 본 SSOT.
+- **직접 발화** ("이거 quick 으로 가자"): orchestration.md §3 mini-graph + 본 SSOT §7 보고 메인이 자율 구성. 강제 X.
+- **dcness-guidelines.md (SessionStart inject)**: 본 문서 read 의무 명시. 매 세션 진입 시 메인 자동 인지.
+
+---
+
+## 1. Step 0 — worktree (선택) + begin-run
+
+### 1.1 worktree 분기
+
+발화에 `worktree` / `wt` / `격리` / `isolate` 키워드 시 진입. 상세 = guidelines §7.
+
+### 1.2 begin-run
+
+```bash
+HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
+RUN_ID=$("$HELPER" begin-run <entry_point> [--issue-num N])
+echo "[<entry>] run started: $RUN_ID"
+```
+
+`<entry_point>` = §7 매트릭스 행의 `entry_point` 컬럼 (예: `quick`, `impl`, `impl-loop`, `qa`, `product-plan`). begin-run 동작: sid auto-detect + run_id 발급 + `live.json.active_runs` 슬롯 + `.by-pid-current-run/{cc_pid}` 박음.
+
+---
+
+## 2. Step 1 — TaskCreate
+
+§7 매트릭스 행의 `task_list` 컬럼대로 일괄 등록. `/impl-loop` inner 의 경우 prefix `b<i>.` 의무 (DCN-CHG-30-12).
+
+```
+TaskCreate("<agent>: <mode 또는 짧은 설명>")
+... (loop 정의 수만큼)
+```
+
+---
+
+## 3. Step 2~N — agent 호출 골격
+
+### 3.1 표준 1 step 시퀀스 (per-agent 의무)
+
+```
+TaskUpdate("<task>", in_progress)
+"$HELPER" begin-step <agent> [<MODE>]
+Agent(subagent_type="<agent>", mode="<MODE>", description="...")
+RUN_DIR=$("$HELPER" run-dir)
+mkdir -p "$RUN_DIR/.prose-staging"
+PROSE_PATH="$RUN_DIR/.prose-staging/<step>.md"
+# 메인이 sub-agent prose 본문을 위 경로에 Write
+ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<csv>" --prose-file "$PROSE_PATH")
+# guidelines §1 의무 echo (5~12 줄)
+TaskUpdate("<task>", completed)
+```
+
+### 3.2 prose-staging 컨벤션 (DCN-30-21)
+
+`/tmp/dcness-*.md` 절대 사용 금지 (멀티세션 race). `<RUN_DIR>/.prose-staging/<step>.md` 만 유효.
+
+`<step>` 명명:
+- 단순: `<agent>` (예: `qa.md`)
+- mode 보유: `<agent>-<MODE>` (예: `architect-MODULE_PLAN.md`)
+- POLISH 사이클 (cycle ≤ 2): `engineer-POLISH-1`, `engineer-POLISH-2`
+- 재호출 (TESTS_FAIL → engineer attempt 1+): `engineer-IMPL-RETRY-1`, `engineer-IMPL-RETRY-2`
+
+각각 별도 begin/end-step 1쌍 (DCN-30-25 안전망).
+
+### 3.3 ENUM 분기
+
+| ENUM | 처리 |
+|------|------|
+| advance enum (§7 행의 `advance` 컬럼) | 다음 step |
+| `SPEC_GAP_FOUND` | architect SPEC_GAP cycle (≤2) 또는 사용자 위임 |
+| `TESTS_FAIL` / validator `FAIL` | engineer 재시도 (attempt < 3) |
+| `SPEC_MISSING` | architect SPEC_GAP |
+| `*_ESCALATE` (hard) | 사용자 위임 (escalate) |
+| `*_ESCALATE` (soft) / `CLARITY_INSUFFICIENT` | 비-yolo: 사용자 위임 / yolo: `auto-resolve` |
+| `CHANGES_REQUESTED` | engineer POLISH cycle (≤2) |
+| `AMBIGUOUS` | guidelines §6 cascade (재호출 1회 → 사용자 위임) |
+| `DESIGN_REVIEW_FAIL` / `UX_FAIL` | 직전 architect/ux-architect 재진입 (cycle ≤2) |
+| `PRODUCT_PLAN_UPDATED` | plan-reviewer skip → ux-architect 직행 |
+
+cycle 한도 = orchestration.md §5. yolo 매핑 = guidelines §5 + helper `auto-resolve` JSON.
+
+---
+
+## 4. Step 4.5 — stories.md / backlog.md sync (impl 계열 한정)
+
+`impl-batch-loop` / `impl-ui-design-loop` / `direct-impl-loop` / `impl-loop` 의 inner batch 에 한정. engineer `IMPL_DONE` 직후, validator 진입 *전*. 메인 직접 mechanical edit (agent 위임 X — 도메인 외).
+
+### 4.5.1 epic 경로 추출
+
+```bash
+EPIC_DIR=$(dirname $(dirname "<batch path>"))
+STORIES_FILE="$EPIC_DIR/stories.md"
+BACKLOG_FILE="$(dirname $(dirname $EPIC_DIR))/../backlog.md"
+```
+
+(실제 경로는 milestone 구조에 따라 메인이 `find` / `Glob` 으로 확인.)
+
+### 4.5.2 갱신 룰
+
+- batch 가 다룬 Story 의 task `[ ]` → `[x]`. batch ## 관련 Story / ## 적용 범위 메타로 식별.
+- Story 하위 모두 `[x]` 면 Story 자체 `[x]`.
+- stories.md 의 모든 Story `[x]` 면 backlog.md 의 epic 라인 `[x]`. 부분 진행 시 backlog 손대지 않음.
+
+### 4.5.3 가시성
+
+```
+[<entry>] step 4.5 — stories.md / backlog.md sync
+- stories.md: Story 1 [ ] → [x] (8 task 모두 완료)
+- backlog.md: epic-01 라인 [ ] → [x]
+```
+
+---
+
+## 5. Step 7 — finalize-run + clean 매트릭스 + commit/PR
+
+### 5.1 finalize-run --auto-review 호출 (DCN-30-27 자동 트리거)
+
+```bash
+STATUS=$("$HELPER" finalize-run --expected-steps <N> --auto-review)
+"$HELPER" end-run
+echo "$STATUS"
+```
+
+`<N>` = §7 매트릭스 `expected_steps` 컬럼. `--auto-review` 가 in-process 로 `harness.run_review` 호출 → review 리포트가 STATUS JSON 뒤에 chained 됨. 메인 Claude 가 guidelines §4 따라 stdout character-for-character echo (Bash collapsed 회피).
+
+`--auto-review` 생략 시 (사용자 명시 opt-out) — `dcness-review --run-id $RUN_ID --repo $(pwd)` 수동 호출 의무 (guidelines §3).
+
+### 5.2 STATUS JSON 구조
+
+```
+{
+  run_id, session_id,
+  steps[{agent, mode, enum, must_fix, prose_excerpt}],
+  has_ambiguous, has_must_fix, step_count
+}
+```
+
+### 5.3 clean 판정 매트릭스
+
+다음 모두 충족 → **clean** (자동 7a):
+1. `has_ambiguous == false` && `has_must_fix == false`
+2. step enum 매트릭스: §7 매트릭스 `clean_enum` 컬럼 모두 정합
+3. git 안전 가드:
+   - `git status --porcelain` 에 `.env` / `secrets.*` / `credentials.*` 없음
+   - unstaged + untracked ≤ 10
+   - submodule 변경 없음
+
+clean 아니면 **7b (caveat)**.
+
+### 5.4 7a — Clean 자동 commit/PR
+
+자동 진행 (사용자 확인 X):
+
+```bash
+CHANGED=$(git diff --name-only HEAD)
+HAS_REMOTE=$(git remote get-url origin >/dev/null 2>&1 && echo yes || echo no)
+
+BRANCH="<prefix>/<short-slug>"   # prefix = §7 매트릭스
+git checkout -b "$BRANCH" main
+git add $CHANGED
+git commit -m "$(cat <<'EOF'
+<한 줄 제목>
+
+<2~3 줄 본문 — engineer prose_excerpt + run_id 참조>
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+if [ "$HAS_REMOTE" = "yes" ]; then
+  git push -u origin "$BRANCH"
+  gh pr create --title "<제목>" --body "<요약 + Test plan + run_id>"
+  gh pr merge --squash --auto 2>/dev/null || gh pr merge --squash || \
+    echo "[<entry>] PR merge 차단 — branch protection / CI 대기"
+  git checkout main && git pull --ff-only 2>/dev/null || true
+fi
+```
+
+worktree 진입 시 squash 흡수 검사 후 `ExitWorktree(action="<keep|remove>")` (guidelines §7).
+
+### 5.5 7b — Caveat 확인
+
+```
+[<entry>] 완료 (caveat)
+- run_id: $RUN_ID · 변경: <src/ 변경 파일>
+- prose 종이: .claude/harness-state/.sessions/{sid}/runs/$RUN_ID/
+
+⚠️ Caveat: <has_ambiguous / has_must_fix / unexpected enum / sensitive untracked>
+
+커밋/PR 진행할까요? (수동 — branch → PR → squash merge)
+```
+
+worktree 처리도 사용자 결정.
+
+**yolo 시**: `has_must_fix == false` + enum unexpected 만 (CHANGES_REQUESTED 1건 등) → 자동 7a 시도. `has_must_fix` 또는 `has_ambiguous` true → yolo 도 7b.
+
+---
+
+## 6. Step 8 — review 결과 인지
+
+`--auto-review` stdout 자동 출력. 메인이 guidelines §4 룰대로 character-for-character echo. review 리포트의 must-fix / waste finding / per-Agent metric 즉시 인지 + 다음 run 회귀 방지에 활용.
+
+review_main 실패 (예외) 시 helper stderr WARN — STATUS JSON 자체는 정상 출력. 메인이 사후 인지 후 수동 `dcness-review` 1회 재시도 권장.
+
+---
+
+## 7. Loop × Step 매트릭스 (핵심)
+
+8 loop × 7 컬럼. **메인 Claude 가 진입 시 본 표 행 보고 §1~§5 mechanics dynamic 구성**.
+
+| loop | entry_point | task_list (Step 1) | agent_sequence | advance / clean_enum | branch_prefix | expected_steps |
+|------|-------------|--------------------|----------------|----------------------|---------------|----------------|
+| `feature-build-loop` (§3.1) | `product-plan` | product-planner / plan-reviewer / ux-architect:UX_FLOW / validator:UX_VALIDATION / architect:SYSTEM_DESIGN / validator:DESIGN_VALIDATION / architect:TASK_DECOMPOSE | 7 step | `PRODUCT_PLAN_READY` → `PLAN_REVIEW_PASS` → `UX_FLOW_READY` → `PASS` → `SYSTEM_DESIGN_READY` → `DESIGN_REVIEW_PASS` → `READY_FOR_IMPL` | (commit X — spec/design 종료) | 7 |
+| `impl-batch-loop` (§2.1) | `impl` | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | 5 step | `READY_FOR_IMPL` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | `feat/<batch-slug>` 또는 `chore/<batch-slug>` | 5 |
+| `impl-ui-design-loop` (§2.2) | `impl` (UI 감지) | architect:MODULE_PLAN / designer + design-critic THREE_WAY / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | 6+ step | `READY_FOR_IMPL` → `VARIANTS_APPROVED` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | `feat/<batch-slug>` | 6 |
+| `quick-bugfix-loop` (§3.5) | `quick` | qa / architect:LIGHT_PLAN / engineer:IMPL / validator:BUGFIX_VALIDATION / pr-reviewer | 5 step | qa ∈ {`FUNCTIONAL_BUG`,`CLEANUP`} → `LIGHT_PLAN_READY` → `IMPL_DONE` → `PASS` → `LGTM` | `fix/<slug>` (FUNCTIONAL_BUG) 또는 `chore/<slug>` (CLEANUP) | 5 |
+| `qa-triage` (§3.6) | `qa` | qa | 1 step | qa ∈ 5 enum (FUNCTIONAL_BUG/CLEANUP/DESIGN_ISSUE/KNOWN_ISSUE/SCOPE_ESCALATE) — advance X, 라우팅 추천 후 종료 | (commit X) | 1 |
+| `ux-design-stage` (§3.2) | `ux` | ux-architect:UX_FLOW / designer | 2 step | `UX_FLOW_READY` → `DESIGN_READY_FOR_REVIEW` | (commit X — design handoff) | 2 |
+| `ux-refine-stage` (§3.3) | `ux` (REFINE) | ux-architect:UX_REFINE / designer:SCREEN | 2 step | `UX_REFINE_READY` → `DESIGN_READY_FOR_REVIEW` | (commit X) | 2 |
+| `direct-impl-loop` (§3.4) | `impl_driver` (future) | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | 5 step | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | 5 |
+
+### 7.1 다중 batch chain (`impl-loop`)
+
+`/impl-loop` = `impl-batch-loop` × N. outer task `impl-<i>: <batch>` + inner 5 sub-task `b<i>.<agent>` (DCN-CHG-30-12). 각 batch clean → 자동 7a + 다음 batch. caveat → 멈춤 + 사용자 위임 (Step 2.5 — `commands/impl-loop.md` 참조).
+
+### 7.2 catastrophic 룰 정합
+
+[`orchestration.md`](orchestration.md) §2.3 4룰 + §7.1 HARNESS_ONLY_AGENTS = `hooks/catastrophic-gate.sh` 강제. 본 SSOT 의 각 loop sequence 가 이 룰 자연 충족 (validator → pr-reviewer 직전 PASS / engineer 직전 plan READY / TASK_DECOMPOSE 직전 DESIGN_REVIEW_PASS / PRD 변경 후 plan-reviewer + ux-architect 검토).
+
+---
+
+## 8. 참조
+
+- [`orchestration.md`](orchestration.md) §2~§7 — loop 카탈로그 / 결정표 / retry / escalate / handoff
+- [`process/dcness-guidelines.md`](process/dcness-guidelines.md) — echo / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy
+- [`conveyor-design.md`](conveyor-design.md) §2 / §3 / §7 — 컨베이어 디자인 + catastrophic gate
+- `harness/session_state.py` — helper CLI (`begin-run` / `end-run` / `begin-step` / `end-step` / `finalize-run` / `run-dir` / `auto-resolve`)
+- `harness/run_review.py` — review 엔진 (`--auto-review` 호출 대상)
+- `commands/<skill>.md` — skill 진입점 (input 정형화 + Loop 추천)

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -126,6 +126,8 @@ flowchart TD
 ## 3. 진입 경로별 시나리오 (mini graph 6개)
 
 > RWHarness `harness-spec.md` §4.3 의 dcNess 변환.
+> **실행 절차** (Step 0~8 mechanics — begin-run / TaskCreate / agent 호출 / finalize-run / 7a 7b / auto-review) 는 [`loop-procedure.md`](loop-procedure.md) §1~§7 SSOT. 본 §3 = *시퀀스* (what), loop-procedure §7 = *실행 매트릭스* (how) 1:1.
+> 8 loop name (`feature-build-loop` §3.1, `impl-batch-loop` §2.1, `impl-ui-design-loop` §2.2, `quick-bugfix-loop` §3.5, `qa-triage` §3.6, `ux-design-stage` §3.2, `ux-refine-stage` §3.3, `direct-impl-loop` §3.4) — loop-procedure.md §7 매트릭스 행 ID.
 
 ### 3.1 신규 기능 / PRD 변경
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,31 @@
 
 ## Records
 
+### DCN-CHG-20260430-27
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 아키텍처 지적 (DCN-30-26 직후) — skill 5종 (`commands/{qa,quick,product-plan,impl,impl-loop}.md`) 이 Step 0~7 실행 절차 (begin-run / TaskCreate / begin-step/Agent/end-step/echo / finalize-run / 7a 7b commit-PR / run-review) 를 통째로 중복 보유 (100~215줄). /run-review 자동 호출 같은 새 룰 추가 시 5 skill 모두 손대야 함 = 중복 누적.
+  - 사용자 의도: **skill = 그 루프를 돌기 위해 필요한 정보를 수집하는 정도** (info-collection trigger). 메인 Claude = orchestration SSOT 읽고 동적 Task 구성. 기술 에픽 도입 사례 evidence — 메인이 룰 보고 task 짠 게 잘 동작.
+  - skill 두께가 메인 thinking 시간 + 토큰 부담 + drift 위험 모두 누적 (DCN-30-21/22 슬림 시도 후에도 100+줄).
+- **Alternatives**:
+  1. *옵션 A — skill 마다 `/run-review` 호출 inline*. 5 skill 동시 수정 = 사용자 아키텍처 정신 위반 ("스킬에 왜 범용적인걸 넣어"). 기각.
+  2. *옵션 B — helper `finalize-run` 자체에 review 통합*. 진짜 mechanical. 단 trigger 책임 = 메인이 finalize-run 부르는 시점 의존. skill 절차에 박혀있는 finalize-run 호출이 곧 review trigger 가 되는 구조 — 옵션 A 와 동일 의존.
+  3. *옵션 C — SessionEnd 훅 자동 fire*. cross-session run false positive 우려 + 훅 stdout transcript 미진입 → review 결과 가시성 ↓. 기각.
+  4. **(채택) 옵션 D — 절차 SSOT (`loop-procedure.md`) 신설 + skill 슬림화 + helper `--auto-review` flag**. skill = 트리거, 절차 = SSOT, review = helper in-process piggy-back. 3 PR 분할 마이그레이션.
+- **Decision**:
+  - **옵션 D 채택** + **3 PR 분할** (SSOT → /qa pilot → 4 skill bulk).
+  - 본 PR (PR1) = SSOT 신설 + cross-ref 박음. skill 변경 / harness 변경 X.
+  - **`docs/loop-procedure.md` 신규** — Step 0~8 골격 + §7 매트릭스 (8 loop × 7 컬럼: entry_point / task_list / agent_sequence / advance / clean_enum / branch_prefix / expected_steps).
+  - **`docs/process/dcness-guidelines.md` §0 신설** — SessionStart inject 시 loop-procedure.md 의무 read 명시. drift mitigation: governance §2.2 doc-sync gate + cross-ref 박힘.
+  - **`docs/orchestration.md` §3 헤더 cross-ref** — §3 mini-graph (시퀀스 카탈로그) 와 loop-procedure.md §7 (실행 매트릭스) 1:1 강제. 8 loop name 매핑 명시.
+  - **SSOT 위치 결정** (사용자 컨펌): orchestration.md §11 신설 ❌ — orchestration = WHAT (시퀀스), procedure = HOW (mechanics) 다른 axis. 별도 파일이 책임 분리 명확. guidelines.md (option C) 도 reject — guidelines = cross-cutting 룰 (echo/yolo/worktree), procedure = 시퀀스 mechanics 다른 축. inject 187줄 → 400+줄 비대화 우려.
+- **Follow-Up**:
+  - **PR2 (DCN-CHG-20260430-28 예정)** — `harness/session_state.py:_cli_finalize_run --auto-review` flag 신설 + `tests/test_session_state.py` wiring 케이스 + `commands/qa.md` slim pilot (~25 줄). qa flow E2E 검증 (jajang reinstall 후 1회).
+  - **PR3 (DCN-CHG-20260430-29 예정)** — `commands/{quick,impl,impl-loop,product-plan}.md` bulk slim. 4 skill 1회씩 dry-run 검증.
+  - **drift 위험 모니터링** — §3 mini-graph ↔ §7 매트릭스 sync 가 doc-sync gate 자동 강제. 매 변경 시 양쪽 동시 update 의무.
+  - **PR1 self-test** — 메인 Claude 가 §7 매트릭스 만 보고 8 loop 모두 task 리스트 + advance enum reconstruct 가능한지 (skill 안 보고). 실패 시 §7 보강 후 PR2 진입.
+  - **review 자동 트리거 v2** — `--auto-review` stdout 폭증 시 후속 Task 로 `--brief` mode 옵션 검토.
+
 ### DCN-CHG-20260430-26
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/dcness-guidelines.md
+++ b/docs/process/dcness-guidelines.md
@@ -4,6 +4,12 @@
 > 룰 추가 시 본 파일에만 append — skill 들은 cross-ref 만.
 > Task-ID: DCN-CHG-20260430-26 (SSOT 분리 + hook inject).
 
+## 0. 루프 실행 절차 SSOT — `docs/loop-procedure.md` (DCN-30-27)
+
+dcness 의 8 loop 공통 실행 절차 (Step 0~8 — worktree / begin-run / TaskCreate / agent 호출 / Step 4.5 stories sync / finalize-run / clean 7a / caveat 7b / auto-review) 는 [`docs/loop-procedure.md`](../loop-procedure.md) 단일 SSOT. **본 가이드라인이 inject 되는 매 세션에서 메인 Claude 는 본 항을 통해 loop-procedure.md 를 의무 read** — skill 트리거 또는 직접 발화 시 동일.
+
+skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure.md.
+
 ## 1. 가시성 룰 (DCN-30-15) — MUST
 
 매 Agent 호출 후 메인이 prose 5~12줄 의무 echo. 의무 템플릿:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260430-27
+- **Date**: 2026-04-30
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/loop-procedure.md` (신규, 252 줄) — dcness 8 loop 의 공통 *실행 절차* SSOT. Step 0 worktree+begin-run / Step 1 TaskCreate / Step 2~N agent 호출 골격 (begin-step → Agent → prose-staging Write → end-step → echo → TaskUpdate) / Step 4.5 stories.md/backlog.md sync (impl 계열) / Step 7 finalize-run --auto-review + clean 매트릭스 + 7a/7b commit-PR / Step 8 review 결과 인지. §7 = `loop × step` 매트릭스 (8 행 × 7 컬럼). 8 loop name 확정: `feature-build-loop` / `impl-batch-loop` / `impl-ui-design-loop` / `quick-bugfix-loop` / `qa-triage` / `ux-design-stage` / `ux-refine-stage` / `direct-impl-loop`.
+  - `docs/process/dcness-guidelines.md` — §0 신설 (loop-procedure.md cross-ref + 의무 read 명시). SessionStart 훅이 guidelines.md inject 시 메인 Claude 가 자동으로 loop-procedure.md 도 인지.
+  - `docs/orchestration.md` §3 헤더 — loop-procedure.md §1~§7 cross-ref + 8 loop name 매핑 (§3.1↔feature-build-loop 등) 추가. §3 = *시퀀스* (what), loop-procedure §7 = *실행 매트릭스* (how) 1:1.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: skill 5종 (`commands/{qa,quick,impl,impl-loop,product-plan}.md`) 이 Step 0~7 *실행 절차* 를 통째로 중복 보유 (100~215줄) — /run-review 같은 새 룰 도입 시 5 군데 동시 수정 = 중복 누적. 사용자 아키텍처 의도: skill = 트리거 + 인풋 정형화, 메인 Claude = SSOT 보고 동적 Task 구성. 본 PR (3 PR migration 의 1단계) = 절차 SSOT 신설 + 진입점 cross-ref. PR2 (`harness/session_state.py --auto-review` + qa.md slim pilot), PR3 (4 skill bulk slim) 후속.
+
 ### DCN-CHG-20260430-26
 - **Date**: 2026-04-30
 - **Change-Type**: spec, hooks


### PR DESCRIPTION
## Summary

skill 5종 (`commands/{qa,quick,impl,impl-loop,product-plan}.md`) 의 Step 0~7 *실행 절차* 중복을 풀어내는 **3 PR migration 의 1단계** — 절차 SSOT 신설 + 진입점 cross-ref.

## 변경

- **신설** `docs/loop-procedure.md` (252 줄) — 8 loop 공통 실행 절차 SSOT.
  - Step 0 (worktree + begin-run)
  - Step 1 (TaskCreate)
  - Step 2~N (begin-step → Agent → prose-staging Write → end-step → echo → TaskUpdate)
  - Step 4.5 (stories.md / backlog.md sync — impl 계열)
  - Step 7 (finalize-run --auto-review + clean 매트릭스 + 7a 자동 commit/PR / 7b caveat)
  - Step 8 (review 결과 인지)
  - **§7 매트릭스** = 8 loop × 7 컬럼 (entry_point / task_list / agent_sequence / advance / clean_enum / branch_prefix / expected_steps)
- **`docs/process/dcness-guidelines.md`** §0 신설 — SessionStart inject 시 loop-procedure.md 의무 read 명시.
- **`docs/orchestration.md`** §3 헤더 — 8 loop name (`feature-build-loop` / `impl-batch-loop` / `impl-ui-design-loop` / `quick-bugfix-loop` / `qa-triage` / `ux-design-stage` / `ux-refine-stage` / `direct-impl-loop`) 매핑 + loop-procedure.md cross-ref.

## 8 loop name 확정

| loop | section |
|---|---|
| `feature-build-loop` | §3.1 |
| `impl-batch-loop` | §2.1 |
| `impl-ui-design-loop` | §2.2 |
| `quick-bugfix-loop` | §3.5 |
| `qa-triage` | §3.6 |
| `ux-design-stage` | §3.2 |
| `ux-refine-stage` | §3.3 |
| `direct-impl-loop` | §3.4 |

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (5 files / docs-only)
- [x] `python3 -m unittest discover -s tests` — 216 ran, 2 pre-existing flaky 무관
- [ ] **self-test (수동 검증)**: 메인 Claude 가 §7 매트릭스만 보고 8 loop 의 task 리스트 + advance enum + clean 조건 reconstruct 가능한지 확인. PR2 진입 *전* 보강 필요한 행 식별.

## 후속 PR

- **PR2** (DCN-CHG-20260430-28 예정) — `harness/session_state.py:_cli_finalize_run --auto-review` flag + `tests/test_session_state.py` wiring 케이스 + `commands/qa.md` slim pilot.
- **PR3** (DCN-CHG-20260430-29 예정) — `commands/{quick,impl,impl-loop,product-plan}.md` bulk slim.

## drift mitigation

- `docs/orchestration.md` §3 (시퀀스 카탈로그) ↔ `docs/loop-procedure.md` §7 (실행 매트릭스) 1:1 강제.
- governance §2.2 doc-sync gate 가 양쪽 동시 update 의무.

🤖 Generated with [Claude Code](https://claude.com/claude-code)