### PR TITLE
docs: §7 매트릭스 행별 풀스펙 보강 (DCN-CHG-20260430-28)

### DIFF
--- a/docs/loop-procedure.md
+++ b/docs/loop-procedure.md
@@ -217,26 +217,210 @@ review_main 실패 (예외) 시 helper stderr WARN — STATUS JSON 자체는 정
 
 ---
 
-## 7. Loop × Step 매트릭스 (핵심)
+## 7. Loop × Step 매트릭스 (인덱스 + 행별 풀스펙)
 
-8 loop × 7 컬럼. **메인 Claude 가 진입 시 본 표 행 보고 §1~§5 mechanics dynamic 구성**.
+§7.0 = 한눈 인덱스 (6 컬럼). 각 loop 의 **풀스펙** (allowed_enums / sub_cycles / 분기 / 4.5 sync 적용 / branch decision rule) 은 §7.1~§7.8 행별 sub-section 참조. **메인 Claude 가 진입 시 인덱스 → 해당 sub-section 까지 read 의무**.
 
-| loop | entry_point | task_list (Step 1) | agent_sequence | advance / clean_enum | branch_prefix | expected_steps |
-|------|-------------|--------------------|----------------|----------------------|---------------|----------------|
-| `feature-build-loop` (§3.1) | `product-plan` | product-planner / plan-reviewer / ux-architect:UX_FLOW / validator:UX_VALIDATION / architect:SYSTEM_DESIGN / validator:DESIGN_VALIDATION / architect:TASK_DECOMPOSE | 7 step | `PRODUCT_PLAN_READY` → `PLAN_REVIEW_PASS` → `UX_FLOW_READY` → `PASS` → `SYSTEM_DESIGN_READY` → `DESIGN_REVIEW_PASS` → `READY_FOR_IMPL` | (commit X — spec/design 종료) | 7 |
-| `impl-batch-loop` (§2.1) | `impl` | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | 5 step | `READY_FOR_IMPL` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | `feat/<batch-slug>` 또는 `chore/<batch-slug>` | 5 |
-| `impl-ui-design-loop` (§2.2) | `impl` (UI 감지) | architect:MODULE_PLAN / designer + design-critic THREE_WAY / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | 6+ step | `READY_FOR_IMPL` → `VARIANTS_APPROVED` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | `feat/<batch-slug>` | 6 |
-| `quick-bugfix-loop` (§3.5) | `quick` | qa / architect:LIGHT_PLAN / engineer:IMPL / validator:BUGFIX_VALIDATION / pr-reviewer | 5 step | qa ∈ {`FUNCTIONAL_BUG`,`CLEANUP`} → `LIGHT_PLAN_READY` → `IMPL_DONE` → `PASS` → `LGTM` | `fix/<slug>` (FUNCTIONAL_BUG) 또는 `chore/<slug>` (CLEANUP) | 5 |
-| `qa-triage` (§3.6) | `qa` | qa | 1 step | qa ∈ 5 enum (FUNCTIONAL_BUG/CLEANUP/DESIGN_ISSUE/KNOWN_ISSUE/SCOPE_ESCALATE) — advance X, 라우팅 추천 후 종료 | (commit X) | 1 |
-| `ux-design-stage` (§3.2) | `ux` | ux-architect:UX_FLOW / designer | 2 step | `UX_FLOW_READY` → `DESIGN_READY_FOR_REVIEW` | (commit X — design handoff) | 2 |
-| `ux-refine-stage` (§3.3) | `ux` (REFINE) | ux-architect:UX_REFINE / designer:SCREEN | 2 step | `UX_REFINE_READY` → `DESIGN_READY_FOR_REVIEW` | (commit X) | 2 |
-| `direct-impl-loop` (§3.4) | `impl_driver` (future) | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | 5 step | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | 5 |
+### 7.0 한눈 인덱스
 
-### 7.1 다중 batch chain (`impl-loop`)
+| loop | entry_point | task_list (Step 1) | advance | clean_enum | expected_steps |
+|------|-------------|--------------------|---------|------------|----------------|
+| `feature-build-loop` (§3.1, §7.1) | `product-plan` | product-planner / plan-reviewer / ux-architect:UX_FLOW / validator:UX_VALIDATION / architect:SYSTEM_DESIGN / validator:DESIGN_VALIDATION / architect:TASK_DECOMPOSE | `PRODUCT_PLAN_READY` → `PLAN_REVIEW_PASS` → `UX_FLOW_READY` → `PASS` → `SYSTEM_DESIGN_READY` → `DESIGN_REVIEW_PASS` → `READY_FOR_IMPL` | advance 동일 | 7 |
+| `impl-batch-loop` (§2.1, §7.2) | `impl` | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | `READY_FOR_IMPL` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 5 |
+| `impl-ui-design-loop` (§2.2, §7.3) | `impl` (UI 감지) | architect:MODULE_PLAN / designer / design-critic / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | `READY_FOR_IMPL` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 7 |
+| `quick-bugfix-loop` (§3.5, §7.4) | `quick` | qa / architect:LIGHT_PLAN / engineer:IMPL / validator:BUGFIX_VALIDATION / pr-reviewer | `FUNCTIONAL_BUG`/`CLEANUP` → `LIGHT_PLAN_READY` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 5 |
+| `qa-triage` (§3.6, §7.5) | `qa` | qa | (5 enum 모두 — 라우팅 추천) | advance 개념 X | 1 |
+| `ux-design-stage` (§3.2, §7.6) | `ux` | ux-architect:UX_FLOW / designer:SCREEN(THREE_WAY) / design-critic | `UX_FLOW_READY` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` | advance 동일 | 3 |
+| `ux-refine-stage` (§3.3, §7.7) | `ux` (REFINE) | ux-architect:UX_REFINE / designer:SCREEN(THREE_WAY) / design-critic | `UX_REFINE_READY` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` | advance 동일 | 3 |
+| `direct-impl-loop` (§3.4, §7.8) | `impl_driver` (future) | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | 5 |
+
+### 7.1 `feature-build-loop` 풀스펙
+
+**branch_prefix**: commit X (spec/design 종료, 구현 진입은 별도 루프).
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums** (`end-step --allowed-enums`):
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | product-planner | `PRODUCT_PLAN_READY,CLARITY_INSUFFICIENT,PRODUCT_PLAN_CHANGE_DIFF,PRODUCT_PLAN_UPDATED,ISSUES_SYNCED` |
+| 3 | plan-reviewer | `PLAN_REVIEW_PASS,PLAN_REVIEW_CHANGES_REQUESTED` |
+| 4 | ux-architect:UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` |
+| 5 | validator:UX_VALIDATION | `PASS,FAIL` |
+| 6 | architect:SYSTEM_DESIGN | `SYSTEM_DESIGN_READY` |
+| 6.5 | validator:DESIGN_VALIDATION | `DESIGN_REVIEW_PASS,DESIGN_REVIEW_FAIL,DESIGN_REVIEW_ESCALATE` |
+| 7 | architect:TASK_DECOMPOSE | `READY_FOR_IMPL` |
+
+**분기**:
+- `PRODUCT_PLAN_UPDATED` → plan-reviewer skip + ux-architect 직행 (이전 PLAN_REVIEW_PASS 활용)
+- `PRODUCT_PLAN_CHANGE_DIFF` → plan-reviewer 변경분만 재심사
+- `CLARITY_INSUFFICIENT` → 사용자 역질문 후 product-planner 재호출
+- `ISSUES_SYNCED` → 동기화 완료, 종료
+- `PLAN_REVIEW_CHANGES_REQUESTED` → product-planner 재진입 (cycle ≤ 2)
+- `UX_REFINE_READY` → designer SCREEN 분기 (ux-design-stage 또는 ux-refine-stage 진입 권장)
+- `UX_FLOW_ESCALATE` → 사용자 위임
+- validator UX `FAIL` → ux-architect 재진입 (cycle ≤ 2)
+- `DESIGN_REVIEW_FAIL` → architect:SYSTEM_DESIGN 재진입 (cycle ≤ 2)
+- `DESIGN_REVIEW_ESCALATE` → 사용자 위임
+
+**sub_cycles**: 위 분기에서 재호출 시 step 이름 컨벤션 = `<agent>-RETRY-<n>` (별도 begin/end-step 1쌍, DCN-30-25).
+
+### 7.2 `impl-batch-loop` 풀스펙
+
+**branch_prefix decision rule**:
+- batch 내 신규 기능 (src 신규 파일 또는 인터페이스 추가) → `feat/<batch-slug>`
+- 리팩토링 / 정리 / 테스트 보강 only → `chore/<batch-slug>`
+- 버그픽스 (의도 vs 실제 격차 수정) → `fix/<batch-slug>`
+- 메인 Claude 가 batch 의 ## 변경 요약 / engineer prose 보고 결정.
+
+**Step 4.5 적용**: ✓ (engineer `IMPL_DONE` 직후, validator 진입 *전* — §4 참조).
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | architect:MODULE_PLAN | `READY_FOR_IMPL,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` |
+| 3 | test-engineer | `TESTS_WRITTEN,SPEC_GAP_FOUND` |
+| 4 | engineer:IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` |
+| 5 | validator:CODE_VALIDATION | `PASS,FAIL,SPEC_MISSING` |
+| 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
+
+**분기**:
+- `SPEC_GAP_FOUND` → architect:SPEC_GAP cycle (≤ 2) → engineer 재진입
+- `TESTS_FAIL` → engineer:IMPL-RETRY-<n> (attempt < 3, cycle 초과 → `IMPLEMENTATION_ESCALATE`)
+- `SPEC_MISSING` → architect:SPEC_GAP
+- `TECH_CONSTRAINT_CONFLICT` / `IMPLEMENTATION_ESCALATE` → 사용자 위임
+- `CHANGES_REQUESTED` → engineer:POLISH-<n> cycle (≤ 2)
+- `validator:FAIL` → engineer:IMPL-RETRY-<n>
+
+**sub_cycles**:
+- `architect:SPEC_GAP` (engineer/test-engineer SPEC_GAP_FOUND 시) — allowed_enums = `SPEC_GAP_RESOLVED,PRODUCT_PLANNER_ESCALATION_NEEDED,TECH_CONSTRAINT_CONFLICT`
+- `engineer:POLISH-<n>` (CHANGES_REQUESTED 시, ≤ 2) — allowed_enums = `POLISH_DONE,IMPLEMENTATION_ESCALATE`
+- `engineer:IMPL-RETRY-<n>` (TESTS_FAIL/FAIL 시, attempt < 3) — allowed_enums = engineer:IMPL 동일
+
+**state-aware skip** (DCN-CHG-30-13): batch 파일 끝에 `MODULE_PLAN_READY` 마커 박혀있으면 Step 2 (architect:MODULE_PLAN) skip — TaskUpdate completed("skipped") + prose 종이는 batch 파일 자체를 `<RUN_DIR>/architect-MODULE_PLAN.md` 로 복사. catastrophic 룰 §2.3.3 통과용.
+
+### 7.3 `impl-ui-design-loop` 풀스펙
+
+**branch_prefix decision rule**: `impl-batch-loop` 와 동일 (`feat` / `chore` / `fix`).
+**Step 4.5 적용**: ✓ (engineer `IMPL_DONE` 직후).
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | architect:MODULE_PLAN | `impl-batch-loop` 동일 |
+| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
+| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
+| 5 | test-engineer | `impl-batch-loop` 동일 |
+| 6 | engineer:IMPL | `impl-batch-loop` 동일 |
+| 7 | validator:CODE_VALIDATION | `impl-batch-loop` 동일 |
+| 8 | pr-reviewer | `impl-batch-loop` 동일 |
+
+**분기**:
+- `VARIANTS_ALL_REJECTED` → designer:SCREEN 재호출 (round < 3)
+- `UX_REDESIGN_SHORTLIST` → ux-architect:UX_REFINE (round ≥ 3, ux-refine-stage 진입)
+- `DESIGN_LOOP_ESCALATE` → 사용자 위임
+- 나머지 = `impl-batch-loop` 분기 동일
+
+**sub_cycles**: `impl-batch-loop` 동일 + `designer:SCREEN-ROUND-<n>` (variants 재생성, round < 3).
+
+### 7.4 `quick-bugfix-loop` 풀스펙
+
+**branch_prefix decision rule**:
+- qa enum `FUNCTIONAL_BUG` → `fix/<slug>`
+- qa enum `CLEANUP` → `chore/<slug>`
+- 그 외 → 자동 진행 X (라우팅 추천 후 종료)
+
+**Step 4.5 적용**: △ (light path — stories.md 갱신은 사용자 결정. backlog 변경 X).
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | qa | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` |
+| 3 | architect:LIGHT_PLAN | `LIGHT_PLAN_READY,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` |
+| 4 | engineer:IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` |
+| 5 | validator:BUGFIX_VALIDATION | `PASS,FAIL` |
+| 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
+
+**qa 분기**:
+- `DESIGN_ISSUE` → 종료 + ux-design-stage 추천 (구현 후)
+- `KNOWN_ISSUE` → 종료
+- `SCOPE_ESCALATE` → 사용자 위임 (분류 모호)
+
+**sub_cycles**: `impl-batch-loop` 와 동일 (`SPEC_GAP` / `POLISH` / `IMPL-RETRY`). test-engineer 단계가 없으므로 TESTS_FAIL 은 engineer 자체 검증 실패 의미.
+
+### 7.5 `qa-triage` 풀스펙
+
+**branch_prefix**: commit X (분류만, 코드 변경 X).
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | qa | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` |
+
+**enum 별 라우팅 추천** (advance 개념 없음 — 메인이 사용자 결정 받음):
+- `FUNCTIONAL_BUG` → `quick-bugfix-loop` (`/quick`) 또는 `impl-batch-loop`
+- `CLEANUP` → `quick-bugfix-loop` (`/quick`) 또는 engineer 직접
+- `DESIGN_ISSUE` → `ux-design-stage` (`/ux`) 또는 designer 직접
+- `KNOWN_ISSUE` → 종료
+- `SCOPE_ESCALATE` → 사용자 위임 (큰 변경 / 다중 모듈)
+
+**sub_cycles**: 없음. AMBIGUOUS 시 guidelines §6 cascade.
+
+### 7.6 `ux-design-stage` 풀스펙
+
+**branch_prefix**: commit X (design handoff, 코드 X).
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | ux-architect:UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` |
+| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
+| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
+
+**designer mode**: THREE_WAY 권장 (3 variant + critic 심사). 사용자 발화에 "한 안만" / "ONE" 키워드 시 ONE_WAY (allowed_enums = `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE`, design-critic 단계 제거 → expected_steps = 2).
+
+**분기**:
+- `VARIANTS_APPROVED` → 사용자 PICK 1개 (메인이 사용자에게 variant 번호 받음) → DESIGN_HANDOFF 패키지 출력 → 종료
+- `VARIANTS_ALL_REJECTED` → designer 재호출 (round < 3)
+- `UX_REDESIGN_SHORTLIST` → ux-refine-stage 진입
+- `UX_REFINE_READY` (ux-architect) → ux-refine-stage 진입
+- `DESIGN_LOOP_ESCALATE` / `UX_FLOW_ESCALATE` → 사용자 위임
+
+**sub_cycles**: `designer:SCREEN-ROUND-<n>` (round < 3).
+
+### 7.7 `ux-refine-stage` 풀스펙
+
+**branch_prefix**: commit X.
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | ux-architect:UX_REFINE | `UX_REFINE_READY,UX_FLOW_ESCALATE` |
+| 2.5 | (사용자 승인) | — (메인이 사용자에게 ux refine 결과 검토 요청. 거절 시 ux-architect 재호출) |
+| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
+| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
+
+**designer mode**: ux-design-stage 와 동일 (THREE_WAY 권장 / "한 안만" 시 ONE_WAY).
+
+**Step 2.5 — 사용자 승인**: ux-architect UX_REFINE_READY 후 designer 진입 *전* 메인이 사용자에게 refine 결과 prose 발췌 + 진행 여부 확인. 사용자 거절 시 ux-architect 재호출 (cycle ≤ 2). step 컨벤션 = `user-approval-2.5` (helper begin/end-step 비대상 — 사용자 단계).
+
+**분기**: `ux-design-stage` 와 동일.
+
+### 7.8 `direct-impl-loop` 풀스펙
+
+`impl-batch-loop` 와 100% 동일. 차이점:
+- entry_point = `impl_driver` CLI (현재 미구현, 후속 Task 예정)
+- 사용자 batch 경로 직접 명시 (skill UI 없음)
+
+allowed_enums / 분기 / sub_cycles / branch_prefix decision rule / Step 4.5 = `impl-batch-loop` (§7.2) 인용.
+
+### 7.9 다중 batch chain (`impl-loop`)
 
 `/impl-loop` = `impl-batch-loop` × N. outer task `impl-<i>: <batch>` + inner 5 sub-task `b<i>.<agent>` (DCN-CHG-30-12). 각 batch clean → 자동 7a + 다음 batch. caveat → 멈춤 + 사용자 위임 (Step 2.5 — `commands/impl-loop.md` 참조).
 
-### 7.2 catastrophic 룰 정합
+### 7.10 catastrophic 룰 정합
 
 [`orchestration.md`](orchestration.md) §2.3 4룰 + §7.1 HARNESS_ONLY_AGENTS = `hooks/catastrophic-gate.sh` 강제. 본 SSOT 의 각 loop sequence 가 이 룰 자연 충족 (validator → pr-reviewer 직전 PASS / engineer 직전 plan READY / TASK_DECOMPOSE 직전 DESIGN_REVIEW_PASS / PRD 변경 후 plan-reviewer + ux-architect 검토).
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,35 @@
 
 ## Records
 
+### DCN-CHG-20260430-28
+- **Date**: 2026-04-30
+- **Rationale**:
+  - PR1 (DCN-30-27 — loop-procedure.md SSOT 신설) 머지 후 self-test 진행. 메인 Claude 가 §7 매트릭스만 보고 8 loop reconstruct 가능한지 확인.
+  - **Gap 발견** (4 loop + 공통 4):
+    - `feature-build-loop` 분기 (PRODUCT_PLAN_UPDATED skip / UX_REFINE_READY / CLARITY_INSUFFICIENT) 매트릭스에 없음
+    - `impl-ui-design-loop` task 모호 — designer + design-critic 가 1 step 인지 2 step 인지 불명, DESIGN_LOOP_ESCALATE 분기 없음
+    - `ux-design-stage` designer mode (ONE/THREE_WAY) / 사용자 PICK 단계 미명시
+    - `ux-refine-stage` 사용자 승인 단계 (§3.3 mini-graph 에 있음) 매트릭스에 없음
+    - 공통: `allowed_enums` full set / `branch_prefix` decision rule (impl-batch-loop feat vs chore 분기 기준) / sub_cycle agent (SPEC_GAP / POLISH / IMPL-RETRY / SCREEN-ROUND) / Step 4.5 적용 여부 컬럼 부재
+  - 사용자 의도: skill 슬림화 후 메인 Claude 가 §7 만 보고 task 동적 구성. baseline reconstruct 가능해도 분기 / sub_cycle 부족하면 실전 운영에서 매번 commands/<skill>.md 또는 orchestration.md §3 / §4 cross-ref 필요 → 슬림화 효과 ↓.
+- **Alternatives**:
+  1. **(채택) Option A — §7 매트릭스 보강 후 PR3 진입**. 매트릭스를 §7.0 인덱스 (간소) + §7.1~§7.8 행별 풀스펙 sub-section 으로 재구조화. 가독성 ↑ + reconstruct 100%.
+  2. *Option B — 매트릭스 그대로 두고 cross-ref 강화*. §7 행마다 "분기 details = §3.3 / §4.X" link 박음. 가벼움. 단 메인 Claude 가 cross-ref 따라가는 부담 ↑ → 슬림화 의도 약화.
+  3. *Option C — 현 상태로 PR2 (qa.md pilot) 진행*. PR2 자체는 가장 단순한 loop (qa-triage 1 step) — 즉시 가능. 단 PR3 진입 *전* 보강 필요 = 결국 미루기. 기각.
+- **Decision**:
+  - Option A 채택 (사용자 명시 컨펌).
+  - **§7 재구조화**:
+    - §7.0 인덱스: 8 loop × 6 컬럼 (loop / entry_point / task_list / advance / clean_enum / expected_steps). 한눈 인지용.
+    - §7.1~§7.8 행별 풀스펙: 각 loop 별 sub-section. 컬럼 = `branch_prefix` / `Step 4.5 적용` / Step 별 `allowed_enums` 표 / 분기 표 / sub_cycles 표.
+    - §7.9 = `impl-loop` multi-batch chain
+    - §7.10 = catastrophic 룰 정합
+  - **Migration Plan 갱신**: PR2 (현재) = §7 보강. PR3 (-29) = `--auto-review` flag + qa.md slim. PR4 (-30) = 4 skill bulk slim. 총 4 PR.
+- **Follow-Up**:
+  - **PR3 (DCN-CHG-20260430-29 예정)**: `harness/session_state.py:_cli_finalize_run --auto-review` flag + tests + `commands/qa.md` slim pilot.
+  - **PR4 (DCN-CHG-20260430-30 예정)**: 4 skill bulk slim.
+  - **drift 가드**: §7.0 인덱스 ↔ §7.1~§7.8 sub-section 행 수 1:1 강제. 행 추가 시 sub-section 추가 의무. cross-ref drift = doc-sync gate 자동 검출 X (수동) — 후속 PR 에서 sanity check script 검토.
+  - **잠재 미흡 부분 모니터링**: ONE_WAY 키워드 트리거 룰 (사용자 발화 어떤 keyword 포함 시?), Step 2.5 사용자 승인 helper 처리 (begin/end-step 비대상 명시 — driver 도입 시 review).
+
 ### DCN-CHG-20260430-27
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,23 @@
 
 ## Records
 
+### DCN-CHG-20260430-28
+- **Date**: 2026-04-30
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/loop-procedure.md` — §7 매트릭스 보강. 252 → 436 줄. PR1 self-test 에서 발견된 gap 반영:
+    - §7.0 인덱스 (한눈) 6 컬럼만
+    - §7.1~§7.8 행별 풀스펙 sub-section 8 개 — Step 별 `allowed_enums` 표 / 분기 / sub_cycles / branch_prefix decision rule / Step 4.5 적용 여부 명시
+    - feature-build-loop §7.1 분기 (PRODUCT_PLAN_UPDATED skip / UX_REFINE_READY / CLARITY_INSUFFICIENT 등) 명시
+    - impl-ui-design-loop §7.3 design-critic 별도 step 으로 분리 + DESIGN_LOOP_ESCALATE / VARIANTS_ALL_REJECTED 분기
+    - ux-design-stage §7.6 / ux-refine-stage §7.7 designer mode (THREE_WAY 권장 / 키워드 ONE_WAY) + 사용자 PICK / Step 2.5 사용자 승인 명시
+    - impl-batch-loop §7.2 state-aware skip (DCN-30-13 MODULE_PLAN_READY 마커) 보존
+    - sub_cycle agent (architect:SPEC_GAP / engineer:POLISH-<n> / engineer:IMPL-RETRY-<n> / designer:SCREEN-ROUND-<n>) allowed_enums 명시
+    - branch_prefix decision rule (impl-batch-loop = feat/chore/fix 결정 기준 / quick-bugfix-loop = qa enum 기반) 명시
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: PR1 (DCN-30-27) self-test 결과 — §7 매트릭스 baseline reconstruct 가능하나 분기 / sub-cycle / allowed_enums full set / branch decision rule 디테일 부족. 사용자 결정 (Option A — 보강 후 PR2 진행) 따라 매트릭스를 §7.0 인덱스 + §7.1~§7.8 행별 풀스펙 으로 재구조화. PR3 (--auto-review + qa.md slim pilot) / PR4 (4 skill bulk slim) 진입 전 SSOT self-sufficiency 확보.
+
 ### DCN-CHG-20260430-27
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only


### PR DESCRIPTION
## Summary

PR1 (#68, DCN-30-27) self-test 결과 반영. baseline reconstruct 가능했으나 분기 / sub-cycle / `allowed_enums` full set / `branch_prefix` decision rule 디테일 부족. PR3 (--auto-review + qa.md slim pilot) 진입 *전* SSOT self-sufficiency 확보.

## Self-test 발견 gap

### 4 loop 디테일 부족
- **`feature-build-loop`** — `PRODUCT_PLAN_UPDATED` skip / `UX_REFINE_READY` / `CLARITY_INSUFFICIENT` 등 분기 매트릭스에 없음
- **`impl-ui-design-loop`** — designer + design-critic 가 1 step 인지 2 step 인지 불명, `DESIGN_LOOP_ESCALATE` / `VARIANTS_ALL_REJECTED` 분기 없음
- **`ux-design-stage`** — designer mode (ONE/THREE_WAY) / 사용자 PICK 단계 미명시
- **`ux-refine-stage`** — §3.3 mini-graph 의 사용자 승인 단계 매트릭스에 없음

### 공통 4 gap
- `allowed_enums` full set (advance + escalate enum) 매트릭스에 advance 만
- `branch_prefix` decision rule (impl-batch-loop feat vs chore 결정 기준)
- sub_cycle agent (`SPEC_GAP` / `POLISH-<n>` / `IMPL-RETRY-<n>` / `SCREEN-ROUND-<n>`)
- Step 4.5 stories sync 적용 여부 컬럼

## 변경

`docs/loop-procedure.md` 252 → 436 줄 (+184 줄):

- **§7.0 인덱스 (한눈, 6 컬럼)** — loop / entry_point / task_list / advance / clean_enum / expected_steps
- **§7.1~§7.8 행별 풀스펙** — 각 loop 별 sub-section
  - `branch_prefix` decision rule
  - `Step 4.5 적용` 여부
  - Step 별 `allowed_enums` 표 (helper `end-step --allowed-enums "<csv>"` 호출용)
  - 분기 표 (escalate / retry / sub-cycle 진입 조건)
  - sub_cycle agent 별 allowed_enums (POLISH / SPEC_GAP / RETRY)
- **§7.9** — `impl-loop` multi-batch chain
- **§7.10** — catastrophic 룰 정합

## Migration Plan 갱신

| # | Task-ID | 변경 |
|---|---|---|
| PR1 ✅ | DCN-30-27 | loop-procedure.md SSOT 신설 |
| **PR2 (본 PR)** | **DCN-30-28** | **§7 매트릭스 보강** |
| PR3 | DCN-30-29 | `--auto-review` flag + tests + qa.md slim pilot |
| PR4 | DCN-30-30 | 4 skill bulk slim (quick / impl / impl-loop / product-plan) |

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (3 files / docs-only)
- [x] `python3 -m unittest discover -s tests` — 216 ran (2 pre-existing flaky 무관)
- [x] **self-test pass 2**: §7.0 인덱스 + §7.1~§7.8 sub-section 으로 8 loop 모두 reconstruct 가능 확인 (allowed_enums / 분기 / sub_cycle / branch decision rule 모두 명시)

## drift 가드

§7.0 행 수 (8) ↔ §7.1~§7.8 sub-section 수 (8) 1:1 강제. 행 추가 시 sub-section 추가 의무.

🤖 Generated with [Claude Code](https://claude.com/claude-code)