### PR TITLE
feat: helper finalize-run --auto-review + qa.md slim pilot (DCN-CHG-20260430-29)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,24 @@
 
 ## 현재 상태
 
+- **🔌 helper finalize-run --auto-review + qa.md slim pilot** (`DCN-CHG-20260430-29`):
+  - 4 PR migration (skill 슬림화 + procedure SSOT) 의 PR3.
+  - `harness/session_state.py:_cli_finalize_run` 에 `--auto-review` flag 추가. STATUS JSON 출력 직후 in-process 로 `harness.run_review.main(["--run-id", rid, "--repo", cwd])` 호출. 메인 Claude 가 finalize-run 부르면 review 자동 piggy-back — 의도적 skip 불가.
+  - 실패 케이스 (review_main 예외) 안전망 — `AUTO_REVIEW_FAIL` stderr WARN + STATUS JSON 자체는 정상 출력 + exit 0.
+  - `commands/qa.md` slim pilot — 127줄 → 28줄 (78% 절감). `qa-triage` loop / Inputs / 후속 라우팅 추천만. 절차는 [`docs/loop-procedure.md`](docs/loop-procedure.md) §1~§6 + §7.5 cross-ref.
+  - `tests/test_session_state.py` 3 신규 (`auto_review_chains_report` / `skip_on_failure` / `off_no_chain`) PASS. 219 ran / 217 PASS / 2 pre-existing flaky 무관.
+  - PR4 후속 — 4 skill (quick / impl / impl-loop / product-plan) bulk slim.
+- **📐 loop-procedure.md §7 매트릭스 행별 풀스펙 보강** (`DCN-CHG-20260430-28`):
+  - PR1 (DCN-30-27) self-test gap 반영. §7.0 한눈 인덱스 + §7.1~§7.8 행별 풀스펙 sub-section. 각 행 = `branch_prefix` decision rule / `Step 4.5 적용` / Step 별 `allowed_enums` 표 / 분기 표 / sub_cycles. 252줄 → 436줄.
+  - feature-build-loop 분기 (PRODUCT_PLAN_UPDATED skip / UX_REFINE_READY / CLARITY_INSUFFICIENT 등) 명시.
+  - impl-ui-design-loop design-critic 별도 step 분리 + DESIGN_LOOP_ESCALATE / VARIANTS_ALL_REJECTED 분기.
+  - ux-design-stage / ux-refine-stage designer mode (THREE_WAY 권장) + 사용자 PICK / Step 2.5 사용자 승인.
+  - sub_cycle agent (architect:SPEC_GAP / engineer:POLISH-<n> / engineer:IMPL-RETRY-<n> / designer:SCREEN-ROUND-<n>) allowed_enums 명시.
+- **📑 loop-procedure.md SSOT 신설 + cross-ref** (`DCN-CHG-20260430-27`):
+  - skill 5종 Step 0~7 *실행 절차* 중복 (100~215줄/skill) 풀어내는 4 PR migration 의 1단계.
+  - `docs/loop-procedure.md` (252줄) — 8 loop 공통 실행 절차 SSOT (Step 0 worktree+begin-run / Step 1 TaskCreate / Step 2~N agent 호출 / Step 4.5 stories sync / Step 7 finalize-run+clean+commit-PR / Step 8 review).
+  - 8 loop name 확정: `feature-build-loop` / `impl-batch-loop` / `impl-ui-design-loop` / `quick-bugfix-loop` / `qa-triage` / `ux-design-stage` / `ux-refine-stage` / `direct-impl-loop`.
+  - `docs/process/dcness-guidelines.md` §0 cross-ref + 의무 read 명시. `docs/orchestration.md` §3 헤더 8 loop name 매핑.
 - **📜 dcness-guidelines.md SSOT + SessionStart 훅 inject** (`DCN-CHG-20260430-26`):
   - 사용자 지적 — quick.md (light path 전용) 에 범용 룰 다 박혀 책임 혼재. + 미래 추가 룰 (Epic/Story 분할, 커스텀 루프) SSOT 필요.
   - `docs/process/dcness-guidelines.md` (신규) — 11 섹션 (가시성 / Step 기록 / **/run-review 의무 (신규)** / **결과 출력 룰 (신규)** / yolo / AMBIGUOUS / worktree / TBD 분할 기준 / TBD 커스텀 루프 / 권한 요청 / Karpathy 참조).

--- a/commands/qa.md
+++ b/commands/qa.md
@@ -1,127 +1,28 @@
 ---
 name: qa
-description: 버그/이슈를 자연어로 받아 qa 에이전트로 분류하고 다음 액션을 추천하는 스킬. 사용자가 "버그 있다", "이슈", "이상해", "안 돼", "오류", "@qa", "QA", "큐에이" 등의 표현을 쓸 때 반드시 이 스킬을 사용한다. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 분류 결과 (FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 에 따라 후속 skill 추천.
-
+description: 버그/이슈를 자연어로 받아 qa 에이전트로 분류하고 다음 액션을 추천하는 스킬. 사용자가 "버그 있다", "이슈", "이상해", "안 돼", "오류", "@qa", "QA", "큐에이" 등의 표현을 쓸 때 반드시 이 스킬을 사용한다. 분류 결과 (FUNCTIONAL_BUG / CLEANUP / DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 에 따라 후속 skill 추천.
 ---
 
-# QA Skill — 버그/이슈 분류 + 라우팅 추천
+# QA Skill
 
-> 공통 룰 (가시성 / AMBIGUOUS / Catastrophic) SSOT = `commands/quick.md`. qa agent 호출 → enum 추출 → 결과 보고. 후속 skill 자동 진입 X.
+## Loop
+`qa-triage` ([orchestration.md §3.6](../docs/orchestration.md) / [loop-procedure.md §7.5](../docs/loop-procedure.md)).
 
-## 사용
+## Inputs (메인이 사용자에게 받아야 할 정보)
+- 이슈 제목 / 발화
+- 재현 조건 (있으면)
+- 화면·기능 / 예상 vs 실제 / 에러 메시지
 
-- 트리거: "버그", "이슈", "이상해", "안 돼", "오류", "에러", "@qa", "QA"
-- 비대상: 한 줄 수정 명확 → `/quick` · 새 기능 → `/product-plan` · 디자인 → `/ux`
+명확화 안 되면 분석 시작 X (대기). qa agent 호출 *전* 위 항목 확보.
 
-## 절차
-
-### Step 0 — run 시작
-
-```bash
-HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run qa)
-echo "[qa] run started: $RUN_ID"
-```
-
-`begin-run` 동작: sid auto-detect (PPID + by-pid) · run_id 생성 · `live.json.active_runs` 슬롯 + `.by-pid-current-run/{cc_pid}` 박음.
-
-### Step 1 — Task 등록
-
-```
-TaskCreate("qa: 이슈 분류")
-```
-
-### Step 2 — 입력 명확화 (필요 시)
-
-agent 호출 전 다음 모호 시 역질문: 재현 조건 / 화면·기능 / 예상 vs 실제 / 에러 메시지 / 발생 범위. 명확화 안 되면 분석 시작 X (대기).
-
-### Step 3 — qa Agent 호출 + enum 추출
-
-```
-TaskUpdate("qa: 이슈 분류", in_progress)
-"$HELPER" begin-step qa
-Agent(subagent_type="qa", description="<사용자 발화 + 명확화 컨텍스트>")
-```
-
-prose 받으면 (DCN-30-21: prose-file 위치를 run-dir 안 격리 dir 로 — `/tmp` 세션 격리 X 결함 fix):
-```bash
-RUN_DIR=$("$HELPER" run-dir)
-mkdir -p "$RUN_DIR/.prose-staging"
-PROSE_PATH="$RUN_DIR/.prose-staging/qa.md"
-
-cat > "$PROSE_PATH" << 'PROSE_EOF'
-<agent prose 본문>
-PROSE_EOF
-
-ENUM=$("$HELPER" end-step qa \
-       --allowed-enums "FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE" \
-       --prose-file "$PROSE_PATH")
-echo "[qa] classification: $ENUM"
-```
-
-`end-step` 동작: prose `.sessions/{sid}/runs/{rid}/qa.md` atomic write · `interpret_with_fallback` (heuristic-only, no haiku — DCN-CHG-30-04) · stdout = enum 또는 `AMBIGUOUS`.
-
-가시성 룰 의무 echo (commands/quick.md 의무 템플릿).
-
-### Step 4 — AMBIGUOUS cascade
-
-`commands/quick.md` SSOT 와 동일:
-1. **재호출 1회** — 결론 enum 명시 요청
-2. **재호출도 AMBIGUOUS** → 사용자 위임:
-
-```
-qa 가 결론을 명확히 안 적었습니다. 본문 발췌:
-   <prose tail>
-
-다음 중 어느 분류로 진행할까요?
-1) FUNCTIONAL_BUG  (기능 버그 — impl 루프)
-2) CLEANUP         (코드 정리 — impl 루프 light)
-3) DESIGN_ISSUE    (디자인 이슈 — designer)
-4) KNOWN_ISSUE    (이미 알려진 — 종료)
-5) SCOPE_ESCALATE  (분류 모호 — 사용자 결정)
-6) 종료
-```
-
-### Step 5 — 결과 보고 + 라우팅 추천
-
-```
-TaskUpdate("qa: 이슈 분류", completed)
-```
-
-```
-[qa 분류 결과] $ENUM
-prose 종이: .claude/harness-state/.sessions/{sid}/runs/{rid}/qa.md
-
-다음 추천:
-- FUNCTIONAL_BUG → /quick 또는 architect LIGHT_PLAN 직접
-- CLEANUP        → /quick 또는 engineer 직접
-- DESIGN_ISSUE   → /ux 또는 designer 직접
-- KNOWN_ISSUE    → 종료
-- SCOPE_ESCALATE → 사용자 결정 필요
-
-진행할까요? 사용자 결정 대기.
-```
+## 후속 라우팅 추천 (qa enum 별)
+- `FUNCTIONAL_BUG` → `quick-bugfix-loop` (`/quick`) 또는 `impl-batch-loop` (`/impl`)
+- `CLEANUP` → `quick-bugfix-loop` (`/quick`) 또는 engineer 직접
+- `DESIGN_ISSUE` → `ux-design-stage` (`/ux` 또는 designer 직접)
+- `KNOWN_ISSUE` → 종료
+- `SCOPE_ESCALATE` → 사용자 위임 (큰 변경 / 다중 모듈)
 
 후속 skill 자동 진입 X — 사용자 결정.
 
-### Step 6 — run 종료
-
-후속 진행 → run 유지. 종료 → `"$HELPER" end-run` (live.json 의 `completed_at` 채움 + `.by-pid-current-run/{cc_pid}` 삭제).
-
-## Catastrophic 룰 정합
-
-qa 는 HARNESS_ONLY_AGENTS 미해당 — run 컨텍스트 없어도 호출 가능. §2.3 4룰 모두 qa 무관 → catastrophic-gate.sh 자동 통과.
-
-## 한계
-
-- 후속 skill 자동 진입 X (사용자 결정)
-- 재현 검증 X — 다음 단계 (engineer/designer) 책임
-- 휴리스틱 fail rate `.metrics/heuristic-calls.jsonl` 누적 — 30%+ 면 agent prose writing guide 정정
-
-## 참조
-
-- `agents/qa.md` (5 결론 enum 출처)
-- `docs/orchestration.md` §3.6 / §4.11
-- `docs/conveyor-design.md` §2 / §3 / §7
-- `harness/session_state.py` (begin-run / begin-step / end-step / end-run)
-- `commands/quick.md` (가시성 / AMBIGUOUS cascade SSOT)
+## 절차
+[`docs/loop-procedure.md`](../docs/loop-procedure.md) §1~§6 + §7.5 (`qa-triage` 풀스펙) 따름. 본 파일은 input 명세 + 라우팅 추천만.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,28 @@
 
 ## Records
 
+### DCN-CHG-20260430-29
+- **Date**: 2026-04-30
+- **Rationale**:
+  - PR1/PR2 (DCN-30-27/28) 로 loop-procedure.md SSOT + §7 풀스펙 매트릭스 확보. 이제 skill 슬림화 + helper 단 자동 트리거 도입 차례.
+  - **`/run-review` 자동 호출 mechanical 강제 필요** — DCN-30-26 에서 dcness-guidelines.md §3 에 "루프 종료 시 의무" 박았으나 directive 일 뿐. 메인 Claude 가 finalize-run 끝나고 commit/PR 하느라 review 호출 잊는 회귀 (DCN-30-26 직전 사례) 우려.
+  - **skill 슬림화 pilot 필요** — PR4 에서 4 skill bulk slim 전, 가장 단순한 1 skill 로 새 SSOT (loop-procedure.md §7) cross-ref 만으로 동작 가능 입증. /qa = qa-triage 1 step → 가장 단순.
+- **Alternatives**:
+  1. *옵션 A — skill prompt 에 `/run-review` 호출 inline*. PR1 분석에서 사용자 reject ("스킬에 왜 범용적인걸 넣어"). 4 skill 동시 변경 = 중복 누적. 기각.
+  2. *옵션 B — SessionEnd 훅 자동 fire*. cross-session run false positive 우려 + 훅 stdout transcript 미진입. 기각 (PR1 plan 단계 동일 결정).
+  3. **(채택) 옵션 C — helper `finalize-run --auto-review` flag (in-process)**. STATUS JSON + review 리포트 한 stdout 에 chained. 메인이 finalize-run 부르면 자동 piggy-back. 의도적 skip 불가 + Bash collapsed 보호 (메인이 가시성 §4 룰대로 character-for-character echo).
+  4. *옵션 D — `dcness-helper` wrapper 가 finalize-run 호출 후 `dcness-review` subprocess 실행*. process 분리 → import 의존 0. 단 stdout 합치기 시 buffering 이슈 우려 + 추가 wrapper 복잡도. 기각.
+- **Decision**:
+  - **옵션 C 채택**.
+  - `_cli_finalize_run` 안에서 `from harness import run_review as _rv; _rv.main(...)` lazy import. argparse `SystemExit` 안전 처리 (정상 흐름 미지장).
+  - 실패 안전망: 모든 `Exception` (SystemExit 제외) → stderr `AUTO_REVIEW_FAIL` WARN, STATUS JSON 보존, exit 0. review 실패가 finalize 자체를 깨트리지 않음.
+  - **qa.md slim pilot**: 127줄 → 28줄. frontmatter / Loop / Inputs / 후속 라우팅 추천 / 절차 cross-ref 의 5 절. helper 호출 / TaskCreate / begin-step / end-step / prose-staging / finalize-run / 7a / 7b 모든 mechanics 제거 — 절차는 loop-procedure.md §7.5 단일 source.
+- **Follow-Up**:
+  - **PR4 (DCN-CHG-20260430-30 예정)** — 4 skill bulk slim (quick / impl / impl-loop / product-plan).
+  - **--auto-review 가시성 검증** — qa pilot E2E 시 stdout 양 확인. review 리포트 폭증 (수백줄) 시 후속 Task 로 `--brief` mode 옵션.
+  - **finalize-run 호출 자체 mechanical 강제는 별도** — 메인이 finalize-run 부르는 step 7 자체를 skip 하는 회귀는 본 PR 으로 해결 X. SessionEnd 훅 또는 Stop 훅 안전망은 후속 검토 (현재는 메인 신뢰).
+  - **drift 모니터링** — qa pilot 진입 시 메인이 loop-procedure.md §7.5 만 보고 mechanics 모두 reconstruct 가능한지 jajang 재install 후 실측.
+
 ### DCN-CHG-20260430-28
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260430-29
+- **Date**: 2026-04-30
+- **Change-Type**: harness, agent, test
+- **Files Changed**:
+  - `harness/session_state.py:_cli_finalize_run` — `--auto-review` flag 추가. STATUS JSON 출력 직후 in-process 로 `harness.run_review.main(["--run-id", rid, "--repo", str(Path.cwd())])` 호출. 출력 = STATUS JSON + 빈 줄 + `--- /run-review (auto) ---` divider + run-review 리포트 chained. 실패 시 (`SystemExit` 제외 모든 예외) `AUTO_REVIEW_FAIL` stderr WARN + STATUS JSON 정상 출력 + exit 0.
+  - `harness/session_state.py:_build_arg_parser` — `finalize-run` 서브커맨드에 `--auto-review` action="store_true" argparse 추가.
+  - `commands/qa.md` — slim pilot. 127줄 → 28줄 (78% 절감). `qa-triage` loop 매핑 / Inputs (이슈 제목 / 재현 / 화면·기능 / 예상 vs 실제 / 에러) / 후속 라우팅 추천 5 enum. 절차는 [`docs/loop-procedure.md`](../docs/loop-procedure.md) §1~§6 + §7.5 cross-ref.
+  - `tests/test_session_state.py` — 3 신규 케이스 (`test_finalize_run_auto_review_chains_report` / `test_finalize_run_auto_review_skip_on_failure` / `test_finalize_run_auto_review_off_no_chain`). `unittest.mock.patch` 으로 `harness.run_review.main` 가짜화. 219 ran / 217 PASS / 2 pre-existing flaky 무관.
+  - `PROGRESS.md` — 본 항목 + DCN-30-28/27 백 entries 갱신.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 4 PR migration (skill 슬림화 + procedure SSOT) 의 PR3. helper 단에서 review 자동 piggy-back 하도록 `--auto-review` flag 신설 — 메인 Claude 가 finalize-run 부르면 review skip 불가. qa.md = 가장 단순한 loop (`qa-triage` 1 step) pilot 으로 새 SSOT (loop-procedure.md §7.5) 만 cross-ref 해서 동작 가능 입증. PR4 (DCN-30-30) 에서 나머지 4 skill bulk slim 진입.
+
 ### DCN-CHG-20260430-28
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1213,6 +1213,26 @@ def _cli_finalize_run(args: Any) -> int:
         "step_count": len(steps),
     }
     print(json.dumps(payload, ensure_ascii=False, indent=2))
+
+    # DCN-CHG-20260430-29: --auto-review flag — in-process /run-review chained.
+    # 메인 Claude 가 finalize-run 호출만 하면 review 자동 piggy-back. 의도적 skip 불가.
+    # SessionEnd 훅 reject (cross-session run false positive 우려).
+    if getattr(args, "auto_review", False):
+        print()
+        print("--- /run-review (auto) ---")
+        try:
+            from harness import run_review as _rv  # lazy import (test mock 용이)
+            _rv.main(["--run-id", rid, "--repo", str(Path.cwd())])
+        except SystemExit:
+            # argparse sys.exit — 정상 케이스. 무시.
+            pass
+        except Exception as exc:
+            print(
+                f"[session_state] AUTO_REVIEW_FAIL — {type(exc).__name__}: {exc}. "
+                f"수동 `dcness-review --run-id {rid}` 1회 재시도 권장.",
+                file=sys.stderr,
+            )
+
     return 0
 
 
@@ -1366,6 +1386,11 @@ def _build_arg_parser() -> Any:
         type=int,
         default=None,
         help="정상 시퀀스 step 수 (예: /impl 5). 미만이면 stderr WARN (DCN-30-25)",
+    )
+    p_fr.add_argument(
+        "--auto-review",
+        action="store_true",
+        help="finalize 직후 in-process 로 /run-review 호출 — STATUS JSON 뒤에 chained (DCN-30-29)",
     )
     p_fr.set_defaults(func=_cli_finalize_run)
 

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -881,6 +881,83 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertNotIn("STEP COUNT WARN", err.getvalue())
 
+    def test_finalize_run_auto_review_chains_report(self) -> None:
+        # DCN-30-29: --auto-review 시 STATUS JSON 뒤에 run-review 호출 chained.
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest.mock import patch
+
+        called = {"argv": None}
+
+        def fake_main(argv):
+            called["argv"] = list(argv)
+            print("[fake-review] OK")
+            return 0
+
+        err = StringIO()
+        out = StringIO()
+        with patch("harness.run_review.main", side_effect=fake_main):
+            with redirect_stderr(err), redirect_stdout(out):
+                rc = ss._cli_finalize_run(SimpleNamespace(
+                    expected_steps=None, auto_review=True,
+                ))
+        self.assertEqual(rc, 0)
+        stdout_val = out.getvalue()
+        self.assertIn("\"run_id\"", stdout_val)  # STATUS JSON 정상
+        self.assertIn("--- /run-review (auto) ---", stdout_val)
+        self.assertIn("[fake-review] OK", stdout_val)
+        self.assertEqual(called["argv"][:2], ["--run-id", self.rid])
+
+    def test_finalize_run_auto_review_skip_on_failure(self) -> None:
+        # DCN-30-29: review_main 예외 시 STATUS 정상 + stderr WARN, exit 0.
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest.mock import patch
+
+        def boom(argv):
+            raise RuntimeError("boom")
+
+        err = StringIO()
+        out = StringIO()
+        with patch("harness.run_review.main", side_effect=boom):
+            with redirect_stderr(err), redirect_stdout(out):
+                rc = ss._cli_finalize_run(SimpleNamespace(
+                    expected_steps=None, auto_review=True,
+                ))
+        self.assertEqual(rc, 0)
+        self.assertIn("\"run_id\"", out.getvalue())  # STATUS JSON 정상
+        self.assertIn("AUTO_REVIEW_FAIL", err.getvalue())
+        self.assertIn("RuntimeError", err.getvalue())
+
+    def test_finalize_run_auto_review_off_no_chain(self) -> None:
+        # --auto-review 미지정 시 review 호출 안 함 (기존 동작 보존).
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest.mock import patch
+
+        called = {"hit": False}
+
+        def should_not(argv):
+            called["hit"] = True
+            return 0
+
+        err = StringIO()
+        out = StringIO()
+        with patch("harness.run_review.main", side_effect=should_not):
+            with redirect_stderr(err), redirect_stdout(out):
+                rc = ss._cli_finalize_run(SimpleNamespace(
+                    expected_steps=None, auto_review=False,
+                ))
+        self.assertEqual(rc, 0)
+        self.assertFalse(called["hit"])
+        self.assertNotIn("/run-review (auto)", out.getvalue())
+
     def test_end_step_writes_prose_and_extracts_enum(self) -> None:
         from harness.session_state import _cli_end_step, session_dir
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary

4 PR migration (skill 슬림화 + procedure SSOT) 의 **PR3**. helper 단 `--auto-review` 자동 트리거 + qa.md 첫 슬림화 pilot.

## 변경

### helper (harness/session_state.py)
- `_cli_finalize_run` 에 `--auto-review` flag (action=store_true)
- STATUS JSON 출력 직후 in-process 로 `harness.run_review.main(["--run-id", rid, "--repo", str(Path.cwd())])` 호출
- 출력: STATUS JSON + 빈 줄 + `--- /run-review (auto) ---` divider + run-review 리포트 chained
- 실패 안전망: 모든 `Exception` (SystemExit 제외) → stderr `AUTO_REVIEW_FAIL` WARN + STATUS JSON 보존 + exit 0

### qa.md slim pilot (127 → 28줄, 78% 절감)
- frontmatter / Loop / Inputs / 후속 라우팅 추천 / 절차 cross-ref 5절
- 모든 mechanics 제거 — `docs/loop-procedure.md` §7.5 (qa-triage 풀스펙) 단일 source

### tests
- `test_finalize_run_auto_review_chains_report` — STATUS JSON + run-review 리포트 stdout chained 확인
- `test_finalize_run_auto_review_skip_on_failure` — review_main 예외 시 STATUS 정상 + WARN
- `test_finalize_run_auto_review_off_no_chain` — flag 미지정 시 review 호출 안 함 (backward compat)

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (6 files / docs-only, harness, test)
- [x] `python3 -m unittest discover -s tests` — 219 ran / 217 PASS / 2 pre-existing flaky 무관
- [x] 신규 3 테스트 모두 PASS

## Migration Plan

| # | Task-ID | 상태 |
|---|---|---|
| PR1 ✅ | DCN-30-27 | loop-procedure.md SSOT 신설 |
| PR2 ✅ | DCN-30-28 | §7 매트릭스 행별 풀스펙 보강 |
| **PR3 (본 PR)** | **DCN-30-29** | **--auto-review flag + qa.md slim pilot** |
| PR4 | DCN-30-30 | 4 skill bulk slim |

🤖 Generated with [Claude Code](https://claude.com/claude-code)