### PR TITLE
docs: loop-procedure.md split + 300줄 cap 룰 (DCN-CHG-20260430-30)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,13 @@
 
 ## 현재 상태
 
+- **✂️ loop-procedure.md split + 300줄 cap 룰 신설** (`DCN-CHG-20260430-30`):
+  - 사용자 지시 — "loop-procedure.md 쪼개자 가급적 300라인 넘기지 말랬잖아 행동지침 md는 이것도 룰로 적어놔줘". loop-procedure.md (436줄) cap 위반.
+  - **`docs/loop-catalog.md` 신규** (239줄) — 8 loop 행별 풀스펙 (allowed_enums / 분기 / sub_cycles / branch_prefix). loop-procedure.md §7.0 인덱스 + §7.1~§7.10 풀스펙 모두 이전.
+  - **`docs/loop-procedure.md` 슬림** (436 → 242줄) — Step 0~8 mechanics 만 보존. §7 = catalog cross-ref + catastrophic 룰 정합 1 항목.
+  - **`docs/process/dcness-guidelines.md` §0 갱신** — 2 SSOT 분담 (procedure + catalog) 명시. §0.1 신설 — **행동지침 md 300줄 cap 룰** (대상 / 대상 외 / Why / How to apply / 현재 알려진 위반).
+  - **`docs/orchestration.md` §3 헤더** — loop-catalog.md cross-ref 추가.
+  - **알려진 위반**: orchestration.md (540줄). split 후속 별도 Task-ID 예정.
 - **🔌 helper finalize-run --auto-review + qa.md slim pilot** (`DCN-CHG-20260430-29`):
   - 4 PR migration (skill 슬림화 + procedure SSOT) 의 PR3.
   - `harness/session_state.py:_cli_finalize_run` 에 `--auto-review` flag 추가. STATUS JSON 출력 직후 in-process 로 `harness.run_review.main(["--run-id", rid, "--repo", cwd])` 호출. 메인 Claude 가 finalize-run 부르면 review 자동 piggy-back — 의도적 skip 불가.

--- a/docs/loop-catalog.md
+++ b/docs/loop-catalog.md
@@ -1,0 +1,239 @@
+# Loop Catalog (8 loop × 컬럼 풀스펙)
+
+> **Status**: ACTIVE
+> **Origin**: `DCN-CHG-20260430-30` (loop-procedure.md split)
+> **Scope**: dcness 8 loop 의 *행별 풀스펙* SSOT. 각 loop 의 entry_point / task_list / advance / clean_enum / branch_prefix / Step 4.5 적용 / Step 별 allowed_enums / 분기 / sub_cycles 단일 source.
+> **Cross-ref**: 실행 절차 (Step 0~8 mechanics) = [`loop-procedure.md`](loop-procedure.md). 시퀀스 mini-graph + 결정표 = [`orchestration.md`](orchestration.md) §2~§7.
+
+---
+
+## 1. 한눈 인덱스
+
+| loop | entry_point | task_list (Step 1) | advance | clean_enum | expected_steps |
+|------|-------------|--------------------|---------|------------|----------------|
+| `feature-build-loop` (§3.1, §2) | `product-plan` | product-planner / plan-reviewer / ux-architect:UX_FLOW / validator:UX_VALIDATION / architect:SYSTEM_DESIGN / validator:DESIGN_VALIDATION / architect:TASK_DECOMPOSE | `PRODUCT_PLAN_READY` → `PLAN_REVIEW_PASS` → `UX_FLOW_READY` → `PASS` → `SYSTEM_DESIGN_READY` → `DESIGN_REVIEW_PASS` → `READY_FOR_IMPL` | advance 동일 | 7 |
+| `impl-batch-loop` (§2.1, §3) | `impl` | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | `READY_FOR_IMPL` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 5 |
+| `impl-ui-design-loop` (§2.2, §4) | `impl` (UI 감지) | architect:MODULE_PLAN / designer / design-critic / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | `READY_FOR_IMPL` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 7 |
+| `quick-bugfix-loop` (§3.5, §5) | `quick` | qa / architect:LIGHT_PLAN / engineer:IMPL / validator:BUGFIX_VALIDATION / pr-reviewer | `FUNCTIONAL_BUG`/`CLEANUP` → `LIGHT_PLAN_READY` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 5 |
+| `qa-triage` (§3.6, §6) | `qa` | qa | (5 enum 모두 — 라우팅 추천) | advance 개념 X | 1 |
+| `ux-design-stage` (§3.2, §7) | `ux` | ux-architect:UX_FLOW / designer:SCREEN(THREE_WAY) / design-critic | `UX_FLOW_READY` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` | advance 동일 | 3 |
+| `ux-refine-stage` (§3.3, §8) | `ux` (REFINE) | ux-architect:UX_REFINE / designer:SCREEN(THREE_WAY) / design-critic | `UX_REFINE_READY` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` | advance 동일 | 3 |
+| `direct-impl-loop` (§3.4, §9) | `impl_driver` (future) | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | 5 |
+
+§3.X = orchestration.md mini-graph 행. §N = 본 문서 행별 풀스펙.
+
+---
+
+## 2. `feature-build-loop` 풀스펙
+
+**branch_prefix**: commit X (spec/design 종료, 구현 진입은 별도 루프).
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums** (`end-step --allowed-enums`):
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | product-planner | `PRODUCT_PLAN_READY,CLARITY_INSUFFICIENT,PRODUCT_PLAN_CHANGE_DIFF,PRODUCT_PLAN_UPDATED,ISSUES_SYNCED` |
+| 3 | plan-reviewer | `PLAN_REVIEW_PASS,PLAN_REVIEW_CHANGES_REQUESTED` |
+| 4 | ux-architect:UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` |
+| 5 | validator:UX_VALIDATION | `PASS,FAIL` |
+| 6 | architect:SYSTEM_DESIGN | `SYSTEM_DESIGN_READY` |
+| 6.5 | validator:DESIGN_VALIDATION | `DESIGN_REVIEW_PASS,DESIGN_REVIEW_FAIL,DESIGN_REVIEW_ESCALATE` |
+| 7 | architect:TASK_DECOMPOSE | `READY_FOR_IMPL` |
+
+**분기**:
+- `PRODUCT_PLAN_UPDATED` → plan-reviewer skip + ux-architect 직행 (이전 PLAN_REVIEW_PASS 활용)
+- `PRODUCT_PLAN_CHANGE_DIFF` → plan-reviewer 변경분만 재심사
+- `CLARITY_INSUFFICIENT` → 사용자 역질문 후 product-planner 재호출
+- `ISSUES_SYNCED` → 동기화 완료, 종료
+- `PLAN_REVIEW_CHANGES_REQUESTED` → product-planner 재진입 (cycle ≤ 2)
+- `UX_REFINE_READY` → designer SCREEN 분기 (ux-design-stage 또는 ux-refine-stage 진입 권장)
+- `UX_FLOW_ESCALATE` → 사용자 위임
+- validator UX `FAIL` → ux-architect 재진입 (cycle ≤ 2)
+- `DESIGN_REVIEW_FAIL` → architect:SYSTEM_DESIGN 재진입 (cycle ≤ 2)
+- `DESIGN_REVIEW_ESCALATE` → 사용자 위임
+
+**sub_cycles**: 위 분기에서 재호출 시 step 이름 컨벤션 = `<agent>-RETRY-<n>` (별도 begin/end-step 1쌍, DCN-30-25).
+
+---
+
+## 3. `impl-batch-loop` 풀스펙
+
+**branch_prefix decision rule**:
+- batch 내 신규 기능 (src 신규 파일 또는 인터페이스 추가) → `feat/<batch-slug>`
+- 리팩토링 / 정리 / 테스트 보강 only → `chore/<batch-slug>`
+- 버그픽스 (의도 vs 실제 격차 수정) → `fix/<batch-slug>`
+- 메인 Claude 가 batch 의 ## 변경 요약 / engineer prose 보고 결정.
+
+**Step 4.5 적용**: ✓ (engineer `IMPL_DONE` 직후, validator 진입 *전* — `loop-procedure.md` §4 참조).
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | architect:MODULE_PLAN | `READY_FOR_IMPL,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` |
+| 3 | test-engineer | `TESTS_WRITTEN,SPEC_GAP_FOUND` |
+| 4 | engineer:IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` |
+| 5 | validator:CODE_VALIDATION | `PASS,FAIL,SPEC_MISSING` |
+| 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
+
+**분기**:
+- `SPEC_GAP_FOUND` → architect:SPEC_GAP cycle (≤ 2) → engineer 재진입
+- `TESTS_FAIL` → engineer:IMPL-RETRY-<n> (attempt < 3, cycle 초과 → `IMPLEMENTATION_ESCALATE`)
+- `SPEC_MISSING` → architect:SPEC_GAP
+- `TECH_CONSTRAINT_CONFLICT` / `IMPLEMENTATION_ESCALATE` → 사용자 위임
+- `CHANGES_REQUESTED` → engineer:POLISH-<n> cycle (≤ 2)
+- `validator:FAIL` → engineer:IMPL-RETRY-<n>
+
+**sub_cycles**:
+- `architect:SPEC_GAP` (engineer/test-engineer SPEC_GAP_FOUND 시) — allowed_enums = `SPEC_GAP_RESOLVED,PRODUCT_PLANNER_ESCALATION_NEEDED,TECH_CONSTRAINT_CONFLICT`
+- `engineer:POLISH-<n>` (CHANGES_REQUESTED 시, ≤ 2) — allowed_enums = `POLISH_DONE,IMPLEMENTATION_ESCALATE`
+- `engineer:IMPL-RETRY-<n>` (TESTS_FAIL/FAIL 시, attempt < 3) — allowed_enums = engineer:IMPL 동일
+
+**state-aware skip** (DCN-CHG-30-13): batch 파일 끝에 `MODULE_PLAN_READY` 마커 박혀있으면 Step 2 (architect:MODULE_PLAN) skip — TaskUpdate completed("skipped") + prose 종이는 batch 파일 자체를 `<RUN_DIR>/architect-MODULE_PLAN.md` 로 복사. catastrophic 룰 §2.3.3 통과용.
+
+---
+
+## 4. `impl-ui-design-loop` 풀스펙
+
+**branch_prefix decision rule**: `impl-batch-loop` 와 동일 (`feat` / `chore` / `fix`).
+**Step 4.5 적용**: ✓ (engineer `IMPL_DONE` 직후).
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | architect:MODULE_PLAN | `impl-batch-loop` 동일 |
+| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
+| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
+| 5 | test-engineer | `impl-batch-loop` 동일 |
+| 6 | engineer:IMPL | `impl-batch-loop` 동일 |
+| 7 | validator:CODE_VALIDATION | `impl-batch-loop` 동일 |
+| 8 | pr-reviewer | `impl-batch-loop` 동일 |
+
+**분기**:
+- `VARIANTS_ALL_REJECTED` → designer:SCREEN 재호출 (round < 3)
+- `UX_REDESIGN_SHORTLIST` → ux-architect:UX_REFINE (round ≥ 3, ux-refine-stage 진입)
+- `DESIGN_LOOP_ESCALATE` → 사용자 위임
+- 나머지 = `impl-batch-loop` 분기 동일
+
+**sub_cycles**: `impl-batch-loop` 동일 + `designer:SCREEN-ROUND-<n>` (variants 재생성, round < 3).
+
+---
+
+## 5. `quick-bugfix-loop` 풀스펙
+
+**branch_prefix decision rule**:
+- qa enum `FUNCTIONAL_BUG` → `fix/<slug>`
+- qa enum `CLEANUP` → `chore/<slug>`
+- 그 외 → 자동 진행 X (라우팅 추천 후 종료)
+
+**Step 4.5 적용**: △ (light path — stories.md 갱신은 사용자 결정. backlog 변경 X).
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | qa | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` |
+| 3 | architect:LIGHT_PLAN | `LIGHT_PLAN_READY,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` |
+| 4 | engineer:IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` |
+| 5 | validator:BUGFIX_VALIDATION | `PASS,FAIL` |
+| 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
+
+**qa 분기**:
+- `DESIGN_ISSUE` → 종료 + ux-design-stage 추천 (구현 후)
+- `KNOWN_ISSUE` → 종료
+- `SCOPE_ESCALATE` → 사용자 위임 (분류 모호)
+
+**sub_cycles**: `impl-batch-loop` 와 동일 (`SPEC_GAP` / `POLISH` / `IMPL-RETRY`). test-engineer 단계가 없으므로 TESTS_FAIL 은 engineer 자체 검증 실패 의미.
+
+---
+
+## 6. `qa-triage` 풀스펙
+
+**branch_prefix**: commit X (분류만, 코드 변경 X).
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | qa | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` |
+
+**enum 별 라우팅 추천** (advance 개념 없음 — 메인이 사용자 결정 받음):
+- `FUNCTIONAL_BUG` → `quick-bugfix-loop` (`/quick`) 또는 `impl-batch-loop`
+- `CLEANUP` → `quick-bugfix-loop` (`/quick`) 또는 engineer 직접
+- `DESIGN_ISSUE` → `ux-design-stage` (`/ux`) 또는 designer 직접
+- `KNOWN_ISSUE` → 종료
+- `SCOPE_ESCALATE` → 사용자 위임 (큰 변경 / 다중 모듈)
+
+**sub_cycles**: 없음. AMBIGUOUS 시 [`process/dcness-guidelines.md`](process/dcness-guidelines.md) §6 cascade.
+
+---
+
+## 7. `ux-design-stage` 풀스펙
+
+**branch_prefix**: commit X (design handoff, 코드 X).
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | ux-architect:UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` |
+| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
+| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
+
+**designer mode**: THREE_WAY 권장 (3 variant + critic 심사). 사용자 발화에 "한 안만" / "ONE" 키워드 시 ONE_WAY (allowed_enums = `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE`, design-critic 단계 제거 → expected_steps = 2).
+
+**분기**:
+- `VARIANTS_APPROVED` → 사용자 PICK 1개 (메인이 사용자에게 variant 번호 받음) → DESIGN_HANDOFF 패키지 출력 → 종료
+- `VARIANTS_ALL_REJECTED` → designer 재호출 (round < 3)
+- `UX_REDESIGN_SHORTLIST` → ux-refine-stage 진입
+- `UX_REFINE_READY` (ux-architect) → ux-refine-stage 진입
+- `DESIGN_LOOP_ESCALATE` / `UX_FLOW_ESCALATE` → 사용자 위임
+
+**sub_cycles**: `designer:SCREEN-ROUND-<n>` (round < 3).
+
+---
+
+## 8. `ux-refine-stage` 풀스펙
+
+**branch_prefix**: commit X.
+**Step 4.5 적용**: X.
+
+**Step 별 allowed_enums**:
+| step | agent[:mode] | allowed_enums |
+|---|---|---|
+| 2 | ux-architect:UX_REFINE | `UX_REFINE_READY,UX_FLOW_ESCALATE` |
+| 2.5 | (사용자 승인) | — (메인이 사용자에게 ux refine 결과 검토 요청. 거절 시 ux-architect 재호출) |
+| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
+| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
+
+**designer mode**: ux-design-stage 와 동일 (THREE_WAY 권장 / "한 안만" 시 ONE_WAY).
+
+**Step 2.5 — 사용자 승인**: ux-architect UX_REFINE_READY 후 designer 진입 *전* 메인이 사용자에게 refine 결과 prose 발췌 + 진행 여부 확인. 사용자 거절 시 ux-architect 재호출 (cycle ≤ 2). step 컨벤션 = `user-approval-2.5` (helper begin/end-step 비대상 — 사용자 단계).
+
+**분기**: `ux-design-stage` 와 동일.
+
+---
+
+## 9. `direct-impl-loop` 풀스펙
+
+`impl-batch-loop` 와 100% 동일. 차이점:
+- entry_point = `impl_driver` CLI (현재 미구현, 후속 Task 예정)
+- 사용자 batch 경로 직접 명시 (skill UI 없음)
+
+allowed_enums / 분기 / sub_cycles / branch_prefix decision rule / Step 4.5 = §3 (`impl-batch-loop`) 인용.
+
+---
+
+## 10. 다중 batch chain (`impl-loop`)
+
+`/impl-loop` = `impl-batch-loop` × N. outer task `impl-<i>: <batch>` + inner 5 sub-task `b<i>.<agent>` (DCN-CHG-30-12). 각 batch clean → 자동 7a + 다음 batch. caveat → 멈춤 + 사용자 위임 (Step 2.5 — `commands/impl-loop.md` 참조).
+
+## 11. catastrophic 룰 정합
+
+[`orchestration.md`](orchestration.md) §2.3 4룰 + §7.1 HARNESS_ONLY_AGENTS = `hooks/catastrophic-gate.sh` 강제. 본 카탈로그의 각 loop sequence 가 이 룰 자연 충족 (validator → pr-reviewer 직전 PASS / engineer 직전 plan READY / TASK_DECOMPOSE 직전 DESIGN_REVIEW_PASS / PRD 변경 후 plan-reviewer + ux-architect 검토).
+
+---
+
+## 12. 참조
+
+- [`loop-procedure.md`](loop-procedure.md) — Step 0~8 mechanics SSOT
+- [`orchestration.md`](orchestration.md) §2~§7 — 시퀀스 mini-graph + 결정표 + retry + escalate + handoff
+- [`process/dcness-guidelines.md`](process/dcness-guidelines.md) — echo / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy

--- a/docs/loop-procedure.md
+++ b/docs/loop-procedure.md
@@ -1,19 +1,19 @@
 # Loop Execution Procedure (메인 Claude 컨베이어 mechanics)
 
 > **Status**: ACTIVE
-> **Origin**: `DCN-CHG-20260430-27`
-> **Scope**: dcness 8 loop 의 *공통 실행 절차* SSOT. 메인 Claude 가 skill 트리거 또는 직접 발화로 루프 시작 시 본 문서를 컨베이어 매뉴얼처럼 따른다.
-> **Cross-ref**: [`orchestration.md`](orchestration.md) §2~§7 (시퀀스 카탈로그 / 결정표 / 권한 매트릭스), [`process/dcness-guidelines.md`](process/dcness-guidelines.md) (echo / yolo / worktree / AMBIGUOUS 등 cross-cutting 룰).
+> **Origin**: `DCN-CHG-20260430-27` (신설), `DCN-CHG-20260430-30` (loop-catalog.md split)
+> **Scope**: dcness 8 loop 의 *공통 실행 절차* SSOT — Step 0~8 mechanics. 메인 Claude 가 skill 트리거 또는 직접 발화로 루프 시작 시 본 문서를 컨베이어 매뉴얼처럼 따른다.
+> **Cross-ref**: 8 loop 별 행별 풀스펙 (allowed_enums / 분기 / sub_cycles / branch_prefix) = [`loop-catalog.md`](loop-catalog.md). 시퀀스 mini-graph + 결정표 = [`orchestration.md`](orchestration.md) §2~§7. cross-cutting 룰 (echo / yolo / worktree / AMBIGUOUS) = [`process/dcness-guidelines.md`](process/dcness-guidelines.md).
 
 ---
 
 ## 0. 진입 모델
 
-skill 트리거 또는 직접 발화 → 메인 Claude 가 **§7 매트릭스** 보고 task 리스트 동적 구성 → §1~§6 mechanics 따름.
+skill 트리거 또는 직접 발화 → 메인 Claude 가 **[`loop-catalog.md`](loop-catalog.md) §1 인덱스 + 해당 loop 풀스펙 sub-section** 보고 task 리스트 동적 구성 → §1~§6 mechanics 따름.
 
-- **skill 경유**: `commands/<skill>.md` 의 `Loop` 필드가 §7 행 가리킴. skill 은 input 정형화 + 라우팅 추천만 — 절차는 본 SSOT.
-- **직접 발화** ("이거 quick 으로 가자"): orchestration.md §3 mini-graph + 본 SSOT §7 보고 메인이 자율 구성. 강제 X.
-- **dcness-guidelines.md (SessionStart inject)**: 본 문서 read 의무 명시. 매 세션 진입 시 메인 자동 인지.
+- **skill 경유**: `commands/<skill>.md` 의 `Loop` 필드가 catalog 행 가리킴. skill 은 input 정형화 + 라우팅 추천만 — 절차는 본 SSOT, loop spec 은 catalog.
+- **직접 발화** ("이거 quick 으로 가자"): orchestration.md §3 mini-graph + catalog §1 인덱스 보고 메인이 자율 구성. 강제 X.
+- **dcness-guidelines.md (SessionStart inject)**: 본 문서 + catalog 모두 read 의무 명시. 매 세션 진입 시 메인 자동 인지.
 
 ---
 
@@ -37,7 +37,7 @@ echo "[<entry>] run started: $RUN_ID"
 
 ## 2. Step 1 — TaskCreate
 
-§7 매트릭스 행의 `task_list` 컬럼대로 일괄 등록. `/impl-loop` inner 의 경우 prefix `b<i>.` 의무 (DCN-CHG-30-12).
+[`loop-catalog.md`](loop-catalog.md) 행의 `task_list` 컬럼대로 일괄 등록. `/impl-loop` inner 의 경우 prefix `b<i>.` 의무 (DCN-CHG-30-12).
 
 ```
 TaskCreate("<agent>: <mode 또는 짧은 설명>")
@@ -79,7 +79,7 @@ TaskUpdate("<task>", completed)
 
 | ENUM | 처리 |
 |------|------|
-| advance enum (§7 행의 `advance` 컬럼) | 다음 step |
+| advance enum (catalog 행의 `advance` 컬럼) | 다음 step |
 | `SPEC_GAP_FOUND` | architect SPEC_GAP cycle (≤2) 또는 사용자 위임 |
 | `TESTS_FAIL` / validator `FAIL` | engineer 재시도 (attempt < 3) |
 | `SPEC_MISSING` | architect SPEC_GAP |
@@ -134,7 +134,7 @@ STATUS=$("$HELPER" finalize-run --expected-steps <N> --auto-review)
 echo "$STATUS"
 ```
 
-`<N>` = §7 매트릭스 `expected_steps` 컬럼. `--auto-review` 가 in-process 로 `harness.run_review` 호출 → review 리포트가 STATUS JSON 뒤에 chained 됨. 메인 Claude 가 guidelines §4 따라 stdout character-for-character echo (Bash collapsed 회피).
+`<N>` = catalog 행 `expected_steps` 컬럼. `--auto-review` 가 in-process 로 `harness.run_review` 호출 → review 리포트가 STATUS JSON 뒤에 chained 됨. 메인 Claude 가 guidelines §4 따라 stdout character-for-character echo (Bash collapsed 회피).
 
 `--auto-review` 생략 시 (사용자 명시 opt-out) — `dcness-review --run-id $RUN_ID --repo $(pwd)` 수동 호출 의무 (guidelines §3).
 
@@ -152,7 +152,7 @@ echo "$STATUS"
 
 다음 모두 충족 → **clean** (자동 7a):
 1. `has_ambiguous == false` && `has_must_fix == false`
-2. step enum 매트릭스: §7 매트릭스 `clean_enum` 컬럼 모두 정합
+2. step enum 매트릭스: catalog 행 `clean_enum` 컬럼 모두 정합
 3. git 안전 가드:
    - `git status --porcelain` 에 `.env` / `secrets.*` / `credentials.*` 없음
    - unstaged + untracked ≤ 10
@@ -168,7 +168,7 @@ clean 아니면 **7b (caveat)**.
 CHANGED=$(git diff --name-only HEAD)
 HAS_REMOTE=$(git remote get-url origin >/dev/null 2>&1 && echo yes || echo no)
 
-BRANCH="<prefix>/<short-slug>"   # prefix = §7 매트릭스
+BRANCH="<prefix>/<short-slug>"   # prefix = catalog 행
 git checkout -b "$BRANCH" main
 git add $CHANGED
 git commit -m "$(cat <<'EOF'
@@ -217,219 +217,25 @@ review_main 실패 (예외) 시 helper stderr WARN — STATUS JSON 자체는 정
 
 ---
 
-## 7. Loop × Step 매트릭스 (인덱스 + 행별 풀스펙)
+## 7. Loop 카탈로그 (cross-ref)
 
-§7.0 = 한눈 인덱스 (6 컬럼). 각 loop 의 **풀스펙** (allowed_enums / sub_cycles / 분기 / 4.5 sync 적용 / branch decision rule) 은 §7.1~§7.8 행별 sub-section 참조. **메인 Claude 가 진입 시 인덱스 → 해당 sub-section 까지 read 의무**.
+8 loop 별 풀스펙 (`entry_point` / `task_list` / `advance` / `clean_enum` / `expected_steps` / `branch_prefix` / Step 별 `allowed_enums` / 분기 / `sub_cycles`) = [`loop-catalog.md`](loop-catalog.md) §1~§9.
 
-### 7.0 한눈 인덱스
+**메인 Claude 진입 시 의무**: catalog §1 인덱스 → 해당 loop sub-section read.
 
-| loop | entry_point | task_list (Step 1) | advance | clean_enum | expected_steps |
-|------|-------------|--------------------|---------|------------|----------------|
-| `feature-build-loop` (§3.1, §7.1) | `product-plan` | product-planner / plan-reviewer / ux-architect:UX_FLOW / validator:UX_VALIDATION / architect:SYSTEM_DESIGN / validator:DESIGN_VALIDATION / architect:TASK_DECOMPOSE | `PRODUCT_PLAN_READY` → `PLAN_REVIEW_PASS` → `UX_FLOW_READY` → `PASS` → `SYSTEM_DESIGN_READY` → `DESIGN_REVIEW_PASS` → `READY_FOR_IMPL` | advance 동일 | 7 |
-| `impl-batch-loop` (§2.1, §7.2) | `impl` | architect:MODULE_PLAN / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | `READY_FOR_IMPL` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 5 |
-| `impl-ui-design-loop` (§2.2, §7.3) | `impl` (UI 감지) | architect:MODULE_PLAN / designer / design-critic / test-engineer / engineer:IMPL / validator:CODE_VALIDATION / pr-reviewer | `READY_FOR_IMPL` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` → `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 7 |
-| `quick-bugfix-loop` (§3.5, §7.4) | `quick` | qa / architect:LIGHT_PLAN / engineer:IMPL / validator:BUGFIX_VALIDATION / pr-reviewer | `FUNCTIONAL_BUG`/`CLEANUP` → `LIGHT_PLAN_READY` → `IMPL_DONE` → `PASS` → `LGTM` | advance 동일 | 5 |
-| `qa-triage` (§3.6, §7.5) | `qa` | qa | (5 enum 모두 — 라우팅 추천) | advance 개념 X | 1 |
-| `ux-design-stage` (§3.2, §7.6) | `ux` | ux-architect:UX_FLOW / designer:SCREEN(THREE_WAY) / design-critic | `UX_FLOW_READY` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` | advance 동일 | 3 |
-| `ux-refine-stage` (§3.3, §7.7) | `ux` (REFINE) | ux-architect:UX_REFINE / designer:SCREEN(THREE_WAY) / design-critic | `UX_REFINE_READY` → `DESIGN_READY_FOR_REVIEW` → `VARIANTS_APPROVED` | advance 동일 | 3 |
-| `direct-impl-loop` (§3.4, §7.8) | `impl_driver` (future) | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | `impl-batch-loop` 동일 | 5 |
+### 7.1 catastrophic 룰 정합
 
-### 7.1 `feature-build-loop` 풀스펙
+[`orchestration.md`](orchestration.md) §2.3 4룰 + §7.1 HARNESS_ONLY_AGENTS = `hooks/catastrophic-gate.sh` 강제. catalog 의 각 loop sequence 가 이 룰 자연 충족 (validator → pr-reviewer 직전 PASS / engineer 직전 plan READY / TASK_DECOMPOSE 직전 DESIGN_REVIEW_PASS / PRD 변경 후 plan-reviewer + ux-architect 검토).
 
-**branch_prefix**: commit X (spec/design 종료, 구현 진입은 별도 루프).
-**Step 4.5 적용**: X.
-
-**Step 별 allowed_enums** (`end-step --allowed-enums`):
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | product-planner | `PRODUCT_PLAN_READY,CLARITY_INSUFFICIENT,PRODUCT_PLAN_CHANGE_DIFF,PRODUCT_PLAN_UPDATED,ISSUES_SYNCED` |
-| 3 | plan-reviewer | `PLAN_REVIEW_PASS,PLAN_REVIEW_CHANGES_REQUESTED` |
-| 4 | ux-architect:UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` |
-| 5 | validator:UX_VALIDATION | `PASS,FAIL` |
-| 6 | architect:SYSTEM_DESIGN | `SYSTEM_DESIGN_READY` |
-| 6.5 | validator:DESIGN_VALIDATION | `DESIGN_REVIEW_PASS,DESIGN_REVIEW_FAIL,DESIGN_REVIEW_ESCALATE` |
-| 7 | architect:TASK_DECOMPOSE | `READY_FOR_IMPL` |
-
-**분기**:
-- `PRODUCT_PLAN_UPDATED` → plan-reviewer skip + ux-architect 직행 (이전 PLAN_REVIEW_PASS 활용)
-- `PRODUCT_PLAN_CHANGE_DIFF` → plan-reviewer 변경분만 재심사
-- `CLARITY_INSUFFICIENT` → 사용자 역질문 후 product-planner 재호출
-- `ISSUES_SYNCED` → 동기화 완료, 종료
-- `PLAN_REVIEW_CHANGES_REQUESTED` → product-planner 재진입 (cycle ≤ 2)
-- `UX_REFINE_READY` → designer SCREEN 분기 (ux-design-stage 또는 ux-refine-stage 진입 권장)
-- `UX_FLOW_ESCALATE` → 사용자 위임
-- validator UX `FAIL` → ux-architect 재진입 (cycle ≤ 2)
-- `DESIGN_REVIEW_FAIL` → architect:SYSTEM_DESIGN 재진입 (cycle ≤ 2)
-- `DESIGN_REVIEW_ESCALATE` → 사용자 위임
-
-**sub_cycles**: 위 분기에서 재호출 시 step 이름 컨벤션 = `<agent>-RETRY-<n>` (별도 begin/end-step 1쌍, DCN-30-25).
-
-### 7.2 `impl-batch-loop` 풀스펙
-
-**branch_prefix decision rule**:
-- batch 내 신규 기능 (src 신규 파일 또는 인터페이스 추가) → `feat/<batch-slug>`
-- 리팩토링 / 정리 / 테스트 보강 only → `chore/<batch-slug>`
-- 버그픽스 (의도 vs 실제 격차 수정) → `fix/<batch-slug>`
-- 메인 Claude 가 batch 의 ## 변경 요약 / engineer prose 보고 결정.
-
-**Step 4.5 적용**: ✓ (engineer `IMPL_DONE` 직후, validator 진입 *전* — §4 참조).
-
-**Step 별 allowed_enums**:
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | architect:MODULE_PLAN | `READY_FOR_IMPL,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` |
-| 3 | test-engineer | `TESTS_WRITTEN,SPEC_GAP_FOUND` |
-| 4 | engineer:IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` |
-| 5 | validator:CODE_VALIDATION | `PASS,FAIL,SPEC_MISSING` |
-| 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
-
-**분기**:
-- `SPEC_GAP_FOUND` → architect:SPEC_GAP cycle (≤ 2) → engineer 재진입
-- `TESTS_FAIL` → engineer:IMPL-RETRY-<n> (attempt < 3, cycle 초과 → `IMPLEMENTATION_ESCALATE`)
-- `SPEC_MISSING` → architect:SPEC_GAP
-- `TECH_CONSTRAINT_CONFLICT` / `IMPLEMENTATION_ESCALATE` → 사용자 위임
-- `CHANGES_REQUESTED` → engineer:POLISH-<n> cycle (≤ 2)
-- `validator:FAIL` → engineer:IMPL-RETRY-<n>
-
-**sub_cycles**:
-- `architect:SPEC_GAP` (engineer/test-engineer SPEC_GAP_FOUND 시) — allowed_enums = `SPEC_GAP_RESOLVED,PRODUCT_PLANNER_ESCALATION_NEEDED,TECH_CONSTRAINT_CONFLICT`
-- `engineer:POLISH-<n>` (CHANGES_REQUESTED 시, ≤ 2) — allowed_enums = `POLISH_DONE,IMPLEMENTATION_ESCALATE`
-- `engineer:IMPL-RETRY-<n>` (TESTS_FAIL/FAIL 시, attempt < 3) — allowed_enums = engineer:IMPL 동일
-
-**state-aware skip** (DCN-CHG-30-13): batch 파일 끝에 `MODULE_PLAN_READY` 마커 박혀있으면 Step 2 (architect:MODULE_PLAN) skip — TaskUpdate completed("skipped") + prose 종이는 batch 파일 자체를 `<RUN_DIR>/architect-MODULE_PLAN.md` 로 복사. catastrophic 룰 §2.3.3 통과용.
-
-### 7.3 `impl-ui-design-loop` 풀스펙
-
-**branch_prefix decision rule**: `impl-batch-loop` 와 동일 (`feat` / `chore` / `fix`).
-**Step 4.5 적용**: ✓ (engineer `IMPL_DONE` 직후).
-
-**Step 별 allowed_enums**:
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | architect:MODULE_PLAN | `impl-batch-loop` 동일 |
-| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
-| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
-| 5 | test-engineer | `impl-batch-loop` 동일 |
-| 6 | engineer:IMPL | `impl-batch-loop` 동일 |
-| 7 | validator:CODE_VALIDATION | `impl-batch-loop` 동일 |
-| 8 | pr-reviewer | `impl-batch-loop` 동일 |
-
-**분기**:
-- `VARIANTS_ALL_REJECTED` → designer:SCREEN 재호출 (round < 3)
-- `UX_REDESIGN_SHORTLIST` → ux-architect:UX_REFINE (round ≥ 3, ux-refine-stage 진입)
-- `DESIGN_LOOP_ESCALATE` → 사용자 위임
-- 나머지 = `impl-batch-loop` 분기 동일
-
-**sub_cycles**: `impl-batch-loop` 동일 + `designer:SCREEN-ROUND-<n>` (variants 재생성, round < 3).
-
-### 7.4 `quick-bugfix-loop` 풀스펙
-
-**branch_prefix decision rule**:
-- qa enum `FUNCTIONAL_BUG` → `fix/<slug>`
-- qa enum `CLEANUP` → `chore/<slug>`
-- 그 외 → 자동 진행 X (라우팅 추천 후 종료)
-
-**Step 4.5 적용**: △ (light path — stories.md 갱신은 사용자 결정. backlog 변경 X).
-
-**Step 별 allowed_enums**:
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | qa | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` |
-| 3 | architect:LIGHT_PLAN | `LIGHT_PLAN_READY,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` |
-| 4 | engineer:IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` |
-| 5 | validator:BUGFIX_VALIDATION | `PASS,FAIL` |
-| 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
-
-**qa 분기**:
-- `DESIGN_ISSUE` → 종료 + ux-design-stage 추천 (구현 후)
-- `KNOWN_ISSUE` → 종료
-- `SCOPE_ESCALATE` → 사용자 위임 (분류 모호)
-
-**sub_cycles**: `impl-batch-loop` 와 동일 (`SPEC_GAP` / `POLISH` / `IMPL-RETRY`). test-engineer 단계가 없으므로 TESTS_FAIL 은 engineer 자체 검증 실패 의미.
-
-### 7.5 `qa-triage` 풀스펙
-
-**branch_prefix**: commit X (분류만, 코드 변경 X).
-**Step 4.5 적용**: X.
-
-**Step 별 allowed_enums**:
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | qa | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` |
-
-**enum 별 라우팅 추천** (advance 개념 없음 — 메인이 사용자 결정 받음):
-- `FUNCTIONAL_BUG` → `quick-bugfix-loop` (`/quick`) 또는 `impl-batch-loop`
-- `CLEANUP` → `quick-bugfix-loop` (`/quick`) 또는 engineer 직접
-- `DESIGN_ISSUE` → `ux-design-stage` (`/ux`) 또는 designer 직접
-- `KNOWN_ISSUE` → 종료
-- `SCOPE_ESCALATE` → 사용자 위임 (큰 변경 / 다중 모듈)
-
-**sub_cycles**: 없음. AMBIGUOUS 시 guidelines §6 cascade.
-
-### 7.6 `ux-design-stage` 풀스펙
-
-**branch_prefix**: commit X (design handoff, 코드 X).
-**Step 4.5 적용**: X.
-
-**Step 별 allowed_enums**:
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | ux-architect:UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` |
-| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
-| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
-
-**designer mode**: THREE_WAY 권장 (3 variant + critic 심사). 사용자 발화에 "한 안만" / "ONE" 키워드 시 ONE_WAY (allowed_enums = `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE`, design-critic 단계 제거 → expected_steps = 2).
-
-**분기**:
-- `VARIANTS_APPROVED` → 사용자 PICK 1개 (메인이 사용자에게 variant 번호 받음) → DESIGN_HANDOFF 패키지 출력 → 종료
-- `VARIANTS_ALL_REJECTED` → designer 재호출 (round < 3)
-- `UX_REDESIGN_SHORTLIST` → ux-refine-stage 진입
-- `UX_REFINE_READY` (ux-architect) → ux-refine-stage 진입
-- `DESIGN_LOOP_ESCALATE` / `UX_FLOW_ESCALATE` → 사용자 위임
-
-**sub_cycles**: `designer:SCREEN-ROUND-<n>` (round < 3).
-
-### 7.7 `ux-refine-stage` 풀스펙
-
-**branch_prefix**: commit X.
-**Step 4.5 적용**: X.
-
-**Step 별 allowed_enums**:
-| step | agent[:mode] | allowed_enums |
-|---|---|---|
-| 2 | ux-architect:UX_REFINE | `UX_REFINE_READY,UX_FLOW_ESCALATE` |
-| 2.5 | (사용자 승인) | — (메인이 사용자에게 ux refine 결과 검토 요청. 거절 시 ux-architect 재호출) |
-| 3 | designer:SCREEN(THREE_WAY) | `DESIGN_READY_FOR_REVIEW,DESIGN_LOOP_ESCALATE` |
-| 4 | design-critic | `VARIANTS_APPROVED,VARIANTS_ALL_REJECTED,UX_REDESIGN_SHORTLIST` |
-
-**designer mode**: ux-design-stage 와 동일 (THREE_WAY 권장 / "한 안만" 시 ONE_WAY).
-
-**Step 2.5 — 사용자 승인**: ux-architect UX_REFINE_READY 후 designer 진입 *전* 메인이 사용자에게 refine 결과 prose 발췌 + 진행 여부 확인. 사용자 거절 시 ux-architect 재호출 (cycle ≤ 2). step 컨벤션 = `user-approval-2.5` (helper begin/end-step 비대상 — 사용자 단계).
-
-**분기**: `ux-design-stage` 와 동일.
-
-### 7.8 `direct-impl-loop` 풀스펙
-
-`impl-batch-loop` 와 100% 동일. 차이점:
-- entry_point = `impl_driver` CLI (현재 미구현, 후속 Task 예정)
-- 사용자 batch 경로 직접 명시 (skill UI 없음)
-
-allowed_enums / 분기 / sub_cycles / branch_prefix decision rule / Step 4.5 = `impl-batch-loop` (§7.2) 인용.
-
-### 7.9 다중 batch chain (`impl-loop`)
-
-`/impl-loop` = `impl-batch-loop` × N. outer task `impl-<i>: <batch>` + inner 5 sub-task `b<i>.<agent>` (DCN-CHG-30-12). 각 batch clean → 자동 7a + 다음 batch. caveat → 멈춤 + 사용자 위임 (Step 2.5 — `commands/impl-loop.md` 참조).
-
-### 7.10 catastrophic 룰 정합
-
-[`orchestration.md`](orchestration.md) §2.3 4룰 + §7.1 HARNESS_ONLY_AGENTS = `hooks/catastrophic-gate.sh` 강제. 본 SSOT 의 각 loop sequence 가 이 룰 자연 충족 (validator → pr-reviewer 직전 PASS / engineer 직전 plan READY / TASK_DECOMPOSE 직전 DESIGN_REVIEW_PASS / PRD 변경 후 plan-reviewer + ux-architect 검토).
+> Note: 이전 §7.0 인덱스 + §7.2~§7.10 행별 풀스펙은 [`loop-catalog.md`](loop-catalog.md) 로 분리 (DCN-CHG-20260430-30 — 행동지침 md 300줄 cap 룰 정합).
 
 ---
 
 ## 8. 참조
 
-- [`orchestration.md`](orchestration.md) §2~§7 — loop 카탈로그 / 결정표 / retry / escalate / handoff
-- [`process/dcness-guidelines.md`](process/dcness-guidelines.md) — echo / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy
+- [`loop-catalog.md`](loop-catalog.md) — 8 loop 행별 풀스펙 (allowed_enums / 분기 / sub_cycles / branch_prefix decision rule)
+- [`orchestration.md`](orchestration.md) §2~§7 — 시퀀스 mini-graph / 결정표 / retry / escalate / handoff
+- [`process/dcness-guidelines.md`](process/dcness-guidelines.md) — echo / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy / 행동지침 md 300줄 cap
 - [`conveyor-design.md`](conveyor-design.md) §2 / §3 / §7 — 컨베이어 디자인 + catastrophic gate
 - `harness/session_state.py` — helper CLI (`begin-run` / `end-run` / `begin-step` / `end-step` / `finalize-run` / `run-dir` / `auto-resolve`)
 - `harness/run_review.py` — review 엔진 (`--auto-review` 호출 대상)

--- a/docs/orchestration.md
+++ b/docs/orchestration.md
@@ -126,8 +126,9 @@ flowchart TD
 ## 3. 진입 경로별 시나리오 (mini graph 6개)
 
 > RWHarness `harness-spec.md` §4.3 의 dcNess 변환.
-> **실행 절차** (Step 0~8 mechanics — begin-run / TaskCreate / agent 호출 / finalize-run / 7a 7b / auto-review) 는 [`loop-procedure.md`](loop-procedure.md) §1~§7 SSOT. 본 §3 = *시퀀스* (what), loop-procedure §7 = *실행 매트릭스* (how) 1:1.
-> 8 loop name (`feature-build-loop` §3.1, `impl-batch-loop` §2.1, `impl-ui-design-loop` §2.2, `quick-bugfix-loop` §3.5, `qa-triage` §3.6, `ux-design-stage` §3.2, `ux-refine-stage` §3.3, `direct-impl-loop` §3.4) — loop-procedure.md §7 매트릭스 행 ID.
+> **실행 절차** (Step 0~8 mechanics — begin-run / TaskCreate / agent 호출 / finalize-run / 7a 7b / auto-review) 는 [`loop-procedure.md`](loop-procedure.md) SSOT.
+> **8 loop 행별 풀스펙** (entry_point / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles) = [`loop-catalog.md`](loop-catalog.md). 본 §3 = *시퀀스 mini-graph* (what), loop-catalog = *행별 풀스펙* (how) 1:1.
+> 8 loop name (`feature-build-loop` §3.1, `impl-batch-loop` §2.1, `impl-ui-design-loop` §2.2, `quick-bugfix-loop` §3.5, `qa-triage` §3.6, `ux-design-stage` §3.2, `ux-refine-stage` §3.3, `direct-impl-loop` §3.4) — loop-catalog 행 ID.
 
 ### 3.1 신규 기능 / PRD 변경
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,28 @@
 
 ## Records
 
+### DCN-CHG-20260430-30
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 사용자 지시 (PR3 작업 중 발화) — "loop-procedure.md 이거 좀 쪼개자 가급적 300라인 넘기지 말랬잖아 행동지침 md는 이것도 룰로 적어놔줘". loop-procedure.md 436줄 = cap 초과. 룰 자체도 dcness-guidelines.md 에 SSOT 화해야 미래 회귀 방지.
+  - 사용자 의도: 행동지침 md (메인/sub-agent 가 결정 시 직접 read 하는 md) 는 토큰 + thinking 시간 부담 ↑ → 300줄 임계 강제. 초과 시 *책임 축* 분리 (단순 복붙 X).
+- **Alternatives**:
+  1. *옵션 1 — loop-procedure.md 전체를 단일 파일 유지 + 사용자에게 "300줄 위반 OK" 요청*. 사용자 지시 거부 = 비대상.
+  2. **(채택) 옵션 2 — procedure (Step 0~8 mechanics) ↔ catalog (8 loop 행별 풀스펙) 책임 축 split**. 자연스러운 분리 (mechanics vs spec). 둘 다 < 300줄.
+  3. *옵션 3 — Step 별 sub-file 8개 (loop-procedure-step-0.md, step-1.md, ...)*. 과도 fragmentation. 메인이 한 루프 reconstruct 위해 8 파일 read = 부담 ↑. 기각.
+  4. *옵션 4 — 행별 sub-file 8개 (loops/feature-build.md, impl-batch.md, ...)*. PR1 plan 단계에서 검토했던 안. 8 파일 = 너무 잘게. 단일 catalog 파일 (옵션 2) 가 보기 좋음.
+- **Decision**:
+  - **옵션 2 채택**.
+  - **`docs/loop-catalog.md` 신규** (239줄) — 8 loop 행별 풀스펙 SSOT. 책임: loop spec.
+  - **`docs/loop-procedure.md` 슬림** (436 → 242줄) — Step 0~8 mechanics 보존. 책임: 절차.
+  - **300줄 cap 룰** = `dcness-guidelines.md` §0.1 신설 — 대상 (skill / agent / loop SSOT / guidelines 자체) / 대상 외 (역사 로그 / spec / proposals / 코드) / Why (토큰 + thinking) / How to apply (모니터링 + split PR + 양방향 cross-ref) / **현재 알려진 위반** (`orchestration.md` 540줄, split 후속 Task-ID 예정 명시).
+  - cross-ref drift 가드: 양 파일 (procedure + catalog) 양방향 link + governance §2.2 doc-sync gate. orchestration.md §3 헤더도 catalog cross-ref 추가.
+- **Follow-Up**:
+  - **PR4 (DCN-CHG-20260430-31 예정)** — 4 skill bulk slim (quick / impl / impl-loop / product-plan). loop-procedure + catalog 2 SSOT cross-ref 만 박는 형태로.
+  - **orchestration.md split (별도 Task-ID 예정)** — 540줄 cap 위반. 책임 축 후보: 시퀀스+결정표 (§2~§4) ↔ retry+escalate+handoff (§5~§7).
+  - **다른 cap 위반 모니터링** — `git ls-files | xargs wc -l` 등 sanity script 검토 (후속).
+  - **사용자 검증** — 다음 세션 SessionStart inject 시 §0 (procedure + catalog 의무 read) + §0.1 (300줄 cap) 모두 반영 확인.
+
 ### DCN-CHG-20260430-29
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/dcness-guidelines.md
+++ b/docs/process/dcness-guidelines.md
@@ -4,11 +4,45 @@
 > 룰 추가 시 본 파일에만 append — skill 들은 cross-ref 만.
 > Task-ID: DCN-CHG-20260430-26 (SSOT 분리 + hook inject).
 
-## 0. 루프 실행 절차 SSOT — `docs/loop-procedure.md` (DCN-30-27)
+## 0. 루프 SSOT — `loop-procedure.md` + `loop-catalog.md` (DCN-30-27 / -30)
 
-dcness 의 8 loop 공통 실행 절차 (Step 0~8 — worktree / begin-run / TaskCreate / agent 호출 / Step 4.5 stories sync / finalize-run / clean 7a / caveat 7b / auto-review) 는 [`docs/loop-procedure.md`](../loop-procedure.md) 단일 SSOT. **본 가이드라인이 inject 되는 매 세션에서 메인 Claude 는 본 항을 통해 loop-procedure.md 를 의무 read** — skill 트리거 또는 직접 발화 시 동일.
+dcness 의 8 loop 운영은 **2 SSOT** 분담:
+- [`docs/loop-procedure.md`](../loop-procedure.md) — *공통 실행 절차* (Step 0~8 mechanics — worktree / begin-run / TaskCreate / agent 호출 / Step 4.5 stories sync / finalize-run / clean 7a / caveat 7b / auto-review)
+- [`docs/loop-catalog.md`](../loop-catalog.md) — *8 loop 행별 풀스펙* (entry_point / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles)
 
-skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure.md.
+**본 가이드라인이 inject 되는 매 세션에서 메인 Claude 는 본 항을 통해 loop-procedure.md + loop-catalog.md 를 의무 read** — skill 트리거 또는 직접 발화 시 동일.
+
+skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure.md, loop spec 은 loop-catalog.md.
+
+## 0.1 행동지침 md 작성 룰 — 300줄 cap (DCN-30-30)
+
+dcness 행동지침 문서 (메인 Claude 또는 sub-agent 가 의사결정 시 *직접 read* 하는 md) 는 **파일당 300줄 cap**. 초과 시 책임 분리 축으로 split.
+
+**대상 파일 (예시)**:
+- `docs/loop-procedure.md` / `docs/loop-catalog.md` (loop SSOT)
+- `docs/process/dcness-guidelines.md` (본 가이드라인)
+- `docs/orchestration.md`
+- `commands/*.md` (skill prompt)
+- `agents/**/*.md` (agent prompt)
+
+**대상 외 (cap 미적용)**:
+- `docs/process/document_update_record.md` / `change_rationale_history.md` (역사 로그 — append-only)
+- `PROGRESS.md` (스냅샷)
+- `docs/spec/**` / `docs/proposals/**` (긴 사양 문서 — 의사결정 직접 read X)
+- `tests/**` / `harness/**` 등 코드
+
+**Why**:
+- 메인 Claude / sub-agent 가 매 결정 시 read → 토큰 누적 + thinking 시간 ↑.
+- 300줄 = 한 read 호출에서 파악 가능한 임계 (RWHarness 경험치 정합).
+- 초과 시 *책임 축* 분리 (mechanics vs catalog / 시퀀스 vs 절차 등) — 복붙 분할 X.
+
+**How to apply**:
+- 새 행동지침 md 작성 시 300줄 목표.
+- 기존 파일 라인 수 모니터링 — 초과 발견 시 split PR (별도 Task-ID).
+- split 시 cross-ref 양방향 + governance §2.2 doc-sync gate 양 파일 동시 update.
+
+**현재 알려진 위반**:
+- `docs/orchestration.md` (540줄) — 시퀀스/결정표/retry/escalate/handoff 동시 보유. split 후속 (책임 축 후보: §2~§4 시퀀스/결정표 ↔ §5~§7 retry/escalate/handoff). 별도 Task-ID 추적.
 
 ## 1. 가시성 룰 (DCN-30-15) — MUST
 

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260430-30
+- **Date**: 2026-04-30
+- **Change-Type**: docs-only, spec
+- **Files Changed**:
+  - `docs/loop-catalog.md` (신규, 239줄) — 8 loop 행별 풀스펙 SSOT. loop-procedure.md 의 §7.0 인덱스 + §7.1~§7.10 풀스펙 (allowed_enums / 분기 / sub_cycles / branch_prefix decision rule / Step 4.5 적용) 통째 이전.
+  - `docs/loop-procedure.md` — 436 → 242줄. §7 = catalog cross-ref 1 단락 + §7.1 catastrophic 룰 정합 만 보존. §0 진입 모델 + §1~§6 Step 0~8 mechanics + §8 참조 (loop-catalog.md 추가).
+  - `docs/process/dcness-guidelines.md` — §0 갱신 (procedure + catalog 2 SSOT 분담). §0.1 신설 (행동지침 md 300줄 cap 룰 + 대상/대상 외 + Why + How to apply + 현재 알려진 위반 = orchestration.md 540줄). 218 → 224줄.
+  - `docs/orchestration.md` — §3 헤더 cross-ref 갱신 (loop-catalog.md 추가).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 사용자 지시 ("쪼개자 가급적 300라인 넘기지 말랬잖아 행동지침 md는 이것도 룰로 적어놔줘") 반영. loop-procedure.md (436줄) split + 300줄 cap 룰을 dcness-guidelines.md SSOT 에 명문화. 책임 축 = procedure (mechanics) ↔ catalog (loop spec) 으로 자연 분리. 양 파일 모두 < 300줄 (242 / 239). orchestration.md (540줄) 는 알려진 위반 — split 후속 Task-ID 예정. PR4 (4 skill bulk slim) 는 -31 로 밀림.
+
 ### DCN-CHG-20260430-29
 - **Date**: 2026-04-30
 - **Change-Type**: harness, agent, test


### PR DESCRIPTION
## Summary

사용자 지시 — "loop-procedure.md 이거 좀 쪼개자 가급적 300라인 넘기지 말랬잖아 행동지침 md는 이것도 룰로 적어놔줘". loop-procedure.md (436줄) 300줄 cap 위반 + 룰 자체가 SSOT 에 부재. 두 가지 동시 처리.

## 책임 축 split

| 파일 | 책임 | 줄 수 |
|---|---|---|
| `docs/loop-procedure.md` (슬림) | Step 0~8 mechanics (절차) | 436 → 242 |
| `docs/loop-catalog.md` (신규) | 8 loop 행별 풀스펙 (allowed_enums / 분기 / sub_cycles / branch_prefix) | 239 |

자연스러운 분리 — mechanics ↔ spec 다른 axis. cross-ref 양방향 + doc-sync gate 강제.

## 300줄 cap 룰 (`dcness-guidelines.md §0.1` 신설)

- **대상**: skill prompt / agent prompt / loop SSOT / guidelines 자체 (메인/sub-agent 결정 시 직접 read 하는 md)
- **대상 외**: 역사 로그 (document_update_record / change_rationale_history) / PROGRESS / spec / proposals / 코드
- **Why**: 결정 시 매 read → 토큰 + thinking 시간 누적. 300줄 = 한 read 임계.
- **How to apply**: 신규 작성 시 목표 / 초과 발견 시 split PR / cross-ref 양방향 + doc-sync 동시 update.
- **현재 알려진 위반**: `docs/orchestration.md` (540줄) — split 후속 별도 Task-ID 예정.

## 변경 파일

- **신설**: `docs/loop-catalog.md` (239줄)
- **수정**: `docs/loop-procedure.md` / `docs/process/dcness-guidelines.md` / `docs/orchestration.md` / doc-sync 3종 / PROGRESS.md

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (7 files / docs-only)
- [x] `python3 -m unittest discover -s tests` — 219 ran (2 pre-existing flaky 무관)
- [x] `wc -l docs/loop-{procedure,catalog}.md` — 242 / 239 (둘 다 < 300)
- [x] 양 파일 cross-ref 양방향 확인 (procedure §0/§7/§8 → catalog, catalog §12 → procedure)

## Migration Plan 갱신

| # | Task-ID | 상태 |
|---|---|---|
| PR1 ✅ | DCN-30-27 | loop-procedure.md SSOT 신설 |
| PR2 ✅ | DCN-30-28 | §7 매트릭스 행별 풀스펙 보강 |
| PR3 ✅ | DCN-30-29 | --auto-review flag + qa.md slim pilot |
| **PR4 (본 PR)** | **DCN-30-30** | **split + 300줄 cap 룰 SSOT** |
| PR5 | DCN-30-31 | 4 skill bulk slim (quick / impl / impl-loop / product-plan) |
| PR6 (별도) | TBD | orchestration.md split (540줄 cap 위반) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)