### PR TITLE
chore: 4 skill bulk slim (DCN-CHG-20260430-31)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,13 @@
 
 ## 현재 상태
 
+- **🪶 4 skill bulk slim (quick/impl/impl-loop/product-plan)** (`DCN-CHG-20260430-31`):
+  - 4 PR migration 의 마지막 PR. 5 skill 합계 660 → 132줄 (80% 절감).
+  - `commands/quick.md` 215 → 32줄 — `quick-bugfix-loop` cross-ref + Inputs (이슈 / 영향 파일 / 재현 / 원하는 방향).
+  - `commands/impl.md` 205 → 32줄 — `impl-batch-loop` + UI 감지 시 `impl-ui-design-loop` 자동 전환 명시. State-aware skip / Step 4.5 / catalog §3 cross-ref.
+  - `commands/impl-loop.md` 127 → 36줄 — `impl-batch-loop × N` chain. outer `impl-<i>` / inner `b<i>.<agent>` 컨벤션 (DCN-30-12). catalog §3 + §10 cross-ref.
+  - `commands/product-plan.md` 113 → 32줄 — `feature-build-loop`. Inputs 정형화 (요구사항 / 시나리오 / 제약 / 우선순위 / 변경 vs 신규) — `CLARITY_INSUFFICIENT` 사전 회피.
+  - 모든 mechanics 제거 — `loop-procedure.md` (Step 0~8) + `loop-catalog.md` (loop spec) 단일 source.
 - **✂️ loop-procedure.md split + 300줄 cap 룰 신설** (`DCN-CHG-20260430-30`):
   - 사용자 지시 — "loop-procedure.md 쪼개자 가급적 300라인 넘기지 말랬잖아 행동지침 md는 이것도 룰로 적어놔줘". loop-procedure.md (436줄) cap 위반.
   - **`docs/loop-catalog.md` 신규** (239줄) — 8 loop 행별 풀스펙 (allowed_enums / 분기 / sub_cycles / branch_prefix). loop-procedure.md §7.0 인덱스 + §7.1~§7.10 풀스펙 모두 이전.

--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -1,127 +1,36 @@
 ---
 name: impl-loop
-description: impl batch list (architect TASK_DECOMPOSE 산출물) 를 순차 자동 chain 으로 처리하는 스킬. 사용자가 "전부 구현", "/impl-loop", "batch 다 돌려", "epic 전체 구현", "/product-plan 후 자동", "끝까지 구현" 등을 말할 때 반드시 이 스킬을 사용한다. 각 batch 마다 /impl skill 의 정식 루프를 실행 + clean run 만 자동 진행 + caveat 시 사용자 위임. /product-plan 종료 후 N 개 batch 한 번에 처리하고 싶을 때.
+description: impl batch list (architect TASK_DECOMPOSE 산출물) 를 순차 자동 chain 으로 처리하는 스킬. 사용자가 "전부 구현", "/impl-loop", "batch 다 돌려", "epic 전체 구현", "/product-plan 후 자동", "끝까지 구현" 등을 말할 때 반드시 이 스킬을 사용한다. 각 batch 마다 /impl 의 정식 루프 실행 + clean run 만 자동 진행 + caveat 시 사용자 위임. /product-plan 종료 후 N 개 batch 한 번에 처리하고 싶을 때.
 ---
 
-# Impl Loop Skill — multi-batch sequential auto chain
+# Impl Loop Skill
 
-> `/impl` 의 multi-batch 래퍼. 공통 룰 SSOT = `commands/quick.md`. inner /impl 시퀀스 = `commands/impl.md`.
+## Loop
+`impl-batch-loop × N` ([loop-catalog.md §10](../docs/loop-catalog.md) — 다중 batch chain).
+inner = `impl-batch-loop` (catalog §3) per batch.
 
-## 사용
+## Inputs (메인이 사용자에게 받아야 할 정보)
+- batch list 또는 epic 경로 (예: `docs/milestones/v0.2/epics/epic-01-*/impl/*.md` glob)
+- 진행 정책 — clean 자동 / caveat 멈춤 (default) 또는 yolo (catalog §3 sub_cycles 자동 시도)
+- attempt 한도 확인 (`/impl` 와 동일 default)
 
-- 트리거: "/impl-loop", "전부 구현", "다 돌려", "epic 전체", "끝까지 구현"
-- 비대상: batch 1개 → `/impl` · 한 줄 → `/quick` · spec/design → `/product-plan`
+## 비대상 (다른 skill 추천)
+- batch 1개 → `/impl`
+- 한 줄 → `/quick`
+- spec / design → `/product-plan`
 
-## 핵심 동작
+## Outer / inner 컨벤션 (DCN-30-12)
+- outer task: `impl-<i>: <batch 파일명>` (batch list 길이 만큼 등록)
+- inner sub-task: `b<i>.<agent>` prefix 의무 (loop-procedure.md §2 inner skip 금지)
 
-각 batch → `/impl` 시퀀스 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer). clean → 자동 commit/PR + 다음 batch. caveat → 멈춤 + 사용자 위임.
-
-## 가시성 (SSOT = quick.md)
-
-inner /impl 의 5 step 모두 `b<i>.<agent>` prefix 로 의무 echo (의무 템플릿 = quick.md). loop level 추가:
-- 매 batch 시작/종료 시 `[impl-loop] batch i/N — <status>` 1줄
-- caveat 멈춤 시 전체 진행 요약 echo (처리 / 남은 / 멈춤 사유)
-
-inner echo 5 의무 ✓ 안 되면 다음 batch 진입 금지.
+## 후속 라우팅
+- 각 batch clean → 자동 7a + 다음 batch
+- caveat → 멈춤 + 사용자 위임 (재호출 또는 수동 처리)
+- 전체 완료 → 보고 (처리 N/N + 각 PR URL)
 
 ## 절차
-
-### Step 0 — batch list 추출 + run 시작
-
-```bash
-# TASK_DECOMPOSE 산출 dir 패턴
-BATCH_LIST=$(ls docs/milestones/v*/epics/epic-*/impl/*.md 2>/dev/null | sort)
-echo "발견된 batch:"; echo "$BATCH_LIST"
-
-HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run impl-loop)
-echo "[impl-loop] run started: $RUN_ID"
-```
-
-또는 사용자가 list 직접 명시. 사용자 확인 (batch N 개 / 시퀀스 / 분기 정책 / yolo 여부 / 진행).
-
-### Step 1 — outer task 등록 (batch 별 1개)
-
-```
-for i in 1..N:
-  TaskCreate(f"impl-{i}: <batch 파일명 + 짧은 제목>")
-```
-
-### Step 2 — 각 batch 순차 처리 (inner sub-task 등록 의무)
-
-⚠️ **inline skip 금지 (DCN-CHG-30-12)**: 각 batch 진입 시 `/impl` 의 5 sub-task 의무 등록. inline begin-step → Agent 직행 X.
-
-```
-for i in 1..N:
-  TaskUpdate(f"impl-{i}: ...", in_progress)
-  INNER_RUN=$("$HELPER" begin-run "impl-batch-$i")
-  echo "[impl-loop] batch $i/$N → INNER_RUN=$INNER_RUN"
-
-  # inner 5 sub-task 의무 등록 (b{i}. prefix)
-  TaskCreate(f"b{i}.architect: MODULE_PLAN")
-  TaskCreate(f"b{i}.test-engineer: TDD attempt 0")
-  TaskCreate(f"b{i}.engineer: IMPL")
-  TaskCreate(f"b{i}.validator: CODE_VALIDATION")
-  TaskCreate(f"b{i}.pr-reviewer: 검토")
-
-  # /impl Step 2~7 진행 (commands/impl.md 참조)
-  if clean:
-    자동 commit/PR (graceful degrade) → INNER_RUN end
-    TaskUpdate(f"impl-{i}: ...", completed)
-  else:
-    Step 2.5 (caveat 멈춤)
-```
-
-가시성 표시 형식:
-```
-◼ impl-1: epic-01 greet lang
-◻ impl-2: epic-02 calc.multiply
-◼ b1.architect: MODULE_PLAN     ← 현재 batch 1 inner step
-◻ b1.test-engineer: TDD attempt 0
-◻ b1.engineer: IMPL
-◻ b1.validator: CODE_VALIDATION
-◻ b1.pr-reviewer: 검토
-```
-
-### Step 2.5 — caveat 멈춤
-
-```
-[impl-loop] batch <i> 멈춤 — caveat
-- batch: <경로> · caveat: <FAIL / AMBIGUOUS / MUST FIX>
-- 처리: <i-1>/<N> · 남은: <list>
-
-옵션:
-1. 사용자 batch <i> 수동 처리 후 /impl-loop 재호출 (남은 batch 인자)
-2. yolo + cycle 한도 내 재시도 (yolo ON 일 때만)
-3. 종료
-```
-
-### Step 3 — 전체 완료 시 보고
-
-```
-[impl-loop] 전체 완료 ✅
-- run_id: $RUN_ID · 처리: <N>/<N>
-- inner run_id + 변경 + PR URL
-
-다음 (선택):
-- 추가 batch → /impl-loop 재호출
-- epic 전체 완료 → /product-plan 다음 epic
-```
-
-## yolo 모드
-
-`/impl` yolo (commands/quick.md SSOT) + multi-batch 추가:
-- 각 batch caveat 도 `auto-resolve` 매핑 적용
-- 매 3 batch 또는 1시간마다 progress 보고 (장시간 무인 안전)
+[`docs/loop-procedure.md`](../docs/loop-procedure.md) §1~§6 + [`docs/loop-catalog.md`](../docs/loop-catalog.md) §3 (inner) + §10 (chain 정책) 따름.
 
 ## 한계
-
-- batch 의존성 자동 판단 X (v1 = 무조건 직렬, list 순서가 의존 표현)
-- 재시도 5회 후 실패 시 그 시점까지 commit 보존 (rollback X — 안전 가드)
-- inner run dir 분리, outer 는 batch 진행 메타만
-- multi-batch resume 미구현 — caveat 후 재실행 시 처음부터, 단 commit 된 batch 는 MODULE_PLAN_READY 자가 검출 (impl.md Step 2.0) 로 skip
-
-## 참조
-
-- `commands/impl.md` (inner 단일 batch 처리) · `commands/product-plan.md` (TASK_DECOMPOSE 산출 = 입력) · `commands/quick.md` (가시성 / yolo / 공통 룰 SSOT)
-- `docs/orchestration.md` §2.1 / §3.1
+- batch 의존성 자동 판단 X (v1 = 무조건 직렬, list 순서 = 의존 표현)
+- multi-batch resume 미구현 — caveat 후 재실행 시 처음부터 (단 commit 된 batch 는 `MODULE_PLAN_READY` 자가 검출로 Step 2 skip)

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -1,205 +1,32 @@
 ---
 name: impl
-description: impl batch (architect TASK_DECOMPOSE 산출물) 1개를 받아 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer) 자동 진행하는 스킬. 사용자가 "구현해줘", "/impl <batch>", "이 batch 구현", "module plan 부터 진행", "impl 루프" 등을 말할 때 반드시 이 스킬을 사용한다. /product-plan 의 후속 — TASK_DECOMPOSE 의 batch list 1개씩 처리. /quick 보다 무거움 (test-engineer + CODE_VALIDATION 포함). dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작.
+description: impl batch (architect TASK_DECOMPOSE 산출물) 1개를 받아 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer) 자동 진행하는 스킬. 사용자가 "구현해줘", "/impl <batch>", "이 batch 구현", "module plan 부터 진행", "impl 루프" 등을 말할 때 반드시 이 스킬을 사용한다. /product-plan 의 후속 — TASK_DECOMPOSE 의 batch list 1개씩 처리. /quick 보다 무거움 (test-engineer + CODE_VALIDATION 포함).
 ---
 
-# Impl Skill — per-batch 정식 impl 루프
+# Impl Skill
 
-> 공통 룰 (가시성 / AMBIGUOUS / Catastrophic / yolo / worktree / Step 7 commit-PR) SSOT = `commands/quick.md`. 본 skill 은 시퀀스 + 분기 + 4.5 sync + 2.0 마커 검사만 명세.
+## Loop
+`impl-batch-loop` ([orchestration.md §2.1](../docs/orchestration.md) / [loop-catalog.md §3](../docs/loop-catalog.md)).
+UI 디자인 mid-loop 필요 시 → `impl-ui-design-loop` (catalog §4) 자동 전환.
 
-## 사용
+## Inputs (메인이 사용자에게 받아야 할 정보)
+- batch 경로 (필수, 예: `docs/milestones/v0.2/epics/epic-01-*/impl/01-*.md`)
+- 이슈 번호 (있으면)
+- attempt 한도 확인 (engineer 3 / POLISH 2 / SPEC_GAP cycle 2 — 기본값)
 
-- 트리거: "구현해줘", "/impl", "이 batch 구현", "module plan", "impl 루프"
-- 비대상: 한 줄 → `/quick` · spec/design → `/product-plan` · multi-batch → `/impl-loop` · batch 부재 → `/quick`
+## 비대상 (다른 skill 추천)
+- 한 줄 / 작은 버그 → `/quick` (`quick-bugfix-loop`)
+- spec / design 단계 → `/product-plan` (`feature-build-loop`)
+- 다중 batch 자동 chain → `/impl-loop`
+- batch 부재 (계획 X) → `/quick` 또는 `/product-plan`
 
-## 시퀀스 (orchestration §2.1)
+## State-aware skip (DCN-30-13)
+batch 파일 끝에 `MODULE_PLAN_READY` 마커 박혀있으면 Step 2 (architect:MODULE_PLAN) skip. 상세 = catalog §3 풀스펙.
 
-```
-architect MODULE_PLAN → test-engineer → engineer IMPL → validator CODE_VALIDATION → pr-reviewer
-```
+## 후속 라우팅
+- 본 loop clean → 자동 commit/PR (branch prefix = catalog §3 decision rule: feat/chore/fix)
+- caveat → 사용자 결정 (수동 7b)
+- multi-batch chain 필요 → `/impl-loop`
 
 ## 절차
-
-### Step 0 — worktree (선택, SSOT)
-
-배치 = src/ 다중 수정 → 충돌 위험 시 권장.
-
-### Step 0b — run 시작
-
-```bash
-HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run impl)
-echo "[impl] run started: $RUN_ID"
-```
-
-batch 경로 추출 (예: `docs/milestones/v0.2/epics/epic-01-*/impl/01-*.md`). 사용자 확인 (batch / 이슈 제목 / 시퀀스 / attempt 한도 — engineer 3 / POLISH 2 / SPEC_GAP cycle 2 / 진행할까요).
-
-### Step 1 — 5 sub-task 등록 (의무, skip 금지 DCN-CHG-30-12)
-
-⚠️ inline skip 금지. begin-step → Agent 직행 X.
-
-**standalone**:
-```
-TaskCreate("architect: MODULE_PLAN")
-TaskCreate("test-engineer: TDD attempt 0")
-TaskCreate("engineer: IMPL")
-TaskCreate("validator: CODE_VALIDATION")
-TaskCreate("pr-reviewer: 검토")
-```
-
-**`/impl-loop` inner**: prefix `b<i>.` (예: `b1.architect: MODULE_PLAN`). `commands/impl-loop.md` Step 2 참조.
-
-### Step 2 — architect MODULE_PLAN (state-aware skip 가능)
-
-#### 2.0 batch 마커 검사 (DCN-CHG-30-13)
-
-```bash
-if grep -q "MODULE_PLAN_READY" "<batch path>"; then
-    echo "[impl] batch 자체 MODULE_PLAN_READY 박힘 — Step 2.1 skip"
-    SKIP_MODULE_PLAN=true
-else
-    SKIP_MODULE_PLAN=false
-fi
-```
-
-조건: `architect TASK_DECOMPOSE` 가 batch 산출 시 ## 생성/수정 파일 / ## 인터페이스 / ## 의사코드 / ## 결정 근거 박고 마지막 줄에 `MODULE_PLAN_READY` 마커 박음.
-
-**SKIP 시**:
-- TaskUpdate("architect: MODULE_PLAN", completed) + label "skipped (batch 자체 MODULE_PLAN_READY)"
-- catastrophic §2.3.3 통과 위해 prose 종이 복사:
-  ```bash
-  cp "<batch path>" "$RUN_DIR/architect-MODULE_PLAN.md"
-  ```
-- Step 3 직진
-
-#### 2.1 정상 호출 (마커 부재 시)
-
-```
-TaskUpdate("architect: MODULE_PLAN", in_progress)
-"$HELPER" begin-step architect MODULE_PLAN
-Agent(subagent_type="architect", mode="MODULE_PLAN",
-      description="impl batch 파일: <batch path>. 모듈 plan — 생성/수정 파일 + 인터페이스 + 의사코드 + 결정 근거. 결론 enum: READY_FOR_IMPL / SPEC_GAP_FOUND / TECH_CONSTRAINT_CONFLICT.")
-# DCN-30-21: prose-file 을 run-dir 안 격리 (멀티세션 안전)
-RUN_DIR=$("$HELPER" run-dir)
-mkdir -p "$RUN_DIR/.prose-staging"
-PROSE_PATH="$RUN_DIR/.prose-staging/architect-MODULE_PLAN.md"
-# (메인이 sub-agent prose 를 위 경로에 Write)
-ENUM=$("$HELPER" end-step architect MODULE_PLAN \
-       --allowed-enums "READY_FOR_IMPL,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT" \
-       --prose-file "$PROSE_PATH")
-# 가시성 룰 의무 echo
-```
-
-### Step 3~6 — 단계 표
-
-매 단계 골격 동일 (TaskUpdate(in_progress) → begin-step → Agent → end-step → 의무 echo → TaskUpdate(completed)):
-
-| Step | agent | mode | allowed-enums | advance |
-|------|-------|------|---------------|---------|
-| 3 | test-engineer | — | `TESTS_WRITTEN,SPEC_GAP_FOUND` | `TESTS_WRITTEN` |
-| 4 | engineer | IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` | `IMPL_DONE` |
-| 5 | validator | CODE_VALIDATION | `PASS,FAIL,SPEC_MISSING` | `PASS` |
-| 6 | pr-reviewer | — | `LGTM,CHANGES_REQUESTED` | `LGTM` |
-
-### 분기 표
-
-| ENUM | 처리 |
-|------|------|
-| `SPEC_GAP_FOUND` | architect SPEC_GAP cycle (≤2) 또는 사용자 위임 |
-| `TESTS_FAIL` / validator `FAIL` | engineer 재시도 (attempt < 3) |
-| `SPEC_MISSING` | architect SPEC_GAP |
-| `TECH_CONSTRAINT_CONFLICT` / `IMPLEMENTATION_ESCALATE` | 사용자 위임 |
-| `CHANGES_REQUESTED` | engineer POLISH cycle (≤2) |
-| `AMBIGUOUS` | `commands/quick.md` cascade |
-
-#### POLISH 사이드 사이클
-
-```
-Agent(subagent_type="engineer", mode="POLISH",
-      description="pr-reviewer CHANGES_REQUESTED. 지적 사항 반영. 결론 enum: POLISH_DONE / IMPLEMENTATION_ESCALATE.")
-```
-
-`POLISH_DONE` 후 pr-reviewer 재호출. cycle ≤ 2.
-
-### Step 4.5 — stories.md / backlog.md 체크박스 sync (DCN-CHG-30-14)
-
-engineer `IMPL_DONE` 직후, validator 진입 *전*. 메인 직접 mechanical edit (agent 위임 X — 도메인 외).
-
-**근거**: 글로벌 `~/.claude/CLAUDE.md` "태스크 완료 → stories.md 체크" 룰. impl.md 시퀀스에 step 으로 박지 않으면 매 batch 누락.
-
-#### 4.5.1 epic 경로 추출
-
-```bash
-EPIC_DIR=$(dirname $(dirname "<batch path>"))
-STORIES_FILE="$EPIC_DIR/stories.md"
-BACKLOG_FILE="$(dirname $(dirname $EPIC_DIR))/../backlog.md"  # milestone root + ..
-```
-
-(실제 경로는 milestone 구조에 따라 메인이 자체 판단 — `find` / `Glob` 으로 확인.)
-
-#### 4.5.2 stories.md 갱신
-
-batch 가 다룬 Story `[ ]` → `[x]`. batch 의 ## 관련 Story / ## 적용 범위 메타로 식별. 부분 task 만 처리 → 해당 task 만 `[x]`. Story 하위 모두 `[x]` 면 Story 자체 `[x]`.
-
-```
-Edit(STORIES_FILE, "- [ ] Story X: ...", "- [x] Story X: ...")
-```
-
-#### 4.5.3 backlog.md 갱신 (epic 완료 시만)
-
-stories.md 의 모든 Story `[x]` 면:
-```
-Edit(BACKLOG_FILE, "- [ ] epic-NN-...", "- [x] epic-NN-...")
-```
-
-부분 진행이면 backlog 손대지 않음.
-
-#### 4.5.4 가시성
-
-```
-[impl] step 4.5 — stories.md / backlog.md sync
-- stories.md: Story 1 [ ] → [x] (8 task 모두 완료)
-- backlog.md: epic-01 라인 [ ] → [x]
-```
-
-다음 step (validator) 은 src/ 만 검증 — stories.md 무시. pr-reviewer 가 코드 + doc 같이 검토.
-
-### Step 7 — finalize-run + clean commit/PR
-
-`commands/quick.md` Step 7 동일. 차이점:
-
-**finalize-run 호출** (DCN-30-25 step 안전망):
-```bash
-STATUS=$("$HELPER" finalize-run --expected-steps 5)  # architect/test-engineer/engineer/validator/pr-reviewer
-```
-미달 시 stderr WARN — inner step 누락 즉시 인지.
-
-**clean 매트릭스**:
-- `architect:MODULE_PLAN.enum == READY_FOR_IMPL`
-- `test-engineer.enum == TESTS_WRITTEN`
-- `engineer:IMPL.enum == IMPL_DONE`
-- `validator:CODE_VALIDATION.enum == PASS`
-- `pr-reviewer.enum == LGTM`
-
-**branch prefix**: `feat/<batch-slug>` 또는 `chore/<batch-slug>`.
-
-worktree 흡수 검사 / commit / PR / merge / 보고 모두 quick.md SSOT.
-
-## Catastrophic 룰 정합
-
-`docs/conveyor-design.md` §2.3 정합:
-- §2.3.1 (pr-reviewer 직전 validator PASS) — Step 5 충족
-- §2.3.3 (engineer/test-engineer 직전 plan READY) — Step 2 (또는 batch 자체 MODULE_PLAN_READY) 충족
-- §2.3.4 / §2.3.5 — TD 본 시퀀스 안 없음 → 비대상
-
-## 한계
-
-- batch list 자동 chain X — `/impl-loop` 사용
-- attempt counter 메인 자체 카운팅 (helper 미지원)
-- POLISH cycle ≤ 2
-
-## 참조
-
-- `agents/architect/{module-plan,task-decompose}.md` · `agents/{test-engineer,engineer,pr-reviewer,validator}.md` · `agents/validator/code-validation.md`
-- `docs/orchestration.md` §2.1 / §4
-- `commands/quick.md` (가시성 / Step 7 / 공통 룰 SSOT) · `commands/product-plan.md` (TASK_DECOMPOSE 산출 = 본 skill 입력) · `commands/impl-loop.md` (multi-batch chain)
+[`docs/loop-procedure.md`](../docs/loop-procedure.md) §1~§6 + [`docs/loop-catalog.md`](../docs/loop-catalog.md) §3 (`impl-batch-loop` 풀스펙, Step 4.5 stories sync 포함) 따름. UI 감지 시 §4 (`impl-ui-design-loop`).

--- a/commands/product-plan.md
+++ b/commands/product-plan.md
@@ -1,113 +1,32 @@
 ---
 name: product-plan
-description: 새 기능 / PRD 변경 / 큰 기획을 받아 product-planner → plan-reviewer → ux-architect → validator UX_VALIDATION → architect SYSTEM_DESIGN → validator DESIGN_VALIDATION → architect TASK_DECOMPOSE 시퀀스로 spec/design 단계까지 진행하는 스킬. 사용자가 "기획자야", "새 기능", "피쳐 추가", "이런 기능이 필요할 것 같아", "기획해줘", "프로덕트 플랜", "/product-plan" 등을 말할 때 반드시 이 스킬을 사용한다. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 구현 진입은 별도 (`/quick` 또는 정식 impl 루프).
+description: 새 기능 / PRD 변경 / 큰 기획을 받아 product-planner → plan-reviewer → ux-architect → validator UX_VALIDATION → architect SYSTEM_DESIGN → validator DESIGN_VALIDATION → architect TASK_DECOMPOSE 시퀀스로 spec/design 단계까지 진행하는 스킬. 사용자가 "기획자야", "새 기능", "피쳐 추가", "이런 기능이 필요할 것 같아", "기획해줘", "프로덕트 플랜", "/product-plan" 등을 말할 때 반드시 이 스킬을 사용한다. 구현 진입은 별도 (`/quick` 또는 `/impl` / `/impl-loop`).
 ---
 
-# Product Plan Skill — spec/design 흐름
+# Product Plan Skill
 
-> 공통 룰 (가시성 / AMBIGUOUS / Catastrophic / yolo / worktree) SSOT = `commands/quick.md`. 본 skill 은 시퀀스 + 분기만 명세.
+## Loop
+`feature-build-loop` ([orchestration.md §3.1](../docs/orchestration.md) / [loop-catalog.md §2](../docs/loop-catalog.md)).
 
-## 사용
+## Inputs (메인이 사용자에게 받아야 할 정보)
+- 요구사항 / 문제 정의 (한 단락)
+- 사용자 시나리오 (Who / When / What / Why)
+- 제약 (기술 / 일정 / 리소스, 있으면)
+- 우선순위 (M0 / M1 / nice-to-have, 있으면)
+- 변경인지 신규인지 (PRD 변경 시 어떤 부분)
 
-- 트리거: "새 기능", "피쳐", "기획", "PRD 변경", "프로덕트 플랜"
-- 비대상: 버그 → `/qa` · 한 줄 수정 → `/quick` · 디자인만 → `/ux`
+명확화 안 되면 product-planner 호출 X (`CLARITY_INSUFFICIENT` 회피 — 메인이 사전 정형화).
 
-## 시퀀스 (orchestration §3.1)
+## 비대상 (다른 skill 추천)
+- 버그 → `/qa` (`qa-triage`)
+- 한 줄 수정 → `/quick` (`quick-bugfix-loop`)
+- 디자인만 → `/ux` (`ux-design-stage`)
 
-```
-product-planner → plan-reviewer → ux-architect → validator UX_VALIDATION
-  → architect SYSTEM_DESIGN → validator DESIGN_VALIDATION → architect TASK_DECOMPOSE
-```
+## 후속 라우팅
+- `READY_FOR_IMPL` → `/impl-loop` (multi-batch) 또는 `/impl` (per-batch) 또는 architect MODULE_PLAN 직접
+- `PRODUCT_PLAN_UPDATED` → plan-reviewer skip + ux-architect 직행 (catalog §2 분기)
+- `UX_REFINE_READY` → `ux-refine-stage` 진입 (`/ux`)
+- escalate enum → 사용자 위임 (catalog §2 분기 표 참조)
 
 ## 절차
-
-### Step 0a — worktree 격리 (선택)
-
-발화에 `worktree` / `wt` / `격리` / `isolate` 시 `EnterWorktree(name="product-plan-{ts_short}")`.
-
-### Step 0b — run 시작
-
-```bash
-HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run product-plan)
-echo "[product-plan] run started: $RUN_ID"
-```
-
-사용자 확인 (요청 / 작업 유형 추정 / 시퀀스 / 진행할까요).
-
-### Step 1 — 7 task 등록
-
-```
-TaskCreate("product-planner: PRD 작성")
-TaskCreate("plan-reviewer: PRD 심사")
-TaskCreate("ux-architect: UX_FLOW")
-TaskCreate("validator: UX_VALIDATION")
-TaskCreate("architect: SYSTEM_DESIGN")
-TaskCreate("validator: DESIGN_VALIDATION")
-TaskCreate("architect: TASK_DECOMPOSE")
-```
-
-### Step 2~7 — 각 단계 표
-
-매 단계 골격 동일:
-
-```
-TaskUpdate("<task>", in_progress)
-"$HELPER" begin-step <agent> [<MODE>]
-Agent(subagent_type="<agent>", mode="<MODE>", description="...")
-# DCN-30-21: prose-file 을 run-dir 안 격리 (멀티세션 안전)
-RUN_DIR=$("$HELPER" run-dir)
-mkdir -p "$RUN_DIR/.prose-staging"
-PROSE_PATH="$RUN_DIR/.prose-staging/<n>.md"
-# (메인이 sub-agent prose 를 위 경로에 Write)
-ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<list>" --prose-file "$PROSE_PATH")
-# 의무 echo (commands/quick.md 가시성 룰 의무 템플릿) → TaskUpdate(completed)
-```
-
-| Step | agent | mode | allowed-enums | advance |
-|------|-------|------|---------------|---------|
-| 2 | product-planner | — | `PRODUCT_PLAN_READY,CLARITY_INSUFFICIENT,PRODUCT_PLAN_CHANGE_DIFF,PRODUCT_PLAN_UPDATED,ISSUES_SYNCED` | `PRODUCT_PLAN_READY` |
-| 3 | plan-reviewer | — | `PLAN_REVIEW_PASS,PLAN_REVIEW_CHANGES_REQUESTED` | `PLAN_REVIEW_PASS` |
-| 4 | ux-architect | UX_FLOW | `UX_FLOW_READY,UX_FLOW_PATCHED,UX_REFINE_READY,UX_FLOW_ESCALATE` | `UX_FLOW_READY` / `UX_FLOW_PATCHED` |
-| 5 | validator | UX_VALIDATION | `PASS,FAIL` | `PASS` |
-| 6 | architect | SYSTEM_DESIGN | `SYSTEM_DESIGN_READY` | `SYSTEM_DESIGN_READY` |
-| 6.5 | validator | DESIGN_VALIDATION | `DESIGN_REVIEW_PASS,DESIGN_REVIEW_FAIL,DESIGN_REVIEW_ESCALATE` | `DESIGN_REVIEW_PASS` |
-| 7 | architect | TASK_DECOMPOSE | `READY_FOR_IMPL` | `READY_FOR_IMPL` |
-
-### 분기 표
-
-| ENUM | 처리 |
-|------|------|
-| `PRODUCT_PLAN_UPDATED` | ux-architect 직행 (plan-reviewer skip — 기존 PASS 활용) |
-| `PRODUCT_PLAN_CHANGE_DIFF` | plan-reviewer 변경분만 재심사 |
-| `CLARITY_INSUFFICIENT` | 사용자 역질문 후 재호출 |
-| `ISSUES_SYNCED` | 동기화 완료 — 종료 |
-| `PLAN_REVIEW_CHANGES_REQUESTED` | product-planner 재진입 (cycle ≤ 2) |
-| `UX_REFINE_READY` | designer SCREEN 흐름 (별도 — `/ux` 권장) |
-| `UX_FLOW_ESCALATE` | 사용자 위임 |
-| validator UX `FAIL` | ux-architect 재진입 (cycle ≤ 2) |
-| `DESIGN_REVIEW_FAIL` | architect SYSTEM_DESIGN 재진입 (cycle ≤ 2) |
-| `DESIGN_REVIEW_ESCALATE` | 사용자 위임 |
-| `AMBIGUOUS` | 재호출 1회 → 사용자 위임 (commands/quick.md cascade 정합) |
-
-cycle 한도 초과 → 사용자 위임 (escalate).
-
-### Step 8 — run 종료
-
-```bash
-"$HELPER" end-run
-```
-
-산출물 보고 (PRD / UX Flow / 시스템 설계 / 태스크 분해 prose 종이 경로) + 다음 단계 추천 (`/quick` light path · architect MODULE_PLAN 직접 · `/impl` per-batch · `/impl-loop` multi-batch). 구현은 본 skill 범위 밖 — 사용자 결정.
-
-worktree 진입 시 `ExitWorktree(action="<keep|remove>")` (구현 이어가면 keep).
-
-## Catastrophic 룰 정합
-
-본 시퀀스는 `docs/conveyor-design.md` §2.3.4 (architect SD/TD 직전 PRD 검토) + §2.3.5 (TD 직전 DESIGN_REVIEW_PASS) 자연 충족. PreToolUse 훅 자동 통과.
-
-## 참조
-
-- `agents/{product-planner,plan-reviewer,ux-architect,architect,validator}.md` + `agents/architect/{system-design,task-decompose}.md` + `agents/validator/{ux-validation,design-validation}.md`
-- `docs/orchestration.md` §3.1 / §4 (enum 결정표)
-- `commands/quick.md` — 가시성 룰 SSOT + AMBIGUOUS cascade + yolo + worktree 룰
+[`docs/loop-procedure.md`](../docs/loop-procedure.md) §1~§6 + [`docs/loop-catalog.md`](../docs/loop-catalog.md) §2 (`feature-build-loop` 풀스펙) 따름. 본 파일은 input 명세 + 라우팅만.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -1,215 +1,32 @@
 ---
 name: quick
-description: 작은 버그픽스·코드 정리를 한 줄로 받아 light path 시퀀스 (qa → architect LIGHT_PLAN → engineer simple → validator BUGFIX_VALIDATION → pr-reviewer) 자동 진행하는 스킬. 사용자가 "간단히 해줘", "작은 수정", "한 줄 버그", "/quick", "퀵", "바로 고쳐줘", "오타 고쳐", "간단한 수정" 등을 말할 때 반드시 이 스킬을 사용한다. dcNess 컨베이어 패턴 (Task tool + Agent + helper + 훅) 으로 동작. 분류 결과가 FUNCTIONAL_BUG / CLEANUP 면 자동 진행, 그 외 (DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 면 사용자 결정.
+description: 작은 버그픽스·코드 정리를 한 줄로 받아 light path (qa → architect LIGHT_PLAN → engineer simple → validator BUGFIX_VALIDATION → pr-reviewer) 자동 진행하는 스킬. 사용자가 "간단히 해줘", "작은 수정", "한 줄 버그", "/quick", "퀵", "바로 고쳐줘", "오타 고쳐", "간단한 수정" 등을 말할 때 반드시 이 스킬을 사용한다. 분류 결과가 FUNCTIONAL_BUG / CLEANUP 면 자동 진행, 그 외 (DESIGN_ISSUE / KNOWN_ISSUE / SCOPE_ESCALATE) 면 사용자 결정.
 ---
 
-# Quick Skill — light path 자동화 + 공통 룰 SSOT
+# Quick Skill
 
-> 본 skill 은 light path 자동화 + dcness 컨베이어 공통 룰 (가시성 / AMBIGUOUS / Catastrophic / yolo / worktree) **SSOT**. 다른 skill 은 본 문서 참조.
+## Loop
+`quick-bugfix-loop` ([orchestration.md §3.5](../docs/orchestration.md) / [loop-catalog.md §5](../docs/loop-catalog.md)).
 
-## 사용
+## Inputs (메인이 사용자에게 받아야 할 정보)
+- 이슈 요약 (한 줄 — 무엇이 잘못됐나)
+- 영향 파일 / 위치 (있으면)
+- 재현 조건 (있으면)
+- 원하는 방향 (있으면)
 
-- 트리거: "간단히", "작은 수정", "퀵", "바로 고쳐", "오타", "한 줄"
-- 비대상: 새 기능 → `/product-plan` · 디자인 → `/ux` · 다중 모듈 → `/qa` 정석 분류
+명확화 안 되면 분석 시작 X (대기). qa agent 호출 *전* 위 항목 확보.
 
-## 시퀀스 (orchestration §3.5 light path)
+## 비대상 (다른 skill 추천)
+- 새 기능 → `/product-plan` (`feature-build-loop`)
+- 디자인 → `/ux` (`ux-design-stage`)
+- 다중 모듈 / 큰 변경 → `/qa` 정석 분류 또는 `/impl`
 
-```
-qa → architect LIGHT_PLAN → engineer IMPL → validator BUGFIX_VALIDATION → pr-reviewer
-```
-
-자동 진행 조건: qa 결론이 `FUNCTIONAL_BUG` 또는 `CLEANUP`. 그 외 → 사용자 결정.
-
-## 공통 룰 (SSOT 외부)
-
-dcness 범용 룰 (가시성 / Step 기록 / yolo / AMBIGUOUS / worktree / 루프 종료 시 /run-review / 결과 출력 / 권한 요청) 은 **`docs/process/dcness-guidelines.md`** 단일 SSOT.
-
-활성 프로젝트의 매 세션 SessionStart 훅이 본 가이드라인을 system-reminder 로 자동 inject (DCN-30-26). skill 측은 본 SSOT 인용만.
+## 후속 라우팅 (qa enum 별)
+- `FUNCTIONAL_BUG` → 본 loop advance · branch prefix `fix/`
+- `CLEANUP` → 본 loop advance · branch prefix `chore/`
+- `DESIGN_ISSUE` → 종료 + `/ux` 추천
+- `KNOWN_ISSUE` → 종료
+- `SCOPE_ESCALATE` → 사용자 위임 (큰 변경 / 다중 모듈)
 
 ## 절차
-
-### Step 0a — worktree (선택, 위 SSOT 참조)
-
-### Step 0b — run 시작
-
-```bash
-HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run quick)
-echo "[quick] run started: $RUN_ID"
-```
-
-사용자 확인 (요청 / 이슈 제목 / depth=simple / 진행할까요).
-
-### Step 1 — 5 task 등록
-
-```
-TaskCreate("qa: 이슈 분류")
-TaskCreate("architect: LIGHT_PLAN")
-TaskCreate("engineer: IMPL (simple)")
-TaskCreate("validator: BUGFIX_VALIDATION")
-TaskCreate("pr-reviewer: 검토")
-```
-
-(commit/PR 은 사용자 결정 — Task 외)
-
-### Step 2~6 — 각 단계 표
-
-매 단계 골격 (`<>` 부분만 step 별 차이):
-
-```
-TaskUpdate("<task>", in_progress)
-"$HELPER" begin-step <agent> [<MODE>]
-Agent(subagent_type="<agent>", mode="<MODE>", description="...")
-# DCN-30-21: prose-file 을 run-dir 안 격리 (멀티세션 안전, /tmp 결함 fix)
-RUN_DIR=$("$HELPER" run-dir)
-mkdir -p "$RUN_DIR/.prose-staging"
-PROSE_PATH="$RUN_DIR/.prose-staging/<step>.md"
-# (메인이 sub-agent prose 를 위 경로에 Write)
-ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<list>" --prose-file "$PROSE_PATH")
-# 가시성 룰 의무 echo → advance 시 TaskUpdate(completed)
-```
-
-| Step | agent | mode | allowed-enums | advance |
-|------|-------|------|---------------|---------|
-| 2 | qa | — | `FUNCTIONAL_BUG,CLEANUP,DESIGN_ISSUE,KNOWN_ISSUE,SCOPE_ESCALATE` | `FUNCTIONAL_BUG` / `CLEANUP` |
-| 3 | architect | LIGHT_PLAN | `LIGHT_PLAN_READY,SPEC_GAP_FOUND,TECH_CONSTRAINT_CONFLICT` | `LIGHT_PLAN_READY` |
-| 4 | engineer | IMPL | `IMPL_DONE,SPEC_GAP_FOUND,TESTS_FAIL,IMPLEMENTATION_ESCALATE` | `IMPL_DONE` |
-| 5 | validator | BUGFIX_VALIDATION | `PASS,FAIL` | `PASS` |
-| 6 | pr-reviewer | — | `LGTM,CHANGES_REQUESTED` | `LGTM` |
-
-### qa 분기 (Step 2 advance 외)
-
-| ENUM | 처리 |
-|------|------|
-| `DESIGN_ISSUE` | 종료 + `/ux` (구현 후) 추천 |
-| `KNOWN_ISSUE` | 종료 |
-| `SCOPE_ESCALATE` | 사용자 위임 (분류 모호) |
-
-### advance 외 분기 공통
-
-- `SPEC_GAP_FOUND` → architect SPEC_GAP 또는 사용자 위임
-- `TECH_CONSTRAINT_CONFLICT` / `IMPLEMENTATION_ESCALATE` → 사용자 위임
-- validator `FAIL` → engineer 재호출 또는 사용자 위임
-- `CHANGES_REQUESTED` → engineer POLISH 호출 (cycle ≤2) 또는 사용자 위임
-- `AMBIGUOUS` → 위 SSOT cascade
-
-### Step 7 — finalize-run + clean 자동 commit/PR
-
-#### 7.1 status 집계
-
-```bash
-STATUS=$("$HELPER" finalize-run --expected-steps 5)  # DCN-30-25: 5 = qa+architect+engineer+validator+pr-reviewer
-"$HELPER" end-run
-echo "$STATUS"
-```
-
-`--expected-steps` 미달 시 helper 가 stderr WARN — 메인이 즉시 인지 + `/run-review` 로 진단.
-
-JSON 구조: `{run_id, session_id, steps[{agent, mode, enum, must_fix, prose_excerpt}], has_ambiguous, has_must_fix, step_count}`.
-
-#### 7.2 clean 판정
-
-다음 모두 충족 → **clean**:
-- `has_ambiguous == false` && `has_must_fix == false`
-- step enum 매트릭스: `qa ∈ {FUNCTIONAL_BUG, CLEANUP}` · `architect:LIGHT_PLAN == LIGHT_PLAN_READY` · `engineer:IMPL == IMPL_DONE` · `validator:BUGFIX_VALIDATION == PASS` · `pr-reviewer == LGTM`
-- git 안전 가드:
-  - `git status --porcelain` 에 `.env` / `secrets.*` / `credentials.*` 없음
-  - unstaged + untracked ≤ 10
-  - submodule 변경 없음
-
-clean 아니면 **7b**.
-
-#### 7a — Clean 자동 commit/PR
-
-자동 진행 (사용자 확인 X):
-
-1. 변경 + remote 확인:
-   ```bash
-   CHANGED=$(git diff --name-only HEAD)
-   HAS_REMOTE=$(git remote get-url origin >/dev/null 2>&1 && echo yes || echo no)
-   ```
-
-2. branch + commit (분류별 prefix — `FUNCTIONAL_BUG` → `fix/`, `CLEANUP` → `chore/`):
-   ```bash
-   BRANCH="fix/<short-slug>"   # 또는 chore/
-   git checkout -b "$BRANCH" main
-   git add $CHANGED
-   git commit -m "$(cat <<'EOF'
-   <한 줄 제목 — Step 0 의 이슈 제목 재사용>
-
-   <2~3 줄 본문 — engineer prose_excerpt + run_id 참조>
-
-   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
-   EOF
-   )"
-   ```
-
-3. remote 있으면 push + PR + squash merge:
-   ```bash
-   if [ "$HAS_REMOTE" = "yes" ]; then
-     git push -u origin "$BRANCH"
-     gh pr create --title "<제목>" --body "$(cat <<'EOF'
-   ## Summary
-   <변경 요약>
-
-   ## Test
-   - validator BUGFIX_VALIDATION: PASS
-   - pr-reviewer: LGTM
-   - run_id: $RUN_ID
-
-   🤖 Generated by /quick (dcNess)
-   EOF
-   )"
-     gh pr merge --squash --auto 2>/dev/null || gh pr merge --squash || \
-       echo "[quick] PR merge 차단 — branch protection / CI 대기"
-     git checkout main && git pull --ff-only 2>/dev/null || true
-   else
-     echo "[quick] remote 없음 — local commit only"
-   fi
-   ```
-
-4. worktree 정리 (위 SSOT — squash 흡수 검사).
-
-5. 사용자 보고:
-   ```
-   [quick] 완료 + 자동 commit/PR ✅
-   - run_id: $RUN_ID · branch: $BRANCH · PR: <URL>
-   - 변경: <changed files 요약>
-   ```
-
-#### 7b — Caveat 확인 (clean 아닐 때)
-
-```
-[quick] 완료 (caveat)
-- run_id: $RUN_ID · 변경: <src/ 변경 파일>
-- prose 종이: .claude/harness-state/.sessions/{sid}/runs/$RUN_ID/
-
-⚠️ Caveat: <has_ambiguous / has_must_fix / unexpected enum / sensitive untracked>
-
-커밋/PR 진행할까요? (수동 — branch → PR → squash merge)
-```
-
-worktree 처리도 사용자 결정.
-
-**yolo 시**: `has_must_fix == false` + enum unexpected 만 (CHANGES_REQUESTED 1건 등) → 자동 7a 시도. `has_must_fix` 또는 `has_ambiguous` true 면 yolo 도 7b.
-
-## Catastrophic 룰 정합
-
-본 시퀀스는 `docs/conveyor-design.md` §2.3 정합:
-- §2.3.1 (pr-reviewer 직전 validator PASS) — Step 5 충족
-- §2.3.3 (engineer 직전 plan READY) — Step 3 충족
-- §2.3.4 (architect SD/TD 직전 PRD 검토) — light path 비대상
-
-PreToolUse 훅 자동 통과.
-
-## 한계
-
-- depth=simple 고정 — 큰 변경은 `/product-plan` 또는 `/impl` 정식 루프
-- SPEC_GAP_FOUND 자동 처리 미구현 (사용자 위임)
-
-## 참조
-
-- `agents/{qa,architect,engineer,pr-reviewer,validator}.md` + `agents/architect/light-plan.md` + `agents/validator/bugfix-validation.md`
-- `docs/orchestration.md` §3.5 (light path) / §4 (enum 결정표)
-- `docs/conveyor-design.md` §2 / §3 / §7 / §8 / §13
-- `commands/qa.md` (분류만) · `commands/product-plan.md` (spec/design) · `commands/impl.md` (정식 루프)
+[`docs/loop-procedure.md`](../docs/loop-procedure.md) §1~§6 + [`docs/loop-catalog.md`](../docs/loop-catalog.md) §5 (`quick-bugfix-loop` 풀스펙) 따름. 본 파일은 input 명세 + 라우팅만.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,30 @@
 
 ## Records
 
+### DCN-CHG-20260430-31
+- **Date**: 2026-04-30
+- **Rationale**:
+  - PR1~PR4 (DCN-30-27/28/29/30) 로 SSOT 인프라 (loop-procedure.md mechanics + loop-catalog.md loop spec + 300줄 cap 룰 + helper --auto-review) 완성.
+  - PR3 에서 `commands/qa.md` slim pilot (127 → 28줄) 으로 새 SSOT cross-ref 만으로 동작 가능 입증.
+  - 사용자 명령 ("줄이고 검증하고 split하자 죽 해") — 나머지 4 skill bulk slim 즉시 진행. migration 본 목표 = skill 통째로 트리거화.
+- **Alternatives**:
+  1. **(채택) 옵션 A — 4 skill 일괄 bulk slim**. PR3 qa.md pilot 패턴 동일 적용. 5 skill 합계 80%+ 절감.
+  2. *옵션 B — 1 skill 씩 4 PR 분할*. 안전 ↑ 단 review 부담 ↑ + drift (간 PR 사이 SSOT 변경) 위험. pilot 이미 완료 → bulk 안전.
+- **Decision**:
+  - 옵션 A.
+  - **slim 형식 (5 절 표준)** — frontmatter (description trigger keyword 보존) / Loop / Inputs / 비대상 + 후속 라우팅 / 절차 cross-ref.
+  - **per-skill 핵심**:
+    - `quick.md` — Inputs (이슈 / 영향 파일 / 재현 / 방향) + qa enum 별 라우팅 (FUNCTIONAL_BUG/CLEANUP advance, DESIGN_ISSUE → /ux 추천).
+    - `impl.md` — batch 경로 필수 Input + UI 감지 시 `impl-ui-design-loop` 자동 전환 + state-aware skip (DCN-30-13).
+    - `impl-loop.md` — outer/inner 컨벤션 명시 (DCN-30-12 의무) + chain 정책 (clean 자동 / caveat 멈춤).
+    - `product-plan.md` — 5 Input 항목 (요구사항 / 시나리오 / 제약 / 우선순위 / 변경 vs 신규) — `CLARITY_INSUFFICIENT` 사전 회피.
+  - 모든 mechanics (helper begin-run / TaskCreate / begin-step / Agent / end-step / prose-staging / finalize-run / 7a 7b / commit-PR) 제거. catalog + procedure 단일 source.
+- **Follow-Up**:
+  - **orchestration.md split** (별도 Task-ID, 540줄 cap 위반) — 책임 축 후보: §2~§4 시퀀스+결정표 ↔ §5~§7 retry+escalate+handoff.
+  - **jajang plugin 재설치 후 검증** — 새 세션에서 SessionStart 훅이 dcness-guidelines.md (§0 + §0.1) inject 확인 + 5 slim skill 모두 catalog/procedure cross-ref 만으로 정상 동작 확인.
+  - **drift 모니터링** — skill 안에 mechanics 재유입 (다음 fix 시 누가 helper 호출 inline 박는지) 감시. /run-review 에서 SKILL_BLOAT 패턴 추가 검토.
+  - **THINKING_LOOP fix** (smart-compact 미해결 #5) — agents/{architect,ux-architect,product-planner}.md "thinking 본문 드래프트 금지" CRITICAL banner 격상 후속.
+
 ### DCN-CHG-20260430-30
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260430-31
+- **Date**: 2026-04-30
+- **Change-Type**: agent (skill prompt)
+- **Files Changed**:
+  - `commands/quick.md` — 215 → 32줄 (85% 절감). `quick-bugfix-loop` cross-ref. Inputs (이슈 요약 / 영향 파일 / 재현 / 원하는 방향) + 비대상 + qa enum 별 후속 라우팅 (advance / 종료 / 위임).
+  - `commands/impl.md` — 205 → 32줄 (84% 절감). `impl-batch-loop` cross-ref + UI 감지 시 `impl-ui-design-loop` 자동 전환. State-aware skip (DCN-30-13) + Step 4.5 (loop-catalog §3 풀스펙) cross-ref.
+  - `commands/impl-loop.md` — 127 → 36줄 (72% 절감). `impl-batch-loop × N` chain. outer task `impl-<i>` / inner sub-task `b<i>.<agent>` 컨벤션 (DCN-30-12). catalog §3 + §10 cross-ref.
+  - `commands/product-plan.md` — 113 → 32줄 (72% 절감). `feature-build-loop` cross-ref. Inputs (요구사항 / 사용자 시나리오 / 제약 / 우선순위 / 변경 vs 신규) — `CLARITY_INSUFFICIENT` 사전 회피.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 4 PR migration (skill 슬림화 + procedure SSOT) 의 마지막 PR. 5 skill 합계 660 → 132줄 (80% 절감). 모든 mechanics 제거 — `loop-procedure.md` (Step 0~8) + `loop-catalog.md` (loop spec) 단일 source. skill = 트리거 + Inputs 정형화 + 후속 라우팅 추천. 메인 Claude 가 catalog 행 + procedure 보고 동적 task 구성. 8 loop 모두 reconstruct 가능 (PR2 self-test pass 2 입증). 후속 — orchestration.md (540줄) split 별도 Task-ID.
+
 ### DCN-CHG-20260430-30
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only, spec


### PR DESCRIPTION
## Summary

4 PR migration (skill 슬림화 + procedure SSOT) 의 **마지막 PR**. 5 skill 합계 660 → 132줄 (**80% 절감**).

## 변경

| skill | before | after | 절감 |
|---|---|---|---|
| `commands/qa.md` (PR3 완료) | 127 | 28 | 78% |
| `commands/quick.md` | 215 | 32 | 85% |
| `commands/impl.md` | 205 | 32 | 84% |
| `commands/impl-loop.md` | 127 | 36 | 72% |
| `commands/product-plan.md` | 113 | 32 | 72% |
| **합계** | **787** | **160** | **80%** |

## slim 5절 표준

각 skill 동일 구조:
1. frontmatter (description trigger keyword 보존 — CC discovery 용)
2. Loop (`<loop-name>` + orchestration / catalog cross-ref)
3. Inputs (메인이 사용자에게 받아야 할 정보)
4. 비대상 (다른 skill 추천) + 후속 라우팅 (enum 별)
5. 절차 cross-ref (loop-procedure.md + loop-catalog.md)

## 모든 mechanics 제거

skill 안에 박혀있던 helper bash / TaskCreate / begin-step / Agent / end-step / prose-staging / finalize-run / 7a 7b / commit-PR 모두 제거. SSOT 2개 단일 source:
- `docs/loop-procedure.md` — Step 0~8 mechanics
- `docs/loop-catalog.md` — 8 loop 행별 풀스펙

## per-skill 핵심

- **quick** — qa enum 별 라우팅 (FUNCTIONAL_BUG/CLEANUP advance, DESIGN_ISSUE → /ux)
- **impl** — batch 경로 필수 Input + UI 감지 시 `impl-ui-design-loop` 자동 전환 + state-aware skip (DCN-30-13)
- **impl-loop** — outer/inner 컨벤션 명시 (DCN-30-12) + chain 정책 (clean 자동 / caveat 멈춤)
- **product-plan** — 5 Input 항목 (요구사항 / 시나리오 / 제약 / 우선순위 / 변경 vs 신규) — `CLARITY_INSUFFICIENT` 사전 회피

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (7 files / docs-only)
- [x] `python3 -m unittest discover -s tests` — 219 ran (2 pre-existing flaky 무관)
- [x] 5 skill 모두 < 50줄 (300줄 cap §0.1 정합)

## Migration 완료

| # | Task-ID | 상태 |
|---|---|---|
| PR1 ✅ | DCN-30-27 | loop-procedure.md SSOT 신설 |
| PR2 ✅ | DCN-30-28 | §7 행별 풀스펙 보강 |
| PR3 ✅ | DCN-30-29 | --auto-review flag + qa.md slim pilot |
| PR4 ✅ | DCN-30-30 | split + 300줄 cap 룰 SSOT |
| **PR5 (본 PR)** | **DCN-30-31** | **4 skill bulk slim** |
| 별도 (다음) | TBD | orchestration.md split (540줄 cap 위반) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)