### PR TITLE
feat: begin-step 시 stale current_step WARN — I4 회귀 방지 (DCN-CHG-20260430-33)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,11 @@
 
 ## 현재 상태
 
+- **🛡️ begin-step 시 stale current_step WARN** (`DCN-CHG-20260430-33`):
+  - jajang impl-loop epic-08 회고 I4 (e08 batch 2 `.steps.jsonl` engineer 누락) 회귀 방지.
+  - `STALE_STEP_TTL_SEC = 30 * 60` (30분) 신설. `update_current_step` 에 stale 검사 — 기존 current_step 의 `last_confirmed_at` 이 30분 초과면 stderr `STALE STEP WARN`.
+  - 자동 보정 X (DCN-30-25 정책 정합 — 안전). end-step 누락 + 다음 begin-step 패턴 (DCN-30-25 미커버) 만 cover.
+  - 테스트 2 케이스 추가 (stale WARN / fresh no-WARN).
 - **✂️ orchestration.md split (handoff-matrix 분리)** (`DCN-CHG-20260430-32`):
   - PR4 의 follow-up — orchestration.md (540줄) 300줄 cap 위반 해소.
   - **`docs/handoff-matrix.md` 신규** (256줄) — agent 측 강제 영역 SSOT. §4 결정표 (12 agent enum) + §5 retry 한도 + §6 escalate 카탈로그 + §7 권한 매트릭스 (호출 / Write / Read / 인프라) 통째 이전.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,20 @@
 
 ## Records
 
+### DCN-CHG-20260430-33
+- **Date**: 2026-04-30
+- **Rationale**: jajang impl-loop epic-08 회고에서 발견된 I4 — e08 batch 2 의 `.steps.jsonl` 에 engineer step 통째 누락. 메인 Claude 가 git 작업으로 distract → engineer end-step 호출 skip → 다음 step 의 begin-step 이 current_step 덮어쓰면서 직전 step 기록 휘발. DCN-30-25 의 end-step drift detector / `--expected-steps` 검증은 *end-step 호출 자체가 발생한 케이스* 만 cover. *end-step 누락 + 다음 begin-step* 패턴은 미커버.
+- **Alternatives**:
+  1. **end-step 자동 보정 (begin-step 시 이전 step 자동 end-step 박음)** — 기각: DCN-30-25 가 명시적 reject ("자동 보정 X — 안전. WARN 으로 메인 사후 인지"). 자동 보정은 잘못된 enum/prose 박을 위험 있음.
+  2. **현 detector (end-step drift) 만 의지 + WARN 출력 강화** — 기각: I4 패턴은 end-step 자체가 미호출 → drift detector 미발동. 새 trigger 필요.
+  3. **채택: begin-step 시 *기존* current_step 의 last_confirmed_at 이 30분 초과 시 stderr WARN** — DCN-30-25 의 정책 (자동 보정 X) 정합. WARN 만 출력, 동작 정상 진행. trigger = next begin-step 호출 시점.
+  4. **timeout-based daemon 으로 polling** — 기각: helper 는 daemon 아님. 추가 인프라 비용 ↑.
+- **Decision**: 옵션 3. `STALE_STEP_TTL_SEC = 30 * 60` (30분) 상수 + `update_current_step` 안에 stale 검사. WARN 메시지 — `[session_state] STALE STEP WARN — previous current_step={agent:mode} stale {N}s. end-step 누락 의심 — .steps.jsonl 에 직전 step 기록 안 됨.`
+- **Follow-Up**:
+  - 효과 측정 — 다음 impl-loop 운용 시 STALE STEP WARN 발생률 측정. 0이면 운영자 행동 변화로 해결됨, 빈발이면 추가 가드 검토.
+  - 30분 cap 자체는 hard-coded — 큰 batch (mobile dense) 작업에서 정상 30분+ 가능. 오탐 잦으면 환경변수로 cap 조정 옵션 검토 (별도 Task).
+  - jajang Epic 09 진행 시 .steps.jsonl 누락 0 검증 — 본 detector 가 미연 차단.
+
 ### DCN-CHG-20260430-32
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,15 @@
 
 ## Records
 
+### DCN-CHG-20260430-33
+- **Date**: 2026-04-30
+- **Change-Type**: harness, test
+- **Files Changed**:
+  - `harness/session_state.py` — `update_current_step` 에 stale current_step WARN 추가. begin-step 호출 시 *기존* current_step 의 `last_confirmed_at` 이 `STALE_STEP_TTL_SEC` (30분) 초과면 stderr `STALE STEP WARN`. `STALE_STEP_TTL_SEC = 30 * 60` 상수 신설.
+  - `tests/test_session_state.py` — 2 케이스 추가 (`test_update_step_warn_when_prev_stale` / `test_update_step_no_warn_when_prev_fresh`).
+  - `docs/process/document_update_record.md` (본 항목) / `docs/process/change_rationale_history.md`
+- **Summary**: I4 (e08 batch 2 `.steps.jsonl` engineer 누락) 회귀 방지. 메인 distract → end-step skip → 다음 begin-step 호출 시 즉시 WARN. 자동 보정 X (DCN-30-25 정책 정합 — 안전).
+
 ### DCN-CHG-20260430-32
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -86,6 +86,7 @@ RUN_ID_RE = re.compile(r"^run-[a-z0-9]{8}$")
 
 DEFAULT_RUN_TTL_SEC = 24 * 60 * 60        # 24h — completed slot 보관 후 cleanup
 DEFAULT_PID_TTL_SEC = 24 * 60 * 60        # 24h — by-pid 파일 stale 기준 (PID 재사용 보호)
+STALE_STEP_TTL_SEC = 30 * 60              # 30min — current_step heartbeat stale 기준 (DCN-30-30)
 LIVE_JSON_VERSION = 1                      # 스키마 진화 추적
 STDIN_TIMEOUT_SEC = 2.0                    # 훅 stdin 읽기 hang 방지
 _ATOMIC_FILE_MODE = 0o600
@@ -498,6 +499,33 @@ def update_current_step(
     if not isinstance(active, dict) or run_id not in active:
         raise ValueError(f"run_id not active: {run_id}")
     slot = dict(active[run_id])
+
+    # DCN-CHG-20260430-30: stale current_step WARN — begin-step 호출 시 *기존*
+    # current_step 의 last_confirmed_at 가 STALE_STEP_TTL_SEC 초과면 stderr WARN.
+    # I4 사례 — engineer step 후 end-step 누락 → 다음 begin-step 시 .steps.jsonl
+    # 의 직전 step 누락 신호. 자동 보정 X (안전).
+    prev_step = slot.get("current_step")
+    prev_confirmed = slot.get("last_confirmed_at")
+    if prev_step and isinstance(prev_step, dict) and prev_confirmed:
+        try:
+            from datetime import datetime, timezone
+            prev_dt = datetime.fromisoformat(prev_confirmed.replace("Z", "+00:00"))
+            now_dt = datetime.now(timezone.utc)
+            stale_sec = (now_dt - prev_dt).total_seconds()
+            if stale_sec > STALE_STEP_TTL_SEC:
+                prev_agent = prev_step.get("agent", "?")
+                prev_mode = prev_step.get("mode")
+                label = f"{prev_agent}{':' + prev_mode if prev_mode else ''}"
+                print(
+                    f"[session_state] STALE STEP WARN — previous current_step={label} "
+                    f"stale {int(stale_sec)}s (> {STALE_STEP_TTL_SEC}s). "
+                    f"end-step 누락 의심 — .steps.jsonl 에 직전 step 기록 안 됨.",
+                    file=sys.stderr,
+                )
+        except Exception:
+            # 시간 파싱 등 실패 silent — begin-step 동작 우선
+            pass
+
     now = _now_iso()
     slot["current_step"] = {
         "agent": agent,

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -470,6 +470,64 @@ class ActiveRunsTests(unittest.TestCase):
                 base_dir=self.base,
             )
 
+    def test_update_step_warn_when_prev_stale(self) -> None:
+        # DCN-30-30: begin-step 호출 시 기존 current_step 의 last_confirmed_at 가
+        # STALE_STEP_TTL_SEC (30min) 초과 → stderr STALE STEP WARN.
+        # I4 사례 — engineer step 후 end-step 누락 시 다음 begin-step 이 잡음.
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        start_run(self.sid, self.run_id, "impl", base_dir=self.base)
+        # 첫 begin-step (engineer)
+        update_current_step(
+            self.sid, self.run_id, "engineer", "IMPL", base_dir=self.base,
+        )
+
+        # last_confirmed_at 를 31분 전으로 강제 — stale 시뮬레이션
+        # update_live 는 last_confirmed_at 자체를 덮지 않으니 raw json write.
+        from datetime import datetime, timedelta, timezone
+        from harness.session_state import live_path
+        live = read_live(self.sid, base_dir=self.base)
+        slot = live["active_runs"][self.run_id]
+        old_iso = (datetime.now(timezone.utc) - timedelta(minutes=31)).isoformat()
+        slot["last_confirmed_at"] = old_iso
+        live["active_runs"][self.run_id] = slot
+        live_path(self.sid, base_dir=self.base).write_text(
+            json.dumps(live, ensure_ascii=False, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+
+        # 두번째 begin-step (validator) — stale WARN 기대
+        err = StringIO()
+        with redirect_stderr(err):
+            update_current_step(
+                self.sid, self.run_id, "validator", "CODE_VALIDATION",
+                base_dir=self.base,
+            )
+        self.assertIn("STALE STEP WARN", err.getvalue())
+        self.assertIn("engineer", err.getvalue())
+        # 새 current_step 박힘 (동작 정상)
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertEqual(slot["current_step"]["agent"], "validator")
+
+    def test_update_step_no_warn_when_prev_fresh(self) -> None:
+        # last_confirmed_at 가 30min 이내면 WARN 없음 (정상 워크플로우 — 빠른 step 전환).
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        start_run(self.sid, self.run_id, "impl", base_dir=self.base)
+        update_current_step(
+            self.sid, self.run_id, "engineer", "IMPL", base_dir=self.base,
+        )
+        # 즉시 다음 begin-step
+        err = StringIO()
+        with redirect_stderr(err):
+            update_current_step(
+                self.sid, self.run_id, "validator", "CODE_VALIDATION",
+                base_dir=self.base,
+            )
+        self.assertNotIn("STALE STEP WARN", err.getvalue())
+
     def test_complete_run(self) -> None:
         start_run(self.sid, self.run_id, "quick", base_dir=self.base)
         complete_run(self.sid, self.run_id, base_dir=self.base)


### PR DESCRIPTION
## Summary

jajang impl-loop epic-08 회고 I4 (e08 batch 2 `.steps.jsonl` engineer step 누락) 회귀 방지. **DCN-30-25 의 end-step drift detector 가 미커버하는 패턴** — *end-step 누락 + 다음 begin-step* — 에 대한 stderr WARN 추가.

## Why

I4 시나리오:
1. engineer step 진행 중 begin-step 호출됨
2. engineer 작업 완료 + commit/PR
3. 메인 Claude 가 다음 작업으로 distract → engineer end-step **호출 skip**
4. 다음 step 의 begin-step 호출 → current_step 덮어쓰기
5. → `.steps.jsonl` 에 engineer step 통째 누락

DCN-30-25 의 end-step drift detector 는 *end-step 호출이 발생한 케이스* 만 catch. 본 패턴 (end-step 자체 미호출) 미커버.

## Approach

- `STALE_STEP_TTL_SEC = 30 * 60` (30분) 신설
- `update_current_step` 에 stale 검사 — 기존 `current_step` 의 `last_confirmed_at` 이 30분 초과면 stderr `STALE STEP WARN`
- **자동 보정 X** — DCN-30-25 의 명시 정책 ("자동 보정 X — 안전. WARN 으로 메인 사후 인지") 정합. 잘못된 enum/prose 자동 박을 위험 회피.

## Test

- `test_update_step_warn_when_prev_stale` — 31분 stale 시 WARN PASS
- `test_update_step_no_warn_when_prev_fresh` — 즉시 다음 step 시 WARN 없음 PASS
- 사전 실패 2건 (`CleanupStaleRunsTests` — hardcoded 2026-04-29 날짜) 은 본 PR 무관, 별도 이슈

## 거버넌스

- Task-ID: DCN-CHG-20260430-33
- Change-Type: harness, test
- 동반:
  - `docs/process/document_update_record.md`
  - `docs/process/change_rationale_history.md`
  - `PROGRESS.md`
- doc-sync gate PASS

## Follow-Up

- 효과 측정 — 다음 impl-loop 운용 시 STALE STEP WARN 발생률 측정
- 30분 cap 환경변수화 검토 (큰 batch 가 정상 30분+ 가능, 오탐 잦으면)
- jajang Epic 09 진행 시 `.steps.jsonl` 누락 0 검증