### PR TITLE
feat: 진단/제안 self-verify 원칙 SSOT — I5 회귀 방지 (DCN-CHG-20260430-35)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,11 @@
 
 ## 현재 상태
 
+- **🛡️ 진단/제안 self-verify 원칙 SSOT** (`DCN-CHG-20260430-35`):
+  - jajang impl-loop epic-08 회고 I5 (메인 sed misdiagnosis "130개 fix" → 실제 0개) 회귀 방지.
+  - `docs/process/dcness-guidelines.md` §12 신설 — 글로벌 `~/.claude/CLAUDE.md` "제1 룰" (실존 검증 강제) 을 dcness skill 진행 컨텍스트에 SessionStart 훅 자동 inject 로 재인용.
+  - 룰 (MUST): 추측 금지 + 실측 후 단언. 검증 방법은 자율 (grep / ls / Read / Bash / WebFetch).
+  - engineer.md §자가 검증 echo (DCN-30-34) 와 짝 — agent 인용 + 메인 실행 verify 양방향.
 - **🛡️ engineer IMPL_PARTIAL + self-verify echo + hallucination catalog** (`DCN-CHG-20260430-34`):
   - jajang impl-loop epic-08 회고 I1/I2/I3 (engineer context overflow 3회) + I5 (메인 sed misdiagnosis) 회귀 방지.
   - **`IMPL_PARTIAL` enum 신설** — 단일 호출 무리 인지 시 자율 분할. handoff-matrix.md §1.5 + §2 (split ≤ 3) / loop-catalog.md §3 §5 (allowed_enums) / dcness-guidelines.md §5 (yolo 매트릭스) 박힘.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,20 @@
 
 ## Records
 
+### DCN-CHG-20260430-35
+- **Date**: 2026-04-30
+- **Rationale**: jajang impl-loop epic-08 회고 I5 — 메인이 "130개 즉시 fix" 진단 사용자에 전달 → 실측 시 0개 → 15분 추가 cycle. 메인 추측 진단 패턴. 글로벌 `~/.claude/CLAUDE.md` "제1 룰 — 실존 검증 강제" 가 *이미 박혀있음* — but dcness skill 진행 중 메인이 해당 룰을 잊는 경향 발견. SessionStart 훅이 dcness-guidelines.md 자동 inject — 본 룰을 §12 로 박아두면 skill 진행 컨텍스트에서 항시 가시.
+- **Alternatives**:
+  1. **commands/quick.md SSOT 1곳 + 4 skill 1줄 참조** (이전 plan) — 기각: SessionStart 훅 자동 inject (DCN-30-26 이후) 가 이미 dcness-guidelines.md 광역 inject. 4 skill 참조 redundant. 검토자 피드백 정합.
+  2. **글로벌 `~/.claude/CLAUDE.md` 제1룰 강화** — 기각: 글로벌 룰 변경은 dcness 범위 밖 (사용자 결정). 본 PR 은 dcness 컨텍스트 보강만.
+  3. **별도 룰 신설 (글로벌과 충돌 없는 새 룰)** — 기각: 룰 순감소 (§2.5) 위반 가능성. 글로벌 룰 재인용 + dcness 컨텍스트 추가가 적합.
+  4. **채택**: dcness-guidelines.md §12 신설 — 글로벌 제1룰 재인용 + dcness skill 진행 컨텍스트에 맞춘 안티패턴 예시 (DCN-30-34 실측 사례). 검증 방법은 자율 (grep / ls / Read / Bash / WebFetch 자기 판단), 형식 X.
+- **Decision**: 옵션 4. dcness-guidelines.md §12 — 룰 (MUST) + 자율 보존 + 안티패턴 (실측 사례) + 효과 (I5 회귀 방지 + agent self-verify echo 와 짝).
+- **Follow-Up**:
+  - 다음 dcness skill 진행 시 메인 추측 진단 발생률 측정 (목표: I5 같은 실측 0건 대비 추측 0).
+  - I5 잔여 — 글로벌 `~/.claude/CLAUDE.md` 제1룰 강화는 사용자 결정 (별도 검토).
+  - dcness-guidelines.md 가 ~256줄 — 300 cap 근접. 다음 룰 추가 시 분리 axis 결정 (`행동 룰` vs `참조 룰` 등).
+
 ### DCN-CHG-20260430-34
 - **Date**: 2026-04-30
 - **Rationale**: jajang impl-loop epic-08 회고 — 5 incident 중 I1 (mobile pivot batch 4 engineer overflow 119 tool uses) / I2 (e08 batch 2 overflow 119) / I3 (e08 batch 3 overflow 170 + sed 보다 Edit 선호) / I5 (메인 sed misdiagnosis "130개 fix" → 실제 0개) 회귀 방지. 부수 발견: architect/validator 가 `setupFilesAfterFramework` (jest 에 없는 키) 출력 — LLM 학습 데이터 노이즈.

--- a/docs/process/dcness-guidelines.md
+++ b/docs/process/dcness-guidelines.md
@@ -225,3 +225,32 @@ agent 별 적용:
 - **원칙 4** — Goal-Driven Execution (검증 가능 success criteria) — test-engineer / validator
 
 각 agent prompt 에 적합한 원칙 박혀있음 (`agents/*.md` 참조).
+
+## 12. 진단/제안 self-verify 원칙 (DCN-30-35, 글로벌 제1룰 정합)
+
+> 출처: `~/.claude/CLAUDE.md` "제1 룰 — 제안 전 *실존 검증* 절대 강제". 글로벌 룰을 dcness skill 진행 컨텍스트에 SessionStart 훅 자동 inject 로 재인용.
+> 적용 incident: jajang impl-loop epic-08 의 I5 — 메인이 "130개 즉시 fix" 진단 → 실측 시 0개 → 잘못된 진단 + 15분 추가 cycle.
+
+### 룰 (MUST)
+
+모든 사용자-facing 진단 / 제안 *제출 전*:
+- 등장하는 파일 경로 / 함수명 / CLI 옵션 → `grep` / `ls` / `Read` 실측 후 단언
+- 등장하는 테스트 결과 / 숫자 / 변경 규모 → 명령 실행 후 인용
+- 추측 표현 (`아마`, `보통`, `대략`, `~ 정도`) 금지
+
+위반 패턴 발견 시 (예: "30+ 파일 vitest import 잔존" 추측 → 실제 0개) 즉시 검증 단계로 되돌아가 사실 확인 후 재구성.
+
+### 자율 보존
+
+*검증 방법은 자율* — grep / ls / Read / Bash / 외부 docs WebFetch 중 자기 판단. 형식 강제 X. 추측 금지 + 실측 후 단언만 강제.
+
+### 안티패턴 (실측 사례 — DCN-30-34 회고)
+
+❌ "벌써 30개 파일 변환됐을 것" — 실측 안 함 → 잘못된 숫자
+❌ "보통 jest config 는 X 키 쓰니까" — 학습 데이터 의존 → hallucination (예: `setupFilesAfterFramework`)
+❌ "이 함수 (대략) 어디 있을 것" — grep 안 함 → 잘못된 경로
+❌ engineer 보고 즉시 신뢰 → 실측 안 함 (`agents/engineer.md` § 자가 검증 echo 의무 와 짝)
+
+### 효과
+
+I5 (메인 sed misdiagnosis) 회귀 방지. agent 측 self-verify echo (engineer.md `## 자가 검증`) 와 짝 — agent 가 인용 + 메인이 그 명령 직접 실행해 verify.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,14 @@
 
 ## Records
 
+### DCN-CHG-20260430-35
+- **Date**: 2026-04-30
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/process/dcness-guidelines.md` — §12 신설: 진단/제안 self-verify 원칙. 글로벌 `~/.claude/CLAUDE.md` "제1 룰" (실존 검증 강제) 을 dcness skill 진행 컨텍스트에 SessionStart 훅 자동 inject 로 재인용. 추측 금지 + 실측 후 단언 (검증 방법은 자율). 256줄 (300 cap 안).
+  - `docs/process/document_update_record.md` (본 항목) / `docs/process/change_rationale_history.md`
+- **Summary**: jajang impl-loop epic-08 의 I5 (메인 sed misdiagnosis "130개 fix" → 실제 0개) 회귀 방지. dcness-guidelines.md SSOT 단일 — skill 광역 1줄 참조 X (SessionStart 훅 자동 inject). engineer.md §자가 검증 echo (DCN-30-34) 와 짝 — agent 인용 + 메인 실행 verify 양방향 hygiene.
+
 ### DCN-CHG-20260430-34
 - **Date**: 2026-04-30
 - **Change-Type**: agent, spec


### PR DESCRIPTION
## Summary

jajang impl-loop epic-08 회고 **I5** (메인 sed misdiagnosis "130개 즉시 fix" → 실제 0개 → 사용자에 잘못된 진단 + 15분 추가 cycle) 회귀 방지. 글로벌 `~/.claude/CLAUDE.md` "제1 룰 — 실존 검증 강제" 를 dcness skill 진행 컨텍스트에 SessionStart 훅 자동 inject 로 재인용.

## Why

글로벌 룰 (제1 룰) 이 *이미 존재*. 하지만 dcness skill 진행 중 메인이 해당 룰을 잊는 경향 발견 (jajang epic-08 사례). SessionStart 훅이 dcness-guidelines.md 자동 inject — 본 룰을 §12 로 박아두면 skill 진행 컨텍스트에서 항시 가시.

## Approach

`docs/process/dcness-guidelines.md` §12 신설:

- **룰 (MUST)**: 추측 금지 + 실측 후 단언
- **자율 보존**: 검증 방법은 자율 (grep / ls / Read / Bash / WebFetch 자기 판단)
- **안티패턴 (실측 사례 — DCN-30-34 회고)**:
  - "벌써 30개 파일 변환됐을 것" — 실측 안 함
  - "보통 jest config 는 X 키 쓰니까" — hallucination
  - engineer 보고 즉시 신뢰 → 실측 안 함 (engineer §자가 검증 echo 와 짝)
- **효과**: I5 회귀 방지 + agent self-verify echo (DCN-30-34) 와 짝 — agent 인용 + 메인 실행 verify 양방향

## 검토자 피드백 정합

- ❌ "commands/quick.md SSOT 1곳 + 4 skill 1줄 참조" → cut. SessionStart 훅 자동 inject (DCN-30-26) 가 이미 dcness-guidelines.md 광역 inject — 4 skill 참조 redundant.
- ✅ dcness-guidelines.md SSOT 단일

## File 크기

| file | lines |
|---|---|
| `docs/process/dcness-guidelines.md` | 256 / 300 cap |

## 거버넌스

- Task-ID: DCN-CHG-20260430-35
- Change-Type: docs-only
- 동반: `document_update_record.md` / `change_rationale_history.md` / `PROGRESS.md`
- doc-sync gate PASS

## Follow-Up

- 다음 dcness skill 진행 시 메인 추측 진단 발생률 측정
- I5 잔여 — 글로벌 `~/.claude/CLAUDE.md` 제1룰 강화는 사용자 결정 (별도)
- dcness-guidelines.md 256줄 — 300 cap 근접. 다음 룰 추가 시 분리 axis 결정