### PR TITLE
feat: engineer prior tool_use_count stderr hint (DCN-CHG-20260430-36)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🎯 engineer prior tool_use_count hint** (`DCN-CHG-20260430-36`):
+  - jajang epic-08/09 회고 추가 분석 — engineer overflow 5회 (102/119/153/170/223 tool uses) 자장 오후 실측. DCN-30-34 IMPL_PARTIAL enum 만으론 LLM self-monitor 불가능 (CC API 미노출 본질 한계) → 실효 부족.
+  - `harness/run_review.py:extract_agent_invocations` 에 `tool_use_count` 필드 (`totalToolUseCount`) 추가.
+  - `harness/session_state.py:_prior_engineer_tool_use_count(sid)` 신규 + `_cli_begin_step` 가 `agent="engineer"` 시 stderr hint (`[hint] prior engineer tool_use_count=N — IMPL_PARTIAL 분할 자율 판단 권고. 강제 X (정보만).`).
+  - 자율 침해 0 — 측정 정보 보충만, 판단은 agent/메인 자율. 측정 source = `toolUseResult.totalToolUseCount` (CC session JSONL).
+  - 신규 3 테스트 (engineer hint / no prior silent / non-engineer silent). 224 ran / 222 PASS / 2 pre-existing flaky 무관.
 - **🛡️ 진단/제안 self-verify 원칙 SSOT** (`DCN-CHG-20260430-35`):
   - jajang impl-loop epic-08 회고 I5 (메인 sed misdiagnosis "130개 fix" → 실제 0개) 회귀 방지.
   - `docs/process/dcness-guidelines.md` §12 신설 — 글로벌 `~/.claude/CLAUDE.md` "제1 룰" (실존 검증 강제) 을 dcness skill 진행 컨텍스트에 SessionStart 훅 자동 inject 로 재인용.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,29 @@
 
 ## Records
 
+### DCN-CHG-20260430-36
+- **Date**: 2026-04-30
+- **Rationale**:
+  - DCN-30-34 IMPL_PARTIAL enum 도입 후 자장 추가 데이터 분석 (오후 5.5MB JSONL) — engineer overflow 5회 발생 (102/119/153/170/223 tool uses). 정상 invocation = 36~64. enum 만으론 self-monitor 불가능 (LLM 이 자기 tool_use_count 모름 — CC API 미노출 본질 한계).
+  - first-principle 재검토 — "측정 정보 부재로 자율 판단 *원천 불가능* 했던 영역에 정보 보충 = 자율 *조건* 보강 (자율 침해 X)".
+  - 측정 source 발견: CC session JSONL `toolUseResult.totalToolUseCount` 필드. 자장 실측에서 119 / 170 등 실제 값 일치 확인.
+- **Alternatives**:
+  1. *옵션 A — agent prompt 안에 숫자 cap (≤ 60 tool uses)*. 자율 침해 ↑. 마법수 기각.
+  2. *옵션 B — IMPL_PARTIAL enum 만 (DCN-30-34 그대로 유지)*. self-monitor 불가능 → 실효 부족 (자장 실측 입증).
+  3. **(채택) 옵션 C — helper 단 prior count 측정 → stderr hint**. 정보 보강만. 메인이 다음 begin-step 호출 시점에 인지 → agent prompt 에 명시 (예: "이전 87, 이번 분할 고려") 가능. 자율 침해 0.
+  4. *옵션 D — agent 호출 시 prompt 에 자동 inject*. 인프라 복잡도 ↑ (agent invocation context 변형). v1 = stderr hint 단순.
+- **Decision**:
+  - 옵션 C 채택.
+  - **`harness/run_review.py:extract_agent_invocations`** 에 `tool_use_count` 필드 추가 (기존 사용처 영향 0).
+  - **`harness/session_state.py:_prior_engineer_tool_use_count(sid)`** 신규. CC session JSONL 단일 파일 (`<sid>.jsonl`) 만 스캔 — 효율 (전체 project dir scan X).
+  - **`_cli_begin_step`** 가 `agent="engineer"` 시 hint 출력. 다른 agent 는 silent (engineer 가 자장 overflow 95% 점유 — 우선순위).
+  - 측정 실패 silent (jsonl 없음 / 파싱 오류 — 노이즈 회피).
+- **Follow-Up**:
+  - **PR2 (DCN-30-37)**: `/run-review` 회귀 4 패턴 추가 (TOOL_USE_OVERFLOW / END_STEP_SKIP / PARTIAL_LOOP / MAIN_SED_MISDIAGNOSIS). hint 효과 *측정* 인프라.
+  - **PR3 (DCN-30-38)**: DCN-30-34 self-verify echo `## 자가 검증` 섹션 → anchor 자유 약화 (substance 의무, 형식 자율). + dcness-guidelines §12 안티패턴 강화 (sed 후 검증 의무 inline).
+  - **임계값 권고 (≥ 60 등) prompt 명시 X** — 메인 자율 판단. hint 가 정보 보강만.
+  - **다른 agent 확장 후속** — architect/validator 도 overflow 발견 시 (자장 architect 64/58 케이스) 같은 hint 확장 검토. 현재 v1 = engineer.
+
 ### DCN-CHG-20260430-35
 - **Date**: 2026-04-30
 - **Rationale**: jajang impl-loop epic-08 회고 I5 — 메인이 "130개 즉시 fix" 진단 사용자에 전달 → 실측 시 0개 → 15분 추가 cycle. 메인 추측 진단 패턴. 글로벌 `~/.claude/CLAUDE.md` "제1 룰 — 실존 검증 강제" 가 *이미 박혀있음* — but dcness skill 진행 중 메인이 해당 룰을 잊는 경향 발견. SessionStart 훅이 dcness-guidelines.md 자동 inject — 본 룰을 §12 로 박아두면 skill 진행 컨텍스트에서 항시 가시.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260430-36
+- **Date**: 2026-04-30
+- **Change-Type**: harness, test
+- **Files Changed**:
+  - `harness/run_review.py:extract_agent_invocations` — `tool_use_count` 필드 추가 (`tur.get("totalToolUseCount", 0)`). 기존 사용처 영향 0 (추가 필드).
+  - `harness/session_state.py:_prior_engineer_tool_use_count(sid)` 신규 — 현재 sid 의 CC session JSONL 에서 직전 `dcness:engineer` invocation 의 `totalToolUseCount` 추출. 측정 실패 silent (None).
+  - `harness/session_state.py:_cli_begin_step` — `agent="engineer"` 시 직전 count > 0 이면 stderr hint (`[hint] prior engineer tool_use_count=N — 단일 호출 capacity 압박 인지 시 IMPL_PARTIAL 분할 자율 판단 권고. 강제 X (정보만).`).
+  - `tests/test_session_state.py` — 3 신규 (`test_begin_step_engineer_emits_tool_use_hint` / `_no_hint_when_no_prior` / `_non_engineer_no_hint`). `_setup_fake_cc_jsonl` helper. 224 ran / 222 PASS / 2 pre-existing flaky 무관.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: jajang impl-loop epic-08/09 회고 — engineer context overflow 5회 (102/119/153/170/223 tool uses) 자장 실측. DCN-30-34 IMPL_PARTIAL enum 만으론 실효 부족 — LLM 이 자기 tool_use_count self-monitor 불가 (CC API 미노출 본질 한계). helper 가 직전 count 측정 → stderr hint 로 흘려 메인이 다음 호출 prompt 에 명시 가능 ("이전 호출 87 tool uses 였음, 이번엔 분할 고려"). 자율 침해 X — 정보 보강만, 판단은 자율. 측정 source = `toolUseResult.totalToolUseCount` (CC session JSONL).
+
 ### DCN-CHG-20260430-35
 - **Date**: 2026-04-30
 - **Change-Type**: docs-only

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -521,6 +521,7 @@ def extract_agent_invocations(repo_path: Path, run_window: tuple[datetime, datet
                     "input_tokens": usage.get("input_tokens", 0),
                     "cache_read": usage.get("cache_read_input_tokens", 0),
                     "cost_usd": cost,
+                    "tool_use_count": tur.get("totalToolUseCount", 0),
                 })
         except OSError:
             continue

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -939,6 +939,50 @@ def _cli_end_run(args: Any) -> int:
     return 0
 
 
+def _prior_engineer_tool_use_count(sid: str) -> Optional[int]:
+    """현재 sid 의 CC session JSONL 에서 직전 engineer sub-agent invocation 의
+    `totalToolUseCount` 추출 (DCN-CHG-20260430-36).
+
+    LLM 은 자기 tool use count self-monitor 불가 (CC API 미노출) — helper 가
+    측정해 stderr hint 로 흘려 IMPL_PARTIAL 자율 판단 *조건* 보강. 자율 침해 X.
+
+    return: 직전 engineer invocation count (int) / 측정 실패 None.
+    """
+    try:
+        from harness.run_review import encode_repo_path_dcness
+    except Exception:
+        return None
+    try:
+        cwd = Path.cwd()
+        encoded = encode_repo_path_dcness(str(cwd))
+        jsonl = Path.home() / ".claude" / "projects" / encoded / f"{sid}.jsonl"
+        if not jsonl.exists():
+            return None
+        latest_count: Optional[int] = None
+        latest_ts = ""
+        for line in jsonl.read_text(encoding="utf-8").splitlines():
+            if '"totalToolUseCount"' not in line or '"agentType"' not in line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            tur = rec.get("toolUseResult") or {}
+            agent_type = (tur.get("agentType") or "").lower()
+            if "engineer" not in agent_type:
+                continue
+            cnt = tur.get("totalToolUseCount")
+            if not isinstance(cnt, int):
+                continue
+            ts = rec.get("timestamp", "")
+            if ts > latest_ts:
+                latest_ts = ts
+                latest_count = cnt
+        return latest_count
+    except Exception:
+        return None
+
+
 def _cli_begin_step(args: Any) -> int:
     """sid+rid auto-detect → update_current_step."""
     sid = auto_detect_session_id()
@@ -948,6 +992,20 @@ def _cli_begin_step(args: Any) -> int:
         return 1
     mode = args.mode if args.mode else None
     update_current_step(sid, rid, args.agent, mode)
+
+    # DCN-CHG-20260430-36: agent="engineer" 시 직전 engineer invocation 의
+    # tool_use_count stderr hint. LLM self-monitor 불가 영역 정보 보강.
+    # 측정 실패 silent (노이즈 회피).
+    if args.agent == "engineer":
+        prior = _prior_engineer_tool_use_count(sid)
+        if prior is not None and prior > 0:
+            print(
+                f"[hint] prior engineer tool_use_count={prior} — "
+                f"단일 호출 capacity 압박 인지 시 IMPL_PARTIAL 분할 자율 판단 권고. "
+                f"강제 X (정보만).",
+                file=sys.stderr,
+            )
+
     print("ok")
     return 0
 

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1016,6 +1016,77 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertFalse(called["hit"])
         self.assertNotIn("/run-review (auto)", out.getvalue())
 
+    def _setup_fake_cc_jsonl(self, sid: str, engineer_counts: list) -> Path:
+        """CC session JSONL fake — engineer toolUseResult 행 N개 박음. ts 오름차순."""
+        from harness.run_review import encode_repo_path_dcness
+        encoded = encode_repo_path_dcness(str(Path.cwd()))
+        proj_dir = Path.home() / ".claude" / "projects" / encoded
+        proj_dir.mkdir(parents=True, exist_ok=True)
+        jsonl = proj_dir / f"{sid}.jsonl"
+        lines = []
+        for i, cnt in enumerate(engineer_counts):
+            lines.append(json.dumps({
+                "timestamp": f"2026-04-30T0{i}:00:00.000Z",
+                "toolUseResult": {
+                    "agentType": "dcness:engineer",
+                    "totalToolUseCount": cnt,
+                    "totalDurationMs": 1000,
+                    "totalTokens": 100,
+                },
+            }))
+        jsonl.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return jsonl
+
+    def test_begin_step_engineer_emits_tool_use_hint(self) -> None:
+        """DCN-30-36: agent='engineer' 시 직전 invocation count stderr hint."""
+        from harness.session_state import _cli_begin_step
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        jsonl = self._setup_fake_cc_jsonl(self.sid, [50, 87])  # 직전 = 87
+        try:
+            err = StringIO()
+            with redirect_stderr(err):
+                rc = _cli_begin_step(SimpleNamespace(agent="engineer", mode="IMPL"))
+            self.assertEqual(rc, 0)
+            stderr = err.getvalue()
+            self.assertIn("[hint]", stderr)
+            self.assertIn("tool_use_count=87", stderr)
+            self.assertIn("IMPL_PARTIAL", stderr)
+        finally:
+            jsonl.unlink(missing_ok=True)
+
+    def test_begin_step_engineer_no_hint_when_no_prior(self) -> None:
+        """JSONL 없거나 engineer invocation 없으면 silent."""
+        from harness.session_state import _cli_begin_step
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        err = StringIO()
+        with redirect_stderr(err):
+            rc = _cli_begin_step(SimpleNamespace(agent="engineer", mode="IMPL"))
+        self.assertEqual(rc, 0)
+        self.assertNotIn("[hint]", err.getvalue())
+
+    def test_begin_step_non_engineer_no_hint(self) -> None:
+        """agent != 'engineer' 면 hint 없음 (다른 agent 도 jsonl 있어도 무관)."""
+        from harness.session_state import _cli_begin_step
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        jsonl = self._setup_fake_cc_jsonl(self.sid, [200])  # 큰 값 박혀도
+        try:
+            err = StringIO()
+            with redirect_stderr(err):
+                rc = _cli_begin_step(SimpleNamespace(agent="validator", mode="CODE_VALIDATION"))
+            self.assertEqual(rc, 0)
+            self.assertNotIn("[hint]", err.getvalue())
+        finally:
+            jsonl.unlink(missing_ok=True)
+
     def test_end_step_writes_prose_and_extracts_enum(self) -> None:
         from harness.session_state import _cli_end_step, session_dir
         from types import SimpleNamespace


### PR DESCRIPTION
## Summary

jajang impl-loop epic-08/09 회고 추가 분석 — engineer context overflow 5회 자장 오후 실측. DCN-30-34 IMPL_PARTIAL enum 만으론 실효 부족 (LLM self-monitor 불가능 — CC API 미노출 본질 한계).

helper 단 prior count 측정 → stderr hint. **자율 침해 0** — 정보 보강만, IMPL_PARTIAL 분할 판단은 agent/메인 자율.

## 자장 실측 데이터

| tool uses | timestamp (UTC) | 결과 |
|---|---|---|
| 223 | 05:47 | overflow + 상태 복구 |
| 170 | 08:53 | overflow → PR #156 PARTIAL |
| 153 | 12:22 | overflow → PR #165 PARTIAL |
| 119 | 08:09 | overflow + POLISH cycle |
| 102 | 04:45 | overflow |

정상 invocation = 36~64 범위.

## 변경

### harness/run_review.py
- `extract_agent_invocations` 에 `tool_use_count` 필드 (`totalToolUseCount`) 추가
- 기존 사용처 영향 0 (추가 필드)

### harness/session_state.py
- `_prior_engineer_tool_use_count(sid)` 신규 — 현재 sid CC session JSONL 단일 파일 스캔, 직전 `dcness:engineer` invocation 의 totalToolUseCount 추출
- 측정 실패 silent (None — 노이즈 회피)
- `_cli_begin_step` — `agent="engineer"` 시 prior count > 0 이면 stderr hint:
  ```
  [hint] prior engineer tool_use_count=87 — 단일 호출 capacity 압박 인지 시 IMPL_PARTIAL 분할 자율 판단 권고. 강제 X (정보만).
  ```

### tests/test_session_state.py (3 신규)
- `test_begin_step_engineer_emits_tool_use_hint` — JSONL 박고 hint 검증
- `test_begin_step_engineer_no_hint_when_no_prior` — JSONL 없으면 silent
- `test_begin_step_non_engineer_no_hint` — agent != engineer silent

## first-principle 정합

| 차원 | 평가 |
|---|---|
| 자율 침해 | ❌ — 정보 보강만, 강제 X |
| 형식 강제 | ❌ — 출력/preamble/marker 강제 X |
| 자율 판단 어려운가? | ✅ cover — LLM self-monitor 불가 영역에 측정 정보 보충 |

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (6 files / docs-only, harness, test)
- [x] `python3 -m unittest discover -s tests` — 224 ran / 222 PASS / 2 pre-existing flaky 무관
- [x] 신규 3 테스트 PASS

## 후속 PR

| # | Task-ID | 변경 |
|---|---|---|
| **PR1 (본 PR)** | DCN-30-36 | helper prior count hint |
| PR2 | DCN-30-37 | /run-review 회귀 4 패턴 (TOOL_USE_OVERFLOW / END_STEP_SKIP / PARTIAL_LOOP / MAIN_SED_MISDIAGNOSIS) |
| PR3 | DCN-30-38 | DCN-34 self-verify anchor 자율화 + §12 안티패턴 강화 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)