### PR TITLE
feat: /run-review 회귀 4 패턴 자동 검출 (DCN-CHG-20260430-37)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,18 @@
 
 ## 현재 상태
 
+- **📊 /run-review 회귀 4 패턴 자동 검출** (`DCN-CHG-20260430-37`):
+  - DCN-30-36 prior count hint 의 *사후 측정* 인프라 + 자장 실 패턴 4종 자동 검출.
+  - `harness/run_review.py:StepRecord.tool_use_count` 필드 + `assign_invocations_to_steps` propagate.
+  - `_scan_main_sed_misdiagnosis` 신규 — CC JSONL 안 메인 self-correction 패턴 검출.
+  - `detect_wastes` signature 확장 (invocations / repo_path / window). 4 신규 패턴:
+    - `TOOL_USE_OVERFLOW` (≥ 100, 자장 실측 임계)
+    - `PARTIAL_LOOP` (IMPL_PARTIAL ≥ 3 in run)
+    - `END_STEP_SKIP` (invocations > steps + margin 1)
+    - `MAIN_SED_MISDIAGNOSIS` (메인 self-correction 텍스트 패턴)
+  - 자장 실 데이터 검증 — run-c0ef57e0 에서 `tool_use_count=153` 즉시 검출 ✓.
+  - 8 신규 테스트. 34 ran / all PASS.
+  - 자율 침해 0 (사후 분석만). MISSING_SELF_VERIFY 는 PR3 (DCN-30-38) 의 anchor 자율화 후 추가.
 - **🎯 engineer prior tool_use_count hint** (`DCN-CHG-20260430-36`):
   - jajang epic-08/09 회고 추가 분석 — engineer overflow 5회 (102/119/153/170/223 tool uses) 자장 오후 실측. DCN-30-34 IMPL_PARTIAL enum 만으론 LLM self-monitor 불가능 (CC API 미노출 본질 한계) → 실효 부족.
   - `harness/run_review.py:extract_agent_invocations` 에 `tool_use_count` 필드 (`totalToolUseCount`) 추가.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,30 @@
 
 ## Records
 
+### DCN-CHG-20260430-37
+- **Date**: 2026-04-30
+- **Rationale**:
+  - DCN-30-36 prior count hint 도입했으나 *효과 측정 인프라* 부재 — 다음 epic 진행 후 회귀 자동 발화 X. /run-review 수동 분석 의존.
+  - 자장 실 데이터 (5.5MB JSONL, 5 epic-08/09 incidents) 분석 결과 — 4 패턴 모두 textually 식별 가능했으나 자동화 부재.
+  - first-principle: 사후 측정은 자율 무관 — 결과 측정만, 실시간 강제 X. **dcness-guidelines.md §0.1 행동지침 md 의 measurement** 인프라가 없으면 회귀 검출이 매번 수동 → 비용 ↑.
+- **Alternatives**:
+  1. *옵션 A — 매 incident 시 사용자가 수동 회고*. 비용 ↑, drift.
+  2. *옵션 B — agent prompt 안에 self-check 룰 inject*. 자율 침해 + 형식 강제 + 토큰 누적.
+  3. **(채택) 옵션 C — `/run-review` 회귀 패턴 4종 자동 검출**. 사후 측정만 — 자율 무관. fix 효과 측정 가능.
+- **Decision**:
+  - 옵션 C 채택. 4 패턴 + StepRecord `tool_use_count` 필드.
+  - `TOOL_USE_OVERFLOW` 임계 `≥ 100` — 자장 실측 5건 (102/119/153/170/223) 모두 PR PARTIAL 회귀. 마법수 아님 — 실측 기반.
+  - `PARTIAL_LOOP` 임계 `≥ 3` — DCN-30-34 권고 cycle ≤ 3 정합.
+  - `END_STEP_SKIP` margin `1` — sub-agent self-recurse / POLISH 같은 정상 변동 흡수.
+  - `MAIN_SED_MISDIAGNOSIS` — 텍스트 패턴 검출 (한국어 + 영어). 휴리스틱 — false positive 가능, 단 sed 후 검증 누락은 큰 incident 라 보수적 검출 가치 ↑.
+  - `MISSING_SELF_VERIFY` 패턴 **제외** (DCN-34 anchor 자율화 후 PR3 에서 추가 — 다중 anchor 옵션 검출 로직 필요).
+  - signature 확장 — kwargs default None 으로 backward compat 보존. 기존 9 test caller 영향 0.
+- **Follow-Up**:
+  - **PR3 (DCN-30-38)**: DCN-34 self-verify echo `## 자가 검증` 섹션 anchor 자율화 (`## 자가 검증` / `## Verification` / `## 검증` 등 다중) + dcness-guidelines.md §12 안티패턴 1줄 강화 (sed 후 실측 의무) + `/run-review` `MISSING_SELF_VERIFY` 패턴 추가.
+  - **자장 실 검증** — 자장 plugin 재install 후 다음 epic 시 4 패턴 모두 자동 검출 확인. 임계값 (100/3/1) tuning 후속.
+  - **`MAIN_SED_MISDIAGNOSIS` false positive 모니터링** — 정상 자기 정정 텍스트도 패턴 매칭 가능. 30일 누적 측정 후 임계 강화 검토.
+  - **render_report 컬럼 확장** — 단계별 표에 `tool_uses` 컬럼 추가 후속 (현재 duration / out_tok / total_tok / cost / matched 만).
+
 ### DCN-CHG-20260430-36
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,25 @@
 
 ## Records
 
+### DCN-CHG-20260430-37
+- **Date**: 2026-04-30
+- **Change-Type**: harness, test
+- **Files Changed**:
+  - `harness/run_review.py:StepRecord` — `tool_use_count: int = 0` 필드 추가 (DCN-30-36 짝).
+  - `harness/run_review.py:assign_invocations_to_steps` — invocation 의 `tool_use_count` 를 step 에 propagate.
+  - `harness/run_review.py:_scan_main_sed_misdiagnosis` 신규 — CC session JSONL 안 메인 self-correction 패턴 (`정정.*0개` / `잘못 진단` / `misdiagnosis` / `sed.*변경.*0` / `실측 시 0`) 검출. 최대 3개 hits 반환.
+  - `harness/run_review.py:detect_wastes` — signature 확장 (`invocations` / `repo_path` / `window` optional). 4 신규 패턴:
+    - `TOOL_USE_OVERFLOW` (HIGH): step.tool_use_count ≥ 100 (자장 실측 임계). DCN-30-36 hint 사후 측정.
+    - `PARTIAL_LOOP` (HIGH): IMPL_PARTIAL ≥ 3 in run (자장 무한 반복 패턴).
+    - `END_STEP_SKIP` (HIGH): agent invocation count > steps row + 1 margin (메인 distract → end-step 누락 사후 검출).
+    - `MAIN_SED_MISDIAGNOSIS` (HIGH): 메인 self-correction 패턴 발견 (I5 회귀 측정).
+  - `harness/run_review.py:build_report` — invocations + window 을 detect_wastes 로 전달.
+  - `tests/test_run_review.py:RegressionPatternsTests` — 8 신규 테스트 (TOOL_USE_OVERFLOW positive/negative/unmatched, PARTIAL_LOOP 3+/2-, END_STEP_SKIP exceeded/within margin, MAIN_SED_MISDIAGNOSIS detect). 34 ran (이전 26) / all PASS.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: DCN-30-36 prior count hint 의 *사후 측정* 인프라 + 자장 실측 패턴 4종 자동 검출. 자장 실 데이터 검증 — run-c0ef57e0 에서 `tool_use_count=153` TOOL_USE_OVERFLOW 즉시 검출 (오프라인 회귀 측정 ✓). fix 효과 측정 가능 → 다음 epic 회고 시 자동 발화. 자율 침해 0 (사후 분석만).
+
 ### DCN-CHG-20260430-36
 - **Date**: 2026-04-30
 - **Change-Type**: harness, test

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -107,6 +107,8 @@ class StepRecord:
     total_tokens: int = 0
     cost_usd: float = 0.0
     matched_invocation: bool = False
+    # DCN-CHG-20260430-37: tool_use_count — TOOL_USE_OVERFLOW 검출 + DCN-30-36 hint 짝.
+    tool_use_count: int = 0
 
 
 @dataclass
@@ -228,7 +230,74 @@ def parse_steps(run_dir: Path) -> list[StepRecord]:
 
 # ── Waste 탐지 ────────────────────────────────────────────────────────
 
-def detect_wastes(steps: list[StepRecord]) -> list[WasteFinding]:
+def _scan_main_sed_misdiagnosis(
+    repo_path: Optional[Path],
+    window: Optional[tuple],
+) -> list[str]:
+    """CC session JSONL within run window 에서 메인 self-correction 패턴 검출
+    (DCN-CHG-20260430-37). I5 회귀 추적 — "정정 — 변경 0" / "잘못 진단" 등.
+
+    return: 매칭된 assistant text excerpt list (최대 3).
+    """
+    if not repo_path or not window:
+        return []
+    first_ts, last_ts = window
+    keyword_filter = ["정정", "잘못 진단", "실측 시", "misdiagnosis", "변경사항 0"]
+    patterns = [
+        r"정정[^\n]{0,80}(0개|0\s*변경|실제\s*0|변경사항\s*0)",
+        r"sed[^\n]{0,80}변경[^\n]{0,20}0",
+        r"실측\s*시\s*0",
+        r"잘못\s*진단",
+        r"misdiagnosis",
+    ]
+    hits: list[str] = []
+    try:
+        for jsonl in find_session_jsonls(repo_path):
+            try:
+                lines = jsonl.read_text(encoding="utf-8").splitlines()
+            except OSError:
+                continue
+            for line in lines:
+                if not any(kw in line for kw in keyword_filter):
+                    continue
+                try:
+                    rec = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if rec.get("type") != "assistant":
+                    continue
+                ts = _parse_iso(rec.get("timestamp", ""))
+                if not ts:
+                    continue
+                ts_naive = ts.replace(tzinfo=None)
+                if ts_naive < first_ts.replace(tzinfo=None) or ts_naive > last_ts.replace(tzinfo=None):
+                    continue
+                content = rec.get("message", {}).get("content", [])
+                matched = False
+                for blk in content:
+                    if blk.get("type") != "text":
+                        continue
+                    text = blk.get("text", "")
+                    for pat in patterns:
+                        if re.search(pat, text):
+                            hits.append(text[:300].replace("\n", " "))
+                            matched = True
+                            break
+                    if matched:
+                        break
+                if len(hits) >= 3:
+                    return hits
+    except Exception:
+        pass
+    return hits
+
+
+def detect_wastes(
+    steps: list[StepRecord],
+    invocations: Optional[list[dict]] = None,
+    repo_path: Optional[Path] = None,
+    window: Optional[tuple] = None,
+) -> list[WasteFinding]:
     findings: list[WasteFinding] = []
 
     # RETRY_SAME_FAIL — 연속 동일 FAIL enum
@@ -369,6 +438,75 @@ def detect_wastes(steps: list[StepRecord]) -> list[WasteFinding]:
                 fix=(f"agents/{s.agent}.md 'thinking 본문 드래프트 금지' 룰 ⚠️ CRITICAL banner 격상 + "
                       "Agent description 에 'extended thinking 의사결정 분기만, prose 즉시 emit' 추가"),
             ))
+
+    # TOOL_USE_OVERFLOW (DCN-CHG-20260430-37) — step 의 tool_use_count ≥ 100.
+    # 자장 epic-08/09 실측 — 102/119/153/170/223 모두 PR PARTIAL 회귀.
+    # DCN-30-36 hint 와 짝 — 사후 측정.
+    for s in steps:
+        if not s.matched_invocation or s.tool_use_count < 100:
+            continue
+        findings.append(WasteFinding(
+            pattern="TOOL_USE_OVERFLOW",
+            severity="HIGH",
+            step_idx=s.idx,
+            agent=s.agent,
+            detail=f"{s.agent} step {s.idx} tool_use_count={s.tool_use_count} (≥ 100). "
+                   f"context overflow / IMPL_PARTIAL 회귀 위험 (자장 실측 임계).",
+            fix="DCN-30-36 prior count hint 활용 + agent prompt 분할 자율 판단 강화. "
+                "임계 ≥ 100 = 자장 실측 5건 모두 PR PARTIAL.",
+        ))
+
+    # PARTIAL_LOOP (DCN-CHG-20260430-37) — IMPL_PARTIAL ≥ 3 in same run.
+    # 자장 패턴 "overflow → PARTIAL → 추가 epic → 또 overflow → 무한 반복".
+    partial_count = sum(1 for s in steps if s.enum == "IMPL_PARTIAL")
+    if partial_count >= 3:
+        findings.append(WasteFinding(
+            pattern="PARTIAL_LOOP",
+            severity="HIGH",
+            step_idx=-1,
+            agent="engineer",
+            detail=f"IMPL_PARTIAL {partial_count}회 — 같은 run 무한 분할 의심.",
+            fix="task 자체 split 필요 (epic 단위 재계획). architect TASK_DECOMPOSE 재진입 또는 "
+                "사용자 위임. DCN-30-34 권고 cycle ≤ 3 정합.",
+        ))
+
+    # END_STEP_SKIP (DCN-CHG-20260430-37) — sub-agent invocation > .steps.jsonl row.
+    # 메인 distract → end-step 호출 skip → .steps.jsonl 누락. DCN-30-25 STEP COUNT WARN /
+    # DCN-30-33 STALE STEP WARN 의 사후 측정 보완.
+    if invocations:
+        from collections import Counter
+        inv_count_per_agent = Counter(i["agent"] for i in invocations)
+        step_count_per_agent = Counter(s.agent for s in steps)
+        for agent_name, inv_n in inv_count_per_agent.items():
+            step_n = step_count_per_agent.get(agent_name, 0)
+            # margin 1 — sub-agent self-recurse 등 false positive 회피.
+            if inv_n > step_n + 1:
+                findings.append(WasteFinding(
+                    pattern="END_STEP_SKIP",
+                    severity="HIGH",
+                    step_idx=-1,
+                    agent=agent_name,
+                    detail=f"{agent_name} invocations={inv_n} > steps={step_n} "
+                           f"(diff={inv_n-step_n}) — end-step 호출 누락 의심.",
+                    fix="commands/<skill>.md begin/end-step 1:1 의무 (DCN-30-25 / DCN-30-33). "
+                        "메인 distract 회피 — Agent 직후 즉시 end-step.",
+                ))
+
+    # MAIN_SED_MISDIAGNOSIS (DCN-CHG-20260430-37) — 메인 self-correction 패턴.
+    # I5 회귀 — "130개 fix" → 실측 0개 → 정정. CC JSONL 텍스트 검출.
+    sed_hits = _scan_main_sed_misdiagnosis(repo_path, window)
+    if sed_hits:
+        findings.append(WasteFinding(
+            pattern="MAIN_SED_MISDIAGNOSIS",
+            severity="HIGH",
+            step_idx=-1,
+            agent="main",
+            detail=f"메인 self-correction 패턴 {len(sed_hits)}회 — 추측 진단 → 사용자 알림 → "
+                   f"실측 시 0 발견 → 정정. 첫 발췌: {sed_hits[0][:120]}...",
+            fix="dcness-guidelines.md §12 self-verify 원칙 (DCN-30-35) — Bash sed/awk 후 "
+                "*전·후* 실측 의무 (git diff --stat / 결과 grep). 글로벌 ~/.claude/CLAUDE.md "
+                "제1룰 정합.",
+        ))
 
     return findings
 
@@ -576,6 +714,7 @@ def assign_invocations_to_steps(steps: list[StepRecord], invocations: list[dict]
             step.total_tokens = inv["total_tokens"]
             step.cost_usd = inv["cost_usd"]
             step.matched_invocation = True
+            step.tool_use_count = inv.get("tool_use_count", 0)
             used.add(best_idx)
 
 
@@ -743,14 +882,19 @@ def build_report(run_dir: Path, repo_path: Path) -> RunReport:
     steps = parse_steps(run_dir)
 
     # DCN-CHG-20260430-20: per-Agent invocation 매칭 — wastes 탐지 *전*에 enrichment.
+    invocations: list[dict] = []
+    window: Optional[tuple] = None
     if steps:
         first_ts = _parse_iso(steps[0].ts)
         last_ts = _parse_iso(steps[-1].ts)
         if first_ts and last_ts:
-            invocations = extract_agent_invocations(repo_path, (first_ts, last_ts))
+            window = (first_ts, last_ts)
+            invocations = extract_agent_invocations(repo_path, window)
             assign_invocations_to_steps(steps, invocations)
 
-    wastes = detect_wastes(steps)
+    # DCN-CHG-20260430-37: detect_wastes 에 invocations + repo_path + window 전달
+    # (END_STEP_SKIP / MAIN_SED_MISDIAGNOSIS run-level 패턴 검출 위해).
+    wastes = detect_wastes(steps, invocations=invocations, repo_path=repo_path, window=window)
     goods = detect_goods(steps)
     cost, in_tok, out_tok = compute_run_cost(run_dir, repo_path)
 

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -355,5 +355,145 @@ class ThinkingLoopDetectionTests(unittest.TestCase):
         self.assertFalse(any(w.pattern == "THINKING_LOOP" for w in wastes))
 
 
+class RegressionPatternsTests(unittest.TestCase):
+    """DCN-CHG-20260430-37 — 4 신규 회귀 패턴."""
+
+    def test_tool_use_overflow_emits_finding(self):
+        # 자장 실측 임계 ≥ 100. 102/119/153/170/223 모두 PARTIAL 회귀.
+        s = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                        enum="IMPL_DONE", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+        s.matched_invocation = True
+        s.tool_use_count = 119
+        wastes = detect_wastes([s])
+        kinds = {w.pattern for w in wastes}
+        self.assertIn("TOOL_USE_OVERFLOW", kinds)
+
+    def test_tool_use_overflow_below_threshold(self):
+        # ≤ 99 = silent. 정상 invocation 36~64 영역.
+        s = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                        enum="IMPL_DONE", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+        s.matched_invocation = True
+        s.tool_use_count = 64
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "TOOL_USE_OVERFLOW" for w in wastes))
+
+    def test_tool_use_overflow_unmatched_invocation_skipped(self):
+        # matched_invocation=False → tool_use_count 신뢰 X → skip
+        s = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                        enum="IMPL_DONE", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+        s.matched_invocation = False
+        s.tool_use_count = 200
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "TOOL_USE_OVERFLOW" for w in wastes))
+
+    def test_partial_loop_three_or_more(self):
+        # IMPL_PARTIAL ≥ 3 회 → PARTIAL_LOOP 검출
+        steps = [
+            StepRecord(idx=i, ts=f"t{i}", agent="engineer", mode="IMPL",
+                        enum="IMPL_PARTIAL", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+            for i in range(3)
+        ]
+        wastes = detect_wastes(steps)
+        kinds = {w.pattern for w in wastes}
+        self.assertIn("PARTIAL_LOOP", kinds)
+
+    def test_partial_loop_two_silent(self):
+        # 2회는 정상 (cycle 한도 ≤ 3 권고 안)
+        steps = [
+            StepRecord(idx=i, ts=f"t{i}", agent="engineer", mode="IMPL",
+                        enum="IMPL_PARTIAL", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+            for i in range(2)
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "PARTIAL_LOOP" for w in wastes))
+
+    def test_end_step_skip_when_invocations_exceed_steps(self):
+        # invocations 3 vs steps 1 (engineer) — 2 누락 의심
+        from datetime import datetime
+        steps = [
+            StepRecord(idx=0, ts="2026-04-30T10:00:00", agent="engineer", mode="IMPL",
+                        enum="IMPL_DONE", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5"),
+        ]
+        invocations = [
+            {"agent": "engineer", "ts": datetime(2026, 4, 30, 10, 0, 0),
+             "duration_ms": 1000, "output_tokens": 100, "total_tokens": 100,
+             "input_tokens": 100, "cache_read": 0, "cost_usd": 0.0,
+             "tool_use_count": 50, "agent_type_raw": "dcness:engineer"},
+            {"agent": "engineer", "ts": datetime(2026, 4, 30, 10, 5, 0),
+             "duration_ms": 1000, "output_tokens": 100, "total_tokens": 100,
+             "input_tokens": 100, "cache_read": 0, "cost_usd": 0.0,
+             "tool_use_count": 60, "agent_type_raw": "dcness:engineer"},
+            {"agent": "engineer", "ts": datetime(2026, 4, 30, 10, 10, 0),
+             "duration_ms": 1000, "output_tokens": 100, "total_tokens": 100,
+             "input_tokens": 100, "cache_read": 0, "cost_usd": 0.0,
+             "tool_use_count": 40, "agent_type_raw": "dcness:engineer"},
+        ]
+        wastes = detect_wastes(steps, invocations=invocations)
+        kinds = {w.pattern for w in wastes}
+        self.assertIn("END_STEP_SKIP", kinds)
+
+    def test_end_step_skip_silent_within_margin(self):
+        # invocations 2 vs steps 1 = diff 1, margin 1 안 → silent
+        from datetime import datetime
+        steps = [
+            StepRecord(idx=0, ts="2026-04-30T10:00:00", agent="engineer", mode="IMPL",
+                        enum="IMPL_DONE", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5"),
+        ]
+        invocations = [
+            {"agent": "engineer", "ts": datetime(2026, 4, 30, 10, 0, 0),
+             "duration_ms": 0, "output_tokens": 0, "total_tokens": 0,
+             "input_tokens": 0, "cache_read": 0, "cost_usd": 0.0,
+             "tool_use_count": 0, "agent_type_raw": "dcness:engineer"},
+            {"agent": "engineer", "ts": datetime(2026, 4, 30, 10, 5, 0),
+             "duration_ms": 0, "output_tokens": 0, "total_tokens": 0,
+             "input_tokens": 0, "cache_read": 0, "cost_usd": 0.0,
+             "tool_use_count": 0, "agent_type_raw": "dcness:engineer"},
+        ]
+        wastes = detect_wastes(steps, invocations=invocations)
+        self.assertFalse(any(w.pattern == "END_STEP_SKIP" for w in wastes))
+
+    def test_main_sed_misdiagnosis_detects_self_correction(self):
+        # CC JSONL 안 메인 self-correction 패턴 — 실제 fixture 박음
+        from datetime import datetime
+        from harness.run_review import encode_repo_path_dcness
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            os.chdir(tmp)
+            try:
+                # CC JSONL fake — 메인 정정 발화
+                encoded = encode_repo_path_dcness(str(tmp))
+                proj = Path.home() / ".claude" / "projects" / encoded
+                proj.mkdir(parents=True, exist_ok=True)
+                jsonl = proj / "fake-sid.jsonl"
+                jsonl.write_text(json.dumps({
+                    "type": "assistant",
+                    "timestamp": "2026-04-30T10:05:00.000Z",
+                    "message": {"content": [
+                        {"type": "text", "text": "**중요 정정** — sed 변경사항 0 (실제 0개)."}
+                    ]},
+                }, ensure_ascii=False) + "\n", encoding="utf-8")
+                try:
+                    steps = [
+                        StepRecord(idx=0, ts="2026-04-30T10:00:00", agent="engineer", mode="IMPL",
+                                    enum="IMPL_DONE", must_fix=False,
+                                    prose_excerpt="line1\nline2\nline3\nline4\nline5"),
+                    ]
+                    window = (datetime(2026, 4, 30, 10, 0, 0), datetime(2026, 4, 30, 10, 30, 0))
+                    wastes = detect_wastes(steps, repo_path=tmp, window=window)
+                    kinds = {w.pattern for w in wastes}
+                    self.assertIn("MAIN_SED_MISDIAGNOSIS", kinds)
+                finally:
+                    jsonl.unlink(missing_ok=True)
+            finally:
+                os.chdir(REPO_ROOT)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

DCN-30-36 prior count hint 의 *사후 측정* 인프라 + 자장 실 데이터 패턴 4종 자동 검출. 자율 침해 0 (사후 분석만 — 실시간 강제 X).

## 신규 패턴 (모두 HIGH severity)

| 패턴 | 검출 조건 | 근거 |
|---|---|---|
| `TOOL_USE_OVERFLOW` | step.tool_use_count ≥ 100 | 자장 실측 5건 (102/119/153/170/223) 모두 PR PARTIAL |
| `PARTIAL_LOOP` | IMPL_PARTIAL ≥ 3 in run | DCN-30-34 권고 cycle ≤ 3 정합. 자장 무한 반복 패턴 |
| `END_STEP_SKIP` | invocations > steps + margin 1 | DCN-30-25 STEP COUNT WARN / DCN-30-33 STALE STEP WARN 사후 측정 보완 |
| `MAIN_SED_MISDIAGNOSIS` | 메인 self-correction 텍스트 패턴 | I5 회귀 측정 |

## 변경

### harness/run_review.py
- `StepRecord.tool_use_count: int = 0` 필드 추가
- `assign_invocations_to_steps` 가 invocation 의 `tool_use_count` propagate
- `_scan_main_sed_misdiagnosis(repo_path, window)` 신규 — CC session JSONL 텍스트 패턴 검출 (한국어 + 영어, max 3 hits)
- `detect_wastes(steps, invocations=None, repo_path=None, window=None)` — signature 확장 (kwargs default None, backward compat ✓)
- `build_report` 가 invocations + window 을 detect_wastes 로 전달

### tests/test_run_review.py — `RegressionPatternsTests` 8 신규
- TOOL_USE_OVERFLOW: positive (119) / negative (64) / unmatched skip
- PARTIAL_LOOP: 3+ detect / 2 silent
- END_STEP_SKIP: 3 inv vs 1 step / margin 1 안 silent
- MAIN_SED_MISDIAGNOSIS: real fixture detection (`ensure_ascii=False` 필수)

## 자장 실 데이터 검증

run-c0ef57e0 에서 즉시 검출:
```
[HIGH] THINKING_LOOP (engineer): duration 1814s > 900s × 1.5 + output 0
[HIGH] TOOL_USE_OVERFLOW (engineer): step 1 tool_use_count=153 (≥ 100)
```

DCN-30-36 hint 와 짝 — 다음 자장 epic 회고 시 자동 발화.

## first-principle 정합

| 차원 | 평가 |
|---|---|
| 자율 침해 | ❌ — 사후 분석만 |
| 형식 강제 | ❌ — 측정 메트릭 |
| 자율 판단 어려움 cover | ✅ — 회귀 자동 검출 |

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (5 files / docs-only, harness, test)
- [x] `python3 -m unittest discover -s tests` — 232 ran / 230 PASS / 2 pre-existing flaky 무관
- [x] 신규 8 테스트 PASS
- [x] 자장 실 데이터 검증 — `tool_use_count=153` 즉시 검출

## 후속 PR

| # | Task-ID | 변경 |
|---|---|---|
| PR1 ✅ | DCN-30-36 | helper prior count hint |
| **PR2 (본 PR)** | DCN-30-37 | /run-review 회귀 4 패턴 |
| PR3 | DCN-30-38 | DCN-34 self-verify anchor 자율화 + §12 안티패턴 강화 + MISSING_SELF_VERIFY 패턴 추가 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)