### PR TITLE
feat: self-verify anchor 자율화 + §12 sed 안티패턴 (DCN-CHG-20260430-38)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,14 @@
 
 ## 현재 상태
 
+- **🪶 self-verify echo anchor 자율화 + §12 sed 안티패턴** (`DCN-CHG-20260430-38`):
+  - DCN-30-34 self-verify `## 자가 검증` 단일 형식 강제 → first-principle ("출력 형식 자유") 회색 영역. anchor 자율화 (다중 옵션) + substance 만 의무.
+  - `agents/engineer.md` 양 섹션 (자가 검증 + IMPL_PARTIAL 남은 작업) anchor 자율 명시.
+  - 4 anchor 옵션: `## 자가 검증` / `## Verification` / `## 검증` / `## Self-Verify`.
+  - `harness/run_review.py:SELF_VERIFY_ANCHORS` 패턴 4 + `_has_self_verify_anchor` helper.
+  - `MISSING_SELF_VERIFY` 패턴 (MEDIUM) — engineer step (IMPL_DONE / IMPL_PARTIAL / POLISH_DONE) 에 anchor 부재 시 emit.
+  - `dcness-guidelines.md` §12 안티패턴 1줄 추가 — Bash sed/awk 후 *전·후* 실측 의무 (방법 자율).
+  - 8 신규 테스트. 240 ran / 238 PASS / 2 pre-existing flaky 무관.
 - **📊 /run-review 회귀 4 패턴 자동 검출** (`DCN-CHG-20260430-37`):
   - DCN-30-36 prior count hint 의 *사후 측정* 인프라 + 자장 실 패턴 4종 자동 검출.
   - `harness/run_review.py:StepRecord.tool_use_count` 필드 + `assign_invocations_to_steps` propagate.

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -93,12 +93,14 @@ impl 에 `## Design Ref` 섹션 있거나 DESIGN_HANDOFF 패키지 직접 받은
 - `useEffect` 비동기 콜백에서 언마운트 후 상태 변경 없음
 - 계획과 다르게 구현한 부분 있으면 prose 본문에 이유 명시
 
-## 작업 분할 — IMPL_PARTIAL (DCN-CHG-20260430-34)
+## 작업 분할 — IMPL_PARTIAL (DCN-CHG-20260430-34, anchor 자율화 DCN-30-38)
 
 단일 호출에 다 끝내기 무리 인지 시 (context 압박 / 도메인 광범위 / 진행 중 새 GAP 발견 등):
 1. 진행한 부분 commit (자체 git OK)
-2. `IMPL_PARTIAL` 결론 + prose 의 `## 남은 작업` 섹션에 미완 항목 명시 (파일 경로 / 의도 / 예상 단위)
+2. `IMPL_PARTIAL` 결론 + prose 안 *남은 작업* 섹션에 미완 항목 명시 (파일 경로 / 의도 / 예상 단위)
 3. 메인이 follow-up 호출 — 새 호출 = 새 context window
+
+**anchor 자율** — `## 남은 작업` / `## Remaining` / `## TODO` / `## 미완` 등 자기 판단. substance (미완 항목 + 파일 경로 + 의도 + 예상 단위) 만 의무.
 
 *숫자 cap 없음 — 자기 capacity 자율 판단*. 분할 자체가 정상 흐름 (jajang epic-08 의 I1/I2/I3 회귀 방지). attempt 카운터 미소비 — 분할은 retry 와 다름.
 
@@ -106,9 +108,11 @@ impl 에 `## Design Ref` 섹션 있거나 DESIGN_HANDOFF 패키지 직접 받은
 
 같은 패턴 N 파일 변환 시 codemod / bash sed / Edit 중 *자율 선택*. 단 단일 호출 capacity 압박 인지 시 codemod·sed 가 일반적으로 가벼움 (참고). 검증은 grep 1줄로 mass result 확인 권고.
 
-## 자가 검증 echo 의무 (DCN-CHG-20260430-34)
+## 자가 검증 echo 의무 (DCN-CHG-20260430-34, anchor 자율화 DCN-30-38)
 
-prose 결과 끝에 `## 자가 검증` 섹션 + 검증 결과 인용 의무. *어느 명령을 쓸지는 자율*. 형식만 강제 — 메인이 결과 신뢰 가능하도록 근거 박힘.
+prose 결과 끝에 *자가 검증 섹션* + 검증 결과 인용 의무. **anchor 자율** — `## 자가 검증` / `## Verification` / `## 검증` / `## Self-Verify` 등 자기 판단. substance (실측 명령 + 결과 수치 인용) 만 의무.
+
+*어느 명령을 쓸지도 자율* — grep / ls / Read / Bash / WebFetch 등. 메인이 결과 신뢰 가능하도록 근거 박힘.
 
 예시 (어느 한 패턴 채택):
 - grep 결과 (변환 잔여 0 확인): `grep -c "vi\." src/__tests__/ -r --exclude-dir=_setup` → 0

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,35 @@
 
 ## Records
 
+### DCN-CHG-20260430-38
+- **Date**: 2026-04-30
+- **Rationale**:
+  - DCN-30-34 self-verify echo `## 자가 검증` 섹션 단일 형식 강제 — first-principle ("출력 형식 자유") 회색 영역. dcness-guidelines §1 가시성 룰 (다중 anchor `## 결론 / ## Summary / ## 변경 요약`) 와 비교 strict.
+  - 사용자 명령 ("자율성을 심하게 저하하는 부분이 있는지 형식에 얽매게하는 부분이 있는지 자율 판단으로 어려운건지 1원칙에 입각해서 고민") — strict anchor 형식 약화 권고.
+  - DCN-30-37 follow-up 으로 `MISSING_SELF_VERIFY` 패턴 추가 약속 — anchor 자율화 후 다중 anchor 검출 로직 필요.
+  - DCN-30-37 follow-up 으로 §12 안티패턴 강화 약속 — Bash sed/awk 후 검증 의무 1줄 (#39 흡수, B안 — SSOT 강화).
+- **Alternatives**:
+  1. *옵션 A — `## 자가 검증` 단일 anchor 유지*. 형식 strict, agent 자율 약함. first-principle 회색.
+  2. *옵션 B — anchor 완전 자율 (특정 섹션 명 X)*. 메인 추출 로직 구현 어려움 (regex 매칭 불가).
+  3. **(채택) 옵션 C — 다중 anchor 옵션 + substance 의무**. dcness §1 가시성 룰 패턴 정합. 자율 + 검출 가능성 양립.
+- **Decision**:
+  - 옵션 C 채택. 4 anchor 옵션:
+    - `## 자가 검증` (기존 DCN-30-34)
+    - `## Verification` (영어)
+    - `## 검증` (한국어 짧은 형)
+    - `## Self-Verify` / `## Self Verify` (영어 dash 변형)
+  - `agents/engineer.md` 양 섹션 (자가 검증 + IMPL_PARTIAL 남은 작업) anchor 자율화 명시.
+  - `harness/run_review.py:SELF_VERIFY_ANCHORS` regex 4개 + `_has_self_verify_anchor(prose)` helper.
+  - `MISSING_SELF_VERIFY` MEDIUM (HIGH 아님) — 누락 시 메인 결과 신뢰 어려운 정도지 critical 아님. engineer agent + IMPL_DONE/IMPL_PARTIAL/POLISH_DONE enum 한정 (escalate enum 비대상).
+  - `dcness-guidelines.md` §12 안티패턴 1줄 추가 — Bash sed/awk 후 *전·후* 실측 의무 (방법 자율: git diff --stat / 결과 grep / Read 등). DCN-30-37 `MAIN_SED_MISDIAGNOSIS` 자동 검출 cross-ref.
+- **Follow-Up**:
+  - **자장 plugin 재install + 새 epic 검증** — DCN-30-33~38 효과 실 측정. 다음 epic 진행 시 prior count hint stderr / `MISSING_SELF_VERIFY` 검출 / `MAIN_SED_MISDIAGNOSIS` 검출 모두 자동 발화 확인.
+  - **agent prompt §4/§5/§6/§7 → handoff-matrix sweep** (DCN-30-32 follow-up) — 별도 PR 후보.
+  - **THINKING_LOOP CRITICAL banner** (smart-compact #5) — agents/{architect,ux-architect,product-planner}.md.
+  - **render_report `tool_uses` 컬럼** — 단계별 표 보강.
+  - **catastrophic-gate.sh handoff-matrix.md 보호 sync 검증**.
+  - **임계값 30일 누적 tuning** — TOOL_USE_OVERFLOW 100 / PARTIAL_LOOP 3 / END_STEP_SKIP margin 1.
+
 ### DCN-CHG-20260430-37
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/dcness-guidelines.md
+++ b/docs/process/dcness-guidelines.md
@@ -250,7 +250,8 @@ agent 별 적용:
 ❌ "보통 jest config 는 X 키 쓰니까" — 학습 데이터 의존 → hallucination (예: `setupFilesAfterFramework`)
 ❌ "이 함수 (대략) 어디 있을 것" — grep 안 함 → 잘못된 경로
 ❌ engineer 보고 즉시 신뢰 → 실측 안 함 (`agents/engineer.md` § 자가 검증 echo 의무 와 짝)
+❌ Bash `sed -i` / `awk -i` / 광역 변환 후 *전·후* 실측 누락 — 변경 결과 의무 검증 (방법 자율: `git diff --stat` / 결과 grep / Read 등). 메인이 sed 직후 "X개 fix" 단언 = I5 회귀 (DCN-30-37 `MAIN_SED_MISDIAGNOSIS` 자동 검출).
 
 ### 효과
 
-I5 (메인 sed misdiagnosis) 회귀 방지. agent 측 self-verify echo (engineer.md `## 자가 검증`) 와 짝 — agent 가 인용 + 메인이 그 명령 직접 실행해 verify.
+I5 (메인 sed misdiagnosis) 회귀 방지. agent 측 self-verify echo (engineer.md *자가 검증* 섹션, anchor 자율) 와 짝 — agent 가 인용 + 메인이 그 명령 직접 실행해 verify.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,20 @@
 
 ## Records
 
+### DCN-CHG-20260430-38
+- **Date**: 2026-04-30
+- **Change-Type**: agent, harness, test, docs-only
+- **Files Changed**:
+  - `agents/engineer.md` `## 자가 검증 echo 의무` — anchor 자율화. `## 자가 검증` 단일 강제 → 다중 anchor 허용 (`## 자가 검증` / `## Verification` / `## 검증` / `## Self-Verify` 등 자율). substance (실측 명령 + 결과 수치) 만 의무. 첫 원칙 ("출력 형식 자유") 정합 강화.
+  - `agents/engineer.md` `## 작업 분할 — IMPL_PARTIAL` `## 남은 작업` — 동일 anchor 자율화 (`## 남은 작업` / `## Remaining` / `## TODO` / `## 미완` 등).
+  - `docs/process/dcness-guidelines.md` §12 안티패턴 1줄 추가 — Bash `sed -i` / `awk -i` / 광역 변환 후 *전·후* 실측 의무 (방법 자율). DCN-30-37 `MAIN_SED_MISDIAGNOSIS` 자동 검출 cross-ref.
+  - `harness/run_review.py` — `SELF_VERIFY_ANCHORS` 패턴 4개 + `_has_self_verify_anchor(prose)` 신규. `detect_wastes` 에 `MISSING_SELF_VERIFY` 패턴 (MEDIUM): engineer step (IMPL_DONE / IMPL_PARTIAL / POLISH_DONE) prose 에 anchor 부재 시 emit.
+  - `tests/test_run_review.py:MissingSelfVerifyTests` — 8 신규 테스트 (missing emit / 한국어 anchor / 영어 verification / Self-Verify / 짧은 검증 / prose 부재 skip / non-engineer skip / non-impl enum skip). 240 ran (이전 232) / 238 PASS / 2 pre-existing flaky 무관.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: DCN-30-34 self-verify echo `## 자가 검증` 섹션 단일 anchor 형식 강제 → 첫 원칙 ("출력 형식 자유") 회색 영역. anchor 자율화 (다중 옵션) + substance 만 의무로 약화. `MISSING_SELF_VERIFY` 회귀 검출 패턴 추가 (DCN-30-37 4 패턴 + 본 PR 1 패턴 = 5 신규 회귀 패턴 누적). dcness-guidelines.md §12 안티패턴에 sed 후 검증 의무 1줄 추가 (#39 흡수). 4 PR migration (skill 슬림화 + procedure SSOT) + 회귀 fix 시리즈 모두 마무리.
+
 ### DCN-CHG-20260430-37
 - **Date**: 2026-04-30
 - **Change-Type**: harness, test

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -87,6 +87,25 @@ EXPECTED_AGENT_BUDGETS: dict[str, dict[str, int]] = {
 
 DCNESS_AGENT_NAMES = set(EXPECTED_AGENT_BUDGETS.keys())
 
+# DCN-CHG-20260430-38: engineer self-verify echo anchor 옵션 (DCN-30-34 강제 → DCN-30-38 자율화).
+# prose 끝에 *어느 한 anchor* 라도 있으면 통과. 형식 자율 + substance 의무.
+SELF_VERIFY_ANCHORS = [
+    r"^\s*#{1,6}\s*자가\s*검증",
+    r"^\s*#{1,6}\s*검증",
+    r"^\s*#{1,6}\s*verification",
+    r"^\s*#{1,6}\s*self[-\s]?verify",
+]
+
+
+def _has_self_verify_anchor(prose: str) -> bool:
+    """engineer prose 에 self-verify anchor 중 하나라도 있는지 (DCN-30-38)."""
+    if not prose:
+        return False
+    for pat in SELF_VERIFY_ANCHORS:
+        if re.search(pat, prose, re.MULTILINE | re.IGNORECASE):
+            return True
+    return False
+
 
 # ── 데이터 모델 ────────────────────────────────────────────────────────
 
@@ -491,6 +510,28 @@ def detect_wastes(
                     fix="commands/<skill>.md begin/end-step 1:1 의무 (DCN-30-25 / DCN-30-33). "
                         "메인 distract 회피 — Agent 직후 즉시 end-step.",
                 ))
+
+    # MISSING_SELF_VERIFY (DCN-CHG-20260430-38) — engineer prose 에 self-verify anchor 부재.
+    # DCN-30-34 의무 (anchor 자율, substance 의무) 회귀 검출. prose_full 부재 시 skip.
+    for s in steps:
+        if s.agent != "engineer":
+            continue
+        if s.enum not in ("IMPL_DONE", "IMPL_PARTIAL", "POLISH_DONE"):
+            continue
+        if not s.prose_full:
+            continue
+        if not _has_self_verify_anchor(s.prose_full):
+            findings.append(WasteFinding(
+                pattern="MISSING_SELF_VERIFY",
+                severity="MEDIUM",
+                step_idx=s.idx,
+                agent="engineer",
+                detail=f"engineer step {s.idx} ({s.enum}) prose 에 자가 검증 anchor 부재 — "
+                       f"DCN-30-34 의무 (anchor 자율: `## 자가 검증` / `## Verification` / "
+                       f"`## 검증` / `## Self-Verify` 등).",
+                fix="agents/engineer.md § 자가 검증 echo 의무 — prose 끝에 anchor 추가 + "
+                    "실측 명령 + 결과 수치 인용. substance (검증 결과) 만 의무.",
+            ))
 
     # MAIN_SED_MISDIAGNOSIS (DCN-CHG-20260430-37) — 메인 self-correction 패턴.
     # I5 회귀 — "130개 fix" → 실측 0개 → 정정. CC JSONL 텍스트 검출.

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -495,5 +495,63 @@ class RegressionPatternsTests(unittest.TestCase):
                 os.chdir(REPO_ROOT)
 
 
+class MissingSelfVerifyTests(unittest.TestCase):
+    """DCN-CHG-20260430-38 — engineer self-verify anchor 자율화 + 회귀 검출."""
+
+    def _engineer_step(self, prose_full: str, enum: str = "IMPL_DONE") -> StepRecord:
+        s = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                        enum=enum, must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+        s.prose_full = prose_full
+        return s
+
+    def test_missing_anchor_emits_finding(self):
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n구현 완료.")
+        wastes = detect_wastes([s])
+        kinds = {w.pattern for w in wastes}
+        self.assertIn("MISSING_SELF_VERIFY", kinds)
+
+    def test_korean_anchor_passes(self):
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n## 자가 검증\ngrep → 0\n")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_english_verification_anchor_passes(self):
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n## Verification\nnpm test → PASS\n")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_self_verify_anchor_passes(self):
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n### Self-Verify\noutput\n")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_short_검증_anchor_passes(self):
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n## 검증\noutput\n")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_skipped_when_no_prose_full(self):
+        # prose_full 부재 시 skip (parse 실패 case 등)
+        s = self._engineer_step(prose_full="")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_skipped_for_non_engineer(self):
+        s = StepRecord(idx=0, ts="t", agent="architect", mode="MODULE_PLAN",
+                        enum="READY_FOR_IMPL", must_fix=False,
+                        prose_excerpt="line1\nline2\nline3\nline4\nline5")
+        s.prose_full = "## 결론\nREADY"  # no self-verify anchor
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_skipped_for_non_impl_enum(self):
+        # SPEC_GAP_FOUND 같은 escalate enum 은 self-verify 의무 비대상
+        s = self._engineer_step(prose_full="## 결론\nSPEC_GAP_FOUND",
+                                 enum="SPEC_GAP_FOUND")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

DCN-30-34 self-verify echo `## 자가 검증` 단일 형식 강제 → first-principle ("출력 형식 자유") 회색 영역. anchor **자율화** + substance 만 의무. + `MISSING_SELF_VERIFY` 회귀 패턴 + §12 sed 안티패턴 1줄 (#39 흡수, B안).

## 변경

### agents/engineer.md (anchor 자율화)
- **자가 검증 echo** — `## 자가 검증` / `## Verification` / `## 검증` / `## Self-Verify` 등 자율
- **IMPL_PARTIAL 남은 작업** — `## 남은 작업` / `## Remaining` / `## TODO` / `## 미완` 등 자율
- substance (실측 명령 + 결과 수치 / 미완 항목 + 파일 경로 + 의도) 만 의무

### harness/run_review.py
- `SELF_VERIFY_ANCHORS` regex 4 + `_has_self_verify_anchor(prose)` helper
- `MISSING_SELF_VERIFY` 패턴 (MEDIUM) — engineer step (IMPL_DONE/IMPL_PARTIAL/POLISH_DONE) prose 에 anchor 부재 검출
- escalate enum (SPEC_GAP_FOUND 등) 비대상

### dcness-guidelines.md §12 안티패턴 1줄
```
❌ Bash `sed -i` / `awk -i` / 광역 변환 후 *전·후* 실측 누락 — 변경 결과
   의무 검증 (방법 자율: `git diff --stat` / 결과 grep / Read 등). 메인이
   sed 직후 "X개 fix" 단언 = I5 회귀 (DCN-30-37 `MAIN_SED_MISDIAGNOSIS`
   자동 검출).
```

## first-principle 정합

| 차원 | DCN-30-34 (이전) | DCN-30-38 (현재) |
|---|---|---|
| 자율 침해 | ⚠️ 단일 anchor 형식 강제 | ❌ 다중 anchor 자율 |
| 형식 강제 | ⚠️ 있음 | ❌ substance 만 |
| dcness §1 가시성 룰 정합 | strict | 다중 anchor 패턴 정합 |

## 신규 회귀 패턴 (1개 추가)

| 패턴 | severity | 검출 조건 |
|---|---|---|
| `MISSING_SELF_VERIFY` | MEDIUM | engineer step (IMPL_DONE/IMPL_PARTIAL/POLISH_DONE) prose 에 4 anchor 중 어느 것도 없음 |

DCN-30-37 4 패턴 + 본 PR 1 패턴 = **누적 5 신규 회귀 패턴**.

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (7 files / agent, docs-only, harness, test)
- [x] `python3 -m unittest discover -s tests` — 240 ran / 238 PASS / 2 pre-existing flaky 무관
- [x] 신규 8 테스트 (`MissingSelfVerifyTests`) PASS
- [x] cap 충족 — `engineer.md` 178줄 / `dcness-guidelines.md` 257줄 (300 cap 안)

## Migration 완전 완료

| # | Task-ID | 상태 |
|---|---|---|
| PR1 ✅ | DCN-30-36 | helper prior count hint |
| PR2 ✅ | DCN-30-37 | /run-review 회귀 4 패턴 |
| **PR3 (본 PR)** | **DCN-30-38** | **anchor 자율화 + §12 강화 + MISSING_SELF_VERIFY** |

## 후속 (별도 Task-ID)

- 자장 plugin 재install + 새 epic 검증 (사용자 환경 의존)
- THINKING_LOOP CRITICAL banner (smart-compact #5)
- agent prompt §4/§5/§6/§7 → handoff-matrix sweep (DCN-30-32 follow-up)
- render_report tool_uses 컬럼 추가
- catastrophic-gate.sh handoff-matrix 보호 sync 검증
- 임계값 30일 누적 tuning

🤖 Generated with [Claude Code](https://claude.com/claude-code)