### PR TITLE
feat: /run-review 후속 cleanup 3건 (DCN-CHG-20260430-39)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🪶 /run-review 후속 cleanup 3건** (`DCN-CHG-20260430-39`):
+  - DCN-30-38 follow-up — 사용자 우선순위 4-3-1 한 PR 묶음 (5번 catastrophic-gate path 보호는 별도).
+  - **(4) cross-ref sweep** — DCN-30-32 split 잔재 1줄 정정. `agents/pr-reviewer.md:86 "(orchestration.md §7 정합)"` → `"(handoff-matrix.md §4 정합)"`. agent prompt grep 매칭 = 단 1줄.
+  - **(3) `tool_uses` 컬럼** — `harness/run_review.py:render_report` 단계별 상세 표 13 컬럼 확장. `≥ 100` 시 `**bold**` 강조 (TOOL_USE_OVERFLOW 임계 정합). 미매칭은 `-`. TOOL_USE_OVERFLOW 회귀 측정 가시성 ↑.
+  - **(1) sub-mode banner** — `agents/architect/{system-design,task-decompose,module-plan,tech-epic,light-plan,docs-sync,spec-gap}.md` 7 파일 H1 직후 `> ⚠️ CRITICAL — extended thinking 본문 드래프트 금지` 1 블록 추가. master 룰 (`agents/architect.md` §자기규율 lines 98-103) 의 sub-mode 가시화. THINKING_LOOP 회귀 회피 (DCN-30-20 jajang 6분 stall).
+  - 테스트 3 신규 (`ToolUsesColumnTests`). 45 ran / 45 PASS. sub-mode 7 파일 모두 300줄 cap 미충돌 (최대 254줄).
 - **🪶 self-verify echo anchor 자율화 + §12 sed 안티패턴** (`DCN-CHG-20260430-38`):
   - DCN-30-34 self-verify `## 자가 검증` 단일 형식 강제 → first-principle ("출력 형식 자유") 회색 영역. anchor 자율화 (다중 옵션) + substance 만 의무.
   - `agents/engineer.md` 양 섹션 (자가 검증 + IMPL_PARTIAL 남은 작업) anchor 자율 명시.

--- a/agents/architect/docs-sync.md
+++ b/agents/architect/docs-sync.md
@@ -1,5 +1,7 @@
 # Docs Sync
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. docs 동기화 patch 본문 = thinking 종료 *후* 즉시 emit 또는 `Edit/Write` 입력값 안에서만. THINKING_LOOP 회귀 회피 (DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 docs 동기화 호출 — impl 완료 후 참조 설계 문서에 파생 서술 추가. 새 설계 결정은 절대 하지 않는다.
 **결론**: prose 마지막 단락에 `DOCS_SYNCED` / `SPEC_GAP_FOUND` / `TECH_CONSTRAINT_CONFLICT` 중 하나 명시.
 **호출자가 prompt 로 전달하는 정보**: 이미 구현 완료된 impl 경로, 동기화 대상 docs 파일 목록.

--- a/agents/architect/light-plan.md
+++ b/agents/architect/light-plan.md
@@ -1,5 +1,7 @@
 # Light Plan
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. plan 본문 / 의사코드 = thinking 종료 *후* 즉시 emit 또는 `Write` 입력값 안에서만. THINKING_LOOP 회귀 회피 (DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 경량 계획 호출 — 아키텍처 변경 없는 국소적 수정. Module Plan 의 경량 버전.
 **결론**: prose 마지막 단락에 `LIGHT_PLAN_READY` 명시.
 **호출자가 prompt 로 전달하는 정보**: 관련 파일 경로 (grep 결과 또는 DESIGN_HANDOFF 대상), GitHub 이슈 제목+본문, 라벨 목록, 이슈 번호.

--- a/agents/architect/module-plan.md
+++ b/agents/architect/module-plan.md
@@ -1,5 +1,7 @@
 # Module Plan
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. plan 본문 / 인터페이스 / 의사코드 = thinking 종료 *후* 즉시 emit 또는 `Write` 입력값 안에서만. thinking 안에서 본문 회전 시 THINKING_LOOP 회귀 (DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 모듈별 구현 계획 호출 — impl 1 개 단위.
 **결론**: prose 마지막 단락에 `READY_FOR_IMPL` 명시.
 **호출자가 prompt 로 전달하는 정보**:

--- a/agents/architect/spec-gap.md
+++ b/agents/architect/spec-gap.md
@@ -1,5 +1,7 @@
 # SPEC_GAP
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. 갭 분석 / 계획 보강 patch 본문 = thinking 종료 *후* 즉시 emit 또는 `Edit/Write` 입력값 안에서만. THINKING_LOOP 회귀 회피 (DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 SPEC_GAP 해결 호출 — engineer/test-engineer 가 SPEC_GAP_FOUND emit 후 진입.
 **결론**: prose 마지막 단락에 `SPEC_GAP_RESOLVED` / `PRODUCT_PLANNER_ESCALATION_NEEDED` / `TECH_CONSTRAINT_CONFLICT` 중 하나 명시.
 **호출자가 prompt 로 전달하는 정보**: SPEC_GAP_FOUND 갭 목록, 영향 받는 impl 경로, 현재 depth (`simple` / `std` / `deep`).

--- a/agents/architect/system-design.md
+++ b/agents/architect/system-design.md
@@ -1,5 +1,7 @@
 # System Design
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. prose 본문 / Domain Model 표 / 모듈 분해 / 산출물 본체 = thinking 종료 *후* 즉시 emit 또는 `Write` 입력값 안에서만. thinking 안에서 본문 회전 시 THINKING_LOOP 회귀 (jajang 6분 stall, DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 시스템 설계 호출. 구현 시작 전 시스템 전체 구조 확정.
 **결론**: prose 마지막 단락에 `SYSTEM_DESIGN_READY` 명시.
 **호출자가 prompt 로 전달하는 정보**: PRODUCT_PLAN_READY 문서 경로, 선택된 옵션, (선택) UX Flow Doc 경로.

--- a/agents/architect/task-decompose.md
+++ b/agents/architect/task-decompose.md
@@ -1,5 +1,7 @@
 # Task Decompose
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. impl 목차 / 각 impl 본문 / 의사코드 = thinking 종료 *후* 즉시 emit 또는 `Write` 입력값 안에서만. thinking 안에서 본문 회전 시 THINKING_LOOP 회귀 (DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 epic stories → 기술 구현 단위 분해 호출. product-planner 완료 후 호출.
 **결론**: 각 분해된 impl 파일 작성 후 prose 마지막 단락에 `READY_FOR_IMPL` 명시 (×N batch 가능).
 **호출자가 prompt 로 전달하는 정보**: Epic stories.md 경로, 설계 문서 경로.

--- a/agents/architect/tech-epic.md
+++ b/agents/architect/tech-epic.md
@@ -1,5 +1,7 @@
 # Technical Epic
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260430-39). thinking = 의사결정 분기만. epic 본문 / 영향도 분석 / 마이그레이션 단계 = thinking 종료 *후* 즉시 emit 또는 `Write` 입력값 안에서만. THINKING_LOOP 회귀 회피 (DCN-30-20). master 룰: `agents/architect.md` §자기규율.
+
 **모드**: architect 의 기술 에픽 작성 호출 — 기술 부채/인프라/리팩토링/아키텍처 변경.
 **결론**: prose 마지막 단락에 `SYSTEM_DESIGN_READY` 명시.
 **호출자가 prompt 로 전달하는 정보**: 개선 목표 설명, 영향 범위.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -83,7 +83,7 @@ model: sonnet
 - 이번 PR 이 수정한 파일 내 레거시 → 통상 기준 적용
 - PR 범위 밖 레거시 발견 → NICE TO HAVE 만 (MUST 금지) + 총평에 "별도 tech-debt 에픽 권고"
 
-## 에이전트 스코프 매트릭스 (orchestration.md §7 정합)
+## 에이전트 스코프 매트릭스 (handoff-matrix.md §4 정합)
 
 스코프 밖 파일에 MUST FIX 발행 → engineer 가 boundary 차단 → no_changes 반복 → MAX 소진 위험. 스코프 분리:
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,29 @@
 
 ## Records
 
+### DCN-CHG-20260430-39
+- **Date**: 2026-04-30
+- **Rationale**:
+  - DCN-30-38 follow-up 3건 묶음 처리 (사용자 우선순위 결정 — 4-3-1 한 PR, 5번 별도).
+  - **(4) cross-ref sweep**: DCN-30-32 split 시 `orchestration.md §4~§7` → `handoff-matrix.md §1~§4` 이전. agent prompt 안 잔재 전수 grep 결과 = 1줄 (`agents/pr-reviewer.md:86 "orchestration.md §7 정합"`). `orchestration.md` 현재 구조 (§0~§6, §216 자체에서 §7 이전 명시) — 진짜 stale.
+  - **(3) tool_uses 컬럼**: DCN-30-37 `StepRecord.tool_use_count` + TOOL_USE_OVERFLOW 패턴 추가 후 단계별 상세 표 미노출 — 회귀 측정 시 한눈에 안 들어옴.
+  - **(1) sub-mode banner**: DCN-30-20 jajang 6분 stall (extended thinking 안 prose 무한 회전, prose emit X) — `agents/architect.md:98-103` master 룰 강함. 단 architect 의 실제 실행은 `agents/architect/<mode>.md` sub-prompt — sub-mode 7개 banner 부재 → 회귀 회피율 ↓.
+- **Alternatives**:
+  1. *옵션 A — master 파일에만 banner 추가*. 사용자 초안. 단 architect 의 mode-별 sub-prompt 가 실제 실행 → master 단순 중복은 효과 ↓.
+  2. *옵션 B — sub-mode 7개 모두 banner*. 가시성 ↑, 단 7 곳 중복 (LLM 토큰 ↑).
+  3. *옵션 C — sub-mode + import 패턴 (`@agents/architect.md` 참조)*. .md 안 import 미지원 — 기각.
+  4. **(채택) 옵션 B**. 토큰 비용 (각 banner 4줄 × 7 = 28줄) 대비 회귀 회피 가치 ↑. master 중복 X (master 에는 이미 §자기규율 lines 98-103 강한 룰 존재).
+  5. *render_report 컬럼 — 표 너비 ↑ 우려*. tool_uses 12 컬럼 → 13 컬럼. 트레이드오프 수용 — TOOL_USE_OVERFLOW 가시성 ↑ 가치 우선.
+  6. *bold 임계 — 100 / 50 / 200 후보*. **100 채택** — `run_review.py:465` `TOOL_USE_OVERFLOW` 검출 임계와 동일. 두 신호 정합.
+- **Decision**:
+  - **(4)** `pr-reviewer.md:86` 1줄 `orchestration.md §7 정합` → `handoff-matrix.md §4 정합`.
+  - **(3)** `render_report` 단계별 상세 표 컬럼 13개로 확장 (`tool_uses` 추가). `≥ 100` 시 `**bold**` 강조. 미매칭 invocation 은 `-`. 헤더 코멘트에 DCN-CHG-20260430-39 cross-ref. 테스트 3개 신규 (`ToolUsesColumnTests`).
+  - **(1)** `agents/architect/{system-design,task-decompose,module-plan,tech-epic,light-plan,docs-sync,spec-gap}.md` 7 파일 H1 직후 1 블록 banner. 텍스트 80~95자, sub-mode 별 prose 본문 키워드 (Domain Model 표 / impl 본문 / plan 본문 / patch 본문) 차등 표기. 모두 master 룰 (`agents/architect.md` §자기규율) cross-ref. 7 파일 모두 300줄 cap 미충돌 (최대 254줄).
+- **Follow-Up**:
+  - **자장 plugin 재install + 다음 epic 측정** — `tool_uses` 컬럼 가시성 + sub-mode banner 효과 실측 (THINKING_LOOP 회귀율 ↓ 여부).
+  - **(5) catastrophic-gate DCNESS_INFRA_PATTERNS path 보호** — 별도 PR (사용자 결정). 실 scope = `tool=Edit/Write` PreToolUse 신규 hook 추가 + `harness/hooks.py` path-pattern 핸들러 + `hooks.json` 등록. 1~2일.
+  - **(2) 임계값 30일 누적 tuning** — 보류 (5월 30일 이후).
+
 ### DCN-CHG-20260430-38
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260430-39
+- **Date**: 2026-04-30
+- **Change-Type**: agent, harness, test
+- **Files Changed**:
+  - `agents/pr-reviewer.md` §"에이전트 스코프 매트릭스" 헤더 cross-ref `(orchestration.md §7 정합)` → `(handoff-matrix.md §4 정합)`. DCN-30-32 split 잔재 정정.
+  - `agents/architect/system-design.md` `agents/architect/task-decompose.md` `agents/architect/module-plan.md` `agents/architect/tech-epic.md` `agents/architect/light-plan.md` `agents/architect/docs-sync.md` `agents/architect/spec-gap.md` — H1 직후 `> ⚠️ CRITICAL — extended thinking 본문 드래프트 금지` banner 1 블록 추가. master 룰 (`agents/architect.md` §자기규율) 의 sub-mode 가시화. THINKING_LOOP 회귀 회피 (DCN-30-20 jajang 6분 stall).
+  - `harness/run_review.py:render_report` 단계별 상세 표 — `tool_uses` 컬럼 신규. `s.tool_use_count ≥ 100` 시 `**bold**` 강조 (TOOL_USE_OVERFLOW 임계 정합, run_review.py:465). 미매칭 step 은 `-`.
+  - `tests/test_run_review.py:ToolUsesColumnTests` — 3 신규 테스트 (header 컬럼 존재 / ≥ 100 bold / 미매칭 dash). `RunReport` import 추가. 45 ran / 45 PASS.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: /run-review 후속 cleanup 3건 묶음. (1) DCN-30-32 orchestration.md split 잔재 cross-ref 1줄 정정 (pr-reviewer.md). (2) `tool_uses` 단계별 표 컬럼 추가 — TOOL_USE_OVERFLOW 회귀 측정 가시성 ↑ (DCN-30-37 임계 정합). (3) architect sub-mode 7개 prompt 에 THINKING_LOOP banner — master 룰 sub-mode 가시화로 회귀 회피율 ↑.
+
 ### DCN-CHG-20260430-38
 - **Date**: 2026-04-30
 - **Change-Type**: agent, harness, test, docs-only

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -864,16 +864,22 @@ def render_report(report: RunReport) -> str:
     lines.append("```")
     lines.append("")
 
-    # 단계별 표 (DCN-30-20: per-Agent metrics + DCN-30-24: local time 시작 컬럼)
+    # 단계별 표 (DCN-30-20: per-Agent metrics + DCN-30-24: local time 시작 컬럼
+    #            + DCN-CHG-20260430-39: tool_uses 컬럼 — TOOL_USE_OVERFLOW 가시성)
     lines.append("## 단계별 상세")
-    lines.append("| # | 시작(local) | agent | mode | elapsed(s) | duration(s) | out_tok | total_tok | cost($) | enum | must_fix | prose줄 |")
-    lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|")
+    lines.append("| # | 시작(local) | agent | mode | elapsed(s) | duration(s) | out_tok | total_tok | tool_uses | cost($) | enum | must_fix | prose줄 |")
+    lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|---|")
     for s in report.steps:
         line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
         dur_s = f"{s.duration_ms / 1000:.0f}" if s.matched_invocation else "-"
         out_tok = f"{s.output_tokens:,}" if s.matched_invocation else "-"
         tot_tok = f"{s.total_tokens:,}" if s.matched_invocation else "-"
         cost = f"{s.cost_usd:.4f}" if s.matched_invocation else "-"
+        if s.matched_invocation:
+            # ≥ 100 시 **bold** — TOOL_USE_OVERFLOW 임계와 동일 (run_review.py:465)
+            tu_str = f"**{s.tool_use_count}**" if s.tool_use_count >= 100 else str(s.tool_use_count)
+        else:
+            tu_str = "-"
         ts_local = "-"
         ts_dt = _parse_iso(s.ts)
         if ts_dt:
@@ -881,7 +887,7 @@ def render_report(report: RunReport) -> str:
             ts_local = ts_dt.astimezone().strftime("%H:%M:%S")
         lines.append(
             f"| {s.idx} | {ts_local} | {s.agent} | {s.mode or '-'} | {s.elapsed_s} | "
-            f"{dur_s} | {out_tok} | {tot_tok} | {cost} | "
+            f"{dur_s} | {out_tok} | {tot_tok} | {tu_str} | {cost} | "
             f"`{s.enum}` | {'⚠️' if s.must_fix else ''} | {line_count} |"
         )
     lines.append("")

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -11,7 +11,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from harness.run_review import (  # noqa: E402
-    StepRecord, build_report, detect_goods, detect_wastes,
+    RunReport, StepRecord, build_report, detect_goods, detect_wastes,
     parse_steps, render_report, list_runs, find_run_dir,
     _normalize_agent_type, assign_invocations_to_steps,
     EXPECTED_AGENT_BUDGETS,
@@ -185,6 +185,41 @@ class LocalTimeRenderTests(unittest.TestCase):
             self.assertIn("시작(local)", text)
             # `:46:47` 부분만 확인 — 시스템 timezone 무관 (분/초는 동일)
             self.assertIn(":46:47", text)
+
+
+class ToolUsesColumnTests(unittest.TestCase):
+    """DCN-CHG-20260430-39: render_report tool_uses 컬럼 + ≥ 100 강조."""
+
+    def _make_report(self, steps: list[StepRecord]) -> RunReport:
+        with tempfile.TemporaryDirectory() as td:
+            return RunReport(run_id="rid", session_id="sid", run_dir=Path(td), steps=steps)
+
+    def test_header_has_tool_uses_column(self):
+        step = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                          enum="IMPL_DONE", must_fix=False,
+                          prose_excerpt="a\nb\nc\nd\ne",
+                          matched_invocation=True, tool_use_count=42)
+        text = render_report(self._make_report([step]))
+        self.assertIn("tool_uses", text)
+        self.assertIn("| 42 |", text)
+
+    def test_overflow_threshold_bolded(self):
+        step = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                          enum="IMPL_DONE", must_fix=False,
+                          prose_excerpt="a\nb\nc\nd\ne",
+                          matched_invocation=True, tool_use_count=153)
+        text = render_report(self._make_report([step]))
+        self.assertIn("**153**", text)
+
+    def test_unmatched_invocation_dash(self):
+        step = StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                          enum="IMPL_DONE", must_fix=False,
+                          prose_excerpt="a\nb\nc\nd\ne",
+                          matched_invocation=False, tool_use_count=0)
+        text = render_report(self._make_report([step]))
+        # 단계별 표 row 안 tool_uses 자리 = "-" (cost 와 동일 형식)
+        # 검사: "| - | - |" 같은 dash 시퀀스 존재 (out_tok / total_tok / tool_uses / cost 모두 dash)
+        self.assertRegex(text, r"\|\s*-\s*\|\s*-\s*\|\s*-\s*\|\s*-\s*\|")
 
 
 class ReportRenderTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

DCN-30-38 follow-up — 사용자 우선순위 4-3-1 한 PR 묶음. (5번 catastrophic-gate path 보호는 별도 PR.)

- **(4) cross-ref sweep**: `agents/pr-reviewer.md:86` 1줄 — `(orchestration.md §7 정합)` → `(handoff-matrix.md §4 정합)`. DCN-30-32 split 잔재 정정. agent prompt grep 매칭 = 단 1줄.
- **(3) `tool_uses` 컬럼**: `harness/run_review.py:render_report` 단계별 상세 표 13 컬럼 확장. `≥ 100` 시 `**bold**` 강조 (TOOL_USE_OVERFLOW 임계 정합, `run_review.py:465`). 미매칭 step 은 `-`.
- **(1) sub-mode THINKING_LOOP banner**: `agents/architect/{system-design,task-decompose,module-plan,tech-epic,light-plan,docs-sync,spec-gap}.md` 7 파일 H1 직후 1 블록 banner. master 룰 (`agents/architect.md` §자기규율 lines 98-103) sub-mode 가시화 — DCN-30-20 jajang 6분 stall 회귀 회피.

## Test plan

- [x] `python3 -m unittest tests.test_run_review` — 45 ran / 45 PASS
- [x] `python3 -m unittest discover -s tests` — 243 ran / 241 PASS / 2 pre-existing flaky 무관
- [x] `node scripts/check_document_sync.mjs` — PASS (13 files / agent + docs-only + harness + test)
- [x] sub-mode 7 파일 모두 300줄 cap 미충돌 (최대 254줄)

## Governance

- Task-ID: `DCN-CHG-20260430-39`
- Change-Type: agent, harness, test
- Document update record / change rationale history / PROGRESS 모두 갱신

## Follow-Up

- **(5) catastrophic-gate `DCNESS_INFRA_PATTERNS` path 보호** — 별도 PR (사용자 결정). 실 scope = `tool=Edit/Write` PreToolUse 신규 hook + path-pattern 핸들러 + `hooks.json` 등록. 1~2일.
- **(2) 임계값 30일 누적 tuning** — 보류 (5월 30일 이후).

🤖 Generated with [Claude Code](https://claude.com/claude-code)