### PR TITLE
fix: SessionStart inject schema + 10K cap (DCN-CHG-20260430-40)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🚨 SessionStart inject 처음부터 작동 0회 — schema fix + 압축** (`DCN-CHG-20260430-40`):
+  - 자장 사용자 보고 — `/product-plan` 진입 시 메인이 dcness 룰 미인지. system-reminder = "OK" 만, 본문 부재. 본 dcness 세션 jsonl `grep` = 0 직접 검증.
+  - 2 bug 동시: (1) JSON schema 잘못 (`{continue, additionalContext}` top-level → CC honor X). 정확 = `{hookSpecificOutput: {hookEventName, additionalContext}}` nested wrapper. (2) 12K char (CC 10K cap 초과).
+  - **fix**: schema `hookSpecificOutput` wrapper + content directive only (~1.2K) — 5 SSOT path + 핵심 강제 룰 4 (가시성 / Step 기록 / self-verify / --auto-review). 글로벌 `~/.claude/CLAUDE.md` 와 동일 레벨 강제.
+  - **검증 의무 (NEXT 세션)** — 머지 후 새 dcness 세션 시작 시 jsonl `grep "DCN-30-40 자동 로드"` ≥ 1 확인. 자장 plugin reinstall + 동일 검증.
+  - **DCN-30-27 ~ -39 의존성 재검증 필요** — inject 작동 후 5 slim skill 메인이 SSOT 만 보고 동작 가능 self-test.
 - **🪶 /run-review 후속 cleanup 3건** (`DCN-CHG-20260430-39`):
   - DCN-30-38 follow-up — 사용자 우선순위 4-3-1 한 PR 묶음 (5번 catastrophic-gate path 보호는 별도).
   - **(4) cross-ref sweep** — DCN-30-32 split 잔재 1줄 정정. `agents/pr-reviewer.md:86 "(orchestration.md §7 정합)"` → `"(handoff-matrix.md §4 정합)"`. agent prompt grep 매칭 = 단 1줄.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,31 @@
 
 ## Records
 
+### DCN-CHG-20260430-40
+- **Date**: 2026-04-30
+- **Rationale**:
+  - 자장 jajang 사용자 보고 — `/product-plan` 진입 시 메인이 dcness 룰 (loop-procedure / Step 기록 / TaskCreate / begin-step) 미인지. SessionStart system-reminder 에 "OK" 만 보일 뿐 dcness 본문 부재.
+  - 본 dcness 세션 jsonl `grep -c "dcness Guidelines (자동 로드"` = 0 직접 검증 — DCN-30-26 inject 처음부터 작동 0회.
+  - 진짜 위반 — DCN-30-26 머지 후 *실제 작동 검증 없이* 후속 PR 5+개 진행. 글로벌 제1룰 ("실존 검증 강제") + dcness §12 self-verify 원칙 (우리 박은 룰) 위반. I5 회귀 패턴 동일.
+- **2 Bug**:
+  - **B1: JSON schema 잘못** — claude-code-guide 검증 결과 `{"continue", "additionalContext"}` top-level 은 CC honor X. 정확 schema = `{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}`. nested wrapper 필수.
+  - **B2: content 10K cap 초과** — guidelines.md 12,077 char inject 시도. CC additionalContext cap 10,000 초과 → truncate 또는 silent drop.
+- **Alternatives**:
+  1. *옵션 A — guidelines.md 자체 < 10K 압축*. SSOT 정보 손실.
+  2. *옵션 B — 핵심 룰 5K inject + 자세 read*. 강제력 약함.
+  3. **(채택) 옵션 C — directive only inject (~1K) + SSOT path + 핵심 강제 룰 4**. CLAUDE.md 와 동일 레벨 강제. cap 회피.
+- **Decision**:
+  - 옵션 C 채택.
+  - Schema fix — `hookSpecificOutput` wrapper.
+  - Content compression — directive 1.2K. 5 SSOT path + 핵심 강제 룰 4 (가시성 echo / Step 기록 / self-verify / finalize-run --auto-review).
+  - 글로벌 강제 표현 — "글로벌 `~/.claude/CLAUDE.md` 와 동일 레벨 강제. 미인지 진행 = 룰 위반".
+- **Follow-Up (의무)**:
+  - **본 PR 머지 후 새 dcness 세션 시작** — system-reminder 에 "DCN-30-40 자동 로드" 출현 확인. 검증 *전* 다른 작업 금지.
+  - **자장 plugin reinstall** — 사용자 환경. 새 자장 세션 → inject 검증 → 새 epic 진입 시 메인이 SSOT read + Step 절차 자율 적용 확인.
+  - **DCN-30-27 ~ -39 의존성 재검증** — inject 작동 후 5 slim skill 메인이 SSOT 만 보고 task 동적 구성 가능 self-test.
+  - **회귀 안전망** — `/run-review` 에 `INJECT_NOT_RECEIVED` 패턴 추가 후속.
+  - **본 incident 회고 룰화** — dcness §12 안티패턴 1줄 추가 ("자기 박은 mechanical 메커니즘도 실 작동 검증 후 후속 PR 진행. 가정 진행 금지").
+
 ### DCN-CHG-20260430-39
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,18 @@
 
 ## Records
 
+### DCN-CHG-20260430-40
+- **Date**: 2026-04-30
+- **Change-Type**: hooks
+- **Files Changed**:
+  - `hooks/session-start.sh` — 2 bug fix:
+    1. **JSON schema** — `{continue, additionalContext}` (top-level, CC honor X) → `{hookSpecificOutput: {hookEventName, additionalContext}}` (CC 정확 schema, claude-code-guide 검증).
+    2. **content 압축** — guidelines.md 본문 inject (12,077 char, CC 10K cap 초과) → directive only (~1.2K). "지금 즉시 read 의무" + 5 SSOT path + 핵심 강제 룰 4 (read 전이라도 즉시 적용). 글로벌 `~/.claude/CLAUDE.md` 와 동일 레벨 강제.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: DCN-30-26 SessionStart inject 처음부터 작동 0회 발견. 검증: 본 dcness 세션 jsonl `grep -c "dcness Guidelines"` = 0 + 자장 jajang 사용자 보고 (system-reminder = "OK" 만, 본문 부재). 2 bug 동시 수정. 후속 PR 5+개 (DCN-30-27 ~ -39) 모두 본 inject 작동 가정 위에 진행 — 가정 거짓 입증. 글로벌 제1룰 + dcness §12 self-verify 원칙 (DCN-30-35) 우리가 박은 룰 자체 위반. 검증 의무: 본 PR 머지 후 *반드시* 새 dcness 세션 시작 시 system-reminder 에 "DCN-30-39 자동 로드" 출현 확인. 자장 plugin reinstall 후 동일 검증.
+
 ### DCN-CHG-20260430-39
 - **Date**: 2026-04-30
 - **Change-Type**: agent, harness, test

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -26,26 +26,49 @@ CC_PID=$PPID
 # Python 으로 stdin 처리 + 핸들러 호출 (silent — stdout 안 씀)
 python3 -m harness.hooks session-start --cc-pid "$CC_PID"
 
-# DCN-CHG-20260430-26: dcness guidelines 를 system-reminder 로 inject.
-# 활성 프로젝트 한정 (위 is-active 게이트 통과 후만 실행). plugin 비활성 X.
-# CC SessionStart 훅 출력 = JSON {continue, additionalContext} → 매 세션 자동 인지.
-GUIDELINES="${CLAUDE_PLUGIN_ROOT:-.}/docs/process/dcness-guidelines.md"
-if [ -f "$GUIDELINES" ]; then
-    python3 -c "
+# DCN-CHG-20260430-26 (신설), DCN-CHG-20260430-40 (schema fix + 압축):
+# dcness 활성 프로젝트 매 세션 SessionStart 시 SSOT read 의무 directive 를
+# system-reminder 로 inject.
+#
+# 본문 inject 가 아닌 *지시* 만 (~1K) — CC additionalContext 10K cap 회피 +
+# CLAUDE.md 와 동일 강제력 ("지금 즉시 read 의무"). 메인 Claude 가 read 후
+# 컨텍스트 안에 SSOT 본문 자체 적재.
+#
+# JSON schema (정확한 CC 형식):
+#   {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
+# top-level 의 {continue, additionalContext} 는 CC 가 honor X (DCN-30-26 bug,
+# DCN-30-40 fix). 자장 jajang 세션에서 inject 0회 검증 후 발견.
+python3 -c "
 import json
-try:
-    with open('$GUIDELINES', encoding='utf-8') as f:
-        content = f.read()
-    msg = (
-        '## dcness Guidelines (자동 로드 — DCN-30-26)\n\n'
-        '**[필수 인지]** 본 프로젝트는 dcness plugin 활성. 아래 룰 모든 dcness skill 진행 시 의무 적용.\n\n'
-        '---\n\n' + content
-    )
-    print(json.dumps({'continue': True, 'additionalContext': msg}))
-except Exception:
-    pass
+msg = '''## dcness Guidelines (DCN-30-40 자동 로드)
+
+**[필수 — 지금 즉시 read 의무]**
+
+본 프로젝트는 dcness plugin 활성. 글로벌 \`~/.claude/CLAUDE.md\` 와 *동일 레벨 강제*. 다음 SSOT 본 메시지 수신 *직후* read:
+
+1. **\`docs/process/dcness-guidelines.md\`** — 가시성 / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy / **§12 self-verify 원칙** / 행동지침 md 300줄 cap
+2. **\`docs/loop-procedure.md\`** — Step 0~8 mechanics (worktree → begin-run → TaskCreate → begin-step → Agent → end-step → finalize-run --auto-review)
+3. **\`docs/loop-catalog.md\`** — 8 loop × 풀스펙 (entry / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles)
+4. **\`docs/orchestration.md\`** §2~§3 — 시퀀스 + 진입 경로 mini-graph
+5. **\`docs/handoff-matrix.md\`** — agent 결정표 / Retry / Escalate / 접근 권한
+
+**룰 의무 적용 범위**: 모든 dcness skill 진행 (\`/qa\`, \`/quick\`, \`/product-plan\`, \`/impl\`, \`/impl-loop\`, \`/run-review\`) + skill 외 직접 발화 (orchestration §3 보고 동적 구성).
+
+**핵심 강제 룰 — read 전이라도 즉시 적용**:
+- 매 Agent 호출 후 prose 5~12줄 의무 echo (가시성 §1)
+- begin-step / end-step 1:1 의무 (§2 Step 기록)
+- 추측 금지 + 실측 후 단언 (§12 self-verify, 글로벌 제1룰 정합)
+- finalize-run 시 \`--auto-review\` flag 의무 (loop-procedure §5.1)
+
+**미인지 진행 = 룰 위반**. read 없이 작업 금지.
+'''
+print(json.dumps({
+    'hookSpecificOutput': {
+        'hookEventName': 'SessionStart',
+        'additionalContext': msg,
+    }
+}))
 " 2>/dev/null
-fi
 
 # 모든 실패는 silent
 exit 0


### PR DESCRIPTION
## 🚨 Critical bug

DCN-30-26 SessionStart inject **처음부터 작동 0회**. 자장 사용자 보고 + 본 dcness 세션 jsonl `grep` = 0 직접 검증. 후속 PR 5+개 (DCN-30-27 ~ -39) 모두 inject 작동 가정 위에 진행 — 가정 거짓 입증.

**자기 룰 위반**: 글로벌 제1룰 ("실존 검증 강제") + dcness §12 self-verify (DCN-30-35 우리 박은 룰) — 머지 후 실 작동 검증 *없이* 후속 진행.

## 2 Bug

### B1: JSON schema 잘못 (claude-code-guide 검증)

| 잘못 (DCN-30-26) | 정확 (DCN-30-40) |
|---|---|
| `{"continue": true, "additionalContext": "..."}` | `{"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}` |

`additionalContext` 가 top-level → CC honor X. `hookSpecificOutput` nested wrapper 필수.

### B2: 12,077 char → CC 10K cap 초과

`docs/process/dcness-guidelines.md` 본문 inject 시도. CC `additionalContext` cap = 10,000 char. truncate 또는 silent drop.

## Fix

### Schema
```python
print(json.dumps({
    'hookSpecificOutput': {
        'hookEventName': 'SessionStart',
        'additionalContext': msg,
    }
}))
```

### Content compression (12K → 1.2K)

guidelines.md 본문 inject ❌ → **directive only**:
- "[필수 — 지금 즉시 read 의무]"
- 글로벌 `~/.claude/CLAUDE.md` 와 동일 레벨 강제 명시
- 5 SSOT path (guidelines / loop-procedure / loop-catalog / orchestration / handoff-matrix)
- 핵심 강제 룰 4 (read 전이라도 즉시 적용):
  1. 매 Agent 호출 후 prose 5~12줄 의무 echo
  2. begin-step / end-step 1:1 의무
  3. 추측 금지 + 실측 후 단언
  4. finalize-run 시 `--auto-review` flag 의무
- "미인지 진행 = 룰 위반"

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (4 files / docs-only, hooks)
- [x] manual run — schema 정확 / 1169 char (cap 안)
  ```
  top keys: ['hookSpecificOutput']
  hookSpecificOutput keys: ['hookEventName', 'additionalContext']
  hookEventName: SessionStart
  additionalContext char len: 1169
  cap (10000): OK
  ```

## 검증 의무 (머지 후 즉시)

**본 PR 머지 후**:
1. 본 dcness 세션 종료 → 새 dcness 세션 시작
2. jsonl `grep -c "DCN-30-40 자동 로드"` ≥ 1 확인
3. system-reminder 에 directive 본문 출현 확인

**자장 (사용자 환경)**:
1. plugin reinstall (`claude plugin uninstall dcness@dcness; claude plugin install dcness@dcness`)
2. 새 자장 세션 시작 → 동일 jsonl 검증
3. `/product-plan` 또는 `/qa` 등 skill 진입 시 메인이 SSOT 자동 read 후 절차 준수 확인

## 후속 (별도 Task)

- DCN-30-27 ~ -39 의존성 재검증 — 5 slim skill 메인이 SSOT 만 보고 task 동적 구성 가능 self-test
- `/run-review` 에 `INJECT_NOT_RECEIVED` 패턴 추가 — 회귀 자동 검출
- dcness §12 안티패턴 1줄 추가 — "자기 박은 mechanical 메커니즘도 *실 작동 검증 후* 후속 PR 진행. 가정 진행 금지" (본 incident 회고 룰화)

🤖 Generated with [Claude Code](https://claude.com/claude-code)