### PR TITLE
feat: sub-agent path 보호 hook (handoff-matrix §4 코드 SSOT) (DCN-CHG-20260501-01)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,17 @@
 
 ## 현재 상태
 
+- **🛡️ sub-agent path 보호 hook (handoff-matrix §4 코드 SSOT)** (`DCN-CHG-20260501-01`):
+  - DCN-30-39 5번 follow-up — `DCNESS_INFRA_PATTERNS` 가 spec only, 코드 enforcement 0. sub-agent 가 인프라 path Edit/Write/Bash 자유.
+  - **첫 원칙 정합** — "강제 = 작업 순서 + 접근 영역" — 접근 영역 강제는 spec only ↔ 코드 drift 해소.
+  - **`harness/agent_boundary.py`** 신규 — `DCNESS_INFRA_PATTERNS` (9) / `ALLOW_MATRIX` (12 agent) / `READ_DENY_MATRIX` / `is_infra_project()` 4 OR / `is_opt_out()` / `check_write/read_allowed()` / `extract_bash_paths()` heuristic.
+  - **`harness/hooks.py` 핸들러 3개** — `handle_pretooluse_agent` 끝 `update_live(active_agent=...)` 등록 + `handle_pretooluse_file_op()` (Edit/Write/Read/Bash) + `handle_posttooluse_agent()` (clear). CLI 2 subcommand 추가.
+  - **hooks/hooks.json** — PreToolUse `Edit|Write|NotebookEdit|Read|Bash` matcher + PostToolUse `Agent` matcher 추가. `hooks/file-guard.sh` + `hooks/post-agent-clear.sh` 신규.
+  - **메인 vs sub-agent 분기** — live.json.active_agent 공유 상태로 식별. 메인 = 통과 (governance Document Sync 가 보호).
+  - **dcness 자체 = 해제** — `is_infra_project()` True 시 모든 룰 우회. user 프로젝트 (자장 등) 만 enforce.
+  - **opt-out** — `.no-dcness-guard` 마커 + `DCNESS_INFRA=1` env + `CLAUDE_PLUGIN_ROOT` env + cwd 화이트리스트 (4 OR).
+  - 38 신규 테스트 (`test_agent_boundary` 27 + `test_hooks` 11). 281 ran / 279 PASS / 2 pre-existing flaky 무관.
+  - `docs/handoff-matrix.md` §4.4 코드 SSOT cross-ref + INFRA pattern 리스트 코드와 동기.
 - **🚨 SessionStart inject 처음부터 작동 0회 — schema fix + 압축** (`DCN-CHG-20260430-40`):
   - 자장 사용자 보고 — `/product-plan` 진입 시 메인이 dcness 룰 미인지. system-reminder = "OK" 만, 본문 부재. 본 dcness 세션 jsonl `grep` = 0 직접 검증.
   - 2 bug 동시: (1) JSON schema 잘못 (`{continue, additionalContext}` top-level → CC honor X). 정확 = `{hookSpecificOutput: {hookEventName, additionalContext}}` nested wrapper. (2) 12K char (CC 10K cap 초과).

--- a/docs/handoff-matrix.md
+++ b/docs/handoff-matrix.md
@@ -219,19 +219,23 @@ force-retry 시 카운터 리셋 (RWHarness PR #11 패턴 정합).
 
 ### 4.4 인프라 패턴 (전 에이전트 공통 차단)
 
+> **코드 SSOT** (DCN-CHG-20260501-01): 실제 강제 패턴은 `harness/agent_boundary.py:DCNESS_INFRA_PATTERNS`. 본 §4.4 와 코드는 항상 동기 — 변경 시 양쪽 함께.
+
 ```python
 DCNESS_INFRA_PATTERNS = [
-    r'[./]claude/',
-    r'hooks/',
-    r'harness/(signal_io|interpret_strategy)\.py',
-    r'docs/orchestration\.md',
-    r'docs/handoff-matrix\.md',
-    r'docs/process/governance\.md',
-    r'scripts/(check_document_sync|check_task_id|setup_branch_protection|analyze_metrics)\.mjs',
+    r'(^|/)\.claude/',
+    r'(^|/)hooks/',
+    r'(^|/)harness/(signal_io|interpret_strategy|hooks|session_state|agent_boundary)\.py$',
+    r'(^|/)docs/orchestration\.md$',
+    r'(^|/)docs/handoff-matrix\.md$',
+    r'(^|/)docs/loop-procedure\.md$',
+    r'(^|/)docs/loop-catalog\.md$',
+    r'(^|/)docs/process/(governance|dcness-guidelines)\.md$',
+    r'(^|/)scripts/(check_document_sync|check_task_id|setup_branch_protection|analyze_metrics)\.mjs$',
 ]
 ```
 
-> RWHarness 의 `HARNESS_INFRA_PATTERNS` 안 `r'orchestration-rules\.md'` 잔재는 dcness 가 정정 — 파일명은 `docs/orchestration.md` + `docs/handoff-matrix.md` (split 후 양쪽).
+> RWHarness 의 `HARNESS_INFRA_PATTERNS` 안 `r'orchestration-rules\.md'` 잔재는 dcness 가 정정 — 파일명은 `docs/orchestration.md` + `docs/handoff-matrix.md` (split 후 양쪽). loop-procedure / loop-catalog / dcness-guidelines / hooks·session_state·agent_boundary 도 dcness 가 추가 보호 (DCN-30-30/31/32 split 산출물).
 
 인프라 프로젝트(`is_infra_project()` True) 에선 위 패턴 해제 (dcness 자체 작업 시 본 SSOT 들도 편집 가능해야 함).
 
@@ -244,7 +248,7 @@ RWHarness 4 신호 OR 정합:
 3. `CLAUDE_PLUGIN_ROOT` 환경변수 non-empty
 4. `cwd.resolve() == Path("/Users/<user>/project/dcness")` (또는 화이트리스트 매칭)
 
-본 판정 코드는 후속 Task — 코드 driver 도입 시 함께.
+> **코드 강제** (DCN-CHG-20260501-01): `harness/agent_boundary.py` 가 본 spec 의 SSOT 구현. `hooks/file-guard.sh` (PreToolUse Edit/Write/Read/Bash) + `hooks/post-agent-clear.sh` (PostToolUse Agent) 가 활성화. opt-out 마커 = `.no-dcness-guard` (cwd) — 사용자 임시 우회.
 
 ---
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,35 @@
 
 ## Records
 
+### DCN-CHG-20260501-01
+- **Date**: 2026-05-01
+- **Rationale**:
+  - DCN-30-39 5번 follow-up — `DCNESS_INFRA_PATTERNS` 가 `handoff-matrix.md §4.4` spec 으로만 박힘, 코드 enforcement 0. `hooks/catastrophic-gate.sh` 가 차단하는 건 PreToolUse Agent 만 — sub-agent 내부 Edit/Write/Bash 는 자유.
+  - 사용자 진단 (자장 plugin 활성 환경): "엔지니어가 아무 문서나 수정할수 있다는거지? 어쩐지 시발 경고 한번 안뜨더라" — 실측 갭 확인.
+  - 첫 원칙 정합 — "강제 = (1) 작업 순서 + (2) 접근 영역". 접근 영역은 dcness 가 코드로 미강제 → 첫 원칙 일부 미이행 (자율 침해 X — 자율 영역 = 출력 형식 / handoff 페이로드 등과 직교).
+  - 검증 (claude-code-guide + RWHarness 실 구현 확인): PreToolUse 훅이 sub-agent 내부 tool 호출에도 fire. 부모 CC session_id 가 PreToolUse stdin 에 그대로 — 메인 vs sub-agent 식별 가능 (live.json 공유 상태 lookup).
+- **Alternatives**:
+  1. *옵션 A — payload `agent_id` 직접 필드*. 사용자 초안. 단 RWHarness 실 구현은 live.json 공유 상태 — `agent-gate.py` 가 `live.json.agent` 기록, `agent-boundary.py` 가 PreToolUse Edit 에서 stdin session_id → live.json 조회로 활성 agent 판정. 더 견고 (Claude Code agent_id payload 호환성 의존 X).
+  2. *옵션 B — Bash 정밀 path 추출 (shlex 등)*. 복잡. v1 = 보수적 heuristic (write indicator + path 토큰 휴리스틱). false positive 회피 우선.
+  3. *옵션 C — agent prompt 안 룰 강화만 (agent-side 자율)*. 자장 5 incident 중 일부는 agent self-monitor 부재 — 자율 의존 시 회귀 (DCN-30-20 jajang 6분 stall 정합).
+  4. **(채택) 옵션 D — RWHarness 패턴 그대로 차용**. live.json.active_agent 기록/해제 + agent_boundary.py 분리 + Edit/Write/Read/Bash matcher 4개. 검증된 구현 (RWHarness `~/.claude/plugins/cache/realworld-harness/0.1.0-alpha/hooks/agent-boundary.py`).
+- **Decision**:
+  - **(1) `harness/agent_boundary.py` 신규** — 9 INFRA pattern + 12 agent ALLOW_MATRIX + 4 agent READ_DENY + `is_infra_project()` 4 OR 신호 + `.no-dcness-guard` opt-out + Bash heuristic.
+  - **(2) `harness/hooks.py` 핸들러 3개**:
+    - `handle_pretooluse_agent` 끝에 `update_live(active_agent=subagent, active_mode=mode)` — sub-agent 식별 등록.
+    - `handle_pretooluse_file_op()` — Edit/Write/NotebookEdit/Read/Bash 검사. Bash 는 write indicator (sed -i / cp / mv / rm / >) 있을 때만 path 추출.
+    - `handle_posttooluse_agent()` — `update_live(active_agent=None, active_mode=None)` 으로 clear.
+  - **(3) `hooks/file-guard.sh` + `hooks/post-agent-clear.sh`** — bash wrapper. is-active 게이트로 미활성 프로젝트 즉시 통과.
+  - **(4) `hooks/hooks.json` matcher 확장** — `Edit|Write|NotebookEdit|Read|Bash` (PreToolUse) + `Agent` (PostToolUse).
+  - **(5) opt-out 다중**: ① `.no-dcness-guard` 마커 (RWHarness `.no-harness` 정합) ② `DCNESS_INFRA=1` env (개발자 모드) ③ `CLAUDE_PLUGIN_ROOT` env ④ cwd 화이트리스트 (현 저장소).
+  - **(6) Bash 휴리스틱 v1 보수적** — write indicator 부재 시 빈 list. quoted pattern 도 path 후보 포함 (false negative 회피). 정밀 추출은 후속.
+- **Follow-Up**:
+  - **자장 plugin 재install + 새 epic 검증** — sub-agent 가 인프라 path Edit/Write 시도 → block 메시지 (`[agent-boundary] ...`) 실 발화 확인. 첫 incident 후 임계값 / 패턴 조정.
+  - **(2) Bash 정밀 path 추출 강화** (후속) — `shlex.split` + 알려진 cmd 별 인자 위치 (예: `cp src dst` → dst index). v1 false positive 발생 시 즉시 진행.
+  - **(2) READ_DENY_MATRIX 정밀화** (후속) — test-engineer impl 외 src 차단 등. v1 = 일부 비어있음.
+  - **(2) NotebookEdit 검증** — 환경 외 동작 미실측. CC 환경에서 발화 시 동작 확인.
+  - **DCN-30-39 (2) 30일 누적 임계값 tuning** — 보류 (5월 30일 이후).
+
 ### DCN-CHG-20260430-40
 - **Date**: 2026-04-30
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,23 @@
 
 ## Records
 
+### DCN-CHG-20260501-01
+- **Date**: 2026-05-01
+- **Change-Type**: harness, hooks, spec, test
+- **Files Changed**:
+  - `harness/agent_boundary.py` (신규) — `DCNESS_INFRA_PATTERNS` 9 패턴 / `ALLOW_MATRIX` 12 agent / `READ_DENY_MATRIX` / `is_infra_project()` 4 OR 신호 / `is_opt_out()` `.no-dcness-guard` 마커 / `check_write_allowed()` / `check_read_allowed()` / `extract_bash_paths()` heuristic. handoff-matrix.md §4 spec 의 코드 SSOT.
+  - `harness/hooks.py` — `handle_pretooluse_agent` 끝에 `update_live(active_agent=subagent, active_mode=mode)` 추가 (sub-agent 식별). `handle_pretooluse_file_op()` 신규 (Edit/Write/Read/Bash agent_boundary 강제). `handle_posttooluse_agent()` 신규 (live.json clear). CLI 2개 subcommand 추가.
+  - `hooks/file-guard.sh` (신규) — PreToolUse Edit/Write/Read/Bash wrapper.
+  - `hooks/post-agent-clear.sh` (신규) — PostToolUse Agent wrapper.
+  - `hooks/hooks.json` — `Edit|Write|NotebookEdit|Read|Bash` matcher 추가 (PreToolUse) + `Agent` matcher 추가 (PostToolUse).
+  - `tests/test_agent_boundary.py` (신규) — 27 테스트 (is_infra_project / write / read / opt-out / Bash heuristic / 통합).
+  - `tests/test_hooks.py` — `FileOpAgentRecordTests` + `FileOpHookTests` + `PostToolUseAgentClearTests` 11 테스트 추가. import 갱신.
+  - `docs/handoff-matrix.md` §4.4 코드 SSOT cross-ref + §4.5 강제 노트 추가. spec 의 INFRA_PATTERNS 리스트도 코드와 동기화 (loop-procedure / loop-catalog / dcness-guidelines / hooks·session_state·agent_boundary 보호 추가).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: handoff-matrix.md §4.4/§4.5 spec 의 코드 enforcement 0 갭 해소. PreToolUse Edit/Write/Read/Bash 훅 신설로 sub-agent 인프라 path 침해 차단. live.json.active_agent 기록 (PreToolUse Agent) + 해제 (PostToolUse Agent) 로 메인 vs sub-agent 분기. user 프로젝트 활성 시만 enforce — dcness 자체 (`is_infra_project()` True) 는 통과. `.no-dcness-guard` opt-out 마커 + DCNESS_INFRA env 우회 가능. 38 신규 테스트 / all PASS.
+
 ### DCN-CHG-20260430-40
 - **Date**: 2026-04-30
 - **Change-Type**: hooks

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -1,0 +1,312 @@
+"""agent_boundary.py — sub-agent 경로 접근 강제 (`docs/handoff-matrix.md` §4 SSOT).
+
+본 모듈은 PreToolUse(Edit/Write/Read/Bash) 훅이 호출하여 활성 sub-agent 의 path
+접근을 차단한다. handoff-matrix.md §4.1~§4.5 의 spec 을 코드로 강제 (DCN-CHG-20260501-01).
+
+핵심 룰 (handoff-matrix.md §4 정합):
+    §4.1 HARNESS_ONLY_AGENTS (engineer 등 컨베이어 경유 필수) — `hooks.py:handle_pretooluse_agent`
+    §4.2 ALLOW_MATRIX — agent 별 Write 허용 path
+    §4.3 READ_DENY_MATRIX — agent 별 Read 금지 path
+    §4.4 DCNESS_INFRA_PATTERNS — 전 agent 공통 차단 (인프라 보호)
+    §4.5 is_infra_project() — dcness 자체 작업 시 §4.2~§4.4 해제
+
+활성 sub-agent 판정: live.json.active_agent (catastrophic-gate 가 PreToolUse Agent
+훅에서 기록, post-agent-clear 가 PostToolUse Agent 훅에서 해제).
+
+규약:
+    - 메인 Claude (active_agent 미설정) = 통과 — governance Document Sync 가 별도 보호.
+    - 미정의 agent_type = 통과 (false positive 회피).
+    - is_infra_project() True = 모든 룰 해제 (dcness 자체 SSOT 편집 가능해야).
+    - opt-out 마커 `.no-dcness-guard` (cwd) 존재 = 모든 룰 해제.
+
+검사 결과:
+    None = allow
+    str  = block reason (stderr 메시지 + exit 1)
+"""
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+__all__ = [
+    "DCNESS_INFRA_PATTERNS",
+    "ALLOW_MATRIX",
+    "READ_DENY_MATRIX",
+    "INFRA_PROJECT_CWD_WHITELIST",
+    "is_infra_project",
+    "is_opt_out",
+    "check_write_allowed",
+    "check_read_allowed",
+    "extract_bash_paths",
+]
+
+
+# ── §4.4 — 인프라 패턴 (전 agent 공통 차단) ──────────────────────────
+# handoff-matrix.md:223 spec 그대로 + dcness 정합 보강.
+DCNESS_INFRA_PATTERNS: tuple[str, ...] = (
+    r'(^|/)\.claude/',
+    r'(^|/)hooks/',
+    r'(^|/)harness/(signal_io|interpret_strategy|hooks|session_state|agent_boundary)\.py$',
+    r'(^|/)docs/orchestration\.md$',
+    r'(^|/)docs/handoff-matrix\.md$',
+    r'(^|/)docs/loop-procedure\.md$',
+    r'(^|/)docs/loop-catalog\.md$',
+    r'(^|/)docs/process/(governance|dcness-guidelines)\.md$',
+    r'(^|/)scripts/(check_document_sync|check_task_id|setup_branch_protection|analyze_metrics)\.mjs$',
+)
+
+
+# ── §4.2 — ALLOW_MATRIX (agent 별 Write 허용) ─────────────────────────
+# handoff-matrix.md:200~209 정합. RWHarness agent-boundary.py:48~84 와 동일 패턴.
+ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
+    "engineer": (
+        r'(^|/)src/',
+        r'(^|/)apps/[^/]+/src/',
+        r'(^|/)apps/[^/]+/app/',
+        r'(^|/)apps/[^/]+/alembic/',
+        r'(^|/)packages/[^/]+/src/',
+        r'(^|/)apps/[^/]+/[^/]+\.toml$',
+        r'(^|/)apps/[^/]+/[^/]+\.cfg$',
+    ),
+    "architect": (
+        r'(^|/)docs/',
+        r'(^|/)backlog\.md$',
+        r'(^|/)trd\.md$',
+    ),
+    "designer": (
+        r'(^|/)design-variants/',
+        r'(^|/)docs/ui-spec',
+    ),
+    "test-engineer": (
+        r'(^|/)src/__tests__/',
+        r'(^|/)src/.*\.test\.[jt]sx?$',
+        r'(^|/)src/.*\.spec\.[jt]sx?$',
+        r'(^|/)apps/[^/]+/tests/',
+        r'(^|/)apps/[^/]+/src/__tests__/',
+        r'(^|/)apps/[^/]+/src/.*\.test\.[jt]sx?$',
+        r'(^|/)apps/[^/]+/src/.*\.spec\.[jt]sx?$',
+        r'(^|/)packages/[^/]+/src/__tests__/',
+    ),
+    "product-planner": (
+        r'(^|/)prd\.md$',
+        r'(^|/)stories\.md$',
+    ),
+    "ux-architect": (
+        r'(^|/)docs/ux-flow\.md$',
+    ),
+    # 판정 전용 agent — Write 0.
+    "qa": (),
+    "validator": (),
+    "design-critic": (),
+    "pr-reviewer": (),
+    "security-reviewer": (),
+    "plan-reviewer": (),
+}
+
+
+# ── §4.3 — READ_DENY_MATRIX (agent 별 Read 금지) ──────────────────────
+READ_DENY_MATRIX: dict[str, tuple[str, ...]] = {
+    "product-planner": (
+        r'(^|/)src/',
+        r'(^|/)docs/impl/',
+        r'(^|/)trd\.md$',
+    ),
+    "designer": (
+        r'(^|/)src/',
+    ),
+    "test-engineer": (
+        # impl 외 src 읽기 금지 — domain 문서 격리. 실 적용은 후속 강화.
+    ),
+    "plan-reviewer": (
+        r'(^|/)src/',
+        r'(^|/)docs/impl/',
+        r'(^|/)trd\.md$',
+    ),
+}
+
+
+# ── §4.5 — is_infra_project() 4 OR 신호 ──────────────────────────────
+INFRA_PROJECT_CWD_WHITELIST: tuple[str, ...] = (
+    "/Users/dc.kim/project/dcNess",
+)
+
+
+def is_infra_project(
+    cwd: Optional[Path] = None,
+    *,
+    env: Optional[dict] = None,
+    home: Optional[Path] = None,
+) -> bool:
+    """4 OR 신호 — handoff-matrix.md §4.5.
+
+    1. DCNESS_INFRA=1 환경변수
+    2. 마커 파일 ~/.claude/.dcness-infra 존재
+    3. CLAUDE_PLUGIN_ROOT 환경변수 non-empty (dcness 개발 모드)
+    4. cwd.resolve() in INFRA_PROJECT_CWD_WHITELIST
+    """
+    e = env if env is not None else os.environ
+    if e.get("DCNESS_INFRA") == "1":
+        return True
+    if e.get("CLAUDE_PLUGIN_ROOT"):
+        return True
+    h = home if home is not None else Path.home()
+    if (h / ".claude" / ".dcness-infra").exists():
+        return True
+    if cwd is None:
+        cwd = Path.cwd()
+    try:
+        resolved = str(cwd.resolve())
+    except (OSError, RuntimeError):
+        return False
+    return resolved in INFRA_PROJECT_CWD_WHITELIST
+
+
+def is_opt_out(cwd: Optional[Path] = None) -> bool:
+    """`.no-dcness-guard` 마커 — 사용자 임시 우회 (RWHarness `.no-harness` 정합)."""
+    if cwd is None:
+        cwd = Path.cwd()
+    return (cwd / ".no-dcness-guard").exists()
+
+
+# ── path 정규화 ───────────────────────────────────────────────────────
+
+
+def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
+    """절대 path → cwd 상대 path. 외부 path 는 그대로 반환."""
+    if cwd is None:
+        cwd = Path.cwd()
+    try:
+        p = Path(file_path)
+        if p.is_absolute():
+            try:
+                return str(p.resolve().relative_to(cwd.resolve()))
+            except ValueError:
+                # cwd 밖 — 그대로 반환 (외부 path 는 패턴 매칭에서 잡거나 통과)
+                return str(p)
+        return file_path
+    except (OSError, ValueError):
+        return file_path
+
+
+def _matches_any(path: str, patterns: Iterable[str]) -> Optional[str]:
+    for pat in patterns:
+        if re.search(pat, path):
+            return pat
+    return None
+
+
+# ── 검사 ─────────────────────────────────────────────────────────────
+
+
+def check_write_allowed(
+    agent: Optional[str],
+    file_path: str,
+    *,
+    cwd: Optional[Path] = None,
+) -> Optional[str]:
+    """Write/Edit 검사 — block reason str / None=allow.
+
+    메인 Claude (agent=None / 빈 문자열) = 통과. 메인 거버넌스는 Document Sync 가 강제.
+    is_infra_project() True = 통과 — dcness 자체 SSOT 편집.
+    `.no-dcness-guard` 마커 = 통과.
+    """
+    if not agent:
+        return None
+    if is_infra_project(cwd):
+        return None
+    if is_opt_out(cwd):
+        return None
+
+    norm = _normalize(file_path, cwd)
+
+    # 1. INFRA pattern → 모든 agent 차단.
+    matched = _matches_any(norm, DCNESS_INFRA_PATTERNS)
+    if matched:
+        return f"인프라 path 보호: matched `{matched}` (handoff-matrix.md §4.4)"
+
+    # 2. ALLOW_MATRIX 미매칭 → 차단.
+    allowed = ALLOW_MATRIX.get(agent)
+    if allowed is None:
+        # 미정의 agent — false positive 회피로 통과.
+        return None
+    if not _matches_any(norm, allowed):
+        return (
+            f"{agent} ALLOW_MATRIX 미매칭: `{norm}` "
+            f"(handoff-matrix.md §4.2 — 허용 = {list(allowed)})"
+        )
+    return None
+
+
+def check_read_allowed(
+    agent: Optional[str],
+    file_path: str,
+    *,
+    cwd: Optional[Path] = None,
+) -> Optional[str]:
+    """Read 검사 — block reason str / None=allow.
+
+    메인 = 통과. is_infra_project = 통과. opt-out = 통과.
+    INFRA pattern = 모든 sub-agent 차단 (인프라 누설 방지).
+    READ_DENY_MATRIX = agent 별 추가 차단.
+    """
+    if not agent:
+        return None
+    if is_infra_project(cwd):
+        return None
+    if is_opt_out(cwd):
+        return None
+
+    norm = _normalize(file_path, cwd)
+
+    matched = _matches_any(norm, DCNESS_INFRA_PATTERNS)
+    if matched:
+        return f"인프라 path 읽기 금지: matched `{matched}` (handoff-matrix.md §4.4)"
+
+    deny = READ_DENY_MATRIX.get(agent, ())
+    matched = _matches_any(norm, deny)
+    if matched:
+        return (
+            f"{agent} READ_DENY_MATRIX 매칭: `{norm}` "
+            f"(handoff-matrix.md §4.3 matched `{matched}`)"
+        )
+    return None
+
+
+# ── Bash heuristic ────────────────────────────────────────────────────
+
+# v1: 명시적 위반 패턴 (sed -i / awk -i / cp / mv / rm / 리다이렉션) 만 잡는다.
+# 정밀 path 추출 X — false negative 우선 (false positive 회피).
+_BASH_WRITE_INDICATORS: tuple[str, ...] = (
+    r'\bsed\b\s+(?:[-]\w*i\w*|--in-place)',
+    r'\bawk\b\s+(?:[-]\w*i\w*|--in-place)',
+    r'\bperl\b\s+[-]\w*i',
+    r'\b(?:cp|mv|rm)\b\s+',
+    r'>\s*\S',     # redirect (writing)
+    r'>>\s*\S',    # append redirect
+    r'\btee\b',
+)
+
+
+def extract_bash_paths(command: str) -> list[str]:
+    """Bash command 안의 의심 path 토큰 추출 (v1: 보수적).
+
+    write 지표 (sed -i / cp / mv / rm / >) 가 보일 때만 토큰 분해 후
+    `/` 또는 `.md`/`.py`/`.json`/`.sh` 확장자 포함 토큰을 path 후보로 반환.
+    indicator 없으면 빈 list — false positive 회피.
+    """
+    if not any(re.search(ind, command) for ind in _BASH_WRITE_INDICATORS):
+        return []
+    # 토큰화 — quote 단순 처리.
+    tokens = re.findall(r"[\"'][^\"']+[\"']|\S+", command)
+    paths: list[str] = []
+    for t in tokens:
+        t = t.strip("\"'")
+        if not t or t.startswith("-"):
+            continue
+        # path 후보 — `/` 포함 또는 알려진 확장자.
+        if "/" in t or re.search(r"\.(md|py|json|sh|mjs|ts|tsx|js|jsx)$", t):
+            paths.append(t)
+    return paths

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -38,6 +38,8 @@ __all__ = [
     "HARNESS_ONLY_AGENTS",
     "handle_session_start",
     "handle_pretooluse_agent",
+    "handle_pretooluse_file_op",
+    "handle_posttooluse_agent",
 ]
 
 
@@ -236,6 +238,121 @@ def handle_pretooluse_agent(
                 )
                 return 1
 
+    # DCN-CHG-20260501-01: 통과 시 live.json.active_agent 기록 — sub-agent 내부
+    # PreToolUse(Edit/Write/Read/Bash) 훅이 활성 agent 판정에 사용 (agent_boundary).
+    if subagent:
+        try:
+            update_live(sid, base_dir=base_dir, active_agent=subagent, active_mode=(mode or None))
+        except (OSError, ValueError):
+            pass  # 실패해도 Agent 호출은 통과 — 식별만 누락.
+
+    return 0
+
+
+# ── DCN-CHG-20260501-01 — sub-agent path 강제 (handoff-matrix.md §4) ─
+
+
+def handle_pretooluse_file_op(
+    stdin_data: Optional[Dict[str, Any]] = None,
+    cc_pid: Optional[int] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """PreToolUse Edit/Write/Read/Bash — agent_boundary 강제.
+
+    활성 sub-agent (live.json.active_agent) 가 있을 때만 검사. 메인 Claude 는
+    governance Document Sync 게이트가 별도 보호하므로 본 훅 통과.
+    """
+    from harness.agent_boundary import (
+        check_read_allowed,
+        check_write_allowed,
+        extract_bash_paths,
+    )
+
+    if stdin_data is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_data = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError):
+            return 0
+
+    if not isinstance(stdin_data, dict):
+        return 0
+
+    sid = _extract_sid(stdin_data)
+    if not valid_session_id(sid):
+        return 0
+
+    live = read_live(sid, base_dir=base_dir) or {}
+    active_agent = live.get("active_agent") or ""
+    if not active_agent:
+        return 0  # 메인 Claude — governance 가 보호.
+
+    tool_name = stdin_data.get("tool_name", "") or ""
+    tool_input = stdin_data.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    cwd = Path.cwd()
+
+    # Read — `file_path` 직접.
+    if tool_name == "Read":
+        fp = tool_input.get("file_path", "") or ""
+        if fp:
+            reason = check_read_allowed(active_agent, fp, cwd=cwd)
+            if reason:
+                print(f"[agent-boundary] {reason}", file=sys.stderr)
+                return 1
+        return 0
+
+    # Edit / Write / NotebookEdit — `file_path` 직접 = write op.
+    if tool_name in ("Edit", "Write", "NotebookEdit"):
+        fp = tool_input.get("file_path", "") or ""
+        if fp:
+            reason = check_write_allowed(active_agent, fp, cwd=cwd)
+            if reason:
+                print(f"[agent-boundary] {reason}", file=sys.stderr)
+                return 1
+        return 0
+
+    # Bash — heuristic. write indicator (sed -i / cp / mv / rm / >) 시만 path 추출.
+    if tool_name == "Bash":
+        cmd = tool_input.get("command", "") or ""
+        for fp in extract_bash_paths(cmd):
+            reason = check_write_allowed(active_agent, fp, cwd=cwd)
+            if reason:
+                print(f"[agent-boundary][Bash] {reason}", file=sys.stderr)
+                return 1
+        return 0
+
+    return 0
+
+
+def handle_posttooluse_agent(
+    stdin_data: Optional[Dict[str, Any]] = None,
+    cc_pid: Optional[int] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """PostToolUse Agent — live.json.active_agent / active_mode 해제."""
+    if stdin_data is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_data = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError):
+            return 0
+
+    if not isinstance(stdin_data, dict):
+        return 0
+
+    sid = _extract_sid(stdin_data)
+    if not valid_session_id(sid):
+        return 0
+
+    try:
+        update_live(sid, base_dir=base_dir, active_agent=None, active_mode=None)
+    except (OSError, ValueError):
+        return 0
     return 0
 
 
@@ -299,6 +416,14 @@ def _main(argv: Optional[list] = None) -> int:
     p_ag = sub.add_parser("pretooluse-agent", help="PreToolUse Agent 훅 처리")
     p_ag.add_argument("--cc-pid", type=int, default=None)
 
+    p_fo = sub.add_parser("pretooluse-file-op",
+                          help="PreToolUse Edit/Write/Read/Bash agent_boundary 강제")
+    p_fo.add_argument("--cc-pid", type=int, default=None)
+
+    p_pa = sub.add_parser("posttooluse-agent",
+                          help="PostToolUse Agent — live.json.active_agent 해제")
+    p_pa.add_argument("--cc-pid", type=int, default=None)
+
     args = parser.parse_args(argv)
 
     # cc_pid 미명시 시 PPID 사용 (bash 훅 의 PPID = CC main)
@@ -308,6 +433,10 @@ def _main(argv: Optional[list] = None) -> int:
         return handle_session_start(cc_pid=cc_pid)
     elif args.cmd == "pretooluse-agent":
         return handle_pretooluse_agent(cc_pid=cc_pid)
+    elif args.cmd == "pretooluse-file-op":
+        return handle_pretooluse_file_op(cc_pid=cc_pid)
+    elif args.cmd == "posttooluse-agent":
+        return handle_posttooluse_agent(cc_pid=cc_pid)
     return 0
 
 

--- a/hooks/file-guard.sh
+++ b/hooks/file-guard.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# dcNess file-guard 훅 — PreToolUse Edit/Write/Read/Bash agent_boundary 강제
+#
+# 트리거: Claude Code PreToolUse event, tool=Edit|Write|Read|Bash
+# stdin: CC payload (sessionId + tool_name + tool_input)
+# 동작: harness/hooks.py 의 handle_pretooluse_file_op 호출
+#
+# 반환:
+#   exit 0: allow (CC 가 tool 호출 진행)
+#   exit 1: block (stderr 메시지 + CC 가 호출 거부)
+#
+# 강제 룰 (handoff-matrix.md §4):
+#   §4.4 DCNESS_INFRA_PATTERNS — 인프라 path (모든 sub-agent 차단)
+#   §4.2 ALLOW_MATRIX — agent 별 Write 허용 path
+#   §4.3 READ_DENY_MATRIX — agent 별 Read 금지 path
+#   §4.5 is_infra_project() — dcness 자체 작업 시 해제
+#
+# 활성 sub-agent 가 없으면 (메인 Claude) 통과 — governance Document Sync 가 별도 보호.
+
+set -uo pipefail
+
+# plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응.
+export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+
+# 활성화 게이트 — 미활성 프로젝트는 즉시 통과.
+python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+
+# bash 의 PPID = CC main process
+CC_PID=$PPID
+
+python3 -m harness.hooks pretooluse-file-op --cc-pid "$CC_PID"
+exit $?

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid 추출 + PreToolUse Agent catastrophic-gate)",
+  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash file-guard + PostToolUse Agent post-clear)",
   "hooks": {
     "SessionStart": [
       {
@@ -20,6 +20,28 @@
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/catastrophic-gate.sh\"",
             "timeout": 10
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit|Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/file-guard.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-agent-clear.sh\"",
+            "timeout": 5
           }
         ]
       }

--- a/hooks/post-agent-clear.sh
+++ b/hooks/post-agent-clear.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# dcNess post-agent-clear 훅 — PostToolUse Agent: live.json.active_agent 해제
+#
+# 트리거: Claude Code PostToolUse event, tool=Agent
+# stdin: CC payload (sessionId)
+# 동작: harness/hooks.py 의 handle_posttooluse_agent 호출 — live.json 의
+#       active_agent / active_mode 필드 clear (sub-agent 종료 후 메인 복귀).
+#
+# 반환:
+#   exit 0: 항상 (PostToolUse 는 차단 권한 X)
+
+set -uo pipefail
+
+export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+
+# 활성화 게이트.
+python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+
+CC_PID=$PPID
+
+python3 -m harness.hooks posttooluse-agent --cc-pid "$CC_PID" 2>/dev/null || true
+exit 0

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1,0 +1,294 @@
+"""tests/test_agent_boundary.py — DCN-CHG-20260501-01 path 보호 단위 테스트.
+
+handoff-matrix.md §4 (4.2 ALLOW_MATRIX / 4.3 READ_DENY / 4.4 INFRA / 4.5 infra-project)
+spec 의 코드 강제 검증.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from harness.agent_boundary import (  # noqa: E402
+    ALLOW_MATRIX,
+    DCNESS_INFRA_PATTERNS,
+    READ_DENY_MATRIX,
+    check_read_allowed,
+    check_write_allowed,
+    extract_bash_paths,
+    is_infra_project,
+    is_opt_out,
+)
+
+
+class IsInfraProjectTests(unittest.TestCase):
+    def test_env_dcness_infra(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertTrue(is_infra_project(cwd, env={"DCNESS_INFRA": "1"}, home=Path(td)))
+
+    def test_env_plugin_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertTrue(
+                is_infra_project(cwd, env={"CLAUDE_PLUGIN_ROOT": "/x"}, home=Path(td))
+            )
+
+    def test_marker_file(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            (home / ".claude").mkdir()
+            (home / ".claude" / ".dcness-infra").write_text("")
+            self.assertTrue(is_infra_project(home, env={}, home=home))
+
+    def test_cwd_whitelist(self):
+        # 현 저장소 path = whitelist 멤버.
+        cwd = Path("/Users/dc.kim/project/dcNess")
+        if not cwd.exists():
+            self.skipTest("환경 외 — whitelist cwd 부재")
+        self.assertTrue(is_infra_project(cwd, env={}, home=Path("/tmp")))
+
+    def test_user_project_not_infra(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)  # /tmp/... — whitelist 외
+            self.assertFalse(is_infra_project(cwd, env={}, home=Path(td)))
+
+
+class WriteAllowedMainBypassTests(unittest.TestCase):
+    """메인 Claude (active_agent 없음) = 통과."""
+
+    def test_main_bypass(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(check_write_allowed(None, "hooks/x.sh", cwd=cwd))
+            self.assertIsNone(check_write_allowed("", "docs/orchestration.md", cwd=cwd))
+
+
+class WriteAllowedInfraProjectBypassTests(unittest.TestCase):
+    """is_infra_project=True 인 cwd = 통과 (dcness 자체 SSOT 편집)."""
+
+    def test_infra_project_bypass(self):
+        with patch.dict(os.environ, {"DCNESS_INFRA": "1"}):
+            with tempfile.TemporaryDirectory() as td:
+                cwd = Path(td)
+                self.assertIsNone(
+                    check_write_allowed("engineer", "hooks/x.sh", cwd=cwd)
+                )
+                self.assertIsNone(
+                    check_write_allowed("engineer", "docs/orchestration.md", cwd=cwd)
+                )
+
+
+class WriteAllowedInfraPatternBlockTests(unittest.TestCase):
+    """user 프로젝트 (infra=False) — INFRA_PATTERN 매칭 시 차단."""
+
+    def setUp(self):
+        # 모든 infra 신호 해제.
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_engineer_blocked_on_hooks(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed("engineer", "hooks/foo.sh", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_architect_blocked_on_orchestration(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed(
+                "architect", "docs/orchestration.md", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_engineer_blocked_on_governance(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed(
+                "engineer", "docs/process/governance.md", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+
+
+class WriteAllowedAllowMatrixTests(unittest.TestCase):
+    """user 프로젝트 — ALLOW_MATRIX 매칭/미매칭."""
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_engineer_src_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("engineer", "src/foo.ts", cwd=cwd)
+            )
+
+    def test_engineer_blocked_on_random(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed("engineer", "README.md", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("ALLOW_MATRIX", reason)
+
+    def test_architect_docs_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("architect", "docs/architecture.md", cwd=cwd)
+            )
+
+    def test_validator_readonly(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed("validator", "src/foo.ts", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("ALLOW_MATRIX", reason)
+
+    def test_unknown_agent_passes(self):
+        # 미정의 agent → false positive 회피로 통과.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("custom-agent", "anywhere/x.ts", cwd=cwd)
+            )
+
+
+class OptOutMarkerTests(unittest.TestCase):
+    """`.no-dcness-guard` 마커 — 사용자 임시 우회."""
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_marker_bypasses(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            (cwd / ".no-dcness-guard").write_text("")
+            self.assertTrue(is_opt_out(cwd))
+            # 우회 — INFRA_PATTERN 매칭이지만 통과.
+            self.assertIsNone(
+                check_write_allowed("engineer", "hooks/x.sh", cwd=cwd)
+            )
+
+    def test_no_marker_no_bypass(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertFalse(is_opt_out(cwd))
+
+
+class ReadAllowedTests(unittest.TestCase):
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_main_bypass(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(check_read_allowed(None, "hooks/x.sh", cwd=cwd))
+
+    def test_infra_pattern_blocks_read(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_read_allowed(
+                "product-planner", "hooks/file-guard.sh", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_product_planner_denied_src(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_read_allowed("product-planner", "src/main.ts", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("READ_DENY_MATRIX", reason)
+
+    def test_engineer_read_src_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_read_allowed("engineer", "src/main.ts", cwd=cwd)
+            )
+
+
+class BashHeuristicTests(unittest.TestCase):
+    def test_no_indicator_returns_empty(self):
+        self.assertEqual(extract_bash_paths("ls -la docs/"), [])
+        self.assertEqual(extract_bash_paths("cat README.md"), [])
+
+    def test_sed_in_place_extracts(self):
+        paths = extract_bash_paths("sed -i 's/x/y/' docs/foo.md")
+        self.assertIn("docs/foo.md", paths)
+
+    def test_redirect_extracts(self):
+        paths = extract_bash_paths("echo hi > hooks/evil.sh")
+        self.assertIn("hooks/evil.sh", paths)
+
+    def test_cp_extracts(self):
+        paths = extract_bash_paths("cp src/a.ts hooks/b.sh")
+        self.assertIn("hooks/b.sh", paths)
+
+    def test_perl_in_place(self):
+        paths = extract_bash_paths("perl -i -pe 's/a/b/' docs/x.md")
+        self.assertIn("docs/x.md", paths)
+
+
+class BashIntegrationTests(unittest.TestCase):
+    """Bash heuristic + check_write_allowed 합."""
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_engineer_sed_blocks_infra(self):
+        # heuristic 은 보수적 — quoted sed pattern 도 path 후보 포함 (`/` 있음).
+        # 어떤 후보든 INFRA 매칭 되면 reason 발화 = OK.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            paths = extract_bash_paths(
+                "sed -i 's/x/y/' hooks/catastrophic-gate.sh"
+            )
+            self.assertIn("hooks/catastrophic-gate.sh", paths)
+            blocked = [
+                p for p in paths
+                if check_write_allowed("engineer", p, cwd=cwd) is not None
+            ]
+            self.assertTrue(any("hooks/" in p for p in blocked))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -39,7 +39,9 @@ from tempfile import TemporaryDirectory
 
 from harness.hooks import (
     HARNESS_ONLY_AGENTS,
+    handle_posttooluse_agent,
     handle_pretooluse_agent,
+    handle_pretooluse_file_op,
     handle_session_start,
 )
 from harness.session_state import (
@@ -559,6 +561,159 @@ class SilentAllowTests(_PreToolBase):
     def test_non_dict_stdin_silent(self) -> None:
         rc = handle_pretooluse_agent(
             stdin_data="invalid",  # type: ignore[arg-type]
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# DCN-CHG-20260501-01 — handle_pretooluse_file_op + handle_posttooluse_agent
+# ---------------------------------------------------------------------------
+
+
+class FileOpAgentRecordTests(_PreToolBase):
+    """PreToolUse Agent 통과 시 live.json.active_agent 기록 확인."""
+
+    def test_active_agent_recorded_on_pass(self) -> None:
+        # qa = HARNESS_ONLY 외 + run 컨텍스트 있음 → 통과
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("qa"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        live = read_live(self.sid, base_dir=self.base)
+        self.assertEqual(live.get("active_agent"), "qa")
+
+    def test_active_agent_with_mode(self) -> None:
+        # validator + DESIGN_VALIDATION = HARNESS_ONLY 아님 (DESIGN_VALIDATION 미포함)
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("validator", mode="DESIGN_VALIDATION"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        live = read_live(self.sid, base_dir=self.base)
+        self.assertEqual(live.get("active_agent"), "validator")
+        self.assertEqual(live.get("active_mode"), "DESIGN_VALIDATION")
+
+
+class FileOpHookTests(_PreToolBase):
+    """PreToolUse Edit/Write/Read/Bash agent_boundary 강제."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        # 모든 infra 신호 해제 — user 프로젝트 시뮬레이션.
+        self._old_env = {}
+        for k in ("DCNESS_INFRA", "CLAUDE_PLUGIN_ROOT"):
+            self._old_env[k] = os.environ.get(k)
+            os.environ.pop(k, None)
+        # cwd 도 whitelist 외로 임시 이동.
+        self._old_cwd = os.getcwd()
+        os.chdir(str(self.base))
+
+    def tearDown(self) -> None:
+        os.chdir(self._old_cwd)
+        for k, v in self._old_env.items():
+            if v is not None:
+                os.environ[k] = v
+        super().tearDown()
+
+    def _file_op_payload(self, tool_name: str, **tool_input) -> dict:
+        return {
+            "sessionId": self.sid,
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+        }
+
+    def test_main_claude_passes(self) -> None:
+        # active_agent 미설정 → 통과.
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload("Edit", file_path="hooks/x.sh"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_engineer_blocked_on_infra_edit(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload(
+                "Edit", file_path="hooks/catastrophic-gate.sh"
+            ),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_engineer_allowed_on_src_edit(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload("Edit", file_path="src/foo.ts"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_engineer_blocked_on_random_path(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload("Write", file_path="README.md"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_product_planner_blocked_on_src_read(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="product-planner")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload("Read", file_path="src/main.ts"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_engineer_bash_sed_blocks_infra(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload(
+                "Bash", command="sed -i 's/x/y/' hooks/foo.sh"
+            ),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_bash_no_indicator_passes(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._file_op_payload("Bash", command="ls -la docs/"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+class PostToolUseAgentClearTests(_PreToolBase):
+    def test_clears_active_agent(self) -> None:
+        update_live(
+            self.sid, base_dir=self.base,
+            active_agent="engineer", active_mode="IMPL",
+        )
+        rc = handle_posttooluse_agent(
+            stdin_data={"sessionId": self.sid},
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        live = read_live(self.sid, base_dir=self.base)
+        self.assertNotIn("active_agent", live)
+        self.assertNotIn("active_mode", live)
+
+    def test_invalid_sid_silent(self) -> None:
+        rc = handle_posttooluse_agent(
+            stdin_data={"sessionId": "!"},
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )


### PR DESCRIPTION
## Summary

DCN-30-39 follow-up #5 — `DCNESS_INFRA_PATTERNS` 가 `handoff-matrix.md §4.4` spec 으로만 박힘, 코드 enforcement **0**. `hooks/catastrophic-gate.sh` 가 차단하는 건 PreToolUse Agent 만 — sub-agent 내부 Edit/Write/Bash 는 자유.

**갭 실측 확인**: 사용자 진단 — "엔지니어가 아무 문서나 수정할수 있다는거지? 어쩐지 시발 경고 한번 안뜨더라". 첫 원칙 ("강제 = 작업 순서 + 접근 영역") drift 해소.

## 변경

- **`harness/agent_boundary.py` 신규** — `DCNESS_INFRA_PATTERNS` (9) / `ALLOW_MATRIX` (12 agent) / `READ_DENY_MATRIX` / `is_infra_project()` 4 OR / `is_opt_out()` `.no-dcness-guard` 마커 / `check_write_allowed()` / `check_read_allowed()` / `extract_bash_paths()` heuristic.
- **`harness/hooks.py` 핸들러 3개** — `handle_pretooluse_agent` 끝 `update_live(active_agent=, active_mode=)` (sub-agent 식별 등록) + `handle_pretooluse_file_op()` (Edit/Write/Read/Bash agent_boundary 강제) + `handle_posttooluse_agent()` (live.json clear). CLI 2 subcommand 추가.
- **`hooks/file-guard.sh` + `hooks/post-agent-clear.sh` 신규** — bash wrapper. is-active 게이트로 미활성 프로젝트 즉시 통과.
- **`hooks/hooks.json`** — PreToolUse `Edit|Write|NotebookEdit|Read|Bash` matcher + PostToolUse `Agent` matcher 추가.
- **`docs/handoff-matrix.md` §4.4** 코드 SSOT cross-ref + INFRA pattern 리스트 코드와 동기.

## 식별 메커니즘 (RWHarness 패턴 차용)

부모 CC `session_id` 가 sub-agent tool 호출 PreToolUse stdin 에 그대로 → live.json 공유 상태 lookup 으로 활성 agent 판정. `agent_id` payload 직접 의존 X (CC 호환성 ↑).

## 격리 / opt-out

- **dcness 자체 = 통과** — `is_infra_project()` True (DCNESS_INFRA env / CLAUDE_PLUGIN_ROOT env / `~/.claude/.dcness-infra` 마커 / cwd 화이트리스트 4 OR). dcness SSOT 편집 가능해야.
- **user 프로젝트 (자장 등) = enforce** — sub-agent 가 인프라 path Edit 시 `[agent-boundary] 인프라 path 보호: matched ...` stderr + exit 1.
- **메인 Claude = 통과** — active_agent 미설정 → governance Document Sync 가 별도 보호.
- **opt-out 마커**: `.no-dcness-guard` (cwd) 임시 우회.

## Test plan

- [x] `python3 -m unittest tests.test_agent_boundary tests.test_hooks` — 71 ran / 71 PASS
- [x] `python3 -m unittest discover -s tests` — 281 ran / 279 PASS / 2 pre-existing flaky 무관
- [x] `node scripts/check_document_sync.mjs` — PASS (12 files / docs-only + harness + hooks + test)
- [x] `harness/agent_boundary.py` import + 모듈 syntax check
- [x] `hooks.json` JSON 유효
- [x] `hooks/*.sh` chmod +x

## Governance

- Task-ID: `DCN-CHG-20260501-01`
- Change-Type: harness, hooks, spec, test
- 38 신규 테스트 (`test_agent_boundary` 27 + `test_hooks` 11)

## Follow-Up

- **자장 plugin 재install + 새 epic 검증** — sub-agent 인프라 path Edit 시 block 메시지 실 발화 확인. 첫 incident 후 임계값 / 패턴 조정.
- **(2) Bash 정밀 path 추출 강화** — `shlex.split` + cmd 별 인자 위치. v1 false positive 발생 시 즉시 진행.
- **(2) READ_DENY_MATRIX 정밀화** — test-engineer impl 외 src 차단 등.
- **DCN-30-39 (2) 30일 누적 임계값 tuning** — 보류 (5월 30일 이후).

🤖 Generated with [Claude Code](https://claude.com/claude-code)