### PR TITLE
docs: main-claude-rules.md SSOT — CLAUDE.md 동일 레벨 강제 read (DCN-CHG-20260501-02)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,20 @@
 > 본 파일은 메인 Claude (Claude Code) 가 dcNess 저장소에서 작업할 때의 지침이다.
 > 거버넌스 규칙은 [`docs/process/governance.md`](docs/process/governance.md) (SSOT) 에 있다 — 본 파일은 *재기술하지 않고 절차·링크만 박는다*.
 
+> 🔴 **[필수 — 본 프로젝트 작업 *직전* read 의무]**
+>
+> 본 CLAUDE.md 와 동일 레벨 강제로 다음 문서 *반드시 read*:
+>
+> 👉 **[`docs/process/main-claude-rules.md`](docs/process/main-claude-rules.md)** — 메인 Claude 행동 룰 SSOT
+>
+> 내용:
+> - §0 **대원칙** — 강제 = (1) 작업 순서 + (2) 접근 영역. 그 외 agent 자율.
+> - §1 **실존 검증 강제** (제1룰)
+> - §2 **dcness 인프라** (300줄 cap / 5 SSOT / 거버넌스 / 핵심 강제 룰 4 / sub-agent path 보호)
+> - §3 **Karpathy 4 원칙 전문**
+>
+> SessionStart inject 작동 안 해도 본 문서 read 로 룰 인지 보장. 미인지 진행 = 룰 위반.
+
 ## 0. 프로젝트 정체성
 
 - **목적**: RWHarness fork-and-refactor — status-JSON-mutate 결정론 + 4 기둥 정합 + 함정 회피 5원칙 (`docs/status-json-mutate-pattern.md` §1~§2.5).
@@ -40,6 +54,7 @@
 
 | 파일 | 역할 |
 |---|---|
+| [`docs/process/main-claude-rules.md`](docs/process/main-claude-rules.md) | 🔴 **메인 Claude 행동 룰 SSOT** — 본 프로젝트 작업 *직전* read 의무. 실존 검증 / dcness 인프라 / Karpathy 4 원칙 전문 |
 | [`docs/process/governance.md`](docs/process/governance.md) | **SSOT** — 모든 거버넌스 룰의 단일 출처 |
 | [`docs/process/document_update_record.md`](docs/process/document_update_record.md) | WHAT 로그 (Task-ID 별 변경 파일) |
 | [`docs/process/change_rationale_history.md`](docs/process/change_rationale_history.md) | WHY 로그 (Task-ID 별 동기·대안·결정·후속) |

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,14 @@
 
 ## 현재 상태
 
+- **📕 main-claude-rules.md SSOT — CLAUDE.md 동일 레벨 강제 read** (`DCN-CHG-20260501-02`):
+  - DCN-30-40 (SessionStart inject 처음부터 작동 0회 회귀) 후속. inject 깨져도 룰 인지 보장하는 *backup 메커니즘*.
+  - `docs/process/main-claude-rules.md` 신규 (204줄, 300 cap 안):
+    - §1 **실존 검증 강제** — 글로벌 `~/.claude/CLAUDE.md` 제1룰 + dcness §12 self-verify 통합. 안티패턴 7건 (DCN-30-37 sed / DCN-30-40 inject / CI 미확인 등).
+    - §2 **dcness 인프라** — 300줄 cap (DCN-30-30) / 5 SSOT 표 / 거버넌스 / 핵심 강제 룰 4 / sub-agent path 보호 (DCN-CHG-20260501-01).
+    - §3 **Karpathy 4 원칙 전문** — `forrestchang/andrej-karpathy-skills/skills/karpathy-guidelines/SKILL.md` (MIT) 인용. dcness agent 별 적용 매핑.
+  - `CLAUDE.md` 상단 🔴 reference 박스 + 문서 지도 추가 — CC 가 CLAUDE.md 자동 로드 → 본 문서 read 자연 유도.
+  - 사용자 요청 3 항목 (실존 검증 강제 / dcness-guide 인프라 / Karpathy 전문) 정확 정합.
 - **🛡️ sub-agent path 보호 hook (handoff-matrix §4 코드 SSOT)** (`DCN-CHG-20260501-01`):
   - DCN-30-39 5번 follow-up — `DCNESS_INFRA_PATTERNS` 가 spec only, 코드 enforcement 0. sub-agent 가 인프라 path Edit/Write/Bash 자유.
   - **첫 원칙 정합** — "강제 = 작업 순서 + 접근 영역" — 접근 영역 강제는 spec only ↔ 코드 drift 해소.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,28 @@
 
 ## Records
 
+### DCN-CHG-20260501-02
+- **Date**: 2026-05-01
+- **Rationale**:
+  - DCN-30-40 발견 — SessionStart inject 처음부터 작동 0회. 후속 PR 5+개 모두 inject 작동 가정 위에 진행 → 가정 거짓 입증. 자기 룰 위반 회귀 패턴 (글로벌 제1룰 + dcness §12 우리가 박은 룰).
+  - 원인: inject 깨져도 룰 인지 보장하는 *backup 메커니즘 부재*. CLAUDE.md = 거버넌스 절차 문서, 행동 룰 (대원칙 / 가정 금지 / Karpathy / 인프라 메타) 은 SSOT 분산 (orchestration §0 / dcness-guidelines / agents/*).
+  - 사용자 요청 — CLAUDE.md 와 동일 레벨 강제 read 단일 문서. 3 항목 + 대원칙: (0) 강제 = 작업 순서 + 접근 영역, (1) 실존 검증 강제, (2) dcness-guide 인프라 메타, (3) Karpathy 4 원칙 전문.
+- **Alternatives**:
+  1. *옵션 A — SessionStart inject 만 의존*. DCN-30-40 회귀 입증. 기각.
+  2. *옵션 B — CLAUDE.md 본체에 룰 직접 추가*. 거버넌스 절차 ↔ 행동 룰 책임 혼재 + 300줄 cap 위반 위험. 기각.
+  3. **(채택) 옵션 C — `docs/process/main-claude-rules.md` 신설 + CLAUDE.md reference**. CC 가 CLAUDE.md 자동 로드 → 본 문서 read 자연 유도. 책임 분리 + cap 충족 (226줄).
+- **Decision**:
+  - 옵션 C 채택. 4 섹션:
+    - **§0 대원칙** — `orchestration.md` §0 / `status-json-mutate-pattern.md` §2.5 직접 인용. 새 룰 도입 시 self-check + 룰 위반 사례 (DCN-30-34 형식 강제) 명시.
+    - **§1 실존 검증 강제** — 글로벌 제1룰 + dcness §12 통합. 안티패턴 7건 실측 사례.
+    - **§2 dcness 인프라** — 300줄 cap / 5 SSOT 표 / 거버넌스 / 핵심 강제 룰 4 / sub-agent path 보호.
+    - **§3 Karpathy 4 원칙 전문** — `forrestchang/andrej-karpathy-skills` (MIT) 인용. agent 별 적용 매핑.
+  - **CLAUDE.md 상단 🔴 reference 박스** — "본 프로젝트 작업 *직전* read 의무". 문서 지도 표 첫 행 추가.
+- **Follow-Up**:
+  - **DCN-CHG-20260501-03 후속** — `tests/test_session_state.py:CleanupStaleRunsTests` time-bomb fix. fixture hardcoded ts 가 시간 흐름 + 24h TTL 으로 stale 판정. CI 7+ 회 fail 누적 (DCN-30-40 작업 중 사용자 GitHub CI 보고로 발견).
+  - **dcness-guidelines.md §12 안티패턴 1줄 추가** — "자기 박은 mechanical 메커니즘도 *실 작동 검증 후* 후속 PR 진행" (DCN-30-40 회고 룰화).
+  - **자장 plugin reinstall + 새 epic 검증** — inject + 본 문서 reference 양측 동시 작동 확인.
+
 ### DCN-CHG-20260501-01
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260501-02
+- **Date**: 2026-05-01
+- **Change-Type**: agent, docs-only
+- **Files Changed**:
+  - `docs/process/main-claude-rules.md` (신규, 204줄) — 메인 Claude 행동 룰 SSOT. SessionStart inject (DCN-30-26 / -40) backup 메커니즘. 글로벌 `~/.claude/CLAUDE.md` 와 동일 레벨 강제.
+    - §1 실존 검증 강제 — 글로벌 제1룰 + dcness §12 self-verify 통합. 안티패턴 7건 (DCN-30-37 sed misdiagnosis / DCN-30-40 inject 가정 / CI 미확인 등).
+    - §2 dcness 인프라 — 300줄 cap (DCN-30-30) / 5 SSOT 표 / 거버넌스 / 핵심 강제 룰 4 / sub-agent path 보호 (DCN-CHG-20260501-01).
+    - §3 Karpathy 4 원칙 전문 — `forrestchang/andrej-karpathy-skills` (MIT) 인용. dcness agent 별 적용 매핑.
+  - `CLAUDE.md` 상단 🔴 reference 박스 + 문서 지도 표에 main-claude-rules.md 추가. 98 → 109줄.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `PROGRESS.md`
+- **Summary**: DCN-30-40 (SessionStart inject 처음부터 작동 0회 회귀) 후속. inject 깨져도 룰 인지 보장하는 backup 으로 main-claude-rules.md 신설. CLAUDE.md 가 reference 강제 — CC 가 CLAUDE.md 자동 로드 → 메인이 본 문서 read 자연 유도. 사용자 요청 3 항목 (실존 검증 강제 / dcness-guide 인프라 / Karpathy 전문) 정확 정합.
+
 ### DCN-CHG-20260501-01
 - **Date**: 2026-05-01
 - **Change-Type**: harness, hooks, spec, test

--- a/docs/process/main-claude-rules.md
+++ b/docs/process/main-claude-rules.md
@@ -1,0 +1,226 @@
+# Main Claude Rules — dcness 작업 시 의무 read
+
+> **[필수 — 본 프로젝트 작업 *직전* read 의무]**
+>
+> 본 문서는 dcness 프로젝트에서 작업하는 메인 Claude 의 행동 룰 SSOT. SessionStart inject (DCN-30-26 / -40) 의 *backup 메커니즘* — inject 작동 0회였던 회귀 (DCN-30-40 발견) 재발 시에도 본 문서 read 로 룰 인지 보장.
+>
+> 글로벌 `~/.claude/CLAUDE.md` 와 *동일 레벨 강제*. `CLAUDE.md` (프로젝트) 에서 본 문서 reference — 미인지 진행 = 룰 위반.
+
+---
+
+## 0. 정체성 — 강제하는 것 / 강제 안 하는 것
+
+> **🔴 대 원칙** (`docs/status-json-mutate-pattern.md` §2.5 / `docs/orchestration.md` §0 직접 인용):
+> **harness 가 강제하는 것은 단 2가지 — (1) 작업 순서, (2) 접근 영역. 그 외 모두 agent 자율.**
+
+- **작업 순서** = 시퀀스 (validator → engineer → pr-reviewer 등) + retry 정책
+- **접근 영역** = file path 경계 (agent-boundary ALLOW / READ_DENY) + 외부 시스템 mutation 차단 (push, gh issue, plugin 디렉토리)
+- **출력 형식 / handoff 형식 / preamble 구조 / marker / status JSON / Flag / 모든 형식적 강제 = agent 자율**. harness 가 강제하지 않는다.
+
+dcness SSOT (orchestration / handoff-matrix / loop-procedure / loop-catalog / dcness-guidelines / 본 문서) 는 위 2개 강제 영역만 정의. 형식 강제 (마커 / status JSON / Flag) 는 `status-json-mutate-pattern.md` 에 의해 폐기 — 본 문서 안에서도 그 어휘는 사용하지 않는다.
+
+### 적용 — 메인 Claude 의 자율 보존 책임
+
+새 룰 / 메커니즘 도입 시 본 원칙 self-check:
+- 작업 순서 또는 접근 영역 강제? → 정합 ✓
+- 출력 형식 / preamble / marker 강제? → **자율 침해**, 재설계
+- agent 가 자율 판단할 영역에 mechanical 강제? → 트레이드오프 명시 + 사용자 승인 후만
+
+본 룰 위반 사례 — DCN-30-34 의 "## 자가 검증" 단일 anchor 형식 강제. 이후 DCN-30-38 에서 anchor 자율화로 정정 (substance 의무 / 형식 자율).
+
+---
+
+## 1. 실존 검증 강제 (제1룰)
+
+> 출처: 글로벌 `~/.claude/CLAUDE.md` "🔴 제1 룰 — 제안 전 *실존 검증* 절대 강제". 본 절은 dcness 컨텍스트 재인용 + dcness §12 self-verify 원칙 (DCN-30-35) 통합.
+
+### 룰 (MUST)
+
+어떤 제안·계획·솔루션을 유저에게 내놓기 *전*, 추측하거나 기억에 의존하지 않고 거기 등장하는 모든 다음 항목을 **실제로 검증한 뒤 제안한다**:
+
+- **CLI 플래그·옵션** (`--xxx`) — `<cli> --help` 또는 직접 실행해서 존재 확인
+- **API 엔드포인트·필드** — 공식 문서 / SDK / 실측 호출로 확인
+- **함수·클래스·모듈** — `grep` / `Glob` 로 코드에 실재하는지 확인
+- **파일 경로** — `Read` / `ls` 실존 확인
+- **환경변수·설정 키** — 실제 set 되는 위치 확인
+- **라이브러리·도구 의존성** — 설치/사용 가능성 확인
+- **테스트 / 빌드 결과** — 명령 실행 후 인용 (특히 *CI 통과 여부*)
+- **파일 변경 결과** — Bash `sed -i` / `awk -i` 후 *전·후* 실측 (`git diff --stat` / 결과 grep)
+- **자기 박은 메커니즘 작동 여부** — hook / inject / 자동화 도입 시 *실 작동 검증 후* 후속 PR 진행 (DCN-30-40 회귀 회고)
+
+### 금지
+
+- "아마 있을 거야", "보통 그렇게 동작해", "공식적으로 지원할 거야" 같은 **추측 기반 제안**
+- 한 번 실측한 결과를 *시간 경과 후 재 단언* (예: "earlier tests passed" — 현재 시점 재검증 필요)
+- 자기가 박은 룰 / 메커니즘이 *실 작동* 한다는 가정 하에 후속 작업 진행 (DCN-30-40 — SessionStart inject 작동 검증 없이 5+ PR 진행 → 가정 거짓 입증)
+- "flaky 무관" 같은 추측 기반 fail dismissal — 실 원인 분석 후 단언
+
+### 적용 시점
+
+모든 user-facing 제안 / commit / PR 의 *제출 직전*. "이렇게 하면 어떨까요" 단계가 아닌 "이렇게 합니다" / "이게 답입니다" 단계엔 **검증 100% 완료 상태**.
+
+### Why
+
+추측 기반 제안 후 "실제론 없어요" 발견 → 같은 자리 재작업 + 유저 frustration. 제안 *전* 30초 검증이 사후 1시간 회복보다 압도적으로 싸다. dcness 자체에서 발견한 회귀 (I5 메인 sed misdiagnosis "130개 fix" → 실제 0개 / DCN-30-40 inject 0회) 가 본 룰 정직 적용 시 회피 가능했음.
+
+### 안티패턴 (실측 사례)
+
+❌ "벌써 30개 파일 변환됐을 것" — 실측 안 함 → 잘못된 숫자
+❌ "보통 jest config 는 X 키 쓰니까" — 학습 데이터 의존 → hallucination (예: `setupFilesAfterFramework`)
+❌ "이 함수 (대략) 어디 있을 것" — grep 안 함 → 잘못된 경로
+❌ engineer 보고 즉시 신뢰 → 실측 안 함 (engineer.md § 자가 검증 echo 와 짝)
+❌ Bash `sed -i` / `awk -i` / 광역 변환 후 *전·후* 실측 누락 — 메인이 sed 직후 "X개 fix" 단언 = I5 회귀 (DCN-30-37 `MAIN_SED_MISDIAGNOSIS` 자동 검출)
+❌ 자기 박은 SessionStart inject 작동 가정 → 실측 검증 없이 후속 PR 진행 (DCN-30-26 → DCN-30-40 회귀, 5+ PR 의존성 깨짐)
+❌ CI 결과 확인 안 함 → "local PASS" 만으로 머지 (DCN-30-40 후속 발견 — 7+ PR 동안 CI fail 누적)
+
+---
+
+## 2. dcness 인프라 — 메인 Claude 도 알아야 할 내용
+
+### 2.1 행동지침 md 300줄 cap (DCN-30-30)
+
+> 출처: `docs/process/dcness-guidelines.md` §0.1.
+
+dcness 행동지침 문서 (메인 Claude 또는 sub-agent 가 의사결정 시 *직접 read* 하는 md) 는 **파일당 300줄 cap**. 초과 시 책임 분리 축으로 split.
+
+**대상**: skill prompt (`commands/*.md`) / agent prompt (`agents/**/*.md`) / SSOT (`docs/loop-procedure.md` / `docs/loop-catalog.md` / `docs/handoff-matrix.md` / `docs/orchestration.md`) / dcness-guidelines.md / 본 문서.
+
+**대상 외**: 역사 로그 (`document_update_record.md` / `change_rationale_history.md`) / `PROGRESS.md` / spec / proposals / 코드.
+
+**Why**: 메인 Claude / sub-agent 가 매 결정 시 read → 토큰 누적 + thinking 시간 ↑. 300줄 = 한 read 임계.
+
+**현재 cap 충족 상태** (사용자 verification 의무 — `wc -l` 실측):
+| 파일 | 줄 수 (작성 시점) |
+|---|---|
+| `docs/orchestration.md` | 298 |
+| `docs/handoff-matrix.md` | 256 |
+| `docs/loop-procedure.md` | 242 |
+| `docs/loop-catalog.md` | 239 |
+| `docs/process/dcness-guidelines.md` | 257 |
+
+### 2.2 5 SSOT 위치 + 책임 축
+
+| 파일 | 책임 | 메인 read 시점 |
+|---|---|---|
+| [`docs/orchestration.md`](../orchestration.md) | 시퀀스 catalog (§0 정체성, §2~§3 시퀀스 + mini-graph) | 신규 작업 시 진입 경로 결정 |
+| [`docs/handoff-matrix.md`](../handoff-matrix.md) | agent 측 강제 영역 (결정표 / Retry / Escalate / 접근 권한) | agent 호출 분기 / 한도 결정 시 |
+| [`docs/loop-procedure.md`](../loop-procedure.md) | Step 0~8 mechanics (worktree → begin-run → TaskCreate → begin-step → Agent → end-step → finalize-run --auto-review) | 매 컨베이어 진행 |
+| [`docs/loop-catalog.md`](../loop-catalog.md) | 8 loop × 풀스펙 (entry / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles) | loop 진입 시 풀스펙 read |
+| [`docs/process/dcness-guidelines.md`](dcness-guidelines.md) | cross-cutting 룰 (echo / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy 참조 / **§12 self-verify 원칙**) | 모든 dcness skill 진행 시 |
+
+### 2.3 거버넌스
+
+> 출처: `docs/process/governance.md` (전체 룰).
+
+- **Task-ID**: `DCN-CHG-YYYYMMDD-NN` (오늘 = `DCN-CHG-20260501-NN`)
+- **Change-Type 7종**: `spec` / `agent` / `harness` / `hooks` / `ci` / `test` / `docs-only` (복수 가능, governance §2.2)
+- **commit 절차**: branch → PR → squash merge. main 직접 push 금지. branch 는 merge 후에도 삭제하지 않음.
+- **doc-sync gate**: `node scripts/check_document_sync.mjs` 통과 필수 — git pre-commit hook + Claude Code PreToolUse hook 동시 차단. `--no-verify` 등 우회 금지.
+- **동반 갱신** (governance §2.6):
+  - `docs/process/document_update_record.md` (모든 변경 — WHAT)
+  - `docs/process/change_rationale_history.md` (spec / agent / harness / hooks / ci 변경 시 — WHY)
+  - `PROGRESS.md` (harness / hooks / ci 변경 시)
+
+### 2.4 핵심 강제 룰 — 매 작업 의무
+
+> 출처: SessionStart inject directive (`hooks/session-start.sh`, DCN-30-40).
+
+1. **매 Agent 호출 후 prose 5~12줄 의무 echo** (가시성 §1, dcness-guidelines.md)
+2. **begin-step / end-step 1:1 의무** (Step 기록 §2)
+3. **추측 금지 + 실측 후 단언** (§12 self-verify, 본 문서 §1 정합)
+4. **finalize-run 시 `--auto-review` flag 의무** (loop-procedure §5.1)
+
+### 2.5 sub-agent path 보호 (DCN-CHG-20260501-01)
+
+> 출처: `harness/agent_boundary.py` + `hooks/file-guard.sh` + handoff-matrix §4.4.
+
+PreToolUse 훅 `Edit|Write|Read|Bash` matcher 등록 — sub-agent 가 dcness 인프라 path (orchestration.md / handoff-matrix.md / loop-procedure.md / loop-catalog.md / dcness-guidelines.md / hooks/ / harness/ 등) 변경 시도 시 차단. `agent_id` payload 로 메인 vs sub 구분 — 메인은 통과 (거버넌스 책임).
+
+`is_infra_project()` 4 OR 신호로 dcness 자체 저장소 작업 시 해제 — 메인이 SSOT 편집 가능.
+
+---
+
+## 3. Karpathy 4 원칙 (전문)
+
+> 출처: [Andrej Karpathy LLM coding pitfalls](https://x.com/karpathy/status/2015883857489522876).
+> 마스터 인용: [andrej-karpathy-skills/skills/karpathy-guidelines/SKILL.md](https://github.com/forrestchang/andrej-karpathy-skills/blob/main/skills/karpathy-guidelines/SKILL.md) (MIT).
+> dcness 적용: agent 별 분배 박힘 (DCN-30-17, `agents/*.md` 참조).
+
+**Tradeoff**: 본 룰은 caution > speed. trivial 작업엔 judgment.
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them — don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it — don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+### dcness 적용 매핑
+
+| 원칙 | 주 적용 agent | 보조 적용 |
+|---|---|---|
+| 1. Think Before | `product-planner`, `qa`, `test-engineer` | 전 agent |
+| 2. Simplicity First | `architect`, `engineer` | `designer` |
+| 3. Surgical Changes | `engineer`, `pr-reviewer` | — |
+| 4. Goal-Driven Execution | `test-engineer`, `validator` | `qa`, `architect` |
+
+각 agent prompt 안 customized 적용은 `agents/*.md §Karpathy 원칙` 참조.
+
+---
+
+## 4. 참조
+
+- 글로벌: `~/.claude/CLAUDE.md` (제1룰 + 새 프로젝트 흐름 + 모듈 단위 작업 순서 + 커밋 절차)
+- 프로젝트: `CLAUDE.md` (dcness 정체성 + 거버넌스 핵심 + 문서 지도)
+- SSOT 5종: `docs/orchestration.md` / `docs/handoff-matrix.md` / `docs/loop-procedure.md` / `docs/loop-catalog.md` / `docs/process/dcness-guidelines.md`
+- 거버넌스: `docs/process/governance.md`
+- 카탈로그: `docs/known-hallucinations.md` (외부 도구 hallucination 누적)


### PR DESCRIPTION
## Summary

DCN-30-40 (SessionStart inject 처음부터 작동 0회) 후속 — inject 깨져도 룰 인지 보장하는 **backup 메커니즘**. CC 가 자동 로드하는 CLAUDE.md 가 본 문서 reference 강제 → 메인 Claude 가 read 자연 유도.

## 신규 — `docs/process/main-claude-rules.md` (226줄, 300 cap 안)

| § | 내용 |
|---|---|
| **§0 대원칙** | 강제 = (1) 작업 순서, (2) 접근 영역. 그 외 agent 자율. `orchestration.md §0` / `status-json-mutate-pattern.md §2.5` 직접 인용. 새 룰 도입 시 self-check + 위반 사례 (DCN-30-34 형식 강제) |
| **§1 실존 검증 강제** | 글로벌 `~/.claude/CLAUDE.md` 제1룰 + dcness §12 self-verify (DCN-30-35) 통합. 룰 / 금지 / 적용 시점 / 안티패턴 7건 (DCN-30-37 sed misdiagnosis / DCN-30-40 inject 가정 / CI 미확인 등) |
| **§2 dcness 인프라** | 300줄 cap (DCN-30-30) / 5 SSOT 표 (orchestration / handoff-matrix / loop-procedure / loop-catalog / dcness-guidelines) / 거버넌스 / 핵심 강제 룰 4 / sub-agent path 보호 (DCN-CHG-20260501-01) |
| **§3 Karpathy 4 원칙 전문** | `forrestchang/andrej-karpathy-skills/skills/karpathy-guidelines/SKILL.md` (MIT) 인용. dcness agent 별 적용 매핑 |

## CLAUDE.md update

- 상단 🔴 reference 박스 — "본 프로젝트 작업 *직전* read 의무"
- 문서 지도 표 첫 행으로 추가
- 98 → 109줄

## 기대 효과

- DCN-30-40 회귀 패턴 회피 — inject 작동 안 해도 CLAUDE.md 자동 로드 → 본 문서 read → 룰 인지
- 자기 룰 위반 회귀 회피 — 매 작업 직전 read 의무로 메인 Claude 자기 점검
- 사용자 요청 정확 정합 (실존 검증 / dcness-guide 인프라 / Karpathy 전문 / 대원칙)

## Test plan

- [x] `node scripts/check_document_sync.mjs` PASS (5 files / agent, docs-only)
- [x] `wc -l docs/process/main-claude-rules.md` = 226 (300 cap 안)
- [x] `wc -l CLAUDE.md` = 109 (300 cap 안)

## 후속

- **DCN-CHG-20260501-03** — `tests/test_session_state.py:CleanupStaleRunsTests` time-bomb fix (CI 7+ 회 fail 누적, DCN-30-40 작업 중 사용자 GitHub CI 보고로 발견)
- dcness-guidelines.md §12 안티패턴 1줄 추가 (DCN-30-40 회고 룰화)
- 자장 plugin reinstall + 새 epic 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)