### PR TITLE
fix: CleanupStaleRunsTests time-bomb fixture (DCN-CHG-20260501-03)

### DIFF
--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,14 @@
 
 ## Records
 
+### DCN-CHG-20260501-03
+- **Date**: 2026-05-01
+- **Change-Type**: test
+- **Files Changed**:
+  - `tests/test_session_state.py:CleanupStaleRunsTests._set_slot` — fixture `started_at` / `last_confirmed_at` hardcoded `"2026-04-29T00:00:00+00:00"` → `datetime.now(timezone.utc).isoformat(timespec="seconds")`. time-bomb 회피.
+  - `docs/process/document_update_record.md` (본 항목)
+- **Summary**: CleanupStaleRunsTests 2건 (`test_keeps_fresh_slot` / `test_removes_completed_old_slot`) GitHub CI 7+ 회 fail 누적 — DCN-30-40 작업 중 사용자 보고 발견. 원인: fixture hardcoded ts (2026-04-29) 가 작성 시점엔 fresh 였으나 24h TTL + 시간 흐름 (2026-05-01 현재) 으로 stale 판정 → cleanup 대상 됨 → "fresh slot 유지" assertion 깨짐. fix: now() 동적 ts 사용. 281 tests all PASS (이전 240 ran 중 2 fail → 회귀 0).
+
 ### DCN-CHG-20260501-02
 - **Date**: 2026-05-01
 - **Change-Type**: agent, docs-only

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -562,13 +562,16 @@ class CleanupStaleRunsTests(unittest.TestCase):
         self._td.cleanup()
 
     def _set_slot(self, run_id: str, **overrides) -> None:
+        # DCN-30-40 fix: hardcoded ts (2026-04-29) → now() — time bomb 회피.
+        # 24h TTL 기준이라 hardcoded ts 가 시간 흐름에 따라 stale 판정 됨.
+        now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
         live = read_live(self.sid, base_dir=self.base) or {}
         active = live.get("active_runs", {}) or {}
         active[run_id] = {
             "run_id": run_id,
             "entry_point": "quick",
-            "started_at": "2026-04-29T00:00:00+00:00",
-            "last_confirmed_at": "2026-04-29T00:00:00+00:00",
+            "started_at": now_iso,
+            "last_confirmed_at": now_iso,
             "completed_at": None,
             "run_dir": "x",
             "current_step": None,


### PR DESCRIPTION
## Summary

GitHub CI Python tests 7+ 회 fail 누적 (DCN-30-37 ~ DCN-30-40 머지 동안 모두 main fail). DCN-30-40 작업 중 사용자가 GitHub CI 보고 발견 — 매번 "pre-existing flaky 무관" 추측으로 dismiss 했던 회귀. **글로벌 제1룰 위반 사례** (실측 안 함).

## Bug — time-bomb fixture

```python
# 잘못 (DCN-30-25 작성 시점)
active[run_id] = {
    ...
    "started_at": "2026-04-29T00:00:00+00:00",
    "last_confirmed_at": "2026-04-29T00:00:00+00:00",
    ...
}
```

`DEFAULT_RUN_TTL_SEC = 24 * 60 * 60` (24h). 작성 시점 (2026-04-29~30) 엔 fresh 판정 → 테스트 PASS. 시간 흐름 (현재 2026-05-01) → 48h+ → stale 판정 → cleanup 대상 → `test_keeps_fresh_slot` assertion (`removed == 0`) 깨짐.

## Fix

```python
# DCN-30-40 fix: hardcoded ts (2026-04-29) → now() — time bomb 회피.
now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
active[run_id] = {
    ...
    "started_at": now_iso,
    "last_confirmed_at": now_iso,
    ...
}
```

## Test plan

- [x] `python3 -m unittest tests.test_session_state.CleanupStaleRunsTests -v` — 3/3 PASS
- [x] `python3 -m unittest discover -s tests` — **281/281 PASS** (이전 240 ran 중 2 fail → 회귀 0)
- [x] `node scripts/check_document_sync.mjs` PASS (2 files / docs-only, test)

## 회고 — 자기 룰 위반

매 PR 머지 시:
- "240 ran / 238 PASS / 2 pre-existing flaky 무관" 추측 dismissal
- GitHub CI 결과 직접 확인 0회
- 사용자 보고 후에야 발견

DCN-30-40 회고 룰 ("자기 박은 메커니즘 / 자기 dismiss 한 fail 도 *실 작동 검증 후* 진행") 동일 영역.

🤖 Generated with [Claude Code](https://claude.com/claude-code)