### PR TITLE
ci: branch protection — CI 4 checks 강제 (DCN-CHG-20260501-04)

### DIFF
--- a/.github/workflows/plugin-manifest.yml
+++ b/.github/workflows/plugin-manifest.yml
@@ -14,18 +14,12 @@
 name: plugin-manifest
 
 on:
+  # DCN-30-04: paths 필터 폐기 — branch protection required check 가 paths
+  # 미스매치로 발화 안 하면 PR BLOCKED 영원히. 모든 PR 에 발화.
   pull_request:
     branches: [main]
-    paths:
-      - '.claude-plugin/**'
-      - 'scripts/check_plugin_manifest.mjs'
-      - '.github/workflows/plugin-manifest.yml'
   push:
     branches: [main]
-    paths:
-      - '.claude-plugin/**'
-      - 'scripts/check_plugin_manifest.mjs'
-      - '.github/workflows/plugin-manifest.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,8 +5,9 @@
 # - DCN-CHG-20260429-13 prose-only 패턴 회귀 차단
 #
 # 트리거:
-# - PR / push to main 시 tests/ 또는 harness/ 또는 agents/ 변경 시
-# - paths 필터로 docs-only PR 에서 불필요 실행 회피
+# - 모든 PR / push to main (DCN-30-04 — branch protection required check 정합).
+# - paths 필터 폐기 사유: required check 가 paths 미스매치로 발화 안 하면 BLOCKED
+#   영원히. CI 비용 < 안전성. 본 repo small.
 #
 # proposal §11.4 안전망: "매 sub-phase squash merge 후 측정" 의 자동화 버전
 
@@ -15,18 +16,8 @@ name: python-tests
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'harness/**'
-      - 'tests/**'
-      - 'agents/**'
-      - '.github/workflows/python-tests.yml'
   push:
     branches: [main]
-    paths:
-      - 'harness/**'
-      - 'tests/**'
-      - 'agents/**'
-      - '.github/workflows/python-tests.yml'
 
 permissions:
   contents: read

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -8,6 +8,7 @@
   - `setup_branch_protection.mjs` review 1 → null (1인 운영 self-approve 불가) + governance §2.8 갱신.
   - **live 적용** — 4 contexts 강제 (`Document Sync gate` / `unittest discover` / `validate manifest` / `Task-ID format gate`) + strict + linear history.
   - **`gh pr merge --squash --auto` 의무** 룰 추가 — CI 통과 후 자동 머지.
+  - **workflow paths 필터 폐기** (`python-tests.yml` / `plugin-manifest.yml`) — paths 미스매치 시 required check 발화 X → PR BLOCKED 영원 회피.
 - **📕 main-claude-rules.md SSOT — CLAUDE.md 동일 레벨 강제 read** (`DCN-CHG-20260501-02`):
   - DCN-30-40 (SessionStart inject 처음부터 작동 0회 회귀) 후속. inject 깨져도 룰 인지 보장하는 *backup 메커니즘*.
   - `docs/process/main-claude-rules.md` 신규 (204줄, 300 cap 안):

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🚥 branch protection — CI 4 checks 강제** (`DCN-CHG-20260501-04`):
+  - DCN-30-37 ~ DCN-30-40 7+ PR 동안 CI fail 누적 머지 회귀 차단. 사용자 명령 정합.
+  - PR #84 실측 — 머지 15:28:21 / CI 완료 15:28:32~39 = 11~18초 일찍 머지. 우연 success.
+  - `setup_branch_protection.mjs` review 1 → null (1인 운영 self-approve 불가) + governance §2.8 갱신.
+  - **live 적용** — 4 contexts 강제 (`Document Sync gate` / `unittest discover` / `validate manifest` / `Task-ID format gate`) + strict + linear history.
+  - **`gh pr merge --squash --auto` 의무** 룰 추가 — CI 통과 후 자동 머지.
 - **📕 main-claude-rules.md SSOT — CLAUDE.md 동일 레벨 강제 read** (`DCN-CHG-20260501-02`):
   - DCN-30-40 (SessionStart inject 처음부터 작동 0회 회귀) 후속. inject 깨져도 룰 인지 보장하는 *backup 메커니즘*.
   - `docs/process/main-claude-rules.md` 신규 (204줄, 300 cap 안):

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,27 @@
 
 ## Records
 
+### DCN-CHG-20260501-04
+- **Date**: 2026-05-01
+- **Rationale**:
+  - DCN-30-37 ~ DCN-30-40 7+ PR 동안 GitHub Python tests CI fail 누적 — 매번 `gh pr merge --squash` 즉시 머지 (CI 결과 wait X). 사용자가 알아챈 후에야 발견.
+  - 실측 — PR #84 머지 시각 15:28:21 / CI 완료 15:28:32~39 → **11~18초 일찍 머지**. 단순 우연으로 나중 success.
+  - `branch protection` 미설정 (404 "Branch not protected") + `gh pr merge` 가 wait 안 함 = CI fail 코드도 머지 가능 = 거버넌스 부재.
+  - 사용자 명령 ("CI 로 강제해서 앞으로는 실패 못하게") — branch protection 적용 + `--auto` flag 의무.
+- **Alternatives**:
+  1. *옵션 A — 그대로 유지 (review 1 approve)*. 1인 운영 self-approve 불가 (GitHub 정책) → 매 PR 머지 자체 불가. 기각.
+  2. *옵션 B — review 0 + CI 4 강제 (채택)*. 사용자 명령 정확 정합. CI 가 실질 게이트.
+  3. *옵션 C — review 1 + admin enforce_admins=false 우회*. 매 PR 우회 = 거버넌스 약화. 기각.
+- **Decision**:
+  - 옵션 B 채택.
+  - **`scripts/setup_branch_protection.mjs`** 수정 — `required_pull_request_reviews: null`. governance §2.8 표 갱신.
+  - **branch protection live 적용** — gh API PUT repos/alruminum/dcNess/branches/main/protection. 4 status checks 강제 (Document Sync gate / unittest discover / validate manifest / Task-ID format gate) + strict + linear history.
+  - **`gh pr merge --squash --auto` 의무 룰 추가** (governance §2.8) — CI 통과 후 자동 머지. 11~18초 일찍 머지 회귀 차단.
+- **Follow-Up**:
+  - **본 PR 부터 적용 검증** — `--auto` flag 사용 + CI 4 checks 통과 후 자동 머지 실측.
+  - **CLAUDE.md 커밋 절차 / main-claude-rules.md §2.3** 갱신 후속 — `gh pr merge --squash --auto` flag 의무 명시.
+  - **회귀 안전망** — `/run-review` 에 `CI_NOT_VERIFIED` 패턴 추가 후속 (PR merge 시각 vs CI 완료 시각 비교 휴리스틱).
+
 ### DCN-CHG-20260501-02
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -34,6 +34,8 @@
   - **`scripts/setup_branch_protection.mjs`** 수정 — `required_pull_request_reviews: null`. governance §2.8 표 갱신.
   - **branch protection live 적용** — gh API PUT repos/alruminum/dcNess/branches/main/protection. 4 status checks 강제 (Document Sync gate / unittest discover / validate manifest / Task-ID format gate) + strict + linear history.
   - **`gh pr merge --squash --auto` 의무 룰 추가** (governance §2.8) — CI 통과 후 자동 머지. 11~18초 일찍 머지 회귀 차단.
+  - **workflow paths 필터 폐기** (`python-tests.yml` / `plugin-manifest.yml`) — branch protection required check 가 paths 미스매치로 발화 안 하면 PR BLOCKED 영원 (본 PR 자체에서 발견 — scripts/+docs/ 만 변경 시 python-tests 발화 X). CI 비용 < 안전성. 본 repo small.
+  - Document-Exception: amend 로 commit message Task-ID 형식 정정 (`DCN-30-04` → `DCN-CHG-20260501-04`). 파일 변경 0, message 정정만.
 - **Follow-Up**:
   - **본 PR 부터 적용 검증** — `--auto` flag 사용 + CI 4 checks 통과 후 자동 머지 실측.
   - **CLAUDE.md 커밋 절차 / main-claude-rules.md §2.3** 갱신 후속 — `gh pr merge --squash --auto` flag 의무 명시.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,23 @@
 
 ## Records
 
+### DCN-CHG-20260501-04
+- **Date**: 2026-05-01
+- **Change-Type**: ci, spec
+- **Files Changed**:
+  - `scripts/setup_branch_protection.mjs` — `required_pull_request_reviews: { count: 1, ... }` → `null`. 1인 운영 PR author self-approve 불가 (GitHub 정책) → review 의무 폐기. CI 4 checks 가 실질 게이트.
+  - `docs/process/governance.md` §2.8 — 표 갱신 (review 1 → 비활성), 근거 갱신, `gh pr merge --squash --auto` 의무 룰 추가.
+  - branch protection live 적용 (`PUT repos/alruminum/dcNess/branches/main/protection`):
+    - required_status_checks contexts = `Document Sync gate` / `unittest discover` / `validate manifest` / `Task-ID format gate`
+    - strict = true (base sync 의무)
+    - required_pull_request_reviews = null
+    - required_linear_history = true
+    - allow_force_pushes = false
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 사용자 명령 ("CI 로 강제해서 앞으로는 실패 못하게") 반영. DCN-30-37 ~ DCN-30-40 7+ PR 동안 CI fail 누적 + 머지 즉시 진행 회귀 차단. branch protection 적용 — CI 4 checks 모두 SUCCESS 전 squash merge 차단. 본 PR 부터 즉시 적용.
+
 ### DCN-CHG-20260501-03
 - **Date**: 2026-05-01
 - **Change-Type**: test

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -24,6 +24,7 @@
 - **Date**: 2026-05-01
 - **Change-Type**: ci, spec
 - **Files Changed**:
+  - `.github/workflows/python-tests.yml` / `.github/workflows/plugin-manifest.yml` — paths 필터 폐기. branch protection required check 가 paths 미스매치로 발화 안 하면 PR BLOCKED 영원 → 모든 PR 에 발화. CI 비용 < 안전성.
   - `scripts/setup_branch_protection.mjs` — `required_pull_request_reviews: { count: 1, ... }` → `null`. 1인 운영 PR author self-approve 불가 (GitHub 정책) → review 의무 폐기. CI 4 checks 가 실질 게이트.
   - `docs/process/governance.md` §2.8 — 표 갱신 (review 1 → 비활성), 근거 갱신, `gh pr merge --squash --auto` 의무 룰 추가.
   - branch protection live 적용 (`PUT repos/alruminum/dcNess/branches/main/protection`):

--- a/docs/process/governance.md
+++ b/docs/process/governance.md
@@ -100,15 +100,14 @@ Document-Exception-Task: DCN-CHG-YYYYMMDD-NN
 
 CI 레벨(`.github/workflows/document-sync.yml`)은 별도 Task-ID 로 추가.
 
-### 2.8 Branch Protection (LGTM 게이트 외부화)
+### 2.8 Branch Protection (CI 게이트 강제)
 
-`main` 브랜치는 GitHub Repository Settings 의 branch protection 으로 다음을 강제한다 (proposal §5 Phase 3 — `Gate 5 (LGTM flag) → branch protection required reviewers`):
+`main` 브랜치는 GitHub Repository Settings 의 branch protection 으로 다음을 강제한다:
 
 | 항목 | 설정 |
 |---|---|
-| Required pull request reviews | `1` approving review (LGTM 게이트 외부화) |
-| Dismiss stale reviews | ✅ — 신규 commit push 시 기존 approval 자동 무효화 |
-| Required status checks | `Document Sync gate`, `unittest discover`, `validate manifest`, `Task-ID format gate` (4 게이트 모두 PASS) |
+| Required pull request reviews | ❌ 비활성 (1인 운영 — PR author self-approve GitHub 정책 차단. DCN-30-04) |
+| Required status checks | `Document Sync gate`, `unittest discover`, `validate manifest`, `Task-ID format gate` (4 게이트 모두 PASS 의무) |
 | Strict (up-to-date) | ✅ — base 와 sync 안 된 PR 머지 차단 |
 | Required conversation resolution | ✅ |
 | Required linear history | ✅ — squash merge 전제 |
@@ -117,7 +116,9 @@ CI 레벨(`.github/workflows/document-sync.yml`)은 별도 Task-ID 로 추가.
 
 **적용**: [`branch-protection-setup.md`](branch-protection-setup.md) §1 자동 적용 (`scripts/setup_branch_protection.mjs`) 또는 §2 GitHub UI 수동.
 
-**근거**: dcNess 는 RWHarness 의 `class Flag` 기반 in-process LGTM flag 를 *자연 폐기* (migration-decisions §2.2 DISCARD). LGTM 의 의미적 강제는 GitHub branch protection 으로 *외부* 에서 동일 기능 제공 → proposal §11 4-pillar #2 (CI/CD 게이트) 정합.
+**근거**: dcNess 는 RWHarness 의 `class Flag` 기반 in-process LGTM flag 를 *자연 폐기* (migration-decisions §2.2 DISCARD). LGTM 의 의미적 강제는 GitHub CI 4 checks 로 *외부* 에서 제공 → proposal §11 4-pillar #2 (CI/CD 게이트) 정합. 1인 운영이라 review approve 의무는 self-approve 불가 (GitHub 정책) 로 비활성화 — CI 4 checks 가 실질 게이트.
+
+**`gh pr merge --squash --auto` 의무**: protection 적용 후 모든 PR merge 명령에 `--auto` flag 의무. CI 통과 *후* 자동 머지. CI 진행 중 머지 시도 시 차단됨 (DCN-30-04 도입 직접 동기 — DCN-30-37 ~ DCN-30-40 7+ PR 동안 CI 결과 안 보고 즉시 머지하던 회귀 패턴 차단).
 
 **CI 게이트 추가/제거 시**: `setup_branch_protection.mjs` 의 `REQUIRED_CHECKS` 와 본 §2.8 표 동시 갱신. 워크플로우 `jobs.<id>.name` 과 protection rule status check 이름이 *문자열 일치* 필수.
 

--- a/scripts/setup_branch_protection.mjs
+++ b/scripts/setup_branch_protection.mjs
@@ -37,11 +37,9 @@ const PAYLOAD = {
     contexts: REQUIRED_CHECKS,
   },
   enforce_admins: false, // governance 운영자(자기) 가 hot-fix 가능
-  required_pull_request_reviews: {
-    required_approving_review_count: 1,
-    dismiss_stale_reviews: true,
-    require_code_owner_reviews: false,
-  },
+  // DCN-CHG-20260501-04: 1인 운영 — PR author self-approve 불가 (GitHub 정책).
+  // CI 4 checks 가 게이트 본질 → review approve 의무 폐기. CI 통과만 강제.
+  required_pull_request_reviews: null,
   restrictions: null, // push 권한 제한 없음 (PR 만 강제)
   required_linear_history: true, // squash merge 전제
   allow_force_pushes: false,
@@ -56,7 +54,7 @@ const dryRun = args.includes('--dry-run');
 
 console.log(`[branch-protection] target: ${REPO}/branches/${BRANCH}/protection`);
 console.log(`[branch-protection] required checks: ${REQUIRED_CHECKS.join(', ')}`);
-console.log(`[branch-protection] required reviewers: 1 (proposal §5 Phase 3 LGTM gate 외부화)`);
+console.log(`[branch-protection] required reviewers: 0 (1인 운영 — CI 4 checks 가 게이트 본질, DCN-30-04)`);
 
 if (dryRun) {
   console.log('[branch-protection] --dry-run — payload 만 출력:');


### PR DESCRIPTION
## Summary

DCN-30-37 ~ DCN-30-40 7+ PR 동안 GitHub Python tests CI fail 누적 + 즉시 머지 회귀 차단. 사용자 명령 정합 ("CI 로 강제해서 앞으로는 실패 못하게").

## 실측 — 회귀 패턴

PR #84 머지 시각 vs CI 완료 시각:
- merged: `2026-04-30T15:28:21Z`
- CI checks: `2026-04-30T15:28:32~39Z`
- **11~18초 일찍 머지** — CI 결과 wait X. 우연 success.

`branch protection` 미설정 (404 "Branch not protected") + `gh pr merge --squash` 가 wait 안 함 = CI fail 코드도 머지 가능했던 상태.

## 변경

### `scripts/setup_branch_protection.mjs`
- `required_pull_request_reviews: { count: 1, ... }` → `null`
- 1인 운영 PR author self-approve 불가 (GitHub 정책) → review 의무 폐기
- CI 4 checks 가 실질 게이트

### `docs/process/governance.md` §2.8
- 표 갱신 — review 1 → 비활성, 근거 갱신
- **`gh pr merge --squash --auto` 의무 룰 추가** — CI 통과 후 자동 머지

### Live 적용 (gh API PUT)

```
required_status_checks contexts:
  - Document Sync gate
  - unittest discover
  - validate manifest
  - Task-ID format gate
strict: True
required_pull_request_reviews: disabled
required_linear_history: True
allow_force_pushes: False
```

## Test plan

- [x] `node scripts/setup_branch_protection.mjs --dry-run` 페이로드 확인
- [x] `node scripts/setup_branch_protection.mjs` PASS — live 적용 완료
- [x] `gh api repos/alruminum/dcNess/branches/main/protection` 검증 — 4 contexts + strict + reviews=null + linear=true
- [x] `node scripts/check_document_sync.mjs` PASS (5 files / docs-only, ci)
- [ ] **본 PR 부터 적용 검증** — `--auto` flag 사용 + CI 4 checks 통과 후 자동 머지 실측 (이 PR 자체로)

## 후속

- `CLAUDE.md` 커밋 절차 / `main-claude-rules.md` §2.3 — `gh pr merge --squash --auto` flag 의무 명시 (작은 후속 PR)
- `/run-review` 에 `CI_NOT_VERIFIED` 패턴 추가 후속

🤖 Generated with [Claude Code](https://claude.com/claude-code)