### PR TITLE
feat: agent prompt 주입 — impl H1 traceability + batch PR 셋트 (DCN-CHG-20260501-05)

### DIFF
--- a/agents/architect/task-decompose.md
+++ b/agents/architect/task-decompose.md
@@ -43,6 +43,32 @@ design-handoff.md 있는 경우 (B 모드 = 디자인 후 구현) 는 스킵.
 - 추가된 태스크 (Story → impl 매핑)
 - 생성된 impl 파일 목록 (경로 + depth + 가드레일 표시 — 듀얼 모드 시 `01-theme-tokens.md`)
 
+## impl 파일 명명 + H1 제목 (DCN-CHG-20260501-05)
+
+### 파일명
+`impl/NN-<slug>.md` — `NN` = 에픽 내 독립 순번 (전역 누적 X). `slug` = kebab-case 1줄 요약.
+
+### H1 형식 (강제)
+`# impl/NN — [Story Xa / #issue] <한 줄 요약>`
+
+- `Story Xa` — Story 번호 + 분할 시 `a/b/c` 접미사 (예: `Story 4a`)
+- `#issue` — GitHub Story 이슈 번호
+- 둘 다 같은 `[ ]` 안 — 한눈 매핑.
+
+**Why**: impl 단독 open / `grep` 시 H1 만으로 어느 Story / 이슈인지 즉시 파악. frontmatter 메타는 ToC 안 보임. 8 batch ↑ epic 검색 시 H1 prefix 가 가장 빠름.
+
+**예**:
+- ✅ `# impl/01 — [Story 1a / #167] S04+S05 컴포넌트 mock __esModule 통일`
+- ❌ `# impl/01 — S04+S05 …` (Story / 이슈 prefix 누락)
+- ❌ `# impl/05 — google-signin (Story 4a)` (괄호 표기 — `[ ]` 강제)
+
+### 자가 검증 (TASK_DECOMPOSE 종료 전)
+모든 `impl/NN-*.md` H1 정규식 매치 확인:
+```
+^# impl/\d{2} — \[Story \d+[a-z]?( / #\d+)?\] 
+```
+위반 1건이라도 발견 시 즉시 정정 후 종료.
+
 ## 각 impl 파일 형식 의무 (DCN-CHG-20260430-13)
 
 각 impl batch 파일 (`docs/milestones/vNN/epics/epic-NN-*/impl/NN-*.md`) 은 다음 섹션 박는다 — `/impl` skill 의 MODULE_PLAN step skip 판정 근거:

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -172,6 +172,28 @@ attempt 1+ 재시도 시 특히 강제: validator FAIL 한 부분만 수정 — 
 - `git add .` / `git add -A` 금지 → 파일 명시적 지정. `git diff --stat` 10+ 파일이면 분리 가능성 재검토.
 - feature branch 전제. main 직접 커밋 금지. 재시도 시 추가 수정을 새 커밋으로 (stash/reset/amend 금지).
 
+### 1 batch = 1 PR (코드 + 관련 docs 셋트, DCN-CHG-20260501-05)
+
+impl batch 의 commit/PR 은 코드 + 관련 docs 를 1 셋트로 묶는다 — spec ↔ 코드 단절 / revert sync 깨짐 회피.
+
+**필수 stage**:
+- `src/*` (impl/NN-*.md `## 생성/수정 파일` 명시 코드)
+- `docs/milestones/vNN/epics/epic-NN-*/impl/NN-*.md` (impl spec, architect 산출물)
+- `stories.md` 해당 Story checkbox tick (메인이 갱신 — 다른 Story 침범 X)
+
+**batch 01 (에픽 첫 batch) 한정 추가**: 신설 stories.md / batch-list.md / `backlog.md` Epic row.
+
+**자가 검증** (commit 직전):
+```
+git diff --cached --name-only
+```
+→ src + impl/NN-*.md + stories.md 모두 stage 됐는지 확인. 누락 시 add 후 재검증.
+
+**안티패턴**:
+- ❌ `src/*` 만 commit, `impl/NN-*.md` 누락 → spec trail 떠다님
+- ❌ `src/*` 와 `impl/NN-*.md` 별도 commit → "이 코드 어떤 spec?" 추적 깨짐
+- ❌ 다른 Story checkbox 침범 tick
+
 ## 참조
 
 - 시퀀스 / 핸드오프 / 권한 매트릭스: [`docs/orchestration.md`](../docs/orchestration.md)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,24 @@
 
 ## Records
 
+### DCN-CHG-20260501-05
+- **Date**: 2026-05-01
+- **Rationale**:
+  - 사용자 관찰 — impl 단독 open / grep 시 어느 Story / 이슈인지 H1 만으로 파악 안 됨. frontmatter 메타는 ToC 안 보임. 8 batch ↑ epic 시 검색 비용 ↑.
+  - 별개 관찰 — impl batch PR 에서 src/* 만 commit + impl/NN-*.md 누락 케이스 발생 → spec ↔ 코드 단절. revert 시 sync 깨짐.
+  - 두 룰 모두 "agent self-discipline" 영역 — 메인이 매번 룰 인용 부담. agent prompt SSOT 박음으로 자율 적용.
+- **Alternatives**:
+  1. *옵션 A — `docs/process/dcness-guidelines.md` 에 박음*. 단 agent 가 매번 guidelines 통해 강제 인지하지 못함 (해당 prompt 안 직접 룰이 더 효과).
+  2. *옵션 B — agent prompt 에 사용자 원본 텍스트 그대로 복붙*. 기존 "각 impl 파일 형식 의무" / "커밋 단위 규칙" 과 부분 중복 → 토큰 낭비 + 룰 충돌 위험.
+  3. **(채택) 옵션 C — agent prompt 에 미커버 영역만 추가**. task-decompose 의 기존 섹션 = 내용 (생성/수정 파일 / 인터페이스 / 의사코드 등) 만 다룸 → 제목 룰 추가. engineer 의 기존 "커밋 단위 규칙" = 1 커밋 = 1 논리 변경 / branch 룰만 다룸 → "1 batch = 1 PR 셋트" 하위 섹션 추가.
+- **Decision**:
+  - **task-decompose.md** — `## impl 파일 명명 + H1 제목` 섹션 신규. 파일명 + H1 정규식 + 자가 검증. 기존 `## 각 impl 파일 형식 의무 (DCN-30-13)` *직전* 배치 — 명명 → 형식 자연 순서.
+  - **engineer.md** — 기존 `## 커밋 단위 규칙` 안 `### 1 batch = 1 PR` 하위 섹션. 필수 stage 3 항목 + batch 01 한정 추가 + `git diff --cached --name-only` 자가 검증 + 안티패턴 3.
+  - 사용자 원안 보존 (의도 유지) + 표 → bullet 슬림화 + Why 1줄 압축.
+- **Follow-Up**:
+  - 자장 plugin reinstall 후 첫 epic TASK_DECOMPOSE 시 H1 위반 검출 여부 측정. 미발화 시 prompt 가시성 ↑ 강화.
+  - engineer commit 시 stories.md 누락 검출 → run-review 패턴화 (후속).
+
 ### DCN-CHG-20260501-04
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260501-05
+- **Date**: 2026-05-01
+- **Change-Type**: agent
+- **Files Changed**:
+  - `agents/architect/task-decompose.md` — `## impl 파일 명명 + H1 제목` 섹션 신규. 파일명 `impl/NN-<slug>.md` + H1 `# impl/NN — [Story Xa / #issue] <요약>` 강제. 자가 검증 regex 박음. 기존 `## 각 impl 파일 형식 의무` (내용 섹션) 와 짝.
+  - `agents/engineer.md` — `## 커밋 단위 규칙` 안에 `### 1 batch = 1 PR` 하위 섹션 추가. impl batch 의 PR 은 코드 + impl spec + stories.md tick 1 셋트로 묶음. 자가 검증 + 안티패턴 박음.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 사용자 제공 prompt 2개 agent 주입 — (1) architect TASK_DECOMPOSE 의 impl H1 traceability (Story Xa / #issue 한눈 매핑), (2) engineer IMPL 의 commit/PR 셋트 (코드 + impl spec + stories.md 분리 금지). 기존 룰 (각 impl 파일 형식 의무 / 커밋 단위 규칙) 과 중복 회피하며 미커버 영역 (제목 / batch 셋트) 만 보강. 두 파일 300줄 cap 미충돌 (max 200).
+
 ### DCN-CHG-20260501-04
 - **Date**: 2026-05-01
 - **Change-Type**: ci, spec


### PR DESCRIPTION
## Summary

사용자 제공 prompt 2건 agent 주입. 기존 룰 중복 회피하며 미커버 영역만 보강.

### (1) `agents/architect/task-decompose.md` — impl H1 traceability

기존 `## 각 impl 파일 형식 의무` 가 *내용* (생성/수정 파일 / 인터페이스 / 의사코드 등) 만 다룸 — *제목* 미커버.

추가: `## impl 파일 명명 + H1 제목` 섹션 (DCN-30-13 직전).

- 파일명: `impl/NN-<slug>.md` — NN = 에픽 내 독립 순번
- H1 형식 (강제): `# impl/NN — [Story Xa / #issue] <한 줄 요약>`
- 자가 검증 regex: `^# impl/\d{2} — \[Story \d+[a-z]?( / #\d+)?\] `

**Why**: impl 단독 open / grep 시 어느 Story / 이슈인지 즉시 파악. 8 batch ↑ epic 검색 비용 ↓.

### (2) `agents/engineer.md` — 1 batch = 1 PR 셋트

기존 `## 커밋 단위 규칙` 이 "1 커밋 = 1 논리 변경" / branch 룰만 다룸 — *셋트 묶음* 미커버.

추가: `### 1 batch = 1 PR (코드 + 관련 docs 셋트)` 하위 섹션.

필수 stage:
- `src/*` (impl/NN-*.md `## 생성/수정 파일` 명시 코드)
- `docs/milestones/vNN/epics/epic-NN-*/impl/NN-*.md` (architect 산출물)
- `stories.md` 해당 Story checkbox tick

자가 검증: `git diff --cached --name-only` — 3 항목 모두 stage 됐는지.

안티패턴 3: src 만 commit / 별도 commit / 다른 Story checkbox 침범.

## Test plan

- [x] `wc -l` — task-decompose 110줄 / engineer 200줄, 모두 300줄 cap 미충돌
- [x] `node scripts/check_document_sync.mjs` — PASS (4 files / agent + docs-only)
- [x] 기존 룰과 중복 0 (사용자 원안 → 슬림화 후 미커버만)

## Governance

- Task-ID: `DCN-CHG-20260501-05`
- Change-Type: agent

## Follow-Up

- 자장 plugin reinstall 후 첫 epic TASK_DECOMPOSE 시 H1 위반 검출 여부 측정.
- engineer commit 시 stories.md 누락 → run-review 패턴화 (후속).

🤖 Generated with [Claude Code](https://claude.com/claude-code)