### PR TITLE
ci: branch protection 폐기 + paths 필터 복구 (DCN-CHG-20260501-06)

### DIFF
--- a/.github/workflows/plugin-manifest.yml
+++ b/.github/workflows/plugin-manifest.yml
@@ -14,12 +14,20 @@
 name: plugin-manifest
 
 on:
-  # DCN-30-04: paths 필터 폐기 — branch protection required check 가 paths
-  # 미스매치로 발화 안 하면 PR BLOCKED 영원히. 모든 PR 에 발화.
+  # DCN-CHG-20260501-06: branch protection 폐기 후 paths 필터 복구.
+  # 매니페스트 / 검증 스크립트 / 본 yml 변경 시만 발화 — docs-only PR 비용 회피.
   pull_request:
     branches: [main]
+    paths:
+      - '.claude-plugin/**'
+      - 'scripts/check_plugin_manifest.mjs'
+      - '.github/workflows/plugin-manifest.yml'
   push:
     branches: [main]
+    paths:
+      - '.claude-plugin/**'
+      - 'scripts/check_plugin_manifest.mjs'
+      - '.github/workflows/plugin-manifest.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,9 +5,10 @@
 # - DCN-CHG-20260429-13 prose-only 패턴 회귀 차단
 #
 # 트리거:
-# - 모든 PR / push to main (DCN-30-04 — branch protection required check 정합).
-# - paths 필터 폐기 사유: required check 가 paths 미스매치로 발화 안 하면 BLOCKED
-#   영원히. CI 비용 < 안전성. 본 repo small.
+# - PR / push to main 시 tests/ 또는 harness/ 또는 agents/ 변경 시
+# - paths 필터로 docs-only PR 에서 불필요 실행 회피
+# - DCN-CHG-20260501-06: branch protection 폐기 후 paths 필터 복구
+#   (BLOCKED 영원히 문제는 protection 자체를 끄면서 자연 해소)
 #
 # proposal §11.4 안전망: "매 sub-phase squash merge 후 측정" 의 자동화 버전
 
@@ -16,8 +17,18 @@ name: python-tests
 on:
   pull_request:
     branches: [main]
+    paths:
+      - 'harness/**'
+      - 'tests/**'
+      - 'agents/**'
+      - '.github/workflows/python-tests.yml'
   push:
     branches: [main]
+    paths:
+      - 'harness/**'
+      - 'tests/**'
+      - 'agents/**'
+      - '.github/workflows/python-tests.yml'
 
 permissions:
   contents: read

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,8 +2,15 @@
 
 ## 현재 상태
 
-- **🚥 branch protection — CI 4 checks 강제** (`DCN-CHG-20260501-04`):
-  - DCN-30-37 ~ DCN-30-40 7+ PR 동안 CI fail 누적 머지 회귀 차단. 사용자 명령 정합.
+- **🔄 branch protection 폐기 + paths 필터 복구 (DCN-CHG-20260501-04 revert)** (`DCN-CHG-20260501-06`):
+  - 사용자 의도 재확인 — "doc-sync 정도의 제어" 였음. 이전 세션 ("CI 강제해서 실패 못하게") 과해석으로 protection ON + paths 필터 OFF 동반 결정. 본 task 로 둘 다 revert.
+  - **branch protection live 폐기** — `gh api -X DELETE repos/alruminum/dcNess/branches/main/protection` 200. 재호출 → 404 "Branch not protected" 확인.
+  - **paths 필터 복구** — `python-tests.yml` (harness/tests/agents/yml) + `plugin-manifest.yml` (plugin/script/yml). docs-only PR 불필요 실행 회피.
+  - **governance.md §2.8** — "Branch Protection (현재 비활성)" 으로 재작성. doc-sync §2.7 3중 hook 만 실질 강제. 나머지 CI 게이트는 표시 레벨.
+  - **`gh pr merge --squash --auto` 의무 룰 폐기** — protection 없으면 작동 X. 일반 `--squash` 머지.
+  - `setup_branch_protection.mjs` / `branch-protection-setup.md` — header 에 ⚠️ OFF 명시. 재활성용 보존.
+- **🚥 branch protection — CI 4 checks 강제** (`DCN-CHG-20260501-04`) — ⚠️ DCN-CHG-20260501-06 으로 revert. 아래 기록 유지 (히스토리):
+  - DCN-30-37 ~ DCN-30-40 7+ PR 동안 CI fail 누적 머지 회귀 차단. 사용자 명령 과해석.
   - PR #84 실측 — 머지 15:28:21 / CI 완료 15:28:32~39 = 11~18초 일찍 머지. 우연 success.
   - `setup_branch_protection.mjs` review 1 → null (1인 운영 self-approve 불가) + governance §2.8 갱신.
   - **live 적용** — 4 contexts 강제 (`Document Sync gate` / `unittest discover` / `validate manifest` / `Task-ID format gate`) + strict + linear history.

--- a/docs/process/branch-protection-setup.md
+++ b/docs/process/branch-protection-setup.md
@@ -1,5 +1,8 @@
 # Branch Protection 설정 가이드
 
+> ⚠️ **현재 상태 (DCN-CHG-20260501-06 이후): OFF**. 본 가이드는 *옵션 도구* — 필요 시 재활성용 보존.
+> 비활성 사유: governance.md §2.8 참조. doc-sync 만 실질 강제하면 충분 + paths 필터 폐기 트레이드오프 회피.
+>
 > 규칙 정의: [`governance.md`](governance.md) §2.8 (SSOT — 본 가이드는 *적용 도구*).
 > Origin: `DCN-CHG-20260429-21` (proposal §5 Phase 3 "Gate 5 → branch protection required reviewers" 외부화).
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,27 @@
 
 ## Records
 
+### DCN-CHG-20260501-06
+- **Date**: 2026-05-01
+- **Rationale**:
+  - DCN-CHG-20260501-04 (branch protection 도입) 가 사용자 의도 과해석. 사용자 원본 명령은 "pytest CI 적용" — doc-sync 정도의 제어 의도였음. 이전 세션 메인이 "CI 강제해서 실패 못하게" 로 확장 + branch protection ON + paths 필터 폐기 동반 결정.
+  - 사용자 직접 지적 — "거버넌스 ci 는 document-sync gate 잘 강제하는거 같은데?". doc-sync 는 §2.7 3중 hook (git pre-commit + Claude Code PreToolUse + AGENTS.md) 으로 commit 시점 차단 → CI 의 역할은 표시. 나머지 게이트도 동일 패턴이면 충분.
+  - paths 필터 폐기 부작용 — docs-only PR 도 python-tests / plugin-manifest 매번 실행 (불필요 비용). protection 폐기 시 자연 해소.
+- **Alternatives**:
+  1. *옵션 A — 현 상태 유지 (protection ON + paths 필터 OFF)*. 사용자 의도 이탈 + paths 비용. 기각.
+  2. *옵션 B — protection OFF + paths 필터 복구 + 로컬 hook 으로 python-tests / Task-ID 도 doc-sync 처럼 commit 차단*. 1인 운영 + `--no-verify` 우회 가능 → mechanical 효력 약함. 사용자 의도 ("doc-sync 정도") 초과. 기각.
+  3. **(채택) 옵션 C — protection OFF + paths 필터 복구. 추가 hook 없음**. 사용자 의도 정합 (doc-sync 만 강제). CI 표시 레벨 유지 — fail 시 PR 페이지 빨갛게 보임 + 사용자 자율 판단.
+- **Decision**:
+  - 옵션 C 채택.
+  - **branch protection live 폐기** — `gh api -X DELETE repos/alruminum/dcNess/branches/main/protection` 200. `gh api ... branches/main/protection` 재호출 → 404 "Branch not protected" 확인.
+  - **workflow paths 필터 복구** — `python-tests.yml` (`harness/**` / `tests/**` / `agents/**` / 본 yml), `plugin-manifest.yml` (`.claude-plugin/**` / `scripts/check_plugin_manifest.mjs` / 본 yml).
+  - **governance.md §2.8** — "Branch Protection (CI 게이트 강제)" → "Branch Protection (현재 비활성)" 으로 재작성. 비활성 사유 / 도입 옵션 / 머지 룰 / 근거 명시. `gh pr merge --squash --auto` 의무 룰 폐기 (protection 없으면 작동 X).
+  - **branch-protection-setup.md / setup_branch_protection.mjs** — header 에 ⚠️ OFF 상태 명시. 스크립트 자체는 보존 (재활성용).
+- **Follow-Up**:
+  - python-tests / plugin-manifest CI fail 시 사용자 시각 의존 — 회귀 잦으면 로컬 hook 도입 재검토.
+  - DCN-30-37 ~ DCN-30-40 회귀 패턴 (CI 결과 안 보고 즉시 머지) 은 메인 행동 룰로 흡수 — `/run-review` `CI_NOT_VERIFIED` 패턴 도입 후속 별 task.
+  - main-claude-rules.md / CLAUDE.md 의 `--auto` flag 의무 룰 (있다면) 함께 폐기 검토 — 본 task 범위 외, 후속.
+
 ### DCN-CHG-20260501-05
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,21 @@
 
 ## Records
 
+### DCN-CHG-20260501-06
+- **Date**: 2026-05-01
+- **Change-Type**: ci, spec
+- **Files Changed**:
+  - `.github/workflows/python-tests.yml` — paths 필터 복구 (`harness/**` / `tests/**` / `agents/**` / 본 yml). docs-only PR 불필요 실행 회피.
+  - `.github/workflows/plugin-manifest.yml` — paths 필터 복구 (`.claude-plugin/**` / `scripts/check_plugin_manifest.mjs` / 본 yml).
+  - `docs/process/governance.md` §2.8 — "Branch Protection (CI 게이트 강제)" → "Branch Protection (현재 비활성)". 비활성 사유 / 도입 옵션 / 머지 룰 / 근거 재작성. doc-sync 만 실질 강제.
+  - `docs/process/branch-protection-setup.md` — header 에 ⚠️ OFF 상태 명시 + 옵션 도구 안내.
+  - `scripts/setup_branch_protection.mjs` — JSDoc header 에 비활성 상태 명시. 스크립트 자체 보존 (재활성용).
+  - branch protection live 폐기 (`DELETE repos/alruminum/dcNess/branches/main/protection`) — `gh api` 200 → `Branch not protected` 확인.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: DCN-CHG-20260501-04 (branch protection 도입) revert. 사용자 의도는 doc-sync 수준 mechanical 차단이지 CI 4 checks 전부 강제 아님 — 사용자 명령 ("pytest CI 적용") 을 과해석한 결과 protection 켜고 paths 필터 폐기까지 동반. 본 task 로 (1) protection OFF (2) paths 필터 복구. doc-sync 는 §2.7 3중 hook 으로 commit 시점 차단 유지. 나머지 CI 게이트는 paths 매칭 시만 발화 + 표시 레벨.
+
 ### DCN-CHG-20260501-05
 - **Date**: 2026-05-01
 - **Change-Type**: agent

--- a/docs/process/governance.md
+++ b/docs/process/governance.md
@@ -100,27 +100,21 @@ Document-Exception-Task: DCN-CHG-YYYYMMDD-NN
 
 CI 레벨(`.github/workflows/document-sync.yml`)은 별도 Task-ID 로 추가.
 
-### 2.8 Branch Protection (CI 게이트 강제)
+### 2.8 Branch Protection (현재 비활성)
 
-`main` 브랜치는 GitHub Repository Settings 의 branch protection 으로 다음을 강제한다:
+**현 상태 (DCN-CHG-20260501-06 이후)**: `main` 브랜치 protection **OFF**. doc-sync gate 만 실질 강제.
 
-| 항목 | 설정 |
-|---|---|
-| Required pull request reviews | ❌ 비활성 (1인 운영 — PR author self-approve GitHub 정책 차단. DCN-30-04) |
-| Required status checks | `Document Sync gate`, `unittest discover`, `validate manifest`, `Task-ID format gate` (4 게이트 모두 PASS 의무) |
-| Strict (up-to-date) | ✅ — base 와 sync 안 된 PR 머지 차단 |
-| Required conversation resolution | ✅ |
-| Required linear history | ✅ — squash merge 전제 |
-| Allow force pushes | ❌ |
-| Allow deletions | ❌ |
+**비활성 사유**:
+- 사용자 의도는 doc-sync 수준의 mechanical 차단. CI 4 checks 전부 강제는 과함.
+- protection 켜면 `paths` 필터 미스매치 PR 이 영원 BLOCKED → workflow 의 `paths` 폐기 동반 강요 → docs-only PR 도 python-tests 실행 (불필요 비용).
+- doc-sync 는 로컬 `pre-commit` hook + Claude Code PreToolUse hook + git pre-commit hook 3중 (§2.7) 으로 commit 시점 차단. CI workflow (`document-sync.yml`) 는 표시만 하면 충분.
+- 나머지 게이트 (`unittest discover`, `validate manifest`, `Task-ID format gate`) 는 *권고* 레벨. paths 필터로 변경 영역만 발화. 실패는 PR 페이지에 표시되지만 mechanical 차단은 안 함.
 
-**적용**: [`branch-protection-setup.md`](branch-protection-setup.md) §1 자동 적용 (`scripts/setup_branch_protection.mjs`) 또는 §2 GitHub UI 수동.
+**도입 옵션 (필요 시 재활성)**: [`branch-protection-setup.md`](branch-protection-setup.md) 자동/수동 적용 가이드 보존. `scripts/setup_branch_protection.mjs` 도 보존. 단 적용 전 `paths` 필터 폐기 트레이드오프 재검토 필요.
 
-**근거**: dcNess 는 RWHarness 의 `class Flag` 기반 in-process LGTM flag 를 *자연 폐기* (migration-decisions §2.2 DISCARD). LGTM 의 의미적 강제는 GitHub CI 4 checks 로 *외부* 에서 제공 → proposal §11 4-pillar #2 (CI/CD 게이트) 정합. 1인 운영이라 review approve 의무는 self-approve 불가 (GitHub 정책) 로 비활성화 — CI 4 checks 가 실질 게이트.
+**머지 룰**: `gh pr merge --squash` (자동 flag `--auto` 의무 폐기 — protection 없으면 작동 X).
 
-**`gh pr merge --squash --auto` 의무**: protection 적용 후 모든 PR merge 명령에 `--auto` flag 의무. CI 통과 *후* 자동 머지. CI 진행 중 머지 시도 시 차단됨 (DCN-30-04 도입 직접 동기 — DCN-30-37 ~ DCN-30-40 7+ PR 동안 CI 결과 안 보고 즉시 머지하던 회귀 패턴 차단).
-
-**CI 게이트 추가/제거 시**: `setup_branch_protection.mjs` 의 `REQUIRED_CHECKS` 와 본 §2.8 표 동시 갱신. 워크플로우 `jobs.<id>.name` 과 protection rule status check 이름이 *문자열 일치* 필수.
+**근거**: dcNess 는 RWHarness 의 `class Flag` 기반 in-process LGTM flag 를 *자연 폐기* (migration-decisions §2.2 DISCARD). dcNess 는 1인 운영 + RWHarness 가드 미적용 환경. mechanical 강제 최소화 (proposal §2.5 함정 회피 — 흐름 강제 최소). doc-sync 는 위반 패턴 잦아서 hook 강제 정당화 — 그 외 CI 게이트는 PR 표시로 충분.
 
 ## 3. 참조 파일
 

--- a/scripts/setup_branch_protection.mjs
+++ b/scripts/setup_branch_protection.mjs
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 /**
- * dcNess main branch protection 일회성 적용 스크립트
+ * dcNess main branch protection 적용 스크립트 (현재 비활성 — 옵션 도구)
  * 규칙 정의: docs/process/governance.md §2.8 (SSOT)
+ *
+ * ⚠️ 현재 상태 (DCN-CHG-20260501-06 이후): main protection OFF.
+ *   doc-sync 만 실질 강제하면 충분 + paths 필터 폐기 트레이드오프 회피.
+ *   본 스크립트는 필요 시 재활성용 보존.
  *
  * 목적:
  *   proposal §5 Phase 3 "Gate 5 (LGTM flag) → branch protection required reviewers"


### PR DESCRIPTION
## Summary
이전 task (`-04`) revert. 사용자 의도 ("doc-sync 정도의 제어") 재확인 → 이전 세션 과해석으로 protection ON + paths 필터 OFF 동반 결정 → 본 PR 둘 다 revert.

## 변경 내용
- **branch protection live 폐기** — `gh api -X DELETE repos/alruminum/dcNess/branches/main/protection` 200. 재호출 → 404 "Branch not protected" 확인.
- **paths 필터 복구**:
  - `python-tests.yml` — `harness/**` / `tests/**` / `agents/**` / 본 yml
  - `plugin-manifest.yml` — `.claude-plugin/**` / `scripts/check_plugin_manifest.mjs` / 본 yml
- **governance.md §2.8** → "Branch Protection (현재 비활성)". doc-sync §2.7 3중 hook 만 실질 강제. 나머지 CI 게이트는 표시 레벨.
- **`gh pr merge --squash --auto` 의무 룰 폐기** (protection 없으면 작동 X).
- `setup_branch_protection.mjs` / `branch-protection-setup.md` — header 에 ⚠️ OFF 명시. 스크립트/가이드 자체는 재활성용 보존.

## 거버넌스
- **Task-ID**: `DCN-CHG-20260501-06` (단일)
- **Change-Type**: ci, spec
- **Document Sync**: PASS (`node scripts/check_document_sync.mjs` — 8 files, ci+docs-only)
- **동반 갱신**: `document_update_record.md` / `change_rationale_history.md` / `PROGRESS.md`

## Test plan
- [x] `gh api repos/alruminum/dcNess/branches/main/protection` → 404
- [x] `node scripts/check_document_sync.mjs` PASS
- [ ] CI 4 checks PASS (paths 매칭으로 본 PR 은 yml 변경이라 발화 정상)

🤖 Generated with [Claude Code](https://claude.com/claude-code)