### PR TITLE
ci: pytest pre-commit 게이트 — paths 분기 mechanical 차단 (DCN-CHG-20260501-07)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,9 @@
    - `docs/process/change_rationale_history.md` (spec / agent / harness / hooks / ci 변경 시)
    - `PROGRESS.md` (harness / hooks / ci 변경 시)
    - 카테고리별 deliverable (governance §2.6)
-5. **commit 직전**: `node scripts/check_document_sync.mjs` 통과 확인.
+5. **commit 직전**: doc-sync + pytest 2 게이트 통과 (자동).
+   - `node scripts/check_document_sync.mjs` (모든 commit)
+   - `sh scripts/check_python_tests.sh` (`harness/` / `tests/` / `agents/` / `python-tests.yml` staged 시만)
    - 자동: Claude Code PreToolUse hook (`scripts/hooks/cc-pre-commit.sh`) + git pre-commit hook 이 동시 차단.
 6. **branch → PR → squash merge** (직접 `main` push 금지).
 
@@ -69,8 +71,9 @@
 | [`scripts/setup_branch_protection.mjs`](scripts/setup_branch_protection.mjs) | main 브랜치 보호 적용 스크립트 (governance §2.8) |
 | [`docs/process/branch-protection-setup.md`](docs/process/branch-protection-setup.md) | branch protection 적용/검증 가이드 |
 | [`docs/process/plugin-dryrun-guide.md`](docs/process/plugin-dryrun-guide.md) | RWHarness 와 공존 plugin 배포 dry-run 절차 (proposal §12 풀어쓴 운영 가이드) |
-| [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook |
-| [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook |
+| [`scripts/check_python_tests.sh`](scripts/check_python_tests.sh) | pytest pre-commit 게이트 (paths 분기) |
+| [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook (doc-sync + pytest 체인) |
+| [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook (doc-sync + pytest 체인) |
 
 ## 4. 개발 명령어
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🧪 pytest pre-commit 게이트 (paths 분기)** (`DCN-CHG-20260501-07`):
+  - 직전 task (`-06`) 로 protection 폐기 → CI `unittest discover` 표시 레벨로 떨어짐. 사용자 — doc-sync 동급 mechanical 차단 원함.
+  - **`scripts/check_python_tests.sh`** 신규 — staged `harness/` / `tests/` / `agents/` / `python-tests.yml` 매칭 시만 `python3 -m unittest discover -s tests`. 비매칭 0초, 매칭 ~3초. `GITHUB_ACTIONS` skip.
+  - **pre-commit chain 화** — `scripts/hooks/pre-commit` + `scripts/hooks/cc-pre-commit.sh` 둘 다 doc-sync 통과 후 pytest 호출.
+  - **governance.md §2.7** — 게이트 매트릭스 표 신설 (doc-sync = 모든 commit / pytest = paths 분기). 우회 = `--no-verify` (룰 위반).
+  - 사용자 PICK 옵션 B (paths 분기) — 사용자 의도 정합. 옵션 A (무조건) / C (branch protection 재활성) 기각.
 - **🔄 branch protection 폐기 + paths 필터 복구 (DCN-CHG-20260501-04 revert)** (`DCN-CHG-20260501-06`):
   - 사용자 의도 재확인 — "doc-sync 정도의 제어" 였음. 이전 세션 ("CI 강제해서 실패 못하게") 과해석으로 protection ON + paths 필터 OFF 동반 결정. 본 task 로 둘 다 revert.
   - **branch protection live 폐기** — `gh api -X DELETE repos/alruminum/dcNess/branches/main/protection` 200. 재호출 → 404 "Branch not protected" 확인.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,27 @@
 
 ## Records
 
+### DCN-CHG-20260501-07
+- **Date**: 2026-05-01
+- **Rationale**:
+  - 직전 task (`-06`) 로 branch protection 폐기 → CI 4 checks 중 `unittest discover` 표시 레벨로 떨어짐. 사용자 — 회귀 잦았던 만큼 (DCN-30-37 ~ -40) doc-sync 동급 mechanical 차단 원함.
+  - 사용자 직접 선택 — "pytest 도 강제 못해?" → 옵션 B (paths 분기) PICK.
+  - 도입 비용 측정 — 현재 unittest 약 3초. 매 commit 강제 시 비용 누적이지만 paths 분기로 비매칭 commit 0초.
+- **Alternatives**:
+  1. *옵션 A — 무조건 실행*. 단순. docs-only commit 도 3초. 비매칭 비용 누적. 기각 (사용자 PICK X).
+  2. **(채택) 옵션 B — paths 분기 (`harness/` / `tests/` / `agents/` / `python-tests.yml`)**. 사용자 PICK. CI workflow paths 필터와 동일 의도 — 변경 영역만 실행.
+  3. *옵션 C — branch protection 재활성*. doc-sync 정도 의도 위반. 직전 task 정합 깨짐. 기각.
+- **Decision**:
+  - **`scripts/check_python_tests.sh`** 신규 — paths 분기 + `GITHUB_ACTIONS` skip (workflow 가 별도 실행) + 실패 시 exit 1 + 우회 안내 (`--no-verify`, 룰 위반 명시).
+  - **`scripts/hooks/pre-commit`** — chain 화 (`set -e` + node doc-sync + sh pytest). 기존 단일 exec 패턴 유지.
+  - **`scripts/hooks/cc-pre-commit.sh`** — `git commit` case 안 doc-sync 통과 후 pytest 게이트 추가. 실패 시 exit 2 (PreToolUse 차단).
+  - **`docs/process/governance.md` §2.7** — 강제 메커니즘 표 신설 (게이트 / 스크립트 / 적용 범위 / 우회). 참조 파일 표에 신규 스크립트 추가.
+  - **`CLAUDE.md`** — §1 commit 직전 단계 + 문서 지도 표 갱신 (2 게이트 명시).
+- **Follow-Up**:
+  - 신규 hook 효력 측정 — 첫 회귀 시 `--no-verify` 사용 여부 자기 모니터링 (1인 운영 자기 룰 위반 패턴 추적).
+  - tests 수 ↑ 또는 elapsed > 10초 도달 시 paths 추가 분기 / parallel 도입 검토.
+  - AGENTS.md (외부 에이전트 지침) 에 pytest 게이트 룰 명시 후속.
+
 ### DCN-CHG-20260501-06
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,20 @@
 
 ## Records
 
+### DCN-CHG-20260501-07
+- **Date**: 2026-05-01
+- **Change-Type**: ci, spec
+- **Files Changed**:
+  - `scripts/check_python_tests.sh` (신규) — staged 파일이 `harness/` / `tests/` / `agents/` / `python-tests.yml` 매칭 시만 `python3 -m unittest discover -s tests`. CI 환경 (`GITHUB_ACTIONS`) skip. 우회 시 `--no-verify` (룰 위반).
+  - `scripts/hooks/pre-commit` — chain 화 (doc-sync + pytest).
+  - `scripts/hooks/cc-pre-commit.sh` — `git commit` 매칭 case 안 doc-sync 통과 후 pytest 게이트 추가.
+  - `docs/process/governance.md` §2.7 — 강제 메커니즘 표 신설 (게이트 / 스크립트 / 적용 범위 / 우회). 참조 파일 표에 `check_python_tests.sh` 추가.
+  - `CLAUDE.md` §1 (commit 직전 단계) + 문서 지도 — 2 게이트 명시.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 사용자 요청 ("pytest 도 강제 못해?") 정합. doc-sync 패턴 그대로 — paths 분기 (옵션 B) 채택. 비매칭 commit 비용 0, 매칭 시 ~3초. branch protection 미사용 환경에서 mechanical 차단 확장.
+
 ### DCN-CHG-20260501-06
 - **Date**: 2026-05-01
 - **Change-Type**: ci, spec

--- a/docs/process/governance.md
+++ b/docs/process/governance.md
@@ -94,11 +94,18 @@ Document-Exception-Task: DCN-CHG-YYYYMMDD-NN
 
 ### 2.7 강제 메커니즘 (3중)
 
-1. **`.git/hooks/pre-commit`** — 모든 사람. 설치: `cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`
-2. **`.claude/settings.json` PreToolUse hook** — Claude Code 자동
+1. **`.git/hooks/pre-commit`** — 모든 사람. 설치: `cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`. 게이트 체인 = doc-sync + pytest (paths 분기, DCN-CHG-20260501-07).
+2. **`.claude/settings.json` PreToolUse hook** — Claude Code 자동. 동일 2 게이트 체인.
 3. **`AGENTS.md` 규칙 명시** — Codex 등 다른 에이전트 강제
 
-CI 레벨(`.github/workflows/document-sync.yml`)은 별도 Task-ID 로 추가.
+**게이트 매트릭스**:
+
+| 게이트 | 스크립트 | 적용 범위 | 우회 |
+|---|---|---|---|
+| doc-sync | `scripts/check_document_sync.mjs` | 모든 commit | `Document-Exception:` 토큰 (§2.4) |
+| pytest | `scripts/check_python_tests.sh` | `harness/` / `tests/` / `agents/` / `python-tests.yml` staged 시만 | `--no-verify` (룰 위반) |
+
+CI 레벨(`.github/workflows/document-sync.yml`, `python-tests.yml`)은 별도 Task-ID 로 추가/유지.
 
 ### 2.8 Branch Protection (현재 비활성)
 
@@ -128,9 +135,10 @@ CI 레벨(`.github/workflows/document-sync.yml`)은 별도 Task-ID 로 추가.
 | `docs/process/branch-protection-setup.md` | §2.8 적용 가이드 (자동 + 수동 + 검증) |
 | `scripts/check_document_sync.mjs` | CI 게이트 구현 |
 | `scripts/check_task_id.mjs` | Task-ID 형식 검증 게이트 (§2.1 강제) |
-| `scripts/setup_branch_protection.mjs` | branch protection 적용 스크립트 (§2.8) |
-| `scripts/hooks/pre-commit` | git pre-commit hook |
-| `scripts/hooks/cc-pre-commit.sh` | Claude Code PreToolUse hook |
+| `scripts/check_python_tests.sh` | pytest pre-commit 게이트 (§2.7 — paths 분기 unittest discover) |
+| `scripts/setup_branch_protection.mjs` | branch protection 적용 스크립트 (§2.8 — 현재 비활성) |
+| `scripts/hooks/pre-commit` | git pre-commit hook (doc-sync + pytest 체인) |
+| `scripts/hooks/cc-pre-commit.sh` | Claude Code PreToolUse hook (doc-sync + pytest 체인) |
 | `.claude/settings.json` | Claude Code 설정(PreToolUse 등록) |
 | `.github/PULL_REQUEST_TEMPLATE.md` | PR 체크리스트 |
 | `AGENTS.md` | 외부 에이전트 지침 |

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# dcNess pytest pre-commit gate (paths 분기)
+# 규칙 정의: docs/process/governance.md §2.7
+#
+# 동작:
+#   1. staged 파일 목록 추출 (git diff --cached --name-only)
+#   2. harness/ | tests/ | agents/ | .github/workflows/python-tests.yml 매칭 시만 실행
+#   3. python3 -m unittest discover -s tests
+#
+# 종료 코드:
+#   0 — 통과 (or 매칭 0)
+#   1 — 테스트 실패
+#
+# 우회: git commit --no-verify (룰 위반).
+
+set -u
+
+# CI 환경 (GITHUB_ACTIONS) 에선 skip — workflow 가 별도 실행
+if [ -n "${GITHUB_ACTIONS:-}" ]; then
+  exit 0
+fi
+
+# staged 파일 매칭 검사
+CHANGED=$(git diff --cached --name-only 2>/dev/null)
+if [ -z "$CHANGED" ]; then
+  exit 0
+fi
+
+if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|\.github/workflows/python-tests\.yml$)'; then
+  # 미매칭 — skip
+  exit 0
+fi
+
+echo "[pytest-gate] harness/tests/agents 변경 감지 — 단위 테스트 실행"
+if ! python3 -m unittest discover -s tests >&2; then
+  echo "[pytest-gate] FAIL — 단위 테스트 회귀. fix 후 재커밋. (우회: --no-verify, 룰 위반)" >&2
+  exit 1
+fi
+echo "[pytest-gate] PASS"
+exit 0

--- a/scripts/hooks/cc-pre-commit.sh
+++ b/scripts/hooks/cc-pre-commit.sh
@@ -33,6 +33,11 @@ case "$COMMAND" in
         exit 2
       fi
     fi
+    if [ -f scripts/check_python_tests.sh ]; then
+      if ! sh scripts/check_python_tests.sh; then
+        exit 2
+      fi
+    fi
     ;;
 esac
 exit 0

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,7 +1,14 @@
 #!/bin/sh
-# dcNess document-sync pre-commit hook
+# dcNess pre-commit hook chain
 # 규칙 정의: docs/process/governance.md §2.7
 #
 # 설치:
 #   cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
-exec node scripts/check_document_sync.mjs
+#
+# 게이트:
+#   1. document-sync (모든 commit)
+#   2. python-tests (harness/tests/agents/yml staged 시만)
+
+set -e
+node scripts/check_document_sync.mjs
+sh scripts/check_python_tests.sh


### PR DESCRIPTION
## Summary
직전 task (`-06`) 로 branch protection 폐기 → CI \`unittest discover\` 표시 레벨로 떨어짐. 사용자 요청 ("pytest 도 강제 못해?") 정합 — doc-sync 동급 mechanical 차단을 pytest 에도 확장.

## 변경 내용
- **`scripts/check_python_tests.sh` 신규** — staged 파일이 \`harness/\` / \`tests/\` / \`agents/\` / \`python-tests.yml\` 매칭 시만 \`python3 -m unittest discover -s tests\`. \`GITHUB_ACTIONS\` skip (workflow 가 별도 실행). 우회 = \`--no-verify\` (룰 위반 명시).
- **`scripts/hooks/pre-commit`** — chain 화 (\`set -e\` + node doc-sync + sh pytest).
- **`scripts/hooks/cc-pre-commit.sh`** — \`git commit\` case 안 doc-sync 통과 후 pytest 게이트 추가. 실패 시 exit 2 (PreToolUse 차단).
- **`governance.md` §2.7** — 강제 메커니즘 표 신설 (게이트 / 스크립트 / 적용 범위 / 우회). 참조 파일 표에 신규 스크립트 추가.
- **`CLAUDE.md`** — commit 직전 단계 + 문서 지도 표 갱신.

## 옵션 PICK
- **(채택) B — paths 분기** (`harness/` / `tests/` / `agents/` / `python-tests.yml`). 비매칭 0초, 매칭 ~3초.
- A (무조건) 기각 — 비매칭 비용 누적.
- C (branch protection 재활성) 기각 — 직전 task 정합 위반.

## 거버넌스
- **Task-ID**: `DCN-CHG-20260501-07` (단일)
- **Change-Type**: ci, agent (CLAUDE.md), spec
- **Document Sync**: PASS (8 files, agent+docs-only+ci)
- **동반 갱신**: `document_update_record.md` / `change_rationale_history.md` / `PROGRESS.md`

## Test plan
- [x] `scripts/check_python_tests.sh` 단독 호출 — 미매칭 stage 면 skip
- [x] `git commit` 본 PR — pre-commit hook chain 통과
- [ ] 의도적 \`tests/\` 깨뜨려서 commit 시도 → block 검증 (후속, 본 PR 범위 외)

🤖 Generated with [Claude Code](https://claude.com/claude-code)