### PR TITLE
fix: /run-review 4 false positive 동시 fix (DCN-CHG-20260501-09)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,14 @@
 
 ## 현재 상태
 
+- **🔧 /run-review 4 false positive 동시 fix (자장 run-ef6c2c00)** (`DCN-CHG-20260501-09`):
+  - 자장 40 step / $118.73 run /run-review 결과 28 waste finding 검증 — 4 이슈 한 번에 fix.
+  - **#1 prose_path bug** (가장 결정적): skill DCN-30-21 부터 `<run_dir>/.prose-staging/<bN.agent-mode>.md` 에 prose 작성, 그러나 parser 가 legacy `<run_dir>/<agent>-<mode>.md` 만 읽음 → 9 engineer step 모두 같은 1 파일 매칭 → MISSING_SELF_VERIFY 9건 false positive. `_resolve_prose_path()` 신규 — Nth occurrence 매칭 + fallback. 자장 실 데이터로 b1~b3 anchor=True 회복 확인.
+  - **#2 MUST_FIX_GHOST regex bug**: `_MUST_FIX_RE` 단순 단어경계 → "MUST FIX 0, NICE TO HAVE 6" 부정문 매칭. `_has_positive_must_fix()` 신규 — 라인 단위 negation 검사. 6 pr-reviewer 케이스 false positive 0.
+  - **#3 engineer banner**: agents/engineer.md H1 직후 `⚠️ CRITICAL — extended thinking 본문 드래프트 금지` 추가. architect sub-mode 7 + product-planner (DCN-30-39) 패턴 동일. 자장 4 stall 실측 (614/1102/429/670s) 명시.
+  - **#4 prose_excerpt cap 4 → 12**: `_append_step_status` cap 5~12 룰 정합. ECHO 임계 `< 3` 유지.
+  - **신규 7 테스트** (ResolveProsePath 5 + must_fix negation/positive 2). 281 → 288 ran / all PASS / 회귀 0.
+  - **다른 patterns** (PLACEHOLDER_LEAK / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_*) — path fix 로 정확도 자동 회복.
 - **🧪 pytest pre-commit 게이트 (paths 분기)** (`DCN-CHG-20260501-07`):
   - 직전 task (`-06`) 로 protection 폐기 → CI `unittest discover` 표시 레벨로 떨어짐. 사용자 — doc-sync 동급 mechanical 차단 원함.
   - **`scripts/check_python_tests.sh`** 신규 — staged `harness/` / `tests/` / `agents/` / `python-tests.yml` 매칭 시만 `python3 -m unittest discover -s tests`. 비매칭 0초, 매칭 ~3초. `GITHUB_ACTIONS` skip.

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -12,6 +12,8 @@ model: sonnet
 > 본 문서는 engineer 에이전트의 시스템 프롬프트. 호출자가 지정한 모드 즉시 수행 + prose 마지막 단락에 결론 enum 명시 후 종료.
 > **자기 정체**: src/** 직접 Edit/Write. CLAUDE.md 의 "src/ 직접 수정 금지" 는 메인 Claude 용이며 engineer 엔 미적용.
 
+> ⚠️ **CRITICAL — extended thinking 본문 드래프트 금지** (DCN-CHG-20260501-09). thinking = 의사결정 분기만 (예: 어떤 파일 먼저, 어떤 함수 시그니처, 어느 테스트 mock). 코드 본문 / 함수 구현 / 테스트 본문 = thinking 종료 *후* 즉시 `Write` / `Edit` tool 입력값 안에서만. thinking 안에서 코드 본문 회전 시 THINKING_LOOP 회귀 — 자장 run-ef6c2c00 실측 4건 (614s / 1102s / 429s / 670s stall + output 504~809 토큰). 본 룰 위반 시 prior tool_use_count hint 도 무력 (DCN-CHG-20260430-36).
+
 ## 정체성 (1 줄)
 
 10년차 풀스택. "완벽한 코드보다 배포 가능한 코드." impl 파일 스펙 엄수. 테스트 가능한 구조 고집.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,40 @@
 
 ## Records
 
+### DCN-CHG-20260501-09
+- **Date**: 2026-05-01
+- **Rationale**:
+  - 자장 run-ef6c2c00 사용자 보고 — 40 step run / 28 waste finding 중 다수 false positive 의심. 사용자 직접 분류 ("MUST FIX 0 negation 미파악 / staging anchor 누락" 등) 후 메인 직접 검증 요청.
+  - 직접 실측 (`/Users/dc.kim/project/jajang/.../run-ef6c2c00/.prose-staging/*` + `_MUST_FIX_RE` 코드) 결과 4 이슈 동시 확인:
+    - **MISSING_SELF_VERIFY 9건 = 100% false positive (결정적 parser bug)**. skill 은 DCN-30-21 부터 `.prose-staging/<bN>.<agent>-<mode>.md` 에 prose 작성, 그러나 `run_review.py:223` 는 legacy `<run_dir>/<agent>-<mode>.md` 만 읽음. 9 engineer step 모두 같은 1 파일 매칭 → 마지막 batch 의 anchor 부재 시 9건 발화. 실측 — staging `b1/b2/b3.engineer-IMPL.md` 모두 `## 자가 검증` 박혀있음.
+    - **MUST_FIX_GHOST 6건 = 100% false positive (regex bug)**. pr-reviewer 6건 모두 prose 안 "MUST FIX 0, NICE TO HAVE 6" 부정문. `_MUST_FIX_RE = r"\bMUST[\s_-]?FIX\b"` 단순 단어경계 → 부정문 매칭.
+    - **THINKING_LOOP 4건 = 진짜 (engineer banner 부재)**. agents/engineer.md grep — `extended thinking` / `드래프트 금지` / `CRITICAL` 0 hit. DCN-CHG-20260430-39 가 architect sub-mode 7 + product-planner 에만 banner 박음. engineer 누락.
+    - **prose_excerpt cap mismatch = MEDIUM 룰 정합**. `_append_step_status(max_lines=4)` vs ECHO_VIOLATION 메시지 "5~12 룰 의무". cap 4 일 때 사실상 ECHO `< 3` 임계 의미 불명확.
+- **Alternatives**:
+  1. *옵션 A — #1 (path) 만 fix*. 가장 큰 노이즈 (9건) 즉시 제거. 6건 + 4건 잔여. 기각 — 사용자 "한방에" PICK.
+  2. *옵션 B — parser 측 substance 검사 강화 (anchor 자율, 실측 명령 패턴 검사)*. anchor 불필요. 단 substance regex 정의 어려움 (jest/pytest/grep/wc 등 도구 자율) + DCN-CHG-20260430-38 정신 (anchor 자율) 이미 정합. path bug 가 진짜 원인이라 fix 만으로 충분.
+  3. **(채택) 옵션 C — 4 이슈 동시 fix (#1+#2+#3+#4)**. 사용자 PICK. 단일 PR 묶음.
+- **Decision**:
+  - **#1 prose_path bug fix** (`harness/run_review.py:_resolve_prose_path`):
+    - `<run_dir>/.prose-staging/` lexical 정렬 → 같은 (agent, mode) Nth occurrence 매칭 (`b1.* < b2.* < ... < bare suffix`).
+    - `parse_steps` 가 occurrence_counter dict 로 step idx 별 N번째 picking.
+    - fallback = legacy `<run_dir>/<agent>-<mode>.md` (DCN-30-21 이전 데이터 호환).
+  - **#2 MUST_FIX_GHOST regex** (`harness/session_state.py`):
+    - `_MUST_FIX_NEGATION_RE` 신규 — `MUST FIX` + `0` (단일 자릿수) / `없[음다]` / `no MUST FIX` 검출.
+    - `_has_positive_must_fix()` 신규 — 라인 단위 매칭. 매칭 라인 중 *부정 컨텍스트 아닌* 라인 1+ → True. 모두 부정 → False. mixed (positive 라인 + 부정 라인) → True (positive 우선).
+    - `_append_step_status` 의 `bool(_MUST_FIX_RE.search(prose))` → `_has_positive_must_fix(prose)`.
+  - **#3 engineer banner** (`agents/engineer.md`):
+    - H1 직후 architect sub-mode 패턴 동일 1 블록 — 자장 4 stall 실측 (614/1102/429/670s) 명시.
+  - **#4 cap mismatch** (`harness/session_state.py`):
+    - `_append_step_status` 의 `_extract_prose_summary(prose, max_lines=4)` → `max_lines=12` (5~12 룰 정합). ECHO 임계 `< 3` 유지 (실 2-liner 케이스 검출).
+  - **신규 7 테스트** — `ResolveProsePathTests` (5) + `test_must_fix_negation_no_false_positive` + `test_must_fix_positive_still_detected`. 281 → 288 ran / all PASS.
+  - **자장 run-ef6c2c00 회귀 직접 검증** — `parse_steps` 후 9 engineer step 중 b1~b3 (= idx 2/7/12) anchor=True 회복 확인. b4~b8 (idx 17/22/27/29/34/37) 은 staging 자체 anchor 부재 → 진짜 위반 6건 (메인 행동 룰).
+- **Follow-Up**:
+  - 진짜 6 MISSING_SELF_VERIFY (b4-b8 staging anchor 부재) 는 메인 행동. dcness-guidelines.md §자가 검증 룰 강도 ↑ 또는 staging template 도입 후속 별 task.
+  - TOOL_USE_OVERFLOW 1건 (batch 06 112 tools) — agent self-discipline. hint 강도 ↑ 또는 IMPL_PARTIAL 임계 자동 trigger 후속.
+  - ECHO_VIOLATION 8 케이스 (실 2-liner) — 메인 가시성 룰 행동 변화. cap 12 정합 후 룰 인식 재교육 후속.
+  - 다른 patterns (PLACEHOLDER_LEAK / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_*) — 본 path fix 로 정확도 자동 회복. 별 검증 후속.
+
 ### DCN-CHG-20260501-08
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,21 @@
 
 ## Records
 
+### DCN-CHG-20260501-09
+- **Date**: 2026-05-01
+- **Change-Type**: harness, agent, test, ci
+- **Files Changed**:
+  - `scripts/check_python_tests.sh` — pre-commit hook 안에서 git env vars (`GIT_INDEX_FILE` / `GIT_DIR` / `GIT_WORK_TREE` / `GIT_PREFIX` / `GIT_EXEC_PATH`) inherited → 자식 `git worktree add` fail 회귀 해소. `env -u <vars>` 로 unset 후 unittest 실행.
+  - `harness/run_review.py` — `_resolve_prose_path()` 신규 (`.prose-staging/<bN.agent-mode>.md` Nth occurrence 매칭). `parse_steps` 가 occurrence_counter 로 같은 (agent, mode) N번째 staging 파일 매칭. fallback = legacy `<run_dir>/<agent>-<mode>.md`.
+  - `harness/session_state.py` — `_MUST_FIX_NEGATION_RE` + `_has_positive_must_fix()` 신규 (라인 단위 negation 컨텍스트 검사). `_append_step_status` 의 must_fix 검출 + `prose_excerpt` cap 4 → 12 (5~12 룰 정합).
+  - `agents/engineer.md` — H1 직후 `> ⚠️ CRITICAL — extended thinking 본문 드래프트 금지` banner 추가 (architect sub-mode 7 + product-planner 패턴 동일 적용).
+  - `tests/test_run_review.py` — `ResolveProsePathTests` 5 신규 (Nth occurrence / fallback / no mode / bare suffix / parse_steps end-to-end).
+  - `tests/test_session_state.py` — `test_must_fix_negation_no_false_positive` (자장 실 케이스 3) + `test_must_fix_positive_still_detected` (positive 3 케이스, mixed 포함).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: 자장 run-ef6c2c00 (40 step, $118.73, 28 waste finding) /run-review 결과 검증 — 4 이슈 한 번에 fix. (1) MISSING_SELF_VERIFY 9건 false positive = parser path mismatch (skill `.prose-staging/` write vs parser legacy `<run_dir>/` read). (2) MUST_FIX_GHOST 6건 false positive = "MUST FIX 0" / "MUST FIX 없음" 부정문 매칭. (3) THINKING_LOOP 4건 (614s/1102s/429s/670s stall) engineer banner 부재. (4) prose_excerpt cap 4 vs 룰 5~12 mismatch. 신규 7 테스트 / 288 ran / all PASS.
+
 ### DCN-CHG-20260501-08
 - **Date**: 2026-05-01
 - **Change-Type**: agent (commands/ 는 미분류이지만 사용자 가시 skill 변경 → governance trail 정책 정합)

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -202,6 +202,38 @@ def _parse_iso(ts: str) -> Optional[datetime]:
         return None
 
 
+def _resolve_prose_path(
+    run_dir: Path,
+    agent: str,
+    mode: Optional[str],
+    occurrence: int,
+) -> Path:
+    """Step 의 prose staging 파일 경로 해결 (DCN-CHG-20260501-09).
+
+    skill 컨벤션 (DCN-30-21): `<run_dir>/.prose-staging/<step>.md` 에 prose 작성.
+    `<step>` 명명 규칙:
+      - impl batch loop:        `b<N>.<agent>-<mode>.md`  (mode 있음)
+      - impl batch (no mode):   `b<N>.<agent>.md`
+      - 단발 skill (quick 등):  `<agent>-<mode>.md` 또는 `<agent>.md`
+
+    같은 (agent, mode) 가 여러 번 발생하면 lexical 정렬 후 N번째 occurrence 매칭
+    (b1 < b2 < b3 < bare suffix). DCN-CHG-20260430-23 path 격리 후 parser 가
+    legacy `<run_dir>/<agent>-<mode>.md` 만 읽어 매 step 동일 파일 회귀.
+
+    Fallback: `.prose-staging/` 부재 또는 미매칭 시 legacy `<run_dir>/<agent>-<mode>.md`.
+    """
+    suffix = f"{agent}-{mode}.md" if mode else f"{agent}.md"
+    staging = run_dir / ".prose-staging"
+    if staging.exists():
+        candidates = sorted(
+            p for p in staging.iterdir()
+            if p.is_file() and (p.name == suffix or p.name.endswith(f".{suffix}"))
+        )
+        if 0 <= occurrence < len(candidates):
+            return candidates[occurrence]
+    return run_dir / suffix
+
+
 def parse_steps(run_dir: Path) -> list[StepRecord]:
     steps: list[StepRecord] = []
     jsonl = run_dir / ".steps.jsonl"
@@ -217,10 +249,14 @@ def parse_steps(run_dir: Path) -> list[StepRecord]:
         except json.JSONDecodeError:
             continue
 
+    occurrence_counter: dict = {}
     for idx, rec in enumerate(raw):
         agent = rec.get("agent", "?")
         mode = rec.get("mode")
-        prose_path = run_dir / (f"{agent}-{mode}.md" if mode else f"{agent}.md")
+        key = (agent, mode)
+        occ = occurrence_counter.get(key, 0)
+        occurrence_counter[key] = occ + 1
+        prose_path = _resolve_prose_path(run_dir, agent, mode, occ)
         prose_full = ""
         if prose_path.exists():
             try:

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1206,6 +1206,38 @@ def _cli_end_step(args: Any) -> int:
 
 _MUST_FIX_RE = re.compile(r"\bMUST[\s_-]?FIX\b", re.IGNORECASE)
 
+# DCN-CHG-20260501-09: 부정 컨텍스트 검출 — pr-reviewer 가 prose 안
+# "MUST FIX 0" / "MUST FIX 0, NICE TO HAVE 6" / "MUST FIX 없음" / "no must fix"
+# 처럼 *부정* 의미로 토큰을 쓰는 케이스 false positive 차단.
+# 자장 run-ef6c2c00 실측 — 6 pr-reviewer step 모두 같은 패턴.
+_MUST_FIX_NEGATION_RE = re.compile(
+    r"\bMUST[\s_-]?FIX\b[\s:=]*"  # "MUST FIX" + 구두점/공백
+    r"(?:0(?!\s*\d)|없[음다])"      # 직후 "0" (단일 자릿수만, "10" 같은 다자릿 제외) 또는 "없음/없다"
+    r"|\bno\s+MUST[\s_-]?FIX\b",   # 또는 영어 "no MUST FIX"
+    re.IGNORECASE,
+)
+
+
+def _has_positive_must_fix(prose: str) -> bool:
+    """prose 안 MUST FIX 가 *positive* (실제 fix 요청) 의미로 등장했는지.
+
+    검사 절차:
+      1. `MUST FIX` 매칭 0개 → False (없음)
+      2. 라인 단위 — 매칭 라인 중 *부정 컨텍스트 아닌* 라인 1개 이상 → True
+      3. 모든 매칭 라인이 부정 컨텍스트 → False
+
+    DCN-CHG-20260501-09 규제 — 단순 단어경계 매칭의 false positive 차단.
+    """
+    if not _MUST_FIX_RE.search(prose):
+        return False
+    for line in prose.splitlines():
+        if not _MUST_FIX_RE.search(line):
+            continue
+        if _MUST_FIX_NEGATION_RE.search(line):
+            continue  # 부정 라인 — skip
+        return True
+    return False
+
 
 def _steps_jsonl_path(sid: str, rid: str, *, base_dir: Optional[Path] = None) -> Path:
     return run_dir(sid, rid, base_dir=base_dir) / ".steps.jsonl"
@@ -1225,8 +1257,8 @@ def _append_step_status(
         "agent": agent,
         "mode": mode,
         "enum": enum,
-        "prose_excerpt": _extract_prose_summary(prose, max_lines=4),
-        "must_fix": bool(_MUST_FIX_RE.search(prose)),
+        "prose_excerpt": _extract_prose_summary(prose, max_lines=12),
+        "must_fix": _has_positive_must_fix(prose),
     }
     target = _steps_jsonl_path(sid, rid)
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -32,7 +32,9 @@ if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|\.github/wor
 fi
 
 echo "[pytest-gate] harness/tests/agents 변경 감지 — 단위 테스트 실행"
-if ! python3 -m unittest discover -s tests >&2; then
+# DCN-CHG-20260501-09: pre-commit 안에서 git env vars (GIT_INDEX_FILE / GIT_DIR /
+# GIT_WORK_TREE) 가 inherited 되어 자식 git worktree add 호출이 fail. unset 후 실행.
+if ! env -u GIT_INDEX_FILE -u GIT_DIR -u GIT_WORK_TREE -u GIT_PREFIX -u GIT_EXEC_PATH python3 -m unittest discover -s tests >&2; then
   echo "[pytest-gate] FAIL — 단위 테스트 회귀. fix 후 재커밋. (우회: --no-verify, 룰 위반)" >&2
   exit 1
 fi

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -14,6 +14,7 @@ from harness.run_review import (  # noqa: E402
     RunReport, StepRecord, build_report, detect_goods, detect_wastes,
     parse_steps, render_report, list_runs, find_run_dir,
     _normalize_agent_type, assign_invocations_to_steps,
+    _resolve_prose_path,
     EXPECTED_AGENT_BUDGETS,
 )
 
@@ -67,6 +68,72 @@ class ParseStepsTests(unittest.TestCase):
             ], prose_files={"architect-SYSTEM_DESIGN.md": "## Domain Model\nEntity X\n"})
             steps = parse_steps(rd)
             self.assertIn("Domain Model", steps[0].prose_full)
+
+
+class ResolveProsePathTests(unittest.TestCase):
+    """DCN-CHG-20260501-09 — staging path resolution (.prose-staging Nth occurrence).
+
+    자장 run-ef6c2c00 회귀 — parser 가 legacy `<run_dir>/<agent>-<mode>.md` 만
+    읽어 9 engineer step 모두 같은 1 파일 매칭 → MISSING_SELF_VERIFY 9건
+    false positive.
+    """
+
+    def _setup(self, tmp: Path) -> Path:
+        rd = tmp / "run"
+        (rd / ".prose-staging").mkdir(parents=True)
+        return rd
+
+    def test_picks_nth_occurrence_in_staging(self):
+        with tempfile.TemporaryDirectory() as td:
+            rd = self._setup(Path(td))
+            (rd / ".prose-staging" / "b1.engineer-IMPL.md").write_text("b1 content")
+            (rd / ".prose-staging" / "b2.engineer-IMPL.md").write_text("b2 content")
+            (rd / ".prose-staging" / "b3.engineer-IMPL.md").write_text("b3 content")
+            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 0).read_text(), "b1 content")
+            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 1).read_text(), "b2 content")
+            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 2).read_text(), "b3 content")
+
+    def test_falls_back_to_legacy_run_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            rd = self._setup(Path(td))
+            (rd / "engineer-IMPL.md").write_text("legacy content")
+            # staging 빈 → fallback
+            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 0).read_text(), "legacy content")
+
+    def test_no_mode_uses_agent_only(self):
+        with tempfile.TemporaryDirectory() as td:
+            rd = self._setup(Path(td))
+            (rd / ".prose-staging" / "b1.pr-reviewer.md").write_text("pr1")
+            (rd / ".prose-staging" / "b2.pr-reviewer.md").write_text("pr2")
+            self.assertEqual(_resolve_prose_path(rd, "pr-reviewer", None, 0).read_text(), "pr1")
+            self.assertEqual(_resolve_prose_path(rd, "pr-reviewer", None, 1).read_text(), "pr2")
+
+    def test_bare_suffix_also_matches(self):
+        # 단발 skill 컨벤션 — bN prefix 없는 `<agent>-<mode>.md`
+        with tempfile.TemporaryDirectory() as td:
+            rd = self._setup(Path(td))
+            (rd / ".prose-staging" / "architect-LIGHT_PLAN.md").write_text("bare")
+            self.assertEqual(_resolve_prose_path(rd, "architect", "LIGHT_PLAN", 0).read_text(), "bare")
+
+    def test_parse_steps_resolves_per_occurrence(self):
+        # End-to-end — parse_steps 가 같은 (agent, mode) 의 N번째 staging 매칭하는지
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x"},
+                {"ts": "2026-04-30T10:05:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x"},
+            ])
+            (rd / ".prose-staging").mkdir()
+            (rd / ".prose-staging" / "b1.engineer-IMPL.md").write_text("first batch\n## 자가 검증\n- jest PASS")
+            (rd / ".prose-staging" / "b2.engineer-IMPL.md").write_text("second batch\nno anchor")
+            steps = parse_steps(rd)
+            self.assertEqual(len(steps), 2)
+            self.assertIn("first batch", steps[0].prose_full)
+            self.assertIn("second batch", steps[1].prose_full)
+            # 회귀 검증 — 두 step 이 *다른* 파일을 보는지
+            self.assertNotEqual(steps[0].prose_full, steps[1].prose_full)
 
 
 class WasteDetectionTests(unittest.TestCase):

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1557,6 +1557,67 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         records = _read_steps_jsonl("sid", "run-aaaa1111")
         self.assertTrue(records[0]["must_fix"])
 
+    def test_must_fix_negation_no_false_positive(self) -> None:
+        """DCN-CHG-20260501-09 — pr-reviewer 의 'MUST FIX 0' / 'MUST FIX 없음' 부정문은 must_fix=False.
+
+        자장 run-ef6c2c00 회귀 — 6 pr-reviewer step 모두 'MUST FIX 0, NICE TO HAVE 6' 패턴 →
+        단순 단어경계 regex 가 매칭 → MUST_FIX_GHOST 6건 false positive.
+        """
+        from harness.session_state import (
+            _append_step_status, _read_steps_jsonl, run_dir,
+            _clear_default_base_cache,
+        )
+        repo = Path(self._tmp.name) / "repo"
+        repo.mkdir()
+        os.chdir(repo)
+        _clear_default_base_cache()
+        run_dir("sid", "run-bbbb2222", create=True)
+        # 자장 실 케이스 그대로
+        _append_step_status(
+            "sid", "run-bbbb2222", "pr-reviewer", None, "LGTM",
+            "MUST FIX 0, NICE TO HAVE 6 (let tree: any / dead code).\nLGTM\n",
+        )
+        _append_step_status(
+            "sid", "run-bbbb2222", "pr-reviewer", None, "LGTM",
+            "MUST FIX: 0\n결론: LGTM\n",
+        )
+        _append_step_status(
+            "sid", "run-bbbb2222", "pr-reviewer", None, "LGTM",
+            "검토 결과: MUST FIX 없음. NICE TO HAVE 3.\nLGTM\n",
+        )
+        records = _read_steps_jsonl("sid", "run-bbbb2222")
+        for r in records:
+            self.assertFalse(r["must_fix"], f"false positive: {r['prose_excerpt'][:60]}")
+
+    def test_must_fix_positive_still_detected(self) -> None:
+        """negation regex 가 *진짜* MUST FIX 케이스는 정확히 검출."""
+        from harness.session_state import (
+            _append_step_status, _read_steps_jsonl, run_dir,
+            _clear_default_base_cache,
+        )
+        repo = Path(self._tmp.name) / "repo"
+        repo.mkdir()
+        os.chdir(repo)
+        _clear_default_base_cache()
+        run_dir("sid", "run-cccc3333", create=True)
+        _append_step_status(
+            "sid", "run-cccc3333", "pr-reviewer", None, "CHANGES_REQUESTED",
+            "## MUST FIX\n- audio buffer underflow on iOS\n",
+        )
+        _append_step_status(
+            "sid", "run-cccc3333", "pr-reviewer", None, "CHANGES_REQUESTED",
+            "MUST FIX: storage 키 충돌 가능\nLGTM 후보 X\n",
+        )
+        # mixed — 부정 라인 + positive 라인 → True (positive 우선)
+        _append_step_status(
+            "sid", "run-cccc3333", "pr-reviewer", None, "CHANGES_REQUESTED",
+            "MUST FIX 0\nMUST FIX: 실제 이슈 발견\n",
+        )
+        records = _read_steps_jsonl("sid", "run-cccc3333")
+        self.assertEqual(len(records), 3)
+        for r in records:
+            self.assertTrue(r["must_fix"], f"missed positive: {r['prose_excerpt'][:60]}")
+
     def test_finalize_run_outputs_status_json(self) -> None:
         from harness.session_state import (
             _cli_finalize_run, _append_step_status,


### PR DESCRIPTION
## Summary
자장 run-ef6c2c00 (40 step / \$118.73 / 28 waste finding) 검증 후 4 이슈 한 번에 fix. 사용자 직접 분류 + 메인 직접 검증.

## #1 prose_path bug (가장 결정적 — 9건 false positive 제거)
skill 은 DCN-30-21 부터 \`<run_dir>/.prose-staging/<bN.agent-mode>.md\` 에 prose 작성, 그러나 \`run_review.py:223\` 는 legacy \`<run_dir>/<agent>-<mode>.md\` 만 읽음. **9 engineer step 모두 같은 1 파일 매칭** → MISSING_SELF_VERIFY 9건 false positive.

**Fix**: \`_resolve_prose_path()\` 신규 — \`.prose-staging/\` lexical 정렬 후 같은 (agent, mode) Nth occurrence 매칭. fallback = legacy \`<run_dir>/<agent>-<mode>.md\`.

**자장 실 데이터 검증**:
\`\`\`
step 2  engineer/IMPL → anchor: True ✓ (b1.engineer-IMPL.md)
step 7  engineer/IMPL → anchor: True ✓ (b2.engineer-IMPL.md)
step 12 engineer/IMPL → anchor: True ✓ (b3.engineer-IMPL.md)
step 17~37 engineer  → anchor: False (b4-b8 staging 자체 anchor 부재 — 진짜 위반)
\`\`\`

## #2 MUST_FIX_GHOST regex bug (6건 false positive 제거)
\`_MUST_FIX_RE\` 단순 단어경계 → "MUST FIX 0, NICE TO HAVE 6" 부정문 매칭. 자장 6 pr-reviewer step 모두 같은 패턴.

**Fix**: \`_has_positive_must_fix()\` — 라인 단위 negation 컨텍스트 검사. \`MUST FIX 0\` / \`MUST FIX 없음\` / \`no MUST FIX\` skip. positive 1+ → True. mixed → True.

## #3 engineer banner (THINKING_LOOP 4건 회귀 차단)
agents/engineer.md grep — \`extended thinking\` / \`드래프트 금지\` / \`CRITICAL\` 0 hit. architect sub-mode 7 + product-planner 만 banner 있음. engineer 누락.

**Fix**: H1 직후 \`⚠️ CRITICAL — extended thinking 본문 드래프트 금지\` 1 블록. 자장 4 stall (614/1102/429/670s) 실측 명시.

## #4 prose_excerpt cap 4 → 12 (룰 정합)
\`_append_step_status(max_lines=4)\` vs ECHO_VIOLATION 메시지 "5~12 룰" mismatch. cap 12 정합. ECHO 임계 \`< 3\` 유지.

## 추가 fix (게이트 인프라)
- \`scripts/check_python_tests.sh\` — pre-commit 안 git env vars (\`GIT_INDEX_FILE\` 등) inherited → 자식 \`git worktree add\` fail. \`env -u\` unset.

## 거버넌스
- **Task-ID**: \`DCN-CHG-20260501-09\` (단일)
- **Change-Type**: harness, agent, test, ci
- **Document Sync**: PASS (9 files, agent+docs-only+harness+ci+test)
- **Test**: 281 → 288 ran / all PASS / 회귀 0
- **신규 7 테스트**: ResolveProsePathTests (5) + must_fix negation/positive (2)
- **동반 갱신**: \`document_update_record.md\` / \`change_rationale_history.md\` / \`PROGRESS.md\`

## Follow-Up (별 task)
- 진짜 6 MISSING_SELF_VERIFY (b4-b8 staging anchor 부재) — 메인 행동 룰 강도 ↑
- TOOL_USE_OVERFLOW 1건 (batch 06 112 tools) — agent self-discipline / hint 강도 ↑
- 다른 patterns (PLACEHOLDER_LEAK / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_*) — path fix 로 자동 회복, 별 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)