### PR TITLE
fix: /run-review must_fix retro 재계산 (DCN-CHG-20260501-10)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,11 @@
 
 ## 현재 상태
 
+- **♻️ /run-review must_fix retro 재계산** (`DCN-CHG-20260501-10`):
+  - DCN-CHG-20260501-09 forward-only 보강 — 이전 run 의 `.steps.jsonl` stale `must_fix` 무력화. parser `parse_steps()` 가 prose_full 보유 시 `_has_positive_must_fix` 재계산, 부재 시 jsonl fallback.
+  - 자장 run-ef6c2c00 (이전 PR 머지 *전* 작성된 stale jsonl) retro 검증 — MUST_FIX_GHOST 6 → 0.
+  - source 분리 자각: finalize-run (session_state) 은 jsonl 사용 (실시간 fresh, 정확). parser (run_review) 는 prose 재계산 (retro 정확). 의도적 분리.
+  - 신규 2 테스트 (recompute / fallback). 288 → 290 ran / all PASS.
 - **🔧 /run-review 4 false positive 동시 fix (자장 run-ef6c2c00)** (`DCN-CHG-20260501-09`):
   - 자장 40 step / $118.73 run /run-review 결과 28 waste finding 검증 — 4 이슈 한 번에 fix.
   - **#1 prose_path bug** (가장 결정적): skill DCN-30-21 부터 `<run_dir>/.prose-staging/<bN.agent-mode>.md` 에 prose 작성, 그러나 parser 가 legacy `<run_dir>/<agent>-<mode>.md` 만 읽음 → 9 engineer step 모두 같은 1 파일 매칭 → MISSING_SELF_VERIFY 9건 false positive. `_resolve_prose_path()` 신규 — Nth occurrence 매칭 + fallback. 자장 실 데이터로 b1~b3 anchor=True 회복 확인.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,23 @@
 
 ## Records
 
+### DCN-CHG-20260501-10
+- **Date**: 2026-05-01
+- **Rationale**:
+  - DCN-CHG-20260501-09 forward-only 한계 — `_append_step_status` 신규 negation-aware regex 가 *기록 시점* 만 적용. 이전 run 의 `.steps.jsonl` 은 stale must_fix 보유 → retro `/run-review` 시 MUST_FIX_GHOST 동일 false positive 잔재. 사용자 지적 — "회고 정확도".
+  - 본질 — `.steps.jsonl` 의 must_fix 는 helper 시점 산출물 (snapshot). parser 는 prose 직접 보유 (이미 prose_full read). prose 가 진짜 source of truth → parser 측에서 재계산 가능.
+- **Alternatives**:
+  1. *옵션 A — parser parse_steps 재계산* (prose_full 있을 때 `_has_positive_must_fix`, 없으면 jsonl fallback). 5줄 + 테스트 2. **(채택)**.
+  2. *옵션 B — 일회성 migration script* (모든 `.steps.jsonl` walk + 재계산 + atomic rewrite). 큰 blast radius. version data. 단발 효용 < 옵션 A.
+  3. *옵션 C — 현 상태 유지 (forward-only)*. 신규 run 은 깨끗하지만 retro 폴루션. 사용자 명시 거부.
+- **Decision**:
+  - 옵션 A 채택. `harness/run_review.py` 에 `_has_positive_must_fix` import (session_state) + `parse_steps()` 안 prose_full 보유 시 재계산.
+  - **Source 분리 자각** — `finalize-run` (session_state) 은 여전히 jsonl `must_fix` 사용. 단 finalize-run 은 *run 중* 호출 (실시간 fresh, DCN-CHG-20260501-09 신규 regex 적용) → 신규 run 은 정확. retro 분석은 parser 만 → 두 측 의도적 분리.
+  - **자장 run-ef6c2c00 retro 검증** — `parse_steps` + `detect_wastes` → MUST_FIX_GHOST 6 → 0 직접 확인.
+  - **신규 2 테스트** — recompute (legacy stale → False 정정) + fallback (prose 부재 → jsonl 신뢰).
+- **Follow-Up**:
+  - 옵션 B (jsonl migration) 도입 검토 — 사용자 다른 retro analysis 도구가 jsonl 직접 읽으면 source 분리 혼란. 본 task 범위 외, 후속 측정.
+
 ### DCN-CHG-20260501-09
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260501-10
+- **Date**: 2026-05-01
+- **Change-Type**: harness, test
+- **Files Changed**:
+  - `harness/run_review.py` — `_has_positive_must_fix` import (session_state). `parse_steps()` 가 `prose_full` 보유 시 `_has_positive_must_fix(prose_full)` 로 must_fix 재계산. 부재 시 jsonl `must_fix` fallback. retro 분석 정확도 회복.
+  - `tests/test_run_review.py` — `test_parse_steps_recomputes_must_fix_from_prose` (legacy stale jsonl + 신규 prose negation → False 정정) + `test_parse_steps_must_fix_falls_back_to_jsonl` (prose 부재 fallback).
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: DCN-CHG-20260501-09 forward-only 한계 보강. 자장 run-ef6c2c00 (이전 PR 머지 *전* 작성된 stale jsonl) 재 review 시 MUST_FIX_GHOST 6 → 0 retro 회복 직접 검증. 290 ran / all PASS.
+
 ### DCN-CHG-20260501-09
 - **Date**: 2026-05-01
 - **Change-Type**: harness, agent, test, ci

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -35,6 +35,16 @@ except Exception:
     def price_for(_model: str) -> dict:  # type: ignore
         return {"in": 15.0, "out": 75.0, "cw5": 18.75, "cw1h": 30.0, "cr": 1.50}
 
+# DCN-CHG-20260501-10: must_fix retroactive recompute.
+# .steps.jsonl 의 must_fix 는 *기록 시점* helper regex 산출물 — DCN-CHG-20260501-09
+# 이전 데이터는 단순 단어경계 매칭의 false positive 포함. parser 가 prose_full 보유 시
+# 신규 negation-aware regex 로 재계산. prose_full 부재 시 jsonl fallback.
+try:
+    from harness.session_state import _has_positive_must_fix
+except Exception:
+    def _has_positive_must_fix(_prose: str) -> bool:  # type: ignore
+        return False
+
 # ── 상수 ───────────────────────────────────────────────────────────────
 
 EXPECTED_FINAL_ENUMS = {
@@ -263,13 +273,19 @@ def parse_steps(run_dir: Path) -> list[StepRecord]:
                 prose_full = prose_path.read_text(encoding="utf-8")
             except OSError:
                 prose_full = ""
+        # DCN-CHG-20260501-10: prose_full 보유 시 must_fix 재계산 (negation-aware).
+        # 부재 시 jsonl `must_fix` fallback (legacy / staging missing).
+        if prose_full:
+            must_fix = _has_positive_must_fix(prose_full)
+        else:
+            must_fix = bool(rec.get("must_fix"))
         steps.append(StepRecord(
             idx=idx,
             ts=rec.get("ts", ""),
             agent=agent,
             mode=mode,
             enum=rec.get("enum", ""),
-            must_fix=bool(rec.get("must_fix")),
+            must_fix=must_fix,
             prose_excerpt=rec.get("prose_excerpt", ""),
             prose_full=prose_full,
         ))

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -115,6 +115,41 @@ class ResolveProsePathTests(unittest.TestCase):
             (rd / ".prose-staging" / "architect-LIGHT_PLAN.md").write_text("bare")
             self.assertEqual(_resolve_prose_path(rd, "architect", "LIGHT_PLAN", 0).read_text(), "bare")
 
+    def test_parse_steps_recomputes_must_fix_from_prose(self):
+        """DCN-CHG-20260501-10 — prose_full 있을 때 must_fix 재계산 (retro accuracy).
+
+        legacy `.steps.jsonl` 에 must_fix=True 기록됐어도 prose 가 "MUST FIX 0" 부정문이면
+        parser 가 must_fix=False 로 정정. 자장 run-ef6c2c00 6 false positive retro 회복 시나리오.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                # legacy regex stale data — must_fix=True 기록됐지만 prose 는 negation
+                {"ts": "2026-04-30T10:00:00", "agent": "pr-reviewer", "mode": None,
+                 "enum": "LGTM", "must_fix": True,
+                 "prose_excerpt": "MUST FIX 0, NICE TO HAVE 6\nLGTM"},
+            ])
+            (rd / ".prose-staging").mkdir()
+            (rd / ".prose-staging" / "pr-reviewer.md").write_text(
+                "MUST FIX 0, NICE TO HAVE 6 (let tree: any / dead code).\nLGTM\n"
+            )
+            steps = parse_steps(rd)
+            self.assertEqual(len(steps), 1)
+            self.assertFalse(steps[0].must_fix, "negation 부정문 → False 재계산")
+
+    def test_parse_steps_must_fix_falls_back_to_jsonl(self):
+        """prose_full 부재 시 jsonl `must_fix` fallback (legacy 데이터 보존)."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "validator", "mode": "CODE_VALIDATION",
+                 "enum": "FAIL", "must_fix": True, "prose_excerpt": "x"},
+            ])
+            # staging 자체 없음 — fallback 시나리오
+            steps = parse_steps(rd)
+            self.assertEqual(len(steps), 1)
+            self.assertTrue(steps[0].must_fix, "prose 부재 → jsonl fallback")
+
     def test_parse_steps_resolves_per_occurrence(self):
         # End-to-end — parse_steps 가 같은 (agent, mode) 의 N번째 staging 매칭하는지
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary
이전 task forward-only 한계 보강. \`.steps.jsonl\` 의 stale \`must_fix\` 무력화 — \`parse_steps()\` 가 \`prose_full\` 보유 시 \`_has_positive_must_fix\` 재계산, 부재 시 jsonl fallback.

## 문제
이전 PR (-09) 의 \`_has_positive_must_fix\` 는 \`_append_step_status\` *기록 시점* 만 적용. 이전 run 의 jsonl 은 stale must_fix 보유 → retro \`/run-review\` 시 MUST_FIX_GHOST 동일 false positive 잔재. 사용자 직접 지적.

## Fix
- \`harness/run_review.py\` — \`_has_positive_must_fix\` import (session_state 재사용). \`parse_steps()\` 안 prose_full 보유 시 재계산 / 부재 시 jsonl fallback.
- 자장 run-ef6c2c00 retro 직접 검증 — MUST_FIX_GHOST **6 → 0**.

## Source 분리 자각
- **finalize-run** (\`session_state.py\`) — jsonl \`must_fix\` 사용. *run 중* 호출 = 실시간 fresh = -09 신규 regex 적용 = 정확.
- **parser** (\`run_review.py\`) — prose 재계산. retro 분석 = 이전 stale jsonl 무력화 = 정확.
- 의도적 분리 — 두 측 source-of-truth 다름 정합.

## 거버넌스
- **Task-ID**: \`DCN-CHG-20260501-10\` (단일)
- **Change-Type**: harness, test
- **Document Sync**: PASS (5 files, harness+test+docs-only)
- **Test**: 288 → 290 ran / all PASS / 회귀 0
- **신규 2 테스트**: recompute (legacy stale → False 정정) + fallback (prose 부재 → jsonl 신뢰)

🤖 Generated with [Claude Code](https://claude.com/claude-code)