### PR TITLE
feat: sub 행동 사후 추적 인프라 (DCN-CHG-20260501-11)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,15 @@
 
 ## 현재 상태
 
+- **🪝 sub 행동 사후 추적 인프라 (PR-1)** (`DCN-CHG-20260501-11`):
+  - 사용자 비전 — 정적 룰 추가 게임 → 추론 기반 judgment 로 패러다임 전환. 4축: 결과 평가 / 행동 추적 / audit log / 학습 진화 (2-layer). PR-1 은 (2)+(3) 코드 인프라만.
+  - **`harness/redo_log.py`** 신규 — `redo-log.jsonl` append/read/tail. 메인이 sub completion 평가 후 PASS/REDO_SAME/REDO_BACK/REDO_DIFF 1줄 기록. POSIX O_APPEND atomic, 4096 bytes 이내 entry. 15 tests.
+  - **`harness/agent_trace.py`** 신규 — `agent-trace.jsonl` append/read/tail. PreToolUse/PostToolUse hook 가 sub 내부 도구 호출마다 1줄 기록. 11 tests.
+  - **`harness/hooks.py` 확장** — `handle_pretooluse_file_op` boundary 통과 시 trace pre append + 신규 `handle_posttooluse_file_op` (PostToolUse Edit/Write/Read/Bash) + CLI subcommand. tool_input 200 bytes truncate (POSIX atomic 보장).
+  - **`hooks/post-file-op-trace.sh`** 신규 wrapper + `hooks/hooks.json` PostToolUse `Edit|Write|Read|Bash` matcher 등록.
+  - **한계 명시**: hook trace = sub *행동* 만. thinking / 중간 message X (`.output` 가공은 P7 미래). 도구 0번 쓰는 sub turn = trace 텅 빔.
+  - **PR-2 (DCN-CHG-20260501-12)** 후속 — SessionStart 감시자 hat 메시지 + `commands/audit-redo.md` skill (Layer 1+2 학습 진화).
+  - 회귀 0 — 신규 35 case (15+11+9), 전체 324 tests OK. 토큰 비용 0 (hook LLM context 외부).
 - **♻️ /run-review must_fix retro 재계산** (`DCN-CHG-20260501-10`):
   - DCN-CHG-20260501-09 forward-only 보강 — 이전 run 의 `.steps.jsonl` stale `must_fix` 무력화. parser `parse_steps()` 가 prose_full 보유 시 `_has_positive_must_fix` 재계산, 부재 시 jsonl fallback.
   - 자장 run-ef6c2c00 (이전 PR 머지 *전* 작성된 stale jsonl) retro 검증 — MUST_FIX_GHOST 6 → 0.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,35 @@
 
 ## Records
 
+### DCN-CHG-20260501-11
+- **Date**: 2026-05-01
+- **Rationale**:
+  - 사용자 비전 (장 토론 산출물): "정적 룰 (path matrix / 도구 화이트리스트) 추가 게임은 끝 없다. 프로젝트 변형마다 화이트리스트 폭발". 룰 5개 cap + 추론 기반 judgment 로 패러다임 전환.
+  - 비전 핵심 4축 (`/Users/dc.kim/.claude/plans/vast-singing-donut.md`): (1) 메인이 sub completion 결과 *깐깐히* 평가 + redo 권한 적극 행사, (2) sub 행동 hook 로 사후 추적, (3) audit log 누적, (4) 학습 진화 (Layer 1 즉시 prompt 첨가, Layer 2 dcness 인프라 환류).
+  - **본 PR (PR-1)** 은 (2) 와 (3) 의 *코드 인프라* 만 — `redo_log.py` + `agent_trace.py` + hook 확장. (1) 과 (4) 는 PR-2 (DCN-CHG-20260501-12) 에서 SessionStart 메시지 + audit-redo skill.
+  - **실시간 polling 폐기** — auto-wakeup 인프라 1일+ + 토큰 비용 30k/sub. 사용자 결정 — "결과 후 평가 + 학습" 으로 충분. 폴링은 P8 미래.
+  - **`.output` 직접 read 폐기** — 시스템 명시 금지 (context 폭발). hook trace + completion notification `<result>` + `<usage>` 만으로 redo 결정 80%+ cover. thinking / 중간 message 추적은 P7 미래.
+- **Alternatives**:
+  1. **외부 supervisor sub-agent** — fresh context 매 호출 → 시계열 누적 판단 X. *기각*.
+  2. **메인 self-review** — 같은 머리 + 같은 맥락 → cognitive lock-in 심화 위험. *기각*.
+  3. **Hook 차단 → sensor 강등** — 현 catastrophic-gate / file-guard 매일 작동 중. 강등 = 안전 후퇴. *기각*.
+  4. **agent-trace + redo-log 분리 vs 단일 파일** — 두 용도 schema 다름 (행동 stream vs 평가 결정). 분리 유지. *채택*.
+  5. **(채택)** **PreToolUse 끝 + PostToolUse 신규** — boundary 통과 행동만 trace, 차단된 행동은 file-guard stderr 로 별도 기록. 단순함 우선 (Karpathy 2). 향후 *모든 시도* 기록 보강 가능.
+- **Decision**:
+  - `harness/redo_log.py` + `harness/agent_trace.py` 분리. 동일 패턴 (append/read_all/tail) 단일 함수 추출 보류 — 단일 사용처 추상화 회피 (Karpathy 2).
+  - 기존 `handle_pretooluse_file_op` 끝 (return 0 직전) 에 trace pre append. 차단 시 (return 1 직전) 미기록.
+  - 신규 `handle_posttooluse_file_op` + `hooks/post-file-op-trace.sh` wrapper + `hooks.json` PostToolUse `Edit|Write|Read|Bash` matcher 등록.
+  - **트레이드오프 명시 (대원칙 §0 self-check)**: 본 변경은 *관측 인프라* — 작업 순서 / 접근 영역 강제 X. agent 자율 침해 0.
+  - tool_input 핵심을 200 bytes 로 truncate (`_summarize_input`) — POSIX append atomic 4096 bytes 이내 보장.
+  - trace append 모든 실패 silent (`_append_trace_safe`) — hook 본 흐름 (boundary 검사) 방해 X.
+- **Follow-Up**:
+  - **(PR-2 / DCN-CHG-20260501-12)** SessionStart 감시자 hat 메시지 + `commands/audit-redo.md` skill (Layer 1 즉시 첨가 + Layer 2 환류 patch 제안).
+  - **(P5 운영)** 1-2 주 redo-log + trace 수집 → 패턴 추출 정확도 측정.
+  - **(P6 환류 / 주기)** N 프로젝트 검증된 패턴 → `agents/*.md` system prompt 영구 patch → plugin release.
+  - **(P7 미래)** `.output` JSONL 가공 helper — sub thinking + 중간 message 추적이 redo 결정에 *현저히 가치* 있다고 측정 시.
+  - **(P8 미래)** Auto-wakeup polling skill — sub 헛수고 토큰 손실이 결정적이라 측정 시.
+  - **(측정)** 1-2 주 후: sub spawn 평균 `tool_uses` / completion 평균 `duration_ms` / redo-log 카테고리 분포.
+
 ### DCN-CHG-20260501-10
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,23 @@
 
 ## Records
 
+### DCN-CHG-20260501-11
+- **Date**: 2026-05-01
+- **Change-Type**: harness, hooks, test
+- **Files Changed**:
+  - `harness/redo_log.py` (신규 — sub cycle 평가 audit log append/read/tail)
+  - `harness/agent_trace.py` (신규 — sub 행동 trace append/read/tail)
+  - `harness/hooks.py` (`handle_pretooluse_file_op` boundary 통과 시 trace pre append + `handle_posttooluse_file_op` 신규 + CLI subcommand 추가)
+  - `hooks/post-file-op-trace.sh` (신규 — PostToolUse Edit/Write/Read/Bash wrapper)
+  - `hooks/hooks.json` (PostToolUse Edit/Write/Read/Bash matcher 등록)
+  - `tests/test_redo_log.py` (신규 — 15 case)
+  - `tests/test_agent_trace.py` (신규 — 11 case)
+  - `tests/test_hooks.py` (`FileOpTraceTests` + `PostToolUseFileOpTests` 신규 — 9 case)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: PR-1 — sub 행동 사후 추적 인프라. PreToolUse/PostToolUse hook 가 sub 내부 `Edit/Write/Read/Bash` 호출마다 `agent-trace.jsonl` 1줄 append (boundary 통과 시만). 메인이 sub completion notification 평가 후 `redo-log.jsonl` 에 PASS/REDO 결정 1줄 기록 (PR-2 에서 SessionStart 메시지 + skill 추가). *행동* 만 cover — thinking / 중간 message 추적은 미래 P7 (`.output` 가공 helper). 토큰 비용 0 (hook LLM context 외부). 신규 35 case + 전체 324 tests OK / 회귀 0.
+
 ### DCN-CHG-20260501-10
 - **Date**: 2026-05-01
 - **Change-Type**: harness, test

--- a/harness/agent_trace.py
+++ b/harness/agent_trace.py
@@ -1,0 +1,108 @@
+"""agent_trace — sub-agent 행동 사후 추적 trace (DCN-CHG-20260501-11).
+
+PreToolUse / PostToolUse hook 에서 sub 내부 도구 호출마다 1줄 append.
+저장 위치: `.sessions/{sid}/runs/{rid}/agent-trace.jsonl`.
+
+cover (행동만):
+    - 도구 호출 + 입력 (Pre)
+    - 도구 결과 metadata (Post — exit code 등)
+
+cover 안 함 (한계):
+    - sub 의 thinking / 중간 assistant message (`.output` 가공 helper 별도)
+    - 도구 0번 쓰는 sub turn (trace 텅 빔)
+
+Schema (강제 X — 권장 필드):
+    ts          (auto)  ISO8601 UTC, 미지정 시 자동 추가
+    phase               "pre" | "post"
+    agent_id            sub task id (메인 hook 발화 시 비어있을 수 있음)
+    agent               subagent type (engineer / architect / ...)
+    tool                Edit / Write / Read / Bash / NotebookEdit
+    input               (pre)  tool_input 의 핵심 (file_path / command 앞부분)
+    exit                (post) exit code (Bash) 또는 0/1 (Edit/Write)
+    stdout_size         (post) 결과 크기 (Bash)
+
+규약:
+    - jsonl, POSIX O_APPEND atomic (4096 bytes 이내)
+    - read 시 malformed line skip
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from harness.session_state import run_dir
+
+
+__all__ = ["append", "read_all", "tail", "TRACE_NAME"]
+
+
+TRACE_NAME = "agent-trace.jsonl"
+
+
+def _trace_path(
+    session_id: str, run_id: str, *, base_dir: Optional[Path] = None
+) -> Path:
+    return run_dir(session_id, run_id, base_dir=base_dir, create=True) / TRACE_NAME
+
+
+def append(
+    session_id: str,
+    run_id: str,
+    entry: Dict[str, Any],
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """agent-trace.jsonl 에 1줄 append. ts 미지정 시 자동.
+
+    POSIX O_APPEND atomic — 4096 bytes 이내 entry 동시 write 안전.
+    """
+    if not isinstance(entry, dict):
+        raise TypeError(f"entry must be dict, got {type(entry).__name__}")
+    if "ts" not in entry:
+        entry = {"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), **entry}
+    line = json.dumps(entry, ensure_ascii=False, separators=(",", ":")) + "\n"
+    target = _trace_path(session_id, run_id, base_dir=base_dir)
+    fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+def read_all(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """모든 entry 반환. 비존재 / 빈 → []. malformed skip."""
+    target = _trace_path(session_id, run_id, base_dir=base_dir)
+    if not target.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    with open(target, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def tail(
+    session_id: str,
+    run_id: str,
+    n: int = 10,
+    *,
+    base_dir: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """마지막 n entry."""
+    if n <= 0:
+        return []
+    return read_all(session_id, run_id, base_dir=base_dir)[-n:]

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -40,7 +40,46 @@ __all__ = [
     "handle_pretooluse_agent",
     "handle_pretooluse_file_op",
     "handle_posttooluse_agent",
+    "handle_posttooluse_file_op",
 ]
+
+
+# ── DCN-CHG-20260501-11 — agent-trace.jsonl 헬퍼 ──────────────────────
+
+
+_TRACE_INPUT_MAX = 200  # entry size cap (POSIX append atomic = 4096 bytes 이내)
+
+
+def _summarize_input(tool_name: str, tool_input: Dict[str, Any]) -> str:
+    """tool_input 핵심을 _TRACE_INPUT_MAX bytes 이하로 요약."""
+    if not isinstance(tool_input, dict):
+        return ""
+    if tool_name == "Bash":
+        s = str(tool_input.get("command", ""))
+    elif tool_name in ("Edit", "Write", "NotebookEdit", "Read"):
+        s = str(tool_input.get("file_path", "") or tool_input.get("path", ""))
+    elif tool_name in ("Glob", "Grep"):
+        s = str(tool_input.get("pattern", ""))
+    else:
+        s = ""
+    if len(s) > _TRACE_INPUT_MAX:
+        s = s[:_TRACE_INPUT_MAX] + "..."
+    return s
+
+
+def _append_trace_safe(
+    sid: str,
+    rid: str,
+    entry: Dict[str, Any],
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """trace append — 어떤 실패도 hook 본 흐름 방해 X."""
+    try:
+        from harness.agent_trace import append as _trace_append
+        _trace_append(sid, rid, entry, base_dir=base_dir)
+    except Exception:  # noqa: BLE001 — silent
+        pass
 
 
 # orchestration.md §7.1 — 컨베이어 경유 필수 agent
@@ -295,7 +334,7 @@ def handle_pretooluse_file_op(
 
     cwd = Path.cwd()
 
-    # Read — `file_path` 직접.
+    # boundary 검사 — 차단 시 즉시 return (trace 미기록 — 차단된 행동은 file-guard 가 stderr 에 별도 기록)
     if tool_name == "Read":
         fp = tool_input.get("file_path", "") or ""
         if fp:
@@ -303,28 +342,99 @@ def handle_pretooluse_file_op(
             if reason:
                 print(f"[agent-boundary] {reason}", file=sys.stderr)
                 return 1
-        return 0
-
-    # Edit / Write / NotebookEdit — `file_path` 직접 = write op.
-    if tool_name in ("Edit", "Write", "NotebookEdit"):
+    elif tool_name in ("Edit", "Write", "NotebookEdit"):
         fp = tool_input.get("file_path", "") or ""
         if fp:
             reason = check_write_allowed(active_agent, fp, cwd=cwd)
             if reason:
                 print(f"[agent-boundary] {reason}", file=sys.stderr)
                 return 1
-        return 0
-
-    # Bash — heuristic. write indicator (sed -i / cp / mv / rm / >) 시만 path 추출.
-    if tool_name == "Bash":
+    elif tool_name == "Bash":
         cmd = tool_input.get("command", "") or ""
         for fp in extract_bash_paths(cmd):
             reason = check_write_allowed(active_agent, fp, cwd=cwd)
             if reason:
                 print(f"[agent-boundary][Bash] {reason}", file=sys.stderr)
                 return 1
+
+    # DCN-CHG-20260501-11 — sub 행동 trace append (rid 활성 시만)
+    rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
+    if rid:
+        _append_trace_safe(
+            sid,
+            rid,
+            {
+                "phase": "pre",
+                "agent": active_agent,
+                "agent_id": stdin_data.get("agent_id", "") or "",
+                "tool": tool_name,
+                "input": _summarize_input(tool_name, tool_input),
+            },
+            base_dir=base_dir,
+        )
+    return 0
+
+
+def handle_posttooluse_file_op(
+    stdin_data: Optional[Dict[str, Any]] = None,
+    cc_pid: Optional[int] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """PostToolUse Edit/Write/Read/Bash — sub 행동 trace post append (DCN-CHG-20260501-11).
+
+    활성 sub-agent 가 있을 때만 기록. 메인 Claude turn 은 noop.
+    PostToolUse 는 차단 권한 X — 항상 exit 0.
+    """
+    if stdin_data is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_data = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError):
+            return 0
+
+    if not isinstance(stdin_data, dict):
         return 0
 
+    sid = _extract_sid(stdin_data)
+    if not valid_session_id(sid):
+        return 0
+
+    live = read_live(sid, base_dir=base_dir) or {}
+    active_agent = live.get("active_agent") or ""
+    if not active_agent:
+        return 0
+
+    rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
+    if not rid:
+        return 0
+
+    tool_name = stdin_data.get("tool_name", "") or ""
+    tool_response = stdin_data.get("tool_response") or {}
+    if not isinstance(tool_response, dict):
+        tool_response = {}
+
+    entry: Dict[str, Any] = {
+        "phase": "post",
+        "agent": active_agent,
+        "agent_id": stdin_data.get("agent_id", "") or "",
+        "tool": tool_name,
+    }
+
+    # Bash — exit code + stdout size
+    exit_code = tool_response.get("exit_code")
+    if isinstance(exit_code, int):
+        entry["exit"] = exit_code
+    stdout = tool_response.get("stdout")
+    if isinstance(stdout, str):
+        entry["stdout_size"] = len(stdout)
+
+    # 모든 도구 — error flag
+    is_error = tool_response.get("is_error") or stdin_data.get("is_error")
+    if is_error is True:
+        entry["is_error"] = True
+
+    _append_trace_safe(sid, rid, entry, base_dir=base_dir)
     return 0
 
 
@@ -424,6 +534,10 @@ def _main(argv: Optional[list] = None) -> int:
                           help="PostToolUse Agent — live.json.active_agent 해제")
     p_pa.add_argument("--cc-pid", type=int, default=None)
 
+    p_pf = sub.add_parser("posttooluse-file-op",
+                          help="PostToolUse Edit/Write/Read/Bash — agent-trace post append")
+    p_pf.add_argument("--cc-pid", type=int, default=None)
+
     args = parser.parse_args(argv)
 
     # cc_pid 미명시 시 PPID 사용 (bash 훅 의 PPID = CC main)
@@ -437,6 +551,8 @@ def _main(argv: Optional[list] = None) -> int:
         return handle_pretooluse_file_op(cc_pid=cc_pid)
     elif args.cmd == "posttooluse-agent":
         return handle_posttooluse_agent(cc_pid=cc_pid)
+    elif args.cmd == "posttooluse-file-op":
+        return handle_posttooluse_file_op(cc_pid=cc_pid)
     return 0
 
 

--- a/harness/redo_log.py
+++ b/harness/redo_log.py
@@ -1,0 +1,101 @@
+"""redo_log — 메인 Claude 의 sub cycle 평가 audit log (DCN-CHG-20260501-11).
+
+매 sub completion notification 평가 후 메인이 1줄 append. 학습 입력.
+저장 위치: `.sessions/{sid}/runs/{rid}/redo-log.jsonl`.
+
+Schema (강제 X — 메인 자율, 권장 필드만):
+    ts          (auto)  ISO8601 UTC, 미지정 시 자동 추가
+    agent_id            sub task id (notification <task-id>)
+    sub                 subagent type (engineer / architect / ...)
+    mode                sub mode (IMPL / MODULE_PLAN / ...)
+    decision            PASS / REDO_SAME / REDO_BACK / REDO_DIFF
+    reason              자유 텍스트
+    next_action         다음 step 결정
+    trace_summary       agent_trace.jsonl 요약 (선택)
+
+규약:
+    - jsonl (line-per-entry), 200 bytes 이하 권장
+    - POSIX O_APPEND atomic — 동시 write race 안전 (PIPE_BUF=4096 이내)
+    - malformed line read 시 skip (silent)
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from harness.session_state import run_dir
+
+
+__all__ = ["append", "read_all", "tail", "REDO_LOG_NAME"]
+
+
+REDO_LOG_NAME = "redo-log.jsonl"
+
+
+def _log_path(
+    session_id: str, run_id: str, *, base_dir: Optional[Path] = None
+) -> Path:
+    return run_dir(session_id, run_id, base_dir=base_dir, create=True) / REDO_LOG_NAME
+
+
+def append(
+    session_id: str,
+    run_id: str,
+    entry: Dict[str, Any],
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """redo-log.jsonl 에 1줄 append. ts 미지정 시 자동 추가.
+
+    POSIX O_APPEND atomic — 4096 bytes 이내 entry 동시 write 안전.
+    """
+    if not isinstance(entry, dict):
+        raise TypeError(f"entry must be dict, got {type(entry).__name__}")
+    if "ts" not in entry:
+        entry = {"ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()), **entry}
+    line = json.dumps(entry, ensure_ascii=False, separators=(",", ":")) + "\n"
+    target = _log_path(session_id, run_id, base_dir=base_dir)
+    fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+def read_all(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """모든 entry 반환 (시간 순). 비존재 / 빈 파일 → []."""
+    target = _log_path(session_id, run_id, base_dir=base_dir)
+    if not target.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    with open(target, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def tail(
+    session_id: str,
+    run_id: str,
+    n: int = 10,
+    *,
+    base_dir: Optional[Path] = None,
+) -> List[Dict[str, Any]]:
+    """마지막 n entry 반환."""
+    if n <= 0:
+        return []
+    return read_all(session_id, run_id, base_dir=base_dir)[-n:]

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash file-guard + PostToolUse Agent post-clear)",
+  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash file-guard + PostToolUse Agent post-clear + PostToolUse Edit/Write/Read/Bash post-file-op-trace)",
   "hooks": {
     "SessionStart": [
       {
@@ -41,6 +41,16 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-agent-clear.sh\"",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit|Read|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/post-file-op-trace.sh\"",
             "timeout": 5
           }
         ]

--- a/hooks/post-file-op-trace.sh
+++ b/hooks/post-file-op-trace.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# dcNess post-file-op-trace 훅 — PostToolUse Edit/Write/Read/Bash sub 행동 trace
+# (DCN-CHG-20260501-11)
+#
+# 트리거: Claude Code PostToolUse event, tool=Edit|Write|NotebookEdit|Read|Bash
+# stdin: CC payload (sessionId + tool_name + tool_input + tool_response)
+# 동작: harness/hooks.py 의 handle_posttooluse_file_op 호출 — 활성 sub-agent 가
+#       있을 때만 agent-trace.jsonl 에 post phase 1줄 append.
+#
+# 반환:
+#   exit 0: 항상 (PostToolUse 는 차단 권한 X)
+#
+# 메인 Claude turn (active_agent 미설정) 은 noop. 비활성 프로젝트도 noop.
+
+set -uo pipefail
+
+export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+
+# 활성화 게이트.
+python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+
+CC_PID=$PPID
+
+python3 -m harness.hooks posttooluse-file-op --cc-pid "$CC_PID" 2>/dev/null || true
+exit 0

--- a/tests/test_agent_trace.py
+++ b/tests/test_agent_trace.py
@@ -1,0 +1,117 @@
+"""test_agent_trace — DCN-CHG-20260501-11.
+
+agent-trace.jsonl append/read/tail. redo_log 와 동일 패턴 — Pre/PostToolUse hook
+가 sub 행동 사후 추적용으로 append.
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.agent_trace import TRACE_NAME, append, read_all, tail
+from harness.session_state import generate_run_id, run_dir
+
+
+SID = "test-trace-sid"
+
+
+class AgentTraceAppendTests(unittest.TestCase):
+    def test_roundtrip_basic(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(
+                SID, rid,
+                {"phase": "pre", "agent": "engineer", "tool": "Edit", "input": "src/foo.py"},
+                base_dir=base,
+            )
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["phase"], "pre")
+            self.assertEqual(entries[0]["agent"], "engineer")
+            self.assertIn("ts", entries[0])
+
+    def test_ts_auto_added(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"phase": "pre"}, base_dir=base)
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertTrue(entries[0]["ts"].endswith("Z"))
+
+    def test_pre_post_order_preserved(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"phase": "pre", "tool": "Bash"}, base_dir=base)
+            append(SID, rid, {"phase": "post", "tool": "Bash", "exit": 0}, base_dir=base)
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual(entries[0]["phase"], "pre")
+            self.assertEqual(entries[1]["phase"], "post")
+            self.assertEqual(entries[1]["exit"], 0)
+
+    def test_entry_not_dict_raises(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            with self.assertRaises(TypeError):
+                append(SID, rid, "x", base_dir=base)  # type: ignore[arg-type]
+
+    def test_file_permission_0o600(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"phase": "pre"}, base_dir=base)
+            target = run_dir(SID, rid, base_dir=base) / TRACE_NAME
+            mode = target.stat().st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+
+
+class AgentTraceReadAllTests(unittest.TestCase):
+    def test_nonexistent_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            self.assertEqual(read_all(SID, rid, base_dir=base), [])
+
+    def test_malformed_skipped(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            target = run_dir(SID, rid, base_dir=base, create=True) / TRACE_NAME
+            target.write_text(
+                json.dumps({"phase": "pre"}) + "\n"
+                + "garbage\n"
+                + json.dumps({"phase": "post"}) + "\n"
+            )
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual([e["phase"] for e in entries], ["pre", "post"])
+
+
+class AgentTraceTailTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        self.rid = generate_run_id()
+        for i in range(4):
+            append(SID, self.rid, {"phase": "pre", "i": i}, base_dir=self.base)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_tail_n_zero(self):
+        self.assertEqual(tail(SID, self.rid, 0, base_dir=self.base), [])
+
+    def test_tail_n_smaller(self):
+        result = tail(SID, self.rid, 2, base_dir=self.base)
+        self.assertEqual([e["i"] for e in result], [2, 3])
+
+    def test_tail_n_larger(self):
+        result = tail(SID, self.rid, 100, base_dir=self.base)
+        self.assertEqual(len(result), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -40,10 +40,12 @@ from tempfile import TemporaryDirectory
 from harness.hooks import (
     HARNESS_ONLY_AGENTS,
     handle_posttooluse_agent,
+    handle_posttooluse_file_op,
     handle_pretooluse_agent,
     handle_pretooluse_file_op,
     handle_session_start,
 )
+from harness.agent_trace import read_all as read_trace
 from harness.session_state import (
     read_live,
     read_pid_session,
@@ -713,6 +715,169 @@ class PostToolUseAgentClearTests(_PreToolBase):
 
     def test_invalid_sid_silent(self) -> None:
         rc = handle_posttooluse_agent(
+            stdin_data={"sessionId": "!"},
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# DCN-CHG-20260501-11 — sub 행동 trace append (Pre + Post)
+# ---------------------------------------------------------------------------
+
+
+class FileOpTraceTests(_PreToolBase):
+    """handle_pretooluse_file_op 통과 시 agent-trace.jsonl pre append."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._old_env = {}
+        for k in ("DCNESS_INFRA", "CLAUDE_PLUGIN_ROOT"):
+            self._old_env[k] = os.environ.get(k)
+            os.environ.pop(k, None)
+        self._old_cwd = os.getcwd()
+        os.chdir(str(self.base))
+
+    def tearDown(self) -> None:
+        os.chdir(self._old_cwd)
+        for k, v in self._old_env.items():
+            if v is not None:
+                os.environ[k] = v
+        super().tearDown()
+
+    def _payload_file(self, tool_name: str, **tool_input) -> dict:
+        return {
+            "sessionId": self.sid,
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+        }
+
+    def test_pre_trace_appended_on_pass(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._payload_file("Edit", file_path="src/foo.py"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["phase"], "pre")
+        self.assertEqual(entries[0]["agent"], "engineer")
+        self.assertEqual(entries[0]["tool"], "Edit")
+        self.assertEqual(entries[0]["input"], "src/foo.py")
+
+    def test_no_trace_on_block(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._payload_file("Edit", file_path="hooks/foo.sh"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(entries, [])
+
+    def test_no_trace_when_main_claude(self) -> None:
+        # active_agent 미설정 → trace 미기록.
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._payload_file("Edit", file_path="src/foo.py"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(entries, [])
+
+    def test_bash_input_in_trace(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._payload_file("Bash", command="ls -la docs/"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["input"], "ls -la docs/")
+
+    def test_long_input_truncated(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        long_cmd = "echo " + "x" * 500
+        rc = handle_pretooluse_file_op(
+            stdin_data=self._payload_file("Bash", command=long_cmd),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        # 200 cap + "..." suffix
+        self.assertTrue(entries[0]["input"].endswith("..."))
+        self.assertLessEqual(len(entries[0]["input"]), 210)
+
+
+class PostToolUseFileOpTests(_PreToolBase):
+    """handle_posttooluse_file_op — sub 행동 post trace append."""
+
+    def _post_payload(
+        self, tool_name: str, tool_response: dict, **tool_input
+    ) -> dict:
+        return {
+            "sessionId": self.sid,
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "tool_response": tool_response,
+        }
+
+    def test_post_trace_appended(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_posttooluse_file_op(
+            stdin_data=self._post_payload(
+                "Bash",
+                {"exit_code": 0, "stdout": "hello"},
+                command="echo hello",
+            ),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["phase"], "post")
+        self.assertEqual(entries[0]["tool"], "Bash")
+        self.assertEqual(entries[0]["exit"], 0)
+        self.assertEqual(entries[0]["stdout_size"], 5)
+
+    def test_post_noop_when_main(self) -> None:
+        # active_agent 미설정 → noop.
+        rc = handle_posttooluse_file_op(
+            stdin_data=self._post_payload("Edit", {}, file_path="src/x.py"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(entries, [])
+
+    def test_post_records_is_error(self) -> None:
+        update_live(self.sid, base_dir=self.base, active_agent="engineer")
+        rc = handle_posttooluse_file_op(
+            stdin_data=self._post_payload(
+                "Bash",
+                {"exit_code": 1, "is_error": True},
+                command="false",
+            ),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        entries = read_trace(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(entries[0]["exit"], 1)
+        self.assertTrue(entries[0]["is_error"])
+
+    def test_post_invalid_sid_silent(self) -> None:
+        rc = handle_posttooluse_file_op(
             stdin_data={"sessionId": "!"},
             cc_pid=self.cc_pid,
             base_dir=self.base,

--- a/tests/test_redo_log.py
+++ b/tests/test_redo_log.py
@@ -1,0 +1,169 @@
+"""test_redo_log — DCN-CHG-20260501-11.
+
+Coverage matrix:
+    append:
+        - 기본 roundtrip (write → read_all 일치)
+        - ts 자동 추가
+        - ts 명시 시 보존
+        - entry 가 dict 아님 → TypeError
+        - 다중 append 라인 순서 보존
+        - 파일 권한 0o600
+
+    read_all:
+        - 비존재 파일 → []
+        - 빈 파일 → []
+        - 빈 라인 skip
+        - malformed line skip
+        - 정상 라인만 추출
+
+    tail:
+        - n=0 → []
+        - n>len → 전체
+        - n<len → 마지막 n
+        - n 음수 → []
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.redo_log import REDO_LOG_NAME, append, read_all, tail
+from harness.session_state import generate_run_id, run_dir
+
+
+SID = "test-redo-log-sid"
+
+
+class RedoLogAppendTests(unittest.TestCase):
+    def test_roundtrip_basic(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            entry = {"sub": "engineer", "decision": "PASS"}
+            append(SID, rid, entry, base_dir=base)
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["sub"], "engineer")
+            self.assertEqual(entries[0]["decision"], "PASS")
+            self.assertIn("ts", entries[0])
+
+    def test_ts_auto_added(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"foo": "bar"}, base_dir=base)
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertIn("ts", entries[0])
+            self.assertTrue(entries[0]["ts"].endswith("Z"))
+
+    def test_ts_preserved_when_specified(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"ts": "2020-01-01T00:00:00Z", "x": 1}, base_dir=base)
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual(entries[0]["ts"], "2020-01-01T00:00:00Z")
+
+    def test_entry_not_dict_raises(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            with self.assertRaises(TypeError):
+                append(SID, rid, "not a dict", base_dir=base)  # type: ignore[arg-type]
+            with self.assertRaises(TypeError):
+                append(SID, rid, ["list"], base_dir=base)  # type: ignore[arg-type]
+
+    def test_multiple_appends_preserve_order(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            for i in range(5):
+                append(SID, rid, {"i": i}, base_dir=base)
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual([e["i"] for e in entries], [0, 1, 2, 3, 4])
+
+    def test_file_permission_0o600(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"x": 1}, base_dir=base)
+            target = run_dir(SID, rid, base_dir=base) / REDO_LOG_NAME
+            mode = target.stat().st_mode & 0o777
+            self.assertEqual(mode, 0o600)
+
+
+class RedoLogReadAllTests(unittest.TestCase):
+    def test_nonexistent_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            self.assertEqual(read_all(SID, rid, base_dir=base), [])
+
+    def test_empty_file_returns_empty(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            target = run_dir(SID, rid, base_dir=base, create=True) / REDO_LOG_NAME
+            target.touch()
+            self.assertEqual(read_all(SID, rid, base_dir=base), [])
+
+    def test_blank_lines_skipped(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            target = run_dir(SID, rid, base_dir=base, create=True) / REDO_LOG_NAME
+            target.write_text(
+                json.dumps({"a": 1}) + "\n\n" + json.dumps({"a": 2}) + "\n"
+            )
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual(len(entries), 2)
+
+    def test_malformed_line_skipped(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            target = run_dir(SID, rid, base_dir=base, create=True) / REDO_LOG_NAME
+            target.write_text(
+                json.dumps({"a": 1}) + "\n"
+                + "not json line\n"
+                + json.dumps({"a": 2}) + "\n"
+            )
+            entries = read_all(SID, rid, base_dir=base)
+            self.assertEqual([e["a"] for e in entries], [1, 2])
+
+
+class RedoLogTailTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        self.rid = generate_run_id()
+        for i in range(5):
+            append(SID, self.rid, {"i": i}, base_dir=self.base)
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def test_tail_n_zero(self):
+        self.assertEqual(tail(SID, self.rid, 0, base_dir=self.base), [])
+
+    def test_tail_n_negative(self):
+        self.assertEqual(tail(SID, self.rid, -1, base_dir=self.base), [])
+
+    def test_tail_n_smaller_than_len(self):
+        result = tail(SID, self.rid, 2, base_dir=self.base)
+        self.assertEqual([e["i"] for e in result], [3, 4])
+
+    def test_tail_n_equal_to_len(self):
+        result = tail(SID, self.rid, 5, base_dir=self.base)
+        self.assertEqual([e["i"] for e in result], [0, 1, 2, 3, 4])
+
+    def test_tail_n_larger_than_len(self):
+        result = tail(SID, self.rid, 100, base_dir=self.base)
+        self.assertEqual([e["i"] for e in result], [0, 1, 2, 3, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-1 / PR-2 분리 작업 — **본 PR-1 은 코드 인프라만**, PR-2 (`DCN-CHG-20260501-12`) 가 SessionStart 감시자 hat + audit-redo skill 후속.

사용자 비전 (장 토론 산출물): 정적 룰 (path matrix / 도구 화이트리스트) 추가 게임 → 추론 기반 judgment 패러다임 전환. 4축 (1) 결과 평가 / (2) 행동 추적 / (3) audit log / (4) 학습 진화. 본 PR 은 (2)+(3) 코드 인프라만.

상세 plan: `~/.claude/plans/vast-singing-donut.md` (사용자 승인 완료).

## 변경

- **`harness/redo_log.py`** 신규 — `redo-log.jsonl` append/read/tail. POSIX O_APPEND atomic. 15 tests.
- **`harness/agent_trace.py`** 신규 — `agent-trace.jsonl` append/read/tail. 11 tests.
- **`harness/hooks.py`** 확장:
  - `handle_pretooluse_file_op` boundary 통과 후 trace pre append (차단 시 미기록)
  - `handle_posttooluse_file_op` 신규 — PostToolUse Edit/Write/Read/Bash 결과 (exit/stdout_size/is_error) 기록
  - tool_input 200 bytes truncate (POSIX append atomic 4096 bytes 보장)
  - 모든 trace 실패 silent (`_append_trace_safe`) — hook 본 흐름 방해 X
- **`hooks/post-file-op-trace.sh`** 신규 wrapper + `hooks/hooks.json` PostToolUse matcher 등록
- **`tests/test_hooks.py`** — `FileOpTraceTests` + `PostToolUseFileOpTests` (9 case)

## 한계 (정직)

- hook trace = sub *행동* 만 cover. thinking / 중간 assistant message 안 들어감 (P7 미래 `.output` 가공)
- 도구 0번 쓰는 sub turn = trace 텅 빔
- `.output` 직접 read 시스템 명시 금지 (context 폭발) — 본 PR 은 hook 만으로 cover

## 대원칙 §0 self-check

본 변경은 *관측 인프라* — 작업 순서 / 접근 영역 강제 X. agent 자율 침해 0.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 324 OK / 회귀 0
- [x] doc-sync gate PASS
- [x] pytest pre-commit gate PASS
- [ ] CI (push 후) — python-tests + doc-sync + plugin-manifest 모두 green 확인
- [ ] (PR-2 후) 실제 background sub spawn → agent-trace 라인 누적 실측

## 후속

- **PR-2 (DCN-CHG-20260501-12)** — SessionStart 감시자 hat 메시지 + `commands/audit-redo.md` skill (Layer 1 즉시 prompt 첨가 + Layer 2 dcness 인프라 환류)
- **P5 운영 (1-2 주)** — redo-log + trace 누적 → 패턴 분석
- **P6 환류 (주기)** — N 프로젝트 검증 패턴 → `agents/*.md` 영구 patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)