### PR TITLE
feat: 감시자 hat + audit-redo skill (DCN-CHG-20260501-12)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🎩 감시자 Hat + audit-redo skill (PR-2)** (`DCN-CHG-20260501-12`):
+  - PR-1 인프라 위에 운영 layer. 사용자 비전 4축 중 (1) 결과 평가 + (4) 학습 진화 (2-layer) 가동.
+  - **`hooks/session-start.sh`** additionalContext 에 "감시자 Hat (권고)" 섹션 추가 — builder + 감시자 두 hat / sub completion 깐깐 평가 / `redo-log` 1줄 append / 루프 재구성 자유. 대원칙 §0 정합 — 권고 어휘만, 형식 강제 X.
+  - **`commands/audit-redo.md`** 신규 skill — `(sub, mode)` 별 redo 분포 + REDO 사유 클러스터 + trace 공통 패턴 → Layer 1 (현 프로젝트 1차 prompt 첨가) + Layer 2 (`agents/*.md` 영구 patch) 후보 제안. `/run-review` 와 직교 (waste vs redo 학습).
+  - **운영 시나리오** — 메인이 매 sub completion 시 권고에 따라 `redo-log.append()` → 1-2 주 누적 후 `/audit-redo` 호출 → 패턴 발견 → Layer 1 즉시 첨가 → N 회 검증 → Layer 2 PR (별도 Task-ID).
+  - **한계** — hook trace = 행동만 (thinking X, P7 미래). 권고 어휘라 메인이 *안 따르면* 효과 0 → 운영 데이터로 강제 escalation 검토.
 - **🪝 sub 행동 사후 추적 인프라 (PR-1)** (`DCN-CHG-20260501-11`):
   - 사용자 비전 — 정적 룰 추가 게임 → 추론 기반 judgment 로 패러다임 전환. 4축: 결과 평가 / 행동 추적 / audit log / 학습 진화 (2-layer). PR-1 은 (2)+(3) 코드 인프라만.
   - **`harness/redo_log.py`** 신규 — `redo-log.jsonl` append/read/tail. 메인이 sub completion 평가 후 PASS/REDO_SAME/REDO_BACK/REDO_DIFF 1줄 기록. POSIX O_APPEND atomic, 4096 bytes 이내 entry. 15 tests.

--- a/commands/audit-redo.md
+++ b/commands/audit-redo.md
@@ -1,0 +1,138 @@
+---
+name: audit-redo
+description: dcness conveyor run 의 redo-log + agent-trace 결합 분석 skill. (sub, mode) 별 redo 빈도 추출 + Layer 1 (현 프로젝트 1차 prompt 첨가) + Layer 2 (dcness plugin agent definition 영구 patch) 후보 제안. 사용자가 "/audit-redo", "redo 분석", "감시자 학습", "패턴 환류" 등을 말할 때 사용. /run-review 와 직교 — /run-review = waste/good findings, /audit-redo = redo 패턴 학습 (DCN-CHG-20260501-12).
+---
+
+# Audit Redo Skill — 메인 감시자 학습 진화 (Layer 1 + Layer 2)
+
+> sub completion 평가 결과 (`redo-log.jsonl`) 와 sub 행동 trace (`agent-trace.jsonl`) 를 결합 분석. 자주 redo 부르는 (sub, mode) 패턴 추출 → 1차 prompt 풍부화 후보 제안. 룰 추가 X, prompt 풍부화 ✅.
+
+## 언제 사용
+
+- 사용자 발화: "/audit-redo", "redo 분석", "감시자 학습", "패턴 환류", "어떤 sub 자주 redo"
+- impl-loop 종료 후 redo 누적 분석
+- 주기 (월 1회 권고) — Layer 2 환류 시점
+
+## 언제 사용하지 않음
+
+- waste / good findings 추출 → `/run-review` (직교 skill)
+- 단일 sub spawn 1회 결과 평가 → SessionStart 메시지의 즉시 평가 (skill 불필요)
+- run 진행 중 → 적어도 1 cycle (sub completion + 메인 평가) 끝난 후
+
+## 핵심 동작
+
+`.sessions/{sid}/runs/{rid}/redo-log.jsonl` + `agent-trace.jsonl` 를 cross-correlation 해서:
+
+1. **(sub, mode) 별 결정 분포** — PASS / REDO_SAME / REDO_BACK / REDO_DIFF 카운트
+2. **REDO 사유 카테고리** — 자유 텍스트 reason 클러스터링 (해시태그 / 키워드)
+3. **trace 패턴 매칭** — 각 redo entry 의 trace 시퀀스 (어떤 tool 어디 썼나) 공통점
+4. **Layer 1 후보** — (sub, mode) 의 redo 비율 임계 초과 시 "다음 spawn 1차 prompt 에 X 사전 보강" 제안
+5. **Layer 2 후보** — Layer 1 적용이 N 프로젝트 / N 회 검증되면 `agents/{sub}.md` 영구 patch 제안
+
+## 절차
+
+### Step 0 — run 식별 (선택)
+
+단일 run 분석 또는 다중 run 누적. 인자:
+
+- 무인자 → 현재 active run (live.json) 단일
+- `--run-id <RID>` → 명시 run 단일
+- `--all-runs` → 본 sid 의 모든 run 누적
+- `--list` → run 목록 (run_id + redo-log entry 수)
+
+### Step 1 — redo-log + trace read
+
+```python
+from harness.redo_log import read_all as read_redos
+from harness.agent_trace import read_all as read_trace
+
+redos = read_redos(sid, rid)
+traces = read_trace(sid, rid)
+```
+
+`redos` 가 비어있으면 → "본 run 평가 기록 0건 — 메인 SessionStart 감시자 hat 비활성 의심" 보고 후 종료.
+
+### Step 2 — (sub, mode) 분포 + REDO 사유 추출
+
+각 redo entry 에서 `sub`, `mode`, `decision` 키로 그룹핑:
+
+```
+engineer / IMPL: PASS=12 / REDO_SAME=2 / REDO_BACK=5 (redo 비율 37%)
+architect / MODULE_PLAN: PASS=8 / REDO_BACK=1 (redo 비율 11%)
+validator / CODE_VALIDATION: PASS=10 (redo 비율 0%)
+```
+
+각 redo entry 의 `reason` 자유 텍스트에서 키워드 추출 (예: "module plan 모호", "테스트 미통과", "boundary 위반"). 동일 키워드 N 회 누적 시 클러스터.
+
+### Step 3 — trace 패턴 매칭
+
+각 REDO entry 의 발생 직전 trace 시퀀스 (마지막 N 줄, agent_id 매칭) 추출. 공통 패턴 (예: "Bash 5회 반복 + exit≠0 무시") 식별.
+
+### Step 4 — Layer 1 / Layer 2 후보 출력
+
+리포트 형식:
+
+```markdown
+## (sub, mode) 별 결정 분포
+
+| sub | mode | total | PASS | REDO_SAME | REDO_BACK | REDO_DIFF | redo 비율 |
+|---|---|---|---|---|---|---|---|
+| engineer | IMPL | 19 | 12 | 2 | 5 | 0 | 37% |
+| ...
+
+## 자주 REDO 부르는 (sub, mode)
+
+### engineer / IMPL — redo 37% (임계 초과)
+
+REDO 사유 클러스터:
+- "module plan 모호" — 4 / 7
+- "테스트 통과 못함" — 2 / 7
+- 기타 — 1 / 7
+
+trace 패턴:
+- 직전 5줄 평균 — Read×3, Edit×1, Bash×2 (exit≠0 1회)
+- 공통 — `Bash pytest exit=1` 후 추가 Edit 없이 종료
+
+### Layer 1 후보 (현 프로젝트 즉시 적용)
+
+다음 architect MODULE_PLAN sub spawn 시 1차 prompt 끝에 추가:
+> "이 프로젝트에서 module plan 모호로 인한 engineer redo 비율 37%. 인터페이스 시그니처 + 의사코드 명시 의무."
+
+### Layer 2 후보 (인프라 환류 — 검증 후)
+
+위 Layer 1 적용이 N 회 (또는 N 프로젝트) 검증되면 `agents/architect/module-plan.md` system prompt 영구 patch 제안:
+> "MODULE_PLAN 산출 시 engineer 가 즉시 구현 가능한 수준 — 인터페이스 시그니처 (타입) + 핵심 로직 의사코드 강제."
+
+→ PR 작성 후 governance §2.2 `agent` Change-Type 으로 머지.
+```
+
+### Step 5 — 후속 액션 권고 (1-3 줄)
+
+리포트 끝에 메인이 1-3 줄로 후속 결정 권고:
+- Layer 1 후보 N 개 → 다음 spawn 시 메인이 직접 prompt 첨가
+- Layer 2 후보 1 개 → 별도 Task-ID 발급 후 PR 진행
+- 후보 0 개 → "본 run 의 redo 패턴 결정적 X — 다음 cycle 모니터 지속"
+
+## 출력 룰
+
+`/run-review` 와 동일 — Bash stdout 리포트를 한 글자도 바꾸지 않고 그대로 응답에 복사. 자체 해석 / 압축 X.
+
+## 호출 예시
+
+```
+사용자: /audit-redo
+메인: (현재 run 분석) → 리포트 그대로 출력 → "Layer 1 후보 1개 (architect MODULE_PLAN 보강) 적용 권고. Layer 2 는 다음 프로젝트 검증 후."
+
+사용자: /audit-redo --all-runs
+메인: (본 sid 의 모든 run 누적) → 더 강한 패턴 → Layer 2 patch 제안 N 개
+
+사용자: 어떤 sub 가 자주 redo?
+메인: /audit-redo skill 호출 → (sub, mode) 분포 표 + 임계 초과 카테고리
+```
+
+## 한계 (정직)
+
+- Hook trace = sub *행동* 만 (thinking / 중간 message X). 추론 사유 분석은 P7 미래 (`.output` 가공)
+- 도구 0번 쓰는 sub turn = trace 텅 빔 → 본 분석 부정확
+- 단일 run 표본 작음 — `--all-runs` 또는 다중 sid 누적이 통계 신뢰 ↑
+- REDO 사유 클러스터링은 자유 텍스트 키워드 매칭 — 정밀도 한계, 메인 정성 판단 보조 필요

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,29 @@
 
 ## Records
 
+### DCN-CHG-20260501-12
+- **Date**: 2026-05-01
+- **Rationale**:
+  - DCN-CHG-20260501-11 (PR-1) 가 인프라만 — `redo_log.py` + `agent_trace.py` + Pre/PostToolUse hook 확장. 단 메인이 *언제 어떻게* 활용할지 가이드 부재 → 인프라가 잠자게 됨.
+  - 본 PR-2 가 비전 4축 중 (1) 결과 평가 + (4) 학습 진화 운영 layer.
+  - **SessionStart 메시지 — 권고 어휘 사용**: 대원칙 §0 "harness 가 강제하는 건 작업 순서 + 접근 영역만, 그 외 agent 자율" 정합. "의무" / "필수" 같은 강제 어휘 자제, "권고" / "권장" / "X = 가장 비싼 실수" 같은 *명시 + 자율 판단* 어휘. 메인 자율 침해 0.
+  - **`/audit-redo` skill 분리**: `/run-review` 와 직교. /run-review = waste/good findings (RWHarness 변환), /audit-redo = redo 패턴 학습. 같은 데이터 (.steps.jsonl + redo-log + trace) 다른 분석축. 단일 skill 통합 X (Karpathy 2 — 단일 책임 분리).
+- **Alternatives**:
+  1. **SessionStart 메시지 의무 어휘** — 대원칙 §0 위반. *기각*.
+  2. **`/audit-redo` 를 `/run-review` 안에 통합** — 분석축 충돌, 사용자 발화 (사후 분석 vs 학습 환류) 다름. *기각*.
+  3. **메인 매 sub spawn 시 자동 prompt 첨가 — 기능 박힘** — 메인이 *판단 없이 기계 첨가* 하면 자율 침해. 첨가 자체는 메인이 `/audit-redo` 결과 보고 결정. *기각*.
+  4. **(채택)** **권고 메시지 + skill 분리 + Layer 1/2 명시** — 메인 자율 + cheap 실험 + 점진 환류.
+- **Decision**:
+  - SessionStart 메시지에 "감시자 Hat (DCN-CHG-20260501-12, 권고)" 섹션 추가. 권고 어휘만 사용. 본문 ~700 byte (CC additionalContext 10K cap 충분 여유).
+  - `commands/audit-redo.md` 신규 skill — Step 0~5 절차. `/run-review` 와 동일한 "stdout 리포트 그대로 복사" 룰 (압축 본능 차단).
+  - **Layer 1 / Layer 2 명시 분리**: 즉시 적용 (Layer 1) vs 인프라 환류 (Layer 2). 후자는 `agents/*.md` patch + governance §2.2 `agent` Change-Type 새 PR.
+- **Follow-Up**:
+  - **(P5 운영 — 1-2 주)** redo-log + trace 누적 → `/audit-redo` 첫 패턴 발견 → Layer 1 첨가 → 효과 측정.
+  - **(P6 환류 — 주기)** Layer 1 적용 N 회 검증된 패턴 → Layer 2 patch PR (별도 Task-ID).
+  - **(측정)** 메인이 SessionStart 권고를 실제 *따르는지* — redo-log entry 수 / cycle 수 비율. 0 이면 권고 효과 0 → 강제 어휘로 escalation 검토 (단 §0 정합 다시 self-check).
+  - **(P7 미래)** `.output` 가공 helper — 본 skill 이 trace 만으로 분석한 redo 패턴이 부족하면 thinking 까지 cover.
+  - **(P8 미래)** Auto-wakeup polling — 본 PR 운영 데이터에서 "결과 후 redo 만으론 헛수고 토큰 큰 손실" 측정 시.
+
 ### DCN-CHG-20260501-11
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260501-12
+- **Date**: 2026-05-01
+- **Change-Type**: hooks, agent
+- **Files Changed**:
+  - `hooks/session-start.sh` (additionalContext 에 "감시자 Hat" 섹션 추가 — 권고 어휘, 형식 강제 X)
+  - `commands/audit-redo.md` (신규 skill — redo-log + agent-trace 결합 분석, Layer 1/2 후보 제안)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: PR-2 — PR-1 인프라 위에 운영 layer 얹기. SessionStart 메시지에 "builder + 감시자 hat 우선 / sub completion 결과 깐깐 평가 / redo-log 1줄 append 권고 / 루프 재구성 자유" 안내. `/audit-redo` skill 신규 — `(sub, mode)` 별 redo 분포 + REDO 사유 클러스터 + trace 공통 패턴 → Layer 1 (현 프로젝트 1차 prompt 첨가) + Layer 2 (`agents/*.md` 영구 patch) 후보 제안. 룰 추가 X, prompt 풍부화 ✅.
+
 ### DCN-CHG-20260501-11
 - **Date**: 2026-05-01
 - **Change-Type**: harness, hooks, test

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -61,6 +61,27 @@ msg = '''## dcness Guidelines (DCN-30-40 자동 로드)
 - finalize-run 시 \`--auto-review\` flag 의무 (loop-procedure §5.1)
 
 **미인지 진행 = 룰 위반**. read 없이 작업 금지.
+
+---
+
+## 감시자 Hat (DCN-CHG-20260501-12, 권고)
+
+builder + 감시자 두 hat. **감시자 우선**.
+
+매 sub completion notification 받으면 1줄 평가 + 결정 권고:
+\`PASS\` / \`REDO_SAME\` / \`REDO_BACK\` / \`REDO_DIFF\` + 사유.
+
+평가 입력: \`<result>\` 응답 텍스트 + \`<usage>\` (tool 횟수 / 시간) + 필요 시 \`agent-trace.jsonl\` tail.
+
+REDO 신호: result 부실 / tool_uses 비정상 (1 미만 or 같은 tool 5회) / boundary 위반 stderr / trace 의 exit≠0 무시.
+
+**미진한 결과 통과 = 가장 비싼 실수** (다음 step 더 큰 redo 부름). 토큰 절약 본능 이기게.
+
+매 cycle 종료 시 \`harness.redo_log.append(sid, rid, {...})\` 1줄 권고. \`agent-trace.jsonl\` 은 hook 자동 — 메인 평가 시 \`harness.agent_trace.tail()\` 참조.
+
+루프 재구성 자유 — 정적 시퀀스 강제 X. architect MODULE_PLAN 재실행, 다른 sub 호출 등 적극.
+
+학습 진화: 같은 (sub, mode) 의 redo 빈도 누적 시 \`/audit-redo\` skill 로 1차 prompt 풍부화 검토 (Layer 1 즉시 + Layer 2 인프라 환류).
 '''
 print(json.dumps({
     'hookSpecificOutput': {


### PR DESCRIPTION
## Summary

PR-1 (`DCN-CHG-20260501-11`) 인프라 위에 **운영 layer** 얹기. 사용자 비전 4축 중 (1) 결과 평가 + (4) 학습 진화 (2-layer) 가동.

상세 plan: `~/.claude/plans/vast-singing-donut.md`.

## 변경

- **`hooks/session-start.sh`** additionalContext 에 "**감시자 Hat (권고)**" 섹션 추가 (~700 byte):
  - builder + 감시자 두 hat / 감시자 우선
  - 매 sub completion 1줄 평가 권고 — `PASS` / `REDO_SAME` / `REDO_BACK` / `REDO_DIFF`
  - 매 cycle 끝 `redo-log.append()` 권고
  - 루프 재구성 자유 (정적 시퀀스 강제 X)
- **`commands/audit-redo.md`** 신규 skill:
  - `(sub, mode)` 별 redo 분포 표
  - REDO 사유 자유 텍스트 클러스터링
  - 각 redo 직전 trace 공통 패턴 매칭
  - **Layer 1 후보** — 현 프로젝트 1차 prompt 첨가 제안
  - **Layer 2 후보** — `agents/*.md` 영구 patch 제안 (별도 PR)
  - `/run-review` 와 직교 — waste/good (RWHarness) vs redo 학습 (본 skill)

## 대원칙 §0 self-check

- SessionStart 메시지 = **권고** 어휘만 (`권고`, `권장`, `자유`). "의무" / "필수" 자제.
- 메인 *판단 없이 자동 prompt 첨가* X — `/audit-redo` 결과 보고 메인이 결정.
- agent 자율 침해 0.

## Test plan

- [x] doc-sync gate PASS (5 files / docs-only + hooks)
- [x] PR-1 코드 인프라 (`harness.redo_log`, `harness.agent_trace`) 정상 import 확인
- [ ] CI green (push 후)
- [ ] 운영 1-2 주 — `/audit-redo` 첫 호출 + Layer 1 후보 발견 검증

## 한계 (정직)

- 권고 어휘 → 메인이 안 따르면 효과 0. 운영 데이터로 강제 escalation 검토.
- hook trace = 행동만 cover. thinking / 중간 message X (P7 미래).
- REDO 사유 클러스터링 = 자유 텍스트 키워드 매칭, 정밀도 한계.

## 후속

- **P5 운영** — 1-2 주 redo-log + trace 누적
- **P6 환류 (주기)** — Layer 2 patch 별도 PR (Task-ID 신규)
- **P7 미래** — `.output` 가공 helper (thinking 추적)
- **P8 미래** — auto-wakeup polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)