### PR TITLE
feat: PostToolUse Agent surface push — histogram + anomaly + auto redo_log (DCN-CHG-20260501-13)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,15 @@
 
 ## 현재 상태
 
+- **📡 PostToolUse Agent surface push (PR-3)** (`DCN-CHG-20260501-13`):
+  - jajang 운영 1 cycle 발견 — 권고 어휘로 메인 능동 retrieval 행동 강제 불가. trace 는 read 함, redo-log 0 entry. jajang 메인 자기 진단 ROI 표 ("룰 추가 < surface 개선") 그대로 반영.
+  - **PostToolUse Agent hook 가 push 채널로** — sub 종료 후 `additionalContext` 로 메인 다음 turn Agent tool result 옆에 system reminder 자동 inject. 공식 docs 확정 메커니즘.
+  - **`harness/sub_eval.py`** 신규 — 보수적 anomaly 룰 (tool_uses<2 / 같은 tool 5회+ / Write 약속+0건 prose-only). 자동 결정 PASS / REDO_SUSPECT.
+  - **`agent_trace.histogram` + `last_agent_id`** helper 추가.
+  - **`handle_posttooluse_agent`** 확장 — sub trace 집계 → histogram 계산 → anomaly 검출 → stdout JSON inject + redo_log 자동 append (`auto:true` 마커).
+  - 정상 메시지 1줄: `[감시자 hook] sub=engineer tool histogram: Bash:2 Read:4 (PASS)`. anomaly 강조: `⚠️ anomaly 감지: prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심) + REDO 권고`.
+  - **트레이드오프 §0 정합** — 정보 inject 만, 강제 X. 메인 자율 판단 보존 (룰 침해 0).
+  - 회귀 0 — 신규 21 case (sub_eval 10 + agent_trace 6 + hooks 5), 전체 345 tests OK.
 - **🎩 감시자 Hat + audit-redo skill (PR-2)** (`DCN-CHG-20260501-12`):
   - PR-1 인프라 위에 운영 layer. 사용자 비전 4축 중 (1) 결과 평가 + (4) 학습 진화 (2-layer) 가동.
   - **`hooks/session-start.sh`** additionalContext 에 "감시자 Hat (권고)" 섹션 추가 — builder + 감시자 두 hat / sub completion 깐깐 평가 / `redo-log` 1줄 append / 루프 재구성 자유. 대원칙 §0 정합 — 권고 어휘만, 형식 강제 X.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,43 @@
 
 ## Records
 
+### DCN-CHG-20260501-13
+- **Date**: 2026-05-01
+- **Rationale**:
+  - PR-2 (`-12`) 머지 후 jajang 운영 데이터 1 cycle: trace 178 호출 정상 캡처 ✅, 메인이 trace read + 정확한 sub 평가 ✅, 단 **redo-log 0 entry** ❌. 권고 어휘로는 메인 능동 retrieval 행동 강제 불가 (메인 자기 진단 — "능동 retrieval 의무 응답률 ~20%").
+  - jajang 메인 자기 진단 (사용자가 인용) ROI 표:
+    | 변경 | ROI | 메인 인지 비용 |
+    |---|---|---|
+    | `<usage>` 옆 tool-histogram | 🔥🔥🔥 | 0 (수동 인지) |
+    | finalize-run 자동 redo_log | 🔥🔥 | 0 |
+    | anomaly 조건부 reminder | 🔥🔥 | 낮음 |
+    | blanket 룰 의무화 | 🟡 | 높음 (theater) |
+  - 핵심 진단 — "**룰 추가 < surface 개선**". 메인이 *자연스럽게 보는 surface* 를 신호 풍부하게 만드는 게 룰 박는 것보다 압도적 효과. retrieval 의무는 *룰 강화로 안 풀림, push 로 바꿔야 풀림*.
+  - PostToolUse hook 의 `hookSpecificOutput.additionalContext` 가 *tool result 옆에* system reminder 로 inject 됨 — 공식 docs 확정 ([code.claude.com/docs/en/hooks](https://code.claude.com/docs/en/hooks)). 즉 SessionStart 가 세션 시작 1회 inject 라면 PostToolUse Agent 는 매 sub 완료마다 inject — *정확히 우리가 원하는 push 채널*.
+- **Alternatives**:
+  1. **권고 어휘 강화 (의무 / 필수 escalation)** — 대원칙 §0 self-check 위반 가능 + theater 위험 (메인이 rote PASS 박기). *기각*.
+  2. **블랭킷 매 sub reminder** — 정상 cycle 에서도 의미 없는 reminder 누적 → 신호 가치 dilution. *기각*.
+  3. **`<usage>` 자체 수정 (tool histogram 박힘)** — Claude Code 플랫폼이 박는 메타라 우리가 직접 못 함. *기각*.
+  4. **(채택)** **PostToolUse Agent hook 가 `additionalContext` 로 histogram + anomaly inject + redo_log 자동 append**.
+- **Decision**:
+  - `harness/sub_eval.py` 신규 — anomaly 룰 (tool_uses<2 / 같은 tool 5회+ / Write 약속+0건 prose-only). 보수적 임계 (`MIN_TOOL_USES=2`, `REPEAT_TOOL_THRESHOLD=5`). 운영 데이터 보고 조정.
+  - `agent_trace.histogram(sid, rid, agent_id)` + `last_agent_id` helper — pre phase 만 카운트 (post 짝 중복 회피).
+  - `handle_posttooluse_agent` 확장:
+    - sub agent_id 식별 — payload `agent_id` 우선, fallback `last_agent_id(trace)`
+    - histogram 계산 + anomaly 검출
+    - **stdout JSON** — `{"hookSpecificOutput": {"hookEventName": "PostToolUse", "additionalContext": "..."}}`
+    - 정상: `[감시자 hook] sub=engineer tool histogram: Bash:2 Read:4 Write:1 (PASS)` (한 줄)
+    - anomaly: `⚠️ anomaly 감지: ... + REDO 권고` (강조 다중 줄)
+    - redo_log 자동 append (`auto:true` 마커)
+  - 모든 실패 silent (`try/except Exception`) — hook 본 흐름 (active_agent clear) 방해 0.
+  - **트레이드오프 §0 self-check**: histogram + anomaly 메시지 = *정보 inject* 으로 작업 순서 / 접근 영역 강제 X. 메인 자율 침해 0. 메인은 inject 메시지 보고 *자기 판단* 으로 REDO 결정 (강제 X). agent 자율 정합.
+- **Follow-Up**:
+  - **(P5 운영 1-2 주)** redo_log 자동 entry 100+ 누적 → anomaly false positive / negative 비율 측정 → 임계값 조정 PR.
+  - **(측정)** 메인이 anomaly 메시지 받고 *실제 redo 결정 비율* — surface push 효과 정량.
+  - **(P6 환류)** anomaly 패턴 검증된 것 → `agents/*.md` system prompt 에 사전 경고 박기.
+  - **(P7 미래)** sub_prompt_hint 확장 — 한국어 키워드 ("작성", "생성") 외 더 정확한 약속 검출.
+  - **(별도 PR)** `/audit-redo` skill 이 `auto:true` entry 와 메인 manual entry 구분 분석 — auto 만으로 패턴 추출 가능한지.
+
 ### DCN-CHG-20260501-12
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,22 @@
 
 ## Records
 
+### DCN-CHG-20260501-13
+- **Date**: 2026-05-01
+- **Change-Type**: harness, hooks, test
+- **Files Changed**:
+  - `harness/agent_trace.py` (`histogram` + `last_agent_id` helper 추가)
+  - `harness/sub_eval.py` (신규 — anomaly 룰 + auto decision)
+  - `harness/hooks.py` (`handle_posttooluse_agent` 확장 — histogram inject + auto redo_log)
+  - `hooks/post-agent-clear.sh` (stdout JSON 통과 — 코멘트 갱신)
+  - `tests/test_sub_eval.py` (신규 — 10 case)
+  - `tests/test_agent_trace.py` (HistogramTests + LastAgentIdTests — 6 case)
+  - `tests/test_hooks.py` (PostToolUseAgentHistogramTests — 5 case)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: PR-3 — surface 개선 (jajang 메인 자기 진단 반영). 권고 어휘 한계 인지 → push 형태로 전환. PostToolUse Agent hook 가 sub 종료 후 (1) `agent-trace` 집계 → tool histogram 계산 → `additionalContext` 로 메인 다음 turn 의 Agent tool result 옆에 시스템 reminder 자동 inject (2) anomaly 룰 (tool_uses<2 / 같은 tool 5+회 / Write 약속+Write 0건 = prose-only) 검출 → ⚠️ 강조 메시지 + REDO 권고 (3) `redo_log` 1줄 자동 append (auto:true 마커). 메인은 자연스럽게 보고 + 필요 시 별도 1줄로 결정 덮어쓰기. 룰 추가 X, surface 풍부화 ✅. 회귀 0 — 324 → 345 tests OK.
+
 ### DCN-CHG-20260501-12
 - **Date**: 2026-05-01
 - **Change-Type**: hooks, agent

--- a/harness/agent_trace.py
+++ b/harness/agent_trace.py
@@ -36,7 +36,7 @@ from typing import Any, Dict, List, Optional
 from harness.session_state import run_dir
 
 
-__all__ = ["append", "read_all", "tail", "TRACE_NAME"]
+__all__ = ["append", "read_all", "tail", "histogram", "last_agent_id", "TRACE_NAME"]
 
 
 TRACE_NAME = "agent-trace.jsonl"
@@ -106,3 +106,50 @@ def tail(
     if n <= 0:
         return []
     return read_all(session_id, run_id, base_dir=base_dir)[-n:]
+
+
+def histogram(
+    session_id: str,
+    run_id: str,
+    *,
+    agent_id: Optional[str] = None,
+    base_dir: Optional[Path] = None,
+) -> Dict[str, int]:
+    """tool 호출 종류별 카운트 (DCN-CHG-20260501-13).
+
+    pre phase 만 카운트 (post 와 짝이라 중복 회피). agent_id 명시 시 해당 sub 만,
+    None 이면 run 전체.
+
+    Args:
+        agent_id: 특정 sub 의 trace 만 집계. None = run 전체.
+
+    Returns:
+        {"Read": 4, "Bash": 2, "Write": 0, "Edit": 0} 등.
+    """
+    counts: Dict[str, int] = {}
+    for entry in read_all(session_id, run_id, base_dir=base_dir):
+        if entry.get("phase") != "pre":
+            continue
+        if agent_id is not None and entry.get("agent_id") != agent_id:
+            continue
+        tool = entry.get("tool", "") or "?"
+        counts[tool] = counts.get(tool, 0) + 1
+    return counts
+
+
+def last_agent_id(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> str:
+    """가장 마지막 entry 의 agent_id (DCN-CHG-20260501-13).
+
+    PostToolUse Agent hook 발화 시점에 직전 sub 식별용. 빈 trace → "".
+    """
+    entries = read_all(session_id, run_id, base_dir=base_dir)
+    for entry in reversed(entries):
+        aid = entry.get("agent_id", "") or ""
+        if aid:
+            return aid
+    return ""

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -444,7 +444,15 @@ def handle_posttooluse_agent(
     *,
     base_dir: Optional[Path] = None,
 ) -> int:
-    """PostToolUse Agent — live.json.active_agent / active_mode 해제."""
+    """PostToolUse Agent — live.json clear + tool histogram inject + redo_log 자동.
+
+    DCN-CHG-20260501-13 — sub 종료 후 agent-trace 집계 → result 옆에 histogram +
+    anomaly 메시지 inject (additionalContext) + redo_log 1줄 자동 append.
+
+    stdout JSON output:
+        {"hookSpecificOutput": {"hookEventName": "PostToolUse",
+                                 "additionalContext": "..."}}
+    """
     if stdin_data is None:
         try:
             raw = sys.stdin.read()
@@ -459,10 +467,79 @@ def handle_posttooluse_agent(
     if not valid_session_id(sid):
         return 0
 
+    # 직전 sub 식별 — payload agent_id 우선, fallback trace 마지막 entry
+    sub_agent_id = stdin_data.get("agent_id", "") or ""
+    sub_type = ""
+    tool_input = stdin_data.get("tool_input") or {}
+    if isinstance(tool_input, dict):
+        sub_type = str(tool_input.get("subagent_type", "") or "")
+
+    rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
+
+    # rid 활성 시만 histogram + redo_log
+    eval_result = None
+    histogram_str = ""
+    if rid:
+        try:
+            from harness.agent_trace import histogram as _trace_hist
+            from harness.agent_trace import last_agent_id as _trace_last
+            from harness.sub_eval import evaluate_sub, format_histogram
+
+            target_aid = sub_agent_id or _trace_last(sid, rid, base_dir=base_dir)
+            hist = _trace_hist(sid, rid, agent_id=target_aid or None, base_dir=base_dir)
+            if hist:
+                histogram_str = format_histogram(hist)
+                # prompt hint — sub 호출 prompt 일부 (Write/Edit 약속 검출용)
+                prompt_hint = ""
+                if isinstance(tool_input, dict):
+                    prompt_hint = str(tool_input.get("prompt", "") or "")[:500]
+                eval_result = evaluate_sub(hist, sub_prompt_hint=prompt_hint)
+
+                # redo_log 자동 append — 보수적 자동 결정. 메인이 별도 1줄로 덮어쓰기 가능.
+                try:
+                    from harness.redo_log import append as _redo_append
+                    _redo_append(sid, rid, {
+                        "auto": True,
+                        "agent_id": target_aid,
+                        "sub": sub_type,
+                        "decision": eval_result["decision"],
+                        "tool_uses": eval_result["tool_uses"],
+                        "histogram": hist,
+                        "anomalies": eval_result["anomalies"],
+                    }, base_dir=base_dir)
+                except Exception:  # noqa: BLE001 — silent, hook 본 흐름 방해 X
+                    pass
+        except Exception:  # noqa: BLE001 — silent
+            pass
+
+    # active_agent 해제 (기존 동작)
     try:
         update_live(sid, base_dir=base_dir, active_agent=None, active_mode=None)
     except (OSError, ValueError):
-        return 0
+        pass
+
+    # additionalContext 작성 — 정상이면 짧은 줄, anomaly 시 강조
+    if histogram_str:
+        if eval_result and eval_result["decision"] == "REDO_SUSPECT":
+            ctx = (
+                f"[감시자 hook] sub={sub_type or '?'} tool histogram: {histogram_str}\n"
+                f"⚠️ anomaly 감지: {'; '.join(eval_result['anomalies'])}\n"
+                f"메인 판단 권고 — REDO_SAME / REDO_BACK / REDO_DIFF 검토 (auto-redo-log 기록됨)"
+            )
+        else:
+            ctx = f"[감시자 hook] sub={sub_type or '?'} tool histogram: {histogram_str} (PASS)"
+
+        try:
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": ctx,
+                }
+            }
+            print(json.dumps(output, ensure_ascii=False))
+        except Exception:  # noqa: BLE001 — silent
+            pass
+
     return 0
 
 

--- a/harness/sub_eval.py
+++ b/harness/sub_eval.py
@@ -1,0 +1,89 @@
+"""sub_eval — sub completion 자동 평가 (DCN-CHG-20260501-13).
+
+PostToolUse Agent hook 가 sub 종료 시 trace 집계 → tool histogram + anomaly 검출
+→ additionalContext inject + redo_log 자동 append.
+
+jajang 메인 자기 진단 반영 (DCN-CHG-20260501-13 plan):
+    - 룰 추가 < surface 개선 (능동 retrieval → push)
+    - 매번 reminder = theater. anomaly 시에만 발화
+    - redo_log 권고 → 인프라 자동화
+
+Anomaly 룰 (보수적):
+    - tool_uses < 2 — sub 가 거의 일 안 함
+    - 같은 tool 5회+ 반복 — 뻘짓 의심
+    - prompt 에 Write/Edit 약속했는데 Write+Edit 0건 — prose-only
+
+자동 결정:
+    - PASS — anomaly 없음
+    - REDO_SUSPECT — anomaly 1+ 검출. 메인이 봐서 재정의 가능.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+__all__ = ["evaluate_sub", "format_histogram", "REPEAT_TOOL_THRESHOLD"]
+
+
+# 보수적 임계값 (운영 데이터 보고 조정 가능)
+REPEAT_TOOL_THRESHOLD = 5
+MIN_TOOL_USES = 2
+
+
+def evaluate_sub(
+    histogram: Dict[str, int],
+    *,
+    sub_prompt_hint: str = "",
+) -> Dict[str, Any]:
+    """histogram + 옵션 prompt hint 기반 자동 평가.
+
+    Args:
+        histogram: agent_trace.histogram 결과 — {"Read": 4, "Bash": 2, ...}
+        sub_prompt_hint: sub 호출 prompt 의 일부 (Write/Edit 약속 검출용). 미사용 가능.
+
+    Returns:
+        {
+            "decision": "PASS" | "REDO_SUSPECT",
+            "anomalies": [str, ...],  # 발견된 anomaly 목록
+            "tool_uses": int,  # 총 호출 수
+        }
+    """
+    total = sum(histogram.values())
+    anomalies: List[str] = []
+
+    # 룰 1 — 너무 적은 호출
+    if total < MIN_TOOL_USES:
+        anomalies.append(f"tool_uses={total} (< {MIN_TOOL_USES})")
+
+    # 룰 2 — 같은 tool 5회+ 반복
+    for tool, count in histogram.items():
+        if count >= REPEAT_TOOL_THRESHOLD:
+            anomalies.append(f"{tool}×{count} (≥ {REPEAT_TOOL_THRESHOLD} 반복)")
+
+    # 룰 3 — prompt 에 Write/Edit 약속 vs 실제 0건
+    write_edit = histogram.get("Write", 0) + histogram.get("Edit", 0)
+    hint_lower = (sub_prompt_hint or "").lower()
+    promised_write = any(
+        kw in hint_lower for kw in ("write", "edit", "create", "작성", "생성")
+    )
+    if promised_write and write_edit == 0 and total > 0:
+        anomalies.append("prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심)")
+
+    decision = "REDO_SUSPECT" if anomalies else "PASS"
+    return {
+        "decision": decision,
+        "anomalies": anomalies,
+        "tool_uses": total,
+    }
+
+
+def format_histogram(histogram: Dict[str, int]) -> str:
+    """histogram → result-옆 inject 용 짧은 문자열.
+
+    Returns:
+        "Read:4 Bash:2 Write:0" 형식. 빈 dict → "(none)".
+    """
+    if not histogram:
+        return "(none)"
+    return " ".join(f"{tool}:{count}" for tool, count in sorted(histogram.items()))

--- a/hooks/post-agent-clear.sh
+++ b/hooks/post-agent-clear.sh
@@ -1,13 +1,19 @@
 #!/usr/bin/env bash
-# dcNess post-agent-clear 훅 — PostToolUse Agent: live.json.active_agent 해제
+# dcNess post-agent-clear 훅 — PostToolUse Agent
+#
+# 동작 (DCN-CHG-20260501-13 — surface 개선):
+#   1. live.json.active_agent / active_mode clear (메인 복귀)
+#   2. agent-trace 집계 → tool histogram + anomaly 검출
+#   3. additionalContext (hookSpecificOutput) stdout JSON 으로 inject
+#      → 메인 다음 turn 의 Agent tool result 옆에 system reminder 로 보임
+#   4. redo_log 1줄 자동 append (메인이 잊는 행동 자동화)
 #
 # 트리거: Claude Code PostToolUse event, tool=Agent
-# stdin: CC payload (sessionId)
-# 동작: harness/hooks.py 의 handle_posttooluse_agent 호출 — live.json 의
-#       active_agent / active_mode 필드 clear (sub-agent 종료 후 메인 복귀).
+# stdin: CC payload (sessionId, agent_id, tool_input.subagent_type 등)
 #
 # 반환:
 #   exit 0: 항상 (PostToolUse 는 차단 권한 X)
+#   stdout: JSON (hookSpecificOutput) — Claude Code 가 인식해서 메인 컨텍스트 inject
 
 set -uo pipefail
 
@@ -18,5 +24,6 @@ python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
 
 CC_PID=$PPID
 
+# stdout (JSON) 그대로 통과시킴 — stderr 만 silence.
 python3 -m harness.hooks posttooluse-agent --cc-pid "$CC_PID" 2>/dev/null || true
 exit 0

--- a/tests/test_agent_trace.py
+++ b/tests/test_agent_trace.py
@@ -10,7 +10,7 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from harness.agent_trace import TRACE_NAME, append, read_all, tail
+from harness.agent_trace import TRACE_NAME, append, histogram, last_agent_id, read_all, tail
 from harness.session_state import generate_run_id, run_dir
 
 
@@ -111,6 +111,62 @@ class AgentTraceTailTests(unittest.TestCase):
     def test_tail_n_larger(self):
         result = tail(SID, self.rid, 100, base_dir=self.base)
         self.assertEqual(len(result), 4)
+
+
+class HistogramTests(unittest.TestCase):
+    def test_empty_run(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            self.assertEqual(histogram(SID, rid, base_dir=base), {})
+
+    def test_pre_only_counted(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            # 같은 도구 호출은 pre + post 짝 — 1회로 셈
+            append(SID, rid, {"phase": "pre", "tool": "Read", "agent_id": "a"}, base_dir=base)
+            append(SID, rid, {"phase": "post", "tool": "Read", "agent_id": "a"}, base_dir=base)
+            append(SID, rid, {"phase": "pre", "tool": "Bash", "agent_id": "a"}, base_dir=base)
+            append(SID, rid, {"phase": "post", "tool": "Bash", "agent_id": "a"}, base_dir=base)
+            hist = histogram(SID, rid, base_dir=base)
+            self.assertEqual(hist, {"Read": 1, "Bash": 1})
+
+    def test_filter_by_agent_id(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"phase": "pre", "tool": "Read", "agent_id": "a"}, base_dir=base)
+            append(SID, rid, {"phase": "pre", "tool": "Read", "agent_id": "a"}, base_dir=base)
+            append(SID, rid, {"phase": "pre", "tool": "Bash", "agent_id": "b"}, base_dir=base)
+            self.assertEqual(histogram(SID, rid, agent_id="a", base_dir=base), {"Read": 2})
+            self.assertEqual(histogram(SID, rid, agent_id="b", base_dir=base), {"Bash": 1})
+            self.assertEqual(histogram(SID, rid, base_dir=base), {"Read": 2, "Bash": 1})
+
+
+class LastAgentIdTests(unittest.TestCase):
+    def test_empty_returns_blank(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            self.assertEqual(last_agent_id(SID, rid, base_dir=base), "")
+
+    def test_returns_last_non_empty(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"phase": "pre", "agent_id": "first"}, base_dir=base)
+            append(SID, rid, {"phase": "post", "agent_id": "first"}, base_dir=base)
+            append(SID, rid, {"phase": "pre", "agent_id": "last"}, base_dir=base)
+            self.assertEqual(last_agent_id(SID, rid, base_dir=base), "last")
+
+    def test_skips_empty_agent_id(self):
+        with TemporaryDirectory() as tmp:
+            base = Path(tmp)
+            rid = generate_run_id()
+            append(SID, rid, {"phase": "pre", "agent_id": "real"}, base_dir=base)
+            append(SID, rid, {"phase": "post", "agent_id": ""}, base_dir=base)
+            self.assertEqual(last_agent_id(SID, rid, base_dir=base), "real")
 
 
 if __name__ == "__main__":

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -45,7 +45,9 @@ from harness.hooks import (
     handle_pretooluse_file_op,
     handle_session_start,
 )
+from harness.agent_trace import append as trace_append
 from harness.agent_trace import read_all as read_trace
+from harness.redo_log import read_all as read_redos
 from harness.session_state import (
     read_live,
     read_pid_session,
@@ -883,6 +885,104 @@ class PostToolUseFileOpTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# DCN-CHG-20260501-13 — PostToolUse Agent histogram inject + auto redo_log
+# ---------------------------------------------------------------------------
+
+
+class PostToolUseAgentHistogramTests(_PreToolBase):
+    """sub 종료 후 trace 집계 → redo_log 자동 append + stdout 메시지."""
+
+    def _seed_trace(self, agent_id: str, tools: list) -> None:
+        for tool in tools:
+            trace_append(self.sid, self.rid, {
+                "phase": "pre", "agent_id": agent_id, "tool": tool,
+            }, base_dir=self.base)
+            trace_append(self.sid, self.rid, {
+                "phase": "post", "agent_id": agent_id, "tool": tool,
+            }, base_dir=self.base)
+
+    def _post_payload(self, sub_type: str, agent_id: str, prompt: str = "") -> dict:
+        return {
+            "sessionId": self.sid,
+            "agent_id": agent_id,
+            "tool_name": "Agent",
+            "tool_input": {
+                "subagent_type": sub_type,
+                "prompt": prompt,
+            },
+        }
+
+    def test_pass_auto_redo_log(self):
+        self._seed_trace("aid-engineer", ["Read", "Read", "Write", "Bash"])
+        rc = handle_posttooluse_agent(
+            stdin_data=self._post_payload("engineer", "aid-engineer"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(len(redos), 1)
+        self.assertEqual(redos[0]["decision"], "PASS")
+        self.assertTrue(redos[0]["auto"])
+        self.assertEqual(redos[0]["sub"], "engineer")
+        self.assertEqual(redos[0]["tool_uses"], 4)
+
+    def test_redo_suspect_on_low_calls(self):
+        self._seed_trace("aid-x", ["Read"])
+        rc = handle_posttooluse_agent(
+            stdin_data=self._post_payload("architect", "aid-x"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(redos[0]["decision"], "REDO_SUSPECT")
+        self.assertTrue(redos[0]["anomalies"])
+
+    def test_redo_suspect_on_prose_only(self):
+        # Read 만 4번 + Write 0건. prompt 에 "create file" 약속.
+        self._seed_trace("aid-arch", ["Read", "Read", "Read", "Read"])
+        rc = handle_posttooluse_agent(
+            stdin_data=self._post_payload(
+                "architect", "aid-arch",
+                prompt="create the impl plan file at docs/foo.md"
+            ),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(redos[0]["decision"], "REDO_SUSPECT")
+        self.assertTrue(any("prose-only" in a for a in redos[0]["anomalies"]))
+
+    def test_clears_active_agent_still_works(self):
+        update_live(
+            self.sid, base_dir=self.base,
+            active_agent="engineer", active_mode="IMPL",
+        )
+        self._seed_trace("aid-engineer", ["Read", "Bash"])
+        rc = handle_posttooluse_agent(
+            stdin_data=self._post_payload("engineer", "aid-engineer"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        live = read_live(self.sid, base_dir=self.base)
+        self.assertNotIn("active_agent", live)
+        self.assertNotIn("active_mode", live)
+
+    def test_no_trace_no_redo_log(self):
+        # trace 비어있으면 자동 redo_log 미추가, hook 본 흐름만.
+        rc = handle_posttooluse_agent(
+            stdin_data=self._post_payload("engineer", "aid-empty"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        self.assertEqual(read_redos(self.sid, self.rid, base_dir=self.base), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_sub_eval.py
+++ b/tests/test_sub_eval.py
@@ -1,0 +1,90 @@
+"""test_sub_eval — DCN-CHG-20260501-13.
+
+Coverage matrix:
+    evaluate_sub:
+        - 정상 PASS — 적당한 호출 수 + 다양한 tool
+        - REDO_SUSPECT: tool_uses 0 (아예 안 함)
+        - REDO_SUSPECT: tool_uses 1 (< MIN_TOOL_USES)
+        - REDO_SUSPECT: 같은 tool 5회 (반복)
+        - REDO_SUSPECT: prompt 에 Write 약속 + Write+Edit 0건 (prose-only)
+        - prompt hint 없으면 prose-only 검사 skip
+        - 다중 anomaly 한 번에 검출
+
+    format_histogram:
+        - 빈 dict → "(none)"
+        - 정렬된 짧은 문자열
+"""
+from __future__ import annotations
+
+import unittest
+
+from harness.sub_eval import (
+    MIN_TOOL_USES,
+    REPEAT_TOOL_THRESHOLD,
+    evaluate_sub,
+    format_histogram,
+)
+
+
+class EvaluateSubTests(unittest.TestCase):
+    def test_pass_normal(self):
+        result = evaluate_sub({"Read": 4, "Bash": 2, "Write": 1})
+        self.assertEqual(result["decision"], "PASS")
+        self.assertEqual(result["anomalies"], [])
+        self.assertEqual(result["tool_uses"], 7)
+
+    def test_redo_zero_calls(self):
+        result = evaluate_sub({})
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+        self.assertTrue(any("tool_uses=0" in a for a in result["anomalies"]))
+
+    def test_redo_below_min(self):
+        result = evaluate_sub({"Read": 1})
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+        self.assertTrue(any(f"< {MIN_TOOL_USES}" in a for a in result["anomalies"]))
+
+    def test_redo_repeat_tool(self):
+        result = evaluate_sub({"Bash": REPEAT_TOOL_THRESHOLD})
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+        self.assertTrue(any("Bash" in a and "반복" in a for a in result["anomalies"]))
+
+    def test_redo_prose_only(self):
+        # Write 약속 prompt + Write+Edit 0건
+        result = evaluate_sub(
+            {"Read": 4, "Bash": 1},
+            sub_prompt_hint="Write the implementation plan to docs/foo.md",
+        )
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+        self.assertTrue(any("prose-only" in a for a in result["anomalies"]))
+
+    def test_no_hint_no_prose_check(self):
+        # 같은 histogram 이지만 hint 없으면 PASS
+        result = evaluate_sub({"Read": 4, "Bash": 1}, sub_prompt_hint="")
+        self.assertEqual(result["decision"], "PASS")
+
+    def test_korean_hint_detected(self):
+        result = evaluate_sub(
+            {"Read": 3},
+            sub_prompt_hint="impl 파일 작성해줘",
+        )
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+
+    def test_multiple_anomalies(self):
+        result = evaluate_sub({"Bash": 6})
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+        # 6 개라 MIN_TOOL_USES 통과, REPEAT_TOOL_THRESHOLD 위반 1개
+        self.assertEqual(len(result["anomalies"]), 1)
+
+
+class FormatHistogramTests(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(format_histogram({}), "(none)")
+
+    def test_normal(self):
+        s = format_histogram({"Read": 4, "Bash": 2, "Write": 0})
+        # sorted alphabetical
+        self.assertEqual(s, "Bash:2 Read:4 Write:0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

PR-2 (\`-12\`) 머지 후 jajang 운영 1 cycle 발견 — **권고 어휘로 메인 능동 retrieval 행동 강제 불가**. trace 178 호출 정상 캡처 ✅, 메인이 trace read + 정확한 평가 ✅, 단 **redo-log 0 entry** ❌.

jajang 메인 자기 진단 (사용자 인용) ROI 표:

| 변경 | ROI | 메인 인지 비용 |
|---|---|---|
| \`<usage>\` 옆 tool-histogram | 🔥🔥🔥 | 0 |
| finalize-run 자동 redo_log | 🔥🔥 | 0 |
| anomaly 조건부 reminder | 🔥🔥 | 낮음 |
| blanket 룰 의무화 | 🟡 | 높음 (theater) |

핵심 진단 — **"룰 추가 < surface 개선"**. retrieval 의무는 룰 강화로 안 풀림, push 로 바꿔야 풀림.

## 채택 — PostToolUse Agent hook 가 push 채널

PostToolUse 의 \`hookSpecificOutput.additionalContext\` 가 *tool result 옆에* system reminder 로 inject — 공식 docs 확정.

## 변경

- **\`harness/sub_eval.py\`** 신규 — anomaly 룰 + auto decision
  - \`tool_uses < 2\` / \`같은 tool 5회+\` / \`Write 약속 + Write+Edit 0건 (prose-only)\`
  - 보수적 임계 (운영 데이터 보고 조정)
- **\`harness/agent_trace.py\`** — \`histogram(sid, rid, agent_id)\` + \`last_agent_id\` helper
- **\`harness/hooks.py:handle_posttooluse_agent\`** 확장 — trace 집계 → stdout JSON inject + auto redo_log append
- **\`hooks/post-agent-clear.sh\`** — stdout JSON 통과 + 코멘트 갱신

## 메시지 형식

정상 (1줄):
\`\`\`
[감시자 hook] sub=engineer tool histogram: Bash:2 Read:4 Write:1 (PASS)
\`\`\`

Anomaly (강조):
\`\`\`
[감시자 hook] sub=architect tool histogram: Read:4
⚠️ anomaly 감지: prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심)
메인 판단 권고 — REDO_SAME / REDO_BACK / REDO_DIFF 검토 (auto-redo-log 기록됨)
\`\`\`

## 대원칙 §0 self-check

- 정보 inject 만 — 작업 순서 / 접근 영역 강제 X
- 메인은 메시지 보고 *자기 판단* 으로 REDO 결정 (강제 X)
- agent 자율 정합

## Test plan

- [x] 신규 21 case (sub_eval 10 + agent_trace 6 + hooks 5) + 회귀 0 / 전체 345 OK
- [x] doc-sync gate PASS
- [x] pytest pre-commit gate PASS
- [ ] CI green (push 후)
- [ ] 실 운영 — 다음 jajang sub cycle 에서 redo_log auto entry 자동 누적 확인
- [ ] 메인 행동 변형 측정 — anomaly 메시지 받고 *실제 REDO 결정 비율*

## Follow-up

- (P5 운영 1-2 주) auto entry 100+ 누적 → false positive/negative 비율 측정 → 임계값 조정 PR
- (P6 환류) anomaly 패턴 검증 → \`agents/*.md\` 사전 경고 박기
- (P7) sub_prompt_hint 한국어 키워드 확장
- (별도 PR) \`/audit-redo\` 가 \`auto:true\` entry 와 메인 manual entry 구분 분석

🤖 Generated with [Claude Code](https://claude.com/claude-code)