### PR TITLE
harness: prose_file 직결로 _resolve_prose_path() 삭제 (DCN-CHG-20260501-14)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,13 @@
 
 ## 현재 상태
 
+- **🔗 prose_file 직결 + `_resolve_prose_path()` 삭제** (`DCN-CHG-20260501-14`):
+  - `.prose-staging/` 파일명 패턴 불일치로 같은 (agent, mode) 반복 시 두번째가 outer prose 덮어씌워 run-review 분실 버그 수정.
+  - `write_prose(occurrence=N)` 추가 — N>0 시 `<agent>[-mode]-N.md` 고유 파일명.
+  - `_append_step_status(prose_path)` → `.steps.jsonl`에 `prose_file` 절대 경로 저장.
+  - `parse_steps()`: `prose_file` 직접 read, legacy fallback 보존. `_resolve_prose_path()` 삭제.
+  - 342 tests OK.
+
 - **📡 PostToolUse Agent surface push (PR-3)** (`DCN-CHG-20260501-13`):
   - jajang 운영 1 cycle 발견 — 권고 어휘로 메인 능동 retrieval 행동 강제 불가. trace 는 read 함, redo-log 0 entry. jajang 메인 자기 진단 ROI 표 ("룰 추가 < surface 개선") 그대로 반영.
   - **PostToolUse Agent hook 가 push 채널로** — sub 종료 후 `additionalContext` 로 메인 다음 turn Agent tool result 옆에 system reminder 자동 inject. 공식 docs 확정 메커니즘.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260501-14
+- **Date**: 2026-05-01
+- **Rationale**: `.prose-staging/` 파일명 컨벤션 불일치로 `_resolve_prose_path()` 패턴 매칭이 실제 파일명과 안 맞음 → 같은 (agent, mode) 반복 시 두번째 end-step이 outer prose를 덮어씌워 `run-review`가 첫번째 결과를 영구 분실.
+- **Alternatives**: (1) `_resolve_prose_path()` 파일명 패턴 수정 — 컨벤션이 skill마다 달라서 유지보수 지속 필요, 근본 해결 아님. (2) `.steps.jsonl`에 `prose_file` 절대 경로 저장 — `end-step`이 쓴 경로를 그대로 기록하므로 패턴 매칭 불필요.
+- **Decision**: (2) 채택. `signal_io.write_prose(occurrence=N)` — 같은 (agent, mode) N번째 호출 시 `<agent>[-mode]-N.md`로 충돌 방지. `_append_step_status()`가 `prose_file` 필드 추가. `parse_steps()`는 `prose_file` 직접 read, legacy fallback 보존. `_resolve_prose_path()` 삭제.
+- **Follow-Up**: `.prose-staging/` 디렉토리는 skill 임시 수집용으로만 남음 (parse_steps가 직접 읽지 않음). 향후 `.prose-staging/` 생성 자체 제거 가능하나 현재 skill 변경 없이 방치해도 무해.
+
 ### DCN-CHG-20260501-13
 - **Date**: 2026-05-01
 - **Rationale**:

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260501-14
+- **Date**: 2026-05-01
+- **Change-Type**: harness, test
+- **Files Changed**:
+  - `harness/signal_io.py`
+  - `harness/session_state.py`
+  - `harness/run_review.py`
+  - `tests/test_run_review.py`
+  - `tests/test_session_state.py`
+- **Summary**: prose_file 필드로 `.steps.jsonl` ↔ prose 직접 연결 — `_resolve_prose_path()` 삭제
+
 ### DCN-CHG-20260501-13
 - **Date**: 2026-05-01
 - **Change-Type**: harness, hooks, test

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -212,38 +212,6 @@ def _parse_iso(ts: str) -> Optional[datetime]:
         return None
 
 
-def _resolve_prose_path(
-    run_dir: Path,
-    agent: str,
-    mode: Optional[str],
-    occurrence: int,
-) -> Path:
-    """Step 의 prose staging 파일 경로 해결 (DCN-CHG-20260501-09).
-
-    skill 컨벤션 (DCN-30-21): `<run_dir>/.prose-staging/<step>.md` 에 prose 작성.
-    `<step>` 명명 규칙:
-      - impl batch loop:        `b<N>.<agent>-<mode>.md`  (mode 있음)
-      - impl batch (no mode):   `b<N>.<agent>.md`
-      - 단발 skill (quick 등):  `<agent>-<mode>.md` 또는 `<agent>.md`
-
-    같은 (agent, mode) 가 여러 번 발생하면 lexical 정렬 후 N번째 occurrence 매칭
-    (b1 < b2 < b3 < bare suffix). DCN-CHG-20260430-23 path 격리 후 parser 가
-    legacy `<run_dir>/<agent>-<mode>.md` 만 읽어 매 step 동일 파일 회귀.
-
-    Fallback: `.prose-staging/` 부재 또는 미매칭 시 legacy `<run_dir>/<agent>-<mode>.md`.
-    """
-    suffix = f"{agent}-{mode}.md" if mode else f"{agent}.md"
-    staging = run_dir / ".prose-staging"
-    if staging.exists():
-        candidates = sorted(
-            p for p in staging.iterdir()
-            if p.is_file() and (p.name == suffix or p.name.endswith(f".{suffix}"))
-        )
-        if 0 <= occurrence < len(candidates):
-            return candidates[occurrence]
-    return run_dir / suffix
-
-
 def parse_steps(run_dir: Path) -> list[StepRecord]:
     steps: list[StepRecord] = []
     jsonl = run_dir / ".steps.jsonl"
@@ -259,26 +227,36 @@ def parse_steps(run_dir: Path) -> list[StepRecord]:
         except json.JSONDecodeError:
             continue
 
-    occurrence_counter: dict = {}
     for idx, rec in enumerate(raw):
         agent = rec.get("agent", "?")
         mode = rec.get("mode")
-        key = (agent, mode)
-        occ = occurrence_counter.get(key, 0)
-        occurrence_counter[key] = occ + 1
-        prose_path = _resolve_prose_path(run_dir, agent, mode, occ)
         prose_full = ""
-        if prose_path.exists():
-            try:
-                prose_full = prose_path.read_text(encoding="utf-8")
-            except OSError:
-                prose_full = ""
-        # DCN-CHG-20260501-10: prose_full 보유 시 must_fix 재계산 (negation-aware).
-        # 부재 시 jsonl `must_fix` fallback (legacy / staging missing).
+
+        # prose_file: end-step 이 기록한 절대 경로 → 직접 읽기
+        prose_file = rec.get("prose_file")
+        if prose_file:
+            p = Path(prose_file)
+            if p.exists():
+                try:
+                    prose_full = p.read_text(encoding="utf-8")
+                except OSError:
+                    pass
+
+        # legacy fallback: prose_file 없는 옛 records → outer <agent>[-mode].md
+        if not prose_full:
+            suffix = f"{agent}-{mode}.md" if mode else f"{agent}.md"
+            legacy = run_dir / suffix
+            if legacy.exists():
+                try:
+                    prose_full = legacy.read_text(encoding="utf-8")
+                except OSError:
+                    pass
+
         if prose_full:
             must_fix = _has_positive_must_fix(prose_full)
         else:
             must_fix = bool(rec.get("must_fix"))
+
         steps.append(StepRecord(
             idx=idx,
             ts=rec.get("ts", ""),

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1167,9 +1167,10 @@ def _cli_end_step(args: Any) -> int:
         # drift detector 자체 실패는 silent — end-step 동작 우선
         pass
 
-    # prose 저장 — base_dir 은 .sessions/{sid}/runs/ (signal_io 가 그 아래 rid 디렉토리 생성)
+    # prose 저장 — occurrence 계산으로 같은 (agent, mode) 반복 시 파일 충돌 방지
     base = session_dir(sid) / "runs"
-    write_prose(args.agent, rid, prose, mode=mode, base_dir=base)
+    occ = _count_step_occurrences(sid, rid, args.agent, mode)
+    prose_path = write_prose(args.agent, rid, prose, mode=mode, base_dir=base, occurrence=occ)
 
     allowed = [s.strip() for s in args.allowed_enums.split(",") if s.strip()]
     if not allowed:
@@ -1197,7 +1198,7 @@ def _cli_end_step(args: Any) -> int:
     if summary:
         print(summary, file=sys.stderr)
     # step status append — finalize-run / 회고용
-    _append_step_status(sid, rid, args.agent, mode, enum, prose)
+    _append_step_status(sid, rid, args.agent, mode, enum, prose, prose_path)
     return 0
 
 
@@ -1243,6 +1244,22 @@ def _steps_jsonl_path(sid: str, rid: str, *, base_dir: Optional[Path] = None) ->
     return run_dir(sid, rid, base_dir=base_dir) / ".steps.jsonl"
 
 
+def _count_step_occurrences(sid: str, rid: str, agent: str, mode: Optional[str]) -> int:
+    """`.steps.jsonl` 에 기록된 (agent, mode) 쌍의 수 반환 (write_prose occurrence 계산용)."""
+    target = _steps_jsonl_path(sid, rid)
+    if not target.exists():
+        return 0
+    count = 0
+    for line in target.read_text(encoding="utf-8").splitlines():
+        try:
+            r = json.loads(line)
+            if r.get("agent") == agent and r.get("mode") == mode:
+                count += 1
+        except json.JSONDecodeError:
+            pass
+    return count
+
+
 def _append_step_status(
     sid: str,
     rid: str,
@@ -1250,6 +1267,7 @@ def _append_step_status(
     mode: Optional[str],
     enum: str,
     prose: str,
+    prose_path: "Path",
 ) -> None:
     """end-step 호출마다 jsonl 에 한 줄 append. atomic 보장 X (append-only)."""
     record = {
@@ -1259,6 +1277,7 @@ def _append_step_status(
         "enum": enum,
         "prose_excerpt": _extract_prose_summary(prose, max_lines=12),
         "must_fix": _has_positive_must_fix(prose),
+        "prose_file": str(prose_path),
     }
     target = _steps_jsonl_path(sid, rid)
     target.parent.mkdir(parents=True, exist_ok=True)

--- a/harness/signal_io.py
+++ b/harness/signal_io.py
@@ -139,13 +139,14 @@ def signal_path(
     run_id: str,
     mode: Optional[str] = None,
     base_dir: Optional[Path] = None,
+    *,
+    occurrence: int = 0,
 ) -> Path:
     """prose 파일의 절대 경로 반환.
 
-    경로 규칙: <base_dir>/<run_id>/<agent>[-<mode>].md
-
-    예) base/run_001/validator-CODE_VALIDATION.md
-        base/run_001/architect.md   (mode None)
+    경로 규칙: <base_dir>/<run_id>/<agent>[-<mode>][-<N>].md
+      N=0 (기본): <agent>[-<mode>].md
+      N>0       : <agent>[-<mode>]-<N>.md  (같은 step 반복 시 충돌 방지)
 
     화이트리스트 + path traversal 자기검증.
     """
@@ -154,7 +155,8 @@ def signal_path(
     _validate_run_id(run_id)
 
     base = _resolve_base(base_dir)
-    name = f"{agent}-{mode}.md" if mode else f"{agent}.md"
+    stem = f"{agent}-{mode}" if mode else agent
+    name = f"{stem}-{occurrence}.md" if occurrence > 0 else f"{stem}.md"
     target = (base / run_id / name).resolve()
 
     try:
@@ -173,8 +175,11 @@ def write_prose(
     *,
     mode: Optional[str] = None,
     base_dir: Optional[Path] = None,
+    occurrence: int = 0,
 ) -> Path:
     """prose 작성. 형식 강제 없음. atomic rename 으로 race 회피.
+
+    occurrence > 0 이면 <agent>[-mode]-<N>.md 로 저장 (같은 step 반복 충돌 방지).
 
     Returns: 작성된 파일의 절대 경로.
 
@@ -186,7 +191,7 @@ def write_prose(
     if not isinstance(prose, str):
         raise TypeError(f"prose must be str, got {type(prose).__name__}")
 
-    target = signal_path(agent, run_id, mode, base_dir)
+    target = signal_path(agent, run_id, mode, base_dir, occurrence=occurrence)
     target.parent.mkdir(parents=True, exist_ok=True)
 
     tmp = target.with_suffix(target.suffix + ".tmp")

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -14,7 +14,6 @@ from harness.run_review import (  # noqa: E402
     RunReport, StepRecord, build_report, detect_goods, detect_wastes,
     parse_steps, render_report, list_runs, find_run_dir,
     _normalize_agent_type, assign_invocations_to_steps,
-    _resolve_prose_path,
     EXPECTED_AGENT_BUDGETS,
 )
 
@@ -62,113 +61,80 @@ class ParseStepsTests(unittest.TestCase):
     def test_loads_full_prose(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
+            prose_path = tmp / "architect-SYSTEM_DESIGN.md"
+            prose_path.write_text("## Domain Model\nEntity X\n")
             rd = _make_run_dir(tmp, "sid1", "rid1", [
                 {"ts": "2026-04-30T10:00:00", "agent": "architect", "mode": "SYSTEM_DESIGN",
-                 "enum": "SYSTEM_DESIGN_READY", "must_fix": False, "prose_excerpt": "x"},
-            ], prose_files={"architect-SYSTEM_DESIGN.md": "## Domain Model\nEntity X\n"})
+                 "enum": "SYSTEM_DESIGN_READY", "must_fix": False, "prose_excerpt": "x",
+                 "prose_file": str(prose_path)},
+            ])
             steps = parse_steps(rd)
             self.assertIn("Domain Model", steps[0].prose_full)
 
 
-class ResolveProsePathTests(unittest.TestCase):
-    """DCN-CHG-20260501-09 — staging path resolution (.prose-staging Nth occurrence).
-
-    자장 run-ef6c2c00 회귀 — parser 가 legacy `<run_dir>/<agent>-<mode>.md` 만
-    읽어 9 engineer step 모두 같은 1 파일 매칭 → MISSING_SELF_VERIFY 9건
-    false positive.
-    """
-
-    def _setup(self, tmp: Path) -> Path:
-        rd = tmp / "run"
-        (rd / ".prose-staging").mkdir(parents=True)
-        return rd
-
-    def test_picks_nth_occurrence_in_staging(self):
-        with tempfile.TemporaryDirectory() as td:
-            rd = self._setup(Path(td))
-            (rd / ".prose-staging" / "b1.engineer-IMPL.md").write_text("b1 content")
-            (rd / ".prose-staging" / "b2.engineer-IMPL.md").write_text("b2 content")
-            (rd / ".prose-staging" / "b3.engineer-IMPL.md").write_text("b3 content")
-            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 0).read_text(), "b1 content")
-            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 1).read_text(), "b2 content")
-            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 2).read_text(), "b3 content")
-
-    def test_falls_back_to_legacy_run_dir(self):
-        with tempfile.TemporaryDirectory() as td:
-            rd = self._setup(Path(td))
-            (rd / "engineer-IMPL.md").write_text("legacy content")
-            # staging 빈 → fallback
-            self.assertEqual(_resolve_prose_path(rd, "engineer", "IMPL", 0).read_text(), "legacy content")
-
-    def test_no_mode_uses_agent_only(self):
-        with tempfile.TemporaryDirectory() as td:
-            rd = self._setup(Path(td))
-            (rd / ".prose-staging" / "b1.pr-reviewer.md").write_text("pr1")
-            (rd / ".prose-staging" / "b2.pr-reviewer.md").write_text("pr2")
-            self.assertEqual(_resolve_prose_path(rd, "pr-reviewer", None, 0).read_text(), "pr1")
-            self.assertEqual(_resolve_prose_path(rd, "pr-reviewer", None, 1).read_text(), "pr2")
-
-    def test_bare_suffix_also_matches(self):
-        # 단발 skill 컨벤션 — bN prefix 없는 `<agent>-<mode>.md`
-        with tempfile.TemporaryDirectory() as td:
-            rd = self._setup(Path(td))
-            (rd / ".prose-staging" / "architect-LIGHT_PLAN.md").write_text("bare")
-            self.assertEqual(_resolve_prose_path(rd, "architect", "LIGHT_PLAN", 0).read_text(), "bare")
+class ProseFileTests(unittest.TestCase):
+    """prose_file 필드 기반 prose 로딩 테스트."""
 
     def test_parse_steps_recomputes_must_fix_from_prose(self):
-        """DCN-CHG-20260501-10 — prose_full 있을 때 must_fix 재계산 (retro accuracy).
-
-        legacy `.steps.jsonl` 에 must_fix=True 기록됐어도 prose 가 "MUST FIX 0" 부정문이면
-        parser 가 must_fix=False 로 정정. 자장 run-ef6c2c00 6 false positive retro 회복 시나리오.
-        """
+        """prose_file 있을 때 must_fix 재계산 (negation-aware retro accuracy)."""
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
+            prose_path = tmp / "pr-reviewer.md"
+            prose_path.write_text("MUST FIX 0, NICE TO HAVE 6 (let tree: any / dead code).\nLGTM\n")
             rd = _make_run_dir(tmp, "sid1", "rid1", [
-                # legacy regex stale data — must_fix=True 기록됐지만 prose 는 negation
                 {"ts": "2026-04-30T10:00:00", "agent": "pr-reviewer", "mode": None,
                  "enum": "LGTM", "must_fix": True,
-                 "prose_excerpt": "MUST FIX 0, NICE TO HAVE 6\nLGTM"},
+                 "prose_excerpt": "MUST FIX 0, NICE TO HAVE 6\nLGTM",
+                 "prose_file": str(prose_path)},
             ])
-            (rd / ".prose-staging").mkdir()
-            (rd / ".prose-staging" / "pr-reviewer.md").write_text(
-                "MUST FIX 0, NICE TO HAVE 6 (let tree: any / dead code).\nLGTM\n"
-            )
             steps = parse_steps(rd)
             self.assertEqual(len(steps), 1)
             self.assertFalse(steps[0].must_fix, "negation 부정문 → False 재계산")
 
     def test_parse_steps_must_fix_falls_back_to_jsonl(self):
-        """prose_full 부재 시 jsonl `must_fix` fallback (legacy 데이터 보존)."""
+        """prose_file 없을 때 jsonl must_fix fallback."""
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             rd = _make_run_dir(tmp, "sid1", "rid1", [
                 {"ts": "2026-04-30T10:00:00", "agent": "validator", "mode": "CODE_VALIDATION",
                  "enum": "FAIL", "must_fix": True, "prose_excerpt": "x"},
             ])
-            # staging 자체 없음 — fallback 시나리오
             steps = parse_steps(rd)
             self.assertEqual(len(steps), 1)
             self.assertTrue(steps[0].must_fix, "prose 부재 → jsonl fallback")
 
-    def test_parse_steps_resolves_per_occurrence(self):
-        # End-to-end — parse_steps 가 같은 (agent, mode) 의 N번째 staging 매칭하는지
+    def test_parse_steps_resolves_per_occurrence_via_prose_file(self):
+        """같은 (agent, mode) 반복 시 prose_file 로 각 step 독립 파일 읽기."""
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
+            p1 = tmp / "engineer-IMPL.md"
+            p2 = tmp / "engineer-IMPL-1.md"
+            p1.write_text("first batch\n## 자가 검증\n- jest PASS")
+            p2.write_text("second batch\nno anchor")
             rd = _make_run_dir(tmp, "sid1", "rid1", [
                 {"ts": "2026-04-30T10:00:00", "agent": "engineer", "mode": "IMPL",
-                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x"},
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x",
+                 "prose_file": str(p1)},
                 {"ts": "2026-04-30T10:05:00", "agent": "engineer", "mode": "IMPL",
-                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x"},
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x",
+                 "prose_file": str(p2)},
             ])
-            (rd / ".prose-staging").mkdir()
-            (rd / ".prose-staging" / "b1.engineer-IMPL.md").write_text("first batch\n## 자가 검증\n- jest PASS")
-            (rd / ".prose-staging" / "b2.engineer-IMPL.md").write_text("second batch\nno anchor")
             steps = parse_steps(rd)
             self.assertEqual(len(steps), 2)
             self.assertIn("first batch", steps[0].prose_full)
             self.assertIn("second batch", steps[1].prose_full)
-            # 회귀 검증 — 두 step 이 *다른* 파일을 보는지
             self.assertNotEqual(steps[0].prose_full, steps[1].prose_full)
+
+    def test_parse_steps_legacy_fallback_outer_file(self):
+        """prose_file 없는 레거시 record → outer <agent>[-mode].md fallback."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "architect", "mode": "SYSTEM_DESIGN",
+                 "enum": "SYSTEM_DESIGN_READY", "must_fix": False, "prose_excerpt": "x"},
+            ], prose_files={"architect-SYSTEM_DESIGN.md": "## Domain Model\nlegacy\n"})
+            steps = parse_steps(rd)
+            self.assertIn("legacy", steps[0].prose_full)
 
 
 class WasteDetectionTests(unittest.TestCase):

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1528,10 +1528,11 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         sid = "test-sid"
         rid = "run-deadbeef"
         run_dir(sid, rid, create=True)
-        _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "qa prose body")
+        _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "qa prose body", Path("/dev/null"))
         _append_step_status(
             sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY",
             "## 결론\nLIGHT_PLAN_READY\n## 변경\n무언가",
+            Path("/dev/null"),
         )
         records = _read_steps_jsonl(sid, rid)
         self.assertEqual(len(records), 2)
@@ -1553,6 +1554,7 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         _append_step_status(
             "sid", "run-aaaa1111", "pr-reviewer", None, "CHANGES_REQUESTED",
             "## 결론\nCHANGES_REQUESTED\n## MUST FIX\n- src/foo.py:10 race condition\n",
+            Path("/dev/null"),
         )
         records = _read_steps_jsonl("sid", "run-aaaa1111")
         self.assertTrue(records[0]["must_fix"])
@@ -1576,14 +1578,17 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         _append_step_status(
             "sid", "run-bbbb2222", "pr-reviewer", None, "LGTM",
             "MUST FIX 0, NICE TO HAVE 6 (let tree: any / dead code).\nLGTM\n",
+            Path("/dev/null"),
         )
         _append_step_status(
             "sid", "run-bbbb2222", "pr-reviewer", None, "LGTM",
             "MUST FIX: 0\n결론: LGTM\n",
+            Path("/dev/null"),
         )
         _append_step_status(
             "sid", "run-bbbb2222", "pr-reviewer", None, "LGTM",
             "검토 결과: MUST FIX 없음. NICE TO HAVE 3.\nLGTM\n",
+            Path("/dev/null"),
         )
         records = _read_steps_jsonl("sid", "run-bbbb2222")
         for r in records:
@@ -1603,15 +1608,18 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         _append_step_status(
             "sid", "run-cccc3333", "pr-reviewer", None, "CHANGES_REQUESTED",
             "## MUST FIX\n- audio buffer underflow on iOS\n",
+            Path("/dev/null"),
         )
         _append_step_status(
             "sid", "run-cccc3333", "pr-reviewer", None, "CHANGES_REQUESTED",
             "MUST FIX: storage 키 충돌 가능\nLGTM 후보 X\n",
+            Path("/dev/null"),
         )
         # mixed — 부정 라인 + positive 라인 → True (positive 우선)
         _append_step_status(
             "sid", "run-cccc3333", "pr-reviewer", None, "CHANGES_REQUESTED",
             "MUST FIX 0\nMUST FIX: 실제 이슈 발견\n",
+            Path("/dev/null"),
         )
         records = _read_steps_jsonl("sid", "run-cccc3333")
         self.assertEqual(len(records), 3)
@@ -1643,15 +1651,15 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         run_dir(sid, rid, create=True)
         write_pid_current_run(cc_pid, rid)
 
-        _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "ok")
+        _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "ok", Path("/dev/null"))
         _append_step_status(
-            sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY", "ok"
+            sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY", "ok", Path("/dev/null")
         )
-        _append_step_status(sid, rid, "engineer", "IMPL", "IMPL_DONE", "fix done")
+        _append_step_status(sid, rid, "engineer", "IMPL", "IMPL_DONE", "fix done", Path("/dev/null"))
         _append_step_status(
-            sid, rid, "validator", "BUGFIX_VALIDATION", "PASS", "verified"
+            sid, rid, "validator", "BUGFIX_VALIDATION", "PASS", "verified", Path("/dev/null")
         )
-        _append_step_status(sid, rid, "pr-reviewer", None, "LGTM", "looks good")
+        _append_step_status(sid, rid, "pr-reviewer", None, "LGTM", "looks good", Path("/dev/null"))
 
         out = StringIO()
         with redirect_stdout(out):


### PR DESCRIPTION
## Summary
- `.prose-staging/` 파일명 패턴 불일치로 같은 (agent, mode) 반복 시 두번째 end-step이 outer prose를 덮어씌워 `run-review`가 첫번째 결과를 분실하는 버그 수정
- `_resolve_prose_path()` (패턴 매칭 100줄) 전체 삭제, `prose_file` 절대 경로 직접 저장으로 대체

## Changes
- `signal_io.write_prose(occurrence=N)`: N>0 시 `<agent>[-mode]-N.md` 고유 파일명 생성
- `session_state._append_step_status(prose_path)`: `.steps.jsonl`에 `prose_file` 절대 경로 저장
- `run_review.parse_steps()`: `prose_file` 직접 read, legacy fallback 보존
- `tests/test_run_review.py`: `ResolveProsePathTests` → `ProseFileTests` 교체

## Test plan
- [x] 342 tests OK (doc-sync + pytest gate 통과)
- [x] legacy records (`prose_file` 없음) → outer `<agent>[-mode].md` fallback 보존

## Governance
- Task-ID: DCN-CHG-20260501-14
- Change-Type: harness, test