### PR TITLE
harness: PostToolUse prose auto-staging, --prose-file optional (DCN-CHG-20260501-15)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,13 @@
 
 ## 현재 상태
 
+- **🪄 PostToolUse prose auto-staging** (`DCN-CHG-20260501-15`):
+  - `handle_posttooluse_agent` — `tool_response.text` 추출 → `write_prose` → `live.json.current_step.prose_file` 기록.
+  - `end-step --prose-file` optional로 변경 — 미제공 시 `current_step.prose_file` 자동 읽기.
+  - 메인 Claude 의 Write/Bash heredoc prose-staging 작업 제거 가능 (매 step 1~2회 절감).
+  - `_count_step_occurrences` `base_dir` 파라미터 추가 (hook test 정합).
+  - 351 tests OK.
+
 - **🔗 prose_file 직결 + `_resolve_prose_path()` 삭제** (`DCN-CHG-20260501-14`):
   - `.prose-staging/` 파일명 패턴 불일치로 같은 (agent, mode) 반복 시 두번째가 outer prose 덮어씌워 run-review 분실 버그 수정.
   - `write_prose(occurrence=N)` 추가 — N>0 시 `<agent>[-mode]-N.md` 고유 파일명.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260501-15
+- **Date**: 2026-05-01
+- **Rationale**: 메인 Claude 가 sub-agent 완료 후 prose 를 `Write/Bash heredoc` 으로 staging 하는 작업은 kabuki — PostToolUse hook stdin 에 `tool_response.text` 로 이미 prose 전체가 있는데 같은 바이트를 메인이 다시 disk 에 옮기는 구조. 매 step 마다 Write/Bash 1~2 회 + Write hook block 회피용 heredoc 사용이 반복.
+- **Alternatives**: (1) `--prose-stdin` pipe — argparse 1줄 추가, 메인은 `echo "$PROSE" | end-step` 호출. 메인에서 prose string 처리 부담이 여전히 남음. (2) `--prose "$PROSE"` inline arg — arg escape 부담 있음. (3) PostToolUse hook 자동 staging + `--prose-file` optional — 메인 Write/Bash 0회, end-step 만 호출.
+- **Decision**: (3) 채택. `handle_posttooluse_agent` 가 `tool_response.text` 추출 → `write_prose` → `live.json.current_step.prose_file` 기록. `_cli_end_step` 이 `args.prose_file=None` 시 `current_step.prose_file` 자동 읽기. `_count_step_occurrences` 에 `base_dir` 추가 (hook test 정합). legacy `--prose-file` 경로 보존.
+- **Follow-Up**: 운영 skill 에서 `Write/Bash heredoc` 제거 가능 (별도 Task-ID). hook 실패 시 (disk 오류 등) end-step 이 `--prose-file 미제공 + hook staging 없음` 으로 rc=1 명시 → 메인에게 가시.
+
 ### DCN-CHG-20260501-14
 - **Date**: 2026-05-01
 - **Rationale**: `.prose-staging/` 파일명 컨벤션 불일치로 `_resolve_prose_path()` 패턴 매칭이 실제 파일명과 안 맞음 → 같은 (agent, mode) 반복 시 두번째 end-step이 outer prose를 덮어씌워 `run-review`가 첫번째 결과를 영구 분실.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260501-15
+- **Date**: 2026-05-01
+- **Change-Type**: harness, test
+- **Files Changed**:
+  - `harness/hooks.py`
+  - `harness/session_state.py`
+  - `tests/test_hooks.py`
+  - `tests/test_session_state.py`
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: PostToolUse hook prose auto-staging — tool_response.text → run_dir 자동 저장, end-step --prose-file optional
+
 ### DCN-CHG-20260501-14
 - **Date**: 2026-05-01
 - **Change-Type**: harness, test

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -27,6 +27,7 @@ from harness.session_state import (
     read_live,
     read_pid_current_run,
     run_dir,
+    session_dir,
     update_live,
     valid_cc_pid,
     valid_session_id,
@@ -475,6 +476,46 @@ def handle_posttooluse_agent(
         sub_type = str(tool_input.get("subagent_type", "") or "")
 
     rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
+
+    # prose auto-staging — tool_response.text → run_dir 에 저장, current_step.prose_file 기록
+    if rid:
+        try:
+            raw_response = stdin_data.get("tool_response") or {}
+            prose_text = ""
+            if isinstance(raw_response, dict):
+                prose_text = str(raw_response.get("text", "") or "")
+            elif isinstance(raw_response, str):
+                prose_text = raw_response
+
+            if prose_text.strip():
+                live_data = read_live(sid, base_dir=base_dir) or {}
+                active = live_data.get("active_runs", {}) or {}
+                slot = active.get(rid, {}) if isinstance(active, dict) else {}
+                cur_step = slot.get("current_step") if isinstance(slot, dict) else None
+
+                if isinstance(cur_step, dict):
+                    step_agent = cur_step.get("agent")
+                    step_mode = cur_step.get("mode") or None
+
+                    if step_agent:
+                        from harness.signal_io import write_prose as _write_prose
+                        from harness.session_state import _count_step_occurrences as _count_occ
+
+                        base = session_dir(sid, base_dir=base_dir) / "runs"
+                        occ = _count_occ(sid, rid, step_agent, step_mode, base_dir=base_dir)
+                        prose_path = _write_prose(
+                            step_agent, rid, prose_text,
+                            mode=step_mode, base_dir=base, occurrence=occ,
+                        )
+                        cur_step = dict(cur_step)
+                        cur_step["prose_file"] = str(prose_path)
+                        slot = dict(slot)
+                        slot["current_step"] = cur_step
+                        active = dict(active)
+                        active[rid] = slot
+                        update_live(sid, base_dir=base_dir, active_runs=active)
+        except Exception:  # noqa: BLE001 — silent, hook 본 흐름 방해 X
+            pass
 
     # rid 활성 시만 histogram + redo_log
     eval_result = None

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1125,11 +1125,6 @@ def _cli_end_step(args: Any) -> int:
         print("[session_state] sid/rid 미해결", file=sys.stderr)
         return 1
 
-    prose = Path(args.prose_file).read_text(encoding="utf-8")
-    if not prose.strip():
-        print("[session_state] empty prose", file=sys.stderr)
-        return 1
-
     mode = args.mode if args.mode else None
 
     # DCN-CHG-20260430-25: drift detector — current_step 와 args.agent 불일치 시 WARN.
@@ -1167,10 +1162,35 @@ def _cli_end_step(args: Any) -> int:
         # drift detector 자체 실패는 silent — end-step 동작 우선
         pass
 
-    # prose 저장 — occurrence 계산으로 같은 (agent, mode) 반복 시 파일 충돌 방지
-    base = session_dir(sid) / "runs"
-    occ = _count_step_occurrences(sid, rid, args.agent, mode)
-    prose_path = write_prose(args.agent, rid, prose, mode=mode, base_dir=base, occurrence=occ)
+    # DCN-CHG-20260501-15: prose 로딩 — --prose-file 제공 시 legacy 경로, 없으면 hook auto-stage.
+    if args.prose_file:
+        prose = Path(args.prose_file).read_text(encoding="utf-8")
+        if not prose.strip():
+            print("[session_state] empty prose", file=sys.stderr)
+            return 1
+        base = session_dir(sid) / "runs"
+        occ = _count_step_occurrences(sid, rid, args.agent, mode)
+        prose_path = write_prose(args.agent, rid, prose, mode=mode, base_dir=base, occurrence=occ)
+    else:
+        # hook auto-staged prose — live.json.current_step.prose_file 에서 경로 읽기
+        try:
+            _live = read_live(sid)
+            _slot = _live.get("active_runs", {}).get(rid, {}) if _live else {}
+            _cur = _slot.get("current_step") if isinstance(_slot, dict) else None
+            _staged = _cur.get("prose_file") if isinstance(_cur, dict) else None
+        except Exception:
+            _staged = None
+        if not _staged:
+            print("[session_state] --prose-file 미제공 + hook staging 없음", file=sys.stderr)
+            return 1
+        prose_path = Path(_staged)
+        if not prose_path.exists():
+            print(f"[session_state] hook staged prose_file 없음: {prose_path}", file=sys.stderr)
+            return 1
+        prose = prose_path.read_text(encoding="utf-8")
+        if not prose.strip():
+            print("[session_state] empty prose (hook staged)", file=sys.stderr)
+            return 1
 
     allowed = [s.strip() for s in args.allowed_enums.split(",") if s.strip()]
     if not allowed:
@@ -1244,9 +1264,16 @@ def _steps_jsonl_path(sid: str, rid: str, *, base_dir: Optional[Path] = None) ->
     return run_dir(sid, rid, base_dir=base_dir) / ".steps.jsonl"
 
 
-def _count_step_occurrences(sid: str, rid: str, agent: str, mode: Optional[str]) -> int:
+def _count_step_occurrences(
+    sid: str,
+    rid: str,
+    agent: str,
+    mode: Optional[str],
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
     """`.steps.jsonl` 에 기록된 (agent, mode) 쌍의 수 반환 (write_prose occurrence 계산용)."""
-    target = _steps_jsonl_path(sid, rid)
+    target = _steps_jsonl_path(sid, rid, base_dir=base_dir)
     if not target.exists():
         return 0
     count = 0
@@ -1496,7 +1523,10 @@ def _build_arg_parser() -> Any:
     p_es.add_argument("agent")
     p_es.add_argument("mode", nargs="?", default="")
     p_es.add_argument("--allowed-enums", required=True, help="comma-separated")
-    p_es.add_argument("--prose-file", required=True, help="prose 본문 파일 경로")
+    p_es.add_argument(
+        "--prose-file", required=False, default=None,
+        help="prose 본문 파일 경로 (미제공 시 hook auto-stage 경로 사용)",
+    )
     p_es.set_defaults(func=_cli_end_step)
 
     p_rd = sub.add_parser("run-dir", help="현재 active run 의 run_dir 절대 경로 (DCN-30-21)")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -36,6 +36,7 @@ import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from typing import Optional
 
 from harness.hooks import (
     HARNESS_ONLY_AGENTS,
@@ -983,6 +984,129 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         )
         self.assertEqual(rc, 0)
         self.assertEqual(read_redos(self.sid, self.rid, base_dir=self.base), [])
+
+
+# ---------------------------------------------------------------------------
+# DCN-CHG-20260501-15 — PostToolUse Agent prose auto-staging
+# ---------------------------------------------------------------------------
+
+
+class PostToolUseAgentProseAutoStageTests(_PreToolBase):
+    """handle_posttooluse_agent — tool_response.text → run_dir prose 자동 저장."""
+
+    def _payload_with_prose(
+        self, sub_type: str, agent: str, mode: Optional[str], prose: str
+    ) -> dict:
+        return {
+            "sessionId": self.sid,
+            "tool_name": "Agent",
+            "tool_input": {
+                "subagent_type": sub_type,
+            },
+            "tool_response": {"type": "text", "text": prose},
+        }
+
+    def _set_current_step(self, agent: str, mode: Optional[str]) -> None:
+        from harness.session_state import update_current_step
+        update_current_step(self.sid, self.rid, agent, mode, base_dir=self.base)
+
+    def test_prose_staged_to_run_dir(self) -> None:
+        self._set_current_step("qa", None)
+        prose = "## 결과\nFUNCTIONAL_BUG\n"
+        rc = handle_posttooluse_agent(
+            stdin_data=self._payload_with_prose("qa", "qa", None, prose),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertTrue(expected.exists())
+        self.assertEqual(expected.read_text(encoding="utf-8"), prose)
+
+    def test_prose_staged_with_mode(self) -> None:
+        self._set_current_step("validator", "PLAN_VALIDATION")
+        prose = "## 결론\nPASS\n"
+        rc = handle_posttooluse_agent(
+            stdin_data=self._payload_with_prose("validator", "validator", "PLAN_VALIDATION", prose),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = (
+            session_dir(self.sid, base_dir=self.base) / "runs" / self.rid
+            / "validator-PLAN_VALIDATION.md"
+        )
+        self.assertTrue(expected.exists())
+
+    def test_prose_file_stored_in_current_step(self) -> None:
+        self._set_current_step("architect", "MODULE_PLAN")
+        prose = "## 결론\nREADY_FOR_IMPL\n"
+        handle_posttooluse_agent(
+            stdin_data=self._payload_with_prose("architect", "architect", "MODULE_PLAN", prose),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        live = read_live(self.sid, base_dir=self.base) or {}
+        slot = live.get("active_runs", {}).get(self.rid, {})
+        cur_step = slot.get("current_step") or {}
+        self.assertIn("prose_file", cur_step)
+        self.assertTrue(cur_step["prose_file"].endswith("architect-MODULE_PLAN.md"))
+
+    def test_empty_prose_no_staging(self) -> None:
+        self._set_current_step("qa", None)
+        rc = handle_posttooluse_agent(
+            stdin_data=self._payload_with_prose("qa", "qa", None, "   "),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertFalse(expected.exists())
+
+    def test_no_tool_response_no_staging(self) -> None:
+        self._set_current_step("qa", None)
+        rc = handle_posttooluse_agent(
+            stdin_data={"sessionId": self.sid, "tool_name": "Agent"},
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertFalse(expected.exists())
+
+    def test_no_current_step_no_staging(self) -> None:
+        prose = "## 결론\nPASS\n"
+        rc = handle_posttooluse_agent(
+            stdin_data=self._payload_with_prose("qa", "qa", None, prose),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertFalse(expected.exists())
+
+    def test_occurrence_increments_on_repeat(self) -> None:
+        import json
+
+        self._set_current_step("engineer", None)
+        # 첫 번째 end-step 기록을 .steps.jsonl 에 직접 박기 (base_dir 정합)
+        steps_path = run_dir(self.sid, self.rid, base_dir=self.base) / ".steps.jsonl"
+        steps_path.parent.mkdir(parents=True, exist_ok=True)
+        steps_path.write_text(
+            json.dumps({"agent": "engineer", "mode": None, "enum": "PASS"}) + "\n",
+            encoding="utf-8",
+        )
+        # 두 번째 sub 호출 → occurrence=1 → engineer-1.md
+        prose = "## 결론\nPASS\n"
+        handle_posttooluse_agent(
+            stdin_data=self._payload_with_prose("engineer", "engineer", None, prose),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        expected = (
+            session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "engineer-1.md"
+        )
+        self.assertTrue(expected.exists())
 
 
 if __name__ == "__main__":

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1137,6 +1137,65 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(out.getvalue().strip(), "AMBIGUOUS")
 
+    def test_end_step_no_prose_file_uses_hook_staged(self) -> None:
+        # DCN-CHG-20260501-15: --prose-file 미제공 시 live.json.current_step.prose_file 사용
+        from harness.session_state import (
+            _cli_end_step, _cli_begin_step, session_dir, read_live, update_live,
+        )
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+
+        # begin-step 으로 current_step 설정
+        _cli_begin_step(SimpleNamespace(agent="qa", mode=""))
+
+        # hook 이 staged 한 것처럼 prose_file 을 live.json.current_step 에 삽입
+        prose_text = "## 결론\nFUNCTIONAL_BUG\n"
+        staged_path = session_dir(self.sid) / "runs" / self.rid / "qa.md"
+        staged_path.parent.mkdir(parents=True, exist_ok=True)
+        staged_path.write_text(prose_text, encoding="utf-8")
+
+        live = read_live(self.sid) or {}
+        active = live.get("active_runs", {}) or {}
+        slot = dict(active.get(self.rid, {}))
+        cur_step = dict(slot.get("current_step") or {})
+        cur_step["prose_file"] = str(staged_path)
+        slot["current_step"] = cur_step
+        active[self.rid] = slot
+        update_live(self.sid, active_runs=active)
+
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="qa",
+                mode="",
+                allowed_enums="FUNCTIONAL_BUG,CONFIG_BUG,CANNOT_REPRODUCE",
+                prose_file=None,
+            ))
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "FUNCTIONAL_BUG")
+
+    def test_end_step_no_prose_file_no_staging_returns_1(self) -> None:
+        # DCN-CHG-20260501-15: --prose-file 없고 hook staging 도 없으면 rc=1
+        from harness.session_state import _cli_end_step, _cli_begin_step
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+
+        _cli_begin_step(SimpleNamespace(agent="qa", mode=""))
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="qa",
+                mode="",
+                allowed_enums="FUNCTIONAL_BUG,CONFIG_BUG",
+                prose_file=None,
+            ))
+        self.assertEqual(rc, 1)
+        self.assertIn("hook staging 없음", err.getvalue())
+
 
 class DefaultBaseWorktreeTests(unittest.TestCase):
     """`_default_base()` γ 설계 — main repo `.claude/harness-state/` 단일 source 검증.


### PR DESCRIPTION
## Summary
- `handle_posttooluse_agent` 가 `tool_response.text` 에서 sub prose 자동 추출 → `write_prose` → `live.json.current_step.prose_file` 경로 기록
- `end-step --prose-file` optional 변경 — 미제공 시 `current_step.prose_file` auto-detect
- `_count_step_occurrences` `base_dir` 파라미터 추가 (hook test 정합)

## Motivation
메인 Claude 가 sub-agent 완료 후 prose 를 Write/Bash heredoc 으로 staging 하는 작업은 kabuki — `tool_response.text` 에 이미 prose 전체가 있는데 같은 byte 를 메인이 다시 disk 에 옮기는 구조. PostToolUse hook 이 이미 `stdin_data["tool_response"]["text"]` 로 prose 를 보유하므로 hook 에서 자동 처리.

## Test plan
- [x] 9 new tests: `PostToolUseAgentProseAutoStageTests` (7) + end-step optional (2)
- [x] 351 tests OK (doc-sync + pytest gate 통과)
- [x] legacy `--prose-file` 경로 보존

## Governance
- Task-ID: DCN-CHG-20260501-15
- Change-Type: harness, test