### PR TITLE
hooks: lazy-load v2 — inject/guidelines 경로 완전 제거 (DCN-CHG-20260501-18)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,11 @@
 
 ## 현재 상태
 
+- **🦥 session-start lazy-load v2** (`DCN-CHG-20260501-18`):
+  - inject lazy 섹션 파일경로 완전 제거 — 경로 나열 자체가 read 트리거였음.
+  - dcness-guidelines.md §0 마크다운 링크 비활성 텍스트로 교체.
+  - 경로는 skill 파일 `## 사전 read` 섹션에만 존재하여 skill 진입 시에만 노출.
+
 - **🦥 session-start lazy-load 최적화** (`DCN-CHG-20260501-17`):
   - session-start inject: 5 docs 즉시 read → `dcness-guidelines.md` 1개만 즉시, 나머지 4개 lazy.
   - `dcness-guidelines.md` §0: "매 세션 의무 read" → "loop 시작 전 read" 변경.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260501-18
+- **Date**: 2026-05-01
+- **Rationale**: DCN-17에서 [lazy] 레이블 아래 파일 경로를 나열했더니 Claude가 레이블을 무시하고 경로를 보는 즉시 read. 경로 존재 자체가 read 트리거. dcness-guidelines.md §0의 마크다운 링크도 동일하게 트리거됨.
+- **Alternatives**: (1) "지금 읽지 말 것" 강조 텍스트 추가 — 텍스트 지시로 행동을 막는 것은 불안정. (2) 파일 경로/링크 자체를 inject와 §0에서 제거 — 경로가 없으면 read 트리거 없음.
+- **Decision**: (2) 채택. inject lazy 섹션에서 파일경로 완전 제거, §0 마크다운 링크를 비활성 텍스트로 교체. 경로는 skill 파일 `## 사전 read` 섹션에만 존재.
+- **Follow-Up**: 다음 세션에서 session-start 시 loop-procedure 등 4개 doc read 여부 재확인.
+
 ### DCN-CHG-20260501-17
 - **Date**: 2026-05-01
 - **Rationale**: dcness 활성 프로젝트 세션 시작 시 5개 SSOT 문서(61KB, ~15K 토큰)가 즉시 read 강제됨. session-start inject 가 "5개 전부 즉시 read 의무"를 선언하고, dcness-guidelines.md §0이 loop-procedure + loop-catalog 추가 즉시 read 강제. 결과: skill 미호출 세션에서도 61KB 전부 컨텍스트 적재 → Messages 32.5k tokens의 주요 원인.

--- a/docs/process/dcness-guidelines.md
+++ b/docs/process/dcness-guidelines.md
@@ -4,15 +4,15 @@
 > 룰 추가 시 본 파일에만 append — skill 들은 cross-ref 만.
 > Task-ID: DCN-CHG-20260430-26 (SSOT 분리 + hook inject).
 
-## 0. 루프 SSOT — `loop-procedure.md` + `loop-catalog.md` (DCN-30-27 / -30)
+## 0. 루프 SSOT (DCN-30-27 / -30)
 
-dcness 의 8 loop 운영은 **2 SSOT** 분담:
-- [`docs/loop-procedure.md`](../loop-procedure.md) — *공통 실행 절차* (Step 0~8 mechanics — worktree / begin-run / TaskCreate / agent 호출 / Step 4.5 stories sync / finalize-run / clean 7a / caveat 7b / auto-review)
-- [`docs/loop-catalog.md`](../loop-catalog.md) — *8 loop 행별 풀스펙* (entry_point / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles)
+dcness 의 8 loop 운영은 **2 SSOT** 분담 (지금 읽지 말 것 — skill 진입 시 사전 read 안내):
+- loop-procedure doc — *공통 실행 절차* (Step 0~8 mechanics — worktree / begin-run / TaskCreate / agent 호출 / Step 4.5 stories sync / finalize-run / clean 7a / caveat 7b / auto-review)
+- loop-catalog doc — *8 loop 행별 풀스펙* (entry_point / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles)
 
-**loop 시작 전 (skill 트리거 또는 직접 발화 시) loop-procedure.md + loop-catalog.md read** — 세션 시작 시에는 읽지 않음. 각 skill 파일 `## 사전 read` 섹션이 진입 시 안내 (DCN-CHG-20260501-17 lazy-load).
+**세션 시작 시 이 두 doc 을 읽지 말 것.** skill 트리거 시 해당 skill 파일의 `## 사전 read` 섹션이 정확한 경로와 섹션 번호를 안내한다 (DCN-CHG-20260501-17 lazy-load).
 
-skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure.md, loop spec 은 loop-catalog.md.
+skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure doc, loop spec 은 loop-catalog doc.
 
 ## 0.1 행동지침 md 작성 룰 — 300줄 cap (DCN-30-30)
 

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260501-18
+- **Date**: 2026-05-01
+- **Change-Type**: hooks + docs-only
+- **Files Changed**:
+  - `hooks/session-start.sh`
+  - `docs/process/dcness-guidelines.md`
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+- **Summary**: lazy-load v2 — inject의 lazy 섹션 파일경로 제거, dcness-guidelines.md §0 링크 비활성화. 경로 나열 자체가 read 트리거였음.
+
 ### DCN-CHG-20260501-17
 - **Date**: 2026-05-01
 - **Change-Type**: hooks + docs-only

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -44,11 +44,7 @@ msg = '''## dcness Guidelines (DCN-CHG-20260501-17 lazy-load)
 **[필수 — 지금 즉시 read]**
 \`docs/process/dcness-guidelines.md\` — 가시성 / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy / §12 self-verify / 300줄 cap / §13 감시자 Hat
 
-**[lazy — 각 skill 파일 \`## 사전 read\` 섹션이 skill 진입 시 안내]**
-- \`docs/loop-procedure.md\` — Step 0~8 mechanics
-- \`docs/loop-catalog.md\` — 8 loop × 풀스펙
-- \`docs/orchestration.md\` §2~§3 — 시퀀스 + 진입 경로
-- \`docs/handoff-matrix.md\` — agent 결정표 / Retry / Escalate
+**나머지 loop 실행 docs (loop-procedure / loop-catalog / orchestration / handoff-matrix) 는 지금 읽지 말 것.** 각 skill 파일 `## 사전 read` 섹션이 진입 시 직접 경로를 안내한다.
 
 **핵심 강제 룰 — dcness-guidelines.md read 전이라도 즉시 적용**:
 - 매 Agent 호출 후 prose 5~12줄 의무 echo (가시성 §1)


### PR DESCRIPTION
## 문제

DCN-17에서 `[lazy]` 레이블 아래 파일 경로를 나열했더니 Claude가 레이블을 무시하고 경로를 보자마자 즉시 read. 경로 존재 자체가 read 트리거.

## 수정

- `session-start.sh` inject: lazy 섹션 파일경로 4개 완전 제거 → "지금 읽지 말 것" 텍스트만
- `dcness-guidelines.md` §0: 마크다운 링크 → 비활성 텍스트 교체

경로는 skill 파일 `## 사전 read` 섹션에만 존재 → skill 진입 시에만 노출됨.

## 검증

- [x] `node scripts/check_document_sync.mjs` PASS
- [ ] 새 CC 세션에서 session-start 시 loop-procedure 등 4개 doc read 없는지 확인