### PR TITLE
harness: loop-insights 누적·주입 (DCN-CHG-20260502-02)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,13 @@
 
 ## 현재 상태
 
+- **📚 loop-insights 누적·주입** (`DCN-CHG-20260502-02`):
+  - `harness/loop_insights.py` 신규 — agent별 insights 파일 read/write (`.claude/loop-insights/<agent>[-<mode>].md`).
+  - `finalize-run --accumulate` — redo-log REDO_* + WASTE/GOOD findings → agent별 파일 append.
+  - `begin-step` stdout 주입 — 해당 agent insights 있으면 `[INSIGHTS: <agent>/<mode>]` 섹션 출력.
+  - `loop-procedure.md` §3.1 강제 문구 추가.
+  - 게이트(sentinel 체크) 없음 — AI 신뢰 원칙 적용.
+
 - **🔒 session-start BLOCKING 게이트 강화** (`DCN-CHG-20260502-01`):
   - inject 3원칙 적용: (1) 출력 금지 조건 — Read 완료 전 텍스트 출력 금지. (2) 검증 토큰 — 첫 응답 첫 줄에 `[dcness-guidelines 로드 완료 — §13 감시자 Hat 장착]` 의무. (3) 예외 없음 명시 — "안녕"/"hi"/"hello"/짧은 질문 전부 포함.
   - 배경: 단순 인사에서 inject 무시 확인. "인사 → 짧은 응답" 패턴 매칭이 system-reminder를 후순위로 밀어냄.

--- a/docs/loop-procedure.md
+++ b/docs/loop-procedure.md
@@ -59,6 +59,8 @@ ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<csv>")
 TaskUpdate("<task>", completed)
 ```
 
+begin-step stdout 에 `[INSIGHTS: <agent>/<mode>]` 섹션이 있으면 Agent prompt 끝에 그대로 포함시킨다 (DCN-CHG-20260502-02). 해당 agent 의 과거 루프 학습 내용 — "하지 말 것" / "잘 됐던 것" — 이 프로젝트 레벨로 누적된 것.
+
 메인이 prose를 직접 Write 할 필요 없음 — PostToolUse Agent hook 이 sub 종료 시 `tool_response.text` 에서 prose 를 자동으로 `<run_dir>/<agent>[-<MODE>].md` 에 저장하고 `live.json.current_step.prose_file` 에 경로 기록 (DCN-CHG-20260501-15). `end-step` 이 이 경로를 자동 읽는다.
 
 ### 3.2 prose 파일 자동 명명 규칙 (DCN-CHG-20260501-15)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,15 @@
 
 ## Records
 
+### DCN-CHG-20260502-02
+- **Date**: 2026-05-02
+- **Rationale**: 루프가 끝날 때 redo-log + WASTE/GOOD findings를 agent별로 누적하고 다음 루프에서 begin-step stdout으로 주입. sentinel/gate 없이 AI 신뢰 원칙 적용.
+- **Alternatives considered**:
+  - sentinel 게이트 (catastrophic-gate 확장) — "자연어끼리 비교라 의미 없음" 기각. 형식 검증은 메인이 문자열만 박고 내용은 생략 가능.
+  - 단일 파일 누적 — agent별 파일 분리로 begin-step 에서 해당 agent 것만 추출 가능.
+- **Decision**: 누적(finalize-run --accumulate) + begin-step stdout 주입 2군데만. 게이트 없음.
+- **Follow-Up**: Layer 2 — agent definition 파일이 스스로 insights 읽는 방향 (별도 Task).
+
 ### DCN-CHG-20260502-01
 - **Date**: 2026-05-02
 - **Rationale**: 기존 inject("지금 즉시 read")가 단순 인사("안녕") 에 대해 무시됨. LLM이 "인사 → 짧은 응답" 패턴으로 즉시 분류, system-reminder를 "나중에 작업할 때 적용" 대상으로 후순위 처리. inject가 읽혔는지 검증할 방법도 없음.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260502-02
+- **Date**: 2026-05-02
+- **Change-Type**: harness + docs-only
+- **Files Changed**:
+  - `harness/loop_insights.py` (신규)
+  - `harness/session_state.py` (begin-step 주입 + finalize-run --accumulate)
+  - `docs/loop-procedure.md` (§3.1 강제 문구)
+  - `tests/test_loop_insights.py` (신규)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: loop-insights 누적·주입 — 루프 종료 시 redo-log + WASTE/GOOD → agent별 .claude/loop-insights/<agent>.md 누적, begin-step 에서 stdout 주입.
+
 ### DCN-CHG-20260502-01
 - **Date**: 2026-05-02
 - **Change-Type**: hooks

--- a/harness/loop_insights.py
+++ b/harness/loop_insights.py
@@ -1,0 +1,143 @@
+"""loop_insights — 루프별 agent 학습 누적 (DCN-CHG-20260502-02).
+
+각 루프 종료 시 redo-log + WASTE/GOOD findings → agent별 파일에 누적.
+begin-step 에서 읽어 메인 Claude 에게 주입.
+
+저장 위치: <cwd>/.claude/loop-insights/<agent>[-<mode>].md
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Optional
+
+from harness import redo_log
+from harness import run_review as rv
+from harness.session_state import run_dir as get_run_dir
+
+
+__all__ = ["insights_path", "read", "append_findings", "append_from_run"]
+
+_INSIGHTS_DIR = Path(".claude") / "loop-insights"
+
+
+def insights_path(
+    agent: str, mode: Optional[str] = None, cwd: Path = Path(".")
+) -> Path:
+    name = agent if not mode else f"{agent}-{mode}"
+    return cwd / _INSIGHTS_DIR / f"{name}.md"
+
+
+def read(
+    agent: str, mode: Optional[str] = None, cwd: Path = Path(".")
+) -> str:
+    p = insights_path(agent, mode, cwd)
+    if not p.exists():
+        return ""
+    return p.read_text(encoding="utf-8").strip()
+
+
+def append_findings(
+    agent: str,
+    mode: Optional[str],
+    bads: list[str],
+    goods: list[str],
+    cwd: Path = Path("."),
+    date_str: Optional[str] = None,
+) -> None:
+    """bads/goods 항목을 agent 파일에 append. 이미 존재하는 항목은 스킵."""
+    if not bads and not goods:
+        return
+
+    p = insights_path(agent, mode, cwd)
+    p.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = p.read_text(encoding="utf-8") if p.exists() else ""
+
+    header = f"# Loop Insights: {agent}" + (f" / {mode}" if mode else "") + "\n"
+    if not existing:
+        existing = header + "\n## 하지 말 것\n\n## 잘 됐던 것\n"
+
+    lines_to_add: list[tuple[str, str]] = []  # (section, item)
+    for item in bads:
+        if item not in existing:
+            lines_to_add.append(("하지 말 것", item))
+    for item in goods:
+        if item not in existing:
+            lines_to_add.append(("잘 됐던 것", item))
+
+    if not lines_to_add:
+        return
+
+    result = existing
+    for section, item in lines_to_add:
+        marker = f"## {section}"
+        if marker in result:
+            idx = result.index(marker) + len(marker)
+            # 다음 ## 또는 끝 전에 삽입
+            next_h = result.find("\n## ", idx)
+            insert_at = next_h if next_h != -1 else len(result)
+            result = result[:insert_at].rstrip() + f"\n- {item}\n" + result[insert_at:]
+        else:
+            result = result.rstrip() + f"\n\n## {section}\n- {item}\n"
+
+    p.write_text(result, encoding="utf-8")
+
+
+def append_from_run(
+    sid: str, rid: str, cwd: Path = Path(".")
+) -> list[str]:
+    """finalize-run --accumulate 진입점. 수정된 파일 경로 목록 반환."""
+    rd = get_run_dir(sid, rid)
+    today = time.strftime("%Y-%m-%d", time.gmtime())
+
+    # 1. redo-log → REDO_* 항목에서 (agent, mode, reason) 추출
+    redo_entries = redo_log.read_all(sid, rid)
+    redo_bads: dict[tuple[str, Optional[str]], list[str]] = {}
+    for e in redo_entries:
+        decision = e.get("decision", "")
+        if not str(decision).startswith("REDO"):
+            continue
+        sub = e.get("sub") or "unknown"
+        mode: Optional[str] = e.get("mode") or None
+        reason = str(e.get("reason", "")).strip()
+        if not reason:
+            continue
+        key = (sub, mode)
+        redo_bads.setdefault(key, []).append(f"{reason} ({decision}, {today})")
+
+    # 2. steps → WASTE/GOOD findings (mode는 step에서 조회)
+    steps = rv.parse_steps(rd)
+    wastes = rv.detect_wastes(steps)
+    goods = rv.detect_goods(steps)
+
+    waste_bads: dict[tuple[str, Optional[str]], list[str]] = {}
+    for w in wastes:
+        m = steps[w.step_idx].mode if w.step_idx < len(steps) else None
+        key = (w.agent, m)
+        waste_bads.setdefault(key, []).append(
+            f"{w.detail} [{w.pattern}] ({today})"
+        )
+
+    good_items: dict[tuple[str, Optional[str]], list[str]] = {}
+    for g in goods:
+        m = steps[g.step_idx].mode if g.step_idx < len(steps) else None
+        key = (g.agent, m)
+        good_items.setdefault(key, []).append(
+            f"{g.detail} [{g.pattern}] ({today})"
+        )
+
+    # 3. 전체 key 수집 → append
+    all_keys: set[tuple[str, Optional[str]]] = (
+        set(redo_bads) | set(waste_bads) | set(good_items)
+    )
+    modified: list[str] = []
+    for key in all_keys:
+        agent, mode = key
+        bads = redo_bads.get(key, []) + waste_bads.get(key, [])
+        gs = good_items.get(key, [])
+        if bads or gs:
+            append_findings(agent, mode, bads, gs, cwd=cwd)
+            modified.append(str(insights_path(agent, mode, cwd)))
+
+    return modified

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1007,6 +1007,18 @@ def _cli_begin_step(args: Any) -> int:
             )
 
     print("ok")
+
+    # DCN-CHG-20260502-02: 해당 agent/mode 의 loop insights 있으면 stdout 주입.
+    # 메인 Claude 가 Bash 결과로 읽고 Agent prompt 에 포함시킨다.
+    try:
+        from harness.loop_insights import read as _li_read
+        _insights = _li_read(args.agent, mode or None)
+        if _insights:
+            label = f"{args.agent}/{mode}" if mode else args.agent
+            print(f"\n[INSIGHTS: {label}]\n{_insights}")
+    except Exception:
+        pass  # insights 주입 실패는 silent — 본 step 차단 X
+
     return 0
 
 
@@ -1397,6 +1409,25 @@ def _cli_finalize_run(args: Any) -> int:
                 file=sys.stderr,
             )
 
+    # DCN-CHG-20260502-02: --accumulate — redo-log + WASTE/GOOD findings →
+    # .claude/loop-insights/<agent>[-<mode>].md 에 누적 (프로젝트 레벨 학습).
+    if getattr(args, "accumulate", False):
+        print()
+        print("--- loop-insights accumulate ---")
+        try:
+            from harness.loop_insights import append_from_run as _li_accumulate
+            modified = _li_accumulate(sid, rid, cwd=Path.cwd())
+            if modified:
+                for p in modified:
+                    print(f"[loop-insights] updated: {p}")
+            else:
+                print("[loop-insights] 누적 항목 없음 (redo 0건 + WASTE 0건)")
+        except Exception as exc:
+            print(
+                f"[session_state] ACCUMULATE_FAIL — {type(exc).__name__}: {exc}.",
+                file=sys.stderr,
+            )
+
     return 0
 
 
@@ -1558,6 +1589,11 @@ def _build_arg_parser() -> Any:
         "--auto-review",
         action="store_true",
         help="finalize 직후 in-process 로 /run-review 호출 — STATUS JSON 뒤에 chained (DCN-30-29)",
+    )
+    p_fr.add_argument(
+        "--accumulate",
+        action="store_true",
+        help="redo-log + WASTE/GOOD → .claude/loop-insights/<agent>.md 누적 (DCN-CHG-20260502-02)",
     )
     p_fr.set_defaults(func=_cli_finalize_run)
 

--- a/tests/test_loop_insights.py
+++ b/tests/test_loop_insights.py
@@ -1,0 +1,217 @@
+"""test_loop_insights — loop_insights 모듈 단위 테스트 (DCN-CHG-20260502-02).
+
+Coverage:
+    insights_path:
+        - mode 있음 / 없음 파일명 규칙
+
+    read:
+        - 파일 없음 → ""
+        - 파일 있음 → 전체 내용 반환
+
+    append_findings:
+        - 신규 파일 생성 + 헤더 + 섹션 구조
+        - 기존 파일에 bads append
+        - 기존 파일에 goods append
+        - 중복 항목 스킵
+        - bads/goods 모두 빈 리스트 → 파일 미생성
+
+    append_from_run:
+        - redo-log REDO_* 항목 → bads 누적
+        - PASS 항목 스킵
+        - redo reason 없는 항목 스킵
+        - 빈 redo-log + 빈 steps → 수정 파일 없음
+"""
+import json
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from harness.loop_insights import (
+    insights_path,
+    read,
+    append_findings,
+    append_from_run,
+)
+
+
+class TestInsightsPath(unittest.TestCase):
+    def test_no_mode(self):
+        p = insights_path("engineer", cwd=Path("/tmp"))
+        self.assertEqual(p.name, "engineer.md")
+
+    def test_with_mode(self):
+        p = insights_path("engineer", "IMPL", cwd=Path("/tmp"))
+        self.assertEqual(p.name, "engineer-IMPL.md")
+
+    def test_dir_structure(self):
+        p = insights_path("validator", "CODE_VALIDATION", cwd=Path("/tmp"))
+        self.assertIn(".claude/loop-insights", str(p))
+
+
+class TestRead(unittest.TestCase):
+    def test_missing_file_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            result = read("engineer", "IMPL", cwd=Path(td))
+            self.assertEqual(result, "")
+
+    def test_existing_file_returns_content(self):
+        with tempfile.TemporaryDirectory() as td:
+            p = insights_path("engineer", "IMPL", cwd=Path(td))
+            p.parent.mkdir(parents=True)
+            p.write_text("# Loop Insights\ncontent", encoding="utf-8")
+            result = read("engineer", "IMPL", cwd=Path(td))
+            self.assertIn("content", result)
+
+
+class TestAppendFindings(unittest.TestCase):
+    def test_creates_new_file_with_header(self):
+        with tempfile.TemporaryDirectory() as td:
+            append_findings("engineer", "IMPL", ["bad thing"], [], cwd=Path(td))
+            p = insights_path("engineer", "IMPL", cwd=Path(td))
+            self.assertTrue(p.exists())
+            content = p.read_text()
+            self.assertIn("# Loop Insights: engineer / IMPL", content)
+            self.assertIn("bad thing", content)
+            self.assertIn("하지 말 것", content)
+
+    def test_creates_new_file_no_mode(self):
+        with tempfile.TemporaryDirectory() as td:
+            append_findings("test-engineer", None, ["bad"], [], cwd=Path(td))
+            p = insights_path("test-engineer", None, cwd=Path(td))
+            content = p.read_text()
+            self.assertIn("# Loop Insights: test-engineer", content)
+            self.assertNotIn("# Loop Insights: test-engineer /", content)
+
+    def test_appends_to_existing(self):
+        with tempfile.TemporaryDirectory() as td:
+            append_findings("engineer", "IMPL", ["first bad"], [], cwd=Path(td))
+            append_findings("engineer", "IMPL", ["second bad"], [], cwd=Path(td))
+            content = insights_path("engineer", "IMPL", cwd=Path(td)).read_text()
+            self.assertIn("first bad", content)
+            self.assertIn("second bad", content)
+
+    def test_appends_goods(self):
+        with tempfile.TemporaryDirectory() as td:
+            append_findings("engineer", "IMPL", [], ["good thing"], cwd=Path(td))
+            content = insights_path("engineer", "IMPL", cwd=Path(td)).read_text()
+            self.assertIn("잘 됐던 것", content)
+            self.assertIn("good thing", content)
+
+    def test_skips_duplicate(self):
+        with tempfile.TemporaryDirectory() as td:
+            append_findings("engineer", "IMPL", ["same bad"], [], cwd=Path(td))
+            append_findings("engineer", "IMPL", ["same bad"], [], cwd=Path(td))
+            content = insights_path("engineer", "IMPL", cwd=Path(td)).read_text()
+            self.assertEqual(content.count("same bad"), 1)
+
+    def test_noop_when_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            append_findings("engineer", "IMPL", [], [], cwd=Path(td))
+            p = insights_path("engineer", "IMPL", cwd=Path(td))
+            self.assertFalse(p.exists())
+
+
+class TestAppendFromRun(unittest.TestCase):
+    def _make_redo_entry(self, sub, mode, decision, reason):
+        return {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "sub": sub,
+            "mode": mode,
+            "decision": decision,
+            "reason": reason,
+        }
+
+    def test_redo_entries_accumulated(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+
+            fake_entries = [
+                self._make_redo_entry("engineer", "IMPL", "REDO_SAME", "pytest 실패 무시"),
+                self._make_redo_entry("engineer", "IMPL", "PASS", "정상"),
+            ]
+
+            with patch("harness.loop_insights.redo_log") as mock_rl, \
+                 patch("harness.loop_insights.rv") as mock_rv, \
+                 patch("harness.loop_insights.get_run_dir") as mock_rd:
+
+                mock_rd.return_value = td_path
+                mock_rl.read_all.return_value = fake_entries
+                mock_rv.parse_steps.return_value = []
+                mock_rv.detect_wastes.return_value = []
+                mock_rv.detect_goods.return_value = []
+
+                modified = append_from_run("sid1", "rid1", cwd=td_path)
+
+            self.assertTrue(len(modified) > 0)
+            content = insights_path("engineer", "IMPL", cwd=td_path).read_text()
+            self.assertIn("pytest 실패 무시", content)
+            self.assertIn("REDO_SAME", content)
+
+    def test_pass_entries_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+
+            fake_entries = [
+                self._make_redo_entry("engineer", "IMPL", "PASS", "정상 완료"),
+            ]
+
+            with patch("harness.loop_insights.redo_log") as mock_rl, \
+                 patch("harness.loop_insights.rv") as mock_rv, \
+                 patch("harness.loop_insights.get_run_dir") as mock_rd:
+
+                mock_rd.return_value = td_path
+                mock_rl.read_all.return_value = fake_entries
+                mock_rv.parse_steps.return_value = []
+                mock_rv.detect_wastes.return_value = []
+                mock_rv.detect_goods.return_value = []
+
+                modified = append_from_run("sid1", "rid1", cwd=td_path)
+
+            self.assertEqual(modified, [])
+
+    def test_empty_reason_skipped(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+
+            fake_entries = [
+                self._make_redo_entry("engineer", "IMPL", "REDO_SAME", ""),
+            ]
+
+            with patch("harness.loop_insights.redo_log") as mock_rl, \
+                 patch("harness.loop_insights.rv") as mock_rv, \
+                 patch("harness.loop_insights.get_run_dir") as mock_rd:
+
+                mock_rd.return_value = td_path
+                mock_rl.read_all.return_value = fake_entries
+                mock_rv.parse_steps.return_value = []
+                mock_rv.detect_wastes.return_value = []
+                mock_rv.detect_goods.return_value = []
+
+                modified = append_from_run("sid1", "rid1", cwd=td_path)
+
+            self.assertEqual(modified, [])
+
+    def test_empty_log_returns_empty(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+
+            with patch("harness.loop_insights.redo_log") as mock_rl, \
+                 patch("harness.loop_insights.rv") as mock_rv, \
+                 patch("harness.loop_insights.get_run_dir") as mock_rd:
+
+                mock_rd.return_value = td_path
+                mock_rl.read_all.return_value = []
+                mock_rv.parse_steps.return_value = []
+                mock_rv.detect_wastes.return_value = []
+                mock_rv.detect_goods.return_value = []
+
+                modified = append_from_run("sid1", "rid1", cwd=td_path)
+
+            self.assertEqual(modified, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `harness/loop_insights.py` 신규: agent별 `.claude/loop-insights/<agent>[-<mode>].md` read/write
- `finalize-run --accumulate`: redo-log REDO_* + run-review WASTE/GOOD findings → agent별 파일 append (중복 스킵)
- `begin-step` stdout 주입: 해당 agent insights 있으면 `[INSIGHTS: <agent>/<mode>]` 섹션 출력 → 메인이 Agent prompt에 포함
- `loop-procedure.md` §3.1 강제 문구 추가

## 설계 결정
sentinel/gate 없음 — 자연어 시스템에서 문자열 비교는 의미 없음. AI 신뢰 원칙 적용.

## Test plan
- [x] 366 unittest 전체 통과
- [x] doc-sync 게이트 PASS
- [x] pytest 게이트 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)