### PR TITLE
hooks: session-start inject 절대 경로 버그 수정 (DCN-CHG-20260502-03)

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -9,6 +9,10 @@
   - `loop-procedure.md` §3.1 강제 문구 추가.
   - 게이트(sentinel 체크) 없음 — AI 신뢰 원칙 적용.
 
+- **🐛 session-start 절대 경로 버그 수정** (`DCN-CHG-20260502-03`):
+  - DCN-01 inject에서 상대 경로 사용 → Read 도구 실패 버그.
+  - `CLAUDE_PROJECT_DIR`로 동적 절대 경로 구성, Python에 `sys.argv[1]`로 전달.
+
 - **🔒 session-start BLOCKING 게이트 강화** (`DCN-CHG-20260502-01`):
   - inject 3원칙 적용: (1) 출력 금지 조건 — Read 완료 전 텍스트 출력 금지. (2) 검증 토큰 — 첫 응답 첫 줄에 `[dcness-guidelines 로드 완료 — §13 감시자 Hat 장착]` 의무. (3) 예외 없음 명시 — "안녕"/"hi"/"hello"/짧은 질문 전부 포함.
   - 배경: 단순 인사에서 inject 무시 확인. "인사 → 짧은 응답" 패턴 매칭이 system-reminder를 후순위로 밀어냄.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260502-03
+- **Date**: 2026-05-02
+- **Rationale**: DCN-01에서 BLOCKING 게이트를 넣었으나 inject 내 Read 경로가 상대 경로("docs/process/dcness-guidelines.md")였음. Read 도구는 절대 경로만 허용하므로 Claude가 Read를 시도해도 즉시 실패 → "파일이 없어 로드는 스킵됐습니다" 오류.
+- **Alternatives**: (1) 파일 내용을 inject에 직접 포함 — 13KB, 10K cap 초과 위험. (2) 절대 경로 하드코딩 — 이식성 없음. (3) CLAUDE_PROJECT_DIR 환경변수로 동적 절대 경로 구성 — 실행 시점에 정확한 경로 확보.
+- **Decision**: (3) 채택. `PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"` → `GUIDELINES_PATH="${PROJ}/docs/process/dcness-guidelines.md"` → Python에 sys.argv[1]로 전달.
+- **Follow-Up**: 다음 세션에서 Read 성공 + 토큰 출력 확인.
+
 ### DCN-CHG-20260502-02
 - **Date**: 2026-05-02
 - **Rationale**: 루프가 끝날 때 redo-log + WASTE/GOOD findings를 agent별로 누적하고 다음 루프에서 begin-step stdout으로 주입. sentinel/gate 없이 AI 신뢰 원칙 적용.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260502-03
+- **Date**: 2026-05-02
+- **Change-Type**: hooks
+- **Files Changed**:
+  - `hooks/session-start.sh`
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+  - `PROGRESS.md`
+- **Summary**: session-start inject 절대 경로 버그 수정 — Read 도구는 절대 경로만 허용, CLAUDE_PROJECT_DIR로 동적 절대 경로 구성.
+
 ### DCN-CHG-20260502-02
 - **Date**: 2026-05-02
 - **Change-Type**: harness + docs-only

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -38,8 +38,13 @@ python3 -m harness.hooks session-start --cc-pid "$CC_PID"
 #
 # JSON schema:
 #   {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
+# Read 도구는 절대 경로만 허용 — CLAUDE_PROJECT_DIR 로 절대 경로 구성.
+PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+GUIDELINES_PATH="${PROJ}/docs/process/dcness-guidelines.md"
+
 python3 -c "
-import json
+import json, sys
+guidelines_path = sys.argv[1]
 msg = '''## [BLOCKING GATE] dcness 세션 시작 강제
 
 **유저의 첫 메시지 종류에 관계없이 — 인사·잡담·질문·작업 요청 전부 포함 —**
@@ -49,8 +54,8 @@ msg = '''## [BLOCKING GATE] dcness 세션 시작 강제
 
 ### STEP 1: 파일 읽기 [스킵 불가 / 예외 없음]
 
-Read 도구로 다음 파일을 *지금 바로* 호출한다:
-  Read(\"docs/process/dcness-guidelines.md\")
+Read 도구로 다음 파일을 *지금 바로* 호출한다 (절대 경로):
+  Read(\"''' + guidelines_path + '''\")
 
 - 이 도구 호출 완료 전까지 텍스트 출력 금지.
 - \"이미 알고 있다\" → 예외 아님. 항상 다시 읽는다.
@@ -66,7 +71,7 @@ Read 도구로 다음 파일을 *지금 바로* 호출한다:
 ---
 
 **나머지 loop 실행 docs (loop-procedure / loop-catalog / orchestration / handoff-matrix) 는 지금 읽지 말 것.**
-각 skill 의 `## 사전 read` 섹션이 진입 시 직접 경로를 안내한다.
+각 skill 의 ## 사전 read 섹션이 진입 시 직접 경로를 안내한다.
 '''
 print(json.dumps({
     'hookSpecificOutput': {
@@ -74,7 +79,7 @@ print(json.dumps({
         'additionalContext': msg,
     }
 }))
-" 2>/dev/null
+" "$GUIDELINES_PATH" 2>/dev/null
 
 # 모든 실패는 silent
 exit 0


### PR DESCRIPTION
## Summary
- DCN-01 BLOCKING 게이트에서 Read 경로를 상대 경로로 써서 Read 도구가 즉시 실패하던 버그 수정
- Read 도구는 절대 경로만 허용 — `CLAUDE_PROJECT_DIR`로 동적 절대 경로 구성

## Root Cause
inject 내 `Read("docs/process/dcness-guidelines.md")` → 상대 경로 → Read 실패 → "파일이 없어 로드는 스킵됐습니다"

## Fix
`PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"` → `GUIDELINES_PATH="${PROJ}/docs/process/..."` → Python `sys.argv[1]`로 전달

## Governance
- Task-ID: DCN-CHG-20260502-03
- Change-Type: hooks
- doc-sync PASS