### PR TITLE
docs: "batch" 용어 전면 제거 — impl 단위 "task"로 통일 (DCN-CHG-20260502-04)

### DIFF
--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260502-04
+- **Date**: 2026-05-02
+- **Rationale**: impl 구현 단위를 "batch"로 불렀으나 직관성이 낮음. 사용자가 보편적으로 쓰는 Jira-style Epic→Story→Task 계층과 불일치 — "batch 다 돌려", "per-batch" 등이 신규 기여자에게 낯설었음.
+- **Alternatives**: (1) "unit" — 너무 추상적, 계층 관계 불명확. (2) "item" — 동일 문제. (3) "task" — `architect TASK_DECOMPOSE`가 이미 task라는 단어를 사용 + Epic→Story→**Task** 계층과 완벽 정합.
+- **Decision**: "task" 채택. 루프명 `impl-batch-loop` → `impl-task-loop`. 행동 변경 없음 — 순수 용어 통일.
+- **Follow-Up**: 과거 change_rationale_history.md / document_update_record.md / PROGRESS.md 의 히스토리 기록은 정확성 보존을 위해 변경하지 않음.
+
 ### DCN-CHG-20260502-03
 - **Date**: 2026-05-02
 - **Rationale**: DCN-01에서 BLOCKING 게이트를 넣었으나 inject 내 Read 경로가 상대 경로("docs/process/dcness-guidelines.md")였음. Read 도구는 절대 경로만 허용하므로 Claude가 Read를 시도해도 즉시 실패 → "파일이 없어 로드는 스킵됐습니다" 오류.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,30 @@
 
 ## Records
 
+### DCN-CHG-20260502-04
+- **Date**: 2026-05-02
+- **Change-Type**: agent | docs-only
+- **Files Changed**:
+  - `commands/impl.md`
+  - `commands/impl-loop.md`
+  - `commands/product-plan.md`
+  - `commands/qa.md`
+  - `commands/run-review.md`
+  - `agents/architect/task-decompose.md`
+  - `agents/architect/module-plan.md`
+  - `agents/architect/spec-gap.md`
+  - `agents/engineer.md`
+  - `agents/validator/design-validation.md`
+  - `docs/loop-catalog.md`
+  - `docs/loop-procedure.md`
+  - `docs/orchestration.md`
+  - `docs/process/dcness-guidelines.md`
+  - `docs/process/manual-smoke-guide.md`
+  - `docs/process/document_update_record.md`
+  - `docs/process/change_rationale_history.md`
+  - `README.md`
+- **Summary**: "batch" 용어 전면 제거 — impl 단위를 "task"로 통일 (Epic→Story→Task 계층 정합), 루프명 `impl-batch-loop` → `impl-task-loop`
+
 ### DCN-CHG-20260502-03
 - **Date**: 2026-05-02
 - **Change-Type**: hooks


### PR DESCRIPTION
## Summary
- `impl-batch-loop` → `impl-task-loop` 루프명 변경
- 스킬/에이전트/문서 전반의 "batch" → "task" 용어 통일
- Epic→Story→**Task** 계층 정합 (`architect TASK_DECOMPOSE` 커맨드명과 자연스럽게 연결)
- 행동 변경 없음 — 순수 용어 통일

## 변경 파일
`commands/`, `agents/`, `docs/` 18개 파일. 역사적 로그(`change_rationale_history.md`, `document_update_record.md`, `PROGRESS.md` 과거 항목)는 정확성 보존을 위해 유지.

## Test plan
- [ ] doc-sync 게이트 통과 확인 (커밋 시 자동)
- [ ] `grep -r "impl-batch" .` 결과 없음 확인 (역사 로그 제외)
- [ ] 스킬 설명 (`/impl`, `/impl-loop`)에 "task" 용어 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)