### PR TITLE
[epic3][story2] git-naming-spec 강제 — CLAUDE.md 정비 + CI/hook 차단 (DCN-CHG-20260503-03~04)

### DIFF
--- a/.github/workflows/git-naming-validation.yml
+++ b/.github/workflows/git-naming-validation.yml
@@ -1,0 +1,34 @@
+# GitHub Actions — git-naming-spec 브랜치명·PR 제목 형식 검증 게이트
+#
+# 규칙 정의: docs/process/git-naming-spec.md (SSOT)
+# PR 생성·수정·재오픈 시마다 브랜치명과 PR 제목이 규칙을 따르는지 검사한다.
+
+name: git-naming-validation
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  naming:
+    name: git-naming-spec gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate branch name
+        run: node scripts/check_git_naming.mjs --branch "${{ github.head_ref }}"
+
+      - name: Validate PR title
+        run: node scripts/check_git_naming.mjs --title "${{ github.event.pull_request.title }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ node scripts/check_document_sync.mjs
 
 # git hook 설치 (clone 후 1회)
 cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
 
 # 하네스 단위 테스트 실행
 python3 -m unittest discover -s tests -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,26 +54,32 @@
 
 ## 3. 문서 지도
 
+### 즉시 읽기 (세션 시작 시 항상)
+
 | 파일 | 역할 |
 |---|---|
-| [`docs/process/main-claude-rules.md`](docs/process/main-claude-rules.md) | 🔴 **메인 Claude 행동 룰 SSOT** — 본 프로젝트 작업 *직전* read 의무. 실존 검증 / dcness 인프라 / Karpathy 4 원칙 전문 |
-| [`docs/process/governance.md`](docs/process/governance.md) | **SSOT** — 모든 거버넌스 룰의 단일 출처 |
-| [`docs/process/document_update_record.md`](docs/process/document_update_record.md) | WHAT 로그 (Task-ID 별 변경 파일) |
-| [`docs/process/change_rationale_history.md`](docs/process/change_rationale_history.md) | WHY 로그 (Task-ID 별 동기·대안·결정·후속) |
-| [`docs/process/document_impact_matrix.md`](docs/process/document_impact_matrix.md) | 변경 → 검토 문서 빠른 참조 |
-| [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) | RWHarness fork-and-refactor proposal (정체성·Phase·원칙) |
-| [`docs/orchestration.md`](docs/orchestration.md) | 오케스트레이션 SSOT — 시퀀스 + 진입 경로 + 결정표 + retry + escalate + 핸드오프 매트릭스 (RWHarness §4.2/§4.3/§3 통합, 형식 어휘 dcNess 변환) |
-| [`PROGRESS.md`](PROGRESS.md) | 현재 상태 / TODO / Blockers |
-| [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 |
-| [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) | PR 체크리스트 |
-| [`scripts/check_document_sync.mjs`](scripts/check_document_sync.mjs) | Document Sync 게이트 구현 |
-| [`scripts/check_task_id.mjs`](scripts/check_task_id.mjs) | Task-ID 형식 검증 게이트 (governance §2.1) |
-| [`scripts/setup_branch_protection.mjs`](scripts/setup_branch_protection.mjs) | main 브랜치 보호 적용 스크립트 (governance §2.8) |
-| [`docs/process/branch-protection-setup.md`](docs/process/branch-protection-setup.md) | branch protection 적용/검증 가이드 |
-| [`docs/process/plugin-dryrun-guide.md`](docs/process/plugin-dryrun-guide.md) | RWHarness 와 공존 plugin 배포 dry-run 절차 (proposal §12 풀어쓴 운영 가이드) |
-| [`scripts/check_python_tests.sh`](scripts/check_python_tests.sh) | pytest pre-commit 게이트 (paths 분기) |
-| [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook (doc-sync + pytest 체인) |
-| [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook (doc-sync + pytest 체인) |
+| [`docs/process/main-claude-rules.md`](docs/process/main-claude-rules.md) | 🔴 **메인 Claude 행동 룰 SSOT** — 실존 검증 / dcness 인프라 / Karpathy 4 원칙 |
+| [`docs/process/governance.md`](docs/process/governance.md) | 거버넌스 SSOT — Task-ID / Change-Type / 게이트 전체 룰 |
+| [`docs/process/git-naming-spec.md`](docs/process/git-naming-spec.md) | 브랜치·커밋·PR 네이밍 규칙 SSOT — 모든 커밋 작업에 적용 |
+
+### 작업 시 읽기 (lazy — 해당 작업 직전에만)
+
+| 파일 | 언제 읽나 |
+|---|---|
+| [`docs/process/document_update_record.md`](docs/process/document_update_record.md) | 모든 변경 기록 시 (WHAT 로그) |
+| [`docs/process/change_rationale_history.md`](docs/process/change_rationale_history.md) | spec / agent / harness / hooks / ci 변경 시 (WHY 로그) |
+| [`docs/process/document_impact_matrix.md`](docs/process/document_impact_matrix.md) | 변경 영향 범위 검토 시 |
+| [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) | 하네스 설계·Phase 수정 시 |
+| [`docs/orchestration.md`](docs/orchestration.md) | 오케스트레이션 로직(시퀀스·retry·escalate) 수정 시 |
+| [`PROGRESS.md`](PROGRESS.md) | 현재 상태·TODO·Blockers 확인 시 |
+| [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 수정 시 |
+| [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) | PR 체크리스트 확인 시 |
+| [`docs/process/branch-protection-setup.md`](docs/process/branch-protection-setup.md) | 브랜치 보호 설정 변경 시 |
+| [`docs/process/plugin-dryrun-guide.md`](docs/process/plugin-dryrun-guide.md) | 플러그인 배포 dry-run 시 |
+| [`scripts/check_document_sync.mjs`](scripts/check_document_sync.mjs) | Document Sync 게이트 구현 참조 시 |
+| [`scripts/check_python_tests.sh`](scripts/check_python_tests.sh) | pytest 게이트 구현 참조 시 |
+| [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook 수정 시 |
+| [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook 수정 시 |
 
 ## 4. 개발 명령어
 
@@ -93,23 +99,23 @@ python3 -m unittest tests.test_signal_io -v   # 단일 모듈
 
 ## 5. 커밋 / PR 절차
 
-> 상세: 글로벌 `~/.claude/CLAUDE.md` "커밋 절차" 섹션 + 본 프로젝트 거버넌스 추가 강제.
+> 네이밍·메시지·PR 템플릿 상세: **[`docs/process/git-naming-spec.md`](docs/process/git-naming-spec.md)** (즉시 읽기 문서).
 
 ```
-1. git checkout -b {type}/{설명} main      # type: chore | feat | fix | docs
+1. git checkout -b {브랜치명} main         # git-naming-spec §1 패턴
 2. (변경 + 거버넌스 동반 파일 갱신)
 3. git add {파일}
 4. node scripts/check_document_sync.mjs    # 게이트 수동 확인 (선택)
 5. git commit -m "..."                      # hook 자동 게이트
-6. git push -u origin {branch}
-7. gh pr create --title "..." --body "..."  # PULL_REQUEST_TEMPLATE 채움
-8. gh pr merge --squash
+6. git push -u origin {브랜치명}
+7. gh pr create --title "..." --body "..."  # git-naming-spec §4~§5 템플릿
+8. gh pr merge                              # regular merge (squash 금지)
 9. git checkout main && git pull
 ```
 
-- **main 직접 commit/push 금지**. 항상 branch → PR → squash merge.
-- **branch 는 merge 후에도 삭제하지 않는다** (글로벌 룰 정합).
-- PR title = commit message subject. PR body = 거버넌스 체크리스트 + 변경 요약.
+- **main 직접 commit/push 금지**. 항상 branch → PR → regular merge.
+- **squash merge 금지** — 커밋별 히스토리 보존 목적.
+- **branch 는 merge 후에도 삭제하지 않는다**.
 
 ## 6. 환경변수
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🏷️ git-naming-spec CI/hook 강제** (`DCN-CHG-20260503-04`):
+  - `scripts/check_git_naming.mjs` 신규 — 브랜치명·커밋/PR 제목 형식 검증 스크립트.
+  - `scripts/hooks/commit-msg` 신규 — 로컬 commit-msg hook (커밋 제목 즉시 차단).
+  - `.github/workflows/git-naming-validation.yml` 신규 — CI 브랜치명·PR 제목 게이트.
+  - `CLAUDE.md` §3 문서 지도 즉시읽기/lazy 분리. §5 squash→regular merge 수정.
+
 - **📦 PR/Commit/Issue 구조화 강제** (`DCN-CHG-20260502-05`):
   - **3-commit 구조** (impl-task-loop 계열): docs(MODULE_PLAN 후) → tests(TESTS_WRITTEN 후) → src+PR(CODE_VALIDATION 후). `loop-procedure.md §3.4` 신설.
   - **catastrophic gate 3개**: §2.3.6(test-engineer=docs commit), §2.3.7(engineer IMPL=tests commit), §2.3.8(pr-reviewer=src commit). impl loop(entry_point=impl) 계열에만 적용.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,14 @@
 
 ## Records
 
+### DCN-CHG-20260503-03
+- **Date**: 2026-05-03
+- **Rationale**: (1) CLAUDE.md 문서 지도가 즉시읽기/lazy 구분 없이 나열되어 세션 시작 시 무엇을 읽어야 하는지 불명확. (2) §5 커밋 절차에 squash merge가 남아 있어 git-naming-spec(regular merge 강제)과 직접 충돌. (3) 브랜치 타입에 chore·feat 잔존으로 새 네이밍 규칙과 불일치.
+- **Alternatives**:
+  - 문서 지도에 주석만 추가 — 즉시읽기/lazy 의도가 모호하게 남음. 실제 행동 변화 없음.
+- **Decision**: 문서 지도 테이블을 즉시읽기/lazy 두 섹션으로 분리. §5를 git-naming-spec 위임 + regular merge로 일원화.
+- **Follow-Up**: PR 제목·브랜치명 포맷 CI/hook 강제 (DCN-CHG-20260503-04).
+
 ### DCN-CHG-20260503-02
 - **Date**: 2026-05-03
 - **Rationale**: dcNess 자체 작업이 epic 분류 없이 Task-ID만으로 관리되어 이슈 추적 구조 부재. git-naming-spec 도입으로 epic/story 기반 브랜치·이슈 규칙이 생겼으므로 dcNess 자신도 동일 구조 적용.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,15 @@
 
 ## Records
 
+### DCN-CHG-20260503-04
+- **Date**: 2026-05-03
+- **Rationale**: git-naming-spec 규칙이 문서로만 존재해 로컬에서 우회 가능. 브랜치명·PR 제목·커밋 제목 위반이 사람 눈에만 걸리면 늦게 발견됨. CI+hook으로 자동 차단해야 규칙이 실제로 작동.
+- **Alternatives**:
+  - PR 리뷰에서 수동 검수 — 리뷰어 부담, 일관성 보장 불가.
+  - task-id-validation.yml 확장 — 관심사 혼합. 별도 파일로 분리가 명확.
+- **Decision**: `scripts/check_git_naming.mjs` 신규 + CI workflow + commit-msg hook 3단 강제. 로컬(commit-msg)→CI(PR open) 두 단계로 조기 차단.
+- **Follow-Up**: CLAUDE.md §4 hook 설치 명령어에 commit-msg 추가.
+
 ### DCN-CHG-20260503-03
 - **Date**: 2026-05-03
 - **Rationale**: (1) CLAUDE.md 문서 지도가 즉시읽기/lazy 구분 없이 나열되어 세션 시작 시 무엇을 읽어야 하는지 불명확. (2) §5 커밋 절차에 squash merge가 남아 있어 git-naming-spec(regular merge 강제)과 직접 충돌. (3) 브랜치 타입에 chore·feat 잔존으로 새 네이밍 규칙과 불일치.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,17 @@
 
 ## Records
 
+### DCN-CHG-20260503-04
+- **Date**: 2026-05-03
+- **Change-Type**: ci
+- **Files Changed**:
+  - `scripts/check_git_naming.mjs` (신규) — branch/title 형식 검증 스크립트
+  - `scripts/hooks/commit-msg` (신규) — 로컬 commit-msg hook
+  - `.github/workflows/git-naming-validation.yml` (신규) — CI 브랜치명·PR 제목 게이트
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: git-naming-spec CI/hook 강제 — 브랜치명·PR 제목·커밋 제목 자동 차단
+
 ### DCN-CHG-20260503-03
 - **Date**: 2026-05-03
 - **Change-Type**: agent

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260503-03
+- **Date**: 2026-05-03
+- **Change-Type**: agent
+- **Files Changed**:
+  - `CLAUDE.md` §3 문서 지도 → 즉시읽기/lazy 분리, git-naming-spec.md 추가
+  - `CLAUDE.md` §5 커밋/PR 절차 → squash→regular merge, 브랜치 타입 수정, git-naming-spec 참조
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: CLAUDE.md 문서 로딩 전략 정비 + squash merge 충돌 해소
+
 ### DCN-CHG-20260503-02
 - **Date**: 2026-05-03
 - **Change-Type**: agent

--- a/scripts/check_git_naming.mjs
+++ b/scripts/check_git_naming.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+/**
+ * git-naming-spec 형식 검증 게이트
+ * 규칙 정의: docs/process/git-naming-spec.md (SSOT)
+ *
+ * 사용:
+ *   node scripts/check_git_naming.mjs --branch <branch-name>
+ *   node scripts/check_git_naming.mjs --title <commit-or-pr-title>
+ *
+ * exit 0: 통과
+ * exit 1: 위반
+ */
+
+const BRANCH_RE = /^(feature\/epic\d+_story\d+_.+|fix\/issue\d+_.+|docs\/.+)$/;
+const TITLE_RE  = /^(\[epic\d+\]\[story\d+\]|\[issue-\d+\]|\[docs\]) .+/;
+
+const args = process.argv.slice(2);
+const mode = args[0];
+const value = args.slice(1).join(' ');
+
+if (!mode || !value) {
+  console.error('[git-naming] 사용법: --branch <name> | --title <title>');
+  process.exit(1);
+}
+
+if (mode === '--branch') {
+  if (!BRANCH_RE.test(value)) {
+    console.error(`[git-naming] FAIL — 브랜치명 형식 위반: "${value}"`);
+    console.error('  허용 패턴:');
+    console.error('    feature/epic{N}_story{N}_{desc}');
+    console.error('    fix/issue{N}_{desc}');
+    console.error('    docs/{desc}');
+    process.exit(1);
+  }
+  console.log(`[git-naming] PASS — branch: ${value}`);
+
+} else if (mode === '--title') {
+  if (!TITLE_RE.test(value)) {
+    console.error(`[git-naming] FAIL — 커밋/PR 제목 형식 위반: "${value}"`);
+    console.error('  허용 패턴:');
+    console.error('    [epic{N}][story{N}] {설명}');
+    console.error('    [issue-{N}] {설명}');
+    console.error('    [docs] {설명}');
+    process.exit(1);
+  }
+  console.log(`[git-naming] PASS — title: ${value}`);
+
+} else {
+  console.error(`[git-naming] 알 수 없는 모드: ${mode}`);
+  process.exit(1);
+}

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,0 +1,14 @@
+#!/bin/sh
+# commit-msg hook — git-naming-spec 커밋 제목 형식 검증
+# 규칙 정의: docs/process/git-naming-spec.md §2 (SSOT)
+#
+# 설치: cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+
+COMMIT_TITLE=$(head -1 "$1")
+
+# 머지 커밋 면제
+if echo "$COMMIT_TITLE" | grep -qE "^Merge (branch|pull request)"; then
+  exit 0
+fi
+
+node "$(git rev-parse --show-toplevel)/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE"


### PR DESCRIPTION
## 변경 요약

### [epic3][story2] CLAUDE.md 문서 지도 정비 + squash merge 충돌 해소 (DCN-CHG-20260503-03)
- **What**: §3 즉시읽기/lazy 분리, §5 squash→regular merge, 브랜치 타입 수정
- **Why**: git-naming-spec 도입 후 CLAUDE.md가 동기화 안 됐고 squash merge 룰이 직접 충돌

### [epic3][story2] git-naming-spec CI/hook 강제 (DCN-CHG-20260503-04)
- **What**: check_git_naming.mjs + commit-msg hook + git-naming-validation.yml CI 워크플로우 신설
- **Why**: 문서 규칙만으로는 로컬 우회 가능 — 로컬(commit-msg)→CI(PR open) 2단 자동 차단으로 실질 강제

## 결정 근거

- task-id-validation.yml과 별도 파일로 분리 — 관심사 혼합 방지
- 머지 커밋은 commit-msg hook에서 자동 면제

## 관련 이슈

- #110 (EPIC03 인프라)

## 참고

- commit-msg hook 로컬 설치 필요: `cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg`