### PR TITLE
[docs] CLAUDE.md §0 프로젝트 정체성 5 룰 추가 (DCN-CHG-20260504-03)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,54 @@
 
 ## 0. 프로젝트 정체성
 
+> 🔴 **메인 Claude 가 자주 까먹는 핵심 — 매번 작업 전 반드시 인지**
+
+### 0.1 본 프로젝트 = 하네스 인프라 (plug-in 배포물)
+
+- 본 프로젝트(dcness)는 **Claude Code 용 plug-in 으로 배포**된다.
+- 사용자(외부 프로젝트)는 **`/init-dcness` 스킬을 통해 활성화**한다.
+- 본 프로젝트에 추가하는 모든 기능은 **dcness 자체를 위한 것이 아니라**, **활성화한 외부 프로젝트에 적용되기 위한 것**이다.
+- 따라서 "이 프로젝트에서 잘 작동하는가" 가 아니라 **"활성화한 외부 프로젝트에서 잘 작동하는가"** 가 기준.
+
+### 0.2 dcness 자체는 init-dcness 미적용 — 자기 규격 미얽매임
+
+- 본 dcness 저장소는 자기 자신에 `/init-dcness` 를 실행하지 **않는다**.
+- 따라서 dcness plug-in 의 규격(`stories.md` 강제 / `issue-lifecycle.md §1.1` 흐름 / `product-planner` 시퀀스 등) 에 **얽매이지 않는다**.
+- dcness 자체의 작업은 다음 4개만 따른다:
+  - `docs/process/governance.md` (Task-ID + Change-Type + 동반 갱신)
+  - `docs/process/git-naming-spec.md` (브랜치·커밋·PR 네이밍)
+  - GitHub 이슈 (필요 시 자유 형식, 메타-스토리·stories.md 불필요)
+  - 본 CLAUDE.md
+- **헷갈리지 마라**: plug-in 규격은 *외부 활성화 프로젝트* 용이지, dcness 자기 자신용이 아니다.
+
+### 0.3 내부 ID 를 외부 배포물에 박지 마라
+
+- `DCN-CHG-YYYYMMDD-NN` 같은 **내부 변경 추적 ID** 는 dcness 내부 거버넌스(`docs/process/document_update_record.md` / `change_rationale_history.md` / commit message) 용이다.
+- **외부에 배포되는 파일** (= plug-in 사용자가 보게 되는 파일: `agents/**`, `commands/**`, `skills/**`, `hooks/**`, 그리고 plug-in 사용자가 따라야 하는 SSOT 인 `docs/issue-lifecycle.md` 등) 안에는 **내부 ID 를 본문으로 박지 않는다**.
+- 외부 사용자에게 "DCN-CHG-20260504-01 에서 ..." 같은 표현은 **잡음**이다. 그 변경 이유 / 작동 룰만 자연어로 설명하면 충분.
+- 단 dcness 자체 거버넌스 로그(`document_update_record.md` / `change_rationale_history.md` / commit message / 본 dcness 자체의 docs/process/) 안에서는 ID 표기 필수 — 이건 *내부* 추적이라 OK.
+
+### 0.4 작성 스타일 — 쉬운 한글 + § 표시 명확히
+
+- 외래어 (Caveats / Disclaimer / Note / TBD 등) 보다는 **명확한 한글** 사용. (예: "Caveats" → "주의사항" / "TBD" → "추후 결정")
+- 영어 약어가 더 정확한 곳(API / SDK / SSOT / PR / CI 등 산업 표준어)은 그대로 사용.
+- **`§` 기호는 명확하게 사용** — `§N`, `§N.M` 형식. 어디서 인용했는지 **반드시 명시** (예: `governance.md §2.3` / `main-claude-rules.md §0`).
+- 단순히 "위 섹션" / "아래 참조" 같은 모호한 표현 X — 항상 `파일명 §번호` 박을 것.
+
+### 0.5 추가한 기능은 반드시 배포 경로에도 포함
+
+- 본 저장소(dcness self) 에만 추가하면 **외부 활성화 프로젝트에서는 작동하지 않는다** — 과거 사례: 기능을 dcness 자체에 추가했는데 정작 설치한 외부 프로젝트(jajang)는 그 기능이 없어 작동 안 함.
+- 모든 기능 추가 작업은 **배포 경로 검증 의무** 가 동반된다. 다음 중 *해당하는 모든 경로* 가 갱신돼야 작업 완료:
+  1. **plug-in 본체 파일** (`agents/**`, `commands/**`, `skills/**`, `hooks/**`) — 사용자가 plug-in 업데이트 시 자동 적용. 본 저장소의 같은 경로에 변경 = plug-in 도 자동 갱신 (단 사용자가 plug-in 버전 업 받은 후).
+  2. **`/init-dcness` 스킬이 사용자 프로젝트로 *복사·배포* 하는 파일** (예: `scripts/check_*.mjs`, `scripts/hooks/commit-msg`, `.github/workflows/*.yml`) — 본 저장소에만 추가하면 신규 프로젝트는 받지만 *기존 활성화 프로젝트* 는 못 받음. **`commands/init-dcness.md` 의 deploy 스텝에 반드시 추가** + 기존 사용자가 재배포받을 방법 고지.
+  3. **사용자가 따라야 하는 SSOT 문서** (예: `docs/issue-lifecycle.md`, `docs/process/git-naming-spec.md` 중 사용자용 부분) — 본 저장소 docs 만 갱신하면 사용자는 못 봄. plug-in 배포물 쪽으로 옮기거나 init-dcness 가 복사하도록 처리.
+- 기능 추가 PR 본문에 **"배포 경로 검증"** 항목 명시 — 어떤 경로(1/2/3) 로 사용자 환경에 도달하는지, 누락 없는지.
+- **검증 안 된 변경은 dcness 자체에서만 작동하는 환상**. 사용자에게 안 닿으면 기능 추가 의미 없음.
+
+---
+
+### 0.6 모드 (위 0.1~0.5 정체성 위에서)
+
 - **목적**: RWHarness fork-and-refactor — status-JSON-mutate 결정론 + 4 기둥 정합 + 함정 회피 5원칙 (`docs/status-json-mutate-pattern.md` §1~§2.5).
 - **모드**: **메인 Claude 직접 작업** (`status-json-mutate-pattern.md` §10 / §11.4 정합).
   - architect / validator / engineer 위임 강제 **없음**.

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,15 @@
 
 ## Records
 
+### DCN-CHG-20260504-03
+- **Date**: 2026-05-04
+- **Rationale**: 작업 중 메인 Claude 가 다음 5 핵심을 반복적으로 까먹어 사용자 frustration 누적. (1) 본 dcness 저장소 자체와 plug-in 배포 후 사용자 환경을 혼동 — dcness 자체에 plug-in 규격을 잘못 적용 (예: 본 저장소에 stories.md / issue-lifecycle.md §1.1 product-planner 흐름을 강제). (2) 내부 추적 ID 를 plug-in 배포 파일 (agents/commands/skills + 사용자용 SSOT) 본문에 그대로 박아 외부 사용자에게 잡음 노출. (3) 외래어 (Caveats / Disclaimer / TBD 등) 남발로 가독성 저하. (4) 인용 시 "위 섹션" 같은 모호 표기 사용으로 SSOT 추적 불가. (5) 기능 추가 시 본 저장소에만 반영하고 plug-in 배포 경로(init-dcness deploy / 사용자 SSOT) 누락 — 과거 jajang 에서 dcness 자체는 작동하는데 정작 사용자 환경은 그 기능 없어 미작동 사고 발생.
+- **Alternatives**:
+  - main-claude-rules.md 에만 추가 — 본 CLAUDE.md 안 읽으면 인지 못 함. CLAUDE.md 가 1차 진입점이라 §0 정체성 박스에 박는 게 가장 강함.
+  - 별도 conventions.md 신규 분리 — 추가 파일 = SSOT 분산 + lazy read 위험. 5 룰은 정체성 직결이라 §0 inline 이 적절.
+- **Decision**: CLAUDE.md §0 프로젝트 정체성 섹션을 5 sub-section 으로 확장. §0.1 plug-in 배포 정체성 (= 활성화 외부 프로젝트가 기준) / §0.2 dcness self 는 init-dcness 미적용 = plug-in 규격 미얽매임 / §0.3 내부 ID 외부 배포물 금지 / §0.4 쉬운 한글 + § 인용 명시 / §0.5 기능 추가 시 배포 경로 (plug-in 본체 / init-dcness 복사 / 사용자 SSOT) 검증 의무. 기존 §0 모드 섹션은 §0.6 으로 강등 (정체성 위에서 작동하는 모드).
+- **Follow-Up**: 외부 배포 SSOT (`docs/issue-lifecycle.md`) 안의 내부 ID 인용 정리 (별도 작업). plug-in 배포 파일 전수 grep 으로 내부 ID 잔존 확인 (별도 작업). 기존 활성화 프로젝트 (jajang 등) 가 init-dcness 재실행 없이도 신규 deploy 받을 방법 검토 (별도 작업).
+
 ### DCN-CHG-20260504-01
 - **Date**: 2026-05-04
 - **Rationale**: GitHub 이슈 생성·완료 룰이 dcness plugin 의 여러 agent 에 분산 + 일관성 없음. (1) epic 이슈는 product-planner, story 이슈는 task-decompose 가 별도 시점에 생성 → ISSUE_SYNC 호출이 자주 skip 됨. (2) 이슈 close 주체·방법이 어디에도 명시 안 됨. (3) task-decompose 가 이슈 부재 시 stories.md fallback 으로 silent 진행 → 적용 프로젝트 (jajang) 가 이슈 등록을 전제로 설계됐음에도 누락 발견 안 됨 (epic-11 사례: PR #180 진행 중 "이슈 번호 없음 — 생략하고 진행"). (4) 라벨 형식이 plugin agent 가정 (`V0N`+`EPIC0N`+`Story0N`) vs jajang 실제 GitHub 라벨 (`v0N`+`epic-NN-<slug>`+`story`) 미스매치 — 그대로 갔으면 이슈 생성 실패.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,15 @@
 
 ## Records
 
+### DCN-CHG-20260504-03
+- **Date**: 2026-05-04
+- **Change-Type**: agent
+- **Files Changed**:
+  - `CLAUDE.md` — §0 프로젝트 정체성 섹션 확장 (§0.1 plug-in 배포 정체성 / §0.2 dcness self 는 init-dcness 미적용 = 자기 규격 미얽매임 / §0.3 내부 ID 외부 배포물 금지 / §0.4 쉬운 한글 + § 인용 명시 / §0.5 추가 기능은 배포 경로에도 포함 의무 / §0.6 = 기존 모드 강등)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 메인 Claude 가 자주 까먹는 5 핵심을 CLAUDE.md §0 에 명시 — (1) plug-in 배포 정체성 / 외부 활성화 프로젝트가 기준 (2) dcness self 는 init-dcness 미적용이라 자기 규격(stories.md / issue-lifecycle §1.1 등) 에 얽매이지 않음 (3) 내부 변경 추적 ID 를 plug-in 배포 파일 (agents/commands/skills/hooks + 사용자용 SSOT) 에 박지 않음 (4) 외래어 지양 + § 인용 위치 명시 (5) 추가 기능은 plug-in 본체 / init-dcness 복사 배포 / 사용자용 SSOT 3 경로 중 해당하는 모든 곳에 포함 — dcness self 만 추가하면 사용자 환경 미작동 (jajang 사례).
+
 ### DCN-CHG-20260504-01
 - **Date**: 2026-05-04
 - **Change-Type**: agent, docs-only


### PR DESCRIPTION
## 변경 요약

### [docs] CLAUDE.md §0 프로젝트 정체성 5 룰 추가 (DCN-CHG-20260504-03)
- **What**: CLAUDE.md §0 프로젝트 정체성 섹션을 5 sub-section 으로 확장 — §0.1 plug-in 배포 정체성 / §0.2 dcness self init-dcness 미적용 / §0.3 내부 ID 외부 배포물 금지 / §0.4 쉬운 한글 + § 인용 명시 / §0.5 추가 기능은 배포 경로 검증 의무 (jajang 사례 반영). 기존 §0 모드는 §0.6 으로 강등.
- **Why**: 메인 Claude 가 작업 중 5 핵심을 반복적으로 까먹어 사용자 frustration 누적 (특히 plug-in 규격을 dcness self 에 잘못 적용 / 추가 기능을 plug-in 배포 경로에 누락하는 사고).

## 결정 근거

- main-claude-rules.md 별도 추가 = lazy read 위험 → CLAUDE.md §0 inline 채택
- 별도 conventions.md 신설 = SSOT 분산 → §0 정체성 박스 유지

## 관련 이슈

- #110 (EPIC03 인프라)

## 배포 경로 검증

- 본 PR 은 dcness self 거버넌스 문서(CLAUDE.md + process logs) 만 수정. plug-in 배포 경로 영향 없음. (CLAUDE.md 자체는 dcness self 진입점 — plug-in 사용자에게 배포되지 않음)