### PR TITLE
[ci] DCN-CHG-20260504-05 Task-ID 게이트 PR title 검사 제거 + branch protection 설정

### DIFF
--- a/.github/workflows/task-id-validation.yml
+++ b/.github/workflows/task-id-validation.yml
@@ -64,9 +64,3 @@ jobs:
 
           node scripts/check_task_id.mjs "$BASE" "$HEAD"
 
-      - name: Validate PR title (PR mode only)
-        if: github.event_name == 'pull_request'
-        run: |
-          set -e
-          TITLE="${{ github.event.pull_request.title }}"
-          node scripts/check_task_id.mjs --pr-title "$TITLE"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,11 @@
 
 ## 현재 상태
 
+- **🔒 Task-ID 게이트 PR title 검사 제거 + branch protection 설정** (`DCN-CHG-20260504-05`):
+  - `scripts/check_task_id.mjs` — `--pr-title` 모드 제거 (커밋 메시지 검사만 유지).
+  - `.github/workflows/task-id-validation.yml` — `Validate PR title` step 제거.
+  - GitHub main branch protection required status checks 설정 (3개 게이트 강제화).
+
 - **🏷️ git-naming-spec CI/hook 강제** (`DCN-CHG-20260503-04`):
   - `scripts/check_git_naming.mjs` 신규 — 브랜치명·커밋/PR 제목 형식 검증 스크립트.
   - `scripts/hooks/commit-msg` 신규 — 로컬 commit-msg hook (커밋 제목 즉시 차단).

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260504-05
+- **Date**: 2026-05-04
+- **Rationale**: PR title 에 Task-ID 를 요구하는 게이트가 git-naming-spec PR title 형식(`[docs] {설명}`)과 충돌 — 둘 다 지키려면 title 에 ID + 설명을 모두 넣어야 해서 가독성 저하. 또한 branch protection 미설정으로 CI 실패해도 merge 가 막히지 않아 게이트 의미 반감.
+- **Alternatives**: PR title 형식에 Task-ID 포함 강제 — git-naming-spec 와 충돌, title 가독성 저하로 기각.
+- **Decision**: PR title 검사 제거 (커밋 메시지 검사로 충분) + branch protection required status checks 설정으로 게이트 강제화.
+- **Follow-Up**: branch protection 설정 후 required checks (`Task-ID format gate` / `Document Sync gate` / `git-naming-spec gate`) 작동 확인.
+
 ### DCN-CHG-20260504-03
 - **Date**: 2026-05-04
 - **Rationale**: 작업 중 메인 Claude 가 다음 5 핵심을 반복적으로 까먹어 사용자 frustration 누적. (1) 본 dcness 저장소 자체와 plug-in 배포 후 사용자 환경을 혼동 — dcness 자체에 plug-in 규격을 잘못 적용 (예: 본 저장소에 stories.md / issue-lifecycle.md §1.1 product-planner 흐름을 강제). (2) 내부 추적 ID 를 plug-in 배포 파일 (agents/commands/skills + 사용자용 SSOT) 본문에 그대로 박아 외부 사용자에게 잡음 노출. (3) 외래어 (Caveats / Disclaimer / TBD 등) 남발로 가독성 저하. (4) 인용 시 "위 섹션" 같은 모호 표기 사용으로 SSOT 추적 불가. (5) 기능 추가 시 본 저장소에만 반영하고 plug-in 배포 경로(init-dcness deploy / 사용자 SSOT) 누락 — 과거 jajang 에서 dcness 자체는 작동하는데 정작 사용자 환경은 그 기능 없어 미작동 사고 발생.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260504-05
+- **Date**: 2026-05-04
+- **Change-Type**: ci
+- **Files Changed**:
+  - `.github/workflows/task-id-validation.yml` — PR title 검사 step (`Validate PR title`) 제거
+  - `scripts/check_task_id.mjs` — `--pr-title` 모드 코드 + 관련 주석 제거
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: Task-ID 게이트에서 PR title 검사 제거 (커밋 메시지 검사만 유지). GitHub branch protection required status checks 설정으로 게이트 강제화.
+
 ### DCN-CHG-20260504-04
 - **Date**: 2026-05-04
 - **Change-Type**: docs-only

--- a/scripts/check_task_id.mjs
+++ b/scripts/check_task_id.mjs
@@ -6,7 +6,6 @@
  * 사용:
  *   node scripts/check_task_id.mjs                 # 로컬: HEAD 커밋 1개 검사
  *   node scripts/check_task_id.mjs <base> <head>   # CI: base..head 범위 검사
- *   node scripts/check_task_id.mjs --pr-title "<title>"  # CI: PR title 검사 (옵션)
  *
  * 규칙:
  *   - 모든 비-머지 커밋은 메시지(subject 또는 body) 안에 정확히 1개의
@@ -14,7 +13,6 @@
  *   - 토큰 패턴: ^DCN-CHG-\d{8}-\d{2}$ (zero-pad 일별 순번)
  *   - 머지 커밋(2개 이상 parent)은 검사 면제 — squash merge 합본 등 자동 생성 케이스.
  *   - Document-Exception-Task: DCN-CHG-... 도 동일 토큰으로 인정.
- *   - PR title 옵션 사용 시 title 안에 1개 이상 매칭이면 PASS.
  *
  * exit 0: 통과
  * exit 1: 위반 (Task-ID 누락 / 형식 위반 / 다중 ID)
@@ -98,24 +96,6 @@ const args = process.argv.slice(2);
 
 if (!isGitRepo() && !args.includes('--pr-title')) {
   console.log('[task-id] not a git repo — skip');
-  process.exit(0);
-}
-
-// PR title 모드
-const prTitleIdx = args.indexOf('--pr-title');
-if (prTitleIdx !== -1) {
-  const title = args[prTitleIdx + 1];
-  if (!title) {
-    console.error('[task-id] --pr-title 인자 누락');
-    process.exit(1);
-  }
-  const result = validateMessage(title);
-  if (!result.ok) {
-    console.error(`[task-id] FAIL — PR title 검증: ${result.error}`);
-    console.error(`  title: ${title}`);
-    process.exit(1);
-  }
-  console.log(`[task-id] PASS — PR title Task-ID: ${result.taskIds[0]}`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## 변경 요약

### [ci] Task-ID 게이트 PR title 검사 제거 + branch protection 설정
- **What**: `check_task_id.mjs` `--pr-title` 모드 제거, `task-id-validation.yml` `Validate PR title` step 제거. GitHub main branch protection required status checks 설정.
- **Why**: PR title Task-ID 요구가 git-naming-spec 형식(`[docs] {설명}`)과 충돌. branch protection 미설정으로 CI 실패해도 merge 가 막히지 않아 게이트 의미 반감.

## 결정 근거

커밋 메시지에 Task-ID 가 있으면 추적 목적은 달성됨 — PR title 중복 요구는 형식 충돌만 유발. branch protection 으로 게이트 강제화하는 것이 더 효과적.

## 관련 이슈

- #125 후속

## 참고

- branch protection required checks: `Task-ID format gate` / `Document Sync gate` / `git-naming-spec gate`
- PR merge 후 `gh api` 로 설정 적용 예정.