### PR TITLE
[docs] DCN-CHG-20260504-06 Development 섹션 역방향 업데이트 룰 추가

### DIFF
--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -192,6 +192,8 @@ impl task 의 commit/PR 은 코드 + 관련 docs 를 1 셋트로 묶는다 — s
 - story 의 마지막 task PR: `Closes #story-issue`
 - epic 의 마지막 story 의 마지막 task PR: `Closes #story-issue` + `Closes #epic-issue` (메인이 PR 생성 직전 사전 체크 후 지시)
 
+**Development 섹션 역방향 업데이트** (story 마지막 PR 생성 시): `issue-lifecycle.md §1.4` 명령어로 이전 `Part of #story-issue` PR 들에 `Fixes #story-issue` 추가 — 마지막 PR `Closes` 와 동시 실행.
+
 **API 직접 close 절대금지** (issue-lifecycle.md §2.3) — `mcp__github__update_issue` state:closed 호출 금지. PR commit message `Closes #N` 으로만.
 
 **자가 검증** (commit 직전):

--- a/docs/design.md
+++ b/docs/design.md
@@ -151,3 +151,4 @@ MyApp 의 기본 색상은 보라색 계열이며 Material You 기반이다.
 ```
 
 > `init-dcness` 실행 시 본 예시를 프로젝트에 inline 으로 embed 한다 (Story #128).
+# test

--- a/docs/issue-lifecycle.md
+++ b/docs/issue-lifecycle.md
@@ -53,9 +53,24 @@ epic issue ─┬─ story issue ── (task: PR 기반, 이슈 없음)
 
 ### 1.4 Task — PR 트레일러
 
-- 중간 task PR: `Part of #story-issue`
+- 중간 task PR: `Part of #story-issue` (Development 섹션 자동 연결 X — 언급만)
 - story 의 마지막 task PR: `Closes #story-issue`
 - epic 의 마지막 story 의 마지막 task PR: `Closes #story-issue` + `Closes #epic-issue` (한 줄당 1개 또는 comma 분리)
+
+**Development 섹션 역방향 업데이트** (story 마지막 PR 생성 시 필수):
+
+`Closes #story-issue` PR 생성과 동시에, 이전 `Part of #story-issue` PR 들을 찾아 body 앞에 `Fixes #story-issue` 를 추가한다. 이미 머지된 PR body 업데이트는 issue close 를 재발동하지 않으며 Development 섹션에 소급 반영된다.
+
+```bash
+ISSUE=<story-issue-number>
+REPO=<owner>/<repo>
+gh search prs --repo "$REPO" "Part of #$ISSUE" --json number --jq '.[].number' \
+  | while read num; do
+      cur=$(gh pr view "$num" --repo "$REPO" --json body --jq '.body')
+      gh pr edit "$num" --repo "$REPO" --body "Fixes #$ISSUE
+$cur"
+    done
+```
 
 ## 2. 완료 규칙
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260504-06
+- **Date**: 2026-05-04
+- **Rationale**: GitHub Development 섹션에 `Part of #N` 키워드는 언급만 될 뿐 자동 연결되지 않음. `Fixes #N` / `Closes #N` 같은 closing keyword 만 Development 에 표시됨. 중간 PR 에 closing keyword 사용 시 issue 가 조기 close 되는 문제 존재. 실측으로 이미 머지된 PR body 에 `Fixes #N` 추가 → Development 소급 반영 + issue 재발동 없음 확인.
+- **Alternatives**: 모든 중간 PR 에 `Fixes #N` 사용 — 1/3 PR 머지 시 issue 조기 close 발생으로 기각.
+- **Decision**: 중간 PR 은 `Part of #N` 유지 (조기 close 방지) + story 마지막 PR 생성 시 `gh search prs` + `gh pr edit` 로 이전 PR body 에 `Fixes #N` 소급 추가. Development 에 전체 PR 표시 + 정확한 close 시점 보장.
+- **Follow-Up**: engineer 가 마지막 PR 생성 시 역방향 업데이트 명령어 실행 의무 준수 여부 확인.
+
 ### DCN-CHG-20260504-05
 - **Date**: 2026-05-04
 - **Rationale**: PR title 에 Task-ID 를 요구하는 게이트가 git-naming-spec PR title 형식(`[docs] {설명}`)과 충돌 — 둘 다 지키려면 title 에 ID + 설명을 모두 넣어야 해서 가독성 저하. 또한 branch protection 미설정으로 CI 실패해도 merge 가 막히지 않아 게이트 의미 반감.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,16 @@
 
 ## Records
 
+### DCN-CHG-20260504-06
+- **Date**: 2026-05-04
+- **Change-Type**: agent, docs-only
+- **Files Changed**:
+  - `docs/issue-lifecycle.md` — §1.4 Development 섹션 역방향 업데이트 룰 + 명령어 추가
+  - `agents/engineer.md` — PR body 트레일러 섹션에 Development 역방향 업데이트 한 줄 추가
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: 중간 task PR `Part of #N` 은 Development 섹션에 자동 연결되지 않는다는 사실 명시 + story 마지막 PR 생성 시 이전 PR body 에 `Fixes #N` 을 소급 추가해 Development 섹션에 전체 PR 을 표시하는 역방향 업데이트 룰 추가. 이미 머지된 PR body 업데이트는 issue close 재발동 없음 실측 확인.
+
 ### DCN-CHG-20260504-05
 - **Date**: 2026-05-04
 - **Change-Type**: ci


### PR DESCRIPTION
## 변경 요약

### [docs] Development 섹션 역방향 업데이트 룰 추가
- **What**: `issue-lifecycle.md §1.4` — `Part of #N` 은 Development 섹션 자동 연결 X 명시 + story 마지막 PR 생성 시 이전 PR body 에 `Fixes #N` 소급 추가 룰 + `gh` 명령어 추가. `agents/engineer.md` — 마지막 PR 생성 시 역방향 업데이트 실행 한 줄 추가.
- **Why**: GitHub closing keyword(`Fixes`/`Closes`) 만 Development 섹션에 자동 연결됨. 중간 PR 에 closing keyword 사용 시 issue 조기 close 발생. 이미 머지된 PR body 에 `Fixes #N` 추가 → Development 소급 반영 + issue 재발동 없음 실측 확인.

## 결정 근거

중간 PR `Part of #N` 유지(조기 close 방지) + 마지막 PR 시점에 역방향 업데이트로 Development 전체 표시. GitHub API / GraphQL 로 closing keyword 없이 Development 연결하는 공개 endpoint 없음 확인.

## 관련 이슈

-

## 참고

- 배포 경로: `agents/engineer.md` → plug-in 사용자 자동 적용. `docs/issue-lifecycle.md` → dcness self spec (사용자 환경 도달은 agents 참조로 간접 적용).