### PR TITLE
[docs] design.md cleanup — 디버그 잔재 / 외부 노출 ID / best practice 정합 (DCN-CHG-20260504-07)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -64,7 +64,7 @@ components:
 | 1 | Overview | 개요 (브랜드 & 스타일) |
 | 2 | Colors | 색상 |
 | 3 | Typography | 타이포그래피 |
-| 4 | Layout | 레이아웃 (레이아웃 & 간격) |
+| 4 | Layout | 레이아웃 & 간격 |
 | 5 | Elevation & Depth | 고도 & 깊이 |
 | 6 | Shapes | 도형 |
 | 7 | Components | 컴포넌트 |
@@ -84,7 +84,7 @@ agent 는 파일 부재를 오류로 처리하지 않는다.
 ### 5.2 토큰 참조 무결성 검증
 
 `{colors.X}` 등 참조가 프론트매터에 실재해야 함.
-**검증 담당**: `agents/validator/code-validation.md` (해당 파일에서 신규 체크 항목으로 추가 — Story #126).
+**검증 담당**: `agents/validator/code-validation.md` (코드 검증 단계의 체크 항목).
 `plan-validation` / `design-validation` 은 본 검증 비대상.
 
 ### 5.3 외부 import 1회 변환
@@ -94,8 +94,9 @@ VoltAgent ecosystem (getdesign.md) 등 외부 `design.md` 가져올 때 LLM 1회
 
 ### 5.4 작성 스타일
 
-본 spec 본문은 `CLAUDE.md §0.4` 정합 — "주의사항" / "추후 결정" 등 명확한 한글 사용.
+명확한 한글 사용 — 외래어 (Caveats / Disclaimer / TBD 등) 는 "주의사항" / "추후 결정" 으로 풀어 쓴다.
 외부 spec 에서 인용하는 라인 (Atmosphere / Tonal Layers 등) 은 영어 그대로 유지 (의미 정확성 우선).
+산업 표준 약어 (API / SDK / SSOT / PR / CI 등) 는 그대로 사용.
 
 ### 5.5 권장 토큰 이름 (Google spec `# Recommended Token Names (Non-Normative)`)
 
@@ -103,7 +104,7 @@ VoltAgent ecosystem (getdesign.md) 등 외부 `design.md` 가져올 때 LLM 1회
 
 **colors**: `primary` / `secondary` / `tertiary` / `neutral` / `surface` / `on-surface` / `error`
 
-**typography**: `headline-display` / `body-lg` / `body-md` / `label-sm`
+**typography**: `headline-display` / `headline-lg` / `headline-md` / `body-lg` / `body-md` / `body-sm` / `label-lg` / `label-md` / `label-sm`
 
 **rounded**: `none` / `sm` / `md` / `lg` / `xl` / `full`
 
@@ -134,9 +135,9 @@ colors:
 typography:
   body-md:
     fontFamily: "Roboto"
-    fontSize: "14px"
-    fontWeight: "400"
-    lineHeight: "20px"
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.43
 ---
 
 ## Overview
@@ -150,5 +151,4 @@ MyApp 의 기본 색상은 보라색 계열이며 Material You 기반이다.
 - `surface`: 배경 기본값
 ```
 
-> `init-dcness` 실행 시 본 예시를 프로젝트에 inline 으로 embed 한다 (Story #128).
-# test
+> `init-dcness` 실행 시 본 예시를 프로젝트에 inline 으로 embed 한다.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,14 @@
 
 ## Records
 
+### DCN-CHG-20260504-07
+- **Date**: 2026-05-04
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `docs/design.md` — 머지된 spec 문서 cleanup 5건 (디버그 잔재 `# test` 라인 삭제 / 외부 노출 부적절 참조 제거 / 사용 예시 best practice 정합 / Layout 한글 표기 정리 / typography 권장 9개 전체 인용)
+  - `docs/process/document_update_record.md` (본 항목)
+- **Summary**: 직전 머지본 `docs/design.md` 의 cleanup. (1) 마지막 줄 `# test` 디버그 잔재 삭제. (2) 외부 사용자에게 의미 없는 dcness 내부 ID (`Story #126` / `Story #128` / `CLAUDE.md §0.4`) 본문에서 제거 — 본 spec 은 plug-in 사용자에게도 도달하는 SSOT 이므로 `CLAUDE.md §0.3` (내부 ID 외부 배포물 금지) 정합. (3) 사용 예시의 fontWeight / lineHeight 를 Google spec 권장 best practice 로 교체 (string `"400"` → bare number `400` / `"20px"` → unitless multiplier `1.43`). (4) §4 표 Layout 한글 표기 동의어 반복 정리. (5) §5.5 권장 typography 9개 (Google spec `# Recommended Token Names`) 전체 인용.
+
 ### DCN-CHG-20260504-06
 - **Date**: 2026-05-04
 - **Change-Type**: agent, docs-only


### PR DESCRIPTION
## 변경 요약

### [docs] design.md cleanup (DCN-CHG-20260504-07)
- **What**: PR #130 머지본 `docs/design.md` 사후 리뷰에서 발견된 5건 일괄 fix.
- **Why**: 본 spec 은 plug-in 사용자에게 도달하는 SSOT — 디버그 잔재·내부 ID·best practice 위반 정리 필요.

### Fix 내역

| # | 항목 | 위치 | 처리 |
|---|---|---|---|
| 1 | `# test` 디버그 잔재 | L154 | 삭제 |
| 2 | dcness 내부 ID 외부 노출 | §5.2 / §5.4 / §7 | `Story #126` / `Story #128` / `CLAUDE.md §0.4` 참조 제거 또는 추상화 — `CLAUDE.md §0.3` 정합 |
| 3 | 사용 예시 best practice | §7 | `fontWeight: "400"` → `400`, `lineHeight: "20px"` → `1.43`, `fontSize: "14px"` → `14px` (Google spec 권장 패턴) |
| 4 | Layout 한글 표기 동의어 반복 | §4 표 | "레이아웃 (레이아웃 & 간격)" → "레이아웃 & 간격" |
| 5 | typography 권장 누락 | §5.5 | Google spec `# Recommended Token Names` 9개 전체 인용 (기존 4개 → 9개) |

## 결정 근거

- 본 spec 은 plug-in 사용자가 따라야 하는 SSOT → `CLAUDE.md §0.3` (내부 ID 외부 배포물 금지) 적용
- 사용 예시는 사용자가 복사하는 minimal 템플릿 → Google spec 권장 패턴 따라야

## 관련 이슈

- #125 (직전 머지본 cleanup)