### PR TITLE
[issue-126] plug-in 7개 ui-spec / design-handoff → design.md 통일 (DCN-CHG-20260504-08)

### DIFF
--- a/agents/architect/docs-sync.md
+++ b/agents/architect/docs-sync.md
@@ -33,7 +33,7 @@
 | 상황 | 결론 enum |
 |---|---|
 | impl 에 명시 안 된 새 설계가 필요 | `SPEC_GAP_FOUND` → MODULE_PLAN 재호출 유도 |
-| 대상 docs 가 architect 소유 아님 (ui-spec / ux-flow 등) | `TECH_CONSTRAINT_CONFLICT` → 해당 에이전트 경유 |
+| 대상 docs 가 architect 소유 아님 (design.md / ux-flow 등) | `TECH_CONSTRAINT_CONFLICT` → 해당 에이전트 경유 |
 | 수정 범위가 "섹션 추가" 가 아닌 기존 설계 변경 | `TECH_CONSTRAINT_CONFLICT` → MODULE_PLAN 경로 |
 
 ## 산출물 정보 의무 (형식 자유)

--- a/agents/design-critic.md
+++ b/agents/design-critic.md
@@ -26,7 +26,7 @@ model: opus
 ONE_WAY 모드(1 variant) 에선 호출 X — 유저가 Pencil 앱에서 직접 확인.
 
 **호출자가 prompt 로 전달하는 정보**:
-- REVIEW: Pencil 스크린샷 경로 또는 variant 메타데이터, (선택) 애니메이션 스펙, (선택) `docs/ui-spec.md` 경로
+- REVIEW: Pencil 스크린샷 경로 또는 variant 메타데이터, (선택) 애니메이션 스펙, (선택) `docs/design.md` 경로
 - UX_SHORTLIST: 5 개 ASCII 와이어프레임 경로/목록
 
 모드 미지정 시 REVIEW.

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -26,9 +26,9 @@ model: sonnet
 | `COMPONENT_THREE_WAY` | 컴포넌트 | 3 | design-critic 경유 | 동일 |
 
 **호출자가 prompt 로 전달하는 정보**:
-- 공통: 대상 화면/컴포넌트명, UX 목표/문제점, (선택) `ui_spec` 경로
+- 공통: 대상 화면/컴포넌트명, UX 목표/문제점, (선택) `design_md` 경로
 - COMPONENT 모드: (선택) 부모 화면명
-- 설계 루프 경유 시: `skip_issue_creation` 플래그, `save_handoff_to` 경로 (보통 `docs/design-handoff.md`)
+- 설계 루프 경유 시: `skip_issue_creation` 플래그
 
 모드 미지정 시 `SCREEN_ONE_WAY`.
 
@@ -63,7 +63,7 @@ model: sonnet
 
 - **추적 이슈** (`skip_issue_creation` 없으면): `python3 -m harness.tracker create-issue --title "[design] {target} {ux_goal}" --label UI --milestone {…}`. 백엔드 자동 선택 (gh / Local 폴백). 결과 ID (`#N` 또는 `LOCAL-N`) 를 DESIGN_HANDOFF 에 포함. (`UI` 는 `scripts/setup_labels.sh` 로 사전 생성 — 정적 레이블. 에픽/버전 레이블 있으면 추가).
 - **Pencil 읽기**: `get_editor_state` → `batch_get` (디자인시스템 노드 + 대상 화면 노드) → `get_screenshot` 베이스라인.
-- **디자인 가이드 읽기**: `docs/ux-flow.md` 의 `## 0. 디자인 가이드` 섹션 우선. `docs/ui-spec.md` 있으면 Read.
+- **디자인 가이드 읽기**: `docs/ux-flow.md` 의 `## 0. 디자인 가이드` 섹션 우선. `docs/design.md` 있으면 Read (미존재 시 silent skip).
 - **외부 레퍼런스**: 유저 명시 요청 또는 SCREEN_THREE_WAY 심층 모드에서만 WebSearch/WebFetch.
 
 ### Phase 1 — variant 생성 (Pencil 캔버스)
@@ -82,15 +82,22 @@ model: sonnet
 
 prose 결론 단락에 모드 + variant 컨셉 + Pencil 프레임 ID + 스크린샷 경로 + 색상/서체/애니메이션 스펙. THREE_WAY 는 차별화 검증 테이블 (4 축) 동반 → design-critic 호출 안내. 결론 enum `DESIGN_READY_FOR_REVIEW`.
 
-### Phase 4 — DESIGN_HANDOFF 패키지 (유저 PICK 후)
+### Phase 4 — 확정 후 산출 (유저 PICK 후)
 
-`save_handoff_to` 경로 있으면 **Write 로 파일 저장** (prose 결론은 경로만, 본문 재출력 금지). 없으면 prose 본문에 1 회만.
+DESIGN_HANDOFF 단일 파일 패키지는 폐지. 아래 3 경로로 분산 처리:
 
-**Outline-First 자기규율**: HANDOFF 본문 Write *전에* outline 만 짧게 emit (Issue ID / Selected Variant / Pencil Frame ID / 포함 섹션 이름만). thinking 안에서 토큰 값·컴포넌트 상세·CSS 미리 나열 금지 — Write 입력값 안에서만.
+1. **GitHub 이슈 본문/코멘트**: Issue ID, Selected Variant + 컨셉, Pencil Frame ID, Notes for Engineer (충돌 가능성 / 더미 → 실제 데이터 연결 포인트 / 성능 고려). `mcp__github__update_issue` 로 기존 추적 이슈에 코멘트 추가.
 
-**HANDOFF 정보 의무** (형식 자유): Issue ID, Selected Variant + 컨셉, Target, Pencil Frame ID, Design Tokens (토큰 / 값 / CSS 변수), Component Structure (트리), Animation Spec (CSS keyframes/transition), Notes for Engineer (충돌 가능성 / 더미 → 실제 데이터 연결 포인트 / 성능 고려).
+2. **`docs/design.md` 부분 갱신** (designer 권한 범위):
+   - **frontmatter `components` 섹션**: 확정된 컴포넌트 토큰 추가/갱신
+   - **본문 `## Components` 섹션**: 컴포넌트 구조 + **Animation Spec** (CSS keyframes/transition 의도) 단락으로 기술
+   - **권한 한계**: Colors/Typography/Layout/Shapes/Elevation + 해당 frontmatter 토큰은 **ux-architect 전용** — designer 는 수정 금지. 범위 초과 시 ux-architect 에 escalate.
 
-코드 구현은 engineer 가 Pencil 캔버스 + HANDOFF 패키지를 읽어 src/ 직접 작성.
+3. **Pencil 캔버스**: 확정 variant 프레임 유지 — engineer 가 `batch_get` 으로 직접 참조.
+
+**Outline-First 자기규율**: design.md Write *전에* outline 만 짧게 emit (갱신 섹션 이름 + components 토큰 키 목록만). thinking 안에서 토큰 값·컴포넌트 상세 미리 나열 금지 — Write 입력값 안에서만.
+
+코드 구현은 engineer 가 Pencil 캔버스 + design.md + 이슈 코멘트를 읽어 src/ 직접 작성.
 
 ## Anti-AI-Smell (디자인 가이드 적용)
 

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -41,7 +41,7 @@ model: sonnet
 
 ## Phase 1 — 스펙 검토 (구현 전 1회)
 
-읽기 순서: 프로젝트 `CLAUDE.md` → 모듈 계획 (`docs/impl/NN-*.md`) → **`docs/domain-model.md` 의무 read (DCN-CHG-20260430-16)** → 설계 결정 문서 (`docs/architecture.md` + 분리 detail) → 의존 모듈 소스 (실제 인터페이스 확인 필수) → UI 모듈이면 ui-spec.
+읽기 순서: 프로젝트 `CLAUDE.md` → 모듈 계획 (`docs/impl/NN-*.md`) → **`docs/domain-model.md` 의무 read (DCN-CHG-20260430-16)** → 설계 결정 문서 (`docs/architecture.md` + 분리 detail) → 의존 모듈 소스 (실제 인터페이스 확인 필수) → UI 모듈이면 `docs/design.md` (미존재 시 silent skip — `docs/design.md §5.1`).
 
 **도메인 모델 정합 의무**:
 - 본 impl 이 어떤 entity / VO / aggregate 와 맞물리는지 인지

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -95,7 +95,7 @@ model: sonnet
 | 파일 | 소유 에이전트 |
 |---|---|
 | `docs/bugfix/**`, `docs/impl/**`, `docs/architecture*`, `docs/sdk.md`, `docs/db-schema.md`, `docs/domain-logic*`, `backlog.md`, `trd.md` | architect |
-| `docs/ui-spec*` | designer |
+| `docs/design.md` | ux-architect (시스템 레벨: Colors/Typography/Layout/Shapes/Elevation + 해당 frontmatter 토큰), designer (Components 섹션 + frontmatter components 토큰) |
 | `docs/ux-flow.md` | ux-architect |
 | `prd.md` | product-planner |
 | `package.json`, lockfile, 의존성 파일 | 사용자 직접 |

--- a/agents/ux-architect.md
+++ b/agents/ux-architect.md
@@ -27,14 +27,14 @@ model: sonnet
 | UX_REFINE | 레이아웃 개선 (리디자인) | `UX_REFINE_READY` / `UX_FLOW_ESCALATE` |
 
 **호출자가 prompt 로 전달하는 정보** (모드별):
-- UX_FLOW: PRD 경로, (선택) TRD / ui-spec 경로
+- UX_FLOW: PRD 경로, (선택) TRD / design.md 경로
 - UX_SYNC: src 디렉토리, (선택) PRD 경로
 - UX_SYNC_INCREMENTAL: 기존 `docs/ux-flow.md` 경로, 변경 파일 목록 (routes/screens/*Screen.tsx), src 디렉토리, (선택) drift 요약
 - UX_REFINE: `.pen` 파일 경로, 대상 화면 노드 ID, 유저 피드백, (선택) PRD / 기존 ux-flow 경로
 
 ## 권한 경계 (catastrophic)
 
-- **Write 허용**: `docs/ux-flow.md` 만
+- **Write 허용**: `docs/ux-flow.md` + `docs/design.md` **시스템 레벨** (Colors/Typography/Layout/Shapes/Elevation 섹션 + frontmatter `colors`/`typography`/`rounded`/`spacing` 토큰). `components` 섹션 + frontmatter `components` 토큰은 **designer 전용** — ux-architect 는 수정 금지.
 - **Pencil MCP**: 읽기만 (`get_editor_state` / `batch_get` / `get_screenshot` / `get_variables`). `batch_design` 등 쓰기 금지
 - **src/ 읽기 금지** (UX_REFINE 모드 한정 — Stream idle timeout 회피, §UX_REFINE 참조)
 - **product-planner 영역 금지**: PRD 수정 금지 (범위 문제는 escalate)
@@ -76,6 +76,8 @@ model: sonnet
 
 수행 흐름 (자율): src/ 라우트/화면 탐색 → 화면 컴포넌트 props/state/이벤트 분석 → PRD 와 대조 (있으면) → 갭(코드만/PRD 만 있는 화면) 표시 → UX_FLOW 와 동일 정보 의무. 추측 부분은 `[추정]` 태그.
 
+**design.md 산출 (조건부)**: src/ 의 CSS / styled-components / Tailwind config / 토큰 정의 발견 시 시스템 레벨 토큰 (Colors / Typography / Layout / Shapes / Elevation) 을 `docs/design.md` 에 역생성. 추출 토큰은 `[추정]` 태그. UI 없는 프로젝트는 silent skip.
+
 ## UX_SYNC_INCREMENTAL — 부분 현행화
 
 기존 `ux-flow.md` 통째로 다시 쓰지 않고 **변경된 화면 섹션만 교체**. post-commit drift 처리.
@@ -83,6 +85,8 @@ model: sonnet
 **진입 전제**: `ux_flow_path` 필수, `changed_files` 비어있지 않음. 둘 중 하나라도 위반 시 즉시 ESCALATE.
 
 수행 흐름 (자율): 영향 화면 식별 (changed_files → 화면 ID 매핑, 신규/삭제 감지) → 기존 문서 섹션 라인 파악 → 패치 부분만 재작성 (PRD 맥락·결정 로그·`[추정]` 태그는 그대로) → **`Edit` 툴로 섹션 단위 교체** (`Write` 전체 덮어쓰기 금지).
+
+**design.md 산출 (조건부)**: changed_files 안에 디자인 토큰 / 테마 / 글로벌 스타일 변경 발견 시 `docs/design.md` 시스템 레벨 토큰 부분 패치 (Colors / Typography / Layout / Shapes / Elevation). 변경 없으면 skip.
 
 **Escalate 조건**: 화면 구조 50%+ 변경 (전체 UX_SYNC 판단), changed_files UX 영향 없음 (훅 오감지), 기존 ux_flow_path 손상.
 
@@ -95,6 +99,8 @@ model: sonnet
 **🔴 Pencil MCP 사용 상한**: `get_editor_state` 1회 + `batch_get(screen_node_id, readDepth: 3)` 1회 + `get_screenshot` 1회 + `get_variables` 1회 = 총 4회. 동일 노드 재조회·readDepth 4+ 금지. 정보 부족해도 추가 조회 대신 escalate.
 
 수행 흐름 (자율): 현재 디자인 분석 → PRD/기존 ux-flow 컨텍스트 수집 → 문제 진단 (배치 / 그룹핑 / 비율 / 스타일 / 정보위계) → 개선된 와이어프레임 (모든 기존 요소 포함, 삭제 금지·재배치만) → 컴포넌트 리디자인 노트 (대상 / 현재 문제 / 변경 지침 / 우선순위) → 해당 화면 섹션만 update.
+
+**design.md 산출 (조건부)**: 리디자인 결과 시스템 레벨 토큰 변경 (예: 새 컬러 / 타이포 스케일 / 라운디드 단계 등) 필요 시 `docs/design.md` 시스템 레벨 섹션 부분 갱신. components 섹션 변경 필요 시 designer 에 escalate (권한 경계).
 
 **결론 emit 시 echo 의무**: prose 결론 단락에 update 한 화면 섹션 원문 그대로 echo (요약 금지) + ux_flow_doc 절대경로.
 

--- a/agents/validator/code-validation.md
+++ b/agents/validator/code-validation.md
@@ -8,7 +8,7 @@
 
 1. 계획 파일 읽기 (`docs/impl/NN-*.md`). **미존재 시**: 즉시 FAIL 금지 — `docs/impl/00-decisions.md` → `CLAUDE.md` 작업 순서 → 그래도 없으면 `SPEC_MISSING` (prose 본문에 expected_path / fallback_searched / request 명시).
 2. 설계 결정 / 구현 파일 / 의존 모듈 소스 읽기 (경계 위반 확인). **`docs/domain-model.md` 권한 read** (DCN-CHG-20260430-16) — 도메인 invariant 위반 / 의존성 방향 위반 의심 시 참조. 수정 금지.
-3. UI 모듈이면 ui-spec 읽기.
+3. UI 모듈이면 design.md 읽기 (미존재 시 silent skip — `docs/design.md §5.1`).
 4. 3 계층 체크리스트 적용.
 
 ## 3 계층 체크리스트
@@ -18,7 +18,8 @@
 - Props 타입 / 함수 시그니처 (계획 vs 구현)
 - 핵심 로직 (계획의 의사코드/스니펫 vs 실제 흐름)
 - 에러 처리 전략 (throw / 반환 / 상태)
-- 주의사항 반영 / ui-spec 일치 (해당 시 색상·레이아웃·상태 UI)
+- 주의사항 반영 / design.md 일치 (frontmatter 토큰 + 본문 룰 — 해당 시 색상·레이아웃·상태 UI)
+- **design.md 토큰 참조 무결성** (design.md 존재 시): `{colors.X}` / `{typography.X}` / `{rounded.X}` / `{spacing.X}` / `{components.X}` 등 참조가 frontmatter 에 실재하는지 확인 (`docs/design.md §5.2` 정합). 미실재 참조 = FAIL
 
 **B. 의존성 규칙 — 하나라도 위반 시 FAIL**:
 - 외부 API/SDK 직접 import 금지 (래퍼 함수 사용)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,13 @@
 
 ## Records
 
+### DCN-CHG-20260504-08
+- **Date**: 2026-05-04
+- **Rationale**: agent 7개에 `ui-spec` / `design-handoff` 참조가 잔존하여 spec ↔ 실제 산출 미스매치 발생. pr-reviewer 스코프 매트릭스엔 `ui-spec*` owner = designer 로 표기됐지만 designer.md Write 책임엔 ui-spec 없음 — UI 작업 시 파일 부재 → silent skip / 혼란. design.md SSOT 도입(Story #125) 후 정합 완료 필요.
+- **Alternatives**: ui-spec 유지 + design.md 병행 — 두 파일 관리 비용 증가, agent 간 읽기 경로 분산으로 기각. design-handoff.md 유지 — 1회성 패키지로 Pencil/이슈/design.md 분산 흡수가 더 명확해 기각.
+- **Decision**: ui-spec/design-handoff 전면 폐지 → design.md 단일 SSOT. 권한 분리(ux-architect = 시스템 레벨, designer = components 섹션)로 충돌 방지. HANDOFF 패키지는 GitHub 이슈 코멘트 + design.md 부분 갱신 + Pencil 캔버스 3 경로로 분산.
+- **Follow-Up**: Story #127 글로벌 CLAUDE.md 반영, Story #128 init-dcness 사용자 배포 처리.
+
 ### DCN-CHG-20260504-06
 - **Date**: 2026-05-04
 - **Rationale**: GitHub Development 섹션에 `Part of #N` 키워드는 언급만 될 뿐 자동 연결되지 않음. `Fixes #N` / `Closes #N` 같은 closing keyword 만 Development 에 표시됨. 중간 PR 에 closing keyword 사용 시 issue 가 조기 close 되는 문제 존재. 실측으로 이미 머지된 PR body 에 `Fixes #N` 추가 → Development 소급 반영 + issue 재발동 없음 확인.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,21 @@
 
 ## Records
 
+### DCN-CHG-20260504-08
+- **Date**: 2026-05-04
+- **Change-Type**: agent
+- **Files Changed**:
+  - `agents/ux-architect.md` — UX_FLOW 입력 ui-spec → design.md, Write 권한에 design.md 시스템 레벨 추가
+  - `agents/designer.md` — 디자인 가이드 읽기 ui-spec → design.md, Phase 4 HANDOFF 슬림화 (3 경로 분산)
+  - `agents/engineer.md` — 읽기 순서 ui-spec → design.md
+  - `agents/design-critic.md` — REVIEW 입력 ui-spec → design.md
+  - `agents/architect/docs-sync.md` — 소유 아님 예시 ui-spec → design.md
+  - `agents/validator/code-validation.md` — ui-spec 읽기 → design.md 읽기, design.md 토큰 참조 무결성 체크 신설
+  - `agents/pr-reviewer.md` — 스코프 매트릭스 ui-spec* → design.md (두 owner 명시)
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: plug-in 7개 agent ui-spec/design-handoff 토큰 → design.md 통일 (Story #126)
+
 ### DCN-CHG-20260504-06
 - **Date**: 2026-05-04
 - **Change-Type**: agent, docs-only


### PR DESCRIPTION
## Summary

- `agents/` 7개 파일에서 `ui-spec` / `design-handoff` 토큰을 `design.md` 로 교체
- `ux-architect.md`: Write 권한에 `design.md` 시스템 레벨 추가 (Colors/Typography/Layout/Shapes/Elevation + 해당 frontmatter 토큰)
- `designer.md`: Phase 4 HANDOFF 슬림화 — GitHub 이슈 코멘트 + design.md 부분 갱신 + Pencil 캔버스 3 경로 분산
- `code-validation.md`: design.md 토큰 참조 무결성 체크 신설 (`docs/design.md §5.2` 정합)
- `pr-reviewer.md`: 스코프 매트릭스 design.md 행 두 owner 명시 (ux-architect / designer)

## 검증 기준 체크

- [x] 7개 agent 파일 모두 `ui-spec` / `design-handoff` 토큰 0건 (grep 실측)
- [x] `ux-architect.md` design.md 시스템 레벨 Write 권한 명시
- [x] `designer.md` design.md Components 섹션 + frontmatter components 토큰 권한 명시
- [x] `code-validation.md` design.md 토큰 참조 무결성 체크 신설
- [x] `pr-reviewer.md` design.md 행 두 owner 명시
- [x] Animation Spec 처리 = design.md 본문 §Components 동작 설명 단락 (1택 확정)
- [ ] plug-in cache 수동 sync (이슈 §"plug-in cache sync" 절차 — merge 후 실행)

## 의존 관계

- **선행**: Story #125 (`docs/design.md` spec) — merged ✅
- **후속**: Story #127 (글로벌 CLAUDE.md 반영) / Story #128 (init-dcness 배포)

## 배포 경로 (CLAUDE.md §0.5)

- `agents/**` 변경 = plug-in 본체 직접 갱신 — 사용자가 plug-in 업데이트 받으면 자동 적용
- merge 후 로컬 cache 수동 sync 필요 (이슈 §"plug-in cache sync" 명령 실행)

Closes #126

DCN-CHG-20260504-08

---

## 리뷰 후 추가 보완 (post-review fixes)

원 코멘트 5건 중 4·5 반영 + Task-ID 충돌 + Closes 트레일러 + scope 갭 명시:

1. **Task-ID 충돌 fix** — `-07` 이 main 의 PR #136 (design.md cleanup) 에 이미 사용. 본 PR 의 commit + record + rationale 의 Task-ID 를 `-08` 로 일괄 변경. force push 1회 (사용자 사전 승인).
2. **`Closes #126` 트레일러** — PR body 끝에 추가 (이전 `Part of #126` 였음). 머지 시 #126 자동 close 활성.
3. **`agents/ux-architect.md` UX_SYNC / UX_SYNC_INCREMENTAL / UX_REFINE 모드 design.md 산출 명시** — Story #126 §How §1 정합. 입력만이 아닌 산출까지 조건부 추가.
4. **`agents/engineer.md` silent skip 룰 reference** — `(미존재 시 silent skip — docs/design.md §5.1)` 박음. code-validation 과 일관성.
5. **Scope 갭 발견 — follow-up 필요**:
   - `agents/architect.md` L45 (Design Ref 섹션 design-handoff 인용)
   - `agents/architect/module-plan.md` L15 (read 목록 ui-spec) / L87 (듀얼 모드 design-handoff)
   - `agents/architect/task-decompose.md` L26 / L38 (듀얼 모드 design-handoff)
   - → Story #126 명시 7개 파일 외 추가 3개 파일에도 토큰 잔존. 별도 이슈로 follow-up 권장.

## 머지 후 작업

- plug-in cache 수동 sync (이슈 §"plug-in cache sync" 절차)
- 위 §"Scope 갭" 3 파일 follow-up 이슈 등록 (Epic #129 후속 추적 항목으로)

