### PR TITLE
[issue-128] init-dcness Step 2.7 design.md SSOT awareness 추가

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -129,6 +129,87 @@ fi
 
 `git-naming-validation.yml` 은 PR open 시 CI 에서 브랜치명·PR 제목을 자동 검사한다. `commit-msg` hook 은 로컬에서 커밋 제목을 사전 차단한다. 두 파일은 커밋 후 프로젝트 repo 에 push 해야 CI 에서 동작한다.
 
+### Step 2.7 — design.md SSOT awareness
+
+dcness plug-in 의 디자인 시스템 SSOT 는 `docs/design.md` (Google `design.md` 공식 spec 채택). plug-in agents (designer / ux-architect / engineer / validator/code-validation 등) 가 UI 작업 시 read 한다. 활성화 프로젝트가 UI 를 다루면 본 SSOT 를 인지/활용해야 plug-in 룰이 완전 작동.
+
+본 Step 은 **bash 자동화 X — 메인 Claude 가 절차 따라 사용자 응답 받고 진행**. 두 단계 모두 멱등.
+
+#### 1. 사용자 CLAUDE.md 매트릭스 패치 제안
+
+프로젝트 root 의 `CLAUDE.md` 가 존재하면 read.
+
+- 파일 부재 시 본 단계 skip.
+- "lazy 읽기" / "작업 시 읽기" 매트릭스 안에 `docs/design.md` 행 부재 시 다음을 사용자에게 출력:
+
+  ```
+  [dcness] CLAUDE.md 매트릭스에 design.md 행이 없습니다. 다음 행을 추가할까요?
+
+  | docs/design.md | UI 모듈 작업 / 디자인 시스템 변경 시 |
+
+  → §3 (또는 동등) lazy 매트릭스에 추가합니다. (Y/n)
+  ```
+
+- 사용자 답변 받은 후에만 메인 Claude 가 Edit 으로 박음. 답 없이 silent skip 금지 — 명시적 응답 1회 의무.
+- 이미 `docs/design.md` 행 있으면 본 단계 skip (`이미 등록됨 — skip` 출력).
+
+#### 2. UI 프로젝트 여부 + design.md 템플릿 시드
+
+```
+[dcness] 이 프로젝트는 UI (화면 / 컴포넌트 / 시각 디자인) 를 다룹니까? (Y/n)
+```
+
+- **n**: 본 단계 종료 (예: dcness self / 백엔드 전용 / CLI 도구).
+- **Y**: `docs/design.md` 부재 시 다음 minimal 템플릿 출력 + Write 동의 1회 질문:
+
+  ```yaml
+  ---
+  version: alpha
+  name: <project name>
+  description: |
+    <atmosphere 한 줄: 브랜드 톤 + 타입 voice + 컬러 철학>
+
+  colors:
+    primary: "#hex"
+    neutral: "#hex"
+    canvas: "#hex"
+  typography:
+    headline-lg:
+      fontFamily: "Inter, sans-serif"
+      fontSize: 32px
+      fontWeight: 600
+      lineHeight: 1.2
+  ---
+
+  ## Overview
+  <프로젝트의 전반적 시각 톤 / 정체성 묘사>
+
+  ## Colors
+  - **Primary** (`{colors.primary}` — #hex): primary CTA / 강조 요소
+  - **Canvas** (`{colors.canvas}` — #hex): 페이지 배경
+  ```
+
+  ```
+  [dcness] 위 템플릿을 docs/design.md 로 생성할까요? (Y/n)
+  ```
+
+  사용자 동의 시 메인 Claude 가 `docs/design.md` Write. 거절 시 skip.
+
+- 이미 `docs/design.md` 파일 존재하면 본 단계 skip (`이미 존재 — skip`).
+
+#### 3. 멱등 보장
+
+- 두 번 실행해도 추가 변경 없음 — 매트릭스 행 있으면 1번 skip / `docs/design.md` 있으면 2번 skip.
+- 사용자가 \"n\" 답변 시 다음 호출 때 다시 묻지 않게 하려면 별도 marker 필요 (v1 범위 외 — 매번 묻되 사용자가 빠르게 \"n\" 가능).
+
+#### 4. 출처 / 갱신 의무
+
+본 Step inline 템플릿은 `docs/design.md` (dcness self repo) §사용 예시와 coupling — Story #125 의 spec 변경 시 본 Step 템플릿도 **수동 동기 의무**. 자동화 검토는 Epic #129 후속 추적.
+
+#### 5. 기존 활성화 프로젝트 — re-run 안내
+
+이미 `/init-dcness` 활성화한 기존 프로젝트는 본 Step 2.7 가 자동 발화하지 않음. 사용자가 본 plug-in 업데이트 받은 후 `/init-dcness` 재실행해야 Step 2.7 발화. 본 안내는 dcness release note / README 에 별도 명시.
+
 ### Step 3 — 사용자 안내
 
 ```
@@ -144,6 +225,10 @@ git-naming 강제 (Step 2.6 완료 시):
 - 로컬: .git/hooks/commit-msg — 커밋 제목 형식 위반 차단
 - CI: .github/workflows/git-naming-validation.yml — 브랜치명·PR 제목 위반 차단
 - scripts/check_git_naming.mjs 를 커밋 후 push 해야 CI 활성화
+
+design.md SSOT (Step 2.7 완료 시):
+- CLAUDE.md 매트릭스에 docs/design.md 행 등록 (UI 작업 시 read 후보)
+- (UI 프로젝트인 경우) docs/design.md minimal 템플릿 시드 — 컬러 / 타이포그래피 / 컴포넌트 토큰 채워 사용
 
 사용 가능한 skill:
 - /qa  — 이슈 분류

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,16 @@
 
 ## Records
 
+### DCN-CHG-20260505-02
+- **Date**: 2026-05-05
+- **Rationale**: Epic #129 (design.md SSOT 도입) 의 마지막 스토리. Story #125 (spec 문서) + #126 (plug-in agents) + #127 (글로벌 / dcness self CLAUDE.md) 만 끝내면 plug-in 본체 + 글로벌 룰은 design.md 인지하지만 *외부 활성화 프로젝트* 의 CLAUDE.md (사용자 진입점) 는 모름. 결과 = "dcness self 에선 작동 / 사용자 환경에선 미작동" 사고 (jajang voice cloning 사단 패턴). CLAUDE.md §0.5 가 "배포 경로 검증 의무" 로 박은 이유.
+- **Alternatives**:
+  - 자동 Edit (사용자 응답 없이 매트릭스 직접 박음) — 사용자 CLAUDE.md 룰 구조 다양 (§ 번호 / 매트릭스 위치 / 표 헤더 형식) → 안전한 자동 패치 어려움. 명시 응답 1회 의무 채택.
+  - minimal 템플릿 외부 파일 reference (init-dcness 가 plug-in cache 에서 read) — init-dcness 실행 시점에 plug-in cache 가 신뢰할 수 있는 경로에 있다는 보장 X. inline embed 안전.
+  - "UI 프로젝트 여부" 자동 추론 (package.json 의 React/Vue/Svelte 의존성 grep) — false positive (백엔드 + 어드민 UI) / false negative (CLI 가 ASCII art 디자인) 모두 발생. 1회 질문이 정확.
+- **Decision**: (a) Step 2.7 신설 위치 = Step 2.6 직후 / Step 3 직전 (패턴 일관). (b) bash 자동화 X — 메인 Claude 가 절차 따라 사용자 응답 받고 Edit/Write. (c) minimal 템플릿 inline embed (`docs/design.md` 의 사용 예시와 coupling 수용 명시 — Epic #129 후속 추적). (d) 멱등 보장 — 매트릭스 행 있으면 1번 skip / `docs/design.md` 파일 있으면 2번 skip. (e) 기존 활성화 프로젝트 re-run 안내 = dcness release note / README 별도 명시.
+- **Follow-Up**: Epic #129 closed gate — 본 PR 머지 후 #129 본문 후속 추적 항목 (글로벌 사용자 전파 / plug-in cache sync 자동화 / 템플릿 source coupling 자동화) 별도 이슈 후보로 박을지 검토. plug-in cache sync = 본 PR 머지 후 일괄 처리 가능.
+
 ### DCN-CHG-20260504-09
 - **Date**: 2026-05-04
 - **Rationale**: 글로벌 `~/.claude/CLAUDE.md` 가 dcness plug-in 영역 룰 (PRD/TRD 작성 흐름 / 설계 문서 owner / 직접 수정 금지 매트릭스 / 모듈 단위 작업 순서 / stories 동기화) 을 중복 보유 → drift 위험 + plug-in SSOT 깨짐. dcness 가 plug-in 으로 분리되기 전 옛 잔재. plug-in agents 본문 + pr-reviewer 스코프 매트릭스 + issue-lifecycle.md 가 이미 동일 룰을 책임지므로 글로벌 중복 제거 가능.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,15 @@
 
 ## Records
 
+### DCN-CHG-20260505-02
+- **Date**: 2026-05-05
+- **Change-Type**: agent
+- **Files Changed**:
+  - `commands/init-dcness.md` — Step 2.7 신설 (design.md SSOT awareness — CLAUDE.md 매트릭스 패치 제안 + UI 프로젝트 여부 1회 질문 + minimal 템플릿 inline embed). Step 3 사용자 안내에 design.md 블록 추가.
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md`
+- **Summary**: Story #128 — `/init-dcness` skill 에 design.md 사용자 환경 도달 보장 스텝 추가. CLAUDE.md §0.5 (배포 경로 검증 의무) 정합. 두 단계 모두 멱등 + 사용자 응답 1회 의무 (silent skip 금지). minimal 템플릿은 inline embed (Story #125 sample 과 수동 동기 — 자동화는 Epic #129 후속).
+
 ### DCN-CHG-20260504-09
 - **Date**: 2026-05-04
 - **Change-Type**: agent


### PR DESCRIPTION
## 변경 요약

### [issue-128] init-dcness Step 2.7 design.md SSOT awareness 추가 (DCN-CHG-20260505-02)
- **What**:
  - `commands/init-dcness.md` Step 2.7 신설 (Step 2.6 직후 / Step 3 직전)
  - 사용자 CLAUDE.md 매트릭스 패치 제안 + UI 프로젝트 여부 1회 질문 + design.md minimal 템플릿 inline embed
  - Step 3 사용자 안내에 design.md 블록 추가
  - 거버넌스 동반 갱신 (DCN-CHG-20260505-02)
- **Why**: Story #125 + #126 + #127 만으로는 외부 활성화 프로젝트 진입점 (사용자 CLAUDE.md) 가 design.md 모름. CLAUDE.md §0.5 (배포 경로 검증 의무) 정합 핵심.

## 결정 근거

- **bash 자동화 X — 메인 Claude 가 절차 따라 사용자 응답 받고 Edit/Write**: 사용자 CLAUDE.md 룰 구조 다양 (§ 번호 / 매트릭스 위치 / 표 헤더 형식) 으로 안전한 자동 패치 어려움. 명시 응답 1회 의무 채택.
- **minimal 템플릿 inline embed**: init-dcness 실행 시점에 plug-in cache 가 신뢰할 수 있는 경로에 있다는 보장 X. external reference 보다 inline embed 안전. Story #125 sample 과 coupling 수용 명시 (Epic #129 후속 추적).
- **\"UI 프로젝트 여부\" 1회 질문**: 자동 추론 (package.json grep) 은 false positive (백엔드 + 어드민) / false negative (CLI ASCII art) 모두 발생. 명시 질문이 정확.

## 검증 기준 (이슈 §검증 기준)

- [x] commands/init-dcness.md 에 Step 2.7 신설 — 위치 = Step 2.6 직후 / Step 3 직전
- [x] CLAUDE.md §0.5 룰 정합 (사용자 환경에 plug-in 기능 도달 보장)
- [x] 멱등 동작 — 두 번 실행해도 추가 변경 없음
- [x] 사용자 승인 메커니즘 명시 — 패치/템플릿 출력 후 사용자 응답 1회 의무, silent skip 금지
- [x] minimal 템플릿 inline embed (Story #125 sample 과 coupling 수용 명시)
- [x] 사용자 \"UI 없는 프로젝트\" 답변 시 design.md 템플릿 안 박음 (dcness self 같은 케이스 보호)

## 기존 활성화 프로젝트 — re-run 안내 (이슈 §검증 기준)

이미 `/init-dcness` 활성화한 기존 프로젝트는 본 Step 2.7 가 자동 발화하지 않음. 사용자가 본 plug-in 업데이트 받은 후 `/init-dcness` 재실행해야 Step 2.7 발화.

→ dcness release note / README 별도 안내 필요 (Epic #129 후속 추적).

## 관련 이슈

- #128 (Epic #129 — 본 PR 머지 후 Epic 닫기 가능)
- 선행 머지: #137 (Story #126), #139 (Story #127), 본 PR 처리 중인 #138 (PR #140)

## 배포 경로 (CLAUDE.md §0.5)

- `commands/init-dcness.md` = plug-in 본체 → 사용자가 plug-in 업데이트 받으면 자동 적용
- 신규 활성화 프로젝트 = 자동 적용. 기존 활성화 프로젝트 = `/init-dcness` re-run 필요 (위 안내)

## 참고

- Epic #129