### PR TITLE
[issue-166] init-dcness dcness-guidelines.md 배포 스텝 누락 수정

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -118,6 +118,11 @@ if [ ! -f "$PROJECT_ROOT/.git/hooks/commit-msg" ]; then
 else
   echo "[dcness] .git/hooks/commit-msg 이미 존재 — skip"
 fi
+
+# 4. dcness-guidelines.md 배포 (SessionStart 훅이 읽는 파일)
+mkdir -p "$PROJECT_ROOT/docs/process"
+cp "$PLUGIN_ROOT/docs/process/dcness-guidelines.md" "$PROJECT_ROOT/docs/process/dcness-guidelines.md"
+echo "[dcness] docs/process/dcness-guidelines.md 배포"
 ```
 
 출력 예시:
@@ -125,6 +130,7 @@ fi
 [dcness] scripts/check_git_naming.mjs 배포
 [dcness] .github/workflows/git-naming-validation.yml 배포
 [dcness] .git/hooks/commit-msg 설치
+[dcness] docs/process/dcness-guidelines.md 배포
 ```
 
 `git-naming-validation.yml` 은 PR open 시 CI 에서 브랜치명·PR 제목을 자동 검사한다. `commit-msg` hook 은 로컬에서 커밋 제목을 사전 차단한다. 두 파일은 커밋 후 프로젝트 repo 에 push 해야 CI 에서 동작한다.
@@ -225,6 +231,7 @@ git-naming 강제 (Step 2.6 완료 시):
 - 로컬: .git/hooks/commit-msg — 커밋 제목 형식 위반 차단
 - CI: .github/workflows/git-naming-validation.yml — 브랜치명·PR 제목 위반 차단
 - scripts/check_git_naming.mjs 를 커밋 후 push 해야 CI 활성화
+- docs/process/dcness-guidelines.md 배포 — SessionStart 훅이 세션마다 읽는 룰 파일
 
 design.md SSOT (Step 2.7 완료 시):
 - CLAUDE.md 매트릭스에 docs/design.md 행 등록 (UI 작업 시 read 후보)

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,15 @@
 
 ## Records
 
+### DCN-CHG-20260506-01
+- **Date**: 2026-05-06
+- **Rationale**: `session-start.sh`이 `${PROJ}/docs/process/dcness-guidelines.md`를 읽지만, `init-dcness.md` Step 2.6 bash 블록에 해당 파일 배포 스텝이 없었음. 결과: jajang 등 사용자 프로젝트에서 파일 미존재 → Read 실패 → 로드 토큰만 출력되고 실제 룰 미로드 상태. 감지 계기: 사용자가 세션 시작 후 "(파일 실존 안 함을 보고합니다)" 메시지 직접 확인.
+- **Alternatives**:
+  - `session-start.sh`이 파일 없으면 플러그인 캐시(`~/.claude/plugins/cache/dcness/...`)에서 직접 읽도록 수정 — 경로 하드코딩 + 캐시 구조 변화 취약. `GUIDELINES_PATH`가 이미 `${PROJ}/docs/process/` 패턴으로 설계됨.
+  - 배포 대신 플러그인 캐시 경로를 `GUIDELINES_PATH`로 변경 — 사용자 프로젝트가 플러그인 캐시 경로 의존 → 이식성 저하.
+- **Decision**: `init-dcness.md` Step 2.6 bash에 스텝 4 추가: `$PLUGIN_ROOT/docs/process/dcness-guidelines.md` → `$PROJECT_ROOT/docs/process/dcness-guidelines.md`. 존재 체크 없이 항상 덮어쓰기 — 플러그인 업데이트 시 최신 버전 자동 반영. Step 3 안내 텍스트에도 항목 추가.
+- **Follow-Up**: jajang 등 기존 활성화 프로젝트는 `/init-dcness` 재실행 필요. README/release note에 re-run 안내 필요.
+
 ### DCN-CHG-20260505-04
 - **Date**: 2026-05-05
 - **Rationale**: DCN-CHG-20260505-03 (#144) 커밋 메시지 body 안에 역사 참조 (`DCN-CHG-20260430-32` — handoff-matrix.md split 사례 비유) 박았는데 Task-ID format gate 가 "다중 Task-ID 발견 — governance §2.1 위반" 으로 fail. 룰의 본질은 "본 작업의 *canonical* Task-ID 1 개" 이지 메시지 텍스트 안 ID-shaped 토큰 갯수 가 아님. body 의 역사 참조는 작업 정체성과 무관 — 게이트가 over-strict.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,13 @@
 
 ## Records
 
+### DCN-CHG-20260506-01
+- **Date**: 2026-05-06
+- **Change-Type**: agent
+- **Files Changed**:
+  - `commands/init-dcness.md` — Step 2.6 bash 블록에 dcness-guidelines.md 배포 스텝 추가 (스텝 4). Step 3 안내 텍스트에 dcness-guidelines.md 항목 추가.
+- **Summary**: init-dcness 가 dcness-guidelines.md 를 사용자 프로젝트에 배포하지 않아 SessionStart 훅 Read 실패하는 버그 수정.
+
 ### DCN-CHG-20260505-04
 - **Date**: 2026-05-05
 - **Change-Type**: ci, docs-only


### PR DESCRIPTION
## Summary

- `session-start.sh`이 사용자 프로젝트의 `docs/process/dcness-guidelines.md`를 Read하도록 지시하지만 `init-dcness.md`에 해당 파일 배포 스텝이 없었음
- `init-dcness.md` Step 2.6 bash 블록에 스텝 4 추가: `$PLUGIN_ROOT/docs/process/dcness-guidelines.md` → `$PROJECT_ROOT/docs/process/dcness-guidelines.md` (항상 덮어쓰기)
- 기존 활성화 프로젝트는 `/init-dcness` 재실행 필요

## 배포 경로 검증 (CLAUDE.md §0.5)

- [x] `commands/init-dcness.md` 수정 → 플러그인 배포물로 자동 반영

## Test plan

- [ ] 새 프로젝트에서 `/init-dcness` 실행 후 `docs/process/dcness-guidelines.md` 생성 확인
- [ ] 세션 재시작 후 `[dcness-guidelines 로드 완료 — §13 감시자 Hat 장착]` 토큰 + 실제 파일 Read 성공 확인
- [ ] 재실행(멱등) 시 파일 덮어쓰기 정상 동작 확인

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)