### PR TITLE
[epic1][story4] README.md / PROGRESS.md 현행화

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,12 @@
 
 ## 현재 상태
 
+- **🧹 Epic 1 — 외부 배포물 정리 (#150)** (`DCN-CHG-20260506-02` ~ `-05`):
+  - **Story 1.1** (`-02`): `.claude-plugin/`, `commands/`, `README.md` RWHarness 고유명사 13건 제거 (표기 "선행 하네스" 통일)
+  - **Story 1.2** (`-03`): 외부 배포 경로 (agents/ 21개 / commands/ 3개 / docs/ 5개 / CLAUDE.md) DCN-CHG 내부 ID 92건 스크럽
+  - **Story 1.3** (`-04`): `docs/archive/` 신설 + 역사 자료 5개 이동 (conveyor-design / epic-index / manual-smoke-guide / migration-decisions / plugin-dryrun-guide) + 인용처 전수 갱신
+  - **Story 1.4** (`-05`): `README.md` / `PROGRESS.md` 현행화 — DCN-CHG 잔여 5건 제거, Status 헤더 갱신, Skill 목록 8→10개, 다음 단계 정리
+
 - **🔧 Task-ID format gate fix — subject-only 검사** (`DCN-CHG-20260505-04`):
   - `scripts/check_task_id.mjs` — `validateMessage` → `validateSubject`. subject 1 줄째에서만 정확히 1 개 검사. body 안 역사 참조 / Document-Exception-Task / 후속 link 자유 허용.
   - `docs/process/governance.md` §2.1 — commit message 위치 룰 명문화 (subject canonical 1 개 / body 자유).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dcNess
 
-> **Status**: `0.1.0-alpha` — Phase 1 (validator 단위, prose-only) 완료
+> **Status**: `0.1.0-alpha` — Phase 1~3 완료 · Plugin 배포 dry-run 예정
 > **Origin**: [`alruminum/realworld-harness`](https://github.com/alruminum/realworld-harness) fork-and-refactor
 > **Spec**: [`docs/status-json-mutate-pattern.md`](docs/status-json-mutate-pattern.md) (Prose-Only Pattern)
 
@@ -10,7 +10,7 @@ Lightweight harness — **prose-only + heuristic enum 추출** 결정론 + **함
 
 | 항목 | 선행 하네스 | dcNess |
 |---|---|---|
-| 결정론 메커니즘 | `parse_marker` regex + `MARKER_ALIASES` 사다리 (~180 LOC) | `signal_io.interpret_signal` — agent prose 자유 emit, **heuristic-only** 단어경계 매칭으로 결론 enum 추출. ambiguous 시 메인 Claude cascade (DCN-CHG-20260430-04) |
+| 결정론 메커니즘 | `parse_marker` regex + `MARKER_ALIASES` 사다리 (~180 LOC) | `signal_io.interpret_signal` — agent prose 자유 emit, **heuristic-only** 단어경계 매칭으로 결론 enum 추출. ambiguous 시 메인 Claude cascade |
 | 형식 강제 | `---MARKER:X---` + alias 변형 12개 | **0** — 형식 / flag / schema 모두 agent 자율. harness 강제 = 작업 순서 + 접근 영역만 |
 | 컨텍스트 layer | 5 layer (CLAUDE.md + agents + agent-config + preamble + sub-doc) | 2 layer (CLAUDE.md + agents) — preamble / agent-config 자동 주입 폐기 |
 | 게이트 | hook 7+ (agent-boundary / commit-gate / etc.) | 거버넌스 + 3 CI workflow (Document Sync + Python tests + Plugin manifest) |
@@ -21,7 +21,7 @@ Lightweight harness — **prose-only + heuristic enum 추출** 결정론 + **함
 > "agent 는 prose 자유롭게 emit.
 >  harness 는 prose 의 결론 enum 을 *휴리스틱 단어경계 매칭* 으로 추출.
 >  ambiguous 시 메인 Claude 가 cascade (재호출 / 사용자 위임).
->  형식 강제 0, flag 0, schema 0, **메타 LLM 호출 0** (DCN-CHG-20260430-04)."
+>  형식 강제 0, flag 0, schema 0, **메타 LLM 호출 0**."
 
 ## 1차 구현 (Phase 1) 현황
 
@@ -106,7 +106,7 @@ except MissingSignal as e:
     else:
         ...  # 즉시 fail (not_found / empty)
 
-# 프로덕션 dcness — heuristic-only (DCN-CHG-20260430-04 정착, 메타 LLM 호출 X)
+# 프로덕션 dcness — heuristic-only (메타 LLM 호출 X)
 # 휴리스틱 ambiguous → MissingSignal propagate → 메인 Claude 가 cascade
 # `interpreter=` 인자는 테스트용 DI swap 만 보존
 ```
@@ -121,16 +121,14 @@ except MissingSignal as e:
 
 PR 절차: [`CLAUDE.md`](CLAUDE.md) §5.
 
-## 다음 단계 (Phase 2 ~ )
+## 다음 단계
 
 [`PROGRESS.md`](PROGRESS.md) §TODO 참조. 핵심 후보:
 
-- 다른 agent docs prose-only 변환 — 13 docs 완료 (`DCN-CHG-20260429-19` Phase 2 종결)
-- Plugin 배포 dry-run — 플러그인 공존 검증 (proposal §12.3.2)
-- DESIGN_VALIDATION step — `/product-plan` 시퀀스에 검증 cycle 추가 완료 (`DCN-CHG-20260430-05`)
+- Plugin 배포 dry-run — 플러그인 공존 검증
 - 후속 skill `/ux` (designer + design-critic, Pencil MCP 의존) — `commands/` 카테고리 확장 후보
 
-## Skill 목록 (`commands/`, 8개)
+## Skill 목록 (`commands/`, 10개)
 
 | 발화 | 역할 |
 |---|---|
@@ -141,13 +139,15 @@ PR 절차: [`CLAUDE.md`](CLAUDE.md) §5.
 | `/impl` | per-task 정식 impl 루프 (architect MODULE_PLAN → test-engineer → engineer → validator CODE_VALIDATION → pr-reviewer) |
 | `/impl-loop` | multi-task sequential auto chain (각 task 마다 /impl 호출 + clean 자동 진행) |
 | `/smart-compact` | 컨텍스트 압축 + 다음 세션 resume prompt 자동 생성 |
-| `/efficiency` | Claude Code 세션 토큰/캐시/비용 분석 + HTML 대시보드 + 6 절감 휴리스틱 (출처: `jha0313/skills_repo` `improve-token-efficiency` 흡수) |
+| `/efficiency` | Claude Code 세션 토큰/캐시/비용 분석 + HTML 대시보드 + 6 절감 휴리스틱 |
+| `/run-review` | dcness conveyor run 사후 분석 — 각 step 잘한 점·잘못한 점·비용 추출, self-improvement 루프 시작점 |
+| `/audit-redo` | redo-log + agent-trace 결합 분석 — (sub, mode) 별 redo 빈도 + Layer 1/2 개선 후보 제안 |
 
 행동형 skill (`/quick` `/product-plan` `/impl` `/impl-loop`) 공통:
 - yolo keyword (`yolo` / `auto` / `끝까지` / `막힘 없이` / `다 알아서`) 검출 시 CLARITY/AMBIGUOUS/ESCALATE 자동 폴백 (catastrophic 룰은 hard safety)
 - worktree keyword (`worktree` / `wt` / `격리` / `isolate`) 검출 시 EnterWorktree 격리
 
-읽기형 skill (`/qa` `/smart-compact` `/efficiency`) 은 keyword 무관 (read-only 분석).
+읽기형 skill (`/qa` `/smart-compact` `/efficiency` `/run-review` `/audit-redo`) 은 keyword 무관 (read-only 분석).
 
 ## 참조 문서
 

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,15 @@
 
 ## Records
 
+### DCN-CHG-20260506-05
+- **Date**: 2026-05-06
+- **Change-Type**: docs-only
+- **Files Changed**:
+  - `README.md` — Status 헤더 갱신, DCN-CHG ID 5건 제거, Skill 목록 8→10개 (audit-redo/run-review 추가), 다음 단계 정리
+  - `PROGRESS.md` — Epic 1 Stories 1.1~1.4 완료 항목 추가
+  - `docs/process/document_update_record.md` (본 항목)
+- **Summary**: README.md / PROGRESS.md 현행화 — 외부 배포물 내 DCN-CHG ID 잔여분 제거, 실제 commands/ 파일 수 반영, Phase 1~3 완료 상태 반영. (Story 1.4 / Issue #156)
+
 ### DCN-CHG-20260506-04
 - **Date**: 2026-05-06
 - **Change-Type**: docs-only + agent


### PR DESCRIPTION
Part of #150 (Epic 1 — 외부 배포물 정리)

## 관련 이슈 번호

- #156

## 배경 및 문제

Story 1.1~1.3 완료 후 README.md에 DCN-CHG 내부 ID 5건 잔류,
Skill 목록이 실제 commands/ 파일 수(10개)와 불일치(8개 표기).
PROGRESS.md에 Epic 1 진행 내역 미기록.

## 작업 내용

**README.md:**
- Status 헤더: `Phase 1 완료` → `Phase 1~3 완료 · Plugin 배포 dry-run 예정`
- DCN-CHG ID 5건 제거 (표 1 / 인용구 1 / 코드 주석 1 / 다음 단계 2)
- Skill 목록 8→10개 (`/audit-redo`, `/run-review` 추가)
- 읽기형 skill 목록 2개 추가 반영
- 다음 단계: 완료된 항목 제거, 미완료 2건만 유지

**PROGRESS.md:**
- Epic 1 Stories 1.1~1.4 완료 항목 상단 추가

## 배포 경로 검증

- 변경 대상 모두 docs-only — `agents/`, `commands/`, `hooks/` 변경 없음
- AGENTS.md 별도 검증: DCN-CHG ID 없음, 링크 정상 — 변경 불필요 확인

## 검증

- `rg 'DCN-CHG-\d{8}-\d{2}' README.md` → 0
- `node scripts/check_document_sync.mjs` → PASS
- Skill 목록 10개 = `ls commands/ | wc -l` 10개 일치

## 거버넌스

- Task-ID: `DCN-CHG-20260506-05`
- Change-Type: `docs-only`
- 동반 갱신: `docs/process/document_update_record.md` ✅