### PR TITLE
[issue-173] main 직접 commit 차단 hook 신설

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,8 @@
 
 ## 현재 상태
 
+- **🔒 main 직접 commit 차단 hook 게이트 신설 (#173)** (`DCN-CHG-20260506-07`): `scripts/hooks/pre-commit` + `scripts/hooks/cc-pre-commit.sh` 양쪽에 main 브랜치 차단 추가. 자연어 룰만 있던 카테고리 mechanical 강제 (Story 1.3 회귀 방지). governance §2.7 게이트 매트릭스에 row 추가.
+
 - **📂 Epic 2 — docs 폴더 분리 (#151)** (진행 중):
   - **Story 2.1** (`DCN-CHG-20260506-06`): `docs/process/dcness-guidelines.md` 분할 → `docs/plugin/skill-guidelines.md` (skill 룰) + `docs/internal/self-guidelines.md` (self 룰). §8/§9 TBD → 이슈 #174/#175. 인용처 17곳 갱신. harness INFRA_PATTERNS 경로 갱신 + 신규 테스트 2케이스.
 

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,25 @@
 
 ## Records
 
+### DCN-CHG-20260506-07
+- **Date**: 2026-05-06
+- **Rationale**: Epic 1 머지 후 reflog 검증 — Story 1.3 (`#155`) commit `2df1113` 이 *main 위에서 직접* 만들어짐 (11:53 main HEAD → commit). PR 도 안 만들어졌고 issue auto-close 도 안 됨. 자연어 룰 (`CLAUDE.md` line 166 "main 직접 commit/push 금지" / `docs/process/git-naming-spec.md` / `docs/process/main-claude-rules.md`) 만으론 메인 Claude / 작업자가 새는 게 dcness self 에서 입증. 다른 강제 카테고리 (doc-sync / Task-ID format / pytest) 는 hook 으로 mechanical 강제 → 새지 않음. main commit 차단만 자연어 룰 → 새는 카테고리.
+- **Alternatives**:
+  1. *현행 자연어 룰만 유지 + 회고 강화* — Story 1.3 같은 회귀가 다시 일어날 거란 입증 끝. 자연어 룰 한계는 dcness 자체 메모리 (`feedback_echo_rule_strict.md`) 와 같은 패턴 — 토큰 절약 본능 / 휴리스틱으로 새는 카테고리.
+  2. *(채택)* **pre-commit hook 에 main 차단 게이트 추가**. git pre-commit + Claude Code PreToolUse hook 양쪽. 현 3중 강제 (doc-sync / Task-ID / pytest) 와 동일 패턴.
+  3. *Document-Exception 우회 메커니즘 같이 도입* — over-engineering 위험. 1차 PR 에선 단순 차단 only. 진짜 필요할 때 별도 이슈로 도입.
+  4. *GitHub branch protection 만 강화* — server-side. 본 회귀는 *commit* 단계 (push 전) 에서 만들어짐. branch protection 은 push 막을 수 있지만 local commit 자체는 못 막음 → root cause 미포착.
+- **Decision**:
+  - 옵션 2 채택. `scripts/hooks/pre-commit` 에 `set -e` 다음 `[ "$current_branch" = "main" ]` 검사 추가 → exit 1 차단.
+  - `scripts/hooks/cc-pre-commit.sh` 의 `*"git commit"*` 매처 안에도 동일 검사 추가 → exit 2 (Claude Code PreToolUse 차단).
+  - 옵션 3 (Document-Exception 우회) 는 deferred — 실제 필요 시 별도 이슈.
+  - 옵션 4 (branch protection) 는 별개 — 보완재. 본 PR 범위 외.
+- **Follow-Up**:
+  - dcness self repo 의 `.git/hooks/pre-commit` 은 PR 머지 후 *수동 재설치* 의무 — `cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x ...`.
+  - 사용자 활성화 프로젝트 (jajang 등) 는 plug-in update 받아도 `.git/hooks/pre-commit` 자동 갱신 X. `/init-dcness` 재실행 시만 갱신. PR body 에 안내 명시.
+  - Story 1.3 회귀의 *짝꿍* 문제 (#146 — PR body `Closes` 키워드 게이트) 는 별개 이슈로 진행. 본 게이트 (main 차단) → branch 강제 → PR 강제 → #146 게이트 발동 → auto-close. 사슬 완성.
+  - Epic 2 진행 시 본 게이트가 박힌 상태라 Story 1.3 같은 회귀 자동 방지.
+
 ### DCN-CHG-20260506-04
 - **Date**: 2026-05-06
 - **Rationale**: `docs/` 최상위와 `docs/process/`에 마이그레이션 완료 자료(migration-decisions.md), 스냅샷(epic-index.md), 폐기 결정 기록(conveyor-design.md), 일회성 가이드(manual-smoke-guide.md, plugin-dryrun-guide.md)가 active SSOT 문서와 섞여 있음. "현행 SSOT"와 "역사 자료"를 한눈에 구분하기 어려움.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,18 @@
 
 ## Records
 
+### DCN-CHG-20260506-07
+- **Date**: 2026-05-06
+- **Change-Type**: ci, docs-only
+- **Files Changed**:
+  - `scripts/hooks/pre-commit` — main 직접 commit 차단 게이트 추가 (set -e 다음)
+  - `scripts/hooks/cc-pre-commit.sh` — `git commit` 매처 안 main 차단 게이트 추가 (exit 2)
+  - `docs/process/governance.md` §2.7 — 게이트 매트릭스에 main-block row 추가, 발견 사례 인용
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md` (Why / Decision)
+  - `PROGRESS.md` (현재 상태 1줄 추가)
+- **Summary**: main 직접 commit 차단 hook 게이트 신설. 자연어 룰만 있던 카테고리에 mechanical 강제 추가 (Story 1.3 회귀 방지). git pre-commit + cc-pre-commit 양쪽. (Issue #173)
+
 ### DCN-CHG-20260506-05
 - **Date**: 2026-05-06
 - **Change-Type**: docs-only

--- a/docs/process/governance.md
+++ b/docs/process/governance.md
@@ -105,8 +105,11 @@ Document-Exception-Task: DCN-CHG-YYYYMMDD-NN
 
 | 게이트 | 스크립트 | 적용 범위 | 우회 |
 |---|---|---|---|
+| main-block | `scripts/hooks/pre-commit` 안 inline 검사 | 모든 commit | 없음 (룰 위반 시 작업자가 branch 만들어 재시도) |
 | doc-sync | `scripts/check_document_sync.mjs` | 모든 commit | `Document-Exception:` 토큰 (§2.4) |
 | pytest | `scripts/check_python_tests.sh` | `harness/` / `tests/` / `agents/` / `python-tests.yml` staged 시만 | `--no-verify` (룰 위반) |
+
+main-block 게이트 — 자연어 룰 (`CLAUDE.md` line 166 / `docs/process/git-naming-spec.md` / `docs/process/main-claude-rules.md`) 만으론 메인 Claude / 작업자가 새는 회귀 방지. 발견 사례: Story 1.3 (#155) commit `2df1113` — 메인이 main 위에서 직접 commit. 차단 이후 회귀 시 `git checkout -b feature/<name>` 안내.
 
 CI 레벨(`.github/workflows/document-sync.yml`, `python-tests.yml`)은 별도 Task-ID 로 추가/유지.
 

--- a/scripts/hooks/cc-pre-commit.sh
+++ b/scripts/hooks/cc-pre-commit.sh
@@ -27,6 +27,13 @@ case "$COMMAND" in
   *"git commit"*)
     # 프로젝트 루트로 이동
     cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}" 2>/dev/null || exit 0
+    # main 직접 commit 차단
+    current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+    if [ "$current_branch" = "main" ]; then
+      echo "ERROR: main 직접 commit 금지. branch 만든 후 commit + PR." >&2
+      echo "  git checkout -b feature/<name>" >&2
+      exit 2
+    fi
     if [ -f scripts/check_document_sync.mjs ]; then
       if ! node scripts/check_document_sync.mjs >&2; then
         # PreToolUse block: exit 2

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -6,9 +6,19 @@
 #   cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 #
 # 게이트:
-#   1. document-sync (모든 commit)
-#   2. python-tests (harness/tests/agents/yml staged 시만)
+#   1. main 직접 commit 차단 (모든 commit)
+#   2. document-sync (모든 commit)
+#   3. python-tests (harness/tests/agents/yml staged 시만)
 
 set -e
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" = "main" ]; then
+  echo "ERROR: main 직접 commit 금지. branch 만든 후 commit + PR." >&2
+  echo "  git checkout -b feature/<name>" >&2
+  echo "  git commit ..." >&2
+  exit 1
+fi
+
 node scripts/check_document_sync.mjs
 sh scripts/check_python_tests.sh


### PR DESCRIPTION
## 관련 이슈

Closes #173

## What

`scripts/hooks/pre-commit` + `scripts/hooks/cc-pre-commit.sh` 양쪽에 main 브랜치 직접 commit 차단 게이트 추가.

## Why — Story 1.3 회귀 사례

Epic 1 머지 후 reflog 검증 — Story 1.3 (#155) commit `2df1113` 이 main 위에서 직접 만들어짐 (11:53 main HEAD → commit). PR 도 안 만들어졌고 issue auto-close 도 안 됨. 자연어 룰 (`CLAUDE.md` line 166 / `docs/process/git-naming-spec.md` / `docs/process/main-claude-rules.md`) 만으론 메인 Claude / 작업자가 새는 게 dcness self 에서 입증.

## How

### `scripts/hooks/pre-commit`

```sh
set -e

current_branch=$(git rev-parse --abbrev-ref HEAD)
if [ "$current_branch" = "main" ]; then
  echo "ERROR: main 직접 commit 금지. branch 만든 후 commit + PR." >&2
  echo "  git checkout -b feature/<name>" >&2
  echo "  git commit ..." >&2
  exit 1
fi

node scripts/check_document_sync.mjs
sh scripts/check_python_tests.sh
```

### `scripts/hooks/cc-pre-commit.sh`

`*"git commit"*` 매처 안에 동일 검사 추가 (exit 2 — Claude Code PreToolUse 차단).

### `docs/process/governance.md` §2.7

게이트 매트릭스에 main-block row 추가 + 발견 사례 인용.

## 자가 검증

- [x] feature/fix 브랜치 commit 통과 (본 PR commit 자체)
- [x] `node scripts/check_document_sync.mjs` PASS (categories: docs-only, ci)
- [x] hook 로직 시뮬레이트: `current_branch=main` → exit 1 / `current_branch=fix/foo` → exit 0
- [ ] CI 게이트 통과 (PR 생성 후)
- [ ] 머지 후 dcness self repo `.git/hooks/pre-commit` 재설치 (수동) → 다음 main commit 시도 자동 차단

## 사용자 활성화 프로젝트 (jajang 등) 영향

plug-in update 받아도 `.git/hooks/pre-commit` 자동 갱신 X. **`/init-dcness` 재실행 시만 갱신**. 기존 활성화 프로젝트는 재실행 권고.

## 짝꿍 — #146 (PR body Closes 키워드 게이트)

본 게이트 (main 차단) → branch 강제 → PR 강제 → #146 게이트 발동 → auto-close. 사슬 완성.

## Document-Exception 우회 — deferred

#173 spec §4 의 `Document-Exception-Main-Commit:` escape hatch 는 1차 PR 에서 *제외* (over-engineering 위험). 진짜 필요 시 별도 이슈로 도입.

## 거버넌스

- Task-ID: `DCN-CHG-20260506-07`
- Change-Type: `ci` + `docs-only`
- 동반 갱신: `docs/process/document_update_record.md` ✅ / `docs/process/change_rationale_history.md` ✅ / `PROGRESS.md` ✅

## 본 PR 자체 — 브랜치 재생성

이전 PR #177 은 브랜치명 (`feature/issue173_...`) 이 git-naming-spec 위반으로 fail → 폐쇄. 본 PR 은 `fix/issue173_...` 로 재생성.