### PR TITLE
[issue-179] harness/ docstring archive 경로 정리

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,8 @@
 
 ## 현재 상태
 
+- **🔧 harness/ docstring archive 경로 정리 (#179)** (`DCN-CHG-20260506-08`): Story 1.3 인용처 갱신 누락분. `harness/session_state.py` + `harness/hooks.py` 의 `docs/conveyor-design.md` 인용 → `docs/archive/conveyor-design.md`.
+
 - **🔒 main 직접 commit 차단 hook 게이트 신설 (#173)** (`DCN-CHG-20260506-07`): `scripts/hooks/pre-commit` + `scripts/hooks/cc-pre-commit.sh` 양쪽에 main 브랜치 차단 추가. 자연어 룰만 있던 카테고리 mechanical 강제 (Story 1.3 회귀 방지). governance §2.7 게이트 매트릭스에 row 추가.
 
 - **📂 Epic 2 — docs 폴더 분리 (#151)** (진행 중):

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,16 @@
 
 ## Records
 
+### DCN-CHG-20260506-08
+- **Date**: 2026-05-06
+- **Rationale**: Story 1.3 (#155) commit `2df1113` 가 `docs/conveyor-design.md` → `docs/archive/conveyor-design.md` 이동 + 인용처 12곳 갱신 했지만 harness 코드 docstring 2건 누락. Epic 1 검증 단계 (Epic 1 머지 후 review) 에서 발견 — `rg -n 'docs/conveyor-design\.md' harness/` → 2 hit. cmd-click 시 깨짐.
+- **Alternatives**:
+  1. *그대로 두기* — dcness self 작업자가 cmd-click 시 매번 깨짐 경험. 작은 비용이지만 누적.
+  2. *(채택)* **단순 path 갱신**: `docs/conveyor-design.md` → `docs/archive/conveyor-design.md`. mechanical fix.
+  3. *Epic 2 Story 2.5 (참조 경로 일괄 갱신) 에 묶어 처리* — Epic 2 진행 시점이 미정. 그때까지 깨진 채. 작은 fix 분리하는 게 회귀 추적 명확.
+- **Decision**: 옵션 2. 즉시 별도 PR 로 정리. Issue #179 생성 후 진행.
+- **Follow-Up**: `harness/` 안 다른 archived 경로 참조 0 — 본 PR 로 정리 완료. 향후 archive 이동 작업 시 `harness/` 도 검증 항목에 포함 의무.
+
 ### DCN-CHG-20260506-07
 - **Date**: 2026-05-06
 - **Rationale**: Epic 1 머지 후 reflog 검증 — Story 1.3 (`#155`) commit `2df1113` 이 *main 위에서 직접* 만들어짐 (11:53 main HEAD → commit). PR 도 안 만들어졌고 issue auto-close 도 안 됨. 자연어 룰 (`CLAUDE.md` line 166 "main 직접 commit/push 금지" / `docs/process/git-naming-spec.md` / `docs/process/main-claude-rules.md`) 만으론 메인 Claude / 작업자가 새는 게 dcness self 에서 입증. 다른 강제 카테고리 (doc-sync / Task-ID format / pytest) 는 hook 으로 mechanical 강제 → 새지 않음. main commit 차단만 자연어 룰 → 새는 카테고리.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260506-08
+- **Date**: 2026-05-06
+- **Change-Type**: harness, docs-only
+- **Files Changed**:
+  - `harness/session_state.py` line 3 — `docs/conveyor-design.md` → `docs/archive/conveyor-design.md`
+  - `harness/hooks.py` line 1 — 동일
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md` (Why)
+  - `PROGRESS.md` (현재 상태 1줄)
+- **Summary**: Story 1.3 (#155) 의 인용처 전수 갱신에서 누락된 harness 코드 docstring 2건을 archive 경로로 정리. (Issue #179)
+- Document-Exception: docstring 만 변경 — 동작 영향 0. tests/** 또는 docs/impl/** 동반 불필요.
+- Document-Exception-Task: DCN-CHG-20260506-08
+
 ### DCN-CHG-20260506-07
 - **Date**: 2026-05-06
 - **Change-Type**: ci, docs-only

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -1,4 +1,4 @@
-"""hooks.py — Claude Code 훅 핸들러 (`docs/conveyor-design.md` §7).
+"""hooks.py — Claude Code 훅 핸들러 (`docs/archive/conveyor-design.md` §7).
 
 bash 훅 (`hooks/*.sh`) 이 stdin payload + cc_pid 를 본 모듈의 핸들러로 전달.
 순수 Python 으로 catastrophic 검사 + by-pid 레지스트리 갱신을 처리.

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1,6 +1,6 @@
 """session_state.py — 세션/run 격리 상태 API (멀티세션 기본 가정).
 
-발상 (`docs/conveyor-design.md` §4 / §6 / §9):
+발상 (`docs/archive/conveyor-design.md` §4 / §6 / §9):
     Claude Code 가 세션 단위 동작 → 한 사용자가 동시 다중 세션 띄울 수 있음.
     각 세션 안에서 컨베이어가 다중 run 가능 (예: 백그라운드 ralph + foreground quick).
     sid × run_id 별 격리된 디렉토리 구조 + `_meta` envelope 으로 leftover 방어.


### PR DESCRIPTION
## 관련 이슈

Closes #179

## What

Story 1.3 ([#155](https://github.com/alruminum/dcNess/issues/155)) 의 인용처 전수 갱신 12곳 검증에서 누락된 harness 코드 docstring 2건을 archive 경로로 정리.

## Files Changed

| 파일 | 라인 | 변경 |
|---|---|---|
| `harness/session_state.py` | line 3 | `docs/conveyor-design.md` → `docs/archive/conveyor-design.md` |
| `harness/hooks.py` | line 1 | 동일 |

## 자가 검증

- [x] `rg -n 'docs/conveyor-design\.md' /Users/dc.kim/project/dcNess/harness/` → 0 hit
- [x] `rg -n 'docs/archive/conveyor-design\.md' /Users/dc.kim/project/dcNess/harness/` → 2 hit
- [x] `python3 -m unittest discover -s tests` → 376 tests PASS
- [x] `node scripts/check_document_sync.mjs` → Document-Exception detected (PASS)
- [x] feature 브랜치 commit 통과 (#178 main 차단 hook 박힌 후 첫 PR 자가 검증)

## Document-Exception

harness change-type 이지만 docstring 만 변경 — 동작 영향 0. tests/** 또는 docs/impl/** 동반 면제.

## 거버넌스

- Task-ID: `DCN-CHG-20260506-08`
- Change-Type: `harness` + `docs-only`
- 동반 갱신: `docs/process/document_update_record.md` ✅ / `docs/process/change_rationale_history.md` ✅ / `PROGRESS.md` ✅