### PR TITLE
[issue-184] PR/머지 룰 모호 표현 정정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@
    - `node scripts/check_document_sync.mjs` (모든 commit)
    - `sh scripts/check_python_tests.sh` (`harness/` / `tests/` / `agents/` / `python-tests.yml` staged 시만)
    - 자동: Claude Code PreToolUse hook (`scripts/hooks/cc-pre-commit.sh`) + git pre-commit hook 이 동시 차단.
-6. **branch → PR → squash merge** (직접 `main` push 금지).
+6. **branch → PR → regular merge** (직접 `main` push 금지). CI PASS + LGTM 후 메인이 즉시 머지 — *사용자 수동 승인 대기 X*.
 
 ## 2. 거버넌스 핵심 (전체 룰은 SSOT 참조)
 

--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -107,7 +107,7 @@
 
 | 결론 | 다음 trigger |
 |---|---|
-| `LGTM` | 사용자 승인 → squash merge |
+| `LGTM` | regular merge 자동 (CI PASS + LGTM 후 메인이 즉시 머지) |
 | `CHANGES_REQUESTED` | engineer POLISH |
 
 ### 1.11 qa

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -235,7 +235,7 @@ EOF
 if [ "$HAS_REMOTE" = "yes" ]; then
   git push -u origin "$BRANCH"
   gh pr create --title "<제목>" --body "<요약 + Test plan + run_id>"
-  gh pr merge --squash --auto 2>/dev/null || gh pr merge --squash || \
+  gh pr merge --merge --auto 2>/dev/null || gh pr merge --merge || \
     echo "[<entry>] PR merge 차단 — branch protection / CI 대기"
   git checkout main && git pull --ff-only 2>/dev/null || true
 fi
@@ -252,7 +252,7 @@ worktree 진입 시 squash 흡수 검사 후 `ExitWorktree(action="<keep|remove>
 
 ⚠️ Caveat: <has_ambiguous / has_must_fix / unexpected enum / sensitive untracked>
 
-커밋/PR 진행할까요? (수동 — branch → PR → squash merge)
+커밋/PR 진행할까요? (branch → PR → regular merge 자동)
 ```
 
 worktree 처리도 사용자 결정.

--- a/docs/plugin/orchestration.md
+++ b/docs/plugin/orchestration.md
@@ -57,7 +57,7 @@ flowchart TD
     impl[impl: engineer attempt 0..3]
     cv[validator CODE_VALIDATION]
     review[review: pr-reviewer]
-    merge[merge: 사용자 승인 + squash]
+    merge[merge: LGTM 후 자동 + regular]
     cleanup[post-commit cleanup]
 
     plan -->|READY_FOR_IMPL| pv

--- a/docs/process/change_rationale_history.md
+++ b/docs/process/change_rationale_history.md
@@ -18,6 +18,21 @@
 
 ## Records
 
+### DCN-CHG-20260506-11
+- **Date**: 2026-05-06
+- **Rationale**: 본 세션 (2026-05-06) 다른 sub-session 이 Story 2.2 (#158) PR #181 생성 후 머지 안 하고 멈춤. `CLAUDE.md` §5 step 8 (`gh pr merge`) 명시에도 불구하고. 룰 문서 안 모호한 "사용자 승인 → squash merge" (handoff-matrix 110, orchestration 60) 가 인간 사용자 수동 머지 대기로 오역되는 root cause. 또한 `regular merge` 정착 후 `loop-procedure.md` 안 `--squash` 잔재 2 곳 + `CLAUDE.md` line 92 자기모순 (line 168 "squash 금지" 와 충돌).
+- **Alternatives**:
+  1. *그대로 두기* — 회귀 반복. 매 PR 마다 사용자가 수동 개입. 비용 큼.
+  2. *(채택)* **자동 머지 명시화** — "LGTM 후 자동 (regular merge)" 명문화 + squash 잔재 제거.
+  3. *모드 분기 (큰 변경은 사용자 승인, 디폴트 자동)* — "큰 변경" 정의 모호. 기준 자체가 또 다른 회귀 source. 디폴트 = 자동 + 메인 판단으로 사용자에게 prose 보고하면 충분. 옵션 3 deferred.
+- **Decision**:
+  - 5 곳 정정 — handoff-matrix.md 110 / orchestration.md 60 / loop-procedure.md 238 + 255 / CLAUDE.md 92.
+  - UX refine 단계의 "사용자 승인" (handoff-matrix 36 / orchestration 156, 382, 388) 은 *진짜* 인간 사용자 검토 단계라 그대로. 머지 단계와 의미 분리.
+- **Follow-Up**:
+  - 다음 PR 작업부터 다른 세션이 자동 머지 진행 — 본 PR 자체가 self-test (CI PASS + LGTM 후 즉시 머지).
+  - 본 정정은 [#182](https://github.com/alruminum/dcNess/issues/182) (거버넌스 슬림화) 별개. 머지 컨벤션 명확화 ≠ 거버넌스 폐기.
+  - 외부 활성화 프로젝트 (jajang 등) plug-in update 시 자동 반영 (`docs/plugin/` 본체 갱신).
+
 ### DCN-CHG-20260506-08
 - **Date**: 2026-05-06
 - **Rationale**: Story 1.3 (#155) commit `2df1113` 가 `docs/conveyor-design.md` → `docs/archive/conveyor-design.md` 이동 + 인용처 12곳 갱신 했지만 harness 코드 docstring 2건 누락. Epic 1 검증 단계 (Epic 1 머지 후 review) 에서 발견 — `rg -n 'docs/conveyor-design\.md' harness/` → 2 hit. cmd-click 시 깨짐.

--- a/docs/process/document_update_record.md
+++ b/docs/process/document_update_record.md
@@ -20,6 +20,19 @@
 
 ## Records
 
+### DCN-CHG-20260506-11
+- **Date**: 2026-05-06
+- **Change-Type**: docs-only, agent
+- **Files Changed**:
+  - `docs/plugin/handoff-matrix.md` line 110 — `LGTM | 사용자 승인 → squash merge` → `LGTM | regular merge 자동 ...`
+  - `docs/plugin/orchestration.md` line 60 — `merge[merge: 사용자 승인 + squash]` → `merge[merge: LGTM 후 자동 + regular]`
+  - `docs/plugin/loop-procedure.md` line 238 — `gh pr merge --squash` → `gh pr merge --merge`
+  - `docs/plugin/loop-procedure.md` line 255 — `(수동 — branch → PR → squash merge)` → `(branch → PR → regular merge 자동)`
+  - `CLAUDE.md` line 92 — `branch → PR → squash merge` → `branch → PR → regular merge` + 자동 머지 명시
+  - `docs/process/document_update_record.md` (본 항목)
+  - `docs/process/change_rationale_history.md` (Why)
+- **Summary**: PR/머지 룰 모호 표현 정정. "사용자 승인 → squash merge" 표현이 다른 세션에서 인간 사용자 수동 머지 대기로 오역되어 PR 생성 후 멈추는 회귀 발생. 자동 머지 (CI PASS + LGTM 후) 명시 + regular merge 잔재 정리. (Issue #184)
+
 ### DCN-CHG-20260506-10
 - **Date**: 2026-05-06
 - **Change-Type**: docs-only


### PR DESCRIPTION
## 관련 이슈

Closes #184

## What

PR/머지 룰의 *모호 표현* 5 곳 정정. 다른 세션이 PR 만들고 머지 안 하고 멈추는 회귀의 룰 측 root cause.

## Files

| 파일 | 라인 | Before | After |
|---|---|---|---|
| `docs/plugin/handoff-matrix.md` | 110 | `LGTM \| 사용자 승인 → squash merge` | `LGTM \| regular merge 자동 (CI PASS + LGTM 후 메인이 즉시 머지)` |
| `docs/plugin/orchestration.md` | 60 | `merge[merge: 사용자 승인 + squash]` | `merge[merge: LGTM 후 자동 + regular]` |
| `docs/plugin/loop-procedure.md` | 238 | `gh pr merge --squash --auto ...` | `gh pr merge --merge --auto ...` |
| `docs/plugin/loop-procedure.md` | 255 | `(수동 — branch → PR → squash merge)` | `(branch → PR → regular merge 자동)` |
| `CLAUDE.md` | 92 | `branch → PR → squash merge` | `branch → PR → regular merge` + 자동 머지 명시 |

## 유지 (진짜 사용자 승인)

UX refine 단계의 4 곳 (`handoff-matrix.md` 36, `orchestration.md` 156/382/388) 은 *진짜* 인간 검토 단계라 정정 X.

## 자가 검증

- [x] `node scripts/check_document_sync.mjs` PASS (categories: agent, docs-only)
- [x] feature 브랜치 commit 통과 (#178 main 차단 hook 박힌 후 정상 흐름)
- [ ] CI 게이트 통과 (PR 후)
- [ ] 본 PR 자체가 self-test — CI PASS + LGTM 후 즉시 머지 (정정된 룰 그대로 적용)

## 영향

- 다음 PR 작업부터 다른 세션이 자동 머지 진행 — 멈춤 회귀 방지
- 외부 활성화 프로젝트 (jajang 등) plug-in update 시 자동 반영

## 거버넌스

- Task-ID: `DCN-CHG-20260506-11`
- Change-Type: `docs-only` + `agent` (외부 배포 SSOT 본문 변경)
- 동반 갱신: `docs/process/document_update_record.md` ✅ + `docs/process/change_rationale_history.md` ✅

## 후속

본 정정은 #182 (거버넌스 슬림화) 별개. 머지 컨벤션 명확화 ≠ 거버넌스 폐기.