### PR TITLE
[issue-151] #151 후속 — 옛 경로 잔존 7건 정리

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,8 @@
 
 ## 현재 상태
 
+- **🔧 #151 후속 — 옛 경로 잔존 7건 정리** (`DCN-CHG-20260506-14`): Epic 2 검증 정규식이 `(../docs/X.md)` 만 잡아 `(../X.md)` 형태 마크다운 링크 누수. `harness/agent_boundary.py` docstring + `docs/internal/main-claude-rules.md` (5건+4링크) + `docs/internal/self-guidelines.md` (2건) + `docs/plugin/handoff-matrix.md` §4.4 (1건) + `commands/init-dcness.md` §4 (dcness self repo 명시 라인) 일괄 갱신.
+
 - **🔧 harness/ docstring archive 경로 정리 (#179)** (`DCN-CHG-20260506-08`): Story 1.3 인용처 갱신 누락분. `harness/session_state.py` + `harness/hooks.py` 의 `docs/conveyor-design.md` 인용 → `docs/archive/conveyor-design.md`.
 
 - **🔒 main 직접 commit 차단 hook 게이트 신설 (#173)** (`DCN-CHG-20260506-07`): `scripts/hooks/pre-commit` + `scripts/hooks/cc-pre-commit.sh` 양쪽에 main 브랜치 차단 추가. 자연어 룰만 있던 카테고리 mechanical 강제 (Story 1.3 회귀 방지). governance §2.7 게이트 매트릭스에 row 추가.

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -210,7 +210,7 @@ dcness plug-in 의 디자인 시스템 SSOT 는 `docs/design.md` (Google `design
 
 #### 4. 출처 / 갱신 의무
 
-본 Step inline 템플릿은 `docs/design.md` (dcness self repo) §사용 예시와 coupling — Story #125 의 spec 변경 시 본 Step 템플릿도 **수동 동기 의무**. 자동화 검토는 Epic #129 후속 추적.
+본 Step inline 템플릿은 `docs/plugin/design.md` (dcness self repo) §사용 예시와 coupling — Story #125 의 spec 변경 시 본 Step 템플릿도 **수동 동기 의무**. 자동화 검토는 Epic #129 후속 추적.
 
 #### 5. 기존 활성화 프로젝트 — re-run 안내
 

--- a/docs/internal/change_rationale_history.md
+++ b/docs/internal/change_rationale_history.md
@@ -18,6 +18,15 @@
 
 ## Records
 
+### DCN-CHG-20260506-14
+- **Date**: 2026-05-06
+- **Rationale**: Epic 2 (#151) closed 후 사용자가 "구현 사항 리뷰" 요청 — 실측 결과 active 코드/문서 7곳에 옛 경로 (`docs/orchestration.md` / `docs/handoff-matrix.md` / `docs/loop-procedure.md` / `docs/design.md` 의 *self-repo* 인용) 잔존. Epic 검증 정규식 `rg '\(\.\./docs/orchestration\.md\)'` 가 `(../orchestration.md)` 형태 (docs/ 한 단계 prefix 없는 internal/ 내부 상대경로) 마크다운 링크를 못 잡아 누수.
+- **Alternatives**:
+  1. *재오픈하지 않고 archive 처리* — 잔존 7건이 모두 historical 로그라면 OK. 그러나 실측 시 `harness/agent_boundary.py` docstring + `main-claude-rules.md` 가 active SSOT cross-ref → 사용자/메인 Claude 실제 read 시 broken link. 패치 필요.
+  2. *(채택)* **#151 후속 hotfix PR (`fix/issue151_followup_path_refs`)** — Story 2.5 검증 누수 정정. 5개 파일 9건 갱신 + 동반 로그 갱신.
+- **Decision**: 옵션 2. Epic 2 검증 기준의 한계 (`(../docs/X.md)` 만 검증) 노출 — 향후 폴더 이동 시 `(../X.md)` 같은 relative depth 변종도 검증 정규식에 포함해야 함. 본 PR 에서는 직접 수정 없이 Follow-Up 으로 기록.
+- **Follow-Up**: 폴더 이동 회귀 검증 시 마크다운 링크 정규식을 `\((\.\./)+(docs/)?(orchestration|handoff-matrix|loop-procedure)\.md\)` 형태로 확장 검토 (별도 작업, scope 외).
+
 ### DCN-CHG-20260506-13
 - **Date**: 2026-05-06
 - **Rationale**: Story 2.5 (#161) — Epic 2 (Story 2.1~2.4) 에서 파일 이동은 완료됐으나 전체 저장소의 구 경로 참조 (~138 occurrence) 가 남아 있음. agents/ footers, commands/ 본문, harness/agent_boundary.py DCNESS_INFRA_PATTERNS, tests, CLAUDE.md/README.md/AGENTS.md, scripts/hooks/.github 주석 등 모든 영역에서 깨진 링크 상태.

--- a/docs/internal/document_update_record.md
+++ b/docs/internal/document_update_record.md
@@ -20,6 +20,20 @@
 
 ## Records
 
+### DCN-CHG-20260506-14
+- **Date**: 2026-05-06
+- **Change-Type**: docs-only, harness
+- **Files Changed**:
+  - `harness/agent_boundary.py` — module docstring 의 `docs/handoff-matrix.md` → `docs/plugin/handoff-matrix.md`
+  - `docs/internal/main-claude-rules.md` — §0 / §2.1 (cap 표) / §2.2 (4 SSOT 표) 의 `docs/orchestration.md` / `docs/handoff-matrix.md` / `docs/loop-procedure.md` 인용 + 마크다운 링크 (`../orchestration.md` 등) 모두 `docs/plugin/...` 경로로 갱신. 본문 5건 + 링크 4건.
+  - `docs/internal/self-guidelines.md` — §1 대상 파일 목록의 `docs/loop-procedure.md` / `docs/orchestration.md` → `docs/plugin/...`
+  - `docs/plugin/handoff-matrix.md` — §4.4 RWHarness 비교 단락 안 `docs/orchestration.md` + `docs/handoff-matrix.md` 텍스트 인용 → `docs/plugin/...`
+  - `commands/init-dcness.md` — §4 출처 단락 (dcness self repo 명시 라인) 의 `docs/design.md` → `docs/plugin/design.md` (다른 라인은 *사용자 프로젝트* docs/design.md 의도, 미변경)
+  - `docs/internal/document_update_record.md` (본 항목)
+  - `docs/internal/change_rationale_history.md` (Why)
+- **Summary**: Story 2.5 (#161) 후속 — Epic 2 (#151) 폴더 분리 후 active 코드/문서에 잔존한 옛 경로 참조 7건 일괄 갱신. 이슈 검증 정규식이 `(../docs/orchestration.md)` 패턴만 잡아 `(../orchestration.md)` 형태 마크다운 링크가 누수된 것을 정정.
+- Document-Exception: harness/agent_boundary.py 변경이 module docstring 1줄 (참조 경로 텍스트) 로 동작 영향 없어 tests/ 동반 변경 불필요.
+
 ### DCN-CHG-20260506-13
 - **Date**: 2026-05-06
 - **Change-Type**: agent, docs-only, harness, test

--- a/docs/internal/main-claude-rules.md
+++ b/docs/internal/main-claude-rules.md
@@ -10,7 +10,7 @@
 
 ## 0. 정체성 — 강제하는 것 / 강제 안 하는 것
 
-> **🔴 대 원칙** (`docs/plugin/prose-only-principle.md` §1 / `docs/orchestration.md` §0 직접 인용):
+> **🔴 대 원칙** (`docs/plugin/prose-only-principle.md` §1 / `docs/plugin/orchestration.md` §0 직접 인용):
 > **harness 가 강제하는 것은 단 2가지 — (1) 작업 순서, (2) 접근 영역. 그 외 모두 agent 자율.**
 
 - **작업 순서** = 시퀀스 (validator → engineer → pr-reviewer 등) + retry 정책
@@ -83,7 +83,7 @@ dcness SSOT (orchestration / handoff-matrix / loop-procedure / skill-guidelines 
 
 dcness 행동지침 문서 (메인 Claude 또는 sub-agent 가 의사결정 시 *직접 read* 하는 md) 는 **파일당 300줄 cap**. 초과 시 책임 분리 축으로 split.
 
-**대상**: skill prompt (`commands/*.md`) / agent prompt (`agents/**/*.md`) / SSOT (`docs/loop-procedure.md` / `docs/handoff-matrix.md` / `docs/orchestration.md`) / `docs/plugin/skill-guidelines.md` / `docs/internal/self-guidelines.md` / 본 문서.
+**대상**: skill prompt (`commands/*.md`) / agent prompt (`agents/**/*.md`) / SSOT (`docs/plugin/loop-procedure.md` / `docs/plugin/handoff-matrix.md` / `docs/plugin/orchestration.md`) / `docs/plugin/skill-guidelines.md` / `docs/internal/self-guidelines.md` / 본 문서.
 
 **대상 외**: 역사 로그 (`document_update_record.md` / `change_rationale_history.md`) / `PROGRESS.md` / spec / proposals / 코드.
 
@@ -92,9 +92,9 @@ dcness 행동지침 문서 (메인 Claude 또는 sub-agent 가 의사결정 시 
 **현재 cap 충족 상태** (사용자 verification 의무 — `wc -l` 실측):
 | 파일 | 줄 수 (작성 시점) | cap |
 |---|---|---|
-| `docs/orchestration.md` | 464 | **500** (DCN-CHG-20260505-03 — loop-catalog 흡수 통합. 다른 SSOT 는 300 유지) |
-| `docs/handoff-matrix.md` | 256 | 300 |
-| `docs/loop-procedure.md` | 240 | 300 |
+| `docs/plugin/orchestration.md` | 464 | **500** (DCN-CHG-20260505-03 — loop-catalog 흡수 통합. 다른 SSOT 는 300 유지) |
+| `docs/plugin/handoff-matrix.md` | 256 | 300 |
+| `docs/plugin/loop-procedure.md` | 240 | 300 |
 | `docs/plugin/skill-guidelines.md` | 232 | 300 |
 | `docs/internal/self-guidelines.md` | 51 | 300 |
 
@@ -102,11 +102,11 @@ dcness 행동지침 문서 (메인 Claude 또는 sub-agent 가 의사결정 시 
 
 | 파일 | 책임 | 메인 read 시점 |
 |---|---|---|
-| [`docs/orchestration.md`](../orchestration.md) | 시퀀스 mini-graph + **8 loop 행별 풀스펙** (entry / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles) | 신규 작업 시 진입 경로 결정 + loop 진입 시 풀스펙 read |
-| [`docs/handoff-matrix.md`](../handoff-matrix.md) | agent 측 강제 영역 (결정표 / Retry / Escalate / 접근 권한) | agent 호출 분기 / 한도 결정 시 |
-| [`docs/loop-procedure.md`](../loop-procedure.md) | Step 0~8 mechanics (worktree → begin-run → TaskCreate → begin-step → Agent → end-step → finalize-run --auto-review) | 매 컨베이어 진행 |
+| [`docs/plugin/orchestration.md`](../plugin/orchestration.md) | 시퀀스 mini-graph + **8 loop 행별 풀스펙** (entry / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles) | 신규 작업 시 진입 경로 결정 + loop 진입 시 풀스펙 read |
+| [`docs/plugin/handoff-matrix.md`](../plugin/handoff-matrix.md) | agent 측 강제 영역 (결정표 / Retry / Escalate / 접근 권한) | agent 호출 분기 / 한도 결정 시 |
+| [`docs/plugin/loop-procedure.md`](../plugin/loop-procedure.md) | Step 0~8 mechanics (worktree → begin-run → TaskCreate → begin-step → Agent → end-step → finalize-run --auto-review) | 매 컨베이어 진행 |
 | [`docs/plugin/skill-guidelines.md`](../plugin/skill-guidelines.md) | cross-cutting 룰 (echo / Step 기록 / yolo / AMBIGUOUS / worktree / 결과 출력 / 권한 요청 / Karpathy 참조 / **§10 self-verify 원칙**) | 모든 dcness skill 진행 시 |
-| [`docs/internal/self-guidelines.md`](../internal/self-guidelines.md) | dcness self 협업 룰 (300줄 cap / §2 self-verify) | dcness 자체 작업 시 |
+| [`docs/internal/self-guidelines.md`](self-guidelines.md) | dcness self 협업 룰 (300줄 cap / §2 self-verify) | dcness 자체 작업 시 |
 
 ### 2.3 거버넌스
 

--- a/docs/internal/self-guidelines.md
+++ b/docs/internal/self-guidelines.md
@@ -8,10 +8,10 @@
 dcness 행동지침 문서 (메인 Claude 또는 sub-agent 가 의사결정 시 *직접 read* 하는 md) 는 **파일당 300줄 cap**. 초과 시 책임 분리 축으로 split.
 
 **대상 파일 (예시)**:
-- `docs/loop-procedure.md` (loop mechanics SSOT)
+- `docs/plugin/loop-procedure.md` (loop mechanics SSOT)
 - `docs/plugin/skill-guidelines.md` (skill 가이드라인)
 - `docs/internal/self-guidelines.md` (본 가이드라인)
-- `docs/orchestration.md` (loop spec SSOT — DCN-CHG-20260505-03 후 cap 500 예외)
+- `docs/plugin/orchestration.md` (loop spec SSOT — DCN-CHG-20260505-03 후 cap 500 예외)
 - `commands/*.md` (skill prompt)
 - `agents/**/*.md` (agent prompt)
 

--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -234,7 +234,7 @@ DCNESS_INFRA_PATTERNS = [
 ]
 ```
 
-> RWHarness 의 `HARNESS_INFRA_PATTERNS` 안 `r'orchestration-rules\.md'` 잔재는 dcness 가 정정 — 파일명은 `docs/orchestration.md` + `docs/handoff-matrix.md` (split 후 양쪽). loop-procedure / skill-guidelines / self-guidelines / hooks·session_state·agent_boundary 도 dcness 가 추가 보호 (DCN-30-30/31/32 split + loop-catalog 흡수 산출물).
+> RWHarness 의 `HARNESS_INFRA_PATTERNS` 안 `r'orchestration-rules\.md'` 잔재는 dcness 가 정정 — 파일명은 `docs/plugin/orchestration.md` + `docs/plugin/handoff-matrix.md` (split 후 양쪽). loop-procedure / skill-guidelines / self-guidelines / hooks·session_state·agent_boundary 도 dcness 가 추가 보호 (DCN-30-30/31/32 split + loop-catalog 흡수 산출물).
 
 인프라 프로젝트(`is_infra_project()` True) 에선 위 패턴 해제 (dcness 자체 작업 시 본 SSOT 들도 편집 가능해야 함).
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -1,4 +1,4 @@
-"""agent_boundary.py — sub-agent 경로 접근 강제 (`docs/handoff-matrix.md` §4 SSOT).
+"""agent_boundary.py — sub-agent 경로 접근 강제 (`docs/plugin/handoff-matrix.md` §4 SSOT).
 
 본 모듈은 PreToolUse(Edit/Write/Read/Bash) 훅이 호출하여 활성 sub-agent 의 path
 접근을 차단한다. handoff-matrix.md §4.1~§4.5 의 spec 을 코드로 강제 (DCN-CHG-20260501-01).


### PR DESCRIPTION
## 변경 요약

### [issue-151] DCN-CHG-20260506-14 #151 후속 — 옛 경로 잔존 7건 정리
- **What**: Epic 2 (#151) 머지 후 active 코드/문서 7곳에 잔존하던 옛 경로 (`docs/orchestration.md` / `docs/handoff-matrix.md` / `docs/loop-procedure.md` / `docs/design.md` self-repo 인용) 일괄 갱신.
  - `harness/agent_boundary.py` docstring 1줄
  - `docs/internal/main-claude-rules.md` 본문 5건 + 마크다운 링크 4건
  - `docs/internal/self-guidelines.md` 2건
  - `docs/plugin/handoff-matrix.md` §4.4 1건
  - `commands/init-dcness.md` §4 (dcness self repo 명시 라인) 1건
- **Why**: Epic 검증 정규식 `rg '\(\.\./docs/orchestration\.md\)'` 가 `(../orchestration.md)` 형태 (internal/ 폴더 안 한 단계 상대경로 마크다운 링크) 변종을 못 잡아 누수. 메인 Claude / sub-agent 가 main-claude-rules / self-guidelines read 시 broken link 발생 위험.

## 결정 근거

- 옵션 A (재오픈 없이 archive 처리) — `harness/agent_boundary.py` 와 `main-claude-rules.md` 가 active SSOT cross-ref 라 broken link 노출. 기각.
- 옵션 B (채택) — #151 후속 hotfix PR. 5개 파일 9건 갱신 + 동반 거버넌스 로그.
- 검증 정규식 확장 (`\((\.\./)+(docs/)?(X)\.md\)`) 은 별도 작업으로 Follow-Up 기록.

## 관련 이슈

- #151 (Epic 2 — docs 폴더 분리)

## 검증

- `rg 'docs/(orchestration|handoff-matrix|loop-procedure)\.md'` active 영역 0건 (PROGRESS.md / document_update_record / change_rationale_history / docs/archive/** 만 historical 잔존)
- doc-sync gate PASS (Document-Exception: harness docstring 1줄)
- pytest 376 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)