### PR TITLE
[issue-198] init-dcness deploy 패턴 정정 — OMC 식 thin shim, fat plugin

### DIFF
--- a/.github/actions/git-naming/action.yml
+++ b/.github/actions/git-naming/action.yml
@@ -1,0 +1,28 @@
+name: 'dcness git-naming validation'
+description: 'Validate branch name / commit / PR title against dcness git-naming-spec'
+inputs:
+  branch:
+    description: 'Branch name to validate (skip if empty)'
+    required: false
+    default: ''
+  title:
+    description: 'PR title or commit subject to validate (skip if empty)'
+    required: false
+    default: ''
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Validate branch name
+      if: inputs.branch != ''
+      shell: bash
+      run: node "${{ github.action_path }}/../../../scripts/check_git_naming.mjs" --branch "${{ inputs.branch }}"
+
+    - name: Validate title
+      if: inputs.title != ''
+      shell: bash
+      run: node "${{ github.action_path }}/../../../scripts/check_git_naming.mjs" --title "${{ inputs.title }}"

--- a/.github/workflows/git-naming-validation.yml
+++ b/.github/workflows/git-naming-validation.yml
@@ -1,7 +1,9 @@
 # GitHub Actions — git-naming-spec 브랜치명·PR 제목 형식 검증 게이트
 #
 # 규칙 정의: docs/plugin/git-naming-spec.md (SSOT)
-# PR 생성·수정·재오픈 시마다 브랜치명과 PR 제목이 규칙을 따르는지 검사한다.
+# 본 dcness self repo 는 자기 composite action (.github/actions/git-naming) 을 dogfooding.
+# 외부 활성화 프로젝트는 init-dcness 가 묻고 Y 답변 시 thin yml 을 사용자 repo 에 배포 — 그 yml 은
+# `uses: alruminum/dcNess/.github/actions/git-naming@main` 1줄로 동일 검증.
 
 name: git-naming-validation
 
@@ -22,13 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Validate branch + PR title via composite action
+        uses: ./.github/actions/git-naming
         with:
-          node-version: '20'
-
-      - name: Validate branch name
-        run: node scripts/check_git_naming.mjs --branch "${{ github.head_ref }}"
-
-      - name: Validate PR title
-        run: node scripts/check_git_naming.mjs --title "${{ github.event.pull_request.title }}"
+          branch: ${{ github.head_ref }}
+          title: ${{ github.event.pull_request.title }}

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -84,56 +84,79 @@ fi
 
 이미 등록된 사용자는 멱등 — `이미 존재` 메시지.
 
-### Step 2.6 — git-naming 강제 (commit-msg hook + CI)
+### Step 2.6 — git-naming 강제 (thin shim, fat plugin)
 
-브랜치명·커밋·PR 제목 형식 위반을 로컬과 CI 양쪽에서 자동 차단한다.
+브랜치명·커밋·PR 제목 형식 위반을 로컬과 (선택적으로) CI 양쪽에서 자동 차단한다.
+
+> **#198 정정**: mjs / skill-guidelines.md 는 사용자 repo 에 cp 안 한다 — plugin SSOT 직접 호출. commit-msg hook 만 thin shim 으로 always-overwrite 한다 (`.git/hooks/` 위치 강제 + plugin 업데이트 자동 갱신).
 
 ```bash
 PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | head -1)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 
-# 1. check_git_naming.mjs 배포 (commit-msg hook + CI 의존)
-mkdir -p "$PROJECT_ROOT/scripts"
-if [ ! -f "$PROJECT_ROOT/scripts/check_git_naming.mjs" ]; then
-  cp "$PLUGIN_ROOT/scripts/check_git_naming.mjs" "$PROJECT_ROOT/scripts/"
-  echo "[dcness] scripts/check_git_naming.mjs 배포"
-else
-  echo "[dcness] scripts/check_git_naming.mjs 이미 존재 — skip"
-fi
+# 1. commit-msg hook (thin shim) — always-overwrite
+#    내용은 plugin path 동적 resolve + check_git_naming.mjs 호출 1줄. 본체 로직 plugin 안.
+cp "$PLUGIN_ROOT/scripts/hooks/commit-msg" "$PROJECT_ROOT/.git/hooks/commit-msg"
+chmod +x "$PROJECT_ROOT/.git/hooks/commit-msg"
+echo "[dcness] .git/hooks/commit-msg 갱신 (thin shim → plugin SSOT 호출)"
 
-# 2. GitHub Actions workflow 배포
-mkdir -p "$PROJECT_ROOT/.github/workflows"
-if [ ! -f "$PROJECT_ROOT/.github/workflows/git-naming-validation.yml" ]; then
-  cp "$PLUGIN_ROOT/.github/workflows/git-naming-validation.yml" "$PROJECT_ROOT/.github/workflows/"
-  echo "[dcness] .github/workflows/git-naming-validation.yml 배포"
-else
-  echo "[dcness] git-naming-validation.yml 이미 존재 — skip"
+# 2. legacy 정리 안내 — 옛 cp 패턴 잔재 제거 권고
+if [ -f "$PROJECT_ROOT/scripts/check_git_naming.mjs" ]; then
+  echo "[dcness] NOTE — scripts/check_git_naming.mjs 가 사용자 repo 에 잔존. 이제 plugin SSOT 에서 호출하므로 제거 권장:"
+  echo "         git rm scripts/check_git_naming.mjs"
 fi
-
-# 3. commit-msg hook 설치
-if [ ! -f "$PROJECT_ROOT/.git/hooks/commit-msg" ]; then
-  cp "$PLUGIN_ROOT/scripts/hooks/commit-msg" "$PROJECT_ROOT/.git/hooks/commit-msg"
-  chmod +x "$PROJECT_ROOT/.git/hooks/commit-msg"
-  echo "[dcness] .git/hooks/commit-msg 설치"
-else
-  echo "[dcness] .git/hooks/commit-msg 이미 존재 — skip"
+if [ -f "$PROJECT_ROOT/docs/plugin/skill-guidelines.md" ]; then
+  echo "[dcness] NOTE — docs/plugin/skill-guidelines.md 가 사용자 repo 에 잔존. session-start.sh 가 이제 plugin SSOT 에서 read. 제거 권장:"
+  echo "         git rm docs/plugin/skill-guidelines.md"
 fi
-
-# 4. skill-guidelines.md 배포 (SessionStart 훅이 읽는 파일)
-mkdir -p "$PROJECT_ROOT/docs/plugin"
-cp "$PLUGIN_ROOT/docs/plugin/skill-guidelines.md" "$PROJECT_ROOT/docs/plugin/skill-guidelines.md"
-echo "[dcness] docs/plugin/skill-guidelines.md 배포"
 ```
 
-출력 예시:
+#### 3. CI 강제 — 사용자 선택 (옵션)
+
+GitHub Actions 에서 git-naming 강제 원하는지 묻는다.
+
 ```
-[dcness] scripts/check_git_naming.mjs 배포
-[dcness] .github/workflows/git-naming-validation.yml 배포
-[dcness] .git/hooks/commit-msg 설치
-[dcness] docs/plugin/skill-guidelines.md 배포
+[dcness] GitHub Actions CI 에서 git-naming 강제할까요?
+  - PR open / sync 시마다 브랜치명 + PR 제목 자동 검증
+  - 본 thin yml 1개만 사용자 repo 에 깔리고, 검증 본체는 alruminum/dcNess composite action 호출
+  - 로컬 commit-msg hook 만으로 충분하면 n
+(Y/n)
 ```
 
-`git-naming-validation.yml` 은 PR open 시 CI 에서 브랜치명·PR 제목을 자동 검사한다. `commit-msg` hook 은 로컬에서 커밋 제목을 사전 차단한다. 두 파일은 커밋 후 프로젝트 repo 에 push 해야 CI 에서 동작한다.
+- **Y**: 다음 thin yml 을 `$PROJECT_ROOT/.github/workflows/git-naming-validation.yml` 로 *always-overwrite* (이미 존재해도 갱신 — plugin 업데이트 자동 반영):
+
+  ```yaml
+  name: git-naming-validation
+  on:
+    pull_request:
+      branches: [main]
+      types: [opened, synchronize, reopened, edited]
+  permissions:
+    contents: read
+    pull-requests: read
+  jobs:
+    naming:
+      name: git-naming-spec gate
+      runs-on: ubuntu-latest
+      steps:
+        - uses: alruminum/dcNess/.github/actions/git-naming@main
+          with:
+            branch: ${{ github.head_ref }}
+            title: ${{ github.event.pull_request.title }}
+  ```
+
+  - 사용자 repo 에 mjs / 검증 로직 본체 cp 0 — 모두 dcNess repo composite action 안.
+  - 사용자가 `@main` 대신 `@v1.2.3` 등 tag pin 으로 버전 고정 가능.
+  - 머지 후 push → 다음 PR 부터 CI 자동 발화.
+
+- **n**: skip. 로컬 commit-msg hook 만으로 강제 (push 전 차단).
+
+출력 예시 (Y 선택):
+```
+[dcness] .git/hooks/commit-msg 갱신 (thin shim → plugin SSOT 호출)
+[dcness] .github/workflows/git-naming-validation.yml 갱신 (composite action 호출)
+[dcness] CI 활성화 — 머지 후 push 시 다음 PR 부터 발화
+```
 
 ### Step 2.7 — design.md SSOT awareness
 
@@ -228,10 +251,9 @@ dcness plug-in 의 디자인 시스템 SSOT 는 `docs/design.md` (Google `design
 - PreToolUse Agent 훅 — catastrophic 룰 (orchestration.md §2.3) 검사
 
 git-naming 강제 (Step 2.6 완료 시):
-- 로컬: .git/hooks/commit-msg — 커밋 제목 형식 위반 차단
-- CI: .github/workflows/git-naming-validation.yml — 브랜치명·PR 제목 위반 차단
-- scripts/check_git_naming.mjs 를 커밋 후 push 해야 CI 활성화
-- docs/plugin/skill-guidelines.md 배포 — SessionStart 훅이 세션마다 읽는 룰 파일
+- 로컬: .git/hooks/commit-msg (thin shim) — 커밋 제목 형식 위반 차단. 본체 로직 plugin SSOT 안.
+- CI (사용자 선택): .github/workflows/git-naming-validation.yml — composite action 호출 1줄
+- skill-guidelines.md / check_git_naming.mjs 는 사용자 repo cp 안 함 — plugin SSOT 직접 호출 (#198)
 
 design.md SSOT (Step 2.7 완료 시):
 - CLAUDE.md 매트릭스에 docs/design.md 행 등록 (UI 작업 시 read 후보)

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -40,7 +40,29 @@ python3 -m harness.hooks session-start --cc-pid "$CC_PID"
 #   {"hookSpecificOutput": {"hookEventName": "SessionStart", "additionalContext": "..."}}
 # Read 도구는 절대 경로만 허용 — CLAUDE_PROJECT_DIR 로 절대 경로 구성.
 PROJ="${CLAUDE_PROJECT_DIR:-$(pwd)}"
-GUIDELINES_PATH="${PROJ}/docs/plugin/skill-guidelines.md"
+
+# skill-guidelines.md 는 plugin SSOT — 사용자 repo cp 폐지 (#198 OMC 식 thin shim).
+# Plugin path 우선 → cache lookup fallback → legacy 사용자 repo 경로 (마이그레이션 호환).
+resolve_guidelines_path() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/docs/plugin/skill-guidelines.md" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}/docs/plugin/skill-guidelines.md"; return 0
+  fi
+  cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/docs/plugin/skill-guidelines.md" ]; then
+      echo "$cache_dir/$latest/docs/plugin/skill-guidelines.md"; return 0
+    fi
+  fi
+  legacy="${PROJ}/docs/plugin/skill-guidelines.md"
+  [ -f "$legacy" ] && echo "$legacy" && return 0
+  return 1
+}
+GUIDELINES_PATH=$(resolve_guidelines_path)
+if [ -z "$GUIDELINES_PATH" ]; then
+  # plugin / cache / legacy 모두 부재 — silent skip (BLOCKING gate 발화 안 함)
+  exit 0
+fi
 
 python3 -c "
 import json, sys

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -1,8 +1,15 @@
 #!/bin/sh
-# commit-msg hook — git-naming-spec 커밋 제목 형식 검증
+# commit-msg hook — git-naming-spec 커밋 제목 형식 검증 (thin shim)
 # 규칙 정의: docs/plugin/git-naming-spec.md §2 (SSOT)
 #
-# 설치: cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+# 본 hook 은 plugin SSOT 에서 검증 스크립트를 직접 호출 — 사용자 repo 에 mjs 복사 X (#198).
+# init-dcness 가 매 실행마다 본 shim 을 .git/hooks/commit-msg 로 always-overwrite — plugin
+# 업데이트가 자동 hook 갱신.
+#
+# Plugin root 동적 resolve 우선순위:
+#   1. CLAUDE_PLUGIN_ROOT 환경변수 (Claude Code 가 set)
+#   2. ~/.claude/plugins/cache/dcness/dcness/* 의 최신 디렉토리 (cache lookup)
+#   3. 위 둘 다 부재 시 사용자 repo 의 scripts/check_git_naming.mjs (legacy fallback)
 
 COMMIT_TITLE=$(head -1 "$1")
 
@@ -11,4 +18,31 @@ if echo "$COMMIT_TITLE" | grep -qE "^Merge (branch|pull request)"; then
   exit 0
 fi
 
-node "$(git rev-parse --show-toplevel)/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE"
+resolve_plugin_script() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs"
+    return 0
+  fi
+  cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/scripts/check_git_naming.mjs" ]; then
+      echo "$cache_dir/$latest/scripts/check_git_naming.mjs"
+      return 0
+    fi
+  fi
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null)/scripts/check_git_naming.mjs"
+  if [ -f "$legacy" ]; then
+    echo "$legacy"
+    return 0
+  fi
+  return 1
+}
+
+SCRIPT_PATH=$(resolve_plugin_script)
+if [ -z "$SCRIPT_PATH" ]; then
+  echo "[commit-msg] WARN — check_git_naming.mjs 미발견 (plugin 미설치 또는 cache 비정상). hook skip." >&2
+  exit 0
+fi
+
+node "$SCRIPT_PATH" --title "$COMMIT_TITLE"


### PR DESCRIPTION
[issue-198] init-dcness deploy 패턴 정정 — OMC 식 thin shim, fat plugin

## 관련 이슈

Closes #198

## 변경 내용

### 신설
- `.github/actions/git-naming/action.yml` — composite action. 외부 활성화 프로젝트 thin yml 이 `uses: alruminum/dcNess/.github/actions/git-naming@main` 으로 호출. 본체 로직 (mjs) 은 dcNess repo 안에만 거주.

### 정정
- `.github/workflows/git-naming-validation.yml` — dcness self CI 도 composite action 사용 (dogfooding).
- `scripts/hooks/commit-msg` — plugin path 동적 resolve thin shim. CLAUDE_PLUGIN_ROOT → cache lookup → legacy 사용자 repo 순.
- `hooks/session-start.sh` — `GUIDELINES_PATH` 동적 resolve. plugin path 우선 → cache → legacy. skill-guidelines.md 사용자 repo cp 의존 폐지.
- `commands/init-dcness.md` Step 2.6 — mjs cp 폐지 / skill-guidelines.md cp 폐지 / commit-msg always-overwrite / **CI 활성화 사용자에게 묻기 분기** 추가.

### 사용자 영향 (마이그레이션)
- 기존 활성화 프로젝트가 `/init-dcness` 재실행 시: commit-msg hook overwrite + 잔존 cp 본 (`scripts/check_git_naming.mjs` / `docs/plugin/skill-guidelines.md`) 제거 권고 메시지 출력. 자동 삭제 X.

## 배포 경로 검증

- (1) plug-in 본체 갱신 — 사용자 plugin update 시 자동 적용 (commit-msg shim / session-start.sh / composite action / init-dcness.md).
- (2) init-dcness 가 사용자 프로젝트로 *복사* 하는 파일 — 이제 (a) commit-msg shim 만 always-overwrite, (b) thin yml 은 사용자 Y 답변 시만. 종전 4파일 → 2파일로 축소.

## 검증

- [x] 376 unit tests PASS
- [x] check_git_naming.mjs 직접 호출 PASS
- [x] git pre-commit hook 정상 발화 (본 commit 자체)
- [ ] CI: 새 composite action 으로 git-naming gate PASS (PR 후 검증)
