### PR TITLE
[docs] PR 템플릿·git-naming-spec §5 관련 이슈 Closes/Part of 키워드 명시

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,8 @@
 
 ## 관련 이슈
 
-- #N
+<!-- issue-lifecycle.md §1.4: 중간 task → `Part of #N` / 마지막 task → `Closes #N` / epic 마지막 task → `Closes #story` + `Closes #epic` -->
+Closes #N
 
 ## 배포 경로 검증
 

--- a/docs/plugin/git-naming-spec.md
+++ b/docs/plugin/git-naming-spec.md
@@ -77,7 +77,8 @@
 
 ## 관련 이슈
 
-- #N
+<!-- issue-lifecycle.md §1.4: 중간 task → `Part of #N` / 마지막 task → `Closes #N` / epic 마지막 task → `Closes #story` + `Closes #epic` -->
+Closes #N
 
 ## 참고
 


### PR DESCRIPTION
## 변경 요약

### [docs] PR 템플릿·git-naming-spec §5 관련 이슈 Closes/Part of 키워드 명시
- **What**: `.github/PULL_REQUEST_TEMPLATE.md` 및 `docs/plugin/git-naming-spec.md §5` 의 `## 관련 이슈` 섹션을 `- #N` → `Closes #N` + `issue-lifecycle.md §1.4` 참조 주석으로 교체
- **Why**: 모든 세션이 PR 템플릿·git-naming-spec §5 만 참조해 `- #162` 형태로만 기입 → GitHub auto-close 미발동 반복 (PR #191, #197 사례). 룰은 `issue-lifecycle.md §1.4` 에 있었으나 세션이 해당 파일을 누락하면 구조적으로 실수 재발.

## 결정 근거

- `agents/engineer.md`, `docs/plugin/loop-procedure.md` 는 이미 `Closes/Part of` 명시됨 — 템플릿·spec 만 누락된 상태였음
- PR 템플릿과 git-naming-spec 이 `issue-lifecycle.md §1.4` 의 키워드 룰을 인라인 주석으로 직접 노출해야 세션이 해당 파일 미조회 시에도 실수 방지 가능

## 관련 이슈

-

## 배포 경로 검증

- `docs/plugin/git-naming-spec.md` — 외부 배포 SSOT. plug-in 본체 파일 경로 갱신으로 사용자 환경에 자동 도달 (배포 경로 1).
- `.github/PULL_REQUEST_TEMPLATE.md` — dcNess self repo 전용.

## Test Plan

- [ ] PR 생성 시 템플릿에 `Closes #N` 노출 확인