### PR TITLE
[docs] PR 템플릿·git-naming-spec §5 default 키워드 Closes → Part of 정정

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,12 @@
 
 ## 관련 이슈
 
-<!-- issue-lifecycle.md §1.4: 중간 task → `Part of #N` / 마지막 task → `Closes #N` / epic 마지막 task → `Closes #story` + `Closes #epic` -->
-Closes #N
+<!-- issue-lifecycle.md §1.4 키워드 룰:
+     - 중간 task → `Part of #N` (default — 본 PR 이 issue 를 끝내지 않으면 이 줄 유지)
+     - 마지막 task → `Closes #N` 으로 변경
+     - epic 마지막 task → `Closes #story` + `Closes #epic` 둘 다 박음
+     under-link 보다 over-close 사고가 더 큼 (#193 → #182 사례) — default 는 안전한 `Part of` -->
+Part of #N
 
 ## 배포 경로 검증
 

--- a/docs/plugin/git-naming-spec.md
+++ b/docs/plugin/git-naming-spec.md
@@ -77,8 +77,12 @@
 
 ## 관련 이슈
 
-<!-- issue-lifecycle.md §1.4: 중간 task → `Part of #N` / 마지막 task → `Closes #N` / epic 마지막 task → `Closes #story` + `Closes #epic` -->
-Closes #N
+<!-- issue-lifecycle.md §1.4 키워드 룰:
+     - 중간 task → `Part of #N` (default — 본 PR 이 issue 를 끝내지 않으면 이 줄 유지)
+     - 마지막 task → `Closes #N` 으로 변경
+     - epic 마지막 task → `Closes #story` + `Closes #epic` 둘 다 박음
+     under-link 보다 over-close 사고가 더 큼 (#193 → #182 사례) — default 는 안전한 `Part of` -->
+Part of #N
 
 ## 참고
 


### PR DESCRIPTION
## 변경 요약

### default 키워드 안전 측 변경
- **What**: `.github/PULL_REQUEST_TEMPLATE.md` + `docs/plugin/git-naming-spec.md §5` default 키워드 `Closes #N` → `Part of #N`. inline 주석 3줄 분할.
- **Why**: PR #200 머지 후 default 가 `Closes` 라 무심코 머지 시 issue 조기 close 위험. PR #193 → #182 가 정확히 그 시나리오. under-link (Development 누락) 보다 over-close (미완료 이슈 close) 가 더 큰 사고.

## 결정 근거

- 옵션 (1) default `Closes` 유지 + 주석 강화 — 사용자 인지 의무. PR #200 직후 사례처럼 세션이 주석 안 읽고 default 그대로 머지하면 사고. 인지 부담 ↑.
- 옵션 (2) **(채택) default `Part of` 로 fail-safe** — 마지막 task 면 사용자가 명시적으로 `Closes` 로 변경. 명시 없으면 issue 안전하게 OPEN 유지.
- 인라인 주석 3줄 list 분할로 가독성 ↑.

## 관련 이슈

<!-- issue-lifecycle.md §1.4 키워드 룰:
     - 중간 task → `Part of #N` (default — 본 PR 이 issue 를 끝내지 않으면 이 줄 유지)
     - 마지막 task → `Closes #N` 으로 변경
     - epic 마지막 task → `Closes #story` + `Closes #epic` 둘 다 박음
     under-link 보다 over-close 사고가 더 큼 (#193 → #182 사례) — default 는 안전한 `Part of` -->
-

## 배포 경로 검증

- `docs/plugin/git-naming-spec.md` — 외부 배포 SSOT. plug-in 본체 갱신 → 사용자 환경 자동 도달 (배포 경로 1).
- `.github/PULL_REQUEST_TEMPLATE.md` — dcNess self repo 전용.

## Test Plan

- [x] 본 PR 자체가 self-test — body 의 `## 관련 이슈` 가 `-` (issue 무관) 로 박힘.

🤖 Generated with [Claude Code](https://claude.com/claude-code)