### PR TITLE
[epic3][story3] release-sync.yml + branch protection 가이드 신규

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -1,0 +1,25 @@
+name: release sync
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: configure git
+        run: |
+          git config user.name "release-sync-bot"
+          git config user.email "release-sync@dcness.local"
+      - name: run sync
+        run: bash scripts/sync_release.sh --yes

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,8 @@
 
 ## 현재 상태
 
+- **✅ Epic 3 Story 3.3 (#164) 완료 — release-sync.yml + branch protection 가이드**: `.github/workflows/release-sync.yml` 신규 (main push 시 자동 release sync, concurrency 그룹으로 중복 실행 방지). `docs/internal/branch-protection-setup.md` 신규 (release 브랜치 보호 설정 절차). PR #TBD.
+
 - **✅ Epic 3 Story 3.2 (#163) 완료 — release 브랜치 + sync_release.sh**: `scripts/sync_release.sh` 신규. origin/main → release 동기화 (dcness self 경로 제거 후 force-with-lease push). release 브랜치 초기화 완료. 검증: docs/internal|archive 0 hit / docs/plugin 9 파일 / tests|harness 0 hit. 부수 수정: pytest 게이트 삭제 트리거 버그(`--diff-filter=ACM`). PR #202.
 
 - **✅ Epic 3 Story 3.1 (#162) 완료 — source.ref GREEN**: `marketplace.json` plugin source 의 `{ "source": "github", "repo": "alruminum/dcNess", "ref": "release-dryrun" }` 실측. docs/internal/ + docs/archive/ cache 미존재 확인. Epic 3 Story 3.2~3.4 진행 가능. 결과: `docs/internal/story-3-1-source-ref-verification.md`.

--- a/docs/internal/branch-protection-setup.md
+++ b/docs/internal/branch-protection-setup.md
@@ -1,0 +1,63 @@
+# release 브랜치 보호 설정 가이드
+
+> **목적**: `release` 브랜치는 `release-sync.yml` workflow 만이 갱신한다. 사람 직접 push / PR merge 로의 갱신을 차단해 "다음 main merge 에서 사라짐" 사고를 방지한다.
+
+## 배경
+
+`sync_release.sh` 는 main 기반 force-reset 방식이다 — release 위 직접 commit 은 다음 sync 에서 덮어써진다. branch protection 없으면 사용자가 release 위 hotfix 를 쌓아두다가 즉시 사라지는 사고 발생.
+
+## GitHub UI 설정 절차
+
+> Settings → Branches → Branch protection rules → Add rule
+
+**Branch name pattern**: `release`
+
+### 설정 항목
+
+| 항목 | 값 | 이유 |
+|---|---|---|
+| Restrict who can push to matching branches | ✅ 활성화 | 사람 직접 push 차단 |
+| 허용 actor 추가 | `github-actions[bot]` | workflow GITHUB_TOKEN 허용 |
+| Allow force pushes | ✅ 활성화 ("Specify who can force push") | sync 는 force-with-lease |
+| force push 허용 actor | `github-actions[bot]` | workflow 만 force push 가능 |
+| Do not allow bypasses | 체크 해제 (위 actor 예외 위해) | — |
+| Restrict creations | 선택사항 | PR merge 경로 차단 시 활성화 |
+
+### 상세 절차
+
+1. **Settings → Branches → Add rule**
+2. Branch name pattern: `release`
+3. "Restrict who can push to matching branches" 체크 → **Add bypass** → `github-actions[bot]` 검색 후 추가
+4. "Allow force pushes" 체크 → "Specify who can force push" 선택 → 위와 동일하게 `github-actions[bot]` 추가
+5. **Save changes**
+
+## GITHUB_TOKEN 권한 확인
+
+`release-sync.yml` 의 `permissions: contents: write` 로 충분하다. PAT 별도 등록 불필요.
+
+주의: branch protection 설정 전에 workflow 가 먼저 돌면 `release` 브랜치 push 는 성공한다 (보호 없으므로). 설정 후에도 `github-actions[bot]` 이 허용 actor 에 추가돼 있으면 force push 포함 정상 작동.
+
+## 검증
+
+branch protection 설정 완료 후:
+
+```sh
+# 1. 사람 직접 push 차단 확인
+git push origin main:release
+# → "protected branch" 에러 기대
+
+# 2. workflow 자동 sync 확인
+# 아무 PR 을 main 에 merge → Actions 탭에서 release-sync workflow 실행 확인
+# release 브랜치 최신 commit 메시지 확인:
+git fetch origin
+git log origin/release --oneline -1
+# → "release sync from main@<sha>" 형태
+
+# 3. 무한 루프 부재 확인
+# release push 후 release-sync workflow 가 다시 trigger 되지 않음 (on.push.branches: [main] 만 trigger)
+```
+
+## 주의사항
+
+- `release` 위 직접 commit 은 다음 main merge 시 **사라진다**. 긴급 패치도 main 브랜치 PR 경로로 진행할 것.
+- release 브랜치는 읽기 전용 배포물이다. 사용자는 이 브랜치를 `git clone --branch release` 또는 plugin source ref 로 참조한다.


### PR DESCRIPTION
## 변경 요약

### [epic3][story3] release-sync.yml + branch-protection-setup.md 신규
- **What**: main push 시 자동으로 release 브랜치를 sync 하는 GitHub Actions workflow 신규. release 브랜치 보호 설정 가이드 문서 신규.
- **Why**: Story 3.2 에서 sync_release.sh 를 만들었지만 CI 자동 실행이 없어 수동 실행 필요 상태. Story 3.3 은 이 자동화 + 브랜치 보호 절차 문서화.

## 결정 근거

- `sync_release.sh --yes` 플래그: 스크립트 내 대화형 confirm() 프롬프트가 CI 환경에서 stdin EOF 로 실패하거나 hang 할 수 있음. `--yes` 로 강제 통과.
- `concurrency: cancel-in-progress: false`: 여러 PR 이 연속 merge 될 때 이전 sync 가 완료되길 기다린 뒤 다음 실행 (중단 시 release 상태 불일치 위험).
- `GITHUB_TOKEN + contents: write` 로 충분. PAT 불필요 (단 branch protection 에서 `github-actions[bot]` 허용 actor 등록 필요 — docs/internal/branch-protection-setup.md 참조).

## 관련 이슈

Closes #164

## 참고

- branch protection 실제 설정은 GitHub UI 에서 수동 진행 필요 (`docs/internal/branch-protection-setup.md` 가이드 참조).
- 무한 루프 없음: workflow trigger 가 `push: branches: [main]` 이므로 release push 는 re-trigger 하지 않음.