### PR TITLE
[docs] branch-protection-setup.md — 관례 기반 정책으로 정정

### DIFF
--- a/docs/internal/branch-protection-setup.md
+++ b/docs/internal/branch-protection-setup.md
@@ -1,63 +1,33 @@
-# release 브랜치 보호 설정 가이드
+# release 브랜치 보호 정책
 
-> **목적**: `release` 브랜치는 `release-sync.yml` workflow 만이 갱신한다. 사람 직접 push / PR merge 로의 갱신을 차단해 "다음 main merge 에서 사라짐" 사고를 방지한다.
+> **결론**: 클래식 Branch Protection Rules 로는 `github-actions[bot]` 만 허용하는 actor-level 제어가 불가능하다. release 브랜치는 **관례 기반 읽기 전용**으로 운영한다.
 
 ## 배경
 
-`sync_release.sh` 는 main 기반 force-reset 방식이다 — release 위 직접 commit 은 다음 sync 에서 덮어써진다. branch protection 없으면 사용자가 release 위 hotfix 를 쌓아두다가 즉시 사라지는 사고 발생.
+`sync_release.sh` 는 main 기반 force-reset 방식이다 — release 위 직접 commit 은 다음 sync 에서 덮어써진다.
 
-## GitHub UI 설정 절차
+GitHub 클래식 Branch Protection Rules 에서 실제 사용 가능한 옵션:
+- **Lock branch** — 완전 읽기 전용이지만 workflow GITHUB_TOKEN 도 차단됨
+- **Allow force pushes** — push 권한 있는 모든 사람에게 허용 (선택적 허용 불가)
+- actor 별 허용/차단은 별도 GitHub Rulesets (Settings → Rules → Rulesets) 에서만 가능
 
-> Settings → Branches → Branch protection rules → Add rule
+workflow 자동 sync 를 유지하면서 사람만 차단하려면 PAT 등록 또는 Rulesets 가 필요해 복잡도가 올라간다. 소규모 프로젝트에서 ROI 없음.
 
-**Branch name pattern**: `release`
+## 운영 정책
 
-### 설정 항목
+**branch protection rule 미적용. 관례로 강제한다.**
 
-| 항목 | 값 | 이유 |
-|---|---|---|
-| Restrict who can push to matching branches | ✅ 활성화 | 사람 직접 push 차단 |
-| 허용 actor 추가 | `github-actions[bot]` | workflow GITHUB_TOKEN 허용 |
-| Allow force pushes | ✅ 활성화 ("Specify who can force push") | sync 는 force-with-lease |
-| force push 허용 actor | `github-actions[bot]` | workflow 만 force push 가능 |
-| Do not allow bypasses | 체크 해제 (위 actor 예외 위해) | — |
-| Restrict creations | 선택사항 | PR merge 경로 차단 시 활성화 |
+- `release` 브랜치는 **`release-sync.yml` workflow 전용**이다.
+- 사람이 직접 push 하거나 PR 을 merge 해선 안 된다.
+- 긴급 패치도 반드시 `main` 브랜치 PR 경로로 진행한다. 다음 main push 시 release 에 자동 반영된다.
 
-### 상세 절차
-
-1. **Settings → Branches → Add rule**
-2. Branch name pattern: `release`
-3. "Restrict who can push to matching branches" 체크 → **Add bypass** → `github-actions[bot]` 검색 후 추가
-4. "Allow force pushes" 체크 → "Specify who can force push" 선택 → 위와 동일하게 `github-actions[bot]` 추가
-5. **Save changes**
-
-## GITHUB_TOKEN 권한 확인
-
-`release-sync.yml` 의 `permissions: contents: write` 로 충분하다. PAT 별도 등록 불필요.
-
-주의: branch protection 설정 전에 workflow 가 먼저 돌면 `release` 브랜치 push 는 성공한다 (보호 없으므로). 설정 후에도 `github-actions[bot]` 이 허용 actor 에 추가돼 있으면 force push 포함 정상 작동.
-
-## 검증
-
-branch protection 설정 완료 후:
+## 검증 (workflow 동작 확인)
 
 ```sh
-# 1. 사람 직접 push 차단 확인
-git push origin main:release
-# → "protected branch" 에러 기대
-
-# 2. workflow 자동 sync 확인
-# 아무 PR 을 main 에 merge → Actions 탭에서 release-sync workflow 실행 확인
-# release 브랜치 최신 commit 메시지 확인:
+# PR merge 후 release 자동 sync 확인
 git fetch origin
 git log origin/release --oneline -1
 # → "release sync from main@<sha>" 형태
-
-# 3. 무한 루프 부재 확인
-# release push 후 release-sync workflow 가 다시 trigger 되지 않음 (on.push.branches: [main] 만 trigger)
 ```
 
-## 주의사항
-
-- `release` 위 직접 commit 은 다음 main merge 시 **사라진다**. 긴급 패치도 main 브랜치 PR 경로로 진행할 것.
-- release 브랜치는 읽기 전용 배포물이다. 사용자는 이 브랜치를 `git clone --branch release` 또는 plugin source ref 로 참조한다.
+Actions 탭에서 `release sync` workflow 실행 기록도 확인 가능.


### PR DESCRIPTION
## 변경 요약

### [docs] branch-protection-setup.md 정정
- **What**: 클래식 Branch Protection Rules 에서 `github-actions[bot]` 만 허용하는 actor-level 제어가 불가능함을 반영. 관례 기반 읽기 전용 정책으로 대체.
- **Why**: 실제 GitHub UI 에 "Restrict who can push to matching branches" actor 지정 옵션 없음 확인.

## 결정 근거

Lock branch + PAT 또는 Rulesets 경로도 있지만 소규모 프로젝트에서 복잡도 대비 ROI 없음. 관례 강제로 충분.

## 관련 이슈

Part of #164

## 참고

-