### PR TITLE
[epic3][story4] marketplace.json source.ref release 전환 + 0.2.0 bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,17 @@
     "email": "alruminum@gmail.com"
   },
   "metadata": {
-    "description": "dcNess 첫 알파 — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙 + Document Sync 거버넌스.",
-    "version": "0.1.0-alpha"
+    "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
+    "version": "0.2.0"
   },
   "plugins": [
     {
       "name": "dcness",
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "alruminum/dcNess",
+        "ref": "release"
+      },
       "description": "Prose-only harness — agent 자유 prose emit, harness 가 메타 LLM 으로 결론 해석. 형식 강제 사다리 폐기.",
       "category": "development",
       "tags": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.1.0-alpha",
+  "version": "0.2.0",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -2,6 +2,8 @@
 
 ## 현재 상태
 
+- **✅ Epic 3 Story 3.4 (#165) 완료 — marketplace.json source.ref → release 전환 + 0.2.0 bump**: `.claude-plugin/marketplace.json` plugin source 를 `{ "source": "github", "repo": "alruminum/dcNess", "ref": "release" }` 로 전환 (로컬 `./` 제거). `plugin.json` + `marketplace.json` metadata.version `0.1.0-alpha` → `0.2.0`. Epic 3 코드 작업 완료 — PR 머지 후 release-sync.yml 자동 발화로 release 브랜치 갱신. 외부 dry-run (jajang `/plugin update dcness`) 은 PR 머지 후 별도 진행. DCN-CHG-20260506-16.
+
 - **✅ Epic 3 Story 3.3 (#164) 완료 — release-sync.yml + branch protection 가이드**: `.github/workflows/release-sync.yml` 신규 (main push 시 자동 release sync, concurrency 그룹으로 중복 실행 방지). `docs/internal/branch-protection-setup.md` 신규 (release 브랜치 보호 설정 절차). PR #205.
 
 - **✅ Epic 3 Story 3.2 (#163) 완료 — release 브랜치 + sync_release.sh**: `scripts/sync_release.sh` 신규. origin/main → release 동기화 (dcness self 경로 제거 후 force-with-lease push). release 브랜치 초기화 완료. 검증: docs/internal|archive 0 hit / docs/plugin 9 파일 / tests|harness 0 hit. 부수 수정: pytest 게이트 삭제 트리거 버그(`--diff-filter=ACM`). PR #202.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dcNess
 
-> **Status**: `0.1.0-alpha` — Phase 1~3 완료 · Plugin 배포 dry-run 예정
+> **Status**: `0.2.0` — Phase 1~3 완료 · Epic 3 완료 (release 브랜치 배포 채널 전환) · Plugin 배포 dry-run 진행 중
 > **Origin**: [`alruminum/realworld-harness`](https://github.com/alruminum/realworld-harness) fork-and-refactor
 > **Spec**: [`docs/plugin/prose-only-principle.md`](docs/plugin/prose-only-principle.md) (Prose-Only 원칙)
 

--- a/docs/archive/change_rationale_history.md
+++ b/docs/archive/change_rationale_history.md
@@ -2615,3 +2615,19 @@
 - **Follow-Up**:
   - Story 2.3 (#159) 에서 `docs/plugin/skill-guidelines.md` 를 `docs/plugin/` 폴더 이동 대상에 포함 확인.
   - Story 2.5 (#161) 에서 agents/ 파일 내 `dcness-guidelines` 잔여 참조 확인 (현재 없음, 검증 완료).
+
+### DCN-CHG-20260506-16
+- **Rationale**:
+  - `marketplace.json` 의 `source: "./"` 는 로컬 경로 — 실제 사용자가 plugin install 시 GitHub 브랜치 콘텐츠를 수신하려면 `{ source: "github", repo, ref }` 형태 필요 (Story 3.1 공식 spec 실측 확인).
+  - `ref: "release"` 를 지정하면 release 브랜치 콘텐츠만 plugin cache 로 복사됨 — Story 3.2 에서 release 브랜치에 `docs/internal/` · `docs/archive/` 제거 완료이므로 사용자 환경에서 자동으로 내부 문서 0.
+  - version `0.1.0-alpha` → `0.2.0` — Epic 3 = 배포 채널 근본 변경 (로컬 → release 브랜치). 알파 딱지 제거 + 명시적 버전 신호.
+- **Alternatives**:
+  1. *`source: "main"` 지정* — main 에는 `docs/internal/` · `docs/archive/` 포함. 제거 의도와 상충. 기각.
+  2. *로컬 `"./"` 유지* — 외부 사용자에게 배포 불가. Story 3 목적 미달. 기각.
+  3. *(채택)* **`ref: "release"`** — Story 3.1~3.3 인프라 위에서 동작하는 최종 전환. release-sync.yml 이 main push 마다 자동 동기화.
+- **Decision**:
+  - 옵션 3 채택. version 0.2.0 bump 동반 (배포 채널 변경 신호).
+  - `init-dcness.md` plugin cache 경로는 `dcness/*` glob — 버전 무관하게 동작, 수정 불필요.
+- **Follow-Up**:
+  - PR 머지 → release-sync.yml 자동 발화 → jajang 에서 `/plugin update dcness` + cache 검증.
+  - `~/.claude/plugins/cache/dcness/dcness/0.2.0/docs/internal/` 미존재 확인.

--- a/docs/archive/document_update_record.md
+++ b/docs/archive/document_update_record.md
@@ -1763,3 +1763,15 @@
   - `docs/process/change_rationale_history.md`
   - `PROGRESS.md`
 - **Summary**: Story 2.1 (#157) — `docs/process/dcness-guidelines.md` (257줄) 를 skill 룰과 self 룰로 분할. §8 / §9 TBD 섹션은 이슈 #174 / #175 로 등록 후 삭제. §12 self-verify 는 양쪽에 포함. DCNESS_INFRA_PATTERNS 경로 갱신 + 신규 테스트 2케이스. 총 인용처 17곳 갱신.
+
+### DCN-CHG-20260506-16
+- **Date**: 2026-05-06
+- **Change-Type**: ci
+- **Files Changed**:
+  - `.claude-plugin/marketplace.json` (source `"./"` → `{ "source": "github", "repo": "alruminum/dcNess", "ref": "release" }` + metadata.version `0.1.0-alpha` → `0.2.0`)
+  - `.claude-plugin/plugin.json` (version `0.1.0-alpha` → `0.2.0`)
+  - `docs/archive/document_update_record.md` (본 항목)
+  - `docs/archive/change_rationale_history.md`
+  - `PROGRESS.md`
+  - `README.md`
+- **Summary**: Story 3.4 (#165) — marketplace.json plugin source 를 로컬 경로(`./`)에서 GitHub release 브랜치 참조로 전환. plugin.json + marketplace.json 버전 0.2.0 bump. Epic 3 코드 작업 완료. PR 머지 후 release-sync.yml 자동 발화로 release 브랜치 갱신 → 외부 활성화 프로젝트가 `/plugin update dcness` 실행 시 docs/internal/ · docs/archive/ 미포함 release 브랜치 콘텐츠 수신.


### PR DESCRIPTION
## 변경 요약

### [epic3][story4] marketplace.json source.ref release 전환 + 0.2.0 bump
- **What**: `.claude-plugin/marketplace.json` plugin source 를 로컬 경로(`"./"`)에서 `{ "source": "github", "repo": "alruminum/dcNess", "ref": "release" }` 로 전환. `plugin.json` + `marketplace.json` metadata.version `0.1.0-alpha` → `0.2.0`.
- **Why**: Story 3.2~3.3 에서 release 브랜치 + release-sync.yml 인프라 완성. 마지막 단계로 marketplace.json 이 release 브랜치를 가리켜야 외부 사용자가 `/plugin install/update dcness` 시 `docs/internal/` · `docs/archive/` 없는 클린 콘텐츠를 수신한다.

## 결정 근거

- **source.ref 스키마**: Story 3.1 공식 spec 실측 결과 (`docs/internal/story-3-1-source-ref-verification.md`) — `{ "source": "github", "repo": "...", "ref": "..." }` 형태 검증 완료.
- **버전 0.2.0**: Epic 3 = 배포 채널 근본 변경 (로컬 → release 브랜치). 알파 딱지 제거 + 사용자에게 명시적 변화 신호. `0.1.0-beta` 대신 0.2.0 선택 — 배포 인프라 완성이 기능 변화 없는 베타 단계가 아닌 의미 있는 마일스톤이라 판단.
- **init-dcness.md 캐시 경로**: `dcness/*` glob 패턴 사용 — 버전 bump 무관 동작 확인, 수정 불필요.

## 배포 경로 검증

- [x] `.claude-plugin/marketplace.json` — plugin 사용자가 `/plugin update dcness` 시 수신하는 source 정의. **본 PR 이 핵심 변경**.
- [x] `.claude-plugin/plugin.json` — version 메타 갱신.
- [ ] **외부 dry-run** — PR 머지 후 release-sync.yml 발화 → jajang 에서 `/plugin update dcness` + `ls ~/.claude/plugins/cache/dcness/dcness/0.2.0/docs/` 검증. **PR 머지 후 별도 진행**.

## 관련 이슈

Closes #165

## 참고

- 선행: Story 3.3 (#164) PR #205 머지 완료, release 브랜치 존재 확인
- roll-back: `marketplace.json source.ref` 를 `"main"` 으로 되돌리면 즉시 복구 가능
