### PR TITLE
[issue-211] sync_release.sh EXCLUDE_PATHS 에서 harness 제거

### DIFF
--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -12,7 +12,6 @@ EXCLUDE_PATHS=(
     "docs/internal"
     "docs/archive"
     "tests"
-    "harness"
     "PROGRESS.md"
     "CLAUDE.md"
     "scripts/sync_release.sh"


### PR DESCRIPTION
## 변경 요약

### [issue-211] sync_release.sh EXCLUDE_PATHS 에서 harness 제거
- **What**: `scripts/sync_release.sh` EXCLUDE_PATHS 에서 `"harness"` 제거.
- **Why**: `scripts/dcness-helper` 가 `harness.session_state` 를 import하는데 release 브랜치에 `harness/` 가 없어 `init-dcness` 실행 시 `ModuleNotFoundError` 발생.

## 결정 근거

`harness/` 는 plugin 사용자가 실행해야 하는 코드 (`dcness-helper` → `session_state` CLI) 이므로 release 브랜치에 포함돼야 함. `tests/` 는 사용자 환경 불필요이므로 계속 제외.

## 관련 이슈

Closes #211
