### PR TITLE
[issue-171] run_review false positive 3건 + end-step staging fallback 수정

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -367,17 +367,19 @@ def detect_wastes(
                 fix=f"agents/{cur.agent}.md fail 전략 강화 또는 impl 보강",
             ))
 
-    # ECHO_VIOLATION (DCN-30-15) — prose_excerpt 가 너무 짧음
+    # ECHO_VIOLATION — prose 전체 줄 수 기준 (prose_full). prose_full 없는 레코드는 skip.
     for s in steps:
-        line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
-        if line_count < 3 and s.enum != "AMBIGUOUS":
+        if not s.prose_full:
+            continue
+        line_count = len([l for l in s.prose_full.splitlines() if l.strip()])
+        if line_count < 5 and s.enum != "AMBIGUOUS":
             findings.append(WasteFinding(
                 pattern="ECHO_VIOLATION",
                 severity="MEDIUM",
                 step_idx=s.idx,
                 agent=s.agent,
-                detail=f"{s.agent} prose 발췌 {line_count}줄 (DCN-30-15 룰 — 5~12줄 의무)",
-                fix="agents/{agent}.md / commands/quick.md 가시성 룰 재인용",
+                detail=f"{s.agent} prose {line_count}줄 (5줄 미만 — 충분한 분석 필요)",
+                fix=f"agents/{s.agent}.md 가시성 룰 강화 또는 prose 내용 보강",
             ))
 
     # PLACEHOLDER_LEAK (DCN-30-18) — Must 직결 placeholder 흔적
@@ -599,15 +601,16 @@ def detect_goods(steps: list[StepRecord]) -> list[GoodFinding]:
                 detail=f"{s.agent} enum={s.enum} (expected 정합)",
             ))
 
-    # PROSE_ECHO_OK — prose_excerpt 5~12줄 + must_fix=False
+    # PROSE_ECHO_OK — prose 충분 (5줄 이상)
     for s in steps:
-        line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
-        if 5 <= line_count <= 12:
+        check_text = s.prose_full or s.prose_excerpt
+        line_count = len([l for l in check_text.splitlines() if l.strip()])
+        if line_count >= 5:
             goods.append(GoodFinding(
                 pattern="PROSE_ECHO_OK",
                 step_idx=s.idx,
                 agent=s.agent,
-                detail=f"{s.agent} prose_excerpt {line_count}줄 (DCN-30-15 룰 정합)",
+                detail=f"{s.agent} prose {line_count}줄 (충분한 분석 포함)",
             ))
 
     # DDD_PHASE_A — architect SYSTEM_DESIGN prose 안 Domain Model 섹션 존재
@@ -900,7 +903,7 @@ def render_report(report: RunReport) -> str:
     lines.append("| # | 시작(local) | agent | mode | elapsed(s) | duration(s) | out_tok | total_tok | tool_uses | cost($) | enum | must_fix | prose줄 |")
     lines.append("|---|---|---|---|---|---|---|---|---|---|---|---|---|")
     for s in report.steps:
-        line_count = len([l for l in s.prose_excerpt.splitlines() if l.strip()])
+        line_count = len([l for l in (s.prose_full or s.prose_excerpt).splitlines() if l.strip()])
         dur_s = f"{s.duration_ms / 1000:.0f}" if s.matched_invocation else "-"
         out_tok = f"{s.output_tokens:,}" if s.matched_invocation else "-"
         tot_tok = f"{s.total_tokens:,}" if s.matched_invocation else "-"

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1121,6 +1121,22 @@ def _extract_prose_summary(prose: str, *, max_lines: int = _SUMMARY_LINE_LIMIT) 
     return "\n".join(out_lines)
 
 
+def _find_prose_fallback(sid: str, rid: str, agent: str, mode: Optional[str]) -> Optional[str]:
+    """hook staging 실패 시 run_dir 에서 prose 파일 패턴 탐색 fallback."""
+    try:
+        rd = run_dir(sid, rid)
+        stem = f"{agent}-{mode}" if mode else agent
+        base_path = rd / f"{stem}.md"
+        if base_path.exists():
+            return str(base_path)
+        candidates = sorted(rd.glob(f"{stem}-*.md"), key=lambda p: p.stat().st_mtime)
+        if candidates:
+            return str(candidates[-1])
+    except Exception:
+        pass
+    return None
+
+
 def _cli_end_step(args: Any) -> int:
     """sid+rid auto-detect → write_prose + interpret_with_fallback.
 
@@ -1194,6 +1210,13 @@ def _cli_end_step(args: Any) -> int:
         except Exception:
             _staged = None
         if not _staged:
+            _staged = _find_prose_fallback(sid, rid, args.agent, mode)
+            if _staged:
+                print(
+                    f"[session_state] hook staging fallback → {Path(_staged).name}",
+                    file=sys.stderr,
+                )
+        if not _staged:
             print("[session_state] --prose-file 미제공 + hook staging 없음", file=sys.stderr)
             return 1
         prose_path = Path(_staged)
@@ -1240,14 +1263,18 @@ def _cli_end_step(args: Any) -> int:
 
 _MUST_FIX_RE = re.compile(r"\bMUST[\s_-]?FIX\b", re.IGNORECASE)
 
-# DCN-CHG-20260501-09: 부정 컨텍스트 검출 — pr-reviewer 가 prose 안
-# "MUST FIX 0" / "MUST FIX 0, NICE TO HAVE 6" / "MUST FIX 없음" / "no must fix"
-# 처럼 *부정* 의미로 토큰을 쓰는 케이스 false positive 차단.
-# 자장 run-ef6c2c00 실측 — 6 pr-reviewer step 모두 같은 패턴.
+# 같은 줄 부정 패턴 — "MUST FIX 0" / "MUST FIX 없음" / "no must fix"
 _MUST_FIX_NEGATION_RE = re.compile(
-    r"\bMUST[\s_-]?FIX\b[\s:=]*"  # "MUST FIX" + 구두점/공백
-    r"(?:0(?!\s*\d)|없[음다])"      # 직후 "0" (단일 자릿수만, "10" 같은 다자릿 제외) 또는 "없음/없다"
-    r"|\bno\s+MUST[\s_-]?FIX\b",   # 또는 영어 "no MUST FIX"
+    r"\bMUST[\s_-]?FIX\b[\s:=]*"
+    r"(?:0(?!\s*\d)|없[음다])"
+    r"|\bno\s+MUST[\s_-]?FIX\b",
+    re.IGNORECASE,
+)
+# Markdown 헤더 단독 줄 — "## MUST FIX" 처럼 내용 없이 헤더만
+_MUST_FIX_HEADER_ONLY_RE = re.compile(r'^\s*#{1,6}\s*MUST[\s_-]?FIX\s*$', re.IGNORECASE)
+# 헤더 다음 줄 부정 패턴 — "없음." / "0건" / "해당 없음" 등
+_NEXT_LINE_NEGATION_RE = re.compile(
+    r'^(?:없[음다]\.?|0건|0개|해당\s*없[음다]\.?|없습니다\.?)\s*$',
     re.IGNORECASE,
 )
 
@@ -1256,19 +1283,26 @@ def _has_positive_must_fix(prose: str) -> bool:
     """prose 안 MUST FIX 가 *positive* (실제 fix 요청) 의미로 등장했는지.
 
     검사 절차:
-      1. `MUST FIX` 매칭 0개 → False (없음)
-      2. 라인 단위 — 매칭 라인 중 *부정 컨텍스트 아닌* 라인 1개 이상 → True
-      3. 모든 매칭 라인이 부정 컨텍스트 → False
-
-    DCN-CHG-20260501-09 규제 — 단순 단어경계 매칭의 false positive 차단.
+      1. MUST FIX 매칭 0개 → False
+      2. 라인 단위 — 같은 줄 부정 컨텍스트 → skip
+      3. Markdown 헤더 단독 줄 (## MUST FIX) → 다음 비어있지 않은 줄이 부정이면 skip
+      4. 위 조건 모두 통과 → True (실제 fix 항목 존재)
     """
     if not _MUST_FIX_RE.search(prose):
         return False
-    for line in prose.splitlines():
+    lines = prose.splitlines()
+    for i, line in enumerate(lines):
         if not _MUST_FIX_RE.search(line):
             continue
         if _MUST_FIX_NEGATION_RE.search(line):
-            continue  # 부정 라인 — skip
+            continue  # 같은 줄 부정
+        if _MUST_FIX_HEADER_ONLY_RE.match(line):
+            # 헤더 단독 줄 — 다음 의미있는 줄 확인
+            next_content = next(
+                (l.strip() for l in lines[i + 1:] if l.strip()), ""
+            )
+            if not next_content or _NEXT_LINE_NEGATION_RE.match(next_content):
+                continue  # 다음 줄이 없거나 부정 → false positive
         return True
     return False
 

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -150,12 +150,24 @@ class WasteDetectionTests(unittest.TestCase):
         self.assertIn("RETRY_SAME_FAIL", kinds)
 
     def test_echo_violation(self):
+        # prose_full 이 짧을 때만 ECHO_VIOLATION (prose_excerpt 기준 X)
+        steps = [
+            StepRecord(idx=0, ts="t", agent="architect", mode="MODULE_PLAN",
+                       enum="READY_FOR_IMPL", must_fix=False,
+                       prose_excerpt="too short",
+                       prose_full="too short\n"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "ECHO_VIOLATION" for w in wastes))
+
+    def test_echo_violation_no_prose_full_skipped(self):
+        # prose_full 없으면 오탐 방지 — skip
         steps = [
             StepRecord(idx=0, ts="t", agent="architect", mode="MODULE_PLAN",
                        enum="READY_FOR_IMPL", must_fix=False, prose_excerpt="too short"),
         ]
         wastes = detect_wastes(steps)
-        self.assertTrue(any(w.pattern == "ECHO_VIOLATION" for w in wastes))
+        self.assertFalse(any(w.pattern == "ECHO_VIOLATION" for w in wastes))
 
     def test_placeholder_leak(self):
         steps = [


### PR DESCRIPTION
## Summary
- `harness/run_review.py`: ECHO_VIOLATION 오탐 수정 — `prose_excerpt`(1줄 요약) → `prose_full`(전체 파일) 기준으로 전환
- `harness/session_state.py`: `_has_positive_must_fix` — `## MUST FIX` 헤더 다음 줄 `없음.` 패턴 부정 인식 추가
- `harness/session_state.py`: `end-step` hook staging 실패 시 run_dir 파일시스템 fallback 추가
- Closes #171

## 배포 경로 검증
- plug-in 본체 파일 (`harness/`) 수정 → release 브랜치 재sync 시 반영

## Test plan
- [x] 377 tests all passing
- [x] ECHO_VIOLATION: prose_full 없는 레코드 skip 동작 확인
- [x] must_fix: `## MUST FIX\n\n없음.` → False, 실제 항목 있는 경우 → True 검증
- [x] end-step fallback: hook staging 실패 시 run_dir 파일 자동 탐색

🤖 Generated with [Claude Code](https://claude.com/claude-code)