### PR TITLE
[docs] release 0.2.1 marketplace + plugin metadata bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.0"
+    "version": "0.2.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/scripts/sync_local_plugin.sh
+++ b/scripts/sync_local_plugin.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+# sync_local_plugin.sh — dcNess repo → 로컬 plugin 경로 동기화 (테스트용)
+# sync_release.sh 와 동일한 EXCLUDE_PATHS 사용.
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+DEST="$HOME/.claude/plugins/marketplaces/dcness"
+
+rsync -a --delete \
+    --exclude=docs/internal \
+    --exclude=docs/archive \
+    --exclude=tests \
+    --exclude=PROGRESS.md \
+    --exclude=CLAUDE.md \
+    --exclude=scripts/sync_release.sh \
+    --exclude=scripts/sync_local_plugin.sh \
+    --exclude=.github/workflows/python-tests.yml \
+    --exclude=.github/workflows/release-sync.yml \
+    --exclude=.claude \
+    "$REPO_ROOT/" "$DEST/"
+
+echo "✔ synced to $DEST"

--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -15,6 +15,7 @@ EXCLUDE_PATHS=(
     "PROGRESS.md"
     "CLAUDE.md"
     "scripts/sync_release.sh"
+    "scripts/sync_local_plugin.sh"
     ".github/workflows/python-tests.yml"
     ".github/workflows/release-sync.yml"
     ".claude"


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.1 marketplace + plugin metadata bump
- **What**: `marketplace.json` `metadata.version` + `plugin.json` `version` 둘 다 0.2.1 로 bump. dcness self 로컬 sync 도구 (`sync_local_plugin.sh`) 신규 commit + `sync_release.sh` EXCLUDE_PATHS 에 추가 (release 브랜치 노출 차단).
- **Why**: `claude plugin update dcness@dcness` 가 `marketplace.json` `metadata.version` 만 비교. `plugin.json` 만 bump 해도 사용자 환경에서 인지 불가 — Option A (마켓 정리 + release sync) 진행.

## 결정 근거

- 단일 commit 으로 묶음 — release 메타와 self 도구 commit 을 분리하면 release 흐름 추적 어려움
- `sync_local_plugin.sh` 는 dcness self 전용 도구 → release 브랜치 EXCLUDE 의무

## 관련 이슈

-

## 참고

머지 후 `bash scripts/sync_release.sh --yes` 로 release 브랜치 force-push → `claude plugin update dcness@dcness` 가 0.2.1 인지.