### PR TITLE
[docs] release 0.2.2 plugin metadata bump

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.1"
+    "version": "0.2.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",


### PR DESCRIPTION
## Summary
- plugin.json / marketplace.json 버전 0.2.1 → 0.2.2
- 이번 릴리즈부터 git tag 병행 관리 시작

## 배포 경로 검증
- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` — plug-in 배포물 직접 갱신

## Test plan
- [ ] 버전 필드 0.2.2 확인