### PR TITLE
[docs] release 0.2.3 — marketplace source 복구 (update 수정)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,16 +8,12 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.2"
+    "version": "0.2.3"
   },
   "plugins": [
     {
       "name": "dcness",
-      "source": {
-        "source": "github",
-        "repo": "alruminum/dcNess",
-        "ref": "release"
-      },
+      "source": "./",
       "description": "Prose-only harness — agent 자유 prose emit, harness 가 메타 LLM 으로 결론 해석. 형식 강제 사다리 폐기.",
       "category": "development",
       "tags": [

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",


### PR DESCRIPTION
## Summary
- `marketplace.json` plugins[].source: github object → `"./"` 복구
- `claude plugin update` 정상 동작 수정
- plugin.json / marketplace.json 버전 0.2.2 → 0.2.3

## 원인
`e68a440`에서 `./"` → github object 형식으로 잘못 변경됨. `install`은 두 포맷 모두 동작하지만 `update`는 `"./"` 만 동작.

## 배포 경로 검증
- `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json` 직접 갱신

## Test plan
- [ ] 버전 0.2.3 확인
- [ ] `claude plugin update dcness@dcness` 정상 동작 확인