### PR TITLE
[docs] 플러그인 릴리즈 절차 + 릴리즈 노트 문서 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@
 | [`scripts/check_python_tests.sh`](scripts/check_python_tests.sh) | pytest 게이트 구현 참조 시 |
 | [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook 수정 시 |
 | [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook 수정 시 |
+| [`docs/internal/plugin-release.md`](docs/internal/plugin-release.md) | 플러그인 릴리즈·버전 배포 요청 시 — 순서·태그·주의사항 |
+| [`docs/internal/release-notes.md`](docs/internal/release-notes.md) | 릴리즈 노트 기록 — 버전별 커밋 범위·변경 요약 |
 
 ## 4. 개발 명령어
 

--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -1,0 +1,59 @@
+# 플러그인 릴리즈 절차
+
+## 1. 버전 파일 위치
+
+두 파일을 항상 같은 버전으로 동시에 올린다.
+
+| 파일 | 필드 |
+|---|---|
+| `.claude-plugin/plugin.json` | `"version"` |
+| `.claude-plugin/marketplace.json` | `"metadata.version"` |
+
+## 2. 주의사항 — marketplace.json source 형식
+
+`plugins[].source` 는 반드시 `"./"` 형식이어야 한다.
+
+```json
+"source": "./"   ✅
+```
+
+GitHub object 형식(`{"source": "github", "repo": "...", "ref": "release"}`)은 `claude plugin install`(신규)은 동작하지만 `claude plugin update`에서 "destination is empty after copy" 오류 발생. (0.2.3에서 수정됨)
+
+## 3. 릴리즈 순서
+
+```sh
+# 1. 브랜치 생성
+git checkout -b docs/release_{버전}_{설명} main
+
+# 2. 버전 bump
+#    .claude-plugin/plugin.json     "version" 필드
+#    .claude-plugin/marketplace.json "metadata.version" 필드
+
+# 3. 커밋
+git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
+git commit -m "[docs] release {버전} — {설명}"
+
+# 4. PR 생성 → CI PASS → merge
+git push -u origin docs/release_{버전}_{설명}
+gh pr create --title "[docs] release {버전} — {설명}" ...
+gh pr merge {번호} --merge
+
+# 5. main pull 후 태그 박기
+git checkout main && git pull
+git tag v{버전} && git push origin v{버전}
+```
+
+## 4. 릴리즈 후 사용자 검증 방법
+
+```sh
+claude plugin marketplace update dcness
+claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness
+cat ~/.claude/plugins/installed_plugins.json | python3 -c \
+  "import json,sys;d=json.load(sys.stdin);print(d['plugins']['dcness@dcness'][0]['version'])"
+```
+
+> `claude plugin update dcness@dcness` 는 현재 정상 동작하나, 문제 발생 시 uninstall → install 로 대체.
+
+## 5. 릴리즈 노트 관리
+
+[`docs/internal/release-notes.md`](release-notes.md) 에 버전별 변경 요약 기록.

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -1,0 +1,37 @@
+# 릴리즈 노트
+
+> 버전별 변경 요약. 상세 커밋은 `git log {prev_tag}..{tag}` 참조.
+
+---
+
+## v0.2.3 (2026-05-07)
+
+**커밋 범위**: `bfd500d..0fb69df`  
+**핵심 변경**: `claude plugin update` 버그 수정
+
+- `marketplace.json` `plugins[].source` 를 github object → `"./"` 로 복구
+- 신규 install 은 두 포맷 모두 동작했으나, update 는 `"./"` 만 동작함을 확인 (`e68a440` 에서 잘못 변경된 것)
+- git 태그 관리 시작 (이 버전부터 `v{버전}` 태그 병행)
+
+---
+
+## v0.2.2 (2026-05-07)
+
+**커밋 범위**: `ff3ae5b..bfd500d`  
+**핵심 변경**: 내부 문서 구조 정리 + dcness-rules 전면 재편
+
+- `dcness-rules.md` 전면 재편 — 대원칙 신설, 루프 구조화, prose-only 통합 (issue-223)
+- `main-claude-rules.md`, `self-guidelines.md`, `governance.md`, `branch-protection-setup.md` 삭제 — 역할 흡수 또는 중복 제거
+- `CLAUDE.md §3` lazy 표 누락 파일 보완
+
+---
+
+## v0.2.1 (2026-05-07)
+
+**커밋**: `ff3ae5bcdbd62c8f2240ca94f31d593133634101` (release branch HEAD)  
+**핵심 변경**: marketplace 배포 경로 정비 + 로컬 게이트 강화
+
+- release 브랜치에서 `marketplace.json` 제거 (sync_local_plugin.sh 폐기, issue-221)
+- `dcness-rules.md` 로 rename + 정제 (issue-217)
+- cc-pre-commit.sh 브랜치명·PR 제목 로컬 게이트 추가 (issue-171)
+- run_review false positive 수정 (issue-171)


### PR DESCRIPTION
## Summary
- `docs/internal/plugin-release.md`: 릴리즈 순서 / 버전 파일 위치 / source 포맷 주의사항 / 검증 방법
- `docs/internal/release-notes.md`: v0.2.1~v0.2.3 커밋 범위·변경 요약
- `CLAUDE.md §3` lazy 표에 두 파일 등록 — 릴리즈 요청 시 읽고 버전 bump 여부 확인

## 배포 경로 검증
docs/internal/ 은 release 브랜치 미포함 (내부 문서). CLAUDE.md 만 plug-in 배포물.

## Test plan
- [ ] docs/internal/ 두 파일 내용 확인
- [ ] CLAUDE.md §3 lazy 표 항목 확인