### PR TITLE
[issue-232] PostToolUse prose 추출 전면 실패 수정 — tool_response list 포맷 처리

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -507,12 +507,18 @@ def handle_posttooluse_agent(
 
     rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
 
-    # prose auto-staging — tool_response.text → run_dir 에 저장, current_step.prose_file 기록
+    # prose auto-staging — tool_response → run_dir 에 저장, current_step.prose_file 기록
     if rid:
         try:
-            raw_response = stdin_data.get("tool_response") or {}
+            raw_response = stdin_data.get("tool_response")
             prose_text = ""
-            if isinstance(raw_response, dict):
+            if isinstance(raw_response, list):
+                # CC Agent PostToolUse 실제 포맷: [{"type": "text", "text": "..."}]
+                for block in raw_response:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        prose_text = str(block.get("text", "") or "")
+                        break
+            elif isinstance(raw_response, dict):
                 prose_text = str(raw_response.get("text", "") or "")
             elif isinstance(raw_response, str):
                 prose_text = raw_response

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -196,6 +196,14 @@ def find_run_dir(sessions_root: Path, run_id: Optional[str], use_latest: bool) -
         for rd in list_runs(sessions_root):
             if rd.name == run_id:
                 return rd
+        # .steps.jsonl 없는 run 도 직접 탐색 (prose staging 실패 등 부분 완료 run)
+        for sid_dir in sessions_root.iterdir():
+            runs_dir = sid_dir / "runs"
+            if not runs_dir.is_dir():
+                continue
+            cand = runs_dir / run_id
+            if cand.is_dir():
+                return cand
         return None
     if use_latest:
         runs = list_runs(sessions_root)

--- a/hooks/post-agent-clear.sh
+++ b/hooks/post-agent-clear.sh
@@ -24,6 +24,6 @@ python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
 
 CC_PID=$PPID
 
-# stdout (JSON) 그대로 통과시킴 — stderr 만 silence.
-python3 -m harness.hooks posttooluse-agent --cc-pid "$CC_PID" 2>/dev/null || true
+# stdout (JSON) 그대로 통과시킴 — stderr 는 /tmp 에 보존 (디버그용).
+python3 -m harness.hooks posttooluse-agent --cc-pid "$CC_PID" 2>>/tmp/dcness-hook-stderr.log || true
 exit 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1142,7 +1142,7 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
             "tool_input": {
                 "subagent_type": sub_type,
             },
-            "tool_response": {"type": "text", "text": prose},
+            "tool_response": [{"type": "text", "text": prose}],
         }
 
     def _set_current_step(self, agent: str, mode: Optional[str]) -> None:
@@ -1195,6 +1195,60 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
         self._set_current_step("qa", None)
         rc = handle_posttooluse_agent(
             stdin_data=self._payload_with_prose("qa", "qa", None, "   "),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertFalse(expected.exists())
+
+    def test_tool_response_dict_format_fallback(self) -> None:
+        """dict 포맷 ({\"text\": ...}) 하위호환 — CC 포맷 변경 전 방어."""
+        self._set_current_step("qa", None)
+        prose = "## 결론\nPASS\n"
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "qa"},
+                "tool_response": {"type": "text", "text": prose},
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertTrue(expected.exists())
+        self.assertEqual(expected.read_text(encoding="utf-8"), prose)
+
+    def test_tool_response_string_format_fallback(self) -> None:
+        """string 포맷 하위호환."""
+        self._set_current_step("qa", None)
+        prose = "## 결론\nPASS\n"
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "qa"},
+                "tool_response": prose,
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertTrue(expected.exists())
+
+    def test_tool_response_empty_list_no_staging(self) -> None:
+        """빈 list → prose 없음."""
+        self._set_current_step("qa", None)
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "qa"},
+                "tool_response": [],
+            },
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )


### PR DESCRIPTION
## Summary

- `handle_posttooluse_agent()`가 CC Agent tool의 실제 `tool_response` 포맷 `[{"type": "text", "text": "..."}]` (list)을 처리 못해 prose auto-staging 전면 실패
- 테스트도 dict 포맷으로 작성돼 실제 CC 포맷 검증 누락
- `find_run_dir`가 `.steps.jsonl` 없는 run을 미탐지
- `post-agent-clear.sh` stderr 묵살로 디버그 불가

## 변경 사항

- **harness/hooks.py**: list 포맷 처리 추가 (CC 실제 포맷), dict/str fallback 유지
- **tests/test_hooks.py**: `_payload_with_prose` → list 포맷 수정, dict/str/empty-list fallback 테스트 3개 추가
- **harness/run_review.py**: `find_run_dir`에 `.steps.jsonl` 없는 run 직접 탐색 fallback 추가
- **hooks/post-agent-clear.sh**: `2>/dev/null` → `/tmp/dcness-hook-stderr.log` 리다이렉트

## Test plan

- [x] 380 tests passed (기존 + 신규 3개 fallback 포맷 테스트)
- [x] pre-commit hook PASS

## Root cause

DCN-CHG-20260501-15에서 prose auto-staging 추가 시 `tool_response = {"text": "..."}` (dict)로 가정했으나 CC는 실제로 `[{"type": "text", "text": "..."}]` (list) 전송. 당시에는 skill이 `--prose-file`을 명시적으로 전달해서 영향 없었으나, 이후 loop-procedure.md 업데이트로 `--prose-file` 생략 → hook 버그 노출.

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)