### PR TITLE
[docs] release 0.2.4 — PostToolUse list 포맷 prose 추출 수정

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,16 @@
 
 ---
 
+## v0.2.4 (2026-05-07)
+
+**커밋 범위**: `0fb69df..6038ceb`  
+**핵심 변경**: PostToolUse prose 추출 전면 실패 수정
+
+- PostToolUse hook 에서 tool_response 가 list 포맷일 때 prose 추출 전면 실패하던 버그 수정 (issue-232)
+- `plugin-release.md` 'bump' → '버전 올리기' 표현 개선
+
+---
+
 ## v0.2.3 (2026-05-07)
 
 **커밋 범위**: `bfd500d..0fb69df`  


### PR DESCRIPTION
## 변경 내용

- `plugin.json`, `marketplace.json` 버전 0.2.3 → 0.2.4
- 릴리즈 노트 추가 (v0.2.4)

## 핵심 변경 (이번 버전 포함 커밋)

- PostToolUse hook에서 tool_response가 list 포맷일 때 prose 추출 전면 실패하던 버그 수정 (issue-232)
- `plugin-release.md` 표현 개선

## 배포 경로 검증

- `plugin.json` / `marketplace.json` 버전 동시 갱신 ✅