### PR TITLE
[docs] pre-push hook 추가 — main 직접 push 차단

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,7 @@ node scripts/check_document_sync.mjs
 # git hook 설치 (clone 후 1회)
 cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+cp scripts/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 
 # 하네스 단위 테스트 실행
 python3 -m unittest discover -s tests -v

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,18 @@
+#!/bin/sh
+# dcNess pre-push hook
+#
+# 설치:
+#   cp scripts/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+#
+# 게이트:
+#   main 직접 push 차단 (force push 포함)
+
+while read local_ref local_sha remote_ref remote_sha; do
+  if [ "$remote_ref" = "refs/heads/main" ]; then
+    echo "ERROR: main 직접 push 금지. branch → PR → merge 절차를 따르세요." >&2
+    echo "  gh pr create --title '...' --body '...'" >&2
+    exit 1
+  fi
+done
+
+exit 0


### PR DESCRIPTION
## Summary

- `scripts/hooks/pre-push` 추가 — `remote_ref == refs/heads/main` 이면 force push 포함 모든 push 차단
- `CLAUDE.md §4` git hook 설치 커맨드에 pre-push 설치 라인 추가

## 배포 경로 검증

- `scripts/hooks/pre-push`: plug-in 본체 파일 — 사용자 plug-in 업데이트 시 자동 적용
- `CLAUDE.md §4`: dcNess 자체 작업 가이드 업데이트

## Test plan

- [ ] `git push origin main` → "ERROR: main 직접 push 금지" 메시지 + exit 1 확인
- [ ] `git push --force origin main` → 동일하게 차단 확인
- [ ] `git push origin docs/add_pre_push_hook` → 정상 통과 확인