### PR TITLE
[docs] CI 대기 MUST 룰 추가 — gh pr merge --auto + checks --watch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,13 +127,15 @@ python3 -m unittest tests.test_signal_io -v   # 단일 모듈
 4. git commit -m "..."                      # hook 자동 게이트 (main-block + pytest)
 5. git push -u origin {브랜치명}
 6. gh pr create --title "..." --body "..."  # git-naming-spec §4~§5 템플릿
-7. gh pr merge                              # regular merge (squash 금지)
+7. gh pr merge --auto                       # regular merge (squash 금지) — CI PASS 후 자동 머지
+   gh pr checks <PR_NUMBER> --watch         # MUST: CI 완료까지 대기, 결과 확인 후 다음 진행
 8. git checkout main && git pull
 ```
 
 - **main 직접 commit/push 금지**. 항상 branch → PR → regular merge.
 - **squash merge 금지** — 커밋별 히스토리 보존 목적.
 - **branch 는 merge 후에도 삭제하지 않는다**.
+- **CI 대기 MUST**: `gh pr merge --auto` 직후 반드시 `gh pr checks <PR_NUMBER> --watch` 실행 — CI 결과 확인 전 다음 작업 진행 금지. CI FAIL 시 머지 취소 후 원인 수정.
 
 ## 6. 환경변수
 

--- a/docs/plugin/git-naming-spec.md
+++ b/docs/plugin/git-naming-spec.md
@@ -96,6 +96,11 @@ Part of #N
 2. (작업 + 커밋)
 3. git push -u origin {브랜치명}
 4. gh pr create --title "..." --body "..."
-5. gh pr merge   # regular merge — 커밋 히스토리 보존 (squash 금지)
+5. gh pr merge --auto                      # regular merge (squash 금지) — CI PASS 후 자동 머지
+   gh pr checks <PR_NUMBER> --watch        # MUST: CI 완료까지 대기, 결과 확인 후 다음 진행
 6. git checkout main && git pull
 ```
+
+- **CI 대기 MUST**: `gh pr merge --auto` 직후 반드시 `gh pr checks <PR_NUMBER> --watch` 실행.
+  CI 결과 확인 전 다음 작업 진행 금지. `<PR_NUMBER>` 는 `gh pr create` 출력에서 확인.
+- **CI FAIL 시**: 머지 취소 — 원인 파악 후 수정 커밋 → 재검증.


### PR DESCRIPTION
## 변경 요약

### [docs] CI 대기 MUST 룰 추가 — gh pr merge --auto + checks --watch
- **What**: git-naming-spec §6 및 CLAUDE.md §5 PR 절차에 CI 완료 대기 단계 추가
- **Why**: jajang PR들이 CI 완료 전 즉시 머지되어 CI 게이트가 무력화됨

## 결정 근거

gh pr merge --auto 단독 사용 시 CI 실행 중에도 머지 가능 (branch protection required checks 미설정 환경). --watch로 명시적 대기를 절차에 박아 룰로 강제.

## 관련 이슈

-

## 참고

-