### PR TITLE
[issue-237] run-25629d18 인프라 결함 4건 수정 — 콜론 표기 / qa 중복 / retry task 재활용

### DIFF
--- a/agents/qa.md
+++ b/agents/qa.md
@@ -78,7 +78,12 @@ model: sonnet
 - **1 이슈 1 설명 원칙 (절대)**: 유저가 한 이슈 설명하면 이슈 1개만 생성. 증상 여러 개·버그+피처 혼합이라도 분리 금지 — 한 본문에 모두 기술.
 - **이슈 본문 정보 의무** (형식 자유): 유저 원문 (한 글자도 수정 금지, `> ` 인용), 증상, 기대 동작, 재현 조건, 근본 원인 (파일 + 위치 + 설명), 수정 지점, QA 분류 (타입 + 심각도 + 라우팅), 체크리스트.
 - **레이블**: `FUNCTIONAL_BUG` 분류 이슈 생성 시 `BugFix` 레이블 필수 추가. 버전 정보 확인 가능하면 동적 버전 레이블 (`V0N`) 도 함께. (`BugFix` 는 `scripts/setup_labels.sh` 로 사전 생성 — 정적 레이블).
-- **이슈 생성 금지 조건**: 관련 모듈/파일 = 0 → SCOPE_ESCALATE 후 중단 / DUPLICATE_OF 로 기존 이슈 중복 / 호출자가 `issue: #N` 또는 `LOCAL-N` 으로 기존 추적 ID 전달.
+- **이슈 생성 금지 조건** (하나라도 해당 시 신규 등록 금지):
+  - 관련 모듈/파일 = 0 → SCOPE_ESCALATE 후 중단
+  - DUPLICATE_OF 로 기존 이슈 중복
+  - 호출자가 `issue: #N` / `LOCAL-N` 으로 기존 추적 ID 전달
+  - 호출자 prompt 자연어로 기존 이슈 언급 — `#N`, `이슈 #N`, `이미 등록`, `이미 생성`, `기존 이슈 N`, `등록 완료`, `이미 #N 있음` 등 *어느 형식이든* `#` 또는 "이미/기존" 키워드 + 번호 조합 발견 시 신규 등록 금지. 추적 ID 가 본문에 명시 안 된 경우엔 메인에게 추적 ID 회신 요청 (추측 금지).
+  - 위 조건 적용 시 prose 본문에 `EXISTING_ISSUE_REUSED: #N` (번호 추출 가능 시) 또는 `EXISTING_ISSUE_REUSED: TRACE_ID_MISSING` 명시.
 - **DESIGN_ISSUE 는 이슈 생성 안 함** — designer 가 Phase 0-0 에서 직접 생성.
 
 **MCP 미가용 폴백** (gh 미설치 / repo 미연결): `mcp__github__create_issue` 실패 시 Bash + `python3 -m harness.tracker create-issue` 폴백. Bash 도 실패하면 prose 본문에 `EXTERNAL_TRACKER_NEEDED` 명시 + 메인 Claude 위임 (단 결론 enum 은 분류 그대로 유지).

--- a/docs/plugin/dcness-rules.md
+++ b/docs/plugin/dcness-rules.md
@@ -170,12 +170,23 @@ REDO 판단 신호: 결과가 질문에 제대로 답하지 못함 / 같은 tool
 
 ## 3.4 step 명명 규칙
 
-같은 에이전트를 재호출할 때 begin/end-step 쌍의 이름:
+begin/end-step 은 `agent mode` **두 개 인자** 형식만 허용:
 
-| 상황 | 이름 패턴 |
-|---|---|
-| POLISH 사이클 | `engineer:POLISH-1`, `engineer:POLISH-2` |
-| TESTS_FAIL 재시도 | `engineer:IMPL-RETRY-1`, `engineer:IMPL-RETRY-2` |
+```bash
+"$HELPER" begin-step <agent> [<MODE>]
+"$HELPER" end-step   <agent> [<MODE>] --allowed-enums "..."
+```
+
+- `agent` — 소문자·하이픈만 (`^[a-z][a-z0-9-]{0,63}$`)
+- `mode` — 대문자·숫자·언더스코어만 (`^[A-Z][A-Z0-9_]{0,63}$`)
+
+**콜론 표기 금지** — `"engineer:POLISH-1"` 형식은 `_validate_agent` 거부 → prose 미기록. 같은 에이전트를 재호출할 때 동일 mode 를 반복 사용하면 occurrence 카운터가 파일명 충돌을 자동 처리한다:
+
+| 상황 | begin/end-step | 생성 파일 |
+|---|---|---|
+| POLISH 1회 | `begin-step engineer POLISH` | `engineer-POLISH.md` |
+| POLISH 2회 | `begin-step engineer POLISH` | `engineer-POLISH-1.md` |
+| IMPL 재시도 | `begin-step engineer IMPL` | `engineer-IMPL-1.md` |
 
 재호출마다 별도 begin/end-step 1쌍 필수.
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -105,6 +105,33 @@ PostToolUse hook 이 `signal_io.signal_path` 기준으로 파일명 결정:
 
 cycle 한도 = orchestration.md §5.
 
+### 3.3.1 retry / POLISH 분기 시 task 재활용 (MUST)
+
+위 표의 **재시도 / 재호출 / cycle / POLISH** 분기로 진입할 때, 신규 `TaskCreate` 금지 — *기존 task 를 `in_progress` 로 되돌린다*.
+
+| 분기 | 재활용 대상 task | 행동 |
+|---|---|---|
+| `TESTS_FAIL` → engineer 재시도 | 직전 engineer IMPL task | `TaskUpdate(<task>, in_progress)` |
+| `CHANGES_REQUESTED` → engineer POLISH | 직전 engineer IMPL task | `TaskUpdate(<task>, in_progress)` |
+| POLISH 후 pr-reviewer 재실행 | 직전 pr-reviewer task | `TaskUpdate(<task>, in_progress)` |
+| `IMPL_PARTIAL` → engineer 재호출 | 직전 engineer IMPL task | `TaskUpdate(<task>, in_progress)` |
+| `DESIGN_REVIEW_FAIL` → architect 재진입 | 직전 architect task | `TaskUpdate(<task>, in_progress)` |
+| `UX_FAIL` → ux-architect 재진입 | 직전 ux-architect task | `TaskUpdate(<task>, in_progress)` |
+| `AMBIGUOUS` 재호출 1회 | 직전 동일 agent task | `TaskUpdate(<task>, in_progress)` |
+| `SPEC_GAP_FOUND` → architect SPEC_GAP | 신규 task (다른 agent/mode) | `TaskCreate` 가능 |
+
+이유: retry / POLISH 는 *동일 step 의 재실행*. 신규 TaskCreate 시 같은 step 이 task list 에 중복 등장 → 진행 추적 오염. cycle 카운터는 step occurrence (`<agent>[-<MODE>]-N.md`) 로 보존되므로 task 는 1개로 유지.
+
+**MUST 순서** (retry / POLISH 진입 시):
+
+```
+TaskUpdate(<기존 task>, in_progress)   # 신규 TaskCreate 금지
+"$HELPER" begin-step <agent> [<MODE>]   # occurrence 자동 증가 → -N.md
+Agent(...)
+ENUM=$("$HELPER" end-step ...)
+TaskUpdate(<기존 task>, completed)
+```
+
 ### yolo 모드
 
 발화에 `yolo` / `auto` / `끝까지` / `막힘 없이` / `다 알아서` 키워드 시 ON.

--- a/docs/plugin/orchestration.md
+++ b/docs/plugin/orchestration.md
@@ -239,7 +239,7 @@ flowchart LR
 - `DESIGN_REVIEW_FAIL` → architect:SYSTEM_DESIGN 재진입 (cycle ≤ 2)
 - `DESIGN_REVIEW_ESCALATE` → 사용자 위임
 
-**sub_cycles**: 위 분기에서 재호출 시 step 이름 컨벤션 = `<agent>-RETRY-<n>` (별도 begin/end-step 1쌍, DCN-30-25).
+**sub_cycles**: 위 분기에서 재호출 시 동일 `<agent> <MODE>` 로 별도 begin/end-step 1쌍 (DCN-30-25). occurrence 카운터가 파일명 충돌을 자동 처리 — `dcness-rules.md §3.4`.
 
 ### 4.3 `impl-task-loop` 풀스펙
 
@@ -269,19 +269,19 @@ flowchart LR
 | 6 | pr-reviewer | `LGTM,CHANGES_REQUESTED` |
 
 **분기**:
-- `IMPL_PARTIAL` → engineer:IMPL-SPLIT-<n> 재호출 (split < 3, 새 context window — DCN-30-34). 초과 시 `IMPLEMENTATION_ESCALATE` (작업 분해 부족 — architect TASK_DECOMPOSE 재진입 권고).
-- `SPEC_GAP_FOUND` → architect:SPEC_GAP cycle (≤ 2) → engineer 재진입
-- `TESTS_FAIL` → engineer:IMPL-RETRY-<n> (attempt < 3, 초과 → `IMPLEMENTATION_ESCALATE`)
-- `SPEC_MISSING` → architect:SPEC_GAP
+- `IMPL_PARTIAL` → engineer IMPL 재호출 (split < 3, 새 context window — DCN-30-34). 초과 시 `IMPLEMENTATION_ESCALATE` (작업 분해 부족 — architect TASK_DECOMPOSE 재진입 권고).
+- `SPEC_GAP_FOUND` → architect SPEC_GAP cycle (≤ 2) → engineer 재진입
+- `TESTS_FAIL` → engineer IMPL 재시도 (attempt < 3, 초과 → `IMPLEMENTATION_ESCALATE`)
+- `SPEC_MISSING` → architect SPEC_GAP
 - `TECH_CONSTRAINT_CONFLICT` / `IMPLEMENTATION_ESCALATE` → 사용자 위임
-- `CHANGES_REQUESTED` → engineer:POLISH-<n> cycle (≤ 2)
-- `validator:FAIL` → engineer:IMPL-RETRY-<n>
+- `CHANGES_REQUESTED` → engineer POLISH cycle (≤ 2)
+- `validator FAIL` → engineer IMPL 재시도
 
-**sub_cycles**:
-- `architect:SPEC_GAP` (engineer/test-engineer SPEC_GAP_FOUND 시) — allowed_enums = `SPEC_GAP_RESOLVED,PRODUCT_PLANNER_ESCALATION_NEEDED,TECH_CONSTRAINT_CONFLICT`
-- `engineer:POLISH-<n>` (CHANGES_REQUESTED 시, ≤ 2) — allowed_enums = `POLISH_DONE,IMPLEMENTATION_ESCALATE`
-- `engineer:IMPL-RETRY-<n>` (TESTS_FAIL/FAIL 시, attempt < 3) — engineer:IMPL 동일
-- `engineer:IMPL-SPLIT-<n>` (IMPL_PARTIAL 시, split < 3, DCN-30-34) — engineer:IMPL 동일. prose 의 `## 남은 작업` 컨텍스트로 진입.
+**sub_cycles** (재호출 시 begin-step 은 동일 `<agent> <MODE>` 사용 — occurrence 카운터가 `<agent>-<MODE>-N.md` 자동 처리. `dcness-rules.md §3.4`):
+- `architect SPEC_GAP` (engineer/test-engineer SPEC_GAP_FOUND 시) — allowed_enums = `SPEC_GAP_RESOLVED,PRODUCT_PLANNER_ESCALATION_NEEDED,TECH_CONSTRAINT_CONFLICT`
+- `engineer POLISH` (CHANGES_REQUESTED 시, ≤ 2 회) — allowed_enums = `POLISH_DONE,IMPLEMENTATION_ESCALATE`
+- `engineer IMPL` 재시도 (TESTS_FAIL/FAIL 시, attempt < 3) — engineer IMPL 동일
+- `engineer IMPL` split (IMPL_PARTIAL 시, split < 3, DCN-30-34) — engineer IMPL 동일. prose 의 `## 남은 작업` 컨텍스트로 진입.
 
 **state-aware skip** (DCN-CHG-30-13): task 파일 끝에 `MODULE_PLAN_READY` 마커 박혀있으면 Step 2 (architect:MODULE_PLAN) skip — TaskUpdate completed("skipped") + task 파일 자체를 `<RUN_DIR>/architect-MODULE_PLAN.md` 로 복사. catastrophic §2.3.3 통과용.
 


### PR DESCRIPTION
## 변경 요약

### [issue-237] run-25629d18 인프라 결함 4건 수정

- **What**: 이슈 #237 보고된 6 결함 중 4건 코드/문서 수정 (3·4·5·6). 1·2 (ECHO_VIOLATION/MISSING_SELF_VERIFY) 는 v0.2.4 (커밋 6038ceb, issue-232) 에서 이미 fix — jajang 측 plug-in update 만 필요.
- **Why**:
  - 콜론 표기 (`engineer:POLISH-1`) 는 `signal_io.py:_AGENT_NAME_RE = ^[a-z][a-z0-9-]{0,63}$` 가 거부 → prose 미기록. 실제로는 occurrence 카운터가 자동 처리하므로 수동 suffix 가 불필요. 문서 (`dcness-rules.md §3.4`, `orchestration.md §4.2/§4.3 sub_cycles`) 가 잘못된 컨벤션 명시.
  - qa agent `agents/qa.md §이슈 등록 규칙` 의 금지 조건이 `issue: #N` / `LOCAL-N` 정형 ID 만 커버 → "이미 #215 등록됨" 같은 자연어 prompt 통과 → 신규 이슈 생성.
  - `loop-procedure.md` 가 retry/POLISH 분기 진입 시 task 재활용 vs 신규 TaskCreate 명시 부재 → 메인이 같은 step 을 task list 에 중복 생성.

## 결정 근거

- **콜론 → 공백 표기 일괄**: `engineer:IMPL-RETRY-<n>` / `engineer:IMPL-SPLIT-<n>` 등 suffix 표기는 `_count_step_occurrences` + `<agent>-<MODE>-N.md` 자동 처리되므로 doc 컨벤션을 코드 동작에 맞춤. 코드 변경은 X — 문서 정정으로 충분.
- **qa 자연어 prompt 검출**: 정규식 강제보다 키워드 휴리스틱 (`#`/`이미`/`기존` + 번호) 으로 명시. 추적 ID 본문 미명시 시 메인에게 회신 요청 (추측 금지) — Karpathy 원칙 1 정합.
- **§3.3.1 신설**: 분기별 재활용 대상 task 표 명기. cycle 카운터는 step occurrence 로 보존되므로 task 1개로 유지.
- **defect 1+2 코드 변경 X**: 이미 v0.2.4 fix. 본 PR 에 다시 패치하면 중복 — 릴리즈 노트 + plug-in update 만으로 해결.

## 관련 이슈

Closes #237

## 검증

- `python3 -m unittest discover -s tests` — 380 tests OK
- 변경 파일: `agents/qa.md`, `docs/plugin/dcness-rules.md`, `docs/plugin/loop-procedure.md`, `docs/plugin/orchestration.md` — 코드 변경 X (문서·agent prompt 만)

## 배포 경로 검증 (CLAUDE.md §0.5)

- `agents/qa.md` — plug-in 본체 (경로 1) — `claude plugin update` 시 외부 사용자 자동 적용
- `docs/plugin/*.md` — plug-in 사용자가 따라야 하는 SSOT (경로 3) — 본 저장소에서 직접 조회됨 (`CLAUDE.md` §3 lazy 표 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)