### PR TITLE
[issue-240] 루프 종료 후 finalize-run 강제 안전망 + REVIEW_READY 신호

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -92,7 +92,7 @@ PostToolUse hook 이 `signal_io.signal_path` 기준으로 파일명 결정:
 
 | ENUM | 처리 |
 |------|------|
-| advance enum (catalog 행의 `advance` 컬럼) | 다음 step |
+| advance enum (catalog 행의 `advance` 컬럼) | 다음 step 있으면 진행 / **마지막 step이면 사용자 대기 없이 즉시 Step 7** |
 | `SPEC_GAP_FOUND` | architect SPEC_GAP cycle (≤2) 또는 사용자 위임 |
 | `TESTS_FAIL` / validator `FAIL` | engineer 재시도 (attempt < 3) |
 | `SPEC_MISSING` | architect SPEC_GAP |
@@ -242,15 +242,19 @@ BACKLOG_FILE="$(dirname $(dirname $EPIC_DIR))/../backlog.md"
 
 ### 5.1 finalize-run --auto-review 호출 (DCN-30-27 자동 트리거)
 
+> **트리거**: 마지막 step advance enum 확인 직후 사용자 대기 없이 즉시 호출 — 루프 종류 무관.
+
 ```bash
 STATUS=$("$HELPER" finalize-run --expected-steps <N> --auto-review)
 "$HELPER" end-run
 echo "$STATUS"
 ```
 
-`<N>` = catalog 행 `expected_steps` 컬럼. `--auto-review` 가 in-process 로 `harness.run_review` 호출 → review 리포트가 STATUS JSON 뒤에 chained 됨. 메인 Claude 가 guidelines §4 따라 stdout character-for-character echo (Bash collapsed 회피).
+`<N>` = catalog 행 `expected_steps` 컬럼. `--auto-review` 가 in-process 로 `harness.run_review` 호출 → review 리포트가 STATUS JSON 뒤에 chained 됨.
 
-`--auto-review` 생략 시 (사용자 명시 opt-out) — `dcness-review --run-id $RUN_ID --repo $(pwd)` 수동 호출 의무 (guidelines §3).
+- review 결과는 `<run_dir>/review.md` 에 저장 + stderr 로 `[REVIEW_READY]` 신호 출력. 메인 Claude 가 guidelines §4 따라 세션에 그대로 출력.
+- **`end-run` 안전망**: `finalize-run` 미호출 상태로 `end-run` 실행 시 자동으로 `finalize-run --auto-review` 대신 실행.
+- `--auto-review` 생략 시 (사용자 명시 opt-out) — `dcness-review --run-id $RUN_ID --repo $(pwd)` 수동 호출 의무 (guidelines §3).
 
 ### 5.2 STATUS JSON 구조
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -933,6 +933,23 @@ def _cli_end_run(args: Any) -> int:
     if not sid or not rid:
         print("[session_state] sid/rid 미해결", file=sys.stderr)
         return 1
+
+    # finalize-run 미호출 시 자동 실행 — 모델이 Step 7 건너뛴 경우 안전망.
+    try:
+        import argparse as _ap
+        _live = read_live(sid)
+        _active = _live.get("active_runs", {}) if _live else {}
+        _slot = _active.get(rid, {}) if isinstance(_active, dict) else {}
+        if not _slot.get("finalized_at"):
+            print(
+                "[session_state] finalize-run 미호출 감지 — auto-running finalize-run --auto-review",
+                file=sys.stderr,
+            )
+            _fake = _ap.Namespace(expected_steps=None, auto_review=True, accumulate=False)
+            _cli_finalize_run(_fake)
+    except Exception as exc:
+        print(f"[session_state] end-run finalize guard FAIL — {exc}", file=sys.stderr)
+
     complete_run(sid, rid)
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
@@ -1425,6 +1442,18 @@ def _cli_finalize_run(args: Any) -> int:
     }
     print(json.dumps(payload, ensure_ascii=False, indent=2))
 
+    # finalized_at 플래그 — end-run 이 미호출 감지용.
+    try:
+        _live = read_live(sid)
+        _active = _live.get("active_runs", {}) if _live else {}
+        if isinstance(_active, dict) and rid in _active:
+            _slot = dict(_active[rid])
+            _slot["finalized_at"] = _now_iso()
+            _active[rid] = _slot
+            update_live(sid, active_runs=_active)
+    except Exception:
+        pass
+
     # DCN-CHG-20260430-29: --auto-review flag — in-process /run-review chained.
     # 메인 Claude 가 finalize-run 호출만 하면 review 자동 piggy-back. 의도적 skip 불가.
     # SessionEnd 훅 reject (cross-session run false positive 우려).
@@ -1432,11 +1461,29 @@ def _cli_finalize_run(args: Any) -> int:
         print()
         print("--- /run-review (auto) ---")
         try:
+            import io
             from harness import run_review as _rv  # lazy import (test mock 용이)
-            _rv.main(["--run-id", rid, "--repo", str(Path.cwd())])
-        except SystemExit:
-            # argparse sys.exit — 정상 케이스. 무시.
-            pass
+            _buf = io.StringIO()
+            _old_stdout = sys.stdout
+            sys.stdout = _buf
+            try:
+                _rv.main(["--run-id", rid, "--repo", str(Path.cwd())])
+            except SystemExit:
+                pass
+            finally:
+                sys.stdout = _old_stdout
+            review_text = _buf.getvalue()
+            if review_text:
+                print(review_text)
+                try:
+                    review_path = run_dir(sid, rid) / "review.md"
+                    review_path.write_text(review_text, encoding="utf-8")
+                    print(
+                        f"[REVIEW_READY] {review_path} — 위 리뷰를 세션에 그대로 출력할 것 (dcness-rules §4)",
+                        file=sys.stderr,
+                    )
+                except Exception:
+                    pass
         except Exception as exc:
             print(
                 f"[session_state] AUTO_REVIEW_FAIL — {type(exc).__name__}: {exc}. "


### PR DESCRIPTION
## 변경 요약

### [issue-240] 루프 종료 후 finalize-run 강제 안전망 + REVIEW_READY 신호
- **What**: end-run이 finalized_at 없으면 자동 finalize-run 실행 / review output을 review.md 저장 + stderr REVIEW_READY 신호 / loop-procedure §3.3 마지막 step → 즉시 Step 7 명시
- **Why**: 마지막 step LGTM 후 모델이 Step 7 진입 없이 멍때리는 케이스 + finalize-run 건너뛰어도 막는 gate 없던 구조적 구멍 두 개를 동시에 잡음

## 결정 근거

- pre-commit hook은 중간 커밋이 있어 불가, end-run이 유일한 "루프 완전 종료" 지점
- stderr REVIEW_READY: Bash stdout은 CC UI에서 collapsed — 모델이 직접 보는 채널로 변경

## 관련 이슈

Closes #240

## 참고

-