### PR TITLE
[docs] release 0.2.5 — 루프 종료 후 finalize-run 강제 안전망 + REVIEW_READY 신호

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.4"
+    "version": "0.2.5"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,19 @@
 
 ---
 
+## v0.2.5 (2026-05-07)
+
+**커밋 범위**: `8d097b4..6612db0`  
+**핵심 변경**: 루프 종료 후 finalize-run 강제 안전망 + REVIEW_READY 신호
+
+- `loop-procedure.md §3.3`: advance enum 마지막 step → 사용자 대기 없이 즉시 Step 7 명시 (issue-240)
+- `loop-procedure.md §5.1`: 트리거 명시 + end-run 안전망 설명 추가
+- `session_state.py _cli_finalize_run`: `finalized_at` 플래그 저장 + review → `review.md` 파일 저장 + stderr `[REVIEW_READY]` 신호
+- `session_state.py _cli_end_run`: `finalized_at` 없으면 자동 `finalize-run --auto-review` 실행
+- `dcness-rules.md`: 파일 경로 채널별 형식 분기 룰 추가 (CC 채팅 = 평문 백틱, 도큐 = 마크다운 링크)
+
+---
+
 ## v0.2.4 (2026-05-07)
 
 **커밋 범위**: `0fb69df..6038ceb`  


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.5
- **What**: 버전 0.2.4 → 0.2.5, 릴리즈 노트 추가
- **Why**: issue-240 변경사항 배포

## 결정 근거

-

## 관련 이슈

Closes #240

## 참고

-