### PR TITLE
[docs] 릴리즈 절차에 사용자 업데이트 가이드 출력 스텝 추가

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -41,6 +41,16 @@ gh pr merge {번호} --merge
 # 5. main pull 후 태그 박기
 git checkout main && git pull
 git tag v{버전} && git push origin v{버전}
+
+# 6. 사용자 업데이트 가이드 출력
+echo "---"
+echo "v{버전} 업데이트 가이드"
+echo ""
+echo "  claude plugin update dcness@dcness"
+echo ""
+echo "문제 발생 시:"
+echo "  claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness"
+echo "---"
 ```
 
 ## 4. 릴리즈 후 사용자 검증 방법

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -15,6 +15,11 @@
 - `session_state.py _cli_end_run`: `finalized_at` 없으면 자동 `finalize-run --auto-review` 실행
 - `dcness-rules.md`: 파일 경로 채널별 형식 분기 룰 추가 (CC 채팅 = 평문 백틱, 도큐 = 마크다운 링크)
 
+**업데이트**:
+```sh
+claude plugin update dcness@dcness
+```
+
 ---
 
 ## v0.2.4 (2026-05-07)


### PR DESCRIPTION
## 변경 요약

### [docs] 릴리즈 절차 — 업데이트 가이드 출력 스텝 추가
- **What**: plugin-release.md §3에 step 6 추가 (업데이트 명령어 echo), release-notes.md 각 버전 항목에 업데이트 명령어 포함
- **Why**: 릴리즈 후 사용자가 어떻게 업데이트하는지 가이드 없었음

## 결정 근거

-

## 관련 이슈

-

## 참고

-