### PR TITLE
[issue-217] post-checkout hook 추가 + 멀티 이슈 브랜치명 패턴 명시

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,7 @@ node scripts/check_document_sync.mjs
 cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
 cp scripts/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+cp scripts/hooks/post-checkout .git/hooks/post-checkout && chmod +x .git/hooks/post-checkout
 
 # 하네스 단위 테스트 실행
 python3 -m unittest discover -s tests -v

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -100,6 +100,12 @@ cp "$PLUGIN_ROOT/scripts/hooks/commit-msg" "$PROJECT_ROOT/.git/hooks/commit-msg"
 chmod +x "$PROJECT_ROOT/.git/hooks/commit-msg"
 echo "[dcness] .git/hooks/commit-msg 갱신 (thin shim → plugin SSOT 호출)"
 
+# 2. post-checkout hook (thin shim) — always-overwrite
+#    브랜치 생성/전환 직후 브랜치명 형식 검증 (위반 시 경고 + git branch -m 안내)
+cp "$PLUGIN_ROOT/scripts/hooks/post-checkout" "$PROJECT_ROOT/.git/hooks/post-checkout"
+chmod +x "$PROJECT_ROOT/.git/hooks/post-checkout"
+echo "[dcness] .git/hooks/post-checkout 갱신 (thin shim → plugin SSOT 호출)"
+
 # 2. legacy 정리 안내 — 옛 cp 패턴 잔재 제거 권고
 if [ -f "$PROJECT_ROOT/scripts/check_git_naming.mjs" ]; then
   echo "[dcness] NOTE — scripts/check_git_naming.mjs 가 사용자 repo 에 잔존. 이제 plugin SSOT 에서 호출하므로 제거 권장:"

--- a/docs/plugin/git-naming-spec.md
+++ b/docs/plugin/git-naming-spec.md
@@ -9,6 +9,7 @@
 |---|---|---|
 | 기능 구현 | `feature/epic{N}_story{N}_{desc}` | `feature/epic3_story2_create_mcp_server` |
 | 버그픽스 | `fix/issue{N}_{desc}` | `fix/issue32_duplicate_touch` |
+| 버그픽스 (복수 이슈) | `fix/issue{N}_{M}_{desc}` | `fix/issue32_45_duplicate_touch` |
 | 문서 | `docs/{desc}` | `docs/update_api_spec` |
 
 - `{desc}`: 소문자 + `_` 구분자. 공백·특수문자 금지.

--- a/scripts/check_git_naming.mjs
+++ b/scripts/check_git_naming.mjs
@@ -11,7 +11,7 @@
  * exit 1: 위반
  */
 
-const BRANCH_RE = /^(feature\/epic\d+_story\d+_.+|fix\/issue\d+_.+|docs\/.+)$/;
+const BRANCH_RE = /^(feature\/epic\d+_story\d+_.+|fix\/issue\d+(?:_\d+)*_.+|docs\/.+)$/;
 const TITLE_RE  = /^(\[epic\d+\]\[story\d+\]|\[issue-\d+\]|\[docs\]) .+/;
 
 const args = process.argv.slice(2);
@@ -28,7 +28,8 @@ if (mode === '--branch') {
     console.error(`[git-naming] FAIL — 브랜치명 형식 위반: "${value}"`);
     console.error('  허용 패턴:');
     console.error('    feature/epic{N}_story{N}_{desc}');
-    console.error('    fix/issue{N}_{desc}');
+    console.error('    fix/issue{N}_{desc}          (단일 이슈)');
+    console.error('    fix/issue{N}_{M}_{desc}      (복수 이슈)');
     console.error('    docs/{desc}');
     process.exit(1);
   }

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,42 @@
+#!/bin/sh
+# post-checkout hook — 브랜치 생성/전환 시 브랜치명 형식 즉시 경고
+# 규칙: docs/plugin/git-naming-spec.md §1 (SSOT)
+#
+# 설치:
+#   cp scripts/hooks/post-checkout .git/hooks/post-checkout && chmod +x .git/hooks/post-checkout
+#
+# post-checkout 은 git 이 exit code 를 무시 — 경고 출력 후 exit 0 (체크아웃 취소 없음)
+# 브랜치 생성 직후 이름이 잘못됐음을 알리고 git branch -m 으로 수정하도록 유도.
+
+CHECKOUT_TYPE=$3  # 1=branch checkout, 0=file checkout
+[ "$CHECKOUT_TYPE" != "1" ] && exit 0
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+case "$BRANCH" in main|master|HEAD|develop) exit 0 ;; esac
+
+resolve_plugin_script() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs"
+    return 0
+  fi
+  cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/scripts/check_git_naming.mjs" ]; then
+      echo "$cache_dir/$latest/scripts/check_git_naming.mjs"
+      return 0
+    fi
+  fi
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null)/scripts/check_git_naming.mjs"
+  [ -f "$legacy" ] && echo "$legacy" && return 0
+  return 1
+}
+
+SCRIPT_PATH=$(resolve_plugin_script)
+[ -z "$SCRIPT_PATH" ] && exit 0
+
+node "$SCRIPT_PATH" --branch "$BRANCH" || {
+  echo "  → 지금 바로 수정: git branch -m <올바른-브랜치명>" >&2
+  echo "  → 예) fix/issue32_desc  /  fix/issue32_45_desc  /  docs/desc" >&2
+}
+exit 0


### PR DESCRIPTION
## 변경 내용

- \`scripts/hooks/post-checkout\` 신규 추가 — 브랜치 생성/전환 직후 브랜치명 형식 검증. 위반 시 경고 + \`git branch -m\` 안내 (push 전 조기 감지)
- \`scripts/check_git_naming.mjs\` — BRANCH_RE를 \`fix\/issue\d+(?:_\d+)*_.+\`로 변경, 복수 이슈 패턴 명시. 에러 메시지에 단일/복수 예시 추가
- \`docs/plugin/git-naming-spec.md\` — 복수 이슈 브랜치명 예시 행 추가
- \`commands/init-dcness.md\` — post-checkout hook 설치 스텝 추가 (commit-msg 직후)
- \`CLAUDE.md §4\` — 설치 명령어에 post-checkout 추가

## 배포 경로 검증

- **plug-in 본체**: \`scripts/hooks/post-checkout\` — plugin 업데이트 시 외부 프로젝트 자동 적용
- **init-dcness 배포**: \`commands/init-dcness.md\` Step 2.6에 설치 스텝 추가 — \`/init-dcness\` 재실행 시 기존 프로젝트도 hook 설치됨

## 동작

브랜치명이 잘못된 경우 생성 직후 경고:
```
[git-naming] FAIL — 브랜치명 형식 위반: "fix/bad-name"
  → 지금 바로 수정: git branch -m <올바른-브랜치명>
```

## 멀티 이슈 지원

\`fix/issue123_456_desc\` (이슈 2개), \`fix/issue123_456_789_desc\` (이슈 3개) 모두 통과.