### PR TITLE
[issue-245] cc-pre-commit case 매칭을 CMD_FIRST_LINE 기준으로 수정

### DIFF
--- a/scripts/hooks/cc-pre-commit.sh
+++ b/scripts/hooks/cc-pre-commit.sh
@@ -42,7 +42,9 @@ resolve_naming_script() {
   return 1
 }
 
-case "$COMMAND" in
+CMD_FIRST_LINE=$(printf '%s' "$COMMAND" | head -1)
+
+case "$CMD_FIRST_LINE" in
   *"git commit"*)
     cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}" 2>/dev/null || exit 0
     current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)


### PR DESCRIPTION
## 원인

`case "$COMMAND"` 가 heredoc 확장된 멀티라인 전체를 glob 매칭 → PR body 안의 예시 코드가 브랜치 생성 게이트를 오발동.

## 수정

`CMD_FIRST_LINE=$(printf '%s' "$COMMAND" | head -1)` 로 첫 줄만 추출해 case 매칭 기준으로 사용.
브랜치명·PR 제목 파싱은 기존처럼 `$COMMAND` 전체 사용 (정상).

## 배포 경로

plug-in 본체 파일 `scripts/hooks/cc-pre-commit.sh` 직접 수정 — plugin 업데이트 시 외부 프로젝트 자동 반영.