### PR TITLE
[issue-249] self-verify anchor heading 부분 매칭 허용

### DIFF
--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -113,7 +113,7 @@ impl 에 `## Design Ref` 섹션 있거나 DESIGN_HANDOFF 패키지 직접 받은
 
 ## 자가 검증 echo 의무 (anchor 자율화 DCN-30-38)
 
-prose 결과 끝에 *자가 검증 섹션* + 검증 결과 인용 의무. **anchor 자율** — `## 자가 검증` / `## Verification` / `## 검증` / `## Self-Verify` 등 자기 판단. substance (실측 명령 + 결과 수치 인용) 만 의무.
+prose 결과 끝에 *자가 검증 섹션* + 검증 결과 인용 의무. **anchor 자율** — `## 자가 검증` / `## Verification` / `## 검증` / `## 수용 기준 검증` / `## Self-Verify` 등 자기 판단. heading 에 `검증` / `verification` / `self-verify` 단어가 포함되면 OK. substance (실측 명령 + 결과 수치 인용) 만 의무.
 
 *어느 명령을 쓸지도 자율* — grep / ls / Read / Bash / WebFetch 등. 메인이 결과 신뢰 가능하도록 근거 박힘.
 

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -99,11 +99,11 @@ DCNESS_AGENT_NAMES = set(EXPECTED_AGENT_BUDGETS.keys())
 
 # DCN-CHG-20260430-38: engineer self-verify echo anchor 옵션 (DCN-30-34 강제 → DCN-30-38 자율화).
 # prose 끝에 *어느 한 anchor* 라도 있으면 통과. 형식 자율 + substance 의무.
+# heading 라인에 검증 / verification / self-verify 단어가 *포함* 되면 매칭 (issue #249 — `## 수용 기준 검증` 같은 변형 허용).
 SELF_VERIFY_ANCHORS = [
-    r"^\s*#{1,6}\s*자가\s*검증",
-    r"^\s*#{1,6}\s*검증",
-    r"^\s*#{1,6}\s*verification",
-    r"^\s*#{1,6}\s*self[-\s]?verify",
+    r"^\s*#{1,6}[^\n]*검증",
+    r"^\s*#{1,6}[^\n]*verification",
+    r"^\s*#{1,6}[^\n]*self[-\s]?verify",
 ]
 
 
@@ -568,7 +568,8 @@ def detect_wastes(
                 agent="engineer",
                 detail=f"engineer step {s.idx} ({s.enum}) prose 에 자가 검증 anchor 부재 — "
                        f"DCN-30-34 의무 (anchor 자율: `## 자가 검증` / `## Verification` / "
-                       f"`## 검증` / `## Self-Verify` 등).",
+                       f"`## 검증` / `## 수용 기준 검증` / `## Self-Verify` 등 — heading 에 "
+                       f"검증/verification/self-verify 단어 포함하면 OK).",
                 fix="agents/engineer.md § 자가 검증 echo 의무 — prose 끝에 anchor 추가 + "
                     "실측 명령 + 결과 수치 인용. substance (검증 결과) 만 의무.",
             ))

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -646,6 +646,17 @@ class MissingSelfVerifyTests(unittest.TestCase):
         wastes = detect_wastes([s])
         self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
 
+    def test_acceptance_criteria_anchor_passes(self):
+        # issue #249 — `## 수용 기준 검증` 같이 heading 에 "검증" 포함된 변형도 통과해야 함.
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n## 수용 기준 검증\n- grep 0줄 ✓\n")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
+    def test_self_verification_anchor_passes(self):
+        s = self._engineer_step(prose_full="## 결론\nIMPL_DONE\n## Self Verification\noutput\n")
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
     def test_skipped_when_no_prose_full(self):
         # prose_full 부재 시 skip (parse 실패 case 등)
         s = self._engineer_step(prose_full="")


### PR DESCRIPTION
## 변경 요약

### [issue-249] self-verify anchor heading 부분 매칭 허용 — `## 수용 기준 검증` 통과
- **What**: `harness/run_review.py` 의 `SELF_VERIFY_ANCHORS` 정규식을 `^\s*#{1,6}[^\n]*검증` 형태로 완화. heading 라인에 `검증`/`verification`/`self-verify` 단어가 포함되면 통과. `agents/engineer.md` anchor 예시 + 룰 명시. 회귀 테스트 2 케이스 추가.
- **Why**: 정규식이 `^\s*#{1,6}\s*검증` 으로 hash 직후 `검증` 만 매칭 → `## 수용 기준 검증` 같이 수식어 붙은 변형 탐지 실패. DCN-30-38 의 "anchor 자율" 의도와 어긋난 과도한 엄격성 (#249 제보).

## 결정 근거

- 대안 1: engineer.md 에서 `## 수용 기준 검증` 사용 금지 표시 → 메인이 자연스럽게 쓴 표현을 막는 게 목적과 안 맞음.
- 채택: heading 단어 *포함* 여부로 매칭 → 자율성 확장 + 의도된 anchor 모두 흡수. false positive 위험은 낮음 (heading 에 `검증` 들어가는 경우 = 사실상 검증 섹션).

## 관련 이슈

Closes #249

## 배포 경로 검증

1. plug-in 본체 (`agents/engineer.md`) — plug-in 업데이트로 사용자 환경 자동 적용. ✓
2. `init-dcness` 복사물 — 해당 없음 (`harness/run_review.py` 는 dcness self 의 run-review skill 에서만 사용).
3. SSOT 문서 — 해당 없음.

## 테스트

- 52/52 unittest PASS (`tests.test_run_review`).
- pre-commit pytest 게이트 PASS (382 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)