### PR TITLE
[issue-216] /impl-loop 한계에 background polling 안티패턴 가드레일

### DIFF
--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -40,3 +40,7 @@ inner = `impl-task-loop` (orchestration §4.3) per task.
 ## 한계
 - task 의존성 자동 판단 X (v1 = 무조건 직렬, SD impl 목차 순서 / list 순서 = 의존 표현)
 - multi-task resume 미구현 — caveat 후 재실행 시 처음부터 (단 commit 된 task 는 정식 위치 + 파일 존재 자동 검출 → default 모드 = test-engineer 직진)
+
+## 안티패턴 (회귀 방지)
+- ❌ task N 개를 `Bash run_in_background=true` 로 동시 spawn 후 `pgrep` / `ps -p` / `tail` 로 ScheduleWakeup polling — v1 spec = 직렬. 메인이 wake 하면서 누적 컨텍스트 cache_read 비용 폭주 ([#216](https://github.com/alruminum/dcNess/issues/216) — pre-dcness RWH 시기 사례 \$1,531 / 단일 세션). ScheduleWakeup tool 가이드 (default 1200~1800s, 270s 금지) 도 동일 권고.
+- ❌ 단일 세션에 8 task 누적 진행 — 컨텍스트 4M+ 토큰까지 부풀어 모든 후속 wake 가 거대 cache_read. task 단위 새 세션 + `/smart-compact` resume 권장.


### PR DESCRIPTION
## 변경 요약

### [issue-216] /impl-loop 한계 섹션에 background polling 안티패턴 가드레일 추가
- **What**: `commands/impl-loop.md` 한계 섹션 직후 "안티패턴 (회귀 방지)" 섹션 신설 — background spawn × N + ScheduleWakeup polling 금지 + 단일 세션 누적 task 금지 가드.
- **Why**: 이슈 본문이 인용한 jajang 폭주 세션 `600e35df` 종료 시점 = **2026-04-26 23:31**, dcness `/impl-loop` skill 도입 (`commit 7e30437`) **2026-04-30** *4일 전*. 즉 폭주는 RWH 잔재. 실측: dcness 시기 (4-30~현재) jajang 698 세션 ScheduleWakeup 폭주 재현 0건. 다만 회귀 방지용 가드는 박을 가치 있음.

## 결정 근거

- 대안 1 (이슈 그대로 — A안 default delay 상향): ScheduleWakeup tool 본체가 이미 `default 1200~1800s` 가이드 박혀있음. dcness 측 추가 변경 ROI 의문.
- 대안 2 (B안 Monitor 채택 / C안 세션 분리): 발생 안 한 회귀 대비 큰 인프라. 가드레일만 박고 실 발생 시 대응 권고.
- 채택: 안티패턴 명시 1 섹션. 미래 자율 메인이 같은 패턴 시도 시 차단.

## 관련 이슈

Closes #216

## 배포 경로 검증 (CLAUDE.md §0.5)

1. **plug-in 본체** (`commands/impl-loop.md`) — plug-in 업데이트로 사용자 환경 자동 적용. ✓
2. init-dcness 복사물 / SSOT 문서 — 해당 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)