### PR TITLE
[issue-225] finalize-run --auto-review 가 자동으로 loop-insights accumulate

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -257,6 +257,7 @@ echo "$STATUS"
 - review 결과는 `<run_dir>/review.md` 에 저장 + stderr 로 `[REVIEW_READY]` 신호 출력. 메인 Claude 가 guidelines §4 따라 세션에 그대로 출력.
 - **`end-run` 안전망**: `finalize-run` 미호출 상태로 `end-run` 실행 시 자동으로 `finalize-run --auto-review` 대신 실행.
 - `--auto-review` 생략 시 (사용자 명시 opt-out) — `dcness-review --run-id $RUN_ID --repo $(pwd)` 수동 호출 의무 (guidelines §3).
+- **loop-insights 자동 누적** (issue #225): `--auto-review` 가 켜지면 동일 라이프사이클로 `redo-log` + WASTE/GOOD findings → `.claude/loop-insights/<agent>[-<mode>].md` 누적. 다음 run 의 `begin-step` 이 자동 read & 주입. 명시 opt-out 시 `--no-accumulate` 추가.
 
 ### 5.2 STATUS JSON 구조
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -945,7 +945,12 @@ def _cli_end_run(args: Any) -> int:
                 "[session_state] finalize-run 미호출 감지 — auto-running finalize-run --auto-review",
                 file=sys.stderr,
             )
-            _fake = _ap.Namespace(expected_steps=None, auto_review=True, accumulate=False)
+            _fake = _ap.Namespace(
+                expected_steps=None,
+                auto_review=True,
+                accumulate=False,
+                no_accumulate=False,
+            )
             _cli_finalize_run(_fake)
     except Exception as exc:
         print(f"[session_state] end-run finalize guard FAIL — {exc}", file=sys.stderr)
@@ -1491,9 +1496,17 @@ def _cli_finalize_run(args: Any) -> int:
                 file=sys.stderr,
             )
 
-    # DCN-CHG-20260502-02: --accumulate — redo-log + WASTE/GOOD findings →
-    # .claude/loop-insights/<agent>[-<mode>].md 에 누적 (프로젝트 레벨 학습).
-    if getattr(args, "accumulate", False):
+    # DCN-CHG-20260502-02 + issue #225: --accumulate — redo-log + WASTE/GOOD
+    # findings → .claude/loop-insights/<agent>[-<mode>].md 에 누적 (프로젝트
+    # 레벨 학습).
+    # issue #225: --auto-review 켜진 경우 자동 accumulate (review 와 학습 누적
+    # = 동일 라이프사이클). --no-accumulate 로 명시 opt-out 가능.
+    _explicit_accumulate = getattr(args, "accumulate", False)
+    _auto_accumulate = (
+        getattr(args, "auto_review", False)
+        and not getattr(args, "no_accumulate", False)
+    )
+    if _explicit_accumulate or _auto_accumulate:
         print()
         print("--- loop-insights accumulate ---")
         try:
@@ -1713,7 +1726,13 @@ def _build_arg_parser() -> Any:
     p_fr.add_argument(
         "--accumulate",
         action="store_true",
-        help="redo-log + WASTE/GOOD → .claude/loop-insights/<agent>.md 누적 (DCN-CHG-20260502-02)",
+        help="redo-log + WASTE/GOOD → .claude/loop-insights/<agent>.md 누적 (DCN-CHG-20260502-02). issue #225: --auto-review 켜지면 자동 발동 — 본 flag 명시 호출은 --auto-review 없는 환경에서만 의미.",
+    )
+    p_fr.add_argument(
+        "--no-accumulate",
+        action="store_true",
+        dest="no_accumulate",
+        help="--auto-review 자동 accumulate 비활성 (issue #225). 명시 opt-out 시에만 사용.",
     )
     p_fr.set_defaults(func=_cli_finalize_run)
 

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1019,6 +1019,82 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertFalse(called["hit"])
         self.assertNotIn("/run-review (auto)", out.getvalue())
 
+    def test_finalize_run_auto_review_triggers_accumulate(self) -> None:
+        # issue #225: --auto-review 가 켜지면 loop-insights accumulate 자동 발동.
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest.mock import patch
+
+        called = {"li_hit": False}
+
+        def fake_li(sid, rid, cwd):
+            called["li_hit"] = True
+            return []
+
+        out = StringIO()
+        err = StringIO()
+        with patch("harness.run_review.main", return_value=0), \
+             patch("harness.loop_insights.append_from_run", side_effect=fake_li):
+            with redirect_stderr(err), redirect_stdout(out):
+                rc = ss._cli_finalize_run(SimpleNamespace(
+                    expected_steps=None, auto_review=True,
+                ))
+        self.assertEqual(rc, 0)
+        self.assertTrue(called["li_hit"], "auto-review 켜졌으면 accumulate 자동 발동 (issue #225)")
+        self.assertIn("--- loop-insights accumulate ---", out.getvalue())
+
+    def test_finalize_run_no_accumulate_opt_out(self) -> None:
+        # issue #225: --no-accumulate 명시 시 auto-review 켜져도 accumulate skip.
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest.mock import patch
+
+        called = {"li_hit": False}
+
+        def fake_li(sid, rid, cwd):
+            called["li_hit"] = True
+            return []
+
+        out = StringIO()
+        err = StringIO()
+        with patch("harness.run_review.main", return_value=0), \
+             patch("harness.loop_insights.append_from_run", side_effect=fake_li):
+            with redirect_stderr(err), redirect_stdout(out):
+                rc = ss._cli_finalize_run(SimpleNamespace(
+                    expected_steps=None, auto_review=True, no_accumulate=True,
+                ))
+        self.assertEqual(rc, 0)
+        self.assertFalse(called["li_hit"], "--no-accumulate opt-out 시 발동 안 함")
+        self.assertNotIn("--- loop-insights accumulate ---", out.getvalue())
+
+    def test_finalize_run_explicit_accumulate_without_auto_review(self) -> None:
+        # back-compat: --auto-review 없이 --accumulate 만 박아도 발동 (기존 호출 보존).
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+        from unittest.mock import patch
+
+        called = {"li_hit": False}
+
+        def fake_li(sid, rid, cwd):
+            called["li_hit"] = True
+            return []
+
+        out = StringIO()
+        err = StringIO()
+        with patch("harness.loop_insights.append_from_run", side_effect=fake_li):
+            with redirect_stderr(err), redirect_stdout(out):
+                rc = ss._cli_finalize_run(SimpleNamespace(
+                    expected_steps=None, auto_review=False, accumulate=True,
+                ))
+        self.assertEqual(rc, 0)
+        self.assertTrue(called["li_hit"], "명시 --accumulate 호출 보존")
+
     def _setup_fake_cc_jsonl(self, sid: str, engineer_counts: list) -> Path:
         """CC session JSONL fake — engineer toolUseResult 행 N개 박음. ts 오름차순."""
         from harness.run_review import encode_repo_path_dcness


### PR DESCRIPTION
## 변경 요약

### [issue-225] finalize-run --auto-review 자동 accumulate
- **What**:
  - `harness/session_state.py:_cli_finalize_run` — `--auto-review` 켜졌으면 `--accumulate` 도 자동 발동. opt-out flag `--no-accumulate` 추가. `--accumulate` 명시 호출은 back-compat 유지.
  - `_cli_end_run` finalize 안전망 — auto-review 와 동일 라이프사이클로 accumulate 자동 발동.
  - `docs/plugin/loop-procedure.md §5.1` — loop-insights 자동 누적 명시 + opt-out 안내.
  - 신규 unittest 3건 (auto-review 자동 발동 / no-accumulate opt-out / 명시 accumulate back-compat).
- **Why**: #225 본문 §1 (hook 등록) / §2 (redo_log 자동 호출) 은 PR-1/2/3 이미 구현 완료 — 본문이 "완전 dead code" 표현했으나 jajang 운영 데이터에 redo-log.jsonl + agent-trace.jsonl 일주일치 누적되어 있음 (실측). 진짜 갭은 `--accumulate` 가 default OFF + 어디에서도 명시 호출 안 박혀 `.claude/loop-insights/` 디렉토리 0건 → 학습 사이클 작동 X. `--auto-review` 와 묶어 자동 발동시켜 누적 사이클 켬.

## 결정 근거

- 대안 1 (`--accumulate` default True 로 argparse 변경): 명시적이지만 `--auto-review` 와 라이프사이클 분리되어 의미 일관성 약함.
- 대안 2 (skill / loop-procedure 측에서 명시 박기): 모든 호출 사이트 갱신 필요 + 사용자 자동 적용 안 됨 (이미 활성화한 프로젝트는 plug-in 업데이트만 받음).
- 채택: `--auto-review` super-flag 패턴 — review = "검토 + 학습 누적" 일체. 변경 1 곳, 명시 opt-out 가능.

## 관련 이슈

Closes #225

## 후속 (별도 결정)

- `harness/run_review.py` 출력에 redo/trace enrichment 섹션 추가 (#225 §3) — 본 PR 미포함. 운영 ROI 검토 후 결정.

## 배포 경로 검증 (CLAUDE.md §0.5)

1. **plug-in 본체** (`harness/session_state.py`, `docs/plugin/loop-procedure.md`) — plug-in 업데이트로 사용자 환경 자동 반영. ✓
2. init-dcness 복사물 / SSOT 문서 사용자용: 해당 없음 (코드 변경은 plug-in cache 의 `harness/` 직접 호출).

## 테스트

- 신규 3 / 기존 finalize_run 6 / 전체 385 PASS.
- 회귀 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)