### PR TITLE
[epic1][story1] 워크트리 기본 켜짐 — 행동형 skill + dcness self

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,11 @@
 
 ## 1. 작업 절차 (모든 변경 공통)
 
+0. **워크트리 기본 켜짐** — 모든 변경 작업 진입 시 자동 `EnterWorktree(name="<목적>-{ts_short}")`. 메인 working tree 보호 + 동시 다중 세션 충돌 회피. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 (예: "워크트리 빼고") 시에만 건너뜀. 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 sub-agent 권한 자동 처리.
 1. **수정 작업**.
 2. **commit 직전**: git pre-commit hook 자동 게이트 (main-block + pytest).
 3. **branch → PR → regular merge** (직접 `main` push 금지). CI PASS 후 메인이 즉시 머지 — *사용자 수동 승인 대기 X*.
+4. **종료 시 ExitWorktree** — squash 흡수 검사 후 자동 `keep`/`remove` (`docs/plugin/loop-procedure.md §1.1`).
 
 ## 2. 게이트 요약
 

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ PR 절차: [`CLAUDE.md`](CLAUDE.md) §5.
 | `/audit-redo` | redo-log + agent-trace 결합 분석 — (sub, mode) 별 redo 빈도 + Layer 1/2 개선 후보 제안 |
 
 행동형 skill (`/quick` `/product-plan` `/impl` `/impl-loop`) 공통:
-- yolo keyword (`yolo` / `auto` / `끝까지` / `막힘 없이` / `다 알아서`) 검출 시 CLARITY/AMBIGUOUS/ESCALATE 자동 폴백 (catastrophic 룰은 hard safety)
-- worktree keyword (`worktree` / `wt` / `격리` / `isolate`) 검출 시 EnterWorktree 격리
+- yolo keyword (`yolo` / `auto` / `끝까지` / `막힘 없이` / `다 알아서`) 검출 시 CLARITY/AMBIGUOUS/ESCALATE 자동 대체 (catastrophic 룰은 hard safety)
+- **워크트리 기본 켜짐** — 진입 시 자동 EnterWorktree. 거부 표현 정규식 `워크트리\s*(빼|없|말)` (예: "워크트리 빼고") 매치 시에만 건너뜀
 
 읽기형 skill (`/qa` `/smart-compact` `/efficiency` `/run-review` `/audit-redo`) 은 keyword 무관 (read-only 분석).
 

--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -31,6 +31,9 @@ inner = `impl-task-loop` (orchestration §4.3) per task.
 ## 사전 read (skill 진입 즉시)
 `docs/plugin/loop-procedure.md` + `docs/plugin/orchestration.md` §4.3 + §4.10 + `docs/plugin/handoff-matrix.md` + `docs/plugin/issue-lifecycle.md` read 후 진행.
 
+## 워크트리 (기본 켜짐)
+Skill 진입 시 *outer* 단계에서 자동 `EnterWorktree(name="impl-loop-{ts_short}")` 1회. 모든 inner task 가 같은 워크트리 안에서 진행. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
+
 ## Pre-flight gate (각 task 진입 직전)
 [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) §6 매치 강제 — 부모 epic stories.md 의 epic/story 이슈 매치 부재 시 해당 task STOP + 사용자 보고. silent skip 금지.
 

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -33,6 +33,9 @@ UI 디자인 mid-loop 필요 시 → `impl-ui-design-loop` (orchestration §4.4)
 ## 사전 read (skill 진입 즉시)
 `docs/plugin/loop-procedure.md` + `docs/plugin/orchestration.md` §4.3 + `docs/plugin/handoff-matrix.md` + `docs/plugin/issue-lifecycle.md` read 후 진행.
 
+## 워크트리 (기본 켜짐)
+Step 0 진입 시 자동 `EnterWorktree(name="impl-{ts_short}")`. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
+
 ## Pre-flight gate (Step 0 직후)
 [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) §6 매치 강제 — 부모 epic stories.md 상단 `**GitHub Epic Issue:** [#\d+]` 또는 `미등록 (사유: …)` 매치 0건 시 즉시 STOP + 사용자 보고. silent skip 금지.
 

--- a/commands/product-plan.md
+++ b/commands/product-plan.md
@@ -31,5 +31,8 @@ description: 새 기능 / PRD 변경 / 큰 기획을 받아 product-planner → 
 ## 사전 read (skill 진입 즉시)
 `docs/plugin/loop-procedure.md` + `docs/plugin/orchestration.md` §2~§3 + §4.2 + `docs/plugin/handoff-matrix.md` read 후 진행.
 
+## 워크트리 (기본 켜짐)
+Step 0 진입 시 자동 `EnterWorktree(name="product-plan-{ts_short}")`. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
+
 ## 절차
 [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1~§6 + [`docs/plugin/orchestration.md`](../docs/plugin/orchestration.md) §4.2 (`feature-build-loop` 풀스펙) 따름. 본 파일은 input 명세 + 라우팅만.

--- a/commands/quick.md
+++ b/commands/quick.md
@@ -31,5 +31,8 @@ description: 작은 버그픽스·코드 정리를 한 줄로 받아 light path 
 ## 사전 read (skill 진입 즉시)
 `docs/plugin/loop-procedure.md` + `docs/plugin/orchestration.md` §4.5 + `docs/plugin/handoff-matrix.md` read 후 진행.
 
+## 워크트리 (기본 켜짐)
+Step 0 진입 시 자동 `EnterWorktree(name="quick-{ts_short}")`. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
+
 ## 절차
 [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1~§6 + [`docs/plugin/orchestration.md`](../docs/plugin/orchestration.md) §4.5 (`quick-bugfix-loop` 풀스펙) 따름. 본 파일은 input 명세 + 라우팅만.

--- a/commands/smart-compact.md
+++ b/commands/smart-compact.md
@@ -136,12 +136,12 @@ EOF
 - /init-dcness skill (enable/disable)
 - /ux skill (Pencil MCP 의존)
 - commands/ 카테고리 추가
-- worktree 도입 (옵션 C: keyword 트리거)
+- ~~worktree 도입~~ → 옵션 D 채택 완료 — 행동형 skill 진입 시 EnterWorktree 기본 켜짐, 거부 표현 시에만 건너뜀 (loop-procedure §1.1)
 - manual smoke (실 claude 에서 /qa /quick 검증)
 
 # 미해결 의논거리
-- worktree 도입 — 옵션 C (keyword) vs D (default opt-out) ?
-- sid fallback 처리 (worktree 진입 시 main repo .claude/ 와 어떻게 cross-ref) ?
+- ~~worktree 옵션 C vs D~~ → **D 채택 완료** (#255 정합). 행동형 skill 기본 켜짐, 거부 표현 정규식 `워크트리\s*(빼|없|말)`
+- sid 대체 처리 (worktree 진입 시 main repo .claude/ 와 어떻게 cross-ref) → γ resolution 으로 해결 (`harness/session_state.py:_default_base`, 5 tests PASS)
 
 # 컨텍스트
 - 핵심: harness/session_state.py, harness/hooks.py, hooks/*.sh, commands/*.md

--- a/docs/plugin/dcness-rules.md
+++ b/docs/plugin/dcness-rules.md
@@ -83,6 +83,8 @@
 | agent 접근 권한 (Write/Read 경계) | [`handoff-matrix.md`](handoff-matrix.md) | §4 |
 | yolo 모드 / worktree 격리 상세 | [`loop-procedure.md`](loop-procedure.md) | §3.3 yolo / §1.1 worktree |
 
+**워크트리 기본 켜짐 (#255 정합)**: 행동형 skill (`/quick` `/impl` `/impl-loop` `/product-plan`) 진입 시 자동으로 EnterWorktree 호출. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` (예: "워크트리 빼고", "워크트리 없이", "워크트리 말고") 매치 시에만 건너뜀. 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 sub-agent 권한 자동 처리. 자세히 = `loop-procedure.md §1.1`.
+
 skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure, loop spec 은 orchestration §4.
 
 ## 3. 에이전트 루프 개요

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -16,15 +16,19 @@ skill 트리거 또는 직접 발화 → 메인 Claude 가 **[`orchestration.md`
 
 ---
 
-## 1. Step 0 — worktree (선택) + begin-run
+## 1. Step 0 — worktree + begin-run
 
-### 1.1 worktree 분기
+### 1.1 worktree 분기 (기본 켜짐)
 
-발화에 `worktree` / `wt` / `격리` / `isolate` 키워드 시 진입:
+**모든 행동형 skill (`/quick` `/impl` `/impl-loop` `/product-plan`) 진입 시 EnterWorktree 자동 호출**. 동시 다중 세션 충돌 회피 + 메인 working tree 보호.
 
 ```
 EnterWorktree(name="<skill>-{ts_short}")
 ```
+
+**거부 표현 시에만 건너뜀** — 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 (예: "워크트리 빼고", "워크트리 없이", "워크트리 말고") 시 EnterWorktree 호출 0, 일반 cwd 그대로 진행.
+
+수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 자동 권한 처리. 수동 워크트리는 sub-agent Write 거부 회귀 (#255 W1).
 
 종료 시 squash 흡수 검사 후 자동:
 


### PR DESCRIPTION
## 변경 요약

### [epic1][story1] 워크트리 기본 켜짐
- **What**:
  - `loop-procedure.md §1.1` — 옵션 C → 옵션 D 전환. 행동형 skill 진입 시 자동 EnterWorktree, 거부 표현 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀.
  - `dcness-rules.md §2` — SessionStart 주입 영역 룰 추가.
  - `README.md` 행동형 skill 공통 룰 갱신.
  - `commands/quick.md` / `impl.md` / `impl-loop.md` / `product-plan.md` 각 skill 에 워크트리 섹션 추가.
  - `smart-compact.md:139~144` 미결 항목 정정.
  - `CLAUDE.md` (dcness self) §1 — self 작업도 워크트리 기본.
- **Why**: #255 W1 — 사용자 수동 `git worktree add` 워크트리에서 sub-agent (engineer) Write/Edit 거부 발생. CC permission 시스템이 EnterWorktree 워크트리만 sub-agent 권한 자동 처리, 수동 워크트리는 새 프로젝트로 인식. 룰을 *기본 켜짐* 으로 전환해 우회 자체 차단. 동시 다중 세션 충돌도 회피.

## 결정 근거

- 대안 1 (옵션 C 키워드 트리거 유지): 사용자가 매번 발화해야 하고, 메인 Claude 가 자율로 수동 git worktree 선택하면 W1 회귀.
- 대안 2 (CC permission 자동 시드 — settings.local.json 수동 갱신): CC 가 이미 EnterWorktree 로 처리하는 영역에 dcness 가 손대면 충돌.
- 채택: 옵션 D — CC native EnterWorktree 강제 + 거부 표현으로 사용자 자율 보존. 코드 변경 0, 룰만 갱신.

## 관련 이슈

Part of #255 (W1 작업 영역). W2/W3 = 이미 v0.2.3 fix (#232). W4/W5/D1 = 별도 처리.

Document-Exception-PR-Close: 본 PR 은 #255 의 W1 만 작업. 5 waste 묶음 issue 인 #255 자체 close 시 W4/W5/D1 손실 — 별도 후속 PR 에서 close 예정.

## 거부 표현

정규식 `워크트리\s*(빼|없|말)` — 매치 예: "워크트리 빼고" / "워크트리 없이" / "워크트리 말고".

## 배포 경로 검증 (CLAUDE.md §0.5)

1. plug-in 본체 (`commands/**`, `docs/plugin/**`, `README.md`) — plug-in 업데이트로 사용자 환경 자동 반영. ✓
2. init-dcness 복사물 — 해당 없음.
3. dcness self (`CLAUDE.md`) — 머지 후 self 작업 즉시 적용. ✓

## γ resolution 검증

`tests/test_session_state.py:DefaultBaseWorktreeTests` 5/5 PASS — worktree → main repo `.claude/harness-state` 단일 source 정합. EnterWorktree 진입 후 dcness helper / hooks 정상 작동 보장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)