### PR TITLE
[issue-255] W5 — hook 매처에 mcp__.* 추가

### DIFF
--- a/hooks/file-guard.sh
+++ b/hooks/file-guard.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# dcNess file-guard 훅 — PreToolUse Edit/Write/Read/Bash agent_boundary 강제
+# dcNess file-guard 훅 — PreToolUse Edit/Write/Read/Bash/mcp__.* agent_boundary 강제 + trace
 #
-# 트리거: Claude Code PreToolUse event, tool=Edit|Write|Read|Bash
+# 트리거: Claude Code PreToolUse event, tool=Edit|Write|NotebookEdit|Read|Bash|mcp__.*
+# mcp__* 도구는 boundary 검사 skip (file_path 인자 부재) + trace pre append 만 — #255 W5 정합.
 # stdin: CC payload (sessionId + tool_name + tool_input)
 # 동작: harness/hooks.py 의 handle_pretooluse_file_op 호출
 #

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash file-guard + PostToolUse Agent post-clear + PostToolUse Edit/Write/Read/Bash post-file-op-trace)",
+  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash/mcp__.* file-guard + PostToolUse Agent post-clear + PostToolUse Edit/Write/Read/Bash/mcp__.* post-file-op-trace)",
   "hooks": {
     "SessionStart": [
       {
@@ -24,7 +24,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|NotebookEdit|Read|Bash",
+        "matcher": "Edit|Write|NotebookEdit|Read|Bash|mcp__.*",
         "hooks": [
           {
             "type": "command",
@@ -46,7 +46,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|NotebookEdit|Read|Bash",
+        "matcher": "Edit|Write|NotebookEdit|Read|Bash|mcp__.*",
         "hooks": [
           {
             "type": "command",

--- a/hooks/post-file-op-trace.sh
+++ b/hooks/post-file-op-trace.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# dcNess post-file-op-trace 훅 — PostToolUse Edit/Write/Read/Bash sub 행동 trace
-# (DCN-CHG-20260501-11)
+# dcNess post-file-op-trace 훅 — PostToolUse Edit/Write/Read/Bash/mcp__.* sub 행동 trace
+# (DCN-CHG-20260501-11 + #255 W5 정합)
 #
-# 트리거: Claude Code PostToolUse event, tool=Edit|Write|NotebookEdit|Read|Bash
+# 트리거: Claude Code PostToolUse event, tool=Edit|Write|NotebookEdit|Read|Bash|mcp__.*
 # stdin: CC payload (sessionId + tool_name + tool_input + tool_response)
 # 동작: harness/hooks.py 의 handle_posttooluse_file_op 호출 — 활성 sub-agent 가
 #       있을 때만 agent-trace.jsonl 에 post phase 1줄 append.

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -838,6 +838,34 @@ class FileOpHookTests(_PreToolBase):
         )
         self.assertEqual(rc, 0)
 
+    def test_mcp_tool_passes_boundary_and_records_trace(self) -> None:
+        # #255 W5 — mcp__* 도구는 boundary 검사 skip + trace pre append.
+        # designer / qa false positive (prose-only 의심) 차단 의도.
+        from harness.session_state import (
+            start_run, generate_run_id, write_pid_current_run, write_pid_session,
+        )
+        from harness.agent_trace import histogram as _hist
+        update_live(self.sid, base_dir=self.base, active_agent="designer")
+        rid = generate_run_id()
+        start_run(self.sid, rid, "designer", base_dir=self.base)
+        write_pid_session(self.cc_pid, self.sid, base_dir=self.base)
+        write_pid_current_run(self.cc_pid, rid, base_dir=self.base)
+        rc = handle_pretooluse_file_op(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "mcp__pencil__batch_design",
+                "tool_input": {"operations": "..."},
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0, "mcp__* 도구는 boundary 차단 X — trace 만 기록")
+        hist = _hist(self.sid, rid, base_dir=self.base)
+        self.assertEqual(
+            hist.get("mcp__pencil__batch_design", 0), 1,
+            "mcp__* 도구가 histogram 에 1 카운트되어야 함",
+        )
+
 
 class PostToolUseAgentClearTests(_PreToolBase):
     def test_clears_active_agent(self) -> None:


### PR DESCRIPTION
## 변경 요약

### [issue-255] W5 — mcp__* 도구 anomaly false positive 차단
- **What**: `hooks/hooks.json` PreToolUse + PostToolUse 매처를 `Edit|Write|NotebookEdit|Read|Bash|mcp__.*` 로 확장. mcp__* 도구 trace 기록 시작 → histogram 에 잡혀 prose-only false positive 차단.
- **Why**: designer agent 가 `mcp__pencil__batch_design` 등으로 frame 정상 생성 후에도 "prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심)" anomaly false positive 발화 — 매처가 mcp__* 미매치 → trace 기록 0 → histogram 0.

## 결정 근거

- `harness/hooks.py:handle_pretooluse_file_op` 가 *이미* 표준 도구 (Read/Edit/Write/NotebookEdit/Bash) 외에는 boundary 검사 skip + trace 만 기록하는 fallback 구조. mcp__* 도구는 boundary 차단 없이 trace 만 기록 — 안전.
- 새 스크립트 추가 X. 매처 1줄 변경 + 트리거 주석 갱신 + 회귀 테스트 1건.

## 관련 이슈

Part of #255 (W5 작업 영역).

Document-Exception-PR-Close: 본 PR 은 #255 의 W5 만 작업. 5 waste 묶음 issue 인 #255 는 W4 / D1 후속 PR 머지 후 close.

## 테스트

- 신규 1: `test_mcp_tool_passes_boundary_and_records_trace`
- 386/386 unittest PASS.

## 배포 경로 검증 (CLAUDE.md §0.5)

1. plug-in 본체 (`hooks/**`) — plug-in 업데이트로 사용자 환경 자동 반영. ✓
2. init-dcness 복사물 / SSOT 문서: 해당 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)