### PR TITLE
[issue-255] W4 — pre-push hook 브랜치명 검증 추가

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -106,7 +106,14 @@ cp "$PLUGIN_ROOT/scripts/hooks/post-checkout" "$PROJECT_ROOT/.git/hooks/post-che
 chmod +x "$PROJECT_ROOT/.git/hooks/post-checkout"
 echo "[dcness] .git/hooks/post-checkout 갱신 (thin shim → plugin SSOT 호출)"
 
-# 2. legacy 정리 안내 — 옛 cp 패턴 잔재 제거 권고
+# 3. pre-push hook (thin shim) — always-overwrite
+#    push 전 브랜치명 형식 검증 — local PASS / 원격 CI FAIL mismatch 회귀 차단 (#255 W4)
+#    main 직접 push 차단 + 브랜치명 위반 차단 둘 다 수행.
+cp "$PLUGIN_ROOT/scripts/hooks/pre-push" "$PROJECT_ROOT/.git/hooks/pre-push"
+chmod +x "$PROJECT_ROOT/.git/hooks/pre-push"
+echo "[dcness] .git/hooks/pre-push 갱신 (thin shim → plugin SSOT 호출, 브랜치명 검증 + main push 차단)"
+
+# 4. legacy 정리 안내 — 옛 cp 패턴 잔재 제거 권고
 if [ -f "$PROJECT_ROOT/scripts/check_git_naming.mjs" ]; then
   echo "[dcness] NOTE — scripts/check_git_naming.mjs 가 사용자 repo 에 잔존. 이제 plugin SSOT 에서 호출하므로 제거 권장:"
   echo "         git rm scripts/check_git_naming.mjs"

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -5,14 +5,56 @@
 #   cp scripts/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 #
 # 게이트:
-#   main 직접 push 차단 (force push 포함)
+#   1. main 직접 push 차단 (force push 포함)
+#   2. 브랜치명 git-naming-spec 형식 검증 — local PASS / 원격 CI FAIL mismatch 회귀 차단 (#255 W4)
+#
+# 규칙: docs/plugin/git-naming-spec.md §1 (SSOT)
+
+resolve_plugin_script() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs"
+    return 0
+  fi
+  cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/scripts/check_git_naming.mjs" ]; then
+      echo "$cache_dir/$latest/scripts/check_git_naming.mjs"
+      return 0
+    fi
+  fi
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null)/scripts/check_git_naming.mjs"
+  [ -f "$legacy" ] && echo "$legacy" && return 0
+  return 1
+}
+
+SCRIPT_PATH=$(resolve_plugin_script)
 
 while read local_ref local_sha remote_ref remote_sha; do
+  # 1. main 직접 push 차단
   if [ "$remote_ref" = "refs/heads/main" ]; then
     echo "ERROR: main 직접 push 금지. branch → PR → merge 절차를 따르세요." >&2
     echo "  gh pr create --title '...' --body '...'" >&2
     exit 1
   fi
+
+  # 2. 브랜치명 검증 — refs/heads/<name> 추출
+  case "$remote_ref" in
+    refs/heads/*)
+      BRANCH="${remote_ref#refs/heads/}"
+      # main / master / HEAD / develop 면 skip (이미 main 차단 별도)
+      case "$BRANCH" in main|master|HEAD|develop) continue ;; esac
+
+      if [ -n "$SCRIPT_PATH" ]; then
+        if ! node "$SCRIPT_PATH" --branch "$BRANCH" >&2; then
+          echo "ERROR: 브랜치명 형식 위반 — push 차단 (#255 W4 정합)." >&2
+          echo "  로컬에서 수정: git branch -m <올바른-브랜치명>" >&2
+          echo "  허용 패턴 = docs/plugin/git-naming-spec.md §1" >&2
+          exit 1
+        fi
+      fi
+      ;;
+  esac
 done
 
 exit 0


### PR DESCRIPTION
## 변경 요약

### [issue-255] W4 — pre-push 브랜치명 검증 추가
- **What**: `scripts/hooks/pre-push` 에 push 대상 브랜치명 git-naming 검증 추가. 위반 시 push 차단 + 수정 안내. `commands/init-dcness.md` Step 2.6 #3 — 사용자 repo 에 pre-push hook 도 always-overwrite 배포.
- **Why**: 기존 local hook 은 commit-msg(title), post-checkout(경고만) 만 있고 *push 전* 브랜치명 차단 부재. local PASS 인데 원격 CI 차단 (mismatch) 회귀 — jajang #226 → rename → #227 cycle 낭비.

## 결정 근거

- 대안 1 (post-checkout 차단): post-checkout 은 git 이 exit code 무시 — 차단 불가.
- 대안 2 (commit-msg 에 브랜치명도 검사): commit 단계에서 차단되면 작업 진행 막힘. 브랜치 rename 기회 없음.
- 채택: pre-push — 작업 다 끝낸 후 push 시점 차단. 사용자가 `git branch -m` 으로 즉시 수정 후 재push 가능.

## 관련 이슈

Part of #255 (W4 작업 영역).

Document-Exception-PR-Close: 본 PR 은 #255 의 W4 만 작업. D1 후속 PR 머지 후 #255 close.

## 실측 검증

```
정상 feature/epic1_story1_test → exit 0 (PASS)
위반 feat/issue-222-foo        → exit 1 (push 차단)
main 직접 push                 → exit 1 (기존 작동)
정상 fix/issue123_foo          → exit 0 (PASS)
```

## 배포 경로 검증 (CLAUDE.md §0.5)

1. plug-in 본체 (`scripts/hooks/pre-push`) — plug-in 업데이트 자동 반영. ✓
2. init-dcness 복사물 — `commands/init-dcness.md` Step 2.6 #3 추가. ✓ (사용자가 `/init-dcness` 재실행 의무)

🤖 Generated with [Claude Code](https://claude.com/claude-code)