### PR TITLE
[issue-252] run_review POLISH self-verify anchor 의무 제외

### DIFF
--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -118,6 +118,8 @@ impl 에 `## Design Ref` 섹션 있거나 DESIGN_HANDOFF 패키지 직접 받은
 
 prose 결과 끝에 *자가 검증 섹션* + 검증 결과 인용 의무. **anchor 자율** — `## 자가 검증` / `## Verification` / `## 검증` / `## 수용 기준 검증` / `## Self-Verify` 등 자기 판단. heading 에 `검증` / `verification` / `self-verify` 단어가 포함되면 OK. substance (실측 명령 + 결과 수치 인용) 만 의무.
 
+**POLISH 제외 (#252)** — POLISH 결과 prose 는 짧은 정리 보고 (테스트 N passed / 변경 범위) 본문 자체가 검증 substance. heading anchor 강제는 잉여 형식 — `MISSING_SELF_VERIFY` 검출 대상 아님. IMPL_DONE / IMPL_PARTIAL 만 anchor 의무.
+
 *어느 명령을 쓸지도 자율* — grep / ls / Read / Bash / WebFetch 등. 메인이 결과 신뢰 가능하도록 근거 박힘.
 
 예시 (어느 한 패턴 채택):

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -553,10 +553,12 @@ def detect_wastes(
 
     # MISSING_SELF_VERIFY (DCN-CHG-20260430-38) — engineer prose 에 self-verify anchor 부재.
     # DCN-30-34 의무 (anchor 자율, substance 의무) 회귀 검출. prose_full 부재 시 skip.
+    # POLISH_DONE 은 제외 (#252) — POLISH 결과 prose 는 짧은 정리 보고 (테스트 N passed 본문 서술)
+    # 자체가 검증 substance. heading anchor 강제는 잉여 형식 + 회귀 false positive.
     for s in steps:
         if s.agent != "engineer":
             continue
-        if s.enum not in ("IMPL_DONE", "IMPL_PARTIAL", "POLISH_DONE"):
+        if s.enum not in ("IMPL_DONE", "IMPL_PARTIAL"):
             continue
         if not s.prose_full:
             continue

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -678,6 +678,16 @@ class MissingSelfVerifyTests(unittest.TestCase):
         wastes = detect_wastes([s])
         self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
 
+    def test_skipped_for_polish_done(self):
+        # #252 — POLISH 짧은 정리 보고는 본문 자체가 검증. anchor 강제 잉여.
+        s = self._engineer_step(
+            prose_full="## POLISH — earphone 헬퍼 추출\n중복 제거. 테스트 34 passed.",
+            enum="POLISH_DONE",
+        )
+        s.mode = "POLISH"
+        wastes = detect_wastes([s])
+        self.assertFalse(any(w.pattern == "MISSING_SELF_VERIFY" for w in wastes))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-252] run_review POLISH self-verify anchor 의무 제외
- **What**: `harness/run_review.py` 의 MISSING_SELF_VERIFY 검사에서 POLISH_DONE 제외 (IMPL_DONE / IMPL_PARTIAL 만 적용). agents/engineer.md § 자가 검증 echo 의무 에 POLISH 제외 명시. 회귀 방지 unittest 추가.
- **Why**: POLISH 결과 prose 는 짧은 정리 보고 (테스트 N passed / 변경 범위) — 본문 자체가 검증 substance. heading anchor 강제는 잉여 형식 → false positive 회귀.

## 결정 근거

- 두 가지 안 검토:
  - (A) POLISH 도 anchor 강제 — 잉여 형식, 사용자 의도 미부합
  - (B) POLISH 만 검출 제외 — 단순, anchor 자율화 (DCN-30-38) 와 정합
- 두 번째 waste (브랜치명 사전 검증) 는 `scripts/hooks/cc-pre-commit.sh` 의 git checkout -b 시점 + `scripts/hooks/pre-push` 의 push 시점에 이미 박혀 있음 (#255 W4). 코드 변경 없음 — `init-dcness` 가 신규 프로젝트에 자동 설치. 기존 프로젝트는 재배포 (`/init-dcness`) 받으면 됨.

## 관련 이슈

Closes #252

## 참고

- DCN-CHG-20260430-38 (anchor 자율화) 정합 유지 — POLISH 만 추가 면제
- tests/test_run_review.py::MissingSelfVerifyTests::test_skipped_for_polish_done 새 테스트