### PR TITLE
[issue-149] Step 7 caveat 회고 → 메모리 저장 의무 룰 추가

### DIFF
--- a/docs/plugin/dcness-rules.md
+++ b/docs/plugin/dcness-rules.md
@@ -69,6 +69,12 @@
 - 대상: `agents/**/*.md` / `commands/*.md` / `docs/plugin/*.md`
 - 대상 외: `PROGRESS.md` / `docs/archive/**` / 코드 / spec
 
+**Step 7 회고 → 메모리 저장 의무 — MUST (#149)**: caveat (7b) 또는 review report 의 waste finding 등 회귀 신호가 있으면 *메모리 candidate* 를 보고 양식 안에 emit + 사용자에게 저장 여부 묻기. prose 본문에만 적고 종료 = 룰 위반 (다음 세션 회귀 발생).
+- 양식 + 의무 디테일 = [`loop-procedure.md`](loop-procedure.md) §5.5
+- 후보 type: `feedback` (반복 실수 / 안티패턴) / `project` (현 작업의 결정 / 제약)
+- 후보 0 일 때도 "없음" 1줄 명시 — 양식 자체 생략 X
+- yolo 라도 메모리 candidate 양식은 emit (yolo = 사용자 결정 위임 우회 *아님* — 본인이 자율 저장 후 진행)
+
 ---
 
 ## 2. 라우팅 가이드

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -327,12 +327,20 @@ worktree 진입 시 squash 흡수 검사 후 `ExitWorktree(action="<keep|remove>
 
 ⚠️ Caveat: <has_ambiguous / has_must_fix / unexpected enum / sensitive untracked>
 
-커밋/PR 진행할까요? (branch → PR → regular merge 자동)
+📝 메모리 candidate (#149):
+- <caveat 발생 사유의 회고 — feedback / project type 후보. 다음 세션 회귀 방지용>
+- <waste finding 의 반복 패턴 (예: ECHO_VIOLATION 2회+, MISSING_SELF_VERIFY 등)>
+- <pr-reviewer NICE TO HAVE 중 자주 등장하는 항목>
+- 후보 없음 시 "없음" 1줄
+
+커밋/PR 진행할까요? (branch → PR → regular merge 자동) + 메모리 저장 진행?
 ```
 
 worktree 처리도 사용자 결정.
 
-**yolo 시**: `has_must_fix == false` + enum unexpected 만 (CHANGES_REQUESTED 1건 등) → 자동 7a 시도. `has_must_fix` 또는 `has_ambiguous` true → yolo 도 7b.
+**메모리 candidate 의무 (#149)**: caveat 발생 = 회귀 방지 신호. prose 본문에만 적고 끝내면 다음 세션에서 동일 caveat 재발. 메인은 위 양식의 *📝 메모리 candidate* 섹션을 *반드시* emit (없으면 "없음" 명시) — 사용자가 저장 여부 결정. 양식 없이 7b 보고 종료 = 룰 위반. 7a (clean) 도 review report 의 waste finding 이 있으면 같은 양식 적용.
+
+**yolo 시**: `has_must_fix == false` + enum unexpected 만 (CHANGES_REQUESTED 1건 등) → 자동 7a 시도. `has_must_fix` 또는 `has_ambiguous` true → yolo 도 7b. yolo 라도 메모리 candidate 양식은 emit (사용자 위임 X — 본인이 저장 후 진행).
 
 ---
 


### PR DESCRIPTION
## 변경 요약

### [issue-149] Step 7 caveat 회고 → 메모리 저장 의무 룰 추가
- **What**: `docs/plugin/loop-procedure.md` §5.5 7b caveat 보고 양식에 "📝 메모리 candidate" 섹션 + 의무 룰 추가. `docs/plugin/dcness-rules.md` 메인 필수 준수 섹션에 "Step 7 회고 → 메모리 저장 의무" 룰 명시 (SessionStart inject 로 매 세션 자동 인지).
- **Why**: caveat 발생 = 회귀 방지 신호. prose 본문에만 적고 종료하면 다음 세션 컨텍스트 손실 후 동일 caveat 재발. 회고 → 메모리 저장 결합을 보고 양식 + 룰 양쪽에 박아야 메인이 매번 자율 저장.

## 결정 근거

- loop-procedure §5.5 양식 = 보고 substance 강제 (양식 위반 = 즉시 보임)
- dcness-rules.md = 메인 행동 룰 SSOT (SessionStart inject 로 자동 적용)
- 두 파일 동시 갱신해야 양식 + 룰 정합 보존
- 7a (clean) 도 review report 의 waste finding 있으면 동일 적용 — 의무가 7b 한정 X
- yolo 라도 양식 emit 의무 — 저장은 자율, 양식 생략은 X

## 관련 이슈

Closes #149

## 참고

- 회귀 사례: jajang epic-11 task 02 (PR #183) / task 03 (PR #184) — 사용자가 캐치 후 사후 저장
- 후보 type 가이드 (feedback / project) 는 글로벌 auto memory 룰 정합