### PR TITLE
[issue-268] cc-pre-commit.sh 워크트리 안 commit 오인 차단 수정

### DIFF
--- a/scripts/hooks/cc-pre-commit.sh
+++ b/scripts/hooks/cc-pre-commit.sh
@@ -37,7 +37,7 @@ resolve_naming_script() {
       echo "$cache_dir/$latest/scripts/check_git_naming.mjs"; return 0
     fi
   fi
-  legacy="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}/scripts/check_git_naming.mjs"
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null || echo "${CLAUDE_PROJECT_DIR:-}")/scripts/check_git_naming.mjs"
   [ -f "$legacy" ] && echo "$legacy" && return 0
   return 1
 }
@@ -46,7 +46,11 @@ CMD_FIRST_LINE=$(printf '%s' "$COMMAND" | head -1)
 
 case "$CMD_FIRST_LINE" in
   *"git commit"*)
-    cd "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null)}" 2>/dev/null || exit 0
+    # cwd 의 git toplevel 우선 — 워크트리 안에서는 워크트리 top, 메인이면 메인 top (#268).
+    # CLAUDE_PROJECT_DIR 우선 시 워크트리 안 commit 이 메인 main 브랜치로 오인 차단됨.
+    TOPLEVEL=$(git rev-parse --show-toplevel 2>/dev/null)
+    [ -z "$TOPLEVEL" ] && TOPLEVEL="${CLAUDE_PROJECT_DIR:-}"
+    cd "$TOPLEVEL" 2>/dev/null || exit 0
     current_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
     if [ "$current_branch" = "main" ]; then
       echo "ERROR: main 직접 commit 금지. branch 만든 후 commit + PR." >&2


### PR DESCRIPTION
## 변경 요약

### [issue-268] cc-pre-commit.sh 워크트리 안 commit 오인 차단 수정
- **What**: `scripts/hooks/cc-pre-commit.sh` line 40, 49 의 cwd / 경로 결정 우선순위를 `git rev-parse --show-toplevel` (현재 cwd) 우선으로 뒤집고 `CLAUDE_PROJECT_DIR` 을 fallback 으로 변경.
- **Why**: 워크트리 (`.claude/worktrees/<name>`) 안 fix 브랜치 위에서 `git commit` 시 hook 이 메인 워크트리 (`CLAUDE_PROJECT_DIR`) 로 강제 cd → 메인의 HEAD = main 검출 → 차단. 워크트리 진입 후 정상 commit 이 불가능했음.

## 결정 근거

- 두 후보:
  - (A) `CLAUDE_PROJECT_DIR` 우선 유지 + 별도 워크트리 환경변수 추가 — 복잡 / Claude Code 내부 동작 의존
  - (B) `git rev-parse --show-toplevel` 우선 + fallback — 단순 / cwd 의 git context 자연 따름. 채택.
- 위험: 사용자가 dcness 무관 git repo cwd 에서 commit 하면 그 repo top 인식 — 하지만 PreToolUse hook 은 dcness CLAUDE_PROJECT_DIR session 한정 발화이므로 무관 repo 진입 후 commit 명령 거의 없음. 안전.

## 자가 검증

- 워크트리 (fix branch) 위 simulation: exit=0 (PASS)
- 메인 워크트리 main 위 simulation: exit=2 (차단, 회귀 방지 OK)
- `sh -n` syntax check OK

## 관련 이슈

Closes #268

## 참고

- 본 세션 (#148, #149, #252) 작업 중 워크트리 hook 차단으로 발견
- `scripts/hooks/pre-commit` 은 cwd 의 git context 직접 사용 — 변경 불필요