### PR TITLE
[docs] release 0.2.6 — engineer 권한 강화 + POLISH 면제 + 회고 메모리 의무 + 워크트리 hook 정정

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.5"
+    "version": "0.2.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,25 @@
 
 ---
 
+## v0.2.6 (2026-05-08)
+
+**커밋 범위**: `09e537f..c69e28a`
+**핵심 변경**: engineer 권한 경계 강화 + POLISH self-verify 면제 + Step 7 회고 메모리 의무 + 워크트리 hook 정정 + DeepEval 마이그레이션
+
+- `agents/engineer.md`: 자체 `git commit/push/branch` 호출 + `stories.md/backlog.md/batch-list.md` 직접 수정 사전 차단 (#148). §권한 경계 / §IMPL_PARTIAL / §커밋 단위 규칙 / §1 task = 1 PR 안티패턴 4 군데 정합. POLISH 자가 검증 anchor 면제 명시 (#252)
+- `harness/run_review.py`: `MISSING_SELF_VERIFY` 검사에서 `POLISH_DONE` 제외 — POLISH prose 본문 자체가 검증 substance, anchor 강제는 잉여 (#252). 회귀 방지 unittest 추가
+- `docs/plugin/loop-procedure.md §5.5`: 7b caveat 보고 양식에 "📝 메모리 candidate" 섹션 + 의무 룰 추가 (#149). 7a clean 도 review report waste finding 시 동일 적용
+- `docs/plugin/dcness-rules.md`: "Step 7 회고 → 메모리 저장 의무" 룰 추가 — SessionStart inject 로 매 세션 자동 인지 (#149)
+- `scripts/hooks/cc-pre-commit.sh`: cwd 결정 우선순위 뒤집기 — `git rev-parse --show-toplevel` 우선, fallback `CLAUDE_PROJECT_DIR` (#268). 워크트리 안 commit 이 메인 main 으로 오인 차단되던 회귀 수정
+- `tests/eval_*.py` + 평가 인프라: AgentEvals → DeepEval 마이그레이션 (#263)
+
+**업데이트**:
+```sh
+claude plugin update dcness@dcness
+```
+
+---
+
 ## v0.2.5 (2026-05-07)
 
 **커밋 범위**: `8d097b4..6612db0`  


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.6
- **What**: `plugin.json` / `marketplace.json` version 0.2.5 → 0.2.6 + `release-notes.md` v0.2.6 항목 추가
- **Why**: v0.2.5 이후 누적 변경 (engineer 권한 강화 / POLISH self-verify 면제 / Step 7 회고 메모리 의무 / 워크트리 hook 정정 / DeepEval 마이그레이션) 사용자 환경 배포

## 핵심 변경

- agents/engineer.md: 자체 git commit/push/branch + stories.md/backlog.md 직접 수정 사전 차단 (#148). POLISH 자가 검증 anchor 면제 명시 (#252)
- harness/run_review.py: MISSING_SELF_VERIFY 에서 POLISH_DONE 제외 + 테스트 (#252)
- docs/plugin/loop-procedure.md §5.5: 7b 보고 양식에 메모리 candidate 섹션 + 의무 (#149)
- docs/plugin/dcness-rules.md: Step 7 회고 → 메모리 저장 의무 룰 추가 (#149)
- scripts/hooks/cc-pre-commit.sh: cwd 우선순위 정정 — 워크트리 안 commit 통과 (#268)
- tests/eval_*.py: AgentEvals → DeepEval 마이그레이션 (#263)

## 관련 이슈

Document-Exception-PR-Close: 본 PR 은 release 메타 변경 (version bump + release-notes). 개별 이슈는 각각의 fix PR 에서 close 완료.

## 참고

- 업데이트: `claude plugin update dcness@dcness`