### PR TITLE
[issue-272] anomaly hook 임계 + prose-only + must_fix sticky + redo agent_id + prose staging 진단 (#273 동시 fix)

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -508,10 +508,12 @@ def handle_posttooluse_agent(
     rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
 
     # prose auto-staging — tool_response → run_dir 에 저장, current_step.prose_file 기록
+    # silent except 제거 (#272 W2 / #273 W1) — staging 미동작 진단 가능하게 단계별
+    # stderr DEBUG. post-agent-clear.sh 가 stderr → /tmp/dcness-hook-stderr.log 보존.
     if rid:
+        prose_text = ""
+        raw_response = stdin_data.get("tool_response")
         try:
-            raw_response = stdin_data.get("tool_response")
-            prose_text = ""
             if isinstance(raw_response, list):
                 # CC Agent PostToolUse 실제 포맷: [{"type": "text", "text": "..."}]
                 for block in raw_response:
@@ -522,23 +524,64 @@ def handle_posttooluse_agent(
                 prose_text = str(raw_response.get("text", "") or "")
             elif isinstance(raw_response, str):
                 prose_text = raw_response
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"[hook prose stage] tool_response 파싱 예외: "
+                f"{type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
 
-            if prose_text.strip():
+        if not prose_text.strip():
+            # 형식 미스매치 진단 정보 — 다음 run 에서 외부 환경 디버그 가능
+            if isinstance(raw_response, dict):
+                _shape = f"dict keys={list(raw_response.keys())[:5]}"
+            elif isinstance(raw_response, list):
+                _shape = f"list len={len(raw_response)}"
+                if raw_response and isinstance(raw_response[0], dict):
+                    _shape += f" item0_keys={list(raw_response[0].keys())[:5]}"
+                    _shape += f" item0_type={raw_response[0].get('type', '?')}"
+            elif isinstance(raw_response, str):
+                _shape = f"str len={len(raw_response)}"
+            else:
+                _shape = f"type={type(raw_response).__name__}"
+            print(
+                f"[hook prose stage] prose 추출 실패 — staging skip. {_shape}",
+                file=sys.stderr,
+            )
+        else:
+            try:
                 live_data = read_live(sid, base_dir=base_dir) or {}
                 active = live_data.get("active_runs", {}) or {}
                 slot = active.get(rid, {}) if isinstance(active, dict) else {}
-                cur_step = slot.get("current_step") if isinstance(slot, dict) else None
+                cur_step = (
+                    slot.get("current_step") if isinstance(slot, dict) else None
+                )
 
-                if isinstance(cur_step, dict):
+                if not isinstance(cur_step, dict):
+                    print(
+                        f"[hook prose stage] current_step 부재 (rid={rid[:8]}…) — "
+                        f"begin-step 호출 누락 의심. staging skip.",
+                        file=sys.stderr,
+                    )
+                else:
                     step_agent = cur_step.get("agent")
                     step_mode = cur_step.get("mode") or None
-
-                    if step_agent:
+                    if not step_agent:
+                        print(
+                            "[hook prose stage] current_step.agent 비어있음 — "
+                            "staging skip.",
+                            file=sys.stderr,
+                        )
+                    else:
                         from harness.signal_io import write_prose as _write_prose
-                        from harness.session_state import _count_step_occurrences as _count_occ
+                        from harness.session_state import (
+                            _count_step_occurrences as _count_occ,
+                        )
 
                         base = session_dir(sid, base_dir=base_dir) / "runs"
-                        occ = _count_occ(sid, rid, step_agent, step_mode, base_dir=base_dir)
+                        occ = _count_occ(
+                            sid, rid, step_agent, step_mode, base_dir=base_dir
+                        )
                         prose_path = _write_prose(
                             step_agent, rid, prose_text,
                             mode=step_mode, base_dir=base, occurrence=occ,
@@ -550,8 +593,11 @@ def handle_posttooluse_agent(
                         active = dict(active)
                         active[rid] = slot
                         update_live(sid, base_dir=base_dir, active_runs=active)
-        except Exception:  # noqa: BLE001 — silent, hook 본 흐름 방해 X
-            pass
+            except Exception as e:  # noqa: BLE001
+                print(
+                    f"[hook prose stage] write 예외: {type(e).__name__}: {e}",
+                    file=sys.stderr,
+                )
 
     # rid 활성 시만 histogram + redo_log
     eval_result = None
@@ -559,10 +605,22 @@ def handle_posttooluse_agent(
     if rid:
         try:
             from harness.agent_trace import histogram as _trace_hist
-            from harness.agent_trace import last_agent_id as _trace_last
+            from harness.agent_trace import read_all as _trace_read
             from harness.sub_eval import evaluate_sub, format_histogram
 
-            target_aid = sub_agent_id or _trace_last(sid, rid, base_dir=base_dir)
+            # #272 W3 — agent_id 폴백 안전성. 기존 _trace_last 폴백은 sub_type 검증 X
+            # 이라 직전 step (예: engineer) 의 agent_id 가 잘못 박혔다. 이제 trace 의
+            # 마지막 entry agent 가 *현재 sub_type 과 일치할 때만* 폴백 사용.
+            target_aid = sub_agent_id
+            if not target_aid:
+                _entries = _trace_read(sid, rid, base_dir=base_dir)
+                _short_sub = (sub_type or "").split(":")[-1] if sub_type else ""
+                for _e in reversed(_entries):
+                    _aid = _e.get("agent_id", "") or ""
+                    _eagent = (_e.get("agent", "") or "").split(":")[-1]
+                    if _aid and (not _short_sub or _eagent == _short_sub):
+                        target_aid = _aid
+                        break
             hist = _trace_hist(sid, rid, agent_id=target_aid or None, base_dir=base_dir)
             if hist:
                 histogram_str = format_histogram(hist)
@@ -570,7 +628,9 @@ def handle_posttooluse_agent(
                 prompt_hint = ""
                 if isinstance(tool_input, dict):
                     prompt_hint = str(tool_input.get("prompt", "") or "")[:500]
-                eval_result = evaluate_sub(hist, sub_prompt_hint=prompt_hint)
+                eval_result = evaluate_sub(
+                    hist, sub_prompt_hint=prompt_hint, sub_type=sub_type,
+                )
 
                 # redo_log 자동 append — 보수적 자동 결정. 메인이 별도 1줄로 덮어쓰기 가능.
                 try:

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1382,6 +1382,24 @@ def _append_step_status(
         f.write(line)
 
 
+def _latest_step_per_role(steps: list) -> list:
+    """`steps` 의 같은 (agent, mode) 쌍 중 *마지막* entry 만 골라 반환 (#272 W4).
+
+    POLISH/retry 사이클 완료 후 LGTM 으로 해소된 must_fix 가 has_must_fix 에 sticky
+    되는 문제 해결용. 최신 step 만 봄으로써 step #N 이 CHANGES_REQUESTED → step #M
+    이 LGTM 이면 latest = LGTM (must_fix=False) 로 평가.
+
+    입력 순서 (시간 순) 유지 — 같은 키 마지막 발생.
+    """
+    out: dict = {}
+    for s in steps:
+        if not isinstance(s, dict):
+            continue
+        key = (s.get("agent"), s.get("mode"))
+        out[key] = s
+    return list(out.values())
+
+
 def _read_steps_jsonl(sid: str, rid: str) -> list:
     """`.steps.jsonl` 전체 읽기. 파일 없으면 빈 리스트."""
     target = _steps_jsonl_path(sid, rid)
@@ -1423,8 +1441,12 @@ def _cli_finalize_run(args: Any) -> int:
         print(json.dumps({"error": "sid/rid 미해결"}), file=sys.stderr)
         return 1
     steps = _read_steps_jsonl(sid, rid)
-    has_ambiguous = any(s.get("enum") == "AMBIGUOUS" for s in steps)
-    has_must_fix = any(s.get("must_fix") for s in steps)
+    # #272 W4 — has_must_fix sticky on LGTM 수정. POLISH/retry 로 해소된 must_fix 가
+    # sticky 로 남아 LGTM final step 임에도 caveat 진입했음. 같은 (agent, mode) 의
+    # *마지막* 발생만 평가해서 후속 step 에서 해소된 신호를 정합 처리.
+    latest_steps = _latest_step_per_role(steps)
+    has_ambiguous = any(s.get("enum") == "AMBIGUOUS" for s in latest_steps)
+    has_must_fix = any(s.get("must_fix") for s in latest_steps)
 
     # DCN-CHG-20260430-25: --expected-steps 검증 — skill 이 정상 시퀀스 step 수
     # 명시 시 .steps.jsonl row count 미만이면 stderr WARN. /impl-loop 자기검증.

--- a/harness/sub_eval.py
+++ b/harness/sub_eval.py
@@ -10,8 +10,10 @@ jajang 메인 자기 진단 반영 (DCN-CHG-20260501-13 plan):
 
 Anomaly 룰 (보수적):
     - tool_uses < 2 — sub 가 거의 일 안 함
-    - 같은 tool 5회+ 반복 — 뻘짓 의심
+    - 도구별 차등 임계 초과 반복 — 뻘짓 의심 (실측 baseline 반영, #272/#273)
     - prompt 에 Write/Edit 약속했는데 Write+Edit 0건 — prose-only
+      단 prose-only agent (qa/validator/pr-reviewer 등) 는 promised_write 검사 자체
+      미적용 (false positive 다발 — #272 W1).
 
 자동 결정:
     - PASS — anomaly 없음
@@ -19,28 +21,60 @@ Anomaly 룰 (보수적):
 """
 from __future__ import annotations
 
-from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 
-__all__ = ["evaluate_sub", "format_histogram", "REPEAT_TOOL_THRESHOLD"]
+__all__ = [
+    "evaluate_sub",
+    "format_histogram",
+    "REPEAT_TOOL_THRESHOLD",
+    "REPEAT_TOOL_THRESHOLDS",
+    "PROSE_ONLY_AGENTS",
+]
 
 
-# 보수적 임계값 (운영 데이터 보고 조정 가능)
-REPEAT_TOOL_THRESHOLD = 5
+# 도구별 차등 임계 (#272/#273 실측 — 정상 architect Read×8 / engineer Edit×6~10
+# / pr-reviewer Read×5 / test-engineer Read×5 모두 false positive 였다).
+# 의미: "같은 도구 N+ 반복" 신호는 *자연스러운 다중 파일 read* 가 아니라
+# *동일 파일 동일 작업 무의미 반복* 을 잡는 것. 자연 baseline 반영해 상향.
+REPEAT_TOOL_THRESHOLDS: Dict[str, int] = {
+    "Read": 15,    # 다중 파일 탐색 / 인접 컨텍스트 자연
+    "Edit": 12,    # 단일 파일 multi-section + 다중 파일
+    "Bash": 10,    # 다중 검증 명령 자연 (test + grep + build)
+    "Write": 8,
+    "Glob": 10,
+    "Grep": 10,
+}
+REPEAT_TOOL_THRESHOLD_DEFAULT = 12
+
+# 호환용 export — 외부 import 안전. 도구 미지정 시 default 와 동일.
+REPEAT_TOOL_THRESHOLD = REPEAT_TOOL_THRESHOLD_DEFAULT
 MIN_TOOL_USES = 2
+
+# prose-only agent — handoff-matrix.md §4.1 ALLOW_MATRIX 상 src 쓰기 권한 X.
+# Write/Edit 0건이 *정상*. promised_write false positive 차단 (#272 W1).
+PROSE_ONLY_AGENTS = frozenset({
+    "qa",
+    "validator",
+    "pr-reviewer",
+    "design-critic",
+    "security-reviewer",
+    "plan-reviewer",
+})
 
 
 def evaluate_sub(
     histogram: Dict[str, int],
     *,
     sub_prompt_hint: str = "",
+    sub_type: str = "",
 ) -> Dict[str, Any]:
-    """histogram + 옵션 prompt hint 기반 자동 평가.
+    """histogram + 옵션 prompt hint + sub_type 기반 자동 평가.
 
     Args:
         histogram: agent_trace.histogram 결과 — {"Read": 4, "Bash": 2, ...}
         sub_prompt_hint: sub 호출 prompt 의 일부 (Write/Edit 약속 검출용). 미사용 가능.
+        sub_type: subagent_type. PROSE_ONLY_AGENTS 검사용. 미지정 시 폴백 검사.
 
     Returns:
         {
@@ -56,19 +90,26 @@ def evaluate_sub(
     if total < MIN_TOOL_USES:
         anomalies.append(f"tool_uses={total} (< {MIN_TOOL_USES})")
 
-    # 룰 2 — 같은 tool 5회+ 반복
+    # 룰 2 — 도구별 차등 임계 초과 반복
     for tool, count in histogram.items():
-        if count >= REPEAT_TOOL_THRESHOLD:
-            anomalies.append(f"{tool}×{count} (≥ {REPEAT_TOOL_THRESHOLD} 반복)")
+        threshold = REPEAT_TOOL_THRESHOLDS.get(tool, REPEAT_TOOL_THRESHOLD_DEFAULT)
+        if count >= threshold:
+            anomalies.append(f"{tool}×{count} (≥ {threshold} 반복)")
 
-    # 룰 3 — prompt 에 Write/Edit 약속 vs 실제 0건
-    write_edit = histogram.get("Write", 0) + histogram.get("Edit", 0)
-    hint_lower = (sub_prompt_hint or "").lower()
-    promised_write = any(
-        kw in hint_lower for kw in ("write", "edit", "create", "작성", "생성")
-    )
-    if promised_write and write_edit == 0 and total > 0:
-        anomalies.append("prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심)")
+    # 룰 3 — prompt 에 Write/Edit 약속 vs 실제 0건 (prose-only agent 제외)
+    sub_short = (sub_type or "").split(":", 1)[0].lower()
+    # plugin-namespaced (e.g. "dcness:qa") 와 short ("qa") 양쪽 호환
+    if ":" in (sub_type or ""):
+        sub_short = sub_type.split(":")[-1].lower()
+    is_prose_only = sub_short in PROSE_ONLY_AGENTS
+    if not is_prose_only:
+        write_edit = histogram.get("Write", 0) + histogram.get("Edit", 0)
+        hint_lower = (sub_prompt_hint or "").lower()
+        promised_write = any(
+            kw in hint_lower for kw in ("write", "edit", "create", "작성", "생성")
+        )
+        if promised_write and write_edit == 0 and total > 0:
+            anomalies.append("prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심)")
 
     decision = "REDO_SUSPECT" if anomalies else "PASS"
     return {

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1152,6 +1152,93 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         self.assertEqual(rc, 0)
         self.assertEqual(read_redos(self.sid, self.rid, base_dir=self.base), [])
 
+    def test_agent_id_fallback_only_on_subtype_match(self):
+        """#272 W3 — payload agent_id 비어있고 trace 의 마지막 entry 가 *다른* sub
+        의 것이면 폴백 사용 X. redo_log 의 agent_id 가 직전 step 으로 오기록되는
+        문제 회귀."""
+        # trace 에 engineer 의 흔적만 있음 (직전 step). 이제 pr-reviewer Agent 가
+        # 호출됐고 (prose-only 라 자기 file-op trace 없음), payload agent_id 비어있음.
+        for tool in ["Read", "Edit", "Bash"]:
+            trace_append(self.sid, self.rid, {
+                "phase": "pre", "agent_id": "aid-engineer",
+                "agent": "engineer", "tool": tool,
+            }, base_dir=self.base)
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "pr-reviewer"},
+                # agent_id 비어있음
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        if redos:
+            # trace 마지막 agent="engineer" ≠ sub_type="pr-reviewer"
+            # → target_aid 폴백 안 됨 → ""
+            self.assertNotEqual(
+                redos[0].get("agent_id"), "aid-engineer",
+                msg="직전 sub 의 agent_id 가 폴백으로 박혔음 (#272 W3 회귀)",
+            )
+
+    def test_agent_id_fallback_uses_matching_subtype(self):
+        """#272 W3 회귀 — trace 의 마지막 entry agent 가 sub_type 과 *일치* 하면 폴백 사용."""
+        # 직전 다른 sub 의 trace + 같은 sub_type (pr-reviewer) 의 trace 둘 다.
+        for aid, agent, tool in [
+            ("aid-engineer", "engineer", "Edit"),
+            ("aid-engineer", "engineer", "Bash"),
+            ("aid-pr1", "pr-reviewer", "Read"),
+            ("aid-pr1", "pr-reviewer", "Read"),
+        ]:
+            trace_append(self.sid, self.rid, {
+                "phase": "pre", "agent_id": aid, "agent": agent, "tool": tool,
+            }, base_dir=self.base)
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "pr-reviewer"},
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        # 폴백 → aid-pr1 (sub_type 일치하는 마지막)
+        self.assertEqual(redos[0]["agent_id"], "aid-pr1")
+        self.assertEqual(redos[0]["sub"], "pr-reviewer")
+
+    def test_prose_only_subtype_not_promised_write(self):
+        """#272 W1 — prose-only sub (qa) 는 promised_write anomaly 발화 X."""
+        for tool in ["Read", "Read", "Read"]:
+            trace_append(self.sid, self.rid, {
+                "phase": "pre", "agent_id": "aid-qa",
+                "agent": "qa", "tool": tool,
+            }, base_dir=self.base)
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "agent_id": "aid-qa",
+                "tool_name": "Agent",
+                "tool_input": {
+                    "subagent_type": "qa",
+                    "prompt": "분석 작성해줘",
+                },
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(redos[0]["decision"], "PASS")
+        # prose-only anomaly 발화 X
+        self.assertFalse(
+            any("prose-only" in a for a in redos[0]["anomalies"]),
+            msg="prose-only 화이트리스트 미적용 (#272 W1 회귀)",
+        )
+
 
 # ---------------------------------------------------------------------------
 # DCN-CHG-20260501-15 — PostToolUse Agent prose auto-staging
@@ -1305,6 +1392,54 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
         self.assertEqual(rc, 0)
         expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
         self.assertFalse(expected.exists())
+
+    def test_no_current_step_emits_diagnostic_stderr(self) -> None:
+        """#272 W2 / #273 W1 — silent fail 제거. current_step 부재 시 stderr 진단 로그.
+
+        post-agent-clear.sh 가 stderr → /tmp/dcness-hook-stderr.log 보존이라
+        다음 run 에서 외부 환경 (jajang) staging 미동작 원인 진단 가능.
+        """
+        import io
+        import contextlib
+
+        prose = "## 결론\nPASS\n"
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            rc = handle_posttooluse_agent(
+                stdin_data=self._payload_with_prose("qa", "qa", None, prose),
+                cc_pid=self.cc_pid,
+                base_dir=self.base,
+            )
+        self.assertEqual(rc, 0)
+        stderr = buf.getvalue()
+        self.assertIn("[hook prose stage]", stderr)
+        self.assertIn("current_step 부재", stderr)
+
+    def test_unrecognized_tool_response_emits_shape_diagnostic(self) -> None:
+        """#272 W2 — tool_response 형식 미스매치 시 stderr 에 형식 정보 출력."""
+        import io
+        import contextlib
+
+        self._set_current_step("qa", None)
+        # CC 가 다른 형식 보낼 가능성 — list of dict 인데 "type" 이 "text" 아닌 경우
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            rc = handle_posttooluse_agent(
+                stdin_data={
+                    "sessionId": self.sid,
+                    "tool_name": "Agent",
+                    "tool_input": {"subagent_type": "qa"},
+                    "tool_response": [{"type": "tool_result", "content": "x"}],
+                },
+                cc_pid=self.cc_pid,
+                base_dir=self.base,
+            )
+        self.assertEqual(rc, 0)
+        stderr = buf.getvalue()
+        self.assertIn("[hook prose stage]", stderr)
+        self.assertIn("prose 추출 실패", stderr)
+        # 형식 정보 포함 — 외부 환경 디버그용
+        self.assertIn("item0_type=tool_result", stderr)
 
     def test_occurrence_increments_on_repeat(self) -> None:
         import json

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1808,6 +1808,129 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         self.assertFalse(payload["has_must_fix"])
         self.assertEqual(len(payload["steps"]), 5)
 
+    def test_finalize_run_must_fix_resolved_by_polish_lgtm(self) -> None:
+        """#272 W4 — pr-reviewer CHANGES_REQUESTED → POLISH → pr-reviewer LGTM 시
+        has_must_fix=False (sticky 미발생). latest-per-role 평가 회귀."""
+        from harness.session_state import (
+            _cli_finalize_run, _append_step_status,
+            run_dir, _clear_default_base_cache, write_pid_session,
+            write_pid_current_run, get_cc_pid_via_ppid_chain,
+        )
+        from io import StringIO
+        from contextlib import redirect_stdout
+        from types import SimpleNamespace
+
+        repo = Path(self._tmp.name) / "repo-mustfix"
+        repo.mkdir()
+        os.chdir(repo)
+        _clear_default_base_cache()
+
+        cc_pid = get_cc_pid_via_ppid_chain()
+        if cc_pid is None:
+            self.skipTest("cc_pid 추출 불가 — CI 환경 의존")
+        sid = "smoke-mustfix-sid"
+        rid = "run-abcd1234"
+        write_pid_session(cc_pid, sid)
+        run_dir(sid, rid, create=True)
+        write_pid_current_run(cc_pid, rid)
+
+        # /quick 전형 시퀀스 — pr-reviewer CHANGES_REQUESTED → engineer POLISH →
+        # pr-reviewer LGTM. 첫 pr-reviewer prose 에 MUST FIX 포함.
+        _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "ok", Path("/dev/null"))
+        _append_step_status(
+            sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY", "ok", Path("/dev/null")
+        )
+        _append_step_status(
+            sid, rid, "engineer", "IMPL", "IMPL_DONE", "first attempt", Path("/dev/null")
+        )
+        _append_step_status(
+            sid, rid, "validator", "BUGFIX_VALIDATION", "PASS", "verified",
+            Path("/dev/null"),
+        )
+        _append_step_status(
+            sid, rid, "pr-reviewer", None, "CHANGES_REQUESTED",
+            "## MUST FIX\n- 1번 항목 고치자\n", Path("/dev/null"),
+        )
+        _append_step_status(
+            sid, rid, "engineer", "POLISH", "POLISH_DONE", "fixed", Path("/dev/null"),
+        )
+        _append_step_status(
+            sid, rid, "pr-reviewer", None, "LGTM",
+            "## 결론\nLGTM\nMUST FIX 없음\n", Path("/dev/null"),
+        )
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_finalize_run(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["step_count"], 7)
+        # latest pr-reviewer = LGTM (must_fix=False) → has_must_fix False 여야 함
+        self.assertFalse(
+            payload["has_must_fix"],
+            msg="POLISH 후 LGTM 으로 해소된 must_fix 가 sticky 됨 (#272 W4 회귀)",
+        )
+        self.assertFalse(payload["has_ambiguous"])
+
+    def test_finalize_run_must_fix_unresolved_still_sticky(self) -> None:
+        """final pr-reviewer 가 여전히 CHANGES_REQUESTED 면 has_must_fix True."""
+        from harness.session_state import (
+            _cli_finalize_run, _append_step_status,
+            run_dir, _clear_default_base_cache, write_pid_session,
+            write_pid_current_run, get_cc_pid_via_ppid_chain,
+        )
+        from io import StringIO
+        from contextlib import redirect_stdout
+        from types import SimpleNamespace
+
+        repo = Path(self._tmp.name) / "repo-mustfix-unres"
+        repo.mkdir()
+        os.chdir(repo)
+        _clear_default_base_cache()
+
+        cc_pid = get_cc_pid_via_ppid_chain()
+        if cc_pid is None:
+            self.skipTest("cc_pid 추출 불가 — CI 환경 의존")
+        sid = "smoke-mustfix2-sid"
+        rid = "run-abcd5678"
+        write_pid_session(cc_pid, sid)
+        run_dir(sid, rid, create=True)
+        write_pid_current_run(cc_pid, rid)
+
+        _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "ok", Path("/dev/null"))
+        _append_step_status(
+            sid, rid, "engineer", "IMPL", "IMPL_DONE", "ok", Path("/dev/null")
+        )
+        _append_step_status(
+            sid, rid, "pr-reviewer", None, "CHANGES_REQUESTED",
+            "## MUST FIX\n- 미해소 항목\n", Path("/dev/null"),
+        )
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_finalize_run(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        payload = json.loads(out.getvalue())
+        # 후속 LGTM 이 없으니 latest pr-reviewer = CHANGES_REQUESTED → must_fix True
+        self.assertTrue(payload["has_must_fix"])
+
+    def test_latest_step_per_role(self) -> None:
+        """_latest_step_per_role — 같은 (agent, mode) 의 마지막 발생만 반환 (#272 W4)."""
+        from harness.session_state import _latest_step_per_role
+        steps = [
+            {"agent": "engineer", "mode": "IMPL", "must_fix": False},
+            {"agent": "pr-reviewer", "mode": None, "must_fix": True, "enum": "CHANGES_REQUESTED"},
+            {"agent": "engineer", "mode": "POLISH", "must_fix": False},
+            {"agent": "pr-reviewer", "mode": None, "must_fix": False, "enum": "LGTM"},
+        ]
+        latest = _latest_step_per_role(steps)
+        # engineer:IMPL, engineer:POLISH 는 다른 mode → 둘 다 살아남음.
+        # pr-reviewer:None 은 마지막 (LGTM, must_fix=False) 만.
+        self.assertEqual(len(latest), 3)
+        pr = next(s for s in latest if s["agent"] == "pr-reviewer")
+        self.assertEqual(pr["enum"], "LGTM")
+        self.assertFalse(pr["must_fix"])
+
     def test_auto_resolve_ux_escalate(self) -> None:
         from harness.session_state import _cli_auto_resolve
         from io import StringIO

--- a/tests/test_sub_eval.py
+++ b/tests/test_sub_eval.py
@@ -5,9 +5,10 @@ Coverage matrix:
         - 정상 PASS — 적당한 호출 수 + 다양한 tool
         - REDO_SUSPECT: tool_uses 0 (아예 안 함)
         - REDO_SUSPECT: tool_uses 1 (< MIN_TOOL_USES)
-        - REDO_SUSPECT: 같은 tool 5회 (반복)
+        - REDO_SUSPECT: 도구별 차등 임계 초과 반복 (#272/#273 baseline 반영)
         - REDO_SUSPECT: prompt 에 Write 약속 + Write+Edit 0건 (prose-only)
         - prompt hint 없으면 prose-only 검사 skip
+        - prose-only sub_type (qa/validator/pr-reviewer …) 시 promised_write 검사 skip
         - 다중 anomaly 한 번에 검출
 
     format_histogram:
@@ -20,7 +21,9 @@ import unittest
 
 from harness.sub_eval import (
     MIN_TOOL_USES,
-    REPEAT_TOOL_THRESHOLD,
+    PROSE_ONLY_AGENTS,
+    REPEAT_TOOL_THRESHOLDS,
+    REPEAT_TOOL_THRESHOLD_DEFAULT,
     evaluate_sub,
     format_histogram,
 )
@@ -33,6 +36,30 @@ class EvaluateSubTests(unittest.TestCase):
         self.assertEqual(result["anomalies"], [])
         self.assertEqual(result["tool_uses"], 7)
 
+    def test_pass_realistic_architect_baseline(self):
+        # #273 W1 — architect MODULE_PLAN 정상 패턴 (Read×8 Bash×5 Write×1 Edit×2)
+        result = evaluate_sub(
+            {"Read": 8, "Bash": 5, "Write": 1, "Edit": 2},
+            sub_type="architect",
+        )
+        self.assertEqual(result["decision"], "PASS", msg=result)
+
+    def test_pass_realistic_engineer_baseline(self):
+        # #273 W1 — engineer IMPL 정상 패턴 (Read×6 Edit×6 Bash×2)
+        result = evaluate_sub(
+            {"Read": 6, "Edit": 6, "Bash": 2},
+            sub_type="engineer",
+        )
+        self.assertEqual(result["decision"], "PASS", msg=result)
+
+    def test_pass_realistic_pr_reviewer_baseline(self):
+        # #272 W1 — pr-reviewer prose-only 정상 (Read×5)
+        result = evaluate_sub(
+            {"Read": 5},
+            sub_type="pr-reviewer",
+        )
+        self.assertEqual(result["decision"], "PASS", msg=result)
+
     def test_redo_zero_calls(self):
         result = evaluate_sub({})
         self.assertEqual(result["decision"], "REDO_SUSPECT")
@@ -43,19 +70,65 @@ class EvaluateSubTests(unittest.TestCase):
         self.assertEqual(result["decision"], "REDO_SUSPECT")
         self.assertTrue(any(f"< {MIN_TOOL_USES}" in a for a in result["anomalies"]))
 
-    def test_redo_repeat_tool(self):
-        result = evaluate_sub({"Bash": REPEAT_TOOL_THRESHOLD})
+    def test_redo_repeat_read(self):
+        # Read 임계 15
+        result = evaluate_sub({"Read": REPEAT_TOOL_THRESHOLDS["Read"]})
         self.assertEqual(result["decision"], "REDO_SUSPECT")
-        self.assertTrue(any("Bash" in a and "반복" in a for a in result["anomalies"]))
+        self.assertTrue(any("Read" in a and "반복" in a for a in result["anomalies"]))
 
-    def test_redo_prose_only(self):
-        # Write 약속 prompt + Write+Edit 0건
+    def test_redo_repeat_edit(self):
+        # Edit 임계 12
+        result = evaluate_sub({"Edit": REPEAT_TOOL_THRESHOLDS["Edit"]})
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+        self.assertTrue(any("Edit" in a for a in result["anomalies"]))
+
+    def test_redo_repeat_unknown_tool_uses_default(self):
+        # 미정의 도구는 default 임계 적용
+        result = evaluate_sub({"Foo": REPEAT_TOOL_THRESHOLD_DEFAULT})
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+
+    def test_under_threshold_read_passes(self):
+        # Read 14 < 15 → PASS
+        result = evaluate_sub({"Read": REPEAT_TOOL_THRESHOLDS["Read"] - 1})
+        self.assertEqual(result["decision"], "PASS", msg=result)
+
+    def test_redo_prose_only_no_sub_type(self):
+        # sub_type 미명시 → 폴백으로 promised_write 검사 진행
         result = evaluate_sub(
             {"Read": 4, "Bash": 1},
             sub_prompt_hint="Write the implementation plan to docs/foo.md",
         )
         self.assertEqual(result["decision"], "REDO_SUSPECT")
         self.assertTrue(any("prose-only" in a for a in result["anomalies"]))
+
+    def test_prose_only_agent_skips_promised_write_check(self):
+        # #272 W1 — qa 는 prose-only. Write 약속 prompt + Write+Edit 0건이 정상.
+        for sub in ("qa", "validator", "pr-reviewer", "design-critic"):
+            with self.subTest(sub=sub):
+                result = evaluate_sub(
+                    {"Read": 4, "Bash": 1},
+                    sub_prompt_hint="Write your validation report",
+                    sub_type=sub,
+                )
+                self.assertEqual(result["decision"], "PASS", msg=f"{sub} → {result}")
+
+    def test_prose_only_agent_namespaced(self):
+        # plugin-namespaced (e.g. "dcness:qa") 도 prose-only 처리
+        result = evaluate_sub(
+            {"Read": 4},
+            sub_prompt_hint="작성해줘",
+            sub_type="dcness:qa",
+        )
+        self.assertEqual(result["decision"], "PASS", msg=result)
+
+    def test_engineer_promised_write_still_fires(self):
+        # engineer 는 prose-only X — Write 약속 후 0건이면 anomaly
+        result = evaluate_sub(
+            {"Read": 4},
+            sub_prompt_hint="구현 코드 작성",
+            sub_type="engineer",
+        )
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
 
     def test_no_hint_no_prose_check(self):
         # 같은 histogram 이지만 hint 없으면 PASS
@@ -66,14 +139,15 @@ class EvaluateSubTests(unittest.TestCase):
         result = evaluate_sub(
             {"Read": 3},
             sub_prompt_hint="impl 파일 작성해줘",
+            sub_type="engineer",
         )
         self.assertEqual(result["decision"], "REDO_SUSPECT")
 
-    def test_multiple_anomalies(self):
-        result = evaluate_sub({"Bash": 6})
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-        # 6 개라 MIN_TOOL_USES 통과, REPEAT_TOOL_THRESHOLD 위반 1개
-        self.assertEqual(len(result["anomalies"]), 1)
+    def test_prose_only_agents_constant(self):
+        # 화이트리스트 회귀 방지 — 핵심 prose-only agent 누락 X
+        for sub in ("qa", "validator", "pr-reviewer", "design-critic",
+                    "security-reviewer", "plan-reviewer"):
+            self.assertIn(sub, PROSE_ONLY_AGENTS)
 
 
 class FormatHistogramTests(unittest.TestCase):


### PR DESCRIPTION
## 변경 요약

### [issue-272] anomaly hook 임계 + prose-only + must_fix sticky + redo agent_id + prose staging 진단 (#273 동시 fix)

- **What**:
  1. anomaly hook 임계 차등화 (Read 15 / Edit 12 / Bash 10 / Write 8) — 정상 architect/engineer 작업 false positive 차단
  2. prose-only agent 화이트리스트 (qa/validator/pr-reviewer/design-critic/security-reviewer/plan-reviewer) — Write/Edit 약속 anomaly 미발화
  3. redo-log agent_id 폴백 안전성 — `_trace_last` 폴백 시 sub_type 일치 entry 만 사용
  4. has_must_fix/ambiguous sticky 차단 — 같은 (agent, mode) 의 *마지막* step 만 평가 (POLISH/retry 후 LGTM 으로 해소된 경우 정합)
  5. prose staging silent except 제거 + 단계별 stderr DEBUG (`[hook prose stage] ...`) — 외부 환경 진단 가능
- **Why**:
  - #272 W1 / #273 W1: jajang run-b88bf6e4 / run-e82fc2f6 에서 정상 architect Read×8 / engineer Edit×6 / pr-reviewer Read×5 가 모두 REDO_SUSPECT 로 false positive (4/5 step) → 메인이 매 step false positive 판별 + echo 부담
  - #272 W3: pr-reviewer 2차 호출 redo-log 의 agent_id 가 직전 engineer step 과 동일 박혀 audit-redo 분석 오염
  - #272 W4: POLISH cycle 로 해소된 must_fix 가 sticky 라 final LGTM 인데도 caveat 진입 → /quick yolo 자동 7a 진입 차단
  - #272 W2 / #273 W1: prose hook staging 0.2.5 helper 도 미동작. silent except 라 외부 환경 (jajang) 의 어디서 fail 인지 진단 불가능

## 결정 근거

- 임계값 조정은 실측 데이터 baseline 우선. #273 의 architect MODULE_PLAN Read×8 + #272 의 engineer Edit×10 모두 정상 작업이었음 → Read 임계 15 / Edit 임계 12 가 자연 baseline 의 약 1.5~2배 안전 마진.
- prose-only 화이트리스트는 handoff-matrix.md §4.1 ALLOW_MATRIX 룰 SSOT 활용 (인덱스 강제 X — 코드 레벨 적용).
- agent_id 폴백 안전성은 *오기록 < 빈 값* 원칙 — sub_type 미일치 시 폴백 X (target_aid="") 가 잘못된 데이터 박는 것보다 정합.
- has_must_fix sticky 는 latest-per-role 평가로 단순 해결. POLISH/retry 의미 정합 (마지막 발생이 결정).
- prose staging 근본 원인은 본 PR 에서 *진단 인프라만* 추가. 외부 환경 (jajang) 의 다음 run stderr.log 분석 후 본 fix — 추측 기반 변경 회피 (글로벌 CLAUDE.md §1 실존 검증 룰).

## 관련 이슈

Closes #272
Closes #273

## 참고

- 본 저장소(dcness self) 미적용 — plug-in 본체 파일 변경 → 사용자 plugin update 시 자동 적용.
- 다음 release (0.2.7 후보) 권고. Release 노트에 "anomaly hook 임계 상향 + prose-only 화이트리스트 — false positive 4/5 → 0/5 기대" 기록 권고.
- 회귀 테스트 +13개 (sub_eval +9 / hooks +5 / session_state +3) 전부 통과 (404 tests OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)