### PR TITLE
[issue-272] agent_id 폴백 제거 + tool_use_id 매칭 (W3 진짜 fix)

### DIFF
--- a/harness/agent_trace.py
+++ b/harness/agent_trace.py
@@ -36,7 +36,10 @@ from typing import Any, Dict, List, Optional
 from harness.session_state import run_dir
 
 
-__all__ = ["append", "read_all", "tail", "histogram", "last_agent_id", "TRACE_NAME"]
+__all__ = [
+    "append", "read_all", "tail", "histogram", "histogram_since",
+    "last_agent_id", "TRACE_NAME",
+]
 
 
 TRACE_NAME = "agent-trace.jsonl"
@@ -131,6 +134,39 @@ def histogram(
         if entry.get("phase") != "pre":
             continue
         if agent_id is not None and entry.get("agent_id") != agent_id:
+            continue
+        tool = entry.get("tool", "") or "?"
+        counts[tool] = counts.get(tool, 0) + 1
+    return counts
+
+
+def histogram_since(
+    session_id: str,
+    run_id: str,
+    since_ts: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Dict[str, int]:
+    """`since_ts` (ISO8601) *이후* pre phase 의 tool 카운트 (#272 W3 진짜 fix).
+
+    PreToolUse Agent 시각 ~ PostToolUse Agent 시각 사이 trace = 그 sub 의 행동.
+    `agent_id` 폴백 (직전 step 오기록 위험) 대신 *시각 범위* 로 정확히 매칭.
+
+    Args:
+        since_ts: ISO8601 UTC ("2026-05-08T01:23:45Z"). 이 시각 *이상* 의 entry 포함.
+
+    Returns:
+        {"Read": 4, ...}. since_ts 빈 문자열이면 빈 dict (안전 폴백 X — 호출자가
+        시각 범위 보장).
+    """
+    if not since_ts:
+        return {}
+    counts: Dict[str, int] = {}
+    for entry in read_all(session_id, run_id, base_dir=base_dir):
+        if entry.get("phase") != "pre":
+            continue
+        ts = entry.get("ts", "") or ""
+        if not ts or ts < since_ts:
             continue
         tool = entry.get("tool", "") or "?"
         counts[tool] = counts.get(tool, 0) + 1

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -316,6 +316,22 @@ def handle_pretooluse_agent(
         except (OSError, ValueError):
             pass  # 실패해도 Agent 호출은 통과 — 식별만 누락.
 
+    # #272 W3 진짜 fix — PreToolUse Agent 의 tool_use_id + 시작 시각을 박아
+    # PostToolUse Agent 가 *시각 범위* 로 sub 의 trace 정확히 식별 (agent_id 폴백
+    # 위험 제거). CC docs: tool_use_id 가 PreToolUse↔PostToolUse 매칭 키.
+    if rid and subagent:
+        tuid = stdin_data.get("tool_use_id", "") or ""
+        if tuid:
+            try:
+                from harness.session_state import set_pending_agent
+                set_pending_agent(
+                    sid, rid,
+                    tool_use_id=tuid, sub_type=subagent, mode=(mode or None),
+                    base_dir=base_dir,
+                )
+            except (OSError, ValueError):
+                pass  # 실패해도 Agent 호출 통과 — histogram 폴백 의존.
+
     return 0
 
 
@@ -602,28 +618,42 @@ def handle_posttooluse_agent(
     # rid 활성 시만 histogram + redo_log
     eval_result = None
     histogram_str = ""
+    pending_match = ""
     if rid:
         try:
-            from harness.agent_trace import histogram as _trace_hist
-            from harness.agent_trace import read_all as _trace_read
+            from harness.agent_trace import histogram_since as _trace_hist_since
+            from harness.session_state import clear_pending_agent
             from harness.sub_eval import evaluate_sub, format_histogram
 
-            # #272 W3 — agent_id 폴백 안전성. 기존 _trace_last 폴백은 sub_type 검증 X
-            # 이라 직전 step (예: engineer) 의 agent_id 가 잘못 박혔다. 이제 trace 의
-            # 마지막 entry agent 가 *현재 sub_type 과 일치할 때만* 폴백 사용.
-            target_aid = sub_agent_id
-            if not target_aid:
-                _entries = _trace_read(sid, rid, base_dir=base_dir)
-                _short_sub = (sub_type or "").split(":")[-1] if sub_type else ""
-                for _e in reversed(_entries):
-                    _aid = _e.get("agent_id", "") or ""
-                    _eagent = (_e.get("agent", "") or "").split(":")[-1]
-                    if _aid and (not _short_sub or _eagent == _short_sub):
-                        target_aid = _aid
-                        break
-            hist = _trace_hist(sid, rid, agent_id=target_aid or None, base_dir=base_dir)
-            if hist:
-                histogram_str = format_histogram(hist)
+            # #272 W3 진짜 fix — pending_agent.started_at *이후* trace = 그 sub 의
+            # 행동. agent_id 폴백 제거 (오기록 원인). tool_use_id 매칭으로 정합 검증.
+            tuid_now = stdin_data.get("tool_use_id", "") or ""
+            pending = clear_pending_agent(sid, rid, base_dir=base_dir)
+            since_ts = ""
+            if isinstance(pending, dict):
+                since_ts = pending.get("started_at", "") or ""
+                # tool_use_id 매칭 검증 — drift 시 stderr WARN (silent fallback X)
+                pending_tuid = pending.get("tool_use_id", "") or ""
+                if tuid_now and pending_tuid and tuid_now != pending_tuid:
+                    print(
+                        f"[hook agent-id] tool_use_id 불일치: pending="
+                        f"{pending_tuid[:12]}… post={tuid_now[:12]}… — "
+                        f"PreToolUse Agent ↔ PostToolUse Agent 매칭 실패. "
+                        f"trace 시각 범위 폴백 사용.",
+                        file=sys.stderr,
+                    )
+                    pending_match = "drift"
+                else:
+                    pending_match = "ok"
+
+            # 시각 범위 기반 histogram. since_ts 없으면 (PreToolUse 미발화 시나리오)
+            # 빈 dict — 폴백 안 함 (오기록 < 빈 데이터 원칙).
+            hist = (
+                _trace_hist_since(sid, rid, since_ts, base_dir=base_dir)
+                if since_ts else {}
+            )
+            if hist or sub_type:
+                histogram_str = format_histogram(hist) if hist else "(none)"
                 # prompt hint — sub 호출 prompt 일부 (Write/Edit 약속 검출용)
                 prompt_hint = ""
                 if isinstance(tool_input, dict):
@@ -632,17 +662,22 @@ def handle_posttooluse_agent(
                     hist, sub_prompt_hint=prompt_hint, sub_type=sub_type,
                 )
 
-                # redo_log 자동 append — 보수적 자동 결정. 메인이 별도 1줄로 덮어쓰기 가능.
+                # redo_log 자동 append. agent_id 박지 X (CC docs 상 PostToolUse Agent
+                # 메인 컨텍스트엔 부재 가능). tool_use_id 가 정확한 매칭 키.
                 try:
                     from harness.redo_log import append as _redo_append
                     _redo_append(sid, rid, {
                         "auto": True,
-                        "agent_id": target_aid,
+                        "tool_use_id": tuid_now or (
+                            pending.get("tool_use_id", "")
+                            if isinstance(pending, dict) else ""
+                        ),
                         "sub": sub_type,
                         "decision": eval_result["decision"],
                         "tool_uses": eval_result["tool_uses"],
                         "histogram": hist,
                         "anomalies": eval_result["anomalies"],
+                        "match": pending_match,
                     }, base_dir=base_dir)
                 except Exception:  # noqa: BLE001 — silent, hook 본 흐름 방해 X
                     pass

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -71,6 +71,8 @@ __all__ = [
     "update_live",
     "start_run",
     "update_current_step",
+    "set_pending_agent",
+    "clear_pending_agent",
     "complete_run",
     "cleanup_stale_runs",
     "is_project_active",
@@ -536,6 +538,69 @@ def update_current_step(
     slot["last_confirmed_at"] = now
     active[run_id] = slot
     update_live(session_id, base_dir=base_dir, active_runs=active)
+
+
+def set_pending_agent(
+    session_id: str,
+    run_id: str,
+    *,
+    tool_use_id: str,
+    sub_type: str,
+    mode: Optional[str] = None,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """`active_runs[run_id].pending_agent` 갱신 — PreToolUse Agent 시점.
+
+    PostToolUse Agent 가 *시각 범위* 로 sub trace 를 식별 (#272 W3 진짜 fix).
+    기존 `agent_id` 폴백은 sub 가 file-op 안 한 경우 직전 step 의 ID 가 들어와
+    오기록 (#272 W3) — CC docs 상 PostToolUse Agent (메인 컨텍스트) 에 agent_id
+    가 *없을 수 있음*. `tool_use_id` (PreToolUse↔PostToolUse 매칭 키) + 시작 시각
+    으로 정확히 식별.
+
+    Args:
+        tool_use_id: CC PreToolUse Agent payload 의 tool_use_id (필수)
+        sub_type: subagent_type (검증/디버그용)
+        mode: 옵션 mode hint
+    """
+    if not tool_use_id:
+        return  # tool_use_id 없으면 매칭 불가 — 폴백 의존 (시각 범위 X)
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict) or run_id not in active:
+        return  # idempotent — run 미시작 케이스 (컨베이어 외부 Agent 호출)
+    slot = dict(active[run_id])
+    slot["pending_agent"] = {
+        "tool_use_id": tool_use_id,
+        "sub_type": sub_type or "",
+        "mode": mode or None,
+        "started_at": _now_iso(),
+    }
+    active = dict(active)
+    active[run_id] = slot
+    update_live(session_id, base_dir=base_dir, active_runs=active)
+
+
+def clear_pending_agent(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    """`active_runs[run_id].pending_agent` 제거 + 직전 값 반환.
+
+    PostToolUse Agent 가 호출. 반환값으로 sub_type / started_at / tool_use_id
+    검증 → trace 시각 범위 집계 + tool_use_id 매칭.
+    """
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict) or run_id not in active:
+        return None
+    slot = dict(active[run_id])
+    pending = slot.pop("pending_agent", None)
+    active = dict(active)
+    active[run_id] = slot
+    update_live(session_id, base_dir=base_dir, active_runs=active)
+    return pending if isinstance(pending, dict) else None
 
 
 def complete_run(

--- a/harness/sub_eval.py
+++ b/harness/sub_eval.py
@@ -86,8 +86,15 @@ def evaluate_sub(
     total = sum(histogram.values())
     anomalies: List[str] = []
 
-    # 룰 1 — 너무 적은 호출
-    if total < MIN_TOOL_USES:
+    sub_short = (sub_type or "").split(":", 1)[0].lower()
+    # plugin-namespaced (e.g. "dcness:qa") 와 short ("qa") 양쪽 호환
+    if ":" in (sub_type or ""):
+        sub_short = sub_type.split(":")[-1].lower()
+    is_prose_only = sub_short in PROSE_ONLY_AGENTS
+
+    # 룰 1 — 너무 적은 호출. prose-only sub 는 file-op 0건도 정상 (#272 W1 보완) —
+    # 예: pr-reviewer 가 메인 컨텍스트에서 prose 검토만 하고 file-op 안 한 경우.
+    if total < MIN_TOOL_USES and not is_prose_only:
         anomalies.append(f"tool_uses={total} (< {MIN_TOOL_USES})")
 
     # 룰 2 — 도구별 차등 임계 초과 반복
@@ -97,11 +104,6 @@ def evaluate_sub(
             anomalies.append(f"{tool}×{count} (≥ {threshold} 반복)")
 
     # 룰 3 — prompt 에 Write/Edit 약속 vs 실제 0건 (prose-only agent 제외)
-    sub_short = (sub_type or "").split(":", 1)[0].lower()
-    # plugin-namespaced (e.g. "dcness:qa") 와 short ("qa") 양쪽 호환
-    if ":" in (sub_type or ""):
-        sub_short = sub_type.split(":")[-1].lower()
-    is_prose_only = sub_short in PROSE_ONLY_AGENTS
     if not is_prose_only:
         write_edit = histogram.get("Write", 0) + histogram.get("Edit", 0)
         hint_lower = (sub_prompt_hint or "").lower()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1061,21 +1061,41 @@ class PostToolUseFileOpTests(_PreToolBase):
 
 
 class PostToolUseAgentHistogramTests(_PreToolBase):
-    """sub 종료 후 trace 집계 → redo_log 자동 append + stdout 메시지."""
+    """sub 종료 후 trace 집계 → redo_log 자동 append + stdout 메시지.
 
-    def _seed_trace(self, agent_id: str, tools: list) -> None:
+    #272 W3 진짜 fix — agent_id 폴백 제거. PreToolUse Agent 의 set_pending_agent
+    + 시각 범위 매칭 (tool_use_id 검증) 으로 정확한 sub 식별.
+    """
+
+    def _simulate_pre(
+        self, sub_type: str, *, tool_use_id: str = "toolu_test_default",
+        mode=None,
+    ) -> None:
+        """PreToolUse Agent 시점 시뮬레이션 — set_pending_agent 박음."""
+        from harness.session_state import set_pending_agent
+        set_pending_agent(
+            self.sid, self.rid,
+            tool_use_id=tool_use_id, sub_type=sub_type, mode=mode,
+            base_dir=self.base,
+        )
+
+    def _seed_trace(self, sub_type: str, tools: list) -> None:
+        """sub 내부 file-op trace — set_pending_agent *후* 호출돼야 시각 범위 매칭."""
         for tool in tools:
             trace_append(self.sid, self.rid, {
-                "phase": "pre", "agent_id": agent_id, "tool": tool,
+                "phase": "pre", "agent": sub_type, "tool": tool,
             }, base_dir=self.base)
             trace_append(self.sid, self.rid, {
-                "phase": "post", "agent_id": agent_id, "tool": tool,
+                "phase": "post", "agent": sub_type, "tool": tool,
             }, base_dir=self.base)
 
-    def _post_payload(self, sub_type: str, agent_id: str, prompt: str = "") -> dict:
+    def _post_payload(
+        self, sub_type: str, *, tool_use_id: str = "toolu_test_default",
+        prompt: str = "",
+    ) -> dict:
         return {
             "sessionId": self.sid,
-            "agent_id": agent_id,
+            "tool_use_id": tool_use_id,
             "tool_name": "Agent",
             "tool_input": {
                 "subagent_type": sub_type,
@@ -1084,9 +1104,10 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         }
 
     def test_pass_auto_redo_log(self):
-        self._seed_trace("aid-engineer", ["Read", "Read", "Write", "Bash"])
+        self._simulate_pre("engineer")
+        self._seed_trace("engineer", ["Read", "Read", "Write", "Bash"])
         rc = handle_posttooluse_agent(
-            stdin_data=self._post_payload("engineer", "aid-engineer"),
+            stdin_data=self._post_payload("engineer"),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
@@ -1097,11 +1118,14 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         self.assertTrue(redos[0]["auto"])
         self.assertEqual(redos[0]["sub"], "engineer")
         self.assertEqual(redos[0]["tool_uses"], 4)
+        # tool_use_id 매칭 검증
+        self.assertEqual(redos[0]["match"], "ok")
 
     def test_redo_suspect_on_low_calls(self):
-        self._seed_trace("aid-x", ["Read"])
+        self._simulate_pre("architect")
+        self._seed_trace("architect", ["Read"])
         rc = handle_posttooluse_agent(
-            stdin_data=self._post_payload("architect", "aid-x"),
+            stdin_data=self._post_payload("architect"),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
@@ -1112,11 +1136,11 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
 
     def test_redo_suspect_on_prose_only(self):
         # Read 만 4번 + Write 0건. prompt 에 "create file" 약속.
-        self._seed_trace("aid-arch", ["Read", "Read", "Read", "Read"])
+        self._simulate_pre("architect")
+        self._seed_trace("architect", ["Read", "Read", "Read", "Read"])
         rc = handle_posttooluse_agent(
             stdin_data=self._post_payload(
-                "architect", "aid-arch",
-                prompt="create the impl plan file at docs/foo.md"
+                "architect", prompt="create the impl plan file at docs/foo.md",
             ),
             cc_pid=self.cc_pid,
             base_dir=self.base,
@@ -1131,9 +1155,10 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
             self.sid, base_dir=self.base,
             active_agent="engineer", active_mode="IMPL",
         )
-        self._seed_trace("aid-engineer", ["Read", "Bash"])
+        self._simulate_pre("engineer", mode="IMPL")
+        self._seed_trace("engineer", ["Read", "Bash"])
         rc = handle_posttooluse_agent(
-            stdin_data=self._post_payload("engineer", "aid-engineer"),
+            stdin_data=self._post_payload("engineer"),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
@@ -1143,90 +1168,89 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         self.assertNotIn("active_mode", live)
 
     def test_no_trace_no_redo_log(self):
-        # trace 비어있으면 자동 redo_log 미추가, hook 본 흐름만.
+        # PreToolUse 안 박혔고 trace 비어있으면 → since_ts="" → hist={} → eval
+        # 발화 안 함 (sub_type 도 없으므로). 자동 redo_log 미추가.
         rc = handle_posttooluse_agent(
-            stdin_data=self._post_payload("engineer", "aid-empty"),
+            stdin_data={"sessionId": self.sid, "tool_name": "Agent"},
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
         self.assertEqual(read_redos(self.sid, self.rid, base_dir=self.base), [])
 
-    def test_agent_id_fallback_only_on_subtype_match(self):
-        """#272 W3 — payload agent_id 비어있고 trace 의 마지막 entry 가 *다른* sub
-        의 것이면 폴백 사용 X. redo_log 의 agent_id 가 직전 step 으로 오기록되는
-        문제 회귀."""
-        # trace 에 engineer 의 흔적만 있음 (직전 step). 이제 pr-reviewer Agent 가
-        # 호출됐고 (prose-only 라 자기 file-op trace 없음), payload agent_id 비어있음.
-        for tool in ["Read", "Edit", "Bash"]:
-            trace_append(self.sid, self.rid, {
-                "phase": "pre", "agent_id": "aid-engineer",
-                "agent": "engineer", "tool": tool,
-            }, base_dir=self.base)
+    def test_prior_step_trace_excluded(self):
+        """#272 W3 진짜 회귀 — 직전 step (engineer) 의 trace 가 *다음* sub 의
+        histogram 에 새지 않음. 시각 범위 매칭의 핵심."""
+        # 직전 engineer 가 file-op 다수 했음 (이미 끝남)
+        self._seed_trace("engineer", ["Read", "Edit", "Edit", "Bash"])
+        # 시각 진행 보장 — _now_iso 1초 단위라 sleep 1.1s 면 충분
+        import time
+        time.sleep(1.1)
+        # 이제 메인이 pr-reviewer (prose-only) 호출 — PreToolUse Agent 박음
+        self._simulate_pre("pr-reviewer", tool_use_id="toolu_pr1")
+        # pr-reviewer 가 file-op 안 함 (prose-only)
         rc = handle_posttooluse_agent(
-            stdin_data={
-                "sessionId": self.sid,
-                "tool_name": "Agent",
-                "tool_input": {"subagent_type": "pr-reviewer"},
-                # agent_id 비어있음
-            },
+            stdin_data=self._post_payload("pr-reviewer", tool_use_id="toolu_pr1"),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
         redos = read_redos(self.sid, self.rid, base_dir=self.base)
-        if redos:
-            # trace 마지막 agent="engineer" ≠ sub_type="pr-reviewer"
-            # → target_aid 폴백 안 됨 → ""
-            self.assertNotEqual(
-                redos[0].get("agent_id"), "aid-engineer",
-                msg="직전 sub 의 agent_id 가 폴백으로 박혔음 (#272 W3 회귀)",
-            )
-
-    def test_agent_id_fallback_uses_matching_subtype(self):
-        """#272 W3 회귀 — trace 의 마지막 entry agent 가 sub_type 과 *일치* 하면 폴백 사용."""
-        # 직전 다른 sub 의 trace + 같은 sub_type (pr-reviewer) 의 trace 둘 다.
-        for aid, agent, tool in [
-            ("aid-engineer", "engineer", "Edit"),
-            ("aid-engineer", "engineer", "Bash"),
-            ("aid-pr1", "pr-reviewer", "Read"),
-            ("aid-pr1", "pr-reviewer", "Read"),
-        ]:
-            trace_append(self.sid, self.rid, {
-                "phase": "pre", "agent_id": aid, "agent": agent, "tool": tool,
-            }, base_dir=self.base)
-        rc = handle_posttooluse_agent(
-            stdin_data={
-                "sessionId": self.sid,
-                "tool_name": "Agent",
-                "tool_input": {"subagent_type": "pr-reviewer"},
-            },
-            cc_pid=self.cc_pid,
-            base_dir=self.base,
-        )
-        self.assertEqual(rc, 0)
-        redos = read_redos(self.sid, self.rid, base_dir=self.base)
-        # 폴백 → aid-pr1 (sub_type 일치하는 마지막)
-        self.assertEqual(redos[0]["agent_id"], "aid-pr1")
+        # pr-reviewer 의 histogram 에는 직전 engineer trace 가 *반영 안 됨*.
+        # prose-only 라 file-op 0건이 정상.
         self.assertEqual(redos[0]["sub"], "pr-reviewer")
+        self.assertEqual(redos[0]["histogram"], {},
+            msg="직전 engineer trace 가 pr-reviewer histogram 으로 새어들어옴 (#272 W3)")
+        self.assertEqual(redos[0]["tool_use_id"], "toolu_pr1")
+        self.assertEqual(redos[0]["match"], "ok")
+
+    def test_tool_use_id_drift_logged(self):
+        """tool_use_id 가 PreToolUse 와 PostToolUse 사이 다르면 stderr WARN."""
+        import io
+        import contextlib
+        self._simulate_pre("engineer", tool_use_id="toolu_pre")
+        self._seed_trace("engineer", ["Read", "Edit"])
+        buf = io.StringIO()
+        with contextlib.redirect_stderr(buf):
+            rc = handle_posttooluse_agent(
+                stdin_data=self._post_payload(
+                    "engineer", tool_use_id="toolu_post_DIFFERENT",
+                ),
+                cc_pid=self.cc_pid,
+                base_dir=self.base,
+            )
+        self.assertEqual(rc, 0)
+        stderr = buf.getvalue()
+        self.assertIn("[hook agent-id]", stderr)
+        self.assertIn("tool_use_id 불일치", stderr)
+        redos = read_redos(self.sid, self.rid, base_dir=self.base)
+        self.assertEqual(redos[0]["match"], "drift")
+
+    def test_pending_agent_cleared_after_post(self):
+        """PostToolUse Agent 후 live.json.active_runs[rid].pending_agent 제거."""
+        from harness.session_state import read_live as _rl
+        self._simulate_pre("engineer", tool_use_id="toolu_x")
+        live = _rl(self.sid, base_dir=self.base)
+        slot = live.get("active_runs", {}).get(self.rid, {})
+        self.assertIn("pending_agent", slot)
+        self._seed_trace("engineer", ["Read"])
+        handle_posttooluse_agent(
+            stdin_data=self._post_payload("engineer", tool_use_id="toolu_x"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        live2 = _rl(self.sid, base_dir=self.base)
+        slot2 = live2.get("active_runs", {}).get(self.rid, {})
+        self.assertNotIn("pending_agent", slot2)
 
     def test_prose_only_subtype_not_promised_write(self):
         """#272 W1 — prose-only sub (qa) 는 promised_write anomaly 발화 X."""
-        for tool in ["Read", "Read", "Read"]:
-            trace_append(self.sid, self.rid, {
-                "phase": "pre", "agent_id": "aid-qa",
-                "agent": "qa", "tool": tool,
-            }, base_dir=self.base)
+        self._simulate_pre("qa", tool_use_id="toolu_qa")
+        self._seed_trace("qa", ["Read", "Read", "Read"])
         rc = handle_posttooluse_agent(
-            stdin_data={
-                "sessionId": self.sid,
-                "agent_id": "aid-qa",
-                "tool_name": "Agent",
-                "tool_input": {
-                    "subagent_type": "qa",
-                    "prompt": "분석 작성해줘",
-                },
-            },
+            stdin_data=self._post_payload(
+                "qa", tool_use_id="toolu_qa", prompt="분석 작성해줘",
+            ),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )

--- a/tests/test_sub_eval.py
+++ b/tests/test_sub_eval.py
@@ -70,6 +70,21 @@ class EvaluateSubTests(unittest.TestCase):
         self.assertEqual(result["decision"], "REDO_SUSPECT")
         self.assertTrue(any(f"< {MIN_TOOL_USES}" in a for a in result["anomalies"]))
 
+    def test_prose_only_sub_skips_min_tool_uses(self):
+        # #272 W1 보완 — prose-only sub 는 file-op 0건도 정상.
+        for sub in ("pr-reviewer", "qa", "validator"):
+            with self.subTest(sub=sub):
+                result = evaluate_sub({}, sub_type=sub)
+                self.assertEqual(
+                    result["decision"], "PASS",
+                    msg=f"{sub} → {result} (prose-only file-op 0 도 정상)",
+                )
+
+    def test_engineer_below_min_still_fires(self):
+        # 일반 sub 는 file-op 1건 미만 시 anomaly 유지
+        result = evaluate_sub({"Read": 1}, sub_type="engineer")
+        self.assertEqual(result["decision"], "REDO_SUSPECT")
+
     def test_redo_repeat_read(self):
         # Read 임계 15
         result = evaluate_sub({"Read": REPEAT_TOOL_THRESHOLDS["Read"]})


### PR DESCRIPTION
## 변경 요약

### [issue-272] agent_id 폴백 제거 + tool_use_id 매칭 + 시각 범위 histogram (W3 진짜 fix)

- **What**: PR #274 의 W3 fix (sub_type 매칭 폴백) 는 *오기록 차단* 일 뿐. 본 PR 은 *왜 동생 이름표가 빈 채로 들어왔나* 의 근본 메커니즘 정합 — `agent_id` 폴백 자체 제거, `tool_use_id` (CC 의 PreToolUse↔PostToolUse 매칭 키) + 시각 범위 (started_at 이후 trace) 로 sub 정확 식별.
- **Why**: CC docs 실측 — `agent_id` 는 sub *내부* hook 에만 박힘. PostToolUse Agent (메인 컨텍스트) 에는 *없을 수 있음*. 우리가 이걸 모르고 `_trace_last` 폴백 했다가 직전 engineer 의 ID 가 pr-reviewer redo-log 에 박힌 게 #272 W3 의 진짜 원인.

### 핵심 변경

1. `harness/session_state.py` — `set_pending_agent` / `clear_pending_agent` 헬퍼 추가. `active_runs[rid].pending_agent = {tool_use_id, sub_type, started_at}`.
2. `harness/agent_trace.py` — `histogram_since(sid, rid, since_ts)` 추가. ts 기준 *이후* pre phase 만 집계.
3. `harness/hooks.py`
   - PreToolUse Agent: `tool_use_id` 받아 set_pending_agent 박음.
   - PostToolUse Agent: clear_pending_agent → started_at + tool_use_id → `histogram_since(started_at)` 으로 *그 sub 의 행동만* 집계. agent_id 폴백 제거.
   - tool_use_id 불일치 시 `[hook agent-id] tool_use_id 불일치` stderr WARN.
   - redo_log 의 `agent_id` 필드 제거, `tool_use_id` + `match` (ok/drift) 로 교체.
4. `harness/sub_eval.py` — prose-only sub 는 `MIN_TOOL_USES` 룰도 skip. pr-reviewer 가 PR 변경을 메인 컨텍스트 prose 만으로 검토하고 file-op 0건 한 경우도 정상.

## 결정 근거

- 추측 X (제1 룰). CC docs (https://code.claude.com/docs/en/hooks) 직접 fetch 후 schema 확인:
  - PreToolUse Agent payload 에 `tool_use_id` 필수 존재 — Pre↔Post 매칭 키.
  - PostToolUse Agent 에 `agent_id` 는 *조건부*. 우리가 의존하면 안 됨.
- 폴백 안전성보다 *근본 매커니즘 교체* 가 정합. 1차 fix (sub_type 매칭) 의 dead code 위험 회피.
- prose-only 의 file-op 0건 정상 처리는 #272 W1 보완 — 화이트리스트 확장 (룰 1 + 룰 3 둘 다 skip).

## 관련 이슈

Closes #272

(이미 PR #274 에서 자동 close 됐을 수 있음 — 본 PR 은 W3 의 근본 메커니즘 fix follow-up. close-keyword gate 통과용 키워드 박음.)

## 참고

- PR #274 머지 직후 PR. #274 의 1차 안전장치 (sub_type 매칭 폴백) 위에 근본 fix 덧붙임.
- 본 저장소(dcness self) 미적용 — plug-in 사용자 update 시 자동 적용. 다음 release (0.2.7 후보) 권고.
- 회귀 테스트 +5개 추가. 407 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)