### PR TITLE
[issue-272] prose 추출 robust extraction (W2 진짜 fix)

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -83,6 +83,56 @@ def _append_trace_safe(
         pass
 
 
+# #272 W2 — prose robust extraction (어떤 nested 형식이든 first non-empty text)
+# CC PostToolUse Agent 의 tool_response 형식 이력:
+#   - 2026-05-01 도입 시 dict {"text": ...} 가정 (실측 X — 항상 fail)
+#   - 2026-05-07 issue-232 가 list[{"type":"text","text":...}] 1형식 추가
+#   - jajang #272/#273: 그래도 fail → 또 다른 nested 변형 추정
+# 본 헬퍼는 *모든 dict/list 변형* depth-first 탐색해 first non-empty text-like 값
+# 추출. CC schema 변동/undocumented format 대응. 후보 키 우선순위는 Anthropic
+# content block 관례 (text > content > value > output).
+_PROSE_TEXT_KEYS = ("text", "content", "value", "output")
+
+
+def _extract_prose_text(obj: Any, _depth: int = 0) -> str:
+    """tool_response → prose text. dict/list/str/nested 모두 robust.
+
+    탐색 정책:
+      - str: 그대로 반환 (strip 비어있으면 "")
+      - dict: 우선순위 키 (`_PROSE_TEXT_KEYS`) 의 string value 만 채택 →
+        그 다음 *dict/list value* 만 재귀 (string value 는 metadata 가능성
+        — type="tool_result" 같은 필드 prose 로 오인 차단)
+      - list: 각 item 재귀, first non-empty 반환
+      - 기타: ""
+
+    depth limit (16) — 무한 재귀 방어 (정상 payload 는 1~3 depth).
+    """
+    if _depth > 16:
+        return ""
+    if isinstance(obj, str):
+        return obj if obj.strip() else ""
+    if isinstance(obj, dict):
+        # 우선순위 키 — 직접 매칭 (string value 만 prose 로 채택)
+        for key in _PROSE_TEXT_KEYS:
+            v = obj.get(key)
+            if isinstance(v, str) and v.strip():
+                return v
+        # 그 외 — nested 컨테이너만 재귀 (string 값 = metadata 가능성, skip)
+        for v in obj.values():
+            if isinstance(v, (dict, list)):
+                r = _extract_prose_text(v, _depth + 1)
+                if r:
+                    return r
+        return ""
+    if isinstance(obj, list):
+        for item in obj:
+            r = _extract_prose_text(item, _depth + 1)
+            if r:
+                return r
+        return ""
+    return ""
+
+
 # orchestration.md §7.1 — 컨베이어 경유 필수 agent
 # (agent_name, mode_or_None) — None = 모든 mode 적용
 HARNESS_ONLY_AGENTS: tuple = (
@@ -524,31 +574,24 @@ def handle_posttooluse_agent(
     rid = _resolve_rid(sid, cc_pid, base_dir=base_dir)
 
     # prose auto-staging — tool_response → run_dir 에 저장, current_step.prose_file 기록
-    # silent except 제거 (#272 W2 / #273 W1) — staging 미동작 진단 가능하게 단계별
-    # stderr DEBUG. post-agent-clear.sh 가 stderr → /tmp/dcness-hook-stderr.log 보존.
+    # #272 W2 진짜 fix — robust extraction. 도입(2026-05-01) 시 dict 만 가정 → fail.
+    # issue-232 가 list[{type:"text",text:...}] 한 형식만 추가 → jajang 보고에서 또 fail.
+    # 이번엔 *어떤 nested 형식이든* first non-empty text 추출 (CC schema 변동·
+    # undocumented 변형 robust). 추출 실패 시에만 stderr 진단.
     if rid:
-        prose_text = ""
         raw_response = stdin_data.get("tool_response")
+        prose_text = ""
         try:
-            if isinstance(raw_response, list):
-                # CC Agent PostToolUse 실제 포맷: [{"type": "text", "text": "..."}]
-                for block in raw_response:
-                    if isinstance(block, dict) and block.get("type") == "text":
-                        prose_text = str(block.get("text", "") or "")
-                        break
-            elif isinstance(raw_response, dict):
-                prose_text = str(raw_response.get("text", "") or "")
-            elif isinstance(raw_response, str):
-                prose_text = raw_response
+            prose_text = _extract_prose_text(raw_response)
         except Exception as e:  # noqa: BLE001
             print(
-                f"[hook prose stage] tool_response 파싱 예외: "
+                f"[hook prose stage] tool_response 추출 예외: "
                 f"{type(e).__name__}: {e}",
                 file=sys.stderr,
             )
 
         if not prose_text.strip():
-            # 형식 미스매치 진단 정보 — 다음 run 에서 외부 환경 디버그 가능
+            # robust extraction 도 fail 한 진짜 예외 — 다음 진단용
             if isinstance(raw_response, dict):
                 _shape = f"dict keys={list(raw_response.keys())[:5]}"
             elif isinstance(raw_response, list):
@@ -561,7 +604,7 @@ def handle_posttooluse_agent(
             else:
                 _shape = f"type={type(raw_response).__name__}"
             print(
-                f"[hook prose stage] prose 추출 실패 — staging skip. {_shape}",
+                f"[hook prose stage] robust extraction 실패 — staging skip. {_shape}",
                 file=sys.stderr,
             )
         else:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1439,13 +1439,70 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
         self.assertIn("[hook prose stage]", stderr)
         self.assertIn("current_step 부재", stderr)
 
-    def test_unrecognized_tool_response_emits_shape_diagnostic(self) -> None:
-        """#272 W2 — tool_response 형식 미스매치 시 stderr 에 형식 정보 출력."""
+    def test_robust_extraction_alt_type_recovers(self) -> None:
+        """#272 W2 진짜 fix — list of dict 인데 type 이 'text' 아닌 'tool_result'
+        같은 변형도 robust 추출. issue-232 1차 fix 가 type=='text' 한 형식만 본
+        한계 회복."""
+        self._set_current_step("qa", None)
+        prose = "## 결론\nPASS\n"
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "qa"},
+                "tool_response": [{"type": "tool_result", "content": prose}],
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertTrue(expected.exists(), msg="content 키 변형도 추출돼야 함")
+        self.assertEqual(expected.read_text(encoding="utf-8"), prose)
+
+    def test_robust_extraction_nested_dict(self) -> None:
+        """nested dict 구조 — `{"result": {"text": prose}}` 같은 wrapping 도 cover."""
+        self._set_current_step("qa", None)
+        prose = "## 결론\nFUNCTIONAL_BUG\n"
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "qa"},
+                "tool_response": {"result": {"text": prose}, "meta": {"n": 1}},
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertTrue(expected.exists(), msg="nested dict 도 추출돼야 함")
+        self.assertEqual(expected.read_text(encoding="utf-8"), prose)
+
+    def test_robust_extraction_value_key(self) -> None:
+        """`value` 키 변형 — 일부 SDK 가 사용."""
+        self._set_current_step("qa", None)
+        prose = "## 결론\nLGTM\n"
+        rc = handle_posttooluse_agent(
+            stdin_data={
+                "sessionId": self.sid,
+                "tool_name": "Agent",
+                "tool_input": {"subagent_type": "qa"},
+                "tool_response": {"value": prose},
+            },
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+        expected = session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "qa.md"
+        self.assertTrue(expected.exists())
+
+    def test_unextractable_emits_diagnostic_stderr(self) -> None:
+        """robust extraction 이 *진짜* 못 뽑는 경우 — 텍스트 키 전무한 metadata 만."""
         import io
         import contextlib
 
         self._set_current_step("qa", None)
-        # CC 가 다른 형식 보낼 가능성 — list of dict 인데 "type" 이 "text" 아닌 경우
         buf = io.StringIO()
         with contextlib.redirect_stderr(buf):
             rc = handle_posttooluse_agent(
@@ -1453,7 +1510,8 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
                     "sessionId": self.sid,
                     "tool_name": "Agent",
                     "tool_input": {"subagent_type": "qa"},
-                    "tool_response": [{"type": "tool_result", "content": "x"}],
+                    # text-like 키 (text/content/value/output) 전무 + 모든 값이 비-문자열
+                    "tool_response": [{"type": "tool_result", "exit_code": 0}],
                 },
                 cc_pid=self.cc_pid,
                 base_dir=self.base,
@@ -1461,7 +1519,7 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
         self.assertEqual(rc, 0)
         stderr = buf.getvalue()
         self.assertIn("[hook prose stage]", stderr)
-        self.assertIn("prose 추출 실패", stderr)
+        self.assertIn("robust extraction 실패", stderr)
         # 형식 정보 포함 — 외부 환경 디버그용
         self.assertIn("item0_type=tool_result", stderr)
 
@@ -1487,6 +1545,102 @@ class PostToolUseAgentProseAutoStageTests(_PreToolBase):
             session_dir(self.sid, base_dir=self.base) / "runs" / self.rid / "engineer-1.md"
         )
         self.assertTrue(expected.exists())
+
+
+class ExtractProseTextTests(unittest.TestCase):
+    """#272 W2 — _extract_prose_text robust 매트릭스."""
+
+    def test_str(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text("hello"), "hello")
+
+    def test_empty_str(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text(""), "")
+        self.assertEqual(_extract_prose_text("   "), "")
+
+    def test_dict_text_key(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text({"text": "hi"}), "hi")
+
+    def test_dict_content_key(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text({"content": "hi"}), "hi")
+
+    def test_dict_value_key(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text({"value": "hi"}), "hi")
+
+    def test_dict_text_priority_over_content(self):
+        from harness.hooks import _extract_prose_text
+        # text 가 우선
+        self.assertEqual(
+            _extract_prose_text({"text": "primary", "content": "secondary"}),
+            "primary",
+        )
+
+    def test_list_of_text_block(self):
+        from harness.hooks import _extract_prose_text
+        # CC 의 issue-232 시점 형식
+        self.assertEqual(
+            _extract_prose_text([{"type": "text", "text": "hi"}]), "hi",
+        )
+
+    def test_list_of_alt_block(self):
+        from harness.hooks import _extract_prose_text
+        # type 다른 변형도 cover
+        self.assertEqual(
+            _extract_prose_text([{"type": "tool_result", "content": "hi"}]), "hi",
+        )
+
+    def test_list_first_non_empty(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(
+            _extract_prose_text([{}, {"text": ""}, {"content": "found"}]),
+            "found",
+        )
+
+    def test_nested_dict(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(
+            _extract_prose_text({"result": {"text": "deep"}}), "deep",
+        )
+
+    def test_nested_list_dict(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(
+            _extract_prose_text({"data": [{"value": "x"}]}), "x",
+        )
+
+    def test_empty_dict(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text({}), "")
+
+    def test_empty_list(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text([]), "")
+
+    def test_none(self):
+        from harness.hooks import _extract_prose_text
+        self.assertEqual(_extract_prose_text(None), "")
+
+    def test_metadata_only(self):
+        from harness.hooks import _extract_prose_text
+        # text-like 키 전무 + 값들이 모두 비-문자열
+        self.assertEqual(
+            _extract_prose_text([{"type": "tool_result", "exit_code": 0}]),
+            "",
+        )
+
+    def test_depth_limit_no_crash(self):
+        from harness.hooks import _extract_prose_text
+        # 의도적으로 깊은 nesting — 무한 재귀 방어 검증
+        deep = {"a": "x"}
+        for _ in range(50):
+            deep = {"a": deep}
+        # depth 16 초과는 "" 반환 (crash X)
+        result = _extract_prose_text(deep)
+        self.assertIsInstance(result, str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

### [issue-272] prose 추출 robust extraction — 어떤 nested 형식이든 cover (W2 진짜 fix)

- **What**: tool_response → prose 추출을 *모든 nested dict/list 변형* depth-first 처리. 우선순위 키 (`text` > `content` > `value` > `output`) 의 string value 만 채택, 그 외는 dict/list 만 재귀 (string metadata 오인 차단).
- **Why**: 도입(2026-05-01) 시 dict 만 가정 → 항상 fail. issue-232 (2026-05-07) 가 list[{type:"text"}] 1형식 추가 → jajang 그래도 fail. PR #274 의 W2 fix 는 stderr DEBUG 만. 본 PR 은 *모든 후보 시도* 로 issue-232 의 "한 형식만 추가" 함정 회피.

## 결정 근거

- 추측 위험 회피 vs robust 처리 — *후보 키 추측* 은 하지만 *모든 후보 시도* 라 한 형식만 놓치는 함정 X.
- string value 우선순위 키일 때만 채택 → `type="tool_result"` 같은 metadata prose 오인 방지.
- robust extraction 도 fail 시 stderr 진단 보존 (last resort — 미지의 또 다른 변형 발견 시).

## 관련 이슈

Closes #272

(이미 PR #274/#275 에서 자동 close 됐을 수 있음 — 본 PR 은 W2 의 진짜 fix follow-up.)

## 참고

- PR #274 W2 (stderr DEBUG, 진단 인프라) + PR #275 W3 (tool_use_id 시각 범위) 위에 W2 진짜 fix 마무리.
- 본 저장소(dcness self) 미적용 — plug-in 사용자 update 시 자동 적용. 다음 release (0.2.7 후보) 권고.
- 회귀 테스트 +19개 (단위 14 + integration 5). 426 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)