### PR TITLE
[issue-272] anomaly hook 자율 친화 재설계 (W1 진짜 fix)

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -658,24 +658,30 @@ def handle_posttooluse_agent(
                     file=sys.stderr,
                 )
 
-    # rid 활성 시만 histogram + redo_log
-    eval_result = None
+    # rid 활성 시만 측정 inject + redo_log auto append
+    # #272 W1 자율 친화 재설계 — hook 은 *raw 측정 데이터* 만 inject.
+    # "REDO_SUSPECT" 같은 결정 X. 임계값 X. prose-only 화이트리스트 X.
+    # 메인 LLM 이 dcness-rules.md §3.3 가이드 보고 자율 판단.
     histogram_str = ""
+    input_repeats_str = ""
     pending_match = ""
+    hist: Dict[str, int] = {}
+    trace_subset: list = []
     if rid:
         try:
             from harness.agent_trace import histogram_since as _trace_hist_since
+            from harness.agent_trace import read_all as _trace_read
             from harness.session_state import clear_pending_agent
-            from harness.sub_eval import evaluate_sub, format_histogram
+            from harness.sub_eval import (
+                format_histogram, format_input_repeats, summarize_input_repeats,
+            )
 
-            # #272 W3 진짜 fix — pending_agent.started_at *이후* trace = 그 sub 의
-            # 행동. agent_id 폴백 제거 (오기록 원인). tool_use_id 매칭으로 정합 검증.
+            # #272 W3 — pending_agent.started_at 이후 trace = 그 sub 의 행동.
             tuid_now = stdin_data.get("tool_use_id", "") or ""
             pending = clear_pending_agent(sid, rid, base_dir=base_dir)
             since_ts = ""
             if isinstance(pending, dict):
                 since_ts = pending.get("started_at", "") or ""
-                # tool_use_id 매칭 검증 — drift 시 stderr WARN (silent fallback X)
                 pending_tuid = pending.get("tool_use_id", "") or ""
                 if tuid_now and pending_tuid and tuid_now != pending_tuid:
                     print(
@@ -689,24 +695,23 @@ def handle_posttooluse_agent(
                 else:
                     pending_match = "ok"
 
-            # 시각 범위 기반 histogram. since_ts 없으면 (PreToolUse 미발화 시나리오)
-            # 빈 dict — 폴백 안 함 (오기록 < 빈 데이터 원칙).
             hist = (
                 _trace_hist_since(sid, rid, since_ts, base_dir=base_dir)
                 if since_ts else {}
             )
+            # 같은 input 반복 — 메인 자율 판단용 raw 신호 (다중 파일 vs 동일 파일 구분)
+            if since_ts:
+                trace_subset = [
+                    e for e in _trace_read(sid, rid, base_dir=base_dir)
+                    if e.get("ts", "") >= since_ts
+                ]
+                input_repeats = summarize_input_repeats(trace_subset)
+                input_repeats_str = format_input_repeats(input_repeats)
+
             if hist or sub_type:
                 histogram_str = format_histogram(hist) if hist else "(none)"
-                # prompt hint — sub 호출 prompt 일부 (Write/Edit 약속 검출용)
-                prompt_hint = ""
-                if isinstance(tool_input, dict):
-                    prompt_hint = str(tool_input.get("prompt", "") or "")[:500]
-                eval_result = evaluate_sub(
-                    hist, sub_prompt_hint=prompt_hint, sub_type=sub_type,
-                )
-
-                # redo_log 자동 append. agent_id 박지 X (CC docs 상 PostToolUse Agent
-                # 메인 컨텍스트엔 부재 가능). tool_use_id 가 정확한 매칭 키.
+                # redo_log auto append — *측정 데이터만*. decision/anomalies 필드 X
+                # (자율 영역). 메인이 직접 판단해서 박을 때만 decision 들어감.
                 try:
                     from harness.redo_log import append as _redo_append
                     _redo_append(sid, rid, {
@@ -716,10 +721,9 @@ def handle_posttooluse_agent(
                             if isinstance(pending, dict) else ""
                         ),
                         "sub": sub_type,
-                        "decision": eval_result["decision"],
-                        "tool_uses": eval_result["tool_uses"],
+                        "tool_uses": sum(hist.values()),
                         "histogram": hist,
-                        "anomalies": eval_result["anomalies"],
+                        "input_repeats": input_repeats_str,
                         "match": pending_match,
                     }, base_dir=base_dir)
                 except Exception:  # noqa: BLE001 — silent, hook 본 흐름 방해 X
@@ -733,16 +737,12 @@ def handle_posttooluse_agent(
     except (OSError, ValueError):
         pass
 
-    # additionalContext 작성 — 정상이면 짧은 줄, anomaly 시 강조
+    # additionalContext — *raw 측정 데이터* + 가이드 1줄. 결정 메시지 X.
+    # 메인 LLM 이 dcness-rules.md §3.3 가이드 (REDO 판단 신호) 보고 자율 판단.
     if histogram_str:
-        if eval_result and eval_result["decision"] == "REDO_SUSPECT":
-            ctx = (
-                f"[감시자 hook] sub={sub_type or '?'} tool histogram: {histogram_str}\n"
-                f"⚠️ anomaly 감지: {'; '.join(eval_result['anomalies'])}\n"
-                f"메인 판단 권고 — REDO_SAME / REDO_BACK / REDO_DIFF 검토 (auto-redo-log 기록됨)"
-            )
-        else:
-            ctx = f"[감시자 hook] sub={sub_type or '?'} tool histogram: {histogram_str} (PASS)"
+        ctx = f"[감시자 hook] sub={sub_type or '?'} tool histogram: {histogram_str}"
+        if input_repeats_str:
+            ctx += f"\n같은 input 반복: {input_repeats_str}"
 
         try:
             output = {

--- a/harness/sub_eval.py
+++ b/harness/sub_eval.py
@@ -1,124 +1,30 @@
-"""sub_eval — sub completion 자동 평가 (DCN-CHG-20260501-13).
+"""sub_eval — sub 측정 데이터 (DCN-CHG-20260501-13, 자율 친화 재설계 #272).
 
-PostToolUse Agent hook 가 sub 종료 시 trace 집계 → tool histogram + anomaly 검출
-→ additionalContext inject + redo_log 자동 append.
+PostToolUse Agent hook 가 sub 종료 시 trace 집계 → tool histogram + 같은 input
+반복 카운트 → additionalContext inject. *결정 X — raw data 만*.
 
-jajang 메인 자기 진단 반영 (DCN-CHG-20260501-13 plan):
-    - 룰 추가 < surface 개선 (능동 retrieval → push)
-    - 매번 reminder = theater. anomaly 시에만 발화
-    - redo_log 권고 → 인프라 자동화
+dcness-rules.md §1 정합 (가이드레일만, 메인 LLM 자율 판단):
+    - 임계값 hardcode X (Read 15 같은 우리 가정 박지 X)
+    - "REDO_SUSPECT" 자동 결정 X (메인이 dcness-rules §3.3 가이드 보고 자율)
+    - 화이트리스트 / 약속-실측 검사 X (룰 박을수록 자율 침해)
 
-Anomaly 룰 (보수적):
-    - tool_uses < 2 — sub 가 거의 일 안 함
-    - 도구별 차등 임계 초과 반복 — 뻘짓 의심 (실측 baseline 반영, #272/#273)
-    - prompt 에 Write/Edit 약속했는데 Write+Edit 0건 — prose-only
-      단 prose-only agent (qa/validator/pr-reviewer 등) 는 promised_write 검사 자체
-      미적용 (false positive 다발 — #272 W1).
+이전 (PR #274 시점) anomaly 룰 (임계 차등 / prose-only 화이트리스트 /
+promised_write) 은 *결정을 hook 에 박는* 패턴이라 자율 영역 침해 — false positive
+4/5 step 매번 메인이 echo 부담 (#272 W1 보고). 본 재설계는 hook 의 책임을
+*가이드레일/측정* 으로 한정.
 
-자동 결정:
-    - PASS — anomaly 없음
-    - REDO_SUSPECT — anomaly 1+ 검출. 메인이 봐서 재정의 가능.
+API 정합 — 기존 호출자 (`harness/hooks.py`) 는 raw measurement 만 사용.
 """
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 
 __all__ = [
-    "evaluate_sub",
     "format_histogram",
-    "REPEAT_TOOL_THRESHOLD",
-    "REPEAT_TOOL_THRESHOLDS",
-    "PROSE_ONLY_AGENTS",
+    "format_input_repeats",
+    "summarize_input_repeats",
 ]
-
-
-# 도구별 차등 임계 (#272/#273 실측 — 정상 architect Read×8 / engineer Edit×6~10
-# / pr-reviewer Read×5 / test-engineer Read×5 모두 false positive 였다).
-# 의미: "같은 도구 N+ 반복" 신호는 *자연스러운 다중 파일 read* 가 아니라
-# *동일 파일 동일 작업 무의미 반복* 을 잡는 것. 자연 baseline 반영해 상향.
-REPEAT_TOOL_THRESHOLDS: Dict[str, int] = {
-    "Read": 15,    # 다중 파일 탐색 / 인접 컨텍스트 자연
-    "Edit": 12,    # 단일 파일 multi-section + 다중 파일
-    "Bash": 10,    # 다중 검증 명령 자연 (test + grep + build)
-    "Write": 8,
-    "Glob": 10,
-    "Grep": 10,
-}
-REPEAT_TOOL_THRESHOLD_DEFAULT = 12
-
-# 호환용 export — 외부 import 안전. 도구 미지정 시 default 와 동일.
-REPEAT_TOOL_THRESHOLD = REPEAT_TOOL_THRESHOLD_DEFAULT
-MIN_TOOL_USES = 2
-
-# prose-only agent — handoff-matrix.md §4.1 ALLOW_MATRIX 상 src 쓰기 권한 X.
-# Write/Edit 0건이 *정상*. promised_write false positive 차단 (#272 W1).
-PROSE_ONLY_AGENTS = frozenset({
-    "qa",
-    "validator",
-    "pr-reviewer",
-    "design-critic",
-    "security-reviewer",
-    "plan-reviewer",
-})
-
-
-def evaluate_sub(
-    histogram: Dict[str, int],
-    *,
-    sub_prompt_hint: str = "",
-    sub_type: str = "",
-) -> Dict[str, Any]:
-    """histogram + 옵션 prompt hint + sub_type 기반 자동 평가.
-
-    Args:
-        histogram: agent_trace.histogram 결과 — {"Read": 4, "Bash": 2, ...}
-        sub_prompt_hint: sub 호출 prompt 의 일부 (Write/Edit 약속 검출용). 미사용 가능.
-        sub_type: subagent_type. PROSE_ONLY_AGENTS 검사용. 미지정 시 폴백 검사.
-
-    Returns:
-        {
-            "decision": "PASS" | "REDO_SUSPECT",
-            "anomalies": [str, ...],  # 발견된 anomaly 목록
-            "tool_uses": int,  # 총 호출 수
-        }
-    """
-    total = sum(histogram.values())
-    anomalies: List[str] = []
-
-    sub_short = (sub_type or "").split(":", 1)[0].lower()
-    # plugin-namespaced (e.g. "dcness:qa") 와 short ("qa") 양쪽 호환
-    if ":" in (sub_type or ""):
-        sub_short = sub_type.split(":")[-1].lower()
-    is_prose_only = sub_short in PROSE_ONLY_AGENTS
-
-    # 룰 1 — 너무 적은 호출. prose-only sub 는 file-op 0건도 정상 (#272 W1 보완) —
-    # 예: pr-reviewer 가 메인 컨텍스트에서 prose 검토만 하고 file-op 안 한 경우.
-    if total < MIN_TOOL_USES and not is_prose_only:
-        anomalies.append(f"tool_uses={total} (< {MIN_TOOL_USES})")
-
-    # 룰 2 — 도구별 차등 임계 초과 반복
-    for tool, count in histogram.items():
-        threshold = REPEAT_TOOL_THRESHOLDS.get(tool, REPEAT_TOOL_THRESHOLD_DEFAULT)
-        if count >= threshold:
-            anomalies.append(f"{tool}×{count} (≥ {threshold} 반복)")
-
-    # 룰 3 — prompt 에 Write/Edit 약속 vs 실제 0건 (prose-only agent 제외)
-    if not is_prose_only:
-        write_edit = histogram.get("Write", 0) + histogram.get("Edit", 0)
-        hint_lower = (sub_prompt_hint or "").lower()
-        promised_write = any(
-            kw in hint_lower for kw in ("write", "edit", "create", "작성", "생성")
-        )
-        if promised_write and write_edit == 0 and total > 0:
-            anomalies.append("prompt 에 Write/Edit 약속, 실제 0건 (prose-only 의심)")
-
-    decision = "REDO_SUSPECT" if anomalies else "PASS"
-    return {
-        "decision": decision,
-        "anomalies": anomalies,
-        "tool_uses": total,
-    }
 
 
 def format_histogram(histogram: Dict[str, int]) -> str:
@@ -130,3 +36,44 @@ def format_histogram(histogram: Dict[str, int]) -> str:
     if not histogram:
         return "(none)"
     return " ".join(f"{tool}:{count}" for tool, count in sorted(histogram.items()))
+
+
+def summarize_input_repeats(
+    trace_entries: List[Dict[str, Any]],
+    *,
+    top_n: int = 3,
+    min_count: int = 2,
+) -> List[Tuple[str, int]]:
+    """trace pre entry 의 `input` 필드 (file_path / command 요약) 반복 카운트.
+
+    "같은 도구 N 반복" 만 봐선 정상 다중 파일 read 와 비정상 *동일 파일* 반복을
+    구분 X. 같은 input 반복 = 의미 있는 신호 (raw data) — 메인이 보고 자율 판단.
+
+    Args:
+        trace_entries: agent_trace.read_all 결과 (또는 시각 범위 필터링된 subset).
+        top_n: 반환 항목 수 상한.
+        min_count: 이 카운트 미만은 제외 (signal-to-noise).
+
+    Returns:
+        [(input, count), ...] 카운트 내림차순. min_count 미만 제외, top_n 상한.
+    """
+    counts: Dict[str, int] = {}
+    for entry in trace_entries:
+        if entry.get("phase") != "pre":
+            continue
+        inp = str(entry.get("input", "") or "").strip()
+        if not inp:
+            continue
+        counts[inp] = counts.get(inp, 0) + 1
+    return sorted(
+        ((k, v) for k, v in counts.items() if v >= min_count),
+        key=lambda x: -x[1],
+    )[:top_n]
+
+
+def format_input_repeats(repeats: List[Tuple[str, int]]) -> str:
+    """summarize_input_repeats 결과 → inject 용 한 줄. 빈 리스트 → ""."""
+    if not repeats:
+        return ""
+    parts = [f"{inp} ×{n}" for inp, n in repeats]
+    return ", ".join(parts)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1103,7 +1103,9 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
             },
         }
 
-    def test_pass_auto_redo_log(self):
+    def test_redo_log_records_measurement_only(self):
+        """#272 W1 자율 친화 — redo_log 는 *측정 데이터만*. decision/anomalies 필드 X
+        (메인이 직접 판단해서 박을 때만 그 필드 들어감)."""
         self._simulate_pre("engineer")
         self._seed_trace("engineer", ["Read", "Read", "Write", "Bash"])
         rc = handle_posttooluse_agent(
@@ -1114,14 +1116,17 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         self.assertEqual(rc, 0)
         redos = read_redos(self.sid, self.rid, base_dir=self.base)
         self.assertEqual(len(redos), 1)
-        self.assertEqual(redos[0]["decision"], "PASS")
         self.assertTrue(redos[0]["auto"])
         self.assertEqual(redos[0]["sub"], "engineer")
         self.assertEqual(redos[0]["tool_uses"], 4)
-        # tool_use_id 매칭 검증
         self.assertEqual(redos[0]["match"], "ok")
+        # 자율 영역 — hook 이 박지 않는 필드
+        self.assertNotIn("decision", redos[0])
+        self.assertNotIn("anomalies", redos[0])
 
-    def test_redo_suspect_on_low_calls(self):
+    def test_low_call_no_anomaly_inject(self):
+        """#272 W1 자율 친화 — file-op 1건 같은 케이스도 hook 이 결정 X.
+        메인 LLM 이 dcness-rules.md §3.3 보고 자율 판단."""
         self._simulate_pre("architect")
         self._seed_trace("architect", ["Read"])
         rc = handle_posttooluse_agent(
@@ -1131,24 +1136,24 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         )
         self.assertEqual(rc, 0)
         redos = read_redos(self.sid, self.rid, base_dir=self.base)
-        self.assertEqual(redos[0]["decision"], "REDO_SUSPECT")
-        self.assertTrue(redos[0]["anomalies"])
+        # hook 의 anomalies/decision X — 측정만
+        self.assertNotIn("decision", redos[0])
+        self.assertEqual(redos[0]["histogram"], {"Read": 1})
 
-    def test_redo_suspect_on_prose_only(self):
-        # Read 만 4번 + Write 0건. prompt 에 "create file" 약속.
+    def test_high_repeat_no_decision_inject(self):
+        """Read×20 같은 다중 호출도 hook 결정 X — 임계값 hardcode 없음."""
         self._simulate_pre("architect")
-        self._seed_trace("architect", ["Read", "Read", "Read", "Read"])
+        self._seed_trace("architect", ["Read"] * 20)
         rc = handle_posttooluse_agent(
-            stdin_data=self._post_payload(
-                "architect", prompt="create the impl plan file at docs/foo.md",
-            ),
+            stdin_data=self._post_payload("architect"),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
         redos = read_redos(self.sid, self.rid, base_dir=self.base)
-        self.assertEqual(redos[0]["decision"], "REDO_SUSPECT")
-        self.assertTrue(any("prose-only" in a for a in redos[0]["anomalies"]))
+        # 임계값 박지 X — 그냥 measurement
+        self.assertNotIn("decision", redos[0])
+        self.assertEqual(redos[0]["tool_uses"], 20)
 
     def test_clears_active_agent_still_works(self):
         update_live(
@@ -1243,8 +1248,10 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         slot2 = live2.get("active_runs", {}).get(self.rid, {})
         self.assertNotIn("pending_agent", slot2)
 
-    def test_prose_only_subtype_not_promised_write(self):
-        """#272 W1 — prose-only sub (qa) 는 promised_write anomaly 발화 X."""
+    def test_prose_only_subtype_no_decision_inject(self):
+        """#272 W1 자율 친화 — prose-only sub 든 일반 sub 든 hook 은 결정 박지 X.
+        화이트리스트 자체가 *우리가 박은 룰* 이라 자율 영역 침해. 본 fix 후 룰 자체
+        제거 — 메인이 dcness-rules §3.3 보고 자율 판단."""
         self._simulate_pre("qa", tool_use_id="toolu_qa")
         self._seed_trace("qa", ["Read", "Read", "Read"])
         rc = handle_posttooluse_agent(
@@ -1256,12 +1263,10 @@ class PostToolUseAgentHistogramTests(_PreToolBase):
         )
         self.assertEqual(rc, 0)
         redos = read_redos(self.sid, self.rid, base_dir=self.base)
-        self.assertEqual(redos[0]["decision"], "PASS")
-        # prose-only anomaly 발화 X
-        self.assertFalse(
-            any("prose-only" in a for a in redos[0]["anomalies"]),
-            msg="prose-only 화이트리스트 미적용 (#272 W1 회귀)",
-        )
+        # hook 결정 X — 측정만
+        self.assertNotIn("decision", redos[0])
+        self.assertNotIn("anomalies", redos[0])
+        self.assertEqual(redos[0]["tool_uses"], 3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sub_eval.py
+++ b/tests/test_sub_eval.py
@@ -1,168 +1,22 @@
-"""test_sub_eval — DCN-CHG-20260501-13.
+"""test_sub_eval — 자율 친화 재설계 (#272 W1).
 
-Coverage matrix:
-    evaluate_sub:
-        - 정상 PASS — 적당한 호출 수 + 다양한 tool
-        - REDO_SUSPECT: tool_uses 0 (아예 안 함)
-        - REDO_SUSPECT: tool_uses 1 (< MIN_TOOL_USES)
-        - REDO_SUSPECT: 도구별 차등 임계 초과 반복 (#272/#273 baseline 반영)
-        - REDO_SUSPECT: prompt 에 Write 약속 + Write+Edit 0건 (prose-only)
-        - prompt hint 없으면 prose-only 검사 skip
-        - prose-only sub_type (qa/validator/pr-reviewer …) 시 promised_write 검사 skip
-        - 다중 anomaly 한 번에 검출
+기존 anomaly 룰 (임계값 / prose-only 화이트리스트 / promised_write) 자체 제거 →
+hook 은 *raw 측정 데이터* 만 inject. 메인 LLM 이 dcness-rules.md §3.3 보고 자율 판단.
 
-    format_histogram:
-        - 빈 dict → "(none)"
-        - 정렬된 짧은 문자열
+Coverage:
+    format_histogram — raw 데이터 포맷 (자율 친화 inject 의 핵심)
+    summarize_input_repeats — 같은 input 반복 카운트 (raw 신호)
+    format_input_repeats — inject 한 줄 포맷
 """
 from __future__ import annotations
 
 import unittest
 
 from harness.sub_eval import (
-    MIN_TOOL_USES,
-    PROSE_ONLY_AGENTS,
-    REPEAT_TOOL_THRESHOLDS,
-    REPEAT_TOOL_THRESHOLD_DEFAULT,
-    evaluate_sub,
     format_histogram,
+    format_input_repeats,
+    summarize_input_repeats,
 )
-
-
-class EvaluateSubTests(unittest.TestCase):
-    def test_pass_normal(self):
-        result = evaluate_sub({"Read": 4, "Bash": 2, "Write": 1})
-        self.assertEqual(result["decision"], "PASS")
-        self.assertEqual(result["anomalies"], [])
-        self.assertEqual(result["tool_uses"], 7)
-
-    def test_pass_realistic_architect_baseline(self):
-        # #273 W1 — architect MODULE_PLAN 정상 패턴 (Read×8 Bash×5 Write×1 Edit×2)
-        result = evaluate_sub(
-            {"Read": 8, "Bash": 5, "Write": 1, "Edit": 2},
-            sub_type="architect",
-        )
-        self.assertEqual(result["decision"], "PASS", msg=result)
-
-    def test_pass_realistic_engineer_baseline(self):
-        # #273 W1 — engineer IMPL 정상 패턴 (Read×6 Edit×6 Bash×2)
-        result = evaluate_sub(
-            {"Read": 6, "Edit": 6, "Bash": 2},
-            sub_type="engineer",
-        )
-        self.assertEqual(result["decision"], "PASS", msg=result)
-
-    def test_pass_realistic_pr_reviewer_baseline(self):
-        # #272 W1 — pr-reviewer prose-only 정상 (Read×5)
-        result = evaluate_sub(
-            {"Read": 5},
-            sub_type="pr-reviewer",
-        )
-        self.assertEqual(result["decision"], "PASS", msg=result)
-
-    def test_redo_zero_calls(self):
-        result = evaluate_sub({})
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-        self.assertTrue(any("tool_uses=0" in a for a in result["anomalies"]))
-
-    def test_redo_below_min(self):
-        result = evaluate_sub({"Read": 1})
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-        self.assertTrue(any(f"< {MIN_TOOL_USES}" in a for a in result["anomalies"]))
-
-    def test_prose_only_sub_skips_min_tool_uses(self):
-        # #272 W1 보완 — prose-only sub 는 file-op 0건도 정상.
-        for sub in ("pr-reviewer", "qa", "validator"):
-            with self.subTest(sub=sub):
-                result = evaluate_sub({}, sub_type=sub)
-                self.assertEqual(
-                    result["decision"], "PASS",
-                    msg=f"{sub} → {result} (prose-only file-op 0 도 정상)",
-                )
-
-    def test_engineer_below_min_still_fires(self):
-        # 일반 sub 는 file-op 1건 미만 시 anomaly 유지
-        result = evaluate_sub({"Read": 1}, sub_type="engineer")
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-
-    def test_redo_repeat_read(self):
-        # Read 임계 15
-        result = evaluate_sub({"Read": REPEAT_TOOL_THRESHOLDS["Read"]})
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-        self.assertTrue(any("Read" in a and "반복" in a for a in result["anomalies"]))
-
-    def test_redo_repeat_edit(self):
-        # Edit 임계 12
-        result = evaluate_sub({"Edit": REPEAT_TOOL_THRESHOLDS["Edit"]})
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-        self.assertTrue(any("Edit" in a for a in result["anomalies"]))
-
-    def test_redo_repeat_unknown_tool_uses_default(self):
-        # 미정의 도구는 default 임계 적용
-        result = evaluate_sub({"Foo": REPEAT_TOOL_THRESHOLD_DEFAULT})
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-
-    def test_under_threshold_read_passes(self):
-        # Read 14 < 15 → PASS
-        result = evaluate_sub({"Read": REPEAT_TOOL_THRESHOLDS["Read"] - 1})
-        self.assertEqual(result["decision"], "PASS", msg=result)
-
-    def test_redo_prose_only_no_sub_type(self):
-        # sub_type 미명시 → 폴백으로 promised_write 검사 진행
-        result = evaluate_sub(
-            {"Read": 4, "Bash": 1},
-            sub_prompt_hint="Write the implementation plan to docs/foo.md",
-        )
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-        self.assertTrue(any("prose-only" in a for a in result["anomalies"]))
-
-    def test_prose_only_agent_skips_promised_write_check(self):
-        # #272 W1 — qa 는 prose-only. Write 약속 prompt + Write+Edit 0건이 정상.
-        for sub in ("qa", "validator", "pr-reviewer", "design-critic"):
-            with self.subTest(sub=sub):
-                result = evaluate_sub(
-                    {"Read": 4, "Bash": 1},
-                    sub_prompt_hint="Write your validation report",
-                    sub_type=sub,
-                )
-                self.assertEqual(result["decision"], "PASS", msg=f"{sub} → {result}")
-
-    def test_prose_only_agent_namespaced(self):
-        # plugin-namespaced (e.g. "dcness:qa") 도 prose-only 처리
-        result = evaluate_sub(
-            {"Read": 4},
-            sub_prompt_hint="작성해줘",
-            sub_type="dcness:qa",
-        )
-        self.assertEqual(result["decision"], "PASS", msg=result)
-
-    def test_engineer_promised_write_still_fires(self):
-        # engineer 는 prose-only X — Write 약속 후 0건이면 anomaly
-        result = evaluate_sub(
-            {"Read": 4},
-            sub_prompt_hint="구현 코드 작성",
-            sub_type="engineer",
-        )
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-
-    def test_no_hint_no_prose_check(self):
-        # 같은 histogram 이지만 hint 없으면 PASS
-        result = evaluate_sub({"Read": 4, "Bash": 1}, sub_prompt_hint="")
-        self.assertEqual(result["decision"], "PASS")
-
-    def test_korean_hint_detected(self):
-        result = evaluate_sub(
-            {"Read": 3},
-            sub_prompt_hint="impl 파일 작성해줘",
-            sub_type="engineer",
-        )
-        self.assertEqual(result["decision"], "REDO_SUSPECT")
-
-    def test_prose_only_agents_constant(self):
-        # 화이트리스트 회귀 방지 — 핵심 prose-only agent 누락 X
-        for sub in ("qa", "validator", "pr-reviewer", "design-critic",
-                    "security-reviewer", "plan-reviewer"):
-            self.assertIn(sub, PROSE_ONLY_AGENTS)
 
 
 class FormatHistogramTests(unittest.TestCase):
@@ -173,6 +27,73 @@ class FormatHistogramTests(unittest.TestCase):
         s = format_histogram({"Read": 4, "Bash": 2, "Write": 0})
         # sorted alphabetical
         self.assertEqual(s, "Bash:2 Read:4 Write:0")
+
+
+class SummarizeInputRepeatsTests(unittest.TestCase):
+    """같은 input 반복 — 메인 자율 판단용 raw 신호.
+
+    *동일 파일* Read 5번 vs *다른 파일 5개* Read 5번 — 후자는 정상, 전자는 의심.
+    임계 hardcode 안 함. 메인이 보고 알아서 판단.
+    """
+
+    def test_empty(self):
+        self.assertEqual(summarize_input_repeats([]), [])
+
+    def test_below_min_count_excluded(self):
+        # min_count=2 default — 1번만 나온 input 은 noise
+        entries = [
+            {"phase": "pre", "input": "src/Foo.tsx"},
+            {"phase": "pre", "input": "src/Bar.tsx"},
+        ]
+        self.assertEqual(summarize_input_repeats(entries), [])
+
+    def test_repeated_input_counted(self):
+        entries = [
+            {"phase": "pre", "input": "src/Foo.tsx"},
+            {"phase": "pre", "input": "src/Foo.tsx"},
+            {"phase": "pre", "input": "src/Foo.tsx"},
+            {"phase": "pre", "input": "src/Bar.tsx"},
+        ]
+        result = summarize_input_repeats(entries)
+        self.assertEqual(result, [("src/Foo.tsx", 3)])
+
+    def test_post_phase_excluded(self):
+        # post entry 는 pre 와 짝 — 중복 카운트 회피
+        entries = [
+            {"phase": "pre", "input": "src/Foo.tsx"},
+            {"phase": "post", "input": "src/Foo.tsx"},  # skip
+            {"phase": "pre", "input": "src/Foo.tsx"},
+        ]
+        result = summarize_input_repeats(entries)
+        self.assertEqual(result, [("src/Foo.tsx", 2)])
+
+    def test_top_n_limit(self):
+        entries = []
+        for inp in ["a", "b", "c", "d"]:
+            entries.extend([{"phase": "pre", "input": inp}] * 3)
+        result = summarize_input_repeats(entries, top_n=2)
+        self.assertEqual(len(result), 2)
+
+    def test_descending_count_order(self):
+        entries = (
+            [{"phase": "pre", "input": "low"}] * 2
+            + [{"phase": "pre", "input": "high"}] * 5
+            + [{"phase": "pre", "input": "mid"}] * 3
+        )
+        result = summarize_input_repeats(entries)
+        self.assertEqual([k for k, _ in result], ["high", "mid", "low"])
+
+
+class FormatInputRepeatsTests(unittest.TestCase):
+    def test_empty(self):
+        self.assertEqual(format_input_repeats([]), "")
+
+    def test_one(self):
+        self.assertEqual(format_input_repeats([("foo.py", 4)]), "foo.py ×4")
+
+    def test_multiple(self):
+        s = format_input_repeats([("a.py", 5), ("b.py", 3)])
+        self.assertEqual(s, "a.py ×5, b.py ×3")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

### [issue-272] anomaly hook 자율 친화 재설계 — 룰 제거, raw 측정 데이터만 (W1 진짜 fix)

- **What**: anomaly 룰 (임계값 차등 / prose-only 화이트리스트 / promised_write 검사) **자체 제거**. hook 은 raw 측정 데이터 (histogram + 같은 input 반복) 만 inject. "REDO_SUSPECT" / "PASS" 결정 X. 메인 LLM 이 `docs/plugin/dcness-rules.md §3.3` 가이드 보고 자율 판단.
- **Why**: PR #274 의 W1 fix (임계 차등 상향) 는 **표면 fix** — false positive 감소만, *판단을 hook 에 박는 패턴* 은 유지. `docs/plugin/dcness-rules.md §1` 의 "harness 강제는 2가지(작업 순서 + 접근 영역) 만, 그 외 = 에이전트 자율" 원칙 위반.

### 핵심 변경

1. `harness/sub_eval.py` — `evaluate_sub` / `REPEAT_TOOL_THRESHOLDS` / `PROSE_ONLY_AGENTS` / `MIN_TOOL_USES` 모두 제거. 새 함수: `format_histogram` / `summarize_input_repeats` / `format_input_repeats` (raw 데이터 포맷 only).
2. `harness/hooks.py handle_posttooluse_agent` —
   - `⚠️ anomaly` 메시지 inject 제거. additionalContext = `[감시자 hook] sub=X tool histogram: Read:8 Edit:2`.
   - 같은 input 반복 (다중 파일 vs 동일 파일 구분 신호) 1줄 추가 — raw signal.
   - redo_log auto append 의 `decision` / `anomalies` 필드 제거. measurement 만 박힘.

## 결정 근거

- 사용자 직접 지적: "가이드레일만 줄뿐 LLM 의 자율에 최대한 맡기는 방향" (dcness-rules §1 정합).
- `같은 input 반복` 카운트는 *raw 신호* — 임계 hardcode X. 메인이 *동일 파일 5번* (의심) vs *다른 파일 5개* (정상) 자율 구분.
- 폴백 안전성보다 *근본 매커니즘 정합* 우선. PR #274 의 dead code (임계 상수 / 화이트리스트) 제거.

## 관련 이슈

Closes #272

(이미 PR #274/#275/#276 에서 자동 close 됐을 수 있음 — 본 PR 은 W1 의 자율 친화 follow-up.)

## 후속 권고

`docs/plugin/dcness-rules.md §3.3` 의 "같은 tool 5회+ 반복" 가이드 명료화 — 현재 표현은 *동일 파일* 인지 *다중 파일* 인지 모호. #273 보고서 참고. 별도 PR 분리.

## 참고

- PR #274 (W1 임계 차등) 이전 fix 의 dead code 제거. PR #275/#276 의 redo_log 시그니처 호환 (decision 필드 제거 — 이미 PR #275 에서 박지 않던 그대로).
- 본 저장소(dcness self) 미적용 — plug-in 사용자 update 시 자동 적용. 다음 release (0.2.7 후보) 권고.
- 회귀 테스트 — sub_eval 전면 재작성 (raw API 만), hook 측정 검증 5개. 416 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)