### PR TITLE
[epic280][story281] prose-only routing 측정 인프라

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -652,6 +652,22 @@ def handle_posttooluse_agent(
                         active = dict(active)
                         active[rid] = slot
                         update_live(sid, base_dir=base_dir, active_runs=active)
+
+                        # issue #281 — prose-only routing 회귀 검증 telemetry.
+                        # 매 agent 종료 시 prose tail 보존. enum heuristic-calls.jsonl
+                        # 와 분리된 별도 파일 (.metrics/routing-decisions.jsonl).
+                        try:
+                            from harness.routing_telemetry import record_agent_call
+                            record_agent_call(
+                                sub=step_agent,
+                                prose=prose_text,
+                                mode=step_mode,
+                                tool_use_id=stdin_data.get("tool_use_id", "") or "",
+                                run_id=rid,
+                                session_id=sid,
+                            )
+                        except Exception:  # noqa: BLE001 — silent, hook 본 흐름 보호
+                            pass
             except Exception as e:  # noqa: BLE001
                 print(
                     f"[hook prose stage] write 예외: {type(e).__name__}: {e}",

--- a/harness/routing_telemetry.py
+++ b/harness/routing_telemetry.py
@@ -1,0 +1,164 @@
+"""routing_telemetry.py — prose-only routing 회귀 검증용 raw 측정 데이터.
+
+이슈 #281 (epic #280): enum 시스템 폐기 *전후* routing 정확도 비교 baseline.
+
+기록 대상 (raw 데이터만 — 정형 검증 X, dcness-rules.md §1 원칙 2 정합):
+
+    1. agent_call    PostToolUse Agent 발화 시 1줄 — 어떤 sub 가 어떤 prose 결론
+                     으로 종료했는지. 이후 메인이 prose 보고 다음 routing 결정.
+                     prose_tail 만 보존 (마지막 1200 자).
+    2. cascade       메인이 결정 못 해 사용자에게 위임한 명시적 marker. CLI/helper
+                     로 메인이 직접 1줄 박는다. enum 시스템의 ambiguous 비율과 동등.
+
+저장 위치:
+    `.metrics/routing-decisions.jsonl`  — 프로젝트 전역 누적 (enum heuristic-calls.jsonl
+    와 동일 패턴). 외부 활성화 프로젝트도 자동 동일 형식.
+
+전제:
+    - 형식 검증 / schema 강제 X. raw append-only.
+    - 회고 분석은 사후 (`scripts/research/*.mjs` 패턴).
+    - DCNESS_LLM_TELEMETRY=0 → 비활성 (테스트·dryrun 회피).
+
+Schema (강제 X — 권장 필드):
+    ts          ISO8601 UTC, 자동
+    event       "agent_call" | "cascade"
+    sub         subagent_type (agent_call 일 때)
+    mode        sub mode (선택)
+    tool_use_id PreToolUse↔PostToolUse 매칭 키 (선택)
+    prose_tail  결론 prose 마지막 1200 자 (agent_call 일 때)
+    reason      cascade 사유 자유 텍스트 (cascade 일 때)
+    run_id      현재 run_id (선택)
+    session_id  현재 session_id (선택)
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+__all__ = [
+    "ROUTING_TELEMETRY_FILE",
+    "record_agent_call",
+    "record_cascade",
+]
+
+
+ROUTING_TELEMETRY_FILE = "routing-decisions.jsonl"
+
+_PROSE_TAIL_LIMIT = 1200
+
+
+def _telemetry_path(base_dir: Optional[Path]) -> Path:
+    base = base_dir or (Path.cwd() / ".metrics")
+    return base / ROUTING_TELEMETRY_FILE
+
+
+def _ts() -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+
+def _append(event: dict, *, base_dir: Optional[Path] = None) -> None:
+    if os.environ.get("DCNESS_LLM_TELEMETRY", "1") == "0":
+        return
+    path = _telemetry_path(base_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, line.encode("utf-8"))
+    finally:
+        os.close(fd)
+
+
+def record_agent_call(
+    sub: str,
+    prose: str,
+    *,
+    mode: Optional[str] = None,
+    tool_use_id: str = "",
+    run_id: str = "",
+    session_id: str = "",
+    base_dir: Optional[Path] = None,
+) -> None:
+    """sub agent 종료 시 1줄 append. prose 결론 부분만 보존 (tail-cap)."""
+    if not isinstance(sub, str) or not sub.strip():
+        return  # 잘못된 sub_type 은 silent skip — 훅 본 흐름 보호
+    if not isinstance(prose, str):
+        prose = ""
+    tail = prose[-_PROSE_TAIL_LIMIT:] if prose else ""
+    event = {
+        "ts": _ts(),
+        "event": "agent_call",
+        "sub": sub,
+        "mode": mode or "",
+        "tool_use_id": tool_use_id or "",
+        "run_id": run_id or "",
+        "session_id": session_id or "",
+        "prose_len": len(prose),
+        "prose_tail": tail,
+    }
+    _append(event, base_dir=base_dir)
+
+
+def record_cascade(
+    reason: str,
+    *,
+    sub: str = "",
+    mode: Optional[str] = None,
+    run_id: str = "",
+    session_id: str = "",
+    base_dir: Optional[Path] = None,
+) -> None:
+    """메인이 routing 결정 못 해 사용자에게 위임 시 1줄 append.
+
+    enum 시스템의 ambiguous 비율과 동등. 메인이 명시적으로 박아야 의미.
+    """
+    event = {
+        "ts": _ts(),
+        "event": "cascade",
+        "sub": sub or "",
+        "mode": mode or "",
+        "run_id": run_id or "",
+        "session_id": session_id or "",
+        "reason": (reason or "")[:500],
+    }
+    _append(event, base_dir=base_dir)
+
+
+def _cli(argv: Optional[list] = None) -> int:
+    """CLI: routing_telemetry record-cascade --reason "..." [--sub ... --mode ...]."""
+    import argparse
+
+    p = argparse.ArgumentParser(prog="routing_telemetry")
+    sub_p = p.add_subparsers(dest="cmd", required=True)
+
+    cas = sub_p.add_parser("record-cascade", help="cascade marker 1줄 append")
+    cas.add_argument("--reason", required=True, help="cascade 사유")
+    cas.add_argument("--sub", default="", help="직전 sub_type (선택)")
+    cas.add_argument("--mode", default="", help="직전 mode (선택)")
+    cas.add_argument("--run-id", default="", help="현재 run_id (선택)")
+    cas.add_argument("--session-id", default="", help="현재 session_id (선택)")
+    cas.add_argument(
+        "--base-dir", default="",
+        help=".metrics 부모 디렉토리. 미지정 시 cwd/.metrics",
+    )
+
+    args = p.parse_args(argv)
+    if args.cmd == "record-cascade":
+        base = Path(args.base_dir) if args.base_dir else None
+        record_cascade(
+            args.reason,
+            sub=args.sub or "",
+            mode=args.mode or None,
+            run_id=args.run_id or "",
+            session_id=args.session_id or "",
+            base_dir=base,
+        )
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/tests/test_routing_telemetry.py
+++ b/tests/test_routing_telemetry.py
@@ -1,0 +1,158 @@
+"""test_routing_telemetry — issue #281 prose-only routing 측정 인프라.
+
+Coverage:
+    - record_agent_call: agent_call 1줄 append, prose tail-cap, 권장 필드.
+    - record_cascade: cascade 1줄 append, reason 보존.
+    - DCNESS_LLM_TELEMETRY=0 → 기록 0.
+    - 잘못된 sub silent skip (hook 본 흐름 보호).
+    - CLI: record-cascade subcommand JSONL 기록.
+    - 다회 호출 시 jsonl append (덮어쓰기 X).
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.routing_telemetry import (
+    ROUTING_TELEMETRY_FILE,
+    record_agent_call,
+    record_cascade,
+)
+
+
+class _Base(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.tele = Path(self._td.name)
+        self.path = self.tele / ROUTING_TELEMETRY_FILE
+        # telemetry 활성 — 외부 환경 무관 보장
+        os.environ.pop("DCNESS_LLM_TELEMETRY", None)
+
+    def tearDown(self) -> None:
+        os.environ.pop("DCNESS_LLM_TELEMETRY", None)
+        self._td.cleanup()
+
+    def _read_events(self) -> list:
+        if not self.path.exists():
+            return []
+        return [
+            json.loads(line)
+            for line in self.path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+
+class RecordAgentCallTests(_Base):
+    def test_records_event_with_required_fields(self) -> None:
+        record_agent_call(
+            sub="engineer",
+            prose="## 결론\n\nIMPL_DONE — 수용 기준 통과\n",
+            mode="IMPL",
+            tool_use_id="toolu_abc",
+            run_id="20260508-r1",
+            session_id="sid_xy",
+            base_dir=self.tele,
+        )
+        events = self._read_events()
+        self.assertEqual(len(events), 1)
+        e = events[0]
+        self.assertEqual(e["event"], "agent_call")
+        self.assertEqual(e["sub"], "engineer")
+        self.assertEqual(e["mode"], "IMPL")
+        self.assertEqual(e["tool_use_id"], "toolu_abc")
+        self.assertEqual(e["run_id"], "20260508-r1")
+        self.assertEqual(e["session_id"], "sid_xy")
+        self.assertIn("IMPL_DONE", e["prose_tail"])
+        self.assertIn("ts", e)
+
+    def test_prose_tail_capped_at_1200(self) -> None:
+        long = "x" * 5000 + "\n결론: PASS\n"
+        record_agent_call(sub="pr-reviewer", prose=long, base_dir=self.tele)
+        events = self._read_events()
+        self.assertEqual(len(events), 1)
+        # 마지막 1200 자만 보존 — 결론 부분이 포함됨
+        self.assertLessEqual(len(events[0]["prose_tail"]), 1200)
+        self.assertIn("결론: PASS", events[0]["prose_tail"])
+        self.assertEqual(events[0]["prose_len"], len(long))
+
+    def test_blank_sub_silent_skip(self) -> None:
+        record_agent_call(sub="", prose="anything", base_dir=self.tele)
+        record_agent_call(sub="   ", prose="anything", base_dir=self.tele)
+        self.assertFalse(self.path.exists())
+
+    def test_multiple_appends_jsonl(self) -> None:
+        for i in range(3):
+            record_agent_call(
+                sub="engineer", prose=f"step{i}", base_dir=self.tele,
+            )
+        events = self._read_events()
+        self.assertEqual(len(events), 3)
+
+
+class RecordCascadeTests(_Base):
+    def test_records_cascade_with_reason(self) -> None:
+        record_cascade(
+            "메인이 architect vs engineer 결정 못 함",
+            sub="qa",
+            mode="QA",
+            run_id="r1",
+            session_id="s1",
+            base_dir=self.tele,
+        )
+        events = self._read_events()
+        self.assertEqual(len(events), 1)
+        e = events[0]
+        self.assertEqual(e["event"], "cascade")
+        self.assertEqual(e["sub"], "qa")
+        self.assertEqual(e["mode"], "QA")
+        self.assertEqual(e["reason"], "메인이 architect vs engineer 결정 못 함")
+        self.assertIn("ts", e)
+
+    def test_long_reason_capped_at_500(self) -> None:
+        record_cascade("x" * 5000, base_dir=self.tele)
+        events = self._read_events()
+        self.assertEqual(len(events[0]["reason"]), 500)
+
+
+class TelemetryToggleTests(_Base):
+    def test_disabled_via_env(self) -> None:
+        os.environ["DCNESS_LLM_TELEMETRY"] = "0"
+        record_agent_call(sub="engineer", prose="x", base_dir=self.tele)
+        record_cascade("y", base_dir=self.tele)
+        self.assertFalse(self.path.exists())
+
+
+class CliTests(_Base):
+    def test_cli_record_cascade_appends(self) -> None:
+        # 모듈을 subprocess 로 실행 — argparse 통합 점검
+        env = {**os.environ, "PYTHONPATH": str(Path.cwd())}
+        result = subprocess.run(
+            [
+                sys.executable, "-m", "harness.routing_telemetry",
+                "record-cascade",
+                "--reason", "사용자에게 위임",
+                "--sub", "architect",
+                "--mode", "MODULE_PLAN",
+                "--base-dir", str(self.tele),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(Path.cwd()),
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        events = self._read_events()
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["event"], "cascade")
+        self.assertEqual(events[0]["sub"], "architect")
+        self.assertEqual(events[0]["mode"], "MODULE_PLAN")
+        self.assertIn("위임", events[0]["reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

### [epic280][story281] prose-only routing 측정 인프라

- **What**: `harness/routing_telemetry.py` 신규. PostToolUse Agent 훅이 매 sub 종료 시 prose 결론 tail (1200자 cap) 을 `.metrics/routing-decisions.jsonl` 에 1줄 append. 메인이 사용자에게 위임할 때는 CLI `record-cascade --reason ...` 로 명시 marker.
- **Why**: 이슈 #277 enum baseline 은 enum heuristic 측. enum 폐기 후 prose-only routing 정확도 회귀 검증을 위한 동등 raw 데이터 신규 (정형 enum 검증 X — 자연어 시스템 형식 검증 의미 X 정합).

## 결정 근거

- 별도 파일(`routing-decisions.jsonl`)로 분리: enum 시스템 유지 상태에서도 baseline 측정 가능 + 폐기 후 동일 형식 누적 가능.
- raw append-only: schema 강제 X, 형식 검증 X — `feedback_sentinel_naturalness.md` 정합.
- DCNESS_LLM_TELEMETRY=0 으로 비활성화 — 기존 패턴 답습.
- prose tail 1200자 cap, reason 500자 cap — 디스크 폭주 방지.

## 관련 이슈

Closes #281
Part of #280

## 참고

- 이슈 #277 baseline (enum heuristic 측 측정)
- `docs/internal/enum-roi-baseline.md` — 폐기 결정 논리
- `harness/interpret_strategy.py` — 병행 동작 (enum 시스템 측 telemetry)
- 8 신규 테스트 PASS, 전체 424 tests OK