### PR TITLE
[epic280][story284] enum 추출 인프라 폐기 + prose-only mode

### DIFF
--- a/docs/plugin/dcness-rules.md
+++ b/docs/plugin/dcness-rules.md
@@ -124,10 +124,15 @@ begin-step 에서 전달된 INSIGHTS 가 있으면 prompt 에 포함.
 ## 3.3 end-step
 
 ```bash
+# prose-only mode (이슈 #284 정착 후 권장):
+"$HELPER" end-step <agent> [<MODE>]
+# legacy compat — 외부 skill 이 enum 추출 필요 시 (deprecated):
 ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<csv>")
 ```
 
 **시점**: Agent 완료 직후 → TaskUpdate(completed) 전
+
+**prose-only mode (이슈 #284)**: `--allowed-enums` 미지정 시 stdout = `PROSE_LOGGED`. 메인 Claude 가 prose 자체 (`<run_dir>/<agent>[-<MODE>].md`) 를 직접 읽고 routing 결정 — `harness/handoff-matrix.md §1` 자연어 가이드 참조. 결정 못 하면 `harness.routing_telemetry record-cascade --reason "..."` 으로 cascade marker 박고 사용자 위임.
 
 ### 결과 echo + 평가 — MUST (5~12줄)
 
@@ -174,11 +179,13 @@ REDO 판단 신호: 결과가 질문에 제대로 답하지 못함 / 같은 tool
 □ 결론 enum + 평가 포함됐는가?
 ```
 
-### AMBIGUOUS 처리
+### AMBIGUOUS 처리 (legacy enum mode 한정)
 
-`end-step` stdout = `AMBIGUOUS` 시:
+`--allowed-enums` 박은 legacy 호출에서 `end-step` stdout = `AMBIGUOUS` 시:
 1. 재호출 1회 (결론 enum 명시 요청)
 2. 재호출도 AMBIGUOUS → 사용자 위임 (enum 후보 + prose 발췌)
+
+prose-only mode (이슈 #284 정착 후 권장) 에선 stdout = `PROSE_LOGGED` — AMBIGUOUS 자체 X. 메인이 prose 직접 읽고 결정 못 할 때만 `record-cascade` 로 cascade marker 박고 사용자 위임.
 
 ### helper 안전망 (자동 검출)
 
@@ -192,7 +199,7 @@ begin/end-step 은 `agent mode` **두 개 인자** 형식만 허용:
 
 ```bash
 "$HELPER" begin-step <agent> [<MODE>]
-"$HELPER" end-step   <agent> [<MODE>] --allowed-enums "..."
+"$HELPER" end-step   <agent> [<MODE>] [--allowed-enums "..."]
 ```
 
 - `agent` — 소문자·하이픈만 (`^[a-z][a-z0-9-]{0,63}$`)

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -74,7 +74,8 @@ TaskCreate("<agent>: <mode 또는 짧은 설명>")
 TaskUpdate("<task>", in_progress)
 "$HELPER" begin-step <agent> [<MODE>]
 Agent(subagent_type="<agent>", mode="<MODE>", description="...")
-ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<csv>")
+"$HELPER" end-step <agent> [<MODE>]   # prose-only mode (이슈 #284 정착 후 권장, stdout=PROSE_LOGGED)
+# legacy compat: ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<csv>")
 # guidelines §1 의무 echo (5~12 줄)
 TaskUpdate("<task>", completed)
 ```

--- a/harness/interpret_strategy.py
+++ b/harness/interpret_strategy.py
@@ -1,33 +1,30 @@
-"""interpret_strategy.py — heuristic-only enum 추출 + telemetry.
+"""interpret_strategy.py — DEPRECATED (issue #284 폐기 진행).
 
-발상 (DCN-CHG-20260430-04 정착):
-    `signal_io.interpret_signal` 의 휴리스틱만 사용.
-    `interpret_with_fallback` = 호환성 wrapper (heuristic 호출 + telemetry 기록).
-    LLM fallback 폐기 — 휴리스틱 ambiguous 시 그대로 raise → 메인 Claude 가 cascade
-    (재호출 / 사용자 위임) 결정.
+이슈 #280 epic — prose-only routing 전환:
+    - 메인 Claude 가 prose 직접 분류해 routing → 휴리스틱 enum 추출 무용지물.
+    - 본 모듈은 *legacy 호환* 을 위해 시그니처만 유지. 신규 호출 추가 X.
 
-LLM fallback 폐기 이유 (DCN-CHG-20260430-04):
-    - dcness 의 도그푸딩 호환 (API 키 의존 회피).
-    - 메타 LLM 호출 = 비용 + latency + 또 다른 사다리 진입 (LLM 결과 검증).
-    - 메인 Claude 가 자체 LLM 이라 별도 LLM judge 불필요.
-    - 트렌드상 [2026 structured output] 으로 가는 길에 [2025 meta LLM] 단계 skip.
+이슈 #284 정착 후 동작:
+    - `interpret_with_fallback` 는 휴리스틱 추출 자체는 *legacy 호환* 으로 보존
+      (기존 외부 skill 이 `--allowed-enums` 박은 채 호출해도 crash 회피).
+    - 단 telemetry 신규 기록은 **중단** — `.metrics/heuristic-calls.jsonl` 에
+      더 이상 append 안 함. 누적된 baseline 데이터는 보존 (회고 자료, 이슈 #277).
+    - 정형 routing telemetry 는 `harness/routing_telemetry.py` 가 대체 (#281).
 
-Outcome 분류 (telemetry):
+폐기 배경 (이슈 #277 ROI baseline + #280 epic 결정):
+    - 99.2% hit rate 는 enum 가치가 아니라 prompt 강제력. 자유 prose 도 동등 routing
+      정확도 가능.
+    - matrix ↔ 코드 drift 9 종 누적. enum 변경 시 다중 SSOT 동기 의무 = 실 비용.
+    - dcness-rules.md §1 원칙 2 (LLM 자율 + 최소 가이드레일) 와 충돌.
+
+Outcome 분류 (legacy):
     - heuristic_hit       : 휴리스틱 단어경계 단일 매칭 → 즉시 결론
-    - heuristic_ambiguous : 휴리스틱 ambiguous → MissingSignal propagate (메인이 cascade)
+    - heuristic_ambiguous : 휴리스틱 ambiguous → MissingSignal propagate
     - heuristic_not_found : 마커 자체 부재
     - heuristic_empty     : prose 자체 비어있음
-
-대 원칙 정합 (proposal §2.5):
-    원칙 1 (룰 순감소): LLM fallback 코드 / 의존성 (anthropic SDK) 제거.
-    원칙 3 (prose-only): agent 자유 emit, 휴리스틱 단어경계로 결론 추출.
-    원칙 5 (30일 측정): telemetry JSONL 누적 → 휴리스틱 hit/ambiguous 비율 분석.
 """
 from __future__ import annotations
 
-import json
-import os
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -38,76 +35,40 @@ __all__ = [
     "HEURISTIC_TELEMETRY_FILE",
 ]
 
+# 폐기됨 — 더 이상 신규 기록 안 함. 외부 분석 스크립트 호환을 위해 상수만 보존.
 HEURISTIC_TELEMETRY_FILE = "heuristic-calls.jsonl"
-
-
-def _telemetry_path(base_dir: Optional[Path]) -> Path:
-    base = base_dir or (Path.cwd() / ".metrics")
-    return base / HEURISTIC_TELEMETRY_FILE
-
-
-def _record(
-    event: dict,
-    *,
-    base_dir: Optional[Path] = None,
-) -> None:
-    if os.environ.get("DCNESS_LLM_TELEMETRY", "1") == "0":
-        return
-    path = _telemetry_path(base_dir)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as f:
-        f.write(json.dumps(event, ensure_ascii=False) + "\n")
 
 
 def interpret_with_fallback(
     prose: str,
     allowed: Iterable[str],
     *,
-    telemetry_dir: Optional[Path] = None,
+    telemetry_dir: Optional[Path] = None,  # 무시 (deprecated)
 ) -> str:
-    """휴리스틱 enum 추출 + telemetry. ambiguous 시 그대로 propagate.
+    """[DEPRECATED — 이슈 #284] 휴리스틱 enum 추출. ambiguous 시 propagate.
 
     Args:
         prose: agent 의 자유 emit.
         allowed: 허용 enum 리스트.
-        telemetry_dir: 로그 디렉토리. None = `.metrics/`.
+        telemetry_dir: 무시됨 (이슈 #284 telemetry 중단).
 
     Returns:
         allowed 안의 단일 enum.
 
     Raises:
         MissingSignal: 휴리스틱이 단일 enum 못 뽑음 (ambiguous / not_found / empty).
-                       메인 Claude 가 cascade (재호출 / 사용자 위임) 결정.
         ValueError: allowed 비어 있음.
 
     Note:
-        함수명에 `_with_fallback` 잔존 — 호환성 (외부 호출자 변경 비용 ↓).
-        실제론 LLM fallback 폐기 (DCN-CHG-20260430-04). 휴리스틱-only.
+        - 본 함수 호출은 legacy compat 영역만. 신규 routing 결정은 메인 Claude 가
+          prose 직접 읽고 판단.
+        - 이슈 #284 정착 후 telemetry 신규 기록 0 — `.metrics/heuristic-calls.jsonl`
+          에 더 이상 append 안 함.
     """
     allowed_list = [str(a) for a in allowed]
     if not allowed_list:
         raise ValueError("allowed must be non-empty")
 
-    base_event = {
-        "ts": datetime.now(timezone.utc).isoformat(),
-        "allowed": allowed_list,
-        "prose_len": len(prose),
-    }
-
-    try:
-        result = interpret_signal(prose, allowed_list)  # interpreter=None → 휴리스틱
-        _record(
-            {**base_event, "outcome": "heuristic_hit", "parsed": result},
-            base_dir=telemetry_dir,
-        )
-        return result
-    except MissingSignal as exc:
-        _record(
-            {
-                **base_event,
-                "outcome": f"heuristic_{exc.reason}",
-                "detail": exc.detail[:200],
-            },
-            base_dir=telemetry_dir,
-        )
-        raise
+    # 휴리스틱 자체는 legacy 호환 (기존 외부 skill `--allowed-enums` 호출 cover).
+    # telemetry 신규 기록 X — 이슈 #284 acceptance.
+    return interpret_signal(prose, allowed_list)  # interpreter=None → 휴리스틱

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1315,13 +1315,29 @@ def _cli_end_step(args: Any) -> int:
             print("[session_state] empty prose (hook staged)", file=sys.stderr)
             return 1
 
-    allowed = [s.strip() for s in args.allowed_enums.split(",") if s.strip()]
-    if not allowed:
-        print("[session_state] empty --allowed-enums", file=sys.stderr)
-        return 1
+    # 이슈 #284 — `--allowed-enums` optional. 미지정 / 빈 값 = prose-only mode
+    # (휴리스틱 추출 호출 zero, telemetry 기록 zero — issue #284 acceptance).
+    allowed_raw = (args.allowed_enums or "").strip()
+    allowed = [s.strip() for s in allowed_raw.split(",") if s.strip()] if allowed_raw else []
 
     agent_label = args.agent if not mode else f"{args.agent}:{mode}"
 
+    if not allowed:
+        # Prose-only mode — 메인 Claude 가 prose 직접 읽고 routing 결정.
+        # stdout 은 sentinel "PROSE_LOGGED" 로 통일 — 외부 skill 이 enum 기대 없는
+        # 경우용. 메인은 이 출력 무시하고 prose 자체를 routing 입력으로.
+        print("PROSE_LOGGED")
+        print(f"[{agent_label} = PROSE_LOGGED]", file=sys.stderr)
+        summary = _extract_prose_summary(prose)
+        if summary:
+            print(summary, file=sys.stderr)
+        _append_step_status(
+            sid, rid, args.agent, mode, "PROSE_LOGGED", prose, prose_path,
+        )
+        return 0
+
+    # legacy compat — 외부 skill 이 `--allowed-enums` 박은 경우 휴리스틱 호출 보존.
+    # interpret_strategy 의 신규 telemetry 기록은 이미 중단됨 (issue #284).
     try:
         enum = interpret_with_fallback(prose, allowed)
     except MissingSignal as e:
@@ -1770,10 +1786,19 @@ def _build_arg_parser() -> Any:
     p_bs.add_argument("mode", nargs="?", default="")
     p_bs.set_defaults(func=_cli_begin_step)
 
-    p_es = sub.add_parser("end-step", help="prose 저장 + enum 추출 (stdout)")
+    p_es = sub.add_parser(
+        "end-step",
+        help="prose 저장 (issue #284 — `--allowed-enums` 미지정 시 prose-only mode)",
+    )
     p_es.add_argument("agent")
     p_es.add_argument("mode", nargs="?", default="")
-    p_es.add_argument("--allowed-enums", required=True, help="comma-separated")
+    p_es.add_argument(
+        "--allowed-enums", required=False, default="",
+        help=(
+            "comma-separated. legacy compat — 미지정 시 prose-only mode "
+            "(stdout=PROSE_LOGGED). 이슈 #284."
+        ),
+    )
     p_es.add_argument(
         "--prose-file", required=False, default=None,
         help="prose 본문 파일 경로 (미제공 시 hook auto-stage 경로 사용)",

--- a/scripts/analyze_metrics.mjs
+++ b/scripts/analyze_metrics.mjs
@@ -2,8 +2,12 @@
 /**
  * dcNess 메타 LLM telemetry 분석기
  *
+ * [이슈 #284 폐기 진행] heuristic-calls.jsonl 신규 기록 0 — 누적 baseline 만 보존.
+ * 신규 prose-only routing telemetry 는 .metrics/routing-decisions.jsonl
+ * (`harness/routing_telemetry.py` — 이슈 #281).
+ *
  * 입력 파일 (기본 `.metrics/`):
- *   - heuristic-calls.jsonl   : interpret_with_fallback 의 매 호출 outcome
+ *   - heuristic-calls.jsonl   : interpret_with_fallback 의 매 호출 outcome (deprecated)
  *   - meta-llm-calls.jsonl    : haiku interpreter 가 실 호출한 케이스 (input/output_tokens, cost_usd)
  *
  * 출력: 콘솔 표 + (옵션) JSON 요약.

--- a/tests/test_interpret_strategy.py
+++ b/tests/test_interpret_strategy.py
@@ -1,18 +1,17 @@
-"""test_interpret_strategy — heuristic-only enum 추출 검증.
+"""test_interpret_strategy — issue #284 폐기 진행: telemetry 중단 검증.
 
-DCN-CHG-20260430-04: LLM fallback 폐기, heuristic-only 정착.
+이슈 #280 epic 정착 후 동작:
+    - `interpret_with_fallback` 휴리스틱 자체는 legacy 호환 (외부 skill `--allowed-enums`).
+    - 단 `.metrics/heuristic-calls.jsonl` 에 신규 append 0.
+    - prose-only routing telemetry 는 `harness/routing_telemetry.py` 가 대체 (#281).
 
 Coverage:
-    - heuristic_hit             : 휴리스틱 단일 매칭
-    - heuristic_ambiguous       : 휴리스틱 0/2+ hit → MissingSignal propagate
-    - heuristic_not_found       : 휴리스틱이 not_found 예외 propagate
-    - telemetry on/off          : DCNESS_LLM_TELEMETRY=0 시 기록 0
-    - allowed empty             : 즉시 ValueError
+    - heuristic 결과 자체는 legacy 호환 (PASS / AMBIGUOUS / not_found 동일).
+    - 모든 outcome 에서 heuristic-calls.jsonl 신규 기록 0 (이슈 #284 acceptance).
+    - allowed empty → ValueError.
 """
 from __future__ import annotations
 
-import json
-import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -32,7 +31,7 @@ class HeuristicHitTests(unittest.TestCase):
     def tearDown(self) -> None:
         self._td.cleanup()
 
-    def test_heuristic_hit_records_outcome(self) -> None:
+    def test_heuristic_hit_returns_enum(self) -> None:
         result = interpret_with_fallback(
             "## 결론\n\nPASS\n",
             ["PASS", "FAIL"],
@@ -40,67 +39,30 @@ class HeuristicHitTests(unittest.TestCase):
         )
         self.assertEqual(result, "PASS")
 
-        log = (self.tele / HEURISTIC_TELEMETRY_FILE).read_text(encoding="utf-8")
-        events = [json.loads(line) for line in log.strip().splitlines()]
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0]["outcome"], "heuristic_hit")
-        self.assertEqual(events[0]["parsed"], "PASS")
-        self.assertEqual(events[0]["allowed"], ["PASS", "FAIL"])
+    def test_no_heuristic_calls_jsonl_written(self) -> None:
+        # 이슈 #284 acceptance — 어떤 outcome 에서도 신규 기록 0.
+        interpret_with_fallback("PASS", ["PASS"], telemetry_dir=self.tele)
+        try:
+            interpret_with_fallback(
+                "no enum here", ["PASS", "FAIL"], telemetry_dir=self.tele,
+            )
+        except MissingSignal:
+            pass
+        self.assertFalse((self.tele / HEURISTIC_TELEMETRY_FILE).exists())
 
 
 class HeuristicAmbiguousTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self._td = TemporaryDirectory()
-        self.tele = Path(self._td.name)
-
-    def tearDown(self) -> None:
-        self._td.cleanup()
-
     def test_ambiguous_propagates_missing_signal(self) -> None:
         with self.assertRaises(MissingSignal) as ctx:
             interpret_with_fallback(
                 "no clear label here",
                 ["PASS", "FAIL"],
-                telemetry_dir=self.tele,
             )
         self.assertEqual(ctx.exception.reason, "ambiguous")
 
-        events = [
-            json.loads(line)
-            for line in (self.tele / HEURISTIC_TELEMETRY_FILE)
-            .read_text(encoding="utf-8")
-            .strip()
-            .splitlines()
-        ]
-        self.assertEqual(events[-1]["outcome"], "heuristic_ambiguous")
-
     def test_empty_prose_propagates_missing_signal(self) -> None:
-        # 빈 prose 도 휴리스틱이 ambiguous (no enum found) 로 처리
         with self.assertRaises(MissingSignal):
-            interpret_with_fallback(
-                "",
-                ["PASS", "FAIL"],
-                telemetry_dir=self.tele,
-            )
-
-
-class TelemetryToggleTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self._td = TemporaryDirectory()
-        self.tele = Path(self._td.name)
-
-    def tearDown(self) -> None:
-        self._td.cleanup()
-        os.environ.pop("DCNESS_LLM_TELEMETRY", None)
-
-    def test_telemetry_disabled_via_env(self) -> None:
-        os.environ["DCNESS_LLM_TELEMETRY"] = "0"
-        interpret_with_fallback(
-            "PASS",
-            ["PASS"],
-            telemetry_dir=self.tele,
-        )
-        self.assertFalse((self.tele / HEURISTIC_TELEMETRY_FILE).exists())
+            interpret_with_fallback("", ["PASS", "FAIL"])
 
 
 class ValidationTests(unittest.TestCase):

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1213,6 +1213,55 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(out.getvalue().strip(), "AMBIGUOUS")
 
+    def test_end_step_prose_only_mode_no_allowed_enums(self) -> None:
+        """이슈 #284 — `--allowed-enums` 미지정 시 prose-only mode (PROSE_LOGGED)."""
+        from harness.session_state import _cli_end_step, session_dir
+        from types import SimpleNamespace
+        prose_path = self.base / "tmp_prose.md"
+        prose_path.write_text(
+            "## 결론\n\n자유로운 자연어 prose. enum 없음. 메인이 직접 routing.\n",
+            encoding="utf-8",
+        )
+
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="qa",
+                mode="",
+                allowed_enums="",  # prose-only mode
+                prose_file=str(prose_path),
+            ))
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "PROSE_LOGGED")
+        # prose 자체는 저장됨 (메인이 직접 읽고 routing)
+        prose_md = session_dir(self.sid) / "runs" / self.rid / "qa.md"
+        self.assertTrue(prose_md.exists())
+        self.assertIn("자연어", prose_md.read_text(encoding="utf-8"))
+
+    def test_end_step_prose_only_mode_attribute_missing(self) -> None:
+        """`--allowed-enums` 자체 미정의 SimpleNamespace 도 prose-only mode."""
+        from harness.session_state import _cli_end_step
+        from types import SimpleNamespace
+        prose_path = self.base / "tmp_prose.md"
+        prose_path.write_text("any text\n", encoding="utf-8")
+
+        from io import StringIO
+        from contextlib import redirect_stdout
+        out = StringIO()
+        with redirect_stdout(out):
+            ns = SimpleNamespace(
+                agent="engineer",
+                mode="IMPL",
+                prose_file=str(prose_path),
+                allowed_enums=None,  # argparse default 시 빈 string, 명시 None 도 cover
+            )
+            rc = _cli_end_step(ns)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "PROSE_LOGGED")
+
     def test_end_step_no_prose_file_uses_hook_staged(self) -> None:
         # DCN-CHG-20260501-15: --prose-file 미제공 시 live.json.current_step.prose_file 사용
         from harness.session_state import (


### PR DESCRIPTION
## 변경 요약

### [epic280][story284] enum 추출 인프라 폐기 + prose-only mode

- **What**: `harness/interpret_strategy.py` 의 telemetry write 코드 제거 (`.metrics/heuristic-calls.jsonl` 신규 기록 0). `_cli_end_step` 의 `--allowed-enums` optional 변경 — 미지정 시 prose-only mode (stdout=`PROSE_LOGGED`). legacy `--allowed-enums` 호출은 호환 보존.
- **Why**: agent prompt enum 강제 자유화 (#283) 이후 휴리스틱 추출 무용지물. 이슈 #284 acceptance: heuristic 호출 zero / heuristic-calls.jsonl 신규 기록 zero / 의존 코드 prose-only 전환.

## 결정 근거

- **legacy compat 유지** — 외부 활성화 프로젝트의 기존 skill 이 `--allowed-enums` 박은 채 호출해도 crash 회피. 점진적 전환.
- **heuristic 자체는 보존** — `interpret_signal` 은 signal_io 안. 단순 단어경계 매칭이라 의존성 없고 비용 0. 단지 telemetry 기록만 중단.
- **`PROSE_LOGGED` sentinel** — 메인은 stdout 무시하고 prose 자체를 routing 입력으로 사용. cascade 시 `harness.routing_telemetry record-cascade` 명시.
- **배포 경로 1 (#285 부분)** — 본 PR 의 모든 변경은 plug-in 본체 경로. `claude plugin update` 자동 적용. 외부 init-dcness 재배포 불필요.
- 426 tests PASS (telemetry 0 검증 + prose-only mode 2 신규).

## 관련 이슈

Closes #284
Part of #285
Part of #280

## 참고

- `docs/internal/enum-roi-baseline.md` (#277 baseline)
- `docs/plugin/handoff-matrix.md` §1 (#282 자연어 가이드)
- `harness/routing_telemetry.py` (#281 신규 routing telemetry — heuristic-calls 의 후속)