### PR TITLE
[docs] release 0.2.7 — prose-only routing 전환 (epic #280)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.6"
+    "version": "0.2.7"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.7

- **What**: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` version 0.2.6 → 0.2.7 bump.
- **Why**: epic #280 (prose-only routing 전환) 의 5 PR (#286~#290) 누적분을 사용자 환경에 전파.

## 결정 근거

- v0.2.7 release notes 는 PR #290 에서 이미 추가됨.
- 본 PR 은 version 필드 2 곳만 동시 업데이트 (`docs/internal/plugin-release.md` 절차 §1).

## 관련 이슈

Document-Exception-PR-Close: 본 PR 은 version bump 만 수행하는 release infra PR. 닫을 issue 없음 (epic #280 은 이미 PR #290 에서 closed).

## 참고

- `docs/internal/release-notes.md` v0.2.7 (변경 요약)
- `docs/internal/plugin-release.md` (절차)