### PR TITLE
[docs] release 0.2.8 — helper picker semver 정렬 회귀 수정 (issue #293)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.7"
+    "version": "0.2.8"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,38 @@
 
 ---
 
+## v0.2.8 (2026-05-09)
+
+**커밋 범위**: `4926adf..(다음 태그)`
+**핵심 변경**: helper picker semver 정렬 — 가장 오래된 cache 선택 회귀 수정 (이슈 #293)
+
+- **이슈 #293** — helper 진입 패턴 `ls -d ${CLAUDE_PLUGIN_ROOT:-.../dcness/dcness/*} | head -1`
+  이 알파벳 순 정렬로 *가장 오래된* cache (예: 6 버전 환경에서 0.2.2) 선택. v0.2.7
+  의 prose-only mode (이슈 #284 정착) 에 도달 못 해 0.2.2 의 enum-required mode +
+  옛 휴리스틱 강제. jajang run-f0c23053 실측에서 휴리스틱 FP 2건 발생 (validator
+  prose "0 FAIL" → enum=FAIL 오추출 / pr-reviewer "MUST FIX 없음 + NICE TO HAVE
+  4건" → must_fix=true 오판정). 4 파일 (총 9 occurrences) 의 picker glob 패턴
+  `head -1` → `sort -V | tail -1` 교체:
+  - `docs/plugin/loop-procedure.md` (1)
+  - `commands/run-review.md` (1)
+  - `commands/init-dcness.md` (5)
+  - `commands/efficiency.md` (2)
+
+**영향**:
+- v0.2.7 의 prose-only mode 가 picker 가 옛 cache 강제로 도달 못 했던 회귀 수정.
+- 본 v0.2.8 부터는 picker 가 항상 최신 semver 선택 → prose-only mode 자연 활용.
+- cache 다중 버전 환경 (`claude plugin update` 누적) 에서 모두 영향.
+
+**업데이트**:
+```sh
+claude plugin update dcness@dcness
+```
+
+기존 cache 가 0.2.7 이 아닌 옛 버전을 picker 강제하던 환경 (jajang 실측 사례) 은
+본 업데이트 후 정상화.
+
+---
+
 ## v0.2.7 (2026-05-08)
 
 **커밋 범위**: `1cff44a..(다음 태그)`


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.8

- **What**: `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` version 0.2.7 → 0.2.8 bump. release-notes.md v0.2.8 항목 추가.
- **Why**: 이슈 #293 (PR #294) — helper picker semver 정렬 회귀 수정을 사용자 환경에 전파. v0.2.7 의 prose-only mode 효과가 picker 가 옛 cache 강제하던 회귀로 무효화됐던 사례 정상화.

## 결정 근거

- v0.2.7 자체는 정상 — 단지 picker 가 가장 오래된 cache (예: 0.2.2) 강제 → 사용자 환경에서 효과 0.
- v0.2.8 부터 picker 항상 최신 semver 선택 → prose-only mode 자연 활용.

## 관련 이슈

Document-Exception-PR-Close: 본 PR 은 version bump 만 수행하는 release infra PR. 닫을 issue 없음 (이슈 #293 은 이미 PR #294 에서 closed).

## 참고

- `docs/internal/release-notes.md` v0.2.8 (이슈 #293 변경 요약)
- `docs/internal/plugin-release.md` (절차)