### PR TITLE
[docs] release 0.2.9 — init-dcness 초기 docs 폼 시드 (issue #296)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.8"
+    "version": "0.2.9"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,31 @@
 
 ---
 
+## v0.2.9 (2026-05-09)
+
+**커밋 범위**: `156691f..(다음 태그)`
+**핵심 변경**: init-dcness 신규 프로젝트 초기 docs 폼 시드 (이슈 #296)
+
+- **이슈 #296** — `/init-dcness` 실행 시 `docs/PRD.md` / `docs/ARCHITECTURE.md` /
+  `docs/ADR.md` 3개 파일 시드 (부재 시만, 멱등). 사용자가 PRD 논의 후 채워넣을
+  표준 placeholder 제공 — 매 프로젝트마다 다른 형태로 시작하던 분산 해소.
+  - `templates/project-init/{PRD,ARCHITECTURE,ADR}.md` 신규.
+  - `commands/init-dcness.md` Step 2.8 추가 — 부재 시 사용자 동의 받고 cp.
+  - 짧고 placeholder 위주 (한 화면 내 완결).
+
+**배포 경로**: 본 변경은 init-dcness 가 사용자 repo 로 *복사·배포* 하는
+인프라 (배포 경로 2). 기존 활성화 프로젝트는 자동 적용 안 됨 — `/init-dcness`
+재실행 시 부재 파일만 시드 (멱등). 신규 프로젝트는 이번 release 부터 자동 시드.
+
+**업데이트**:
+```sh
+claude plugin update dcness@dcness
+```
+
+기존 활성화 프로젝트에서 docs 폼 받고 싶으면 `/init-dcness` 재실행 (멱등).
+
+---
+
 ## v0.2.8 (2026-05-09)
 
 **커밋 범위**: `4926adf..(다음 태그)`


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.9 — init-dcness 초기 docs 폼 시드 (issue #296)

- **What**: plugin.json + marketplace.json 0.2.8 → 0.2.9. release-notes.md v0.2.9 항목 추가.
- **Why**: v0.2.8 이후 머지된 #296 (init-dcness 초기 docs 폼 시드) 사용자 환경 적용 위한 release.

## 관련 이슈

Closes #296

## 참고

- v0.2.8..HEAD 단일 PR (#297) — init-dcness 가 신규 프로젝트에 PRD/ARCHITECTURE/ADR 시드.
- 배포 경로 2 (init-dcness 가 사용자 repo 로 복사). 기존 활성화 프로젝트는 `/init-dcness` 재실행 시 부재 파일만 시드 (멱등).

🤖 Generated with [Claude Code](https://claude.com/claude-code)