### PR TITLE
[issue-299] auto-loop 야간 자판기 — impl task 단위 새 프로세스 발사

### DIFF
--- a/commands/auto-loop.md
+++ b/commands/auto-loop.md
@@ -1,0 +1,125 @@
+---
+name: auto-loop
+description: impl task list 를 야간 자동 batch 로 처리하는 스킬. 매 task 마다 새 `claude -p` (cold start) 발사 → 컨텍스트 자동 클리어. 사용자가 "야간 자판기", "자고 일어나서 결과", "전체 epic 자동 실행", "/auto-loop", "밤새 돌려" 등을 말할 때 사용. /impl-loop 가 단일 세션 누적 (#216 사례 \$1,531) 이라면 본 스킬은 task 단위 cold start 로 컨텍스트 격리. 사용자 부재 환경 (야간) 가정 — escalate 신호 감지 시 즉시 정지.
+---
+
+# Auto Loop Skill — 야간 자판기
+
+> impl task 디렉토리를 받아 매 task 마다 새 `claude -p` 프로세스 (cold start) 로 발사. dcness 활성 프로젝트의 SessionStart hook 이 자동 발화 → CLAUDE.md / docs / INSIGHTS / MEMORY 자동 inject. 매 task 끝나면 프로세스 종료 = 자동 컨텍스트 클리어.
+
+## 언제 사용
+
+- 사용자 발화: "야간 자판기", "/auto-loop", "자고 일어나서", "밤새 돌려", "전체 epic 자동"
+- impl task 5+ 개를 *사용자 부재 환경* 에서 자동 진행하고 싶을 때
+- 매 task 새 세션 = 컨텍스트 누적 0 (cache_read 폭주 회피, #216)
+
+## 비대상
+
+- 단일 task → `/impl`
+- 대화 모드 chain → `/impl-loop` (사용자 옆에 있을 때)
+- 한 줄 → `/quick`
+
+## Inputs
+
+- impl 디렉토리 경로 (예: `docs/milestones/v1/epics/epic-X/impl/`)
+- (옵션) 매 호출 비용 cap (`--max-budget-usd <amount>` 기본 0.5)
+- (옵션) 호출 모델 (기본 dcness 활성 모델)
+
+## 사전 게이트 — issue-lifecycle.md §6 강제
+
+skill 진입 즉시 메인 Claude 가 다음 매치 검증:
+
+1. impl 디렉토리의 부모 stories.md 위치 추출 (`docs/milestones/vNN/epics/epic-NN-*/stories.md`)
+2. stories.md 상단 매치 확인:
+   - `**GitHub Epic Issue:** [#\d+]` (정식 등록), 또는
+   - `**GitHub Epic Issue:** 미등록 (사유: …)` (issue-lifecycle.md §3 허용 모드)
+3. 매치 0건 → 즉시 STOP + 사용자 보고. silent skip 금지.
+4. 각 story 헤더 직하 `**GitHub Issue:** [#\d+]` 매치도 확인.
+
+게이트 통과 후 자판기 발사.
+
+## 핵심 동작
+
+```bash
+PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
+python3 "$PLUGIN_ROOT/scripts/auto_loop.py" <impl_dir> [--max-budget-usd 0.5]
+```
+
+자판기가 하는 일:
+1. `<impl_dir>/*.md` 정렬 후 순차 처리 (파일명 prefix `NN-` 기준)
+2. 각 파일마다 새 `claude -p` 프로세스 발사
+   - dcness 활성 프로젝트라면 SessionStart hook 자동 발화 → CLAUDE.md / docs / SSOT inject
+   - 매 호출 cold start = 자동 컨텍스트 클리어
+3. prompt 에 inject:
+   - 작업 본문 (impl/NN-foo.md 통째)
+   - "(retry 시) 직전 시도 prose 파일 path"
+4. 결과 prose 마지막 단락에서 결론 enum 추출
+   - 정상 완료 (`IMPL_DONE` 등) → 다음 task 진행
+   - escalate 계열 (`IMPLEMENTATION_ESCALATE`, `SPEC_GAP_FOUND`, `DESIGN_REVIEW_ESCALATE` 등) → 즉시 종료
+   - 실패 (status 불명) → retry (최대 3회, prev_error path 자동 inject)
+5. 매 호출 timestamp 기록 (stderr → log 파일)
+
+## 자판기가 *안 하는* 것 (자율 영역)
+
+- PR 생성 / 트레일러 분기 — 임시 메인 (claude -p 안) 이 자율 판단 (issue-lifecycle.md §1.4 따라)
+- stories.md / backlog.md 체크박스 갱신 — 임시 메인이 자율 처리
+- agent 호출 순서 결정 — 임시 메인이 dcness 룰 따라 자율
+- escalate 결론 박을지 말지 — 임시 메인 자율
+
+자판기는 *발사 + escalate 감지 + retry 카운팅* 만. 모든 작업 판단은 임시 메인 자율 = §1 자율성 정합.
+
+## escalate enum 감지 (자판기 → 즉시 종료)
+
+자판기가 결론 enum 보고 종료 결정:
+
+| enum | 동작 |
+|---|---|
+| `IMPL_DONE` / `IMPL_PARTIAL` / `LIGHT_PLAN_READY` 등 정상 | 다음 task 진행 |
+| `IMPLEMENTATION_ESCALATE` | 자판기 종료 |
+| `SPEC_GAP_FOUND` | 자판기 종료 (architect SPEC_GAP 분기 — 야간엔 사용자 위임) |
+| `DESIGN_REVIEW_ESCALATE` / `UX_REVIEW_ESCALATE` | 자판기 종료 |
+| `VARIANTS_ALL_REJECTED` | 자판기 종료 |
+| status 불명 (enum 추출 실패) | retry — 3회 후 자판기 종료 |
+
+## 결과 보고
+
+자판기 종료 시 stderr 에 1 페이지 요약:
+- 처리 task: N/M
+- 각 task: 이름 + 결과 enum + 소요 시간
+- 종료 사유 (전체 완료 / escalate / retry 한도 초과)
+
+## 워크트리
+
+자판기는 *외부 프로세스* — 메인 Claude 의 워크트리 / 세션과 별개. 자판기 자체는 사용자 cwd 에서 발사. 매 `claude -p` 호출도 동일 cwd.
+
+워크트리 분기는 *임시 메인 (claude -p 안)* 이 자율 판단:
+- 매 호출이 dcness 활성 프로젝트로 진입 → SessionStart hook 발화 → 임시 메인이 dcness 룰 따라 워크트리 처리
+
+## 비용 제어
+
+- `--max-budget-usd <amount>` 매 호출 cap (기본 $0.5). 폭주 방지.
+- *전체 batch 비용* = 매 호출 cap × task 수 + retry 비용
+
+추정 (epic 1개 = 10 task 가정):
+- Opus 4.7 (1M context): ~$8~10
+- Haiku 4.5 (사용자 선택 옵션): 큰 폭 ↓ (quality 트레이드)
+
+## 사전 read
+
+- [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) §6 (mid-flow 게이트) + §1.4 (PR 트레일러)
+- [`docs/plugin/handoff-matrix.md`](../docs/plugin/handoff-matrix.md) (escalate enum 카탈로그)
+- [`docs/plugin/dcness-rules.md`](../docs/plugin/dcness-rules.md) §1 (자율성 원칙)
+
+## 한계 / v1 범위
+
+- 의존성 자동 판단 X (impl 목차 순서 = 의존)
+- task 병렬 실행 X (직렬만)
+- 매 호출이 *별 다른 prompt* 라 prompt cache 효율 제한적
+- Agent tool 호출 가능 여부 첫 호출에서 검증 (가능 = 하이브리드, 불가 = 단순 batch)
+
+## 안티패턴 (회귀 방지)
+
+- ❌ 단일 세션에 8 task 누적 — `/impl-loop` 의 #216 사례. 본 스킬이 그것의 cold start 자동화 버전.
+- ❌ 자판기가 PR body 트레일러를 직접 박음 — *형식 강제*. 임시 메인 자율 영역.
+- ❌ 자판기가 status JSON 신설 컨벤션 도입 — dcness §1 위반. GitHub 이슈 시스템 그대로 활용.
+- ❌ escalate 신호 무시하고 다음 task 진행 — 사용자 부재 환경에서 추측 진행 = 폭주.

--- a/scripts/auto_loop.py
+++ b/scripts/auto_loop.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Auto Loop — 야간 자판기 (Issue #299).
+
+dcness 활성 프로젝트의 impl task 디렉토리를 받아 매 task 마다 새 `claude -p`
+프로세스 (cold start) 로 발사한다. 매 호출이 새 프로세스 = 자동 컨텍스트 클리어.
+dcness SessionStart hook 이 매 호출 자동 발화 → CLAUDE.md / docs / SSOT inject.
+
+자판기의 책임은 *발사 + escalate 감지 + retry 카운팅* 만.
+모든 작업 판단 (PR 생성 / agent 호출 순서 / 워크트리 / 트레일러 분기 등) 은
+임시 메인 (claude -p 안의 클로드) 자율. dcness §1 자율성 원칙 정합.
+
+Usage:
+    python3 auto_loop.py <impl_dir> [--max-budget-usd 0.5] [--retry 3]
+
+예시:
+    python3 auto_loop.py docs/milestones/v1/epics/epic-X/impl
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Optional
+
+KST = timezone(timedelta(hours=9))
+
+# escalate 결론 enum — handoff-matrix.md §6 카탈로그 정합.
+# 발견 시 자판기 즉시 종료 (사용자 위임).
+ESCALATE_ENUMS = {
+    "IMPLEMENTATION_ESCALATE",
+    "SPEC_GAP_FOUND",
+    "DESIGN_REVIEW_ESCALATE",
+    "UX_REVIEW_ESCALATE",
+    "VARIANTS_ALL_REJECTED",
+    "ESCALATE",
+}
+
+# 정상 완료 enum — 다음 task 진행.
+ADVANCE_ENUMS = {
+    "IMPL_DONE",
+    "IMPL_PARTIAL",
+    "LIGHT_PLAN_READY",
+    "VALIDATED",
+    "LGTM",
+    "DOCS_SYNC_READY",
+    "PRODUCT_PLAN_READY",
+    "TASK_DONE",
+}
+
+
+def stamp() -> str:
+    return datetime.now(KST).strftime("%Y-%m-%dT%H:%M:%S%z")
+
+
+def log(msg: str):
+    print(f"[auto-loop {stamp()}] {msg}", file=sys.stderr, flush=True)
+
+
+def discover_tasks(impl_dir: Path) -> list[Path]:
+    """impl/*.md 정렬 (파일명 prefix `NN-` 기준)."""
+    if not impl_dir.is_dir():
+        log(f"ERROR: {impl_dir} not a directory")
+        sys.exit(1)
+    tasks = sorted(impl_dir.glob("*.md"))
+    if not tasks:
+        log(f"ERROR: {impl_dir} 에 *.md 없음")
+        sys.exit(1)
+    return tasks
+
+
+def extract_enum(prose: str) -> Optional[str]:
+    """prose 마지막 1500자 안에서 결론 enum 추출.
+
+    dcness §1 — prose 마지막 영역에서 enum heuristic. handoff-matrix 카탈로그
+    + 정상 advance enum 둘 다 매칭. 가장 마지막에 등장하는 enum 우선.
+    """
+    if not prose:
+        return None
+    tail = prose[-1500:]
+    candidates = ESCALATE_ENUMS | ADVANCE_ENUMS
+    found = []
+    for token in re.finditer(r"\b([A-Z][A-Z_]{4,})\b", tail):
+        word = token.group(1)
+        if word in candidates:
+            found.append((token.start(), word))
+    if not found:
+        return None
+    found.sort(key=lambda x: x[0])
+    return found[-1][1]
+
+
+def extract_prose(claude_json: dict) -> str:
+    """claude -p --output-format json 응답에서 prose 추출.
+
+    응답 구조는 claude 버전에 따라 다를 수 있음. fail-soft 로 여러 키 시도.
+    """
+    for key in ("result", "text", "content", "output"):
+        v = claude_json.get(key)
+        if isinstance(v, str) and v.strip():
+            return v
+        if isinstance(v, list):
+            joined = "\n".join(
+                item.get("text", "") if isinstance(item, dict) else str(item)
+                for item in v
+            )
+            if joined.strip():
+                return joined
+    return json.dumps(claude_json, ensure_ascii=False)
+
+
+def build_prompt(task_file: Path, prev_prose_path: Optional[Path]) -> str:
+    """claude -p 에 발사할 prompt 생성.
+
+    - 작업 본문 (impl/NN-foo.md 통째)
+    - (retry 시) 직전 시도 prose 파일 path inject — 임시 메인 자율 read
+    - dcness §1 정합: 형식 강제 X. 임시 메인이 자율 판단.
+    """
+    body = task_file.read_text(encoding="utf-8")
+    sections = []
+
+    if prev_prose_path and prev_prose_path.exists():
+        sections.append(
+            f"## ⚠ 이전 시도 실패\n\n"
+            f"직전 시도의 prose 결과: `{prev_prose_path}`\n"
+            f"필요시 read 후 직전 실패 분석. 같은 실수 회피."
+        )
+
+    sections.append(
+        f"## 작업\n\n"
+        f"파일: `{task_file}`\n\n"
+        f"본 작업을 dcness 룰 따라 진행. 워크트리 / 에이전트 호출 순서 / "
+        f"PR 생성 / 트레일러 분기 모두 임시 자율 판단 (dcness §1).\n\n"
+        f"끝나면 prose 마지막 단락에 결론 enum 명시 (예: IMPL_DONE / "
+        f"IMPLEMENTATION_ESCALATE / SPEC_GAP_FOUND 등 — handoff-matrix.md §6).\n\n"
+        f"---\n\n{body}"
+    )
+
+    return "\n\n---\n\n".join(sections)
+
+
+def invoke_claude(
+    prompt: str,
+    cwd: Path,
+    max_budget_usd: float,
+    output_dir: Path,
+    task_name: str,
+    attempt: int,
+) -> tuple[Optional[str], Optional[Path], int]:
+    """claude -p 1회 호출. 반환 = (prose, prose_path, exit_code)."""
+    cmd = [
+        "claude", "-p",
+        "--output-format", "json",
+        "--no-session-persistence",
+        "--max-budget-usd", str(max_budget_usd),
+        "--dangerously-skip-permissions",
+        prompt,
+    ]
+    log(f"  발사: {task_name} (시도 {attempt})")
+    t0 = time.monotonic()
+    try:
+        result = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=3600,
+        )
+    except subprocess.TimeoutExpired:
+        log(f"  ⚠ TIMEOUT (3600s) — {task_name} 시도 {attempt}")
+        return None, None, -1
+
+    elapsed = int(time.monotonic() - t0)
+    log(f"  완료: {task_name} 시도 {attempt} [{elapsed}s, exit {result.returncode}]")
+
+    # raw output 저장 (디버깅용)
+    raw_path = output_dir / f"{task_name}-attempt{attempt}.json"
+    raw_path.write_text(result.stdout or "", encoding="utf-8")
+
+    # prose 추출
+    prose = ""
+    try:
+        if result.stdout:
+            data = json.loads(result.stdout)
+            prose = extract_prose(data)
+            # budget 초과 / error 감지
+            if data.get("is_error") or data.get("subtype", "").startswith("error_"):
+                log(f"  ⚠ claude error: {data.get('subtype', 'unknown')}")
+                if "max_budget" in str(data.get("subtype", "")):
+                    log(f"  ⚠ budget 초과 — 자판기 종료")
+                    return prose, raw_path, 2
+    except json.JSONDecodeError:
+        log(f"  ⚠ JSON 파싱 실패. stdout 일부: {result.stdout[:200] if result.stdout else '(empty)'}")
+        prose = result.stdout or ""
+
+    # prose 별도 저장 (다음 시도의 prev_prose_path 후보)
+    prose_path = output_dir / f"{task_name}-attempt{attempt}.md"
+    prose_path.write_text(prose, encoding="utf-8")
+
+    return prose, prose_path, result.returncode
+
+
+def run_task(
+    task_file: Path,
+    cwd: Path,
+    max_budget_usd: float,
+    max_retry: int,
+    output_dir: Path,
+) -> tuple[str, Optional[str]]:
+    """단일 task 실행 (retry 포함). 반환 = (status, enum)
+
+    status: "completed" | "escalate" | "failed" | "budget_exhausted"
+    """
+    task_name = task_file.stem
+    prev_prose_path = None
+
+    for attempt in range(1, max_retry + 1):
+        prompt = build_prompt(task_file, prev_prose_path)
+        prose, prose_path, exit_code = invoke_claude(
+            prompt, cwd, max_budget_usd, output_dir, task_name, attempt,
+        )
+
+        if exit_code == 2:
+            return "budget_exhausted", None
+
+        enum = extract_enum(prose) if prose else None
+        log(f"  결론 enum: {enum or '(추출 실패)'}")
+
+        if enum in ESCALATE_ENUMS:
+            return "escalate", enum
+
+        if enum in ADVANCE_ENUMS:
+            return "completed", enum
+
+        # enum 추출 실패 또는 모호 → retry
+        if attempt < max_retry:
+            log(f"  ↻ retry {attempt}/{max_retry} — enum 불명")
+            prev_prose_path = prose_path
+        else:
+            log(f"  ✗ {max_retry}회 시도 후 실패 — 자판기 종료")
+            return "failed", enum
+
+    return "failed", None
+
+
+def report(results: list[dict], stop_reason: str):
+    log("=" * 60)
+    log(f"자판기 종료: {stop_reason}")
+    log(f"처리: {sum(1 for r in results if r['status'] == 'completed')}/{len(results)}")
+    for r in results:
+        mark = {
+            "completed": "✓",
+            "escalate": "⏸",
+            "failed": "✗",
+            "budget_exhausted": "💰",
+        }.get(r["status"], "?")
+        log(f"  {mark} {r['task']}: {r['status']} ({r.get('enum') or '-'})")
+    log("=" * 60)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="dcness 야간 자판기 (Issue #299)")
+    parser.add_argument("impl_dir", help="impl task 디렉토리 (예: docs/milestones/v1/epics/epic-X/impl)")
+    parser.add_argument("--max-budget-usd", type=float, default=0.5, help="매 호출 비용 cap (기본 0.5)")
+    parser.add_argument("--retry", type=int, default=3, help="실패 시 retry 횟수 (기본 3)")
+    parser.add_argument("--cwd", default=".", help="claude -p 실행 cwd (기본 현재 디렉토리)")
+    args = parser.parse_args()
+
+    impl_dir = Path(args.impl_dir).resolve()
+    cwd = Path(args.cwd).resolve()
+
+    output_dir = impl_dir.parent / ".auto-loop"
+    output_dir.mkdir(exist_ok=True)
+    log(f"output dir: {output_dir} (디버깅용 prose / json dump)")
+
+    tasks = discover_tasks(impl_dir)
+    log(f"task {len(tasks)} 개 발견. cwd={cwd}, budget=${args.max_budget_usd}/call")
+
+    results = []
+    stop_reason = "전체 완료"
+
+    for i, task_file in enumerate(tasks, 1):
+        log(f"━━━ Task {i}/{len(tasks)}: {task_file.name} ━━━")
+        status, enum = run_task(
+            task_file, cwd, args.max_budget_usd, args.retry, output_dir,
+        )
+        results.append({"task": task_file.name, "status": status, "enum": enum})
+
+        if status != "completed":
+            stop_reason = f"task {i}/{len(tasks)} 에서 {status} ({enum or '?'})"
+            break
+
+    report(results, stop_reason)
+    sys.exit(0 if stop_reason == "전체 완료" else 2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 변경 요약

### [issue-299] auto-loop 야간 자판기

- **What**: `/auto-loop {impl_dir}` skill + `scripts/auto_loop.py` 자판기 신설. impl task 디렉토리를 받아 매 task 마다 새 `claude -p` 프로세스 발사 (cold start = 자동 컨텍스트 클리어). escalate 결론 enum 감지 시 즉시 종료. 실패 시 직전 시도 prose 파일 path 만 prompt 에 inject 하여 retry (최대 3회).
- **Why**: 사용자가 루프 1개 돌리고 수동 `/clear` 패턴 사용 중. /impl-loop 는 단일 세션 누적 (#216 사례 \$1,531 / 4M+ 토큰) 이라 야간 자동 batch 부적합. task 단위 cold start 가 안티패턴 (impl-loop.md line 49) 으로 명시되어 있지만 자동화 안 됨 — 본 PR 이 그 자동화.

## 결정 근거

### dcness §1 자율성 원칙 정합

자판기 책임을 *발사 + escalate 감지 + retry 카운팅* 만으로 한정. 모든 작업 판단은 임시 메인 (claude -p 안) 자율:

| 영역 | 누가 결정 |
|---|---|
| PR 생성 + 트레일러 분기 (issue-lifecycle.md §1.4) | 임시 메인 자율 |
| agent 호출 순서 / handoff | 임시 메인 자율 (dcness 룰 따라) |
| 워크트리 분기 | 임시 메인 자율 (SessionStart hook 발화 후 dcness 룰) |
| stories.md / backlog.md 체크박스 | 임시 메인 자율 |
| 결론 enum 박을지 말지 | 임시 메인 자율 |
| 자판기는? | impl/*.md 순서 / claude -p 발사 / enum 감지 / retry 카운팅 |

### "도입 안 할 것" 회피 (dcness-rules.md §1)

- 출력 형식 강제 (status JSON 신설) ❌ → GitHub 이슈 시스템 그대로 활용
- handoff 형식 강제 (next_actions[] 등) ❌ → enum heuristic 만, 형식 강제 X
- preamble 자동 주입 ❌ → prose path 만 inject (통째 X)
- 에이전트 자율성 침해 ❌ → agent system prompt 변경 0

### jha0313 분석 결과 — 진짜 신규 갭만 차용

| jha0313 패턴 | dcness 에 있나? | 차용? |
|---|---|---|
| 단계 설계 7 원칙 | architect MODULE_PLAN / product-planner Given/When/Then ✅ | X (이미 있음) |
| 자기완결 산출물 | impl/*.md 자체가 자기완결 ✅ | X |
| 외부 영구 관찰 | GitHub 이슈 + PR 트레일러 ✅ (jha0313 의 index.json 보다 우월) | X |
| escalate 즉시 종료 | escalate 결론 enum (handoff-matrix.md) ✅ | X — 자판기가 enum 매핑만 |
| prose 자동 file 저장 | PostToolUse hook (harness/hooks.py:576) ✅ | X |
| INSIGHTS / MEMORY inject | SessionStart hook ✅ | X |
| `claude -p` cold start | ❌ | **✅ 본 PR** |
| prev_error path inject | △ 자율만 | **✅ 본 PR — path 만 (자율 read)** |

## 관련 이슈

Closes #299

## PoC 검증 (#299 코멘트 참조)

- `claude -p` 옵션 다 존재 (--print / --output-format / --dangerously-skip-permissions / --max-budget-usd / --no-session-persistence)
- jajang (dcness 활성) 에서 발사 시 cache_creation 38K 토큰 = **SessionStart hook 자동 발화 확인**
- `--max-budget-usd` 작동 (폭주 방지)
- Agent tool 호출 가능 여부는 *진짜 가동 시점에 첫 task 결과로 검증* — 가능하면 하이브리드 (sub-agent 활용), 불가면 단순 batch

## 한계 / v1 범위

- 의존성 자동 판단 X (impl 목차 순서 = 의존)
- 병렬 X (직렬만)
- 매 호출 별 다른 prompt → cache_read 효율 제한적
- 비용 추정 epic 1개 (10 task) ~\$8~10 (Opus 4.7 1M)

## 검증

- [x] python3 -c "ast.parse" 문법 OK
- [x] python3 scripts/auto_loop.py --help 작동
- [x] dcness git-naming-spec 통과 (커밋 메시지 hook PASS)
- [ ] 실제 가동: 본 PR merge 후 jajang 또는 다른 활성 프로젝트의 작은 epic 으로 v1 검증