### PR TITLE
[issue-307] 워크트리 자동 진입을 impl 류 루프로 좁힘

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@
 
 ## 1. 작업 절차 (모든 변경 공통)
 
-0. **워크트리 기본 켜짐** — 모든 변경 작업 진입 시 자동 `EnterWorktree(name="<목적>-{ts_short}")`. 메인 working tree 보호 + 동시 다중 세션 충돌 회피. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 (예: "워크트리 빼고") 시에만 건너뜀. 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 sub-agent 권한 자동 처리.
+0. **워크트리 (impl 류 루프 한정)** — *코드 변경 batch* (`/impl` `/impl-loop` `/auto-loop` `/quick`) 진입 시만 자동 `EnterWorktree(name="<목적>-{ts_short}")`. 메인 working tree 보호 + 동시 다중 세션 충돌 회피. **`/product-plan` / 모듈 설계 / 문서·시드 작업은 워크트리 X** — 충돌 회피 목적 부재. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 (예: "워크트리 빼고") 시에만 건너뜀. 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 sub-agent 권한 자동 처리.
 1. **수정 작업**.
 2. **commit 직전**: git pre-commit hook 자동 게이트 (main-block + pytest).
 3. **branch → PR → regular merge** (직접 `main` push 금지). CI PASS 후 메인이 즉시 머지 — *사용자 수동 승인 대기 X*.

--- a/commands/product-plan.md
+++ b/commands/product-plan.md
@@ -31,8 +31,8 @@ description: 새 기능 / PRD 변경 / 큰 기획을 받아 product-planner → 
 ## 사전 read (skill 진입 즉시)
 `docs/plugin/loop-procedure.md` + `docs/plugin/orchestration.md` §2~§3 + §4.2 + `docs/plugin/handoff-matrix.md` read 후 진행.
 
-## 워크트리 (기본 켜짐)
-Step 0 진입 시 자동 `EnterWorktree(name="product-plan-{ts_short}")`. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
+## 워크트리 (X)
+`/product-plan` 은 워크트리 자동 진입 안 함. 기획·설계는 동시 다중 batch 충돌 회피 목적 부재 — 메인 working tree 에서 별 branch 따고 직접 진행. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
 
 ## 절차
 [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1~§6 + [`docs/plugin/orchestration.md`](../docs/plugin/orchestration.md) §4.2 (`feature-build-loop` 풀스펙) 따름. 본 파일은 input 명세 + 라우팅만.

--- a/docs/plugin/dcness-rules.md
+++ b/docs/plugin/dcness-rules.md
@@ -89,7 +89,7 @@
 | agent 접근 권한 (Write/Read 경계) | [`handoff-matrix.md`](handoff-matrix.md) | §4 |
 | yolo 모드 / worktree 격리 상세 | [`loop-procedure.md`](loop-procedure.md) | §3.3 yolo / §1.1 worktree |
 
-**워크트리 기본 켜짐 (#255 정합)**: 행동형 skill (`/quick` `/impl` `/impl-loop` `/product-plan`) 진입 시 자동으로 EnterWorktree 호출. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` (예: "워크트리 빼고", "워크트리 없이", "워크트리 말고") 매치 시에만 건너뜀. 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 sub-agent 권한 자동 처리. 자세히 = `loop-procedure.md §1.1`.
+**워크트리 기본 켜짐 — impl 류 루프 한정 (#255 정합)**: 행동형 skill 중 *코드 변경 batch* (`/quick` `/impl` `/impl-loop` `/auto-loop`) 진입 시만 자동으로 EnterWorktree 호출. **`/product-plan` / 모듈 설계 / 문서·시드 작업은 워크트리 X** — 본 작업은 동시 다중 batch 충돌 회피 목적 부재라 격리 비용 (cwd 점프 / 머지 후 정리 / 추적 부하) 만 발생. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` (예: "워크트리 빼고", "워크트리 없이", "워크트리 말고") 매치 시에만 건너뜀. 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 sub-agent 권한 자동 처리. 자세히 = `loop-procedure.md §1.1`.
 
 skill 들은 input 정형화 + Loop 추천만, 절차는 loop-procedure, loop spec 은 orchestration §4.
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -18,12 +18,14 @@ skill 트리거 또는 직접 발화 → 메인 Claude 가 **[`orchestration.md`
 
 ## 1. Step 0 — worktree + begin-run
 
-### 1.1 worktree 분기 (기본 켜짐)
+### 1.1 worktree 분기 (impl 류 루프 한정)
 
-**모든 행동형 skill (`/quick` `/impl` `/impl-loop` `/product-plan`) 진입 시 EnterWorktree 자동 호출**. 동시 다중 세션 충돌 회피 + 메인 working tree 보호.
+**행동형 skill 중 *코드 변경 batch* (`/quick` `/impl` `/impl-loop` `/auto-loop`) 진입 시만 EnterWorktree 자동 호출**. 동시 다중 세션 충돌 회피 + 메인 working tree 보호.
+
+**`/product-plan` / 모듈 설계 / 문서·시드 작업은 워크트리 X** — 본 작업은 충돌 회피 목적 부재. 메인 working tree 에서 별 branch 따고 직접 진행.
 
 ```
-EnterWorktree(name="<skill>-{ts_short}")
+EnterWorktree(name="<skill>-{ts_short}")   # impl 류만
 ```
 
 **거부 표현 시에만 건너뜀** — 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 (예: "워크트리 빼고", "워크트리 없이", "워크트리 말고") 시 EnterWorktree 호출 0, 일반 cwd 그대로 진행.


### PR DESCRIPTION
## 변경 요약

### [issue-307] 워크트리 자동 진입을 impl 류 루프로 좁힘

- **What**: 워크트리 자동 진입 트리거에서 `/product-plan` 제거 + `/auto-loop` 추가. *코드 변경 batch* 만 자동 진입. 4 파일 정합 갱신.
- **Why**: 워크트리 본 목적 = 동시 다중 impl batch 충돌 회피. `/product-plan` / 모듈 설계 / 문서·시드 작업은 그 목적 부재 → 격리 비용 (cwd 점프 / 머지 후 정리 / 추적 부하) 만 발생.

## 결정 근거

- impl 류 한정 (`/impl` / `/impl-loop` / `/auto-loop` / `/quick` 코드 변경) — 충돌 회피 목적 정합
- `/product-plan` / 모듈 설계 / 문서·시드 — 워크트리 X 로 명시 (혼동 방지)
- [`commands/product-plan.md`](commands/product-plan.md) 의 "워크트리 (기본 켜짐)" → "워크트리 (X)" 명시 — 사용자가 본 skill 만 봐도 룰 인지

## 변경 파일

| 파일 | 변경 |
|---|---|
| [`CLAUDE.md`](CLAUDE.md) §1 단계 0 | "모든 변경 작업" → "impl 류 루프 진입 시" |
| [`docs/plugin/dcness-rules.md`](docs/plugin/dcness-rules.md) §2 | 트리거 목록 정합 + /product-plan 워크트리 X 명시 |
| [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md) §1.1 | 같은 표현 정합 |
| [`commands/product-plan.md`](commands/product-plan.md) | "워크트리 (X)" 섹션으로 갱신 |

## 관련 이슈

Closes #307

## 배포 경로 검증 (CLAUDE.md §0.5)

- (1) plug-in 본체: [`docs/plugin/*.md`](docs/plugin/) + [`CLAUDE.md`](CLAUDE.md) + [`commands/product-plan.md`](commands/product-plan.md) — `claude plugin update` 자동 적용 ✓
- (2) init-dcness 복사물: 본 룰은 사용자 repo cp X (SSOT 직접 호출) — N/A
- (3) 사용자 SSOT: [`dcness-rules.md`](docs/plugin/dcness-rules.md) 가 SessionStart hook 으로 inject — 외부 활성화 프로젝트도 매 세션 자동 받음 ✓

## 검증

- [x] 4 파일 표현 정합 — `/product-plan` 제거 일관 적용
- [x] commit-msg hook PASS
- [ ] CI PASS 후 머지