### PR TITLE
[issue-306] sub-agent 호출 prompt 작성 룰 + worktree path 명시 의무

### DIFF
--- a/docs/plugin/dcness-rules.md
+++ b/docs/plugin/dcness-rules.md
@@ -121,6 +121,18 @@ Agent(subagent_type=<agent>, mode=<MODE>, description="...")
 
 begin-step 에서 전달된 INSIGHTS 가 있으면 prompt 에 포함.
 
+### 호출 prompt 작성 — MUST
+
+**호출 직전 해당 agent.md §"호출자가 prompt 로 전달하는 정보" 항목 read 후 prompt 작성**. 항목에 명시된 정보를 누락 없이 prompt 에 박는다 (형식 자유 — 정보 명시 의무만).
+
+**worktree 활성 시 worktree 절대 경로 prompt 에 추가 명시 — MUST (모든 agent 공통)**:
+
+- cwd 가 `.claude/worktrees/<name>/` 안이면 sub-agent prompt 에 worktree 절대 경로 명시 (예: "현재 worktree: `/Users/.../.claude/worktrees/<name>/`")
+- sub-agent 의 file path read 는 worktree 경로 prefix 사용
+- main repo abs path (`/Users/.../project/<repo>/`) 사용 금지 — 머지 전 옛 코드 read 로 false positive 발생 (anthropics/claude-code#31546 / #48096 알려진 결함)
+
+근거: CC Task tool 에 cwd parameter 부재 (anthropics/claude-code#12748), subagent frontmatter cwd field 부재 (#31940) — sub-agent 가 자기 cwd 인지 불가. 메인 (호출자) 이 명시 책임.
+
 ## 3.3 end-step
 
 ```bash


### PR DESCRIPTION
## 변경 요약

### [issue-306] sub-agent 호출 prompt 작성 룰 + worktree path 명시 의무

- **What**: `docs/plugin/dcness-rules.md` §3.2 에 §"호출 prompt 작성 — MUST" 신규. 메인 Claude 가 sub-agent 호출 직전 (a) 해당 agent.md §"호출자 정보" 항목 read 후 prompt 작성, (b) worktree 활성 시 worktree 절대 경로 명시 의무 룰 2건.
- **Why**: jajang Epic 12 task 02 cycle 2 에서 pr-reviewer 가 worktree 안 PR 검토 시 메인 working tree path 를 read → 머지 전 옛 코드 기준 false positive → yolo 모드 추가 cycle 비용. 같은 구조적 결함이 read-only sub-agent 8개에 잠재.

## 결정 근거

### 검토한 대안

| 대안 | 폐기 사유 |
|---|---|
| pr-reviewer 만 Bash 권한 추가 + `gh pr diff` SSOT | 같은 구조적 결함이 read-only agent 8개 모두에 존재 — 부분 해결 |
| helper begin-step 가 stdout 에 [CONTEXT] 블록 자동 inject | dcness-rules §1 위반: "preamble 자동 주입 X" + "출력 형식 강제 X" + "강제는 시퀀스 + 접근 영역 단 2가지" |
| agent.md 23 file 일괄 worktree 항목 추가 | §1 안티패턴 1번 위반: "룰이 룰을 부르는 reactive cycle — 신규 룰 추가 전 기존 룰 제거 검토". SSOT 1곳에 박는 것으로 흡수 가능 |
| file-guard hook 으로 main path read 차단 | 정당한 main path read 도 차단 — 부작용 큼 |

### 채택 — dcness-rules.md §3.2 1곳 룰 박기

§1 정합 검증:
- "출력 형식 강제 X" — 정보 명시 의무만, 형식 자유 (호출자 prompt `description=` 어떻게 쓸지 메인 자율)
- "preamble 자동 주입 X" — helper inject 폐기, 메인 자율
- "안티패턴 1 — 룰이 룰을 부르는" — SSOT 1곳, agent.md 23 file 분산 폐기
- "강제는 시퀀스 + 접근 영역" — worktree path 명시는 접근 영역 *예방*. block 아닌 자연어 룰

## 근본 원인 — CC 알려진 결함

- [anthropics/claude-code#12748](https://github.com/anthropics/claude-code/issues/12748) — Task tool 에 cwd parameter 부재 (feature request)
- [#31546](https://github.com/anthropics/claude-code/issues/31546) — Subagents resolve to main repo root instead of worktree directory (closed as duplicate)
- [#31940](https://github.com/anthropics/claude-code/issues/31940) — subagent frontmatter cwd / additionalDirectories field 부재
- [#48096](https://github.com/anthropics/claude-code/issues/48096) — memory namespace 가 main repo 면 main path read

→ sub-agent 가 자기 cwd 인지 수단 자체 부재. 메인 (호출자) 이 prompt 에 명시할 수밖에 없음.

## 배포 경로 검증

- `docs/plugin/dcness-rules.md` = plug-in 본체 파일. plug-in update 시 외부 사용자 자동 갱신 (`hooks/session-start.sh` 가 plugin SSOT 직접 read — `commands/init-dcness.md` 에서 cp 폐지 #198 정합)
- 별도 cp / deploy 단계 불필요

## 검증 / 후속

- [ ] 본 PR 머지 후 jajang 다음 impl-loop 시 worktree path 명시 의무 적용 확인
- [ ] 누락 패턴 누적 시 사후 측정 (PreToolUse Agent hook stderr WARN + run_review MAIN_PATH_LEAK waste finding) 별 PR 검토 — issue #306 개선점 1 후속 트랙

## 관련 이슈

Part of #306

Document-Exception-PR-Close: #306 은 4 개선점 묶음 — 본 PR 은 1번 (pr-reviewer cwd 오인식) 만 처리. 개선점 2/3/4 는 별 PR 예정. issue 전체 close 아닌 부분 fix 라 Closes 부적절.

## 참고

- #306 개선점 2 (`.claude` → `.claire` 오타) — 본 룰의 부수 효과로 worktree abs path 명시되면 typo 자연 감소 가능. 5회+ 누적 시 별 검토.
- #306 개선점 3 (engineer plan boundary 무시) / 4 (PR body Closes vs Part of) — 본 PR 범위 외, 별 fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)