### PR TITLE
[issue-306] loop_insights + routing_telemetry main repo root 기준 (worktree 손실 방지)

### DIFF
--- a/harness/loop_insights.py
+++ b/harness/loop_insights.py
@@ -3,7 +3,12 @@
 각 루프 종료 시 redo-log + WASTE/GOOD findings → agent별 파일에 누적.
 begin-step 에서 읽어 메인 Claude 에게 주입.
 
-저장 위치: <cwd>/.claude/loop-insights/<agent>[-<mode>].md
+저장 위치: <main_repo_root>/.claude/loop-insights/<agent>[-<mode>].md
+
+worktree 진입 후에도 main repo root 기준으로 저장 — ExitWorktree(remove)
+시 누적분 손실 회피 (#306 개선점 5). main repo root 해석은
+`_resolve_project_root` (`session_state.py`) 의 git common-dir γ-resolution
+재사용. git 미설치 / 리포 아님 시 cwd 폴백.
 """
 from __future__ import annotations
 
@@ -14,6 +19,7 @@ from typing import Optional
 from harness import redo_log
 from harness import run_review as rv
 from harness.session_state import run_dir as get_run_dir
+from harness.session_state import _resolve_project_root
 
 
 __all__ = ["insights_path", "read", "append_findings", "append_from_run"]
@@ -21,11 +27,22 @@ __all__ = ["insights_path", "read", "append_findings", "append_from_run"]
 _INSIGHTS_DIR = Path(".claude") / "loop-insights"
 
 
+def _normalize_cwd(cwd: Path) -> Path:
+    """cwd 를 main repo root 로 정규화 (#306 개선점 5).
+
+    worktree 안 cwd 면 main repo root 반환. git 미사용 환경 폴백 시 cwd 자체.
+    """
+    try:
+        return _resolve_project_root(Path(cwd).resolve()).resolve()
+    except OSError:
+        return Path(cwd).resolve()
+
+
 def insights_path(
     agent: str, mode: Optional[str] = None, cwd: Path = Path(".")
 ) -> Path:
     name = agent if not mode else f"{agent}-{mode}"
-    return cwd / _INSIGHTS_DIR / f"{name}.md"
+    return _normalize_cwd(cwd) / _INSIGHTS_DIR / f"{name}.md"
 
 
 def read(

--- a/harness/routing_telemetry.py
+++ b/harness/routing_telemetry.py
@@ -51,8 +51,16 @@ _PROSE_TAIL_LIMIT = 1200
 
 
 def _telemetry_path(base_dir: Optional[Path]) -> Path:
-    base = base_dir or (Path.cwd() / ".metrics")
-    return base / ROUTING_TELEMETRY_FILE
+    if base_dir is not None:
+        return base_dir / ROUTING_TELEMETRY_FILE
+    # worktree 안에서도 main repo root 기준으로 저장 — ExitWorktree(remove)
+    # 시 누적분 손실 회피 (#306 개선점 5). git 미사용 환경 폴백 시 cwd.
+    try:
+        from harness.session_state import _resolve_project_root
+        root = _resolve_project_root(Path.cwd().resolve()).resolve()
+    except (OSError, ImportError):
+        root = Path.cwd()
+    return root / ".metrics" / ROUTING_TELEMETRY_FILE
 
 
 def _ts() -> str:

--- a/tests/test_loop_insights.py
+++ b/tests/test_loop_insights.py
@@ -213,5 +213,78 @@ class TestAppendFromRun(unittest.TestCase):
             self.assertEqual(modified, [])
 
 
+class TestWorktreeNormalization(unittest.TestCase):
+    """worktree 안 cwd → main repo root 정규화 (#306 개선점 5).
+
+    worktree 진입 후에도 loop-insights 가 main repo root 에 저장돼야 함.
+    ExitWorktree(remove) 시 누적분 손실 회피.
+    """
+
+    def test_insights_path_normalizes_worktree_to_main_root(self):
+        with tempfile.TemporaryDirectory() as td:
+            main_root = Path(td) / "main"
+            worktree = main_root / ".claude" / "worktrees" / "wt1"
+            main_root.mkdir(parents=True)
+            worktree.mkdir(parents=True)
+
+            with patch(
+                "harness.loop_insights._resolve_project_root",
+                return_value=main_root,
+            ):
+                p = insights_path("engineer", "IMPL", cwd=worktree)
+
+            self.assertTrue(
+                str(p).startswith(str(main_root.resolve()) + os.sep),
+                f"insights_path={p} 가 main_root={main_root} 안이 아님",
+            )
+            self.assertIn(".claude/loop-insights", str(p))
+            self.assertNotIn("worktrees/wt1", str(p))
+
+    def test_append_findings_writes_to_main_root_not_worktree(self):
+        """append_findings 가 worktree cwd 받아도 main repo root 에 저장."""
+        with tempfile.TemporaryDirectory() as td:
+            main_root = Path(td) / "main"
+            worktree = main_root / ".claude" / "worktrees" / "wt1"
+            main_root.mkdir(parents=True)
+            worktree.mkdir(parents=True)
+
+            with patch(
+                "harness.loop_insights._resolve_project_root",
+                return_value=main_root,
+            ):
+                append_findings(
+                    "engineer", "IMPL",
+                    ["worktree path leak detected"], [],
+                    cwd=worktree,
+                )
+
+            worktree_path = worktree / ".claude" / "loop-insights" / "engineer-IMPL.md"
+            self.assertFalse(worktree_path.exists())
+
+            main_path = main_root / ".claude" / "loop-insights" / "engineer-IMPL.md"
+            self.assertTrue(main_path.exists())
+            self.assertIn("worktree path leak detected", main_path.read_text())
+
+    def test_read_resolves_from_main_root_after_worktree_remove(self):
+        """worktree 안에서 호출돼도 main_root 에서 read — ExitWorktree(remove) 후 영속성."""
+        with tempfile.TemporaryDirectory() as td:
+            main_root = Path(td) / "main"
+            worktree = main_root / ".claude" / "worktrees" / "wt1"
+            main_root.mkdir(parents=True)
+            worktree.mkdir(parents=True)
+
+            main_path = main_root / ".claude" / "loop-insights" / "architect.md"
+            main_path.parent.mkdir(parents=True)
+            main_path.write_text("# Loop Insights\ncontent X", encoding="utf-8")
+
+            with patch(
+                "harness.loop_insights._resolve_project_root",
+                return_value=main_root,
+            ):
+                result = read("architect", cwd=worktree)
+
+            self.assertIn("content X", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_routing_telemetry.py
+++ b/tests/test_routing_telemetry.py
@@ -154,5 +154,44 @@ class CliTests(_Base):
         self.assertIn("위임", events[0]["reason"])
 
 
+class WorktreeNormalizationTests(unittest.TestCase):
+    """worktree 안 cwd → main repo root 정규화 (#306 개선점 5).
+
+    base_dir 미지정 시 _telemetry_path 가 main repo root 기준 `.metrics/` 사용.
+    ExitWorktree(remove) 후 누적분 손실 회피.
+    """
+
+    def test_default_path_uses_main_repo_root_when_in_worktree(self):
+        from unittest.mock import patch
+        from harness.routing_telemetry import _telemetry_path
+        with TemporaryDirectory() as td:
+            main_root = Path(td) / "main"
+            worktree = main_root / ".claude" / "worktrees" / "wt1"
+            main_root.mkdir(parents=True)
+            worktree.mkdir(parents=True)
+            with patch("pathlib.Path.cwd", return_value=worktree), \
+                 patch(
+                     "harness.session_state._resolve_project_root",
+                     return_value=main_root,
+                 ):
+                p = _telemetry_path(None)
+            self.assertTrue(
+                str(p).startswith(str(main_root.resolve()) + os.sep),
+                f"telemetry_path={p} 가 main_root={main_root} 안이 아님",
+            )
+            self.assertNotIn("worktrees/wt1", str(p))
+            self.assertIn(".metrics", str(p))
+            self.assertIn(ROUTING_TELEMETRY_FILE, str(p))
+
+    def test_explicit_base_dir_overrides(self):
+        """base_dir 명시 시 그대로 사용 (worktree 정규화 skip)."""
+        from harness.routing_telemetry import _telemetry_path
+        with TemporaryDirectory() as td:
+            explicit = Path(td) / "custom-metrics"
+            p = _telemetry_path(explicit)
+            self.assertEqual(p.parent, explicit)
+            self.assertEqual(p.name, ROUTING_TELEMETRY_FILE)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-306] loop_insights + routing_telemetry main repo root 기준 저장

- **What**: `harness/loop_insights.py` + `harness/routing_telemetry.py` 가 `cwd` 기반으로 path 결정하던 것을 `_resolve_project_root()` (γ-resolution) 으로 main repo root 기준 저장하도록 변경. 기존 테스트 23 + 신규 5 = 28 PASS, 전체 431 테스트 PASS.
- **Why**: worktree 안에서 `finalize-run --auto-review` 실행 시 누적분 (loop-insights / routing-decisions.jsonl) 이 worktree path 에 저장 → ExitWorktree(action="remove") 시 손실. jajang Epic 12 product-plan run-cf83861d 7 파일 손실 실측.

## 결정 근거

### 검토한 대안

| 대안 | 폐기 사유 |
|---|---|
| ExitWorktree hook 으로 종료 시 main 으로 merge | hook 추가 + race condition. 본 fix 가 단순 |
| `cwd` 기본값 자체를 main_root 로 변경 | 모든 호출 측 변경 필요 + 명시 인터페이스 손상 |
| 함수 시그니처에 `repo_root` 명시 추가 | 호출 측 23+ 파일 영향 |

### 채택 — 함수 내부에서 `_normalize_cwd()` 정규화

- `_resolve_project_root()` 가 이미 worktree 안에서 main repo root 추적 (`session_state.py:903-911`, `git rev-parse --git-common-dir` 활용)
- 호출 측 변경 0 (cwd 그대로 받아 내부 정규화)
- git 미사용 환경 폴백 → cwd 자체 (legacy 동작 유지)

## 코드 변경

### harness/loop_insights.py
- 신규 `_normalize_cwd()` helper
- `insights_path()` 가 정규화된 cwd 사용
- 모듈 docstring `<cwd>` → `<main_repo_root>`

### harness/routing_telemetry.py
- `_telemetry_path()` 가 base_dir 미지정 시 `_resolve_project_root()` 사용. ImportError 폴백 안전망

### tests/test_loop_insights.py — TestWorktreeNormalization 3 신규
1. insights_path 가 worktree cwd → main_root path
2. append_findings 가 main_root 에 저장 (worktree 안 X)
3. read 가 worktree cwd 받아도 main_root 에서 read

### tests/test_routing_telemetry.py — WorktreeNormalizationTests 2 신규
1. _telemetry_path(None) 이 worktree cwd 환경에서 main_root 사용
2. base_dir 명시 시 정규화 skip

## 검증

- [x] 기존 23 테스트 그대로 PASS (loop_insights + routing_telemetry)
- [x] 신규 5 테스트 PASS (worktree 시나리오 mock 기반)
- [x] 전체 unittest 431 PASS
- [x] pre-commit pytest gate PASS
- [x] git-naming gate PASS

## 배포 경로 검증

- `harness/` = plug-in 본체 일부. plug-in update 시 외부 사용자 자동 갱신
- 별도 cp / deploy 단계 불필요

## 영향 범위 — heuristic 자동화 트랙 영속성 회복

#316 머지 (#306 개선점 1 prompt 룰) + 본 PR 머지 (#306 개선점 5) = [#315 항목 2.1](https://github.com/alruminum/dcNess/issues/315#issuecomment-4412573391) heuristic 자동화 4 패턴 추가의 *선행 조건* 충족:
- loop-insights 영속성 보장 → `[INSIGHTS: <agent>/<mode>]` inject 효과 회복
- routing-decisions.jsonl 누적 영속성 → enum 결정 분석 / cascade 측정 회복

## 관련 이슈

Part of #306

Document-Exception-PR-Close: #306 은 4 개선점 + 추가 발견 5 묶음 — 본 PR 은 개선점 5 (loop_insights worktree 손실) + 추가 발견 (routing_telemetry 같은 패턴) 만 처리. 개선점 3/4 는 별 PR 예정. issue 전체 close 아닌 부분 fix 라 Closes 부적절.

## 참고

- #316 (개선점 1 머지 완료, 2026-05-09T15:21:39Z) — prompt 룰 사전 차단
- 본 PR — heuristic 자동화 트랙 영속성 fix (사후 검출 + 학습)
- 다음 별 PR — 개선점 3 (engineer plan boundary SOP) / 개선점 4 (PR body Closes pre-flight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)