### PR TITLE
[issue-302] RETRY_SAME_FAIL allow-list 보강 (PROSE_LOGGED + prose 차이)

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -358,22 +358,37 @@ def detect_wastes(
     findings: list[WasteFinding] = []
 
     # RETRY_SAME_FAIL — 연속 동일 FAIL enum
+    # 이슈 #302 #1: prose-only mode (#284) 정착 후 PROSE_LOGGED 가 표준 advance enum.
+    # 또한 같은 (agent, mode) 가 N task 순회 정상 호출 (예: architect MODULE_PLAN × 4)
+    # 시 동일 enum 반복은 *retry 가 아닌 정상 호출* — prose 내용이 다르면 다른 step.
+    ADVANCE_ENUMS = {
+        "PASS", "READY_FOR_IMPL", "IMPL_DONE", "TESTS_WRITTEN", "LGTM",
+        "SECURE", "DESIGN_REVIEW_PASS", "BUGFIX_PASS", "PLAN_VALIDATION_PASS",
+        "UX_REVIEW_PASS", "SYSTEM_DESIGN_READY", "DOCS_SYNCED", "POLISH_DONE",
+        "SPEC_GAP_RESOLVED", "LIGHT_PLAN_READY", "PRODUCT_PLAN_READY",
+        "PLAN_REVIEW_PASS",
+        "PROSE_LOGGED",  # #284 prose-only mode default sentinel — 정상 종료
+    }
     for i in range(1, len(steps)):
         prev, cur = steps[i - 1], steps[i]
-        if prev.agent == cur.agent and prev.enum == cur.enum and prev.enum not in (
-            "PASS", "READY_FOR_IMPL", "IMPL_DONE", "TESTS_WRITTEN", "LGTM",
-            "SECURE", "DESIGN_REVIEW_PASS", "BUGFIX_PASS", "PLAN_VALIDATION_PASS",
-            "UX_REVIEW_PASS", "SYSTEM_DESIGN_READY", "DOCS_SYNCED", "POLISH_DONE",
-            "SPEC_GAP_RESOLVED", "LIGHT_PLAN_READY", "PRODUCT_PLAN_READY",
-        ):
-            findings.append(WasteFinding(
-                pattern="RETRY_SAME_FAIL",
-                severity="MEDIUM",
-                step_idx=i,
-                agent=cur.agent,
-                detail=f"step {i-1}→{i} 동일 enum 반복: {cur.enum}",
-                fix=f"agents/{cur.agent}.md fail 전략 강화 또는 impl 보강",
-            ))
+        if prev.agent != cur.agent or prev.enum != cur.enum:
+            continue
+        if prev.enum in ADVANCE_ENUMS:
+            continue
+        # prose 내용이 *다르면* 같은 enum 이라도 다른 invocation (N task 순회 등)
+        # — retry 아님. prose_excerpt 가 동일할 때만 진짜 retry 후보.
+        prev_prose = prev.prose_full or prev.prose_excerpt
+        cur_prose = cur.prose_full or cur.prose_excerpt
+        if prev_prose and cur_prose and prev_prose != cur_prose:
+            continue
+        findings.append(WasteFinding(
+            pattern="RETRY_SAME_FAIL",
+            severity="MEDIUM",
+            step_idx=i,
+            agent=cur.agent,
+            detail=f"step {i-1}→{i} 동일 enum 반복: {cur.enum}",
+            fix=f"agents/{cur.agent}.md fail 전략 강화 또는 impl 보강",
+        ))
 
     # ECHO_VIOLATION — prose 전체 줄 수 기준 (prose_full). prose_full 없는 레코드는 skip.
     for s in steps:

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -149,6 +149,40 @@ class WasteDetectionTests(unittest.TestCase):
         kinds = {w.pattern for w in wastes}
         self.assertIn("RETRY_SAME_FAIL", kinds)
 
+    def test_retry_same_fail_prose_logged_skip(self):
+        """이슈 #302 #1 — PROSE_LOGGED 는 prose-only mode 정상 sentinel.
+        연속 발생해도 RETRY_SAME_FAIL false positive 안 됨."""
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="architect", mode="MODULE_PLAN",
+                       enum="PROSE_LOGGED", must_fix=False, prose_excerpt="task 01"),
+            StepRecord(idx=1, ts="t2", agent="architect", mode="MODULE_PLAN",
+                       enum="PROSE_LOGGED", must_fix=False, prose_excerpt="task 02"),
+            StepRecord(idx=2, ts="t3", agent="architect", mode="MODULE_PLAN",
+                       enum="PROSE_LOGGED", must_fix=False, prose_excerpt="task 03"),
+        ]
+        wastes = detect_wastes(steps)
+        kinds = {w.pattern for w in wastes}
+        self.assertNotIn("RETRY_SAME_FAIL", kinds,
+                         "PROSE_LOGGED 는 advance sentinel — 연속 발생해도 retry 아님")
+
+    def test_retry_same_fail_different_prose_skip(self):
+        """이슈 #302 #1 — 같은 enum 이라도 prose 내용이 다르면 다른 invocation (N task 순회 등).
+        retry 아님."""
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="engineer", mode="IMPL",
+                       enum="TESTS_FAIL", must_fix=False,
+                       prose_excerpt="task 01 첫 시도",
+                       prose_full="task 01 첫 시도\n실패 원인 A"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="IMPL",
+                       enum="TESTS_FAIL", must_fix=False,
+                       prose_excerpt="task 02 첫 시도",
+                       prose_full="task 02 첫 시도\n실패 원인 B"),
+        ]
+        wastes = detect_wastes(steps)
+        kinds = {w.pattern for w in wastes}
+        self.assertNotIn("RETRY_SAME_FAIL", kinds,
+                         "다른 task / 다른 prose = 다른 invocation, retry 아님")
+
     def test_echo_violation(self):
         # prose_full 이 짧을 때만 ECHO_VIOLATION (prose_excerpt 기준 X)
         steps = [


### PR DESCRIPTION
## 변경 요약

### [issue-302] RETRY_SAME_FAIL allow-list 보강 (PROSE_LOGGED + prose 차이)
- **What**: `harness/run_review.py` 의 RETRY_SAME_FAIL heuristic 에 (a) PROSE_LOGGED advance enum 등록 (b) prose 내용 다르면 다른 invocation 으로 판정 룰 추가. 회귀 테스트 2 추가.
- **Why**: jajang Epic 12 product-plan run-cf83861d false positive 3건 — architect MODULE_PLAN × 4 task 정상 호출이 retry 로 오인됨 → review trust 저하 → 메인 Claude 가 review.md 무시 → 진짜 valid finding 도 묻힘.

## 결정 근거

- 실증 검증 — `grep PROSE_LOGGED` 결과 `harness/session_state.py:1329` 가 prose-only mode (#284) 표준 stdout sentinel. `docs/plugin/dcness-rules.md §147` 명문화 — *정상 종료* 표시. 이게 RETRY allow-list 에 빠져있던 게 root cause.
- 추가 룰 (prose 비교) 은 미래 신규 advance enum 등록 누락 시에도 회귀 방지 — N task 순회는 구조적으로 prose 가 task 별 다름.
- pytest 결과: 433 tests 전체 통과 (기존 `test_retry_same_fail` 도 그대로 통과 — 진짜 retry 케이스는 prose 동일 + fail enum 으로 검출 유지).

## 관련 이슈

Part of #302

Document-Exception-PR-Close: #302 는 3 sub-item (개선점 1/2/3) 묶음. 본 PR 은 #1 (RETRY_SAME_FAIL false positive) 의 root fix. #2 (SD hex 분포 사전표) 와 #3 (stale step warning) 은 별도 PR.

## 배포 경로 검증 (CLAUDE.md §0.5)

- **(1) plug-in 본체**: `harness/run_review.py` 변경 — plug-in 업데이트 자동 반영
- **(2) init-dcness 배포**: N/A — harness 모듈은 plug-in cache 직접 호출
- **(3) SSOT 문서**: N/A — 룰 자체 변경은 없고 heuristic 정확도 개선

## 참고

- 실증 출처: jajang run-cf83861d review.md `RETRY_SAME_FAIL ... PROSE_LOGGED` × 3건
- pytest: `tests/test_run_review.py` 55개 (신규 2 포함) 전체 PASS
- 풀 스위트: 433 tests PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)