### PR TITLE
[issue-321] STRAY_DIR_LEAK detector 추가 (#321 C 1/4)

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -69,6 +69,10 @@ PLACEHOLDER_PATTERNS = [
     r"NotImplementedError", r"^\s*#\s*TODO\b", r"후보\s*\d+\s*개\s*비교",
 ]
 
+# 이슈 #321 C STRAY_DIR_LEAK — known infra dir 와 fuzzy match (typo 의심)
+# 예: `.claire` (실측 jajang run-dbd49faf task 1/2/3 사례) → `.claude` 의 typo
+KNOWN_INFRA_DIR_NAMES = [".claude", ".git", ".github"]
+
 INFRA_PATH_PATTERNS = [
     "/.claude/harness-state/", "/.claude/harness-logs/",
     "harness-memory.md", "harness.config.json", "/.claude/harness/",
@@ -115,6 +119,39 @@ def _has_self_verify_anchor(prose: str) -> bool:
         if re.search(pat, prose, re.MULTILINE | re.IGNORECASE):
             return True
     return False
+
+
+def _detect_stray_infra_dirs(prose: str) -> list[tuple[str, str, float]]:
+    """이슈 #321 C STRAY_DIR_LEAK — `.claude` / `.git` / `.github` 와 typo 의심 디렉토리.
+
+    prose 안 `.<word>(/|\\b)` 매치 + KNOWN_INFRA_DIR_NAMES 와 difflib similarity ≥ 0.78
+    이지만 정확 매치 아닌 후보 → typo 의심.
+
+    Returns list of (typo_name, intended_name, similarity_ratio).
+    """
+    if not prose:
+        return []
+    import difflib  # 표준 라이브러리. 모듈 top import 와 분리 (사용 시점 import 비용 무시).
+    # 4~10 문자 word — `.claude` (7자) / `.git` (4자) / `.github` (7자) 모두 커버
+    candidates = re.findall(r'(?<![./\w])\.([a-zA-Z][a-zA-Z0-9_-]{3,9})(?=[/\s\b]|$)', prose)
+    leaks: list[tuple[str, str, float]] = []
+    seen = set()
+    for cand in candidates:
+        full = "." + cand
+        full_lower = full.lower()
+        if full_lower in {n.lower() for n in KNOWN_INFRA_DIR_NAMES}:
+            continue
+        if full_lower in seen:
+            continue
+        seen.add(full_lower)
+        for known in KNOWN_INFRA_DIR_NAMES:
+            ratio = difflib.SequenceMatcher(None, full_lower, known).ratio()
+            # 0.70 = .claire/.claude 케이스 (실측 0.714) 커버, .vscode/.cargo/.cache
+            # 등 false positive 0건 (실측 모두 0.57 이하)
+            if ratio >= 0.70:
+                leaks.append((full, known, ratio))
+                break
+    return leaks
 
 
 # ── 데이터 모델 ────────────────────────────────────────────────────────
@@ -418,6 +455,21 @@ def detect_wastes(
                     fix="agents/architect/system-design.md §Spike Gate 정합 — concrete 구현 + sdk.md 갱신",
                 ))
                 break
+
+    # STRAY_DIR_LEAK — `.claude` 와 typo 의심 디렉토리 흔적 (#321 C)
+    # 실측: jajang run-dbd49faf task 1/2/3 `.claire` 3 회 연속.
+    for s in steps:
+        if not s.prose_full:
+            continue
+        for typo, intended, ratio in _detect_stray_infra_dirs(s.prose_full):
+            findings.append(WasteFinding(
+                pattern="STRAY_DIR_LEAK",
+                severity="MEDIUM",
+                step_idx=s.idx,
+                agent=s.agent,
+                detail=f"{s.agent} prose 안 `{typo}/` 흔적 — `{intended}/` typo 의심 (similarity {ratio:.2f})",
+                fix=f"agents/{s.agent}.md 디렉토리명 정확 인지 룰 보강 또는 사용자 환경 검증",
+            ))
 
     # MUST_FIX_GHOST — must_fix=true 이후 다음 step 진행
     for i, s in enumerate(steps):

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -203,6 +203,44 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertFalse(any(w.pattern == "ECHO_VIOLATION" for w in wastes))
 
+    def test_stray_dir_leak_detected(self):
+        """이슈 #321 C STRAY_DIR_LEAK — `.claire` 같은 .claude typo 검출."""
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False,
+                       prose_excerpt="x",
+                       prose_full="작업 위치 .claire/worktrees/foo/ 시작 — 검증 완료"),
+        ]
+        wastes = detect_wastes(steps)
+        leak = [w for w in wastes if w.pattern == "STRAY_DIR_LEAK"]
+        self.assertEqual(len(leak), 1)
+        self.assertIn(".claire", leak[0].detail)
+        self.assertIn(".claude", leak[0].detail)
+
+    def test_stray_dir_leak_correct_dir_skipped(self):
+        """정확 `.claude` 는 typo 아님 — 검출 X."""
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False,
+                       prose_excerpt="x",
+                       prose_full="작업 위치 .claude/worktrees/foo/ 시작 — 검증 완료"),
+        ]
+        wastes = detect_wastes(steps)
+        kinds = {w.pattern for w in wastes}
+        self.assertNotIn("STRAY_DIR_LEAK", kinds)
+
+    def test_stray_dir_leak_unrelated_dir_skipped(self):
+        """완전 다른 디렉토리 (`.vscode` 같은) 는 fuzzy match 안 됨 — 검출 X."""
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False,
+                       prose_excerpt="x",
+                       prose_full="설정 파일 .vscode/settings.json 갱신"),
+        ]
+        wastes = detect_wastes(steps)
+        kinds = {w.pattern for w in wastes}
+        self.assertNotIn("STRAY_DIR_LEAK", kinds)
+
     def test_placeholder_leak(self):
         steps = [
             StepRecord(idx=0, ts="t", agent="architect", mode="SYSTEM_DESIGN",


### PR DESCRIPTION
## 변경 요약

### [issue-321] STRAY_DIR_LEAK detector 추가
- **What**: `harness/run_review.py:detect_wastes` 에 `.claude` / `.git` / `.github` 와 fuzzy match (typo 의심) 디렉토리 검출. difflib similarity 0.70+ threshold + KNOWN_INFRA_DIR_NAMES allow-list. 회귀 테스트 3 추가.
- **Why**: jajang run-dbd49faf 에서 task 1/2/3 세 번 연속 `.claire/worktrees/...` typo 발생 (`.claude` 의 typo). dcness review 가 이를 학습 신호로 누적 못 함 → 다음 run 도 같은 typo 반복 위험. 사용자 통찰: "단순 패턴으로 뽑아낸 장단점이 의미가 있을까?" — 구체 path/typo 학습 가치.

## 결정 근거

threshold 0.70 검증 — 실측:
\```
.claire vs .claude  = 0.714  ← 진짜 typo 사례 (jajang 실측)
.claud  vs .claude  = 0.923
.cluade vs .claude  = 0.857
.vscode vs .claude  = 0.571  ← 무관 디렉토리 (false positive 안 됨)
.cargo, .cache, .idea, .npm, .next, .cursor, .aider, .codeium 등 모두 0.70 미만
\```

대안 검토:
- ❌ `pip install python-Levenshtein`: 외부 의존성 — 표준 라이브러리 difflib 가 동등 ratio 제공
- ❌ 더 빡빡한 0.78: `.claire` 케이스 (0.714) miss → 진짜 사단 회귀 검출 못 함
- ❌ 더 느슨한 0.60: false positive 위험 (확인 안 했지만 도메인 어휘 침범 가능)

## 관련 이슈

Part of #321

Document-Exception-PR-Close: #321 C 는 4 detector 묶음 (STRAY_DIR_LEAK / PLAN_BOUNDARY_VIOLATION / WORKTREE_PATH_FALLBACK / PR_BODY_CLOSES_MISMATCH). 본 PR 은 STRAY_DIR_LEAK 1개만 처리. 나머지 3개는 별도 follow-up:
- PLAN_BOUNDARY_VIOLATION: prose 만으론 정확 검출 어려움 (plan body read 필요)
- WORKTREE_PATH_FALLBACK: 환경 path 분기 다양 — 별도 실증 후 detector
- PR_BODY_CLOSES_MISMATCH: PR #324 가 root fix. 사후 검출 detector 는 follow-up.

#321 의 다른 sub-item (A 압축 / B 등급 / D 정책 명문화) 도 별도 PR.

## 배포 경로 검증 (CLAUDE.md §0.5)

- **(1) plug-in 본체**: `harness/run_review.py` 변경 — plug-in 업데이트 자동 반영
- **(2) init-dcness 배포**: N/A — harness 모듈은 plug-in cache 직접 호출
- **(3) SSOT 문서**: N/A — heuristic 추가, 룰 자체는 변경 X

## 참고

- pytest 결과: 436 tests (기존 + 신규 3) 전체 PASS
- false positive 검증 완료 — `.vscode` / `.cargo` / `.cache` / `.idea` / `.npm` / `.next` / `.cursor` / `.aider` / `.codeium` 모두 검출 안 됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)