### PR TITLE
[issue-292] Step 4.5 범위 외 path 명문화 (drift root cause 부분 명시)

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -239,6 +239,14 @@ git checkout main && git pull --ff-only 2>/dev/null || true
 
 `impl-task-loop` / `impl-ui-design-loop` / `direct-impl-loop` / `impl-loop` 의 inner task 에 한정. engineer `IMPL_DONE` 직후, validator 진입 *전*. 메인 직접 mechanical edit (agent 위임 X — 도메인 외).
 
+> **범위 외 path 사용자 책임 (#292 root cause 일부)** — 본 Step 4.5 자동 sync 는 위 4 loop 한정. 다음 path 들은 *자동 sync 없음* — 메인이 별도 처리:
+>
+> - `/quick` (`quick-bugfix-loop`) — 작은 버그픽스 / cleanup 용. 일반적으로 stories.md task 와 직접 매핑 안 됨. 단 *드물게* stories.md task 를 다루는 경우 메인이 PR 머지 후 stories.md `[x]` 직접 박을 것.
+> - engineer 직접 호출 (skill 우회) / 메인 직접 commit — *사용자 우회 path*. dcness 룰 미적용 영역.
+> - **dcness 도입 *이전* 작업분** — 룰 도입 전 commit 들의 stories.md 잔재. 1회 backfill 이 정상 (예: jajang PR #232 패턴 — `gh issue list --state closed` 매핑 → unchecked task 일괄 `[x]`). 이후 path 가 정상화되면 drift 0 유지.
+>
+> drift 검출은 `/run-review` / `/audit-redo` 가 사후 안내 (현재 detector 부재 — 후속 추적).
+
 ### 4.5.1 epic 경로 추출
 
 ```bash


### PR DESCRIPTION
## 변경 요약

### [issue-292] Step 4.5 범위 외 path 명문화
- **What**: `loop-procedure.md §4` 본문에 *Step 4.5 자동 sync 범위 외 path* (/quick / engineer 직접 호출 / 메인 직접 commit / dcness 도입 이전 잔재) 사용자 책임 룰 명문화. backfill 가이드 cross-link.
- **Why**: jajang main 전수검사 stories.md drift 177건 — root cause 검증 결과 `quick-bugfix-loop` 가 Step 4.5 범위 미포함 (`commands/quick.md` grep 실측 0건) + dcness 도입 이전 잔재 + 메인 우회 path. 명시 부재로 메인 Claude 가 sync 잊음.

## 결정 근거

- 본 PR 은 #292 root cause 4가지 중 *명문화* 만 처리. detector 추가는 별도:
  - dcness 도입 이전 잔재 = 룰과 무관 (historical, 1회 backfill 패턴 cross-link)
  - /quick path 미적용 = 명문화 보강 (본 PR)
  - retroactive sync 부재 = detector 후속 (#321 B/C follow-up)
  - 메인 부주의 = 룰 명시화로 환경 압박 ↓ (본 PR)

#204 분석 결과 — *진짜 bug 아님*: `issue-lifecycle.md §1.3` 가 이미 "Issue body 에 task 체크리스트 박지 마라" 명시. 옛 issue 잔재일 뿐 (Epic 03 v1.3.1 #190 등은 룰 도입 이전). 별도 PR 으로 close 권유.

## 관련 이슈

Part of #292

Document-Exception-PR-Close: #292 root cause 4가지 중 1개 (룰 명문화) 만 본 PR 처리. drift detector / backfill 자동화는 별도 follow-up.

## 배포 경로 검증 (CLAUDE.md §0.5)

- **(1) plug-in 본체**: `docs/plugin/loop-procedure.md` — plug-in 업데이트 자동 반영
- **(2) init-dcness 배포**: N/A
- **(3) SSOT 문서**: `loop-procedure.md` 자체가 SSOT — 본 PR 이 명시 보강

## 참고

- 실증 출처: `commands/quick.md` grep 결과 stories.md / Step 4.5 / backlog.md 룰 0건 매치
- jajang PR #232 backfill 패턴 cross-link (재사용 가능)

🤖 Generated with [Claude Code](https://claude.com/claude-code)