### PR TITLE
[issue-320] TDD 게이트 phase 2 — polyglot universal (node/python/rust/go)

### DIFF
--- a/.github/actions/tdd-gate/action.yml
+++ b/.github/actions/tdd-gate/action.yml
@@ -1,29 +1,54 @@
 name: 'dcness TDD gate'
 description: |
   Run full project test suite as a required status check before merge.
-  Phase 1 — node 프로젝트 한정 (vitest/jest/등 — package.json scripts.test 위임).
-  package manager 자동 검출 (pnpm-lock.yaml / yarn.lock / bun.lock(b) / 기본 npm).
+  Phase 2 — polyglot universal: node / python / rust / go 자동 검출 + 매트릭스 실행.
+  검출된 모든 언어 테스트가 PASS 해야 게이트 PASS. 둘 이상 검출 시 모두 실행.
 inputs:
   node-version:
-    description: 'Node.js version to use'
+    description: 'Node.js version to use (node 검출 시)'
     required: false
     default: '20'
+  python-version:
+    description: 'Python version to use (python 검출 시)'
+    required: false
+    default: '3.12'
+  go-version:
+    description: 'Go version to use (go 검출 시)'
+    required: false
+    default: 'stable'
 runs:
   using: composite
   steps:
-    - name: Verify node project
+    # ── Step 1: 언어 검출 ──────────────────────────────────────────────
+    - name: Detect languages
+      id: detect
       shell: bash
       run: |
-        if [ ! -f package.json ]; then
-          echo "::error::package.json 부재 — phase 1 TDD 게이트는 node 프로젝트 한정. 비-node 프로젝트는 본 workflow 제거 또는 후속 phase 대기." >&2
-          exit 1
+        HAS_NODE=false
+        HAS_PYTHON=false
+        HAS_RUST=false
+        HAS_GO=false
+        [ -f package.json ] && HAS_NODE=true
+        if [ -f pyproject.toml ] || [ -f setup.py ] || [ -f setup.cfg ] \
+           || ls requirements*.txt 2>/dev/null | grep -q .; then
+          HAS_PYTHON=true
         fi
-        if [ -z "$(node -e "const p=require('./package.json'); process.stdout.write(p.scripts && p.scripts.test || '')" 2>/dev/null)" ]; then
-          echo "::error::package.json scripts.test 미정의 — TDD 게이트가 강제할 테스트 명령 부재. scripts.test 정의 후 재시도." >&2
+        [ -f Cargo.toml ] && HAS_RUST=true
+        [ -f go.mod ] && HAS_GO=true
+        echo "has_node=$HAS_NODE" >> "$GITHUB_OUTPUT"
+        echo "has_python=$HAS_PYTHON" >> "$GITHUB_OUTPUT"
+        echo "has_rust=$HAS_RUST" >> "$GITHUB_OUTPUT"
+        echo "has_go=$HAS_GO" >> "$GITHUB_OUTPUT"
+        echo "[tdd-gate] detect: node=$HAS_NODE python=$HAS_PYTHON rust=$HAS_RUST go=$HAS_GO"
+        if [ "$HAS_NODE" = "false" ] && [ "$HAS_PYTHON" = "false" ] \
+           && [ "$HAS_RUST" = "false" ] && [ "$HAS_GO" = "false" ]; then
+          echo "::error::지원 언어 검출 안 됨 (node/python/rust/go). 다음 중 하나 필요: package.json / pyproject.toml / setup.py / setup.cfg / requirements*.txt / Cargo.toml / go.mod. 비-지원 언어는 workflow 제거 또는 후속 phase 대기." >&2
           exit 1
         fi
 
-    - name: Detect package manager
+    # ── Step 2: Node.js block ─────────────────────────────────────────
+    - name: Detect package manager (node)
+      if: steps.detect.outputs.has_node == 'true'
       id: pm
       shell: bash
       run: |
@@ -36,25 +61,35 @@ runs:
         else
           echo "pm=npm" >> "$GITHUB_OUTPUT"
         fi
-        echo "[tdd-gate] package manager: $(cat "$GITHUB_OUTPUT" | grep ^pm= | tail -1)"
+
+    - name: Verify scripts.test (node)
+      if: steps.detect.outputs.has_node == 'true'
+      shell: bash
+      run: |
+        if [ -z "$(node -e "const p=require('./package.json'); process.stdout.write(p.scripts && p.scripts.test || '')" 2>/dev/null)" ]; then
+          echo "::error::package.json scripts.test 미정의 — node 테스트 명령 부재. monorepo 면 root scripts.test 에 위임 명령 박을 것 (예: npm workspaces = \"npm test --workspaces --if-present\")." >&2
+          exit 1
+        fi
 
     - name: Setup pnpm
-      if: steps.pm.outputs.pm == 'pnpm'
+      if: steps.detect.outputs.has_node == 'true' && steps.pm.outputs.pm == 'pnpm'
       uses: pnpm/action-setup@v3
       with:
         version: 9
 
     - name: Setup Bun
-      if: steps.pm.outputs.pm == 'bun'
+      if: steps.detect.outputs.has_node == 'true' && steps.pm.outputs.pm == 'bun'
       uses: oven-sh/setup-bun@v2
 
     - name: Setup Node.js
+      if: steps.detect.outputs.has_node == 'true'
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ steps.pm.outputs.pm == 'bun' && '' || steps.pm.outputs.pm }}
 
-    - name: Install dependencies
+    - name: Install node dependencies
+      if: steps.detect.outputs.has_node == 'true'
       shell: bash
       run: |
         case "${{ steps.pm.outputs.pm }}" in
@@ -64,7 +99,8 @@ runs:
           *)    npm ci ;;
         esac
 
-    - name: Run tests
+    - name: Run node tests
+      if: steps.detect.outputs.has_node == 'true'
       shell: bash
       run: |
         case "${{ steps.pm.outputs.pm }}" in
@@ -73,3 +109,60 @@ runs:
           bun)  bun test ;;
           *)    npm test ;;
         esac
+
+    # ── Step 3: Python block ──────────────────────────────────────────
+    - name: Setup Python
+      if: steps.detect.outputs.has_python == 'true'
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: 'pip'
+
+    - name: Install python dependencies
+      if: steps.detect.outputs.has_python == 'true'
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        # 프로젝트 자체 install — pyproject.toml / setup.py 우선
+        if [ -f pyproject.toml ] || [ -f setup.py ]; then
+          pip install -e . 2>/dev/null || pip install . 2>/dev/null || echo "[tdd-gate] project install skip"
+        fi
+        # requirements*.txt 모두 install
+        for req in requirements*.txt; do
+          [ -f "$req" ] && pip install -r "$req"
+        done
+        # pytest 미설치 시 보조 install (unittest 폴백 케이스도 pytest 가 unittest 잘 검출)
+        python -c "import pytest" 2>/dev/null || pip install pytest
+
+    - name: Run python tests
+      if: steps.detect.outputs.has_python == 'true'
+      shell: bash
+      run: |
+        # pytest 우선 — tests/ 또는 test/ 자동 검출. 둘 다 없으면 cwd 전체 discover.
+        # pytest 가 unittest 테스트도 자동 검출 (TestCase 상속 클래스) → unittest 프로젝트도 cover.
+        if [ -d tests ] || [ -d test ]; then
+          pytest
+        else
+          pytest . || python -m unittest discover
+        fi
+
+    # ── Step 4: Rust block ────────────────────────────────────────────
+    - name: Run rust tests
+      if: steps.detect.outputs.has_rust == 'true'
+      shell: bash
+      run: |
+        # ubuntu-latest 에 rustc/cargo 기본 포함. toolchain pin 필요 시 사용자 workflow 에서 추가.
+        cargo test --all --verbose
+
+    # ── Step 5: Go block ──────────────────────────────────────────────
+    - name: Setup Go
+      if: steps.detect.outputs.has_go == 'true'
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ inputs.go-version }}
+        cache: true
+
+    - name: Run go tests
+      if: steps.detect.outputs.has_go == 'true'
+      shell: bash
+      run: go test ./...

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -358,33 +358,55 @@ done
 
 이미 `/init-dcness` 활성화한 기존 프로젝트는 본 Step 2.8 이 자동 발화하지 않음. 사용자가 본 plug-in 업데이트 받은 후 `/init-dcness` 재실행해야 Step 2.8 발화. 단 시드는 *부재 시만* 이라 기존 docs 가 있으면 skip — 안전.
 
-### Step 2.9 — TDD 게이트 (옵션, node 프로젝트 한정)
+### Step 2.9 — TDD 게이트 (옵션, polyglot universal)
 
 GitHub Actions CI 에서 *PR 머지 전 풀 테스트 스위트 PASS 강제*. branch protection 의 `required status check` 에 등록되면 진짜 mechanical wall (admin 외 우회 불가) 가 됨. 산업 표준 3 단 enforcement (로컬 incremental → CI 풀 → branch protection) 중 *CI 풀* 단.
 
 > **배경 (#320 #1)**: jajang Epic 12 task 03 에서 plan §3.5 가 `useAuthStore 기존 (변경 X)` 명시했는데 engineer 가 selector 패턴으로 바꿔서 *기존* 26 테스트 깨짐. engineer 의 자체 테스트는 *새 테스트 파일만* 돌리고 풀 스위트 미실행 → cascade 발견 지연. CI 풀 테스트 게이트 + branch protection 으로 mechanical 차단.
 
-#### 1. node 프로젝트 검출
+> **phase 2 — polyglot universal**: composite action 이 4 언어 (node / python / rust / go) 자동 검출. 검출된 *모든* 언어 테스트 PASS 해야 게이트 PASS. jajang (mobile=js/jest + api=python/pytest) 같은 polyglot 모노레포도 추가 설정 없이 cover.
+
+#### 1. 지원 언어 검출
+
+다음 마커 중 1+ 매치 시 TDD 게이트 적용 가능:
+
+| 언어 | 검출 마커 | 테스트 명령 |
+|---|---|---|
+| node | `package.json` | `<pm> test` (pm = pnpm/yarn/bun/npm 자동) |
+| python | `pyproject.toml` / `setup.py` / `setup.cfg` / `requirements*.txt` | `pytest` (unittest 자동 검출 포함) |
+| rust | `Cargo.toml` | `cargo test --all` |
+| go | `go.mod` | `go test ./...` |
 
 ```bash
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
-if [ ! -f "$PROJECT_ROOT/package.json" ]; then
-  echo "[dcness] package.json 부재 — TDD 게이트 skip (phase 1 = node 한정)"
+HAS_SUPPORTED=false
+[ -f "$PROJECT_ROOT/package.json" ] && HAS_SUPPORTED=true
+[ -f "$PROJECT_ROOT/pyproject.toml" ] || [ -f "$PROJECT_ROOT/setup.py" ] \
+  || [ -f "$PROJECT_ROOT/setup.cfg" ] \
+  || ls "$PROJECT_ROOT"/requirements*.txt 2>/dev/null | grep -q . \
+  && HAS_SUPPORTED=true
+[ -f "$PROJECT_ROOT/Cargo.toml" ] && HAS_SUPPORTED=true
+[ -f "$PROJECT_ROOT/go.mod" ] && HAS_SUPPORTED=true
+if [ "$HAS_SUPPORTED" = "false" ]; then
+  echo "[dcness] 지원 언어 (node/python/rust/go) 검출 안 됨 — TDD 게이트 skip"
   # Step 2.9 종료
 fi
 ```
 
-비-node 프로젝트 (Python / Rust / Go 등) 는 phase 2 후속. 본 단계 silent skip.
+지원 외 (Elixir / Ruby / Java / .NET / PHP / Swift 등) 는 phase 3 후속. 본 단계 silent skip.
 
 #### 2. 사용자 옵트인
 
-`package.json` 존재 시 사용자에게 묻는다.
+지원 언어 검출 시 사용자에게 묻는다.
 
 ```
 [dcness] GitHub Actions CI 에서 TDD 게이트 강제할까요?
-  - PR 마다 풀 테스트 스위트 (`<pm> test`) 자동 실행 — 1건이라도 FAIL 시 PR 머지 차단 (branch protection 필요)
-  - package manager 자동 검출 (pnpm-lock.yaml / yarn.lock / bun.lock(b) / 기본 npm)
-  - `package.json` `scripts.test` 미정의면 본 게이트 fail (테스트 명령 정의 의무)
+  - PR 마다 풀 테스트 스위트 자동 실행 — 1건이라도 FAIL 시 PR 머지 차단 (branch protection 필요)
+  - polyglot universal — node / python / rust / go 자동 검출 + 모두 실행
+  - node: package.json scripts.test 위임 (monorepo 면 root 에 `npm test --workspaces --if-present` 같은 위임 명령 박을 것)
+  - python: pyproject.toml / requirements*.txt 자동 install + pytest 실행 (tests/ 또는 test/ 자동 검출, unittest 도 pytest 가 cover)
+  - rust: cargo test --all
+  - go: go test ./...
   - 본 thin yml 1개만 사용자 repo 에 깔리고, 검증 본체는 alruminum/dcNess composite action 호출
   - 로컬에서만 테스트 돌리고 CI 강제 원치 않으면 n
 (Y/n)
@@ -443,11 +465,13 @@ CI workflow 깔린 것만으론 *PR 머지를 차단* 안 됨 — branch protect
 
 본 안내는 *출력만* — 메인 Claude 가 사용자 권한 확인 후 자동 실행할지 사용자 결정에 위임 (admin 권한 가정 위험 회피).
 
-#### 4. 한계 (phase 1)
+#### 4. 한계 (phase 2)
 
-- node 한정 — Python / Rust / Go 등 후속 phase 추가 예정.
-- 풀 스위트만 — incremental (`vitest --changed` / `jest --findRelatedTests`) 로컬 hook 은 phase 2.
+- 지원 언어 4 (node / python / rust / go) — Elixir / Ruby / Java / .NET / PHP / Swift 는 phase 3 후속.
+- 풀 스위트만 — incremental (`vitest --changed` / `jest --findRelatedTests`) 로컬 hook 은 phase 4.
 - branch protection 자동 설정 안 함 — admin 권한 가정 위험. 안내문만 출력.
+- python: poetry / pdm / uv 같은 modern tooling 은 phase 3. 현재 pip 만 (`pip install -e .` + `requirements*.txt`).
+- rust: toolchain pin 필요 시 사용자 workflow 에서 추가. 기본은 ubuntu-latest 의 stable.
 
 #### 5. 기존 활성화 프로젝트 — re-run 안내
 
@@ -477,8 +501,9 @@ design.md SSOT (Step 2.7 완료 시):
 - docs/PRD.md / ARCHITECTURE.md / ADR.md placeholder — 기획 논의 후 채워넣는 용도
 - 부재 시만 시드 (멱등) — 기존 파일은 보호
 
-TDD 게이트 (Step 2.9 완료 시 — node 프로젝트 한정):
+TDD 게이트 (Step 2.9 완료 시 — polyglot universal):
 - .github/workflows/tdd-gate.yml — PR 마다 풀 테스트 스위트 강제 (composite action 호출)
+- 지원 언어 4: node / python / rust / go 자동 검출. polyglot 모노레포 (jajang 같이 js + python) 도 추가 설정 없이 cover
 - branch protection 의 required status checks 등록은 사용자 수동 (안내문 출력)
 - 산업 표준 3 단 enforcement 중 *CI 풀* 단. 로컬 incremental + branch protection 결합으로 진짜 wall 완성 (#320 #1 root fix)
 


### PR DESCRIPTION
## 변경 요약

### [issue-320] TDD 게이트 phase 2 — polyglot universal
- **What**: `.github/actions/tdd-gate/action.yml` 을 node 한정 → 4 언어 (node/python/rust/go) universal 로 확장. 자동 검출 + 검출된 모든 언어 매트릭스 실행. `commands/init-dcness.md` Step 2.9 안내문 갱신.
- **Why**: v0.2.10 phase 1 가정 (node + root `scripts.test`) 이 polyglot 모노레포에 안 맞음. jajang (mobile=js/jest + api=python/pytest) 사례. 사용자 측 우회 (root scripts.test 위임 + 별도 pytest workflow) 만으론 모든 polyglot 프로젝트가 매번 같은 우회 패턴 누적 → dcness 본체 phase 2 도입이 진짜 root fix.

## 결정 근거

지원 언어 선정 — GitHub Actions ubuntu-latest 기본 지원 + 표준 테스트 러너 명확한 4 언어:
- node: `setup-node` + pm 자동 검출
- python: `setup-python` + pytest (unittest 자동 cover)
- rust: 기본 cargo + `cargo test --all`
- go: `setup-go` + `go test ./...`

Elixir/Ruby/Java/.NET/PHP/Swift 는 phase 3 후속 — 사용 빈도 평가 후.

검출 마커:
| 언어 | 마커 |
|---|---|
| node | `package.json` |
| python | `pyproject.toml` / `setup.py` / `setup.cfg` / `requirements*.txt` |
| rust | `Cargo.toml` |
| go | `go.mod` |

## 5 케이스 실측 검증

\```
[polyglot js+python]      node=true  python=true  rust=false go=false
[rust only]               node=false python=false rust=true  go=false
[elixir 비지원]            node=false python=false rust=false go=false ← fail (의도)
[python requirements only] node=false python=true  rust=false go=false
[node + go]               node=true  python=false rust=false go=true
\```

비-지원 언어 = composite action fail (의도) — branch protection wall 효과 유지. 사용자가 비-지원 언어면 workflow 제거 또는 phase 3 대기.

## 관련 이슈

Part of #320

Document-Exception-PR-Close: #320 의 3 sub-item 중 #1 phase 2 확장. #1 자체는 v0.2.10 phase 1 으로 일부 처리. 본 PR 은 phase 2 까지 확장 — #1 완전 처리. 단 #2 (PR body Closes pre-flight, PR #324) / #3 (별도) 남아 있어 #320 close 불가.

## 배포 경로 검증 (CLAUDE.md §0.5)

- **(1) plug-in 본체**: `.github/actions/tdd-gate/action.yml` — plug-in 업데이트 자동 반영. 외부 thin yml 의 `@main` 또는 tag pin 통해 즉시 발화
- **(2) init-dcness 배포**: `commands/init-dcness.md` Step 2.9 안내문 갱신. 기존 활성 프로젝트는 `/init-dcness` 재실행 시 새 안내문 받음 (thin yml 자체는 unchanged — 외부 dcness composite action 호출 1줄만 박혀있어 자동 phase 2 적용)
- **(3) SSOT 문서**: N/A — 룰 자체 변경 X, capability 확장

## 참고

- jajang 적용 방법: `claude plugin update dcness@dcness` → `/init-dcness` 재실행 (멱등). 별도 root scripts.test 작성 / 별도 pytest workflow 불필요.
- 한계 (phase 2): Elixir/Ruby/Java/.NET/PHP/Swift 미지원 (phase 3) / Python tooling = pip 만 (poetry/pdm/uv phase 3) / 풀 스위트만 (incremental 로컬 hook phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)