### PR TITLE
[issue-320] TDD 게이트 phase 3 — affected detection 자동 (사용자 설정 0)

### DIFF
--- a/.github/actions/tdd-gate/action.yml
+++ b/.github/actions/tdd-gate/action.yml
@@ -1,33 +1,57 @@
 name: 'dcness TDD gate'
 description: |
-  Run full project test suite as a required status check before merge.
-  Phase 2 — polyglot universal: node / python / rust / go 자동 검출 + 매트릭스 실행.
-  검출된 모든 언어 테스트가 PASS 해야 게이트 PASS. 둘 이상 검출 시 모두 실행.
+  Run affected tests as required status check before merge.
+  Phase 3 — polyglot universal + 자동 affected detection.
+  node (nx / turbo / pnpm workspaces) / python (변경 .py root) / rust (workspace member) /
+  go (변경 package path) — 각 언어별 변경분 + 의존성 그래프 자동 적용. 사용자 설정 0.
 inputs:
   node-version:
-    description: 'Node.js version to use (node 검출 시)'
+    description: 'Node.js version'
     required: false
     default: '20'
   python-version:
-    description: 'Python version to use (python 검출 시)'
+    description: 'Python version'
     required: false
     default: '3.12'
   go-version:
-    description: 'Go version to use (go 검출 시)'
+    description: 'Go version'
     required: false
     default: 'stable'
 runs:
   using: composite
   steps:
-    # ── Step 1: 언어 검출 ──────────────────────────────────────────────
+    # ── Step 0: PR base 식별 (diff base) ────────────────────────────
+    - name: Resolve diff base
+      id: base
+      shell: bash
+      run: |
+        BASE_SHA="${{ github.event.pull_request.base.sha }}"
+        if [ -z "$BASE_SHA" ]; then
+          # PR 이벤트 아님 (예: workflow_dispatch / push to main) → origin/main 폴백
+          git fetch origin main --depth=1 2>/dev/null || true
+          BASE_SHA=$(git rev-parse origin/main 2>/dev/null || git rev-parse HEAD~1)
+        fi
+        echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+        echo "[tdd-gate] diff base: $BASE_SHA"
+
+    - name: Extract changed files
+      id: changed
+      shell: bash
+      run: |
+        BASE="${{ steps.base.outputs.base_sha }}"
+        # 충분한 history fetch (shallow clone 회피)
+        git fetch origin "$BASE" --depth=50 2>/dev/null || true
+        CHANGED=$(git diff --name-only "$BASE"...HEAD 2>/dev/null || git diff --name-only "$BASE" HEAD)
+        echo "$CHANGED" > /tmp/dcness-changed.txt
+        echo "[tdd-gate] 변경 파일 $(echo "$CHANGED" | grep -c . || echo 0)개:"
+        echo "$CHANGED" | head -20
+
+    # ── Step 1: 언어 검출 ──────────────────────────────────────────
     - name: Detect languages
       id: detect
       shell: bash
       run: |
-        HAS_NODE=false
-        HAS_PYTHON=false
-        HAS_RUST=false
-        HAS_GO=false
+        HAS_NODE=false; HAS_PYTHON=false; HAS_RUST=false; HAS_GO=false
         [ -f package.json ] && HAS_NODE=true
         if [ -f pyproject.toml ] || [ -f setup.py ] || [ -f setup.cfg ] \
            || ls requirements*.txt 2>/dev/null | grep -q .; then
@@ -35,40 +59,38 @@ runs:
         fi
         [ -f Cargo.toml ] && HAS_RUST=true
         [ -f go.mod ] && HAS_GO=true
-        echo "has_node=$HAS_NODE" >> "$GITHUB_OUTPUT"
+        echo "has_node=$HAS_NODE"     >> "$GITHUB_OUTPUT"
         echo "has_python=$HAS_PYTHON" >> "$GITHUB_OUTPUT"
-        echo "has_rust=$HAS_RUST" >> "$GITHUB_OUTPUT"
-        echo "has_go=$HAS_GO" >> "$GITHUB_OUTPUT"
+        echo "has_rust=$HAS_RUST"     >> "$GITHUB_OUTPUT"
+        echo "has_go=$HAS_GO"         >> "$GITHUB_OUTPUT"
         echo "[tdd-gate] detect: node=$HAS_NODE python=$HAS_PYTHON rust=$HAS_RUST go=$HAS_GO"
         if [ "$HAS_NODE" = "false" ] && [ "$HAS_PYTHON" = "false" ] \
            && [ "$HAS_RUST" = "false" ] && [ "$HAS_GO" = "false" ]; then
-          echo "::error::지원 언어 검출 안 됨 (node/python/rust/go). 다음 중 하나 필요: package.json / pyproject.toml / setup.py / setup.cfg / requirements*.txt / Cargo.toml / go.mod. 비-지원 언어는 workflow 제거 또는 후속 phase 대기." >&2
+          echo "::error::지원 언어 검출 안 됨 (node/python/rust/go). 비-지원 언어는 workflow 제거 또는 후속 phase 대기." >&2
           exit 1
         fi
 
-    # ── Step 2: Node.js block ─────────────────────────────────────────
-    - name: Detect package manager (node)
+    # ── Step 2: Node block — affected detection + 실행 ──────────────
+    - name: Detect node package manager
       if: steps.detect.outputs.has_node == 'true'
       id: pm
       shell: bash
       run: |
-        if [ -f pnpm-lock.yaml ]; then
-          echo "pm=pnpm" >> "$GITHUB_OUTPUT"
-        elif [ -f yarn.lock ]; then
-          echo "pm=yarn" >> "$GITHUB_OUTPUT"
-        elif [ -f bun.lockb ] || [ -f bun.lock ]; then
-          echo "pm=bun" >> "$GITHUB_OUTPUT"
-        else
-          echo "pm=npm" >> "$GITHUB_OUTPUT"
+        if   [ -f pnpm-lock.yaml ]; then echo "pm=pnpm" >> "$GITHUB_OUTPUT"
+        elif [ -f yarn.lock ];      then echo "pm=yarn" >> "$GITHUB_OUTPUT"
+        elif [ -f bun.lockb ] || [ -f bun.lock ]; then echo "pm=bun" >> "$GITHUB_OUTPUT"
+        else echo "pm=npm" >> "$GITHUB_OUTPUT"
         fi
 
-    - name: Verify scripts.test (node)
+    - name: Detect node monorepo tool
       if: steps.detect.outputs.has_node == 'true'
+      id: nodetool
       shell: bash
       run: |
-        if [ -z "$(node -e "const p=require('./package.json'); process.stdout.write(p.scripts && p.scripts.test || '')" 2>/dev/null)" ]; then
-          echo "::error::package.json scripts.test 미정의 — node 테스트 명령 부재. monorepo 면 root scripts.test 에 위임 명령 박을 것 (예: npm workspaces = \"npm test --workspaces --if-present\")." >&2
-          exit 1
+        if   [ -f nx.json ];             then echo "tool=nx"     >> "$GITHUB_OUTPUT"
+        elif [ -f turbo.json ];          then echo "tool=turbo"  >> "$GITHUB_OUTPUT"
+        elif [ -f pnpm-workspace.yaml ]; then echo "tool=pnpm-ws" >> "$GITHUB_OUTPUT"
+        else echo "tool=none" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Setup pnpm
@@ -99,18 +121,39 @@ runs:
           *)    npm ci ;;
         esac
 
-    - name: Run node tests
+    - name: Run node tests (affected)
       if: steps.detect.outputs.has_node == 'true'
       shell: bash
       run: |
-        case "${{ steps.pm.outputs.pm }}" in
-          pnpm) pnpm test ;;
-          yarn) yarn test ;;
-          bun)  bun test ;;
-          *)    npm test ;;
+        BASE="${{ steps.base.outputs.base_sha }}"
+        TOOL="${{ steps.nodetool.outputs.tool }}"
+        PM="${{ steps.pm.outputs.pm }}"
+        case "$TOOL" in
+          nx)
+            npx nx affected --target=test --base="$BASE" --head=HEAD
+            ;;
+          turbo)
+            case "$PM" in
+              pnpm) pnpm exec turbo run test --filter="...[$BASE]" ;;
+              yarn) yarn turbo run test --filter="...[$BASE]" ;;
+              *)    npx turbo run test --filter="...[$BASE]" ;;
+            esac
+            ;;
+          pnpm-ws)
+            pnpm --filter "...[$BASE]" test
+            ;;
+          *)
+            # 단일 패키지 또는 native filter 미지원 (yarn classic / npm workspaces / bun) → 풀
+            case "$PM" in
+              pnpm) pnpm test ;;
+              yarn) yarn test ;;
+              bun)  bun test ;;
+              *)    npm test ;;
+            esac
+            ;;
         esac
 
-    # ── Step 3: Python block ──────────────────────────────────────────
+    # ── Step 3: Python block — 변경 .py 의 root pyproject 식별 ──────
     - name: Setup Python
       if: steps.detect.outputs.has_python == 'true'
       uses: actions/setup-python@v5
@@ -118,43 +161,93 @@ runs:
         python-version: ${{ inputs.python-version }}
         cache: 'pip'
 
-    - name: Install python dependencies
+    - name: Run python tests (affected)
       if: steps.detect.outputs.has_python == 'true'
       shell: bash
       run: |
+        # 변경 .py 파일 추출
+        CHANGED_PY=$(grep '\.py$' /tmp/dcness-changed.txt || true)
+        if [ -z "$CHANGED_PY" ]; then
+          echo "[tdd-gate] python 변경 0건 — skip"
+          exit 0
+        fi
+        # 각 .py 의 가장 가까운 상위 pyproject.toml / setup.py 디렉토리 식별
+        ROOTS=$(for f in $CHANGED_PY; do
+          dir=$(dirname "$f")
+          while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+            if [ -f "$dir/pyproject.toml" ] || [ -f "$dir/setup.py" ] || [ -f "$dir/setup.cfg" ]; then
+              echo "$dir"
+              break
+            fi
+            dir=$(dirname "$dir")
+          done
+          # root 까지 못 찾으면 cwd 사용
+          if [ "$dir" = "." ] || [ "$dir" = "/" ]; then
+            echo "."
+          fi
+        done | sort -u)
+        echo "[tdd-gate] python affected roots:"
+        echo "$ROOTS"
+        # 각 root 별 install + pytest
         python -m pip install --upgrade pip
-        # 프로젝트 자체 install — pyproject.toml / setup.py 우선
-        if [ -f pyproject.toml ] || [ -f setup.py ]; then
-          pip install -e . 2>/dev/null || pip install . 2>/dev/null || echo "[tdd-gate] project install skip"
-        fi
-        # requirements*.txt 모두 install
-        for req in requirements*.txt; do
-          [ -f "$req" ] && pip install -r "$req"
+        for root in $ROOTS; do
+          echo "[tdd-gate] >>> python root: $root"
+          (
+            cd "$root"
+            if [ -f pyproject.toml ] || [ -f setup.py ]; then
+              pip install -e . 2>/dev/null || pip install . 2>/dev/null || echo "[install skip]"
+            fi
+            for req in requirements*.txt; do
+              [ -f "$req" ] && pip install -r "$req"
+            done
+            python -c "import pytest" 2>/dev/null || pip install pytest
+            if [ -d tests ] || [ -d test ]; then
+              pytest
+            else
+              pytest . || python -m unittest discover
+            fi
+          )
         done
-        # pytest 미설치 시 보조 install (unittest 폴백 케이스도 pytest 가 unittest 잘 검출)
-        python -c "import pytest" 2>/dev/null || pip install pytest
 
-    - name: Run python tests
-      if: steps.detect.outputs.has_python == 'true'
-      shell: bash
-      run: |
-        # pytest 우선 — tests/ 또는 test/ 자동 검출. 둘 다 없으면 cwd 전체 discover.
-        # pytest 가 unittest 테스트도 자동 검출 (TestCase 상속 클래스) → unittest 프로젝트도 cover.
-        if [ -d tests ] || [ -d test ]; then
-          pytest
-        else
-          pytest . || python -m unittest discover
-        fi
-
-    # ── Step 4: Rust block ────────────────────────────────────────────
-    - name: Run rust tests
+    # ── Step 4: Rust block — workspace member 자동 detect ───────────
+    - name: Run rust tests (affected)
       if: steps.detect.outputs.has_rust == 'true'
       shell: bash
       run: |
-        # ubuntu-latest 에 rustc/cargo 기본 포함. toolchain pin 필요 시 사용자 workflow 에서 추가.
-        cargo test --all --verbose
+        CHANGED_RS=$(grep -E '\.(rs|toml)$' /tmp/dcness-changed.txt || true)
+        if [ -z "$CHANGED_RS" ]; then
+          echo "[tdd-gate] rust 변경 0건 — skip"
+          exit 0
+        fi
+        # root Cargo.toml 에 [workspace] 있으면 member 별 -p, 아니면 cargo test
+        if grep -q '^\[workspace\]' Cargo.toml 2>/dev/null; then
+          # 변경 파일의 가장 가까운 상위 Cargo.toml (root 외) 식별
+          PKGS=$(for f in $CHANGED_RS; do
+            dir=$(dirname "$f")
+            while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
+              if [ -f "$dir/Cargo.toml" ] && [ "$dir" != "." ]; then
+                # package name 추출 (Cargo.toml 의 name = "...")
+                grep -E '^name\s*=' "$dir/Cargo.toml" | head -1 | sed -E 's/name\s*=\s*"(.+)"/\1/'
+                break
+              fi
+              dir=$(dirname "$dir")
+            done
+          done | sort -u)
+          if [ -z "$PKGS" ]; then
+            # root 직접 변경 (workspace 멤버 아님) → 풀
+            cargo test --all
+          else
+            for pkg in $PKGS; do
+              echo "[tdd-gate] >>> cargo test -p $pkg"
+              cargo test -p "$pkg"
+            done
+          fi
+        else
+          # 단일 crate
+          cargo test
+        fi
 
-    # ── Step 5: Go block ──────────────────────────────────────────────
+    # ── Step 5: Go block — 변경 package path 만 ─────────────────────
     - name: Setup Go
       if: steps.detect.outputs.has_go == 'true'
       uses: actions/setup-go@v5
@@ -162,7 +255,19 @@ runs:
         go-version: ${{ inputs.go-version }}
         cache: true
 
-    - name: Run go tests
+    - name: Run go tests (affected)
       if: steps.detect.outputs.has_go == 'true'
       shell: bash
-      run: go test ./...
+      run: |
+        CHANGED_GO=$(grep '\.go$' /tmp/dcness-changed.txt || true)
+        if [ -z "$CHANGED_GO" ]; then
+          echo "[tdd-gate] go 변경 0건 — skip"
+          exit 0
+        fi
+        # 변경 .go 파일의 package path 추출 (디렉토리 단위) — 유니크
+        PKGS=$(for f in $CHANGED_GO; do dirname "$f"; done | sort -u)
+        echo "[tdd-gate] go affected packages:"
+        echo "$PKGS"
+        for pkg in $PKGS; do
+          go test "./$pkg/..."
+        done

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -358,13 +358,20 @@ done
 
 이미 `/init-dcness` 활성화한 기존 프로젝트는 본 Step 2.8 이 자동 발화하지 않음. 사용자가 본 plug-in 업데이트 받은 후 `/init-dcness` 재실행해야 Step 2.8 발화. 단 시드는 *부재 시만* 이라 기존 docs 가 있으면 skip — 안전.
 
-### Step 2.9 — TDD 게이트 (옵션, polyglot universal)
+### Step 2.9 — TDD 게이트 (옵션, polyglot universal + affected detection)
 
-GitHub Actions CI 에서 *PR 머지 전 풀 테스트 스위트 PASS 강제*. branch protection 의 `required status check` 에 등록되면 진짜 mechanical wall (admin 외 우회 불가) 가 됨. 산업 표준 3 단 enforcement (로컬 incremental → CI 풀 → branch protection) 중 *CI 풀* 단.
+GitHub Actions CI 에서 *PR 머지 전 affected 테스트 PASS 강제*. branch protection 의 `required status check` 에 등록되면 진짜 mechanical wall (admin 외 우회 불가) 가 됨.
 
-> **배경 (#320 #1)**: jajang Epic 12 task 03 에서 plan §3.5 가 `useAuthStore 기존 (변경 X)` 명시했는데 engineer 가 selector 패턴으로 바꿔서 *기존* 26 테스트 깨짐. engineer 의 자체 테스트는 *새 테스트 파일만* 돌리고 풀 스위트 미실행 → cascade 발견 지연. CI 풀 테스트 게이트 + branch protection 으로 mechanical 차단.
+> **배경 (#320 #1)**: jajang Epic 12 task 03 에서 plan §3.5 가 `useAuthStore 기존 (변경 X)` 명시했는데 engineer 가 selector 패턴으로 바꿔서 *기존* 26 테스트 깨짐. CI 테스트 게이트 + branch protection 으로 mechanical 차단.
 
-> **phase 2 — polyglot universal**: composite action 이 4 언어 (node / python / rust / go) 자동 검출. 검출된 *모든* 언어 테스트 PASS 해야 게이트 PASS. jajang (mobile=js/jest + api=python/pytest) 같은 polyglot 모노레포도 추가 설정 없이 cover.
+> **phase 3 — affected detection 자동**: composite action 이 4 언어 (node / python / rust / go) 자동 검출 + 변경분 affected 만 실행. 사용자 설정 0.
+>
+> - **node**: nx / turbo / pnpm workspaces 자동 검출 → `nx affected` / `turbo --filter=...[base]` / `pnpm -F "...[base]"` (dependency 그래프 자동 포함). 단일 패키지 / yarn classic / npm workspaces → 풀 폴백.
+> - **python**: 변경 `.py` 파일의 *가장 가까운 상위* `pyproject.toml` / `setup.py` 식별 → 그 안에서만 pytest. 변경 0건 → skip.
+> - **rust**: `[workspace]` 검출 시 변경 파일 → member 매핑 → `cargo test -p <member>`. 단일 crate → `cargo test`.
+> - **go**: 변경 `.go` 파일의 package path 추출 → `go test ./<path>/...`. 변경 0건 → skip.
+>
+> jajang (apps/mobile=js + apps/api=python) 같은 polyglot 모노레포 자동 cover — 웹 변경 = mobile 테스트만, api 변경 = api 테스트만.
 
 #### 1. 지원 언어 검출
 
@@ -401,12 +408,13 @@ fi
 
 ```
 [dcness] GitHub Actions CI 에서 TDD 게이트 강제할까요?
-  - PR 마다 풀 테스트 스위트 자동 실행 — 1건이라도 FAIL 시 PR 머지 차단 (branch protection 필요)
-  - polyglot universal — node / python / rust / go 자동 검출 + 모두 실행
-  - node: package.json scripts.test 위임 (monorepo 면 root 에 `npm test --workspaces --if-present` 같은 위임 명령 박을 것)
-  - python: pyproject.toml / requirements*.txt 자동 install + pytest 실행 (tests/ 또는 test/ 자동 검출, unittest 도 pytest 가 cover)
-  - rust: cargo test --all
-  - go: go test ./...
+  - PR 마다 affected 테스트 자동 실행 — 1건이라도 FAIL 시 PR 머지 차단 (branch protection 필요)
+  - polyglot universal — node / python / rust / go 자동 검출
+  - 변경분 기반 (사용자 설정 0):
+    - node: nx / turbo / pnpm workspaces 자동 detect → affected 만. 의존성 그래프 자동 포함.
+    - python: 변경 .py 의 root pyproject 식별 → 그 안에서만 pytest
+    - rust: workspace 멤버 자동 매핑 → cargo test -p <member>
+    - go: 변경 package path 만 → go test ./<path>/...
   - 본 thin yml 1개만 사용자 repo 에 깔리고, 검증 본체는 alruminum/dcNess composite action 호출
   - 로컬에서만 테스트 돌리고 CI 강제 원치 않으면 n
 (Y/n)
@@ -465,12 +473,13 @@ CI workflow 깔린 것만으론 *PR 머지를 차단* 안 됨 — branch protect
 
 본 안내는 *출력만* — 메인 Claude 가 사용자 권한 확인 후 자동 실행할지 사용자 결정에 위임 (admin 권한 가정 위험 회피).
 
-#### 4. 한계 (phase 2)
+#### 4. 한계 (phase 3)
 
-- 지원 언어 4 (node / python / rust / go) — Elixir / Ruby / Java / .NET / PHP / Swift 는 phase 3 후속.
-- 풀 스위트만 — incremental (`vitest --changed` / `jest --findRelatedTests`) 로컬 hook 은 phase 4.
+- 지원 언어 4 (node / python / rust / go) — Elixir / Ruby / Java / .NET / PHP / Swift 는 phase 4 후속.
 - branch protection 자동 설정 안 함 — admin 권한 가정 위험. 안내문만 출력.
-- python: poetry / pdm / uv 같은 modern tooling 은 phase 3. 현재 pip 만 (`pip install -e .` + `requirements*.txt`).
+- python: poetry / pdm / uv 같은 modern tooling = pip 폴백. 진정한 native 지원은 phase 4.
+- python/rust/go 의 dependency 그래프 자동 포함 = phase 4 (현재는 path 기반).
+- node yarn classic / npm workspaces / bun = 풀 스위트 폴백 (native affected filter 약함).
 - rust: toolchain pin 필요 시 사용자 workflow 에서 추가. 기본은 ubuntu-latest 의 stable.
 
 #### 5. 기존 활성화 프로젝트 — re-run 안내
@@ -501,11 +510,13 @@ design.md SSOT (Step 2.7 완료 시):
 - docs/PRD.md / ARCHITECTURE.md / ADR.md placeholder — 기획 논의 후 채워넣는 용도
 - 부재 시만 시드 (멱등) — 기존 파일은 보호
 
-TDD 게이트 (Step 2.9 완료 시 — polyglot universal):
-- .github/workflows/tdd-gate.yml — PR 마다 풀 테스트 스위트 강제 (composite action 호출)
-- 지원 언어 4: node / python / rust / go 자동 검출. polyglot 모노레포 (jajang 같이 js + python) 도 추가 설정 없이 cover
+TDD 게이트 (Step 2.9 완료 시 — polyglot universal + affected detection):
+- .github/workflows/tdd-gate.yml — PR 마다 affected 테스트 강제 (composite action 호출)
+- 지원 언어 4: node / python / rust / go 자동 검출 + 변경분만 실행
+- node: nx / turbo / pnpm workspaces 자동 detect → dependency 그래프 포함 affected
+- python/rust/go: 변경 파일 path 기반 root 식별 → 해당 root 만 테스트
 - branch protection 의 required status checks 등록은 사용자 수동 (안내문 출력)
-- 산업 표준 3 단 enforcement 중 *CI 풀* 단. 로컬 incremental + branch protection 결합으로 진짜 wall 완성 (#320 #1 root fix)
+- 사용자 설정 0 — 도구 분기 / 위임 명령 작성 불필요 (#320 #1 phase 3 root fix)
 
 사용 가능한 skill:
 - /qa  — 이슈 분류


### PR DESCRIPTION
## 변경 요약

### [issue-320] TDD 게이트 phase 3 — affected detection 자동
- **What**: composite action 이 4 언어 변경분 affected 만 자동 실행. 사용자 설정 0.
- **Why**: v0.2.11 phase 2 풀 스위트 가 CI watch 병목 (2~5분/PR × N task). "웹 변경했는데 앱 코드 다 확인할 필요가 없는데" 사용자 지적. 프로젝트별 override 박는 것도 부담 → 자동 검출이 root fix.

## 동작

```
변경 파일 추출: git diff --name-only ${pr.base.sha}...HEAD

node:
  - nx.json     → nx affected --target=test --base=<base>
  - turbo.json  → turbo run test --filter=...[<base>]
  - pnpm-workspace.yaml → pnpm -F "...[<base>]" test
  - 그 외 → 풀 폴백 (yarn classic / npm workspaces / bun 의 native filter 약함)

python:
  - 변경 .py 의 가장 가까운 상위 pyproject.toml / setup.py 식별
  - 그 root 별 pip install -e . + pytest
  - 변경 0건 → skip

rust:
  - Cargo.toml [workspace] 검출 시 변경 파일 → member 매핑 → cargo test -p <member>
  - 단일 crate → cargo test
  - 변경 0건 → skip

go:
  - 변경 .go 의 dirname (유니크) → go test ./<path>/...
  - 변경 0건 → skip
```

## 의존성 그래프 자동 포함

- **node** (nx / turbo / pnpm): `...[<base>]` filter 가 dependency graph 자동 적용 → 변경 workspace + dependents 모두
- **python/rust/go**: 변경 파일의 root path 기반 (의존성 그래프는 phase 4)

## jajang 효과

- apps/mobile (js + pnpm workspaces) 변경 → 해당 workspace + dependents jest
- apps/api (python) 변경 → apps/api 안 pytest 만
- 둘 다 변경 안 됐으면 skip
- 사용자 작업 0 — `package.json` override / root scripts.test 작성 불필요

## 관련 이슈

Part of #320

Document-Exception-PR-Close: #320 #1 의 phase 3. #1 자체는 v0.2.10/v0.2.11/본 PR 단계로 진화. #2 (PR #324 처리) / #3 (별도) 남음.

## 배포 경로 검증 (CLAUDE.md §0.5)

- (1) plug-in 본체: `.github/actions/tdd-gate/action.yml` — plug-in 업데이트 자동 반영
- (2) init-dcness 배포: thin yml unchanged, composite action 호출 1줄만 박힘 → 자동 phase 3 적용
- (3) SSOT 문서: N/A (capability 확장)

## 검증

bash 로직 단위 검증 (ubuntu-latest runner = bash):
- python root detection: `apps/api/src/main.py` → `apps/api` (pyproject.toml 매칭) ✅
- go pkg detection: `cmd/server/main.go` → `cmd/server`, `internal/auth/*.go` → `internal/auth` ✅

## 참고

- 한계 (phase 3): python/rust/go dependency 그래프 자동 포함 = phase 4 (현재 path 기반). yarn classic / npm workspaces / bun = 풀 폴백.
- phase 4 후속: 비-지원 언어 (Elixir/Ruby/Java/.NET/PHP/Swift) / Python modern tooling (poetry/pdm/uv) / path → dependency 그래프 확장

🤖 Generated with [Claude Code](https://claude.com/claude-code)