### PR TITLE
[docs] release 0.2.12 — TDD 게이트 phase 3 affected detection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.11"
+    "version": "0.2.12"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,51 @@
 
 ---
 
+## v0.2.12 (2026-05-11)
+
+**커밋 범위**: `v0.2.11..(다음 태그)`
+**핵심 변경**: TDD 게이트 phase 3 — affected detection 자동 (CI 병목 해소, 사용자 설정 0)
+
+- **이슈 #320 #1 phase 3 (PR #330)** — composite action 이 4 언어 변경분 affected
+  만 자동 실행. v0.2.11 phase 2 풀 스위트의 CI watch 병목 (2~5분/PR × N task)
+  해소.
+  - **node**: nx.json / turbo.json / pnpm-workspace.yaml 자동 검출 →
+    `nx affected` / `turbo run test --filter=...[<base>]` /
+    `pnpm -F "...[<base>]" test`. dependency 그래프 자동 포함.
+    - 미검출 (yarn classic / npm workspaces / bun / 단일) → 풀 폴백
+  - **python**: 변경 .py 파일의 가장 가까운 상위 `pyproject.toml` / `setup.py` /
+    `setup.cfg` 식별 → 그 root 별 pip install + pytest. 변경 0건 → skip.
+  - **rust**: Cargo.toml `[workspace]` 검출 시 변경 파일 → member 매핑 →
+    `cargo test -p <member>`. 단일 crate → `cargo test`. 변경 0건 → skip.
+  - **go**: 변경 .go 의 dirname (유니크) → `go test ./<path>/...`. 변경 0건 → skip.
+  - **PR base 자동 추출**: `github.event.pull_request.base.sha` 또는 origin/main 폴백
+
+**jajang 효과**:
+- apps/mobile (js + pnpm workspaces) 변경 → 해당 workspace + dependents 만 jest
+- apps/api (python) 변경 → apps/api 안 pytest 만
+- 둘 다 변경 안 됐으면 skip
+- 사용자 작업 0 — `package.json["dcness"]["testCommand"]` override 박을 필요 없음
+
+**배포 경로** (CLAUDE.md §0.5):
+- (1) plug-in 본체 — `.github/actions/tdd-gate/action.yml` plug-in 업데이트 자동
+- (2) init-dcness 배포 — Step 2.9 안내문 갱신. thin yml unchanged (composite action
+  호출 1줄만 박힘 → 자동 phase 3 적용)
+- (3) SSOT 문서 — N/A (capability 확장)
+
+**한계 (phase 3)**:
+- python/rust/go dependency 그래프 자동 포함 = phase 4 (현재 path 기반)
+- yarn classic / npm workspaces / bun affected = 풀 폴백 (native filter 약함)
+- 비-지원 언어 (Elixir/Ruby/Java/.NET/PHP/Swift) = phase 4
+
+**업데이트**:
+```sh
+claude plugin update dcness@dcness
+```
+
+기존 활성화 프로젝트는 thin yml 그대로 — composite action 만 phase 3 자동 적용 (다음 PR 부터).
+
+---
+
 ## v0.2.11 (2026-05-11)
 
 **커밋 범위**: `v0.2.10..(다음 태그)`


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.12 — TDD 게이트 phase 3 affected detection
- **What**: plugin.json + marketplace.json version 0.2.11 → 0.2.12. release-notes.md v0.2.12 entry.
- **Why**: PR #330 (TDD 게이트 phase 3 affected detection) 배포. CI watch 병목 (2~5분 → 변경분만, 수초~분 단위) 해소.

## 포함 PR

- **#330** (#320 #1 phase 3): 4 언어 변경분 affected 자동 (nx/turbo/pnpm + python root + rust workspace + go pkg)

## 관련 이슈

Document-Exception-PR-Close: release PR — issue 매핑 없음.

## 사용자 업데이트 절차

\```sh
claude plugin update dcness@dcness
\```

기존 활성화 프로젝트는 thin yml unchanged → composite action 만 자동 phase 3 적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)