### PR TITLE
[issue-320] pre-commit TDD 게이트 — commit 단 차단 (phase 4)

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -486,6 +486,80 @@ CI workflow 깔린 것만으론 *PR 머지를 차단* 안 됨 — branch protect
 
 이미 `/init-dcness` 활성화한 기존 프로젝트는 본 Step 2.9 가 자동 발화하지 않음. 사용자가 본 plug-in 업데이트 받은 후 `/init-dcness` 재실행해야 발화.
 
+### Step 2.10 — Pre-commit TDD 게이트 (옵션, commit 단 차단)
+
+CI tdd-gate (Step 2.9) 가 *PR 머지 차단* 인 반면, 본 Step 2.10 은 *commit 자체 차단* — 깨진 코드가 *push 전*, *PR 전* 단계에서 거름. branch protection 의존성 0 — 진짜 자체완결 wall.
+
+> **배경 (#320 #1 phase 4)**: CI 게이트 는 branch protection 등록 *후* 만 wall. 사용자 추가 설정 의존성. 또한 `gh pr checks --watch` 강제 (git-naming-spec §6) 가 Claude 흐름 병목. commit-msg hook 으로 commit 단 차단 = 사용자 추가 설정 0 + 즉시 발화.
+
+> **진짜 TDD**: test-engineer 작성 test → engineer 구현 → test 통과해야 commit. *변경분 test 만* 실행 (5~15개 단위, 수초). 풀 스위트 아님.
+
+#### 1. 룰
+
+commit-msg hook 발화 시점에:
+
+1. **옵트인 마커 검사** — `.dcness/tdd-gate-enabled` 파일 없으면 silent PASS (다른 프로젝트 영향 회피)
+2. **skip marker 검사** — commit message 안 `[skip-test: <사유>]` 매치 → PASS (단순 typo / 문서 변경 우회)
+3. **staged 분석**:
+   - `staged_src` = staged 안 코드 확장자 파일 (test 제외)
+   - `staged_test` + `branch_diff_test` (origin/main...HEAD 의 test) → `all_test`
+4. **분기**:
+   - `staged_src` 0 → PASS (docs / config 변경)
+   - `staged_src` 1+ 있고 `all_test` 0 → BLOCK
+   - `all_test` 1+ → 그 test 실행 → 1건이라도 FAIL → BLOCK
+
+#### 2. 사용자 옵트인
+
+```
+[dcness] Pre-commit TDD 게이트 활성화할까요?
+  - staged 안 src 변경 = test 변경 함께 staged 또는 같은 branch 안 있어야 commit 통과
+  - 검출된 test 만 실행 (5~15개 단위, 수초) — 풀 스위트 X
+  - 4 언어 자동 검출 (node jest/vitest, python pytest, rust cargo, go go test)
+  - dcness 의 3-commit 구조 (docs/tests/src) 와 자연 정합 — commit2 의 test 가 branch diff 에 인식됨
+  - 우회: commit message 에 `[skip-test: <사유>]` marker
+  - 옵트인 마커 `.dcness/tdd-gate-enabled` 가 활성화 신호. 다른 프로젝트 영향 0.
+(Y/n)
+```
+
+- **Y**:
+  - `.dcness/tdd-gate-enabled` 빈 파일 작성 (git add 권장 — 팀 공유)
+  - 사용자에게 commit-msg shim 이 이미 깔려있음을 안내 (Step 2.6 의 thin shim 이 자동으로 TDD 게이트 chain 호출)
+- **n**: skip — 마커 작성 안 함. hook 은 silent pass-through.
+
+```bash
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+mkdir -p "$PROJECT_ROOT/.dcness"
+touch "$PROJECT_ROOT/.dcness/tdd-gate-enabled"
+echo "[dcness] .dcness/tdd-gate-enabled 마커 작성 — pre-commit TDD 게이트 활성. 다음 commit 부터 발화."
+echo "[dcness] 권장: git add .dcness/tdd-gate-enabled (팀 공유)"
+```
+
+#### 3. 3-commit 구조 정합
+
+dcness 의 impl-task-loop 가 박는 3-commit (loop-procedure §3.4):
+
+| commit | stage | staged_src | all_test | TDD 게이트 |
+|---|---|---|---|---|
+| commit1 (docs) | `docs/impl/NN-*.md` | 0 | 0 | PASS |
+| commit2 (tests) | `src/__tests__/**` | 0 (test 만) | branch test | PASS + test 실행 |
+| commit3 (src) | `src/**` + stories.md | 있음 | commit2 의 test 가 branch diff 에 인식 | PASS + test 실행 |
+
+위반 (3-commit 구조 우회 / 임의 commit):
+- src 만 stage, test 0 → BLOCK
+- 사용자 `[skip-test: <사유>]` marker 또는 test 추가 후 재시도
+
+#### 4. 한계 (v0.2.13)
+
+- node test runner: jest / vitest 자동. 그 외 (mocha / ava 등) → `npm test` 폴백
+- python: `pytest <files>` 직접. unittest 만 쓰는 프로젝트 면 marker 우회
+- rust: 단순화 — `cargo test` 풀 폴백 (변경 test 파일만 실행 native 한계)
+- go: 변경 test 의 dirname → `go test ./<dir>/...`
+- 형식 강제 + 실행 강제 둘 다 — 변경분만이라 빠름 (수초)
+
+#### 5. 기존 활성화 프로젝트 — re-run 안내
+
+이미 `/init-dcness` 활성화한 기존 프로젝트는 본 Step 2.10 이 자동 발화하지 않음. plug-in 업데이트 + `/init-dcness` 재실행 시 발화. commit-msg shim 은 이미 chain 로직 박혀있어 마커만 작성하면 즉시 동작.
+
 ### Step 3 — 사용자 안내
 
 ```
@@ -517,6 +591,15 @@ TDD 게이트 (Step 2.9 완료 시 — polyglot universal + affected detection):
 - python/rust/go: 변경 파일 path 기반 root 식별 → 해당 root 만 테스트
 - branch protection 의 required status checks 등록은 사용자 수동 (안내문 출력)
 - 사용자 설정 0 — 도구 분기 / 위임 명령 작성 불필요 (#320 #1 phase 3 root fix)
+
+Pre-commit TDD 게이트 (Step 2.10 완료 시 — commit 단 차단):
+- commit-msg hook chain — git-naming 검증 후 TDD 게이트 발화
+- 옵트인 마커 `.dcness/tdd-gate-enabled` 있을 때만 발화 (다른 프로젝트 영향 0)
+- staged src 변경 = staged 또는 branch diff 안 test 함께 있어야 commit 통과
+- 검출된 변경분 test 만 실행 (5~15개 단위, 수초) — 풀 스위트 X
+- 4 언어 자동 (node jest/vitest, python pytest, rust cargo, go go test)
+- 우회: commit message 안 `[skip-test: <사유>]` marker
+- branch protection 의존성 0 — 진짜 자체완결 wall (#320 #1 phase 4 root fix)
 
 사용 가능한 skill:
 - /qa  — 이슈 분류

--- a/scripts/check_tdd_staged.mjs
+++ b/scripts/check_tdd_staged.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * dcness pre-commit TDD gate (commit-msg hook 본체)
+ *
+ * 룰 (v0.2.13):
+ *   1. staged 안에 *src 변경* 있고 *test 변경 0건* (staged 또는 branch diff) → BLOCK
+ *   2. test 변경 1+ 있음 → 그 test 들 실행. 1건이라도 FAIL → BLOCK
+ *   3. commit message 안 `[skip-test: <사유>]` marker → 우회 (PASS)
+ *   4. 비-코드 변경만 (md / json / yml / toml 등) → PASS
+ *   5. 옵트인 마커 `.dcness/tdd-gate-enabled` 부재 → silent PASS (사용자가 init-dcness 에서 Y 선택해야 발화)
+ *
+ * 호출 시점: git commit-msg hook chain (git-naming 후)
+ *   인자 $1 = commit message 파일 경로
+ *
+ * 실증 검증 (3-commit 구조):
+ *   commit1 (docs): staged_src 0 → PASS
+ *   commit2 (tests): staged_src 0 (test 만) → PASS
+ *   commit3 (src): staged_src 있음 + branch test 있음 → PASS + 실행
+ *   위반: staged_src 있음 + test 0 → BLOCK
+ */
+
+import { execSync, spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const OPTIN_MARKER = ".dcness/tdd-gate-enabled";
+
+// test 매처 — 4 언어 universal
+const TEST_PATTERNS = [
+  /\.test\.(js|jsx|ts|tsx|mjs|cjs)$/,
+  /\.spec\.(js|jsx|ts|tsx|mjs|cjs)$/,
+  /(^|\/)__tests__\//,
+  /(^|\/)tests?\//,           // tests/ 또는 test/
+  /(^|\/)test_[^/]+\.py$/,
+  /_test\.py$/,
+  /_test\.go$/,
+];
+// src 매처 — 코드 확장자 (test 제외)
+const SRC_EXTENSIONS = /\.(js|jsx|ts|tsx|mjs|cjs|py|rs|go|java|kt|swift)$/;
+
+function isTest(p) { return TEST_PATTERNS.some((re) => re.test(p)); }
+function isSrc(p) { return SRC_EXTENSIONS.test(p) && !isTest(p); }
+
+function run(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function log(msg) { console.error(`[tdd-gate] ${msg}`); }
+function fail(msg) { console.error(`[tdd-gate] BLOCKED — ${msg}`); process.exit(1); }
+
+// ── 1. 옵트인 마커 검사 ───────────────────────────────────────────
+const projectRoot = run("git rev-parse --show-toplevel");
+if (!projectRoot) process.exit(0);  // git repo 아님 — silent pass
+
+if (!existsSync(resolve(projectRoot, OPTIN_MARKER))) {
+  process.exit(0);  // 옵트인 X — silent pass (다른 프로젝트 영향 회피)
+}
+
+// ── 2. skip marker 검사 ──────────────────────────────────────────
+const commitMsgFile = process.argv[2];
+if (commitMsgFile && existsSync(commitMsgFile)) {
+  const msg = readFileSync(commitMsgFile, "utf8");
+  const skipMatch = msg.match(/\[skip-test:\s*([^\]]+)\]/);
+  if (skipMatch) {
+    log(`[skip-test: ${skipMatch[1].trim()}] marker — 우회 PASS`);
+    process.exit(0);
+  }
+}
+
+// ── 3. staged + branch diff 분석 ─────────────────────────────────
+const staged = run("git diff --cached --name-only").split("\n").filter(Boolean);
+const stagedSrc = staged.filter(isSrc);
+const stagedTest = staged.filter(isTest);
+
+// branch diff — origin/main 과 비교. 없으면 HEAD 만.
+let branchTest = [];
+const branchDiff = run("git diff --name-only origin/main...HEAD 2>/dev/null");
+if (branchDiff) {
+  branchTest = branchDiff.split("\n").filter(Boolean).filter(isTest);
+}
+
+const allTest = [...new Set([...stagedTest, ...branchTest])];
+
+// ── 4. 분기 ──────────────────────────────────────────────────────
+if (stagedSrc.length === 0) {
+  process.exit(0);  // src 변경 0 = PASS (docs/config 변경 등)
+}
+
+if (allTest.length === 0) {
+  const srcList = stagedSrc.slice(0, 5).map((p) => "  " + p).join("\n");
+  const more = stagedSrc.length > 5 ? `\n  ... (외 ${stagedSrc.length - 5}개)` : "";
+  fail(`staged 안 src 변경 (${stagedSrc.length}개) 있는데 test 변경 0건.
+
+src 변경:
+${srcList}${more}
+
+다음 중 하나:
+1. test 추가 후 함께 commit (TDD: 테스트 먼저)
+2. commit message 에 [skip-test: <사유>] marker 박기
+   (단순 typo / 문서 변경 / refactor 무영향 등 정당 사유)
+3. test-engineer 가 별도 commit 한 후 src commit 진행 (impl-task-loop 의 3-commit 구조)`);
+}
+
+// ── 5. test 실행 — staged + branch 안 test 만 ────────────────────
+log(`staged src ${stagedSrc.length}개 + 인지된 test ${allTest.length}개 → 실행`);
+
+// 언어별 분류
+const nodeTests = allTest.filter((t) => /\.(test|spec)\.|\/__tests__\//.test(t));
+const pyTests = allTest.filter((t) => /\.py$/.test(t));
+const goTests = allTest.filter((t) => /_test\.go$/.test(t));
+const rsTests = allTest.filter((t) => /(^|\/)tests\/.*\.rs$/.test(t));
+
+// node — jest / vitest 자동 검출
+if (nodeTests.length > 0) {
+  log(`node tests (${nodeTests.length}): 실행`);
+  const pkgPath = resolve(projectRoot, "package.json");
+  if (!existsSync(pkgPath)) fail("package.json 부재인데 node test 검출됨");
+  const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+  const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+  let cmd, args;
+  if (deps.vitest) { cmd = "npx"; args = ["vitest", "run", ...nodeTests]; }
+  else if (deps.jest) { cmd = "npx"; args = ["jest", ...nodeTests]; }
+  else {
+    // 폴백 — npm test (test runner 미상)
+    cmd = "npm"; args = ["test", "--", ...nodeTests];
+  }
+  const r = spawnSync(cmd, args, { stdio: "inherit", cwd: projectRoot });
+  if (r.status !== 0) fail(`node tests FAIL (${cmd} ${args.slice(0, 2).join(" ")} ...)`);
+}
+
+if (pyTests.length > 0) {
+  log(`python tests (${pyTests.length}): 실행`);
+  const r = spawnSync("pytest", pyTests, { stdio: "inherit", cwd: projectRoot });
+  if (r.status !== 0) fail("python tests FAIL");
+}
+
+if (goTests.length > 0) {
+  // go test 는 파일 단위 X — 디렉토리 단위. 유니크 dir.
+  const dirs = [...new Set(goTests.map((t) => {
+    const i = t.lastIndexOf("/");
+    return i < 0 ? "." : t.slice(0, i);
+  }))];
+  log(`go tests (${dirs.length} dir): 실행`);
+  for (const d of dirs) {
+    const r = spawnSync("go", ["test", `./${d}/...`], { stdio: "inherit", cwd: projectRoot });
+    if (r.status !== 0) fail(`go tests FAIL (./${d}/...)`);
+  }
+}
+
+if (rsTests.length > 0) {
+  // rust — integration test 파일 단위 가능. 단순화: cargo test 만.
+  log(`rust tests (${rsTests.length}): cargo test 실행`);
+  const r = spawnSync("cargo", ["test"], { stdio: "inherit", cwd: projectRoot });
+  if (r.status !== 0) fail("rust tests FAIL");
+}
+
+log("PASS — TDD 게이트 통과");
+process.exit(0);

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -18,31 +18,37 @@ if echo "$COMMIT_TITLE" | grep -qE "^Merge (branch|pull request)"; then
   exit 0
 fi
 
-resolve_plugin_script() {
-  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs" ]; then
-    echo "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs"
+resolve_plugin_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "${CLAUDE_PLUGIN_ROOT}/scripts" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}"
     return 0
   fi
   cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
   if [ -d "$cache_dir" ]; then
     latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
-    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/scripts/check_git_naming.mjs" ]; then
-      echo "$cache_dir/$latest/scripts/check_git_naming.mjs"
+    if [ -n "$latest" ] && [ -d "$cache_dir/$latest/scripts" ]; then
+      echo "$cache_dir/$latest"
       return 0
     fi
   fi
-  legacy="$(git rev-parse --show-toplevel 2>/dev/null)/scripts/check_git_naming.mjs"
-  if [ -f "$legacy" ]; then
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -f "$legacy/scripts/check_git_naming.mjs" ]; then
     echo "$legacy"
     return 0
   fi
   return 1
 }
 
-SCRIPT_PATH=$(resolve_plugin_script)
-if [ -z "$SCRIPT_PATH" ]; then
-  echo "[commit-msg] WARN — check_git_naming.mjs 미발견 (plugin 미설치 또는 cache 비정상). hook skip." >&2
+PLUGIN_ROOT=$(resolve_plugin_root)
+if [ -z "$PLUGIN_ROOT" ]; then
+  echo "[commit-msg] WARN — plugin root 미발견 (plugin 미설치 또는 cache 비정상). hook skip." >&2
   exit 0
 fi
 
-node "$SCRIPT_PATH" --title "$COMMIT_TITLE"
+# 1. git-naming 검증
+node "$PLUGIN_ROOT/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE" || exit 1
+
+# 2. TDD 게이트 (옵트인 `.dcness/tdd-gate-enabled` 마커 있을 때만 발화)
+if [ -f "$PLUGIN_ROOT/scripts/check_tdd_staged.mjs" ]; then
+  node "$PLUGIN_ROOT/scripts/check_tdd_staged.mjs" "$1" || exit 1
+fi


### PR DESCRIPTION
## 변경 요약

### [issue-320] pre-commit TDD 게이트 — commit 단 차단
- **What**: `scripts/check_tdd_staged.mjs` 신규 + `scripts/hooks/commit-msg` chain 갱신 + init-dcness Step 2.10. 옵트인 마커 (`.dcness/tdd-gate-enabled`) 활성 시 commit-msg hook 에서 TDD 게이트 발화 — staged src 변경 = test 변경 함께 + 변경분 test 실행 PASS 강제.
- **Why**: v0.2.12 phase 3 CI affected 는 *PR 머지* 차단 (branch protection 등록 후 만 wall + Claude `--watch` 병목). 진짜 자체완결 wall = commit 단. test-engineer 가 작성한 task 용 test (5~15개) 만 실행 = 수초 — 풀 스위트 아님.

## 동작

```
commit-msg hook (git-naming 후 chain):
  1. .dcness/tdd-gate-enabled 마커 부재 → silent PASS
  2. commit message [skip-test: <사유>] marker → 우회 PASS
  3. staged 분석:
     - staged_src = staged 안 코드 확장자 (test 제외)
     - all_test = staged_test + branch_diff_test (origin/main...HEAD)
  4. 분기:
     - staged_src 0 → PASS (docs/config 변경)
     - staged_src 1+ AND all_test 0 → BLOCK
     - all_test 1+ → 그 test 실행 (jest/vitest/pytest/go test/cargo test) → FAIL 시 BLOCK
```

## 실증 — 6 케이스

3-commit 구조 (loop-procedure §3.4) 정합 + 위반 검증:

| 케이스 | stage | exit |
|---|---|---|
| commit1 (docs) | `docs/impl/NN.md` | 0 PASS |
| commit2 (tests) | `src/__tests__/foo.test.ts` | 0 PASS |
| commit3 (src) + skip marker | `src/foo.ts` + branch test | 0 PASS (우회) |
| **위반: src 만, marker 없음** | `src/bar.ts` | **1 BLOCK** ✅ |
| 위반 + skip marker | `src/bar.ts` + [skip-test: typo] | 0 PASS (우회) |
| 옵트인 X | (마커 부재) | 0 silent PASS |

## 결정 근거

대안 검토:
- ❌ pre-commit hook (별개): commit message 가 아직 hook 에 전달 안 됨 → skip marker 검사 불가. 실측 검증.
- ❌ env var (`DCNESS_SKIP_TEST=...`): 매번 사용자가 박아야 — 번거로움
- ✅ commit-msg hook chain: staged + message 둘 다 보임. git-naming 후 자연 chain.

옵트인 마커 (`.dcness/tdd-gate-enabled`):
- 사용자 repo 안 파일 → 팀 공유 가능 (git add 권장)
- 다른 프로젝트 영향 0 — silent pass
- 외부 활성 프로젝트가 옵트인 안 한 경우 자동 발화 X (안전)

## 관련 이슈

Part of #320

Document-Exception-PR-Close: #320 #1 의 phase 4. v0.2.10 (phase 1) → v0.2.11 (phase 2 polyglot) → v0.2.12 (phase 3 affected) → 본 PR (phase 4 commit 단). #1 자체는 layered defense 완성 — commit (본 PR) + CI (phase 3) + branch protection (옵션).

## 배포 경로 검증 (CLAUDE.md §0.5)

- (1) plug-in 본체: `scripts/check_tdd_staged.mjs` 신규 + `scripts/hooks/commit-msg` chain — plug-in 업데이트 자동 반영
- (2) init-dcness 배포: Step 2.10 신규. 기존 활성 프로젝트는 `/init-dcness` 재실행 시 발화. commit-msg shim 은 이미 chain 로직 박혀있어 사용자가 옵트인 마커만 작성하면 즉시 동작.
- (3) SSOT 문서: N/A

## 한계 (v0.2.13)

- node test runner: jest / vitest 자동. 그 외 (mocha / ava 등) → npm test 폴백
- rust: 단순화 — `cargo test` 풀 폴백 (변경 test 파일만 native 한계)
- python: pytest 만 (unittest 만 쓰는 프로젝트면 skip marker 우회)

🤖 Generated with [Claude Code](https://claude.com/claude-code)