### PR TITLE
[issue-320] tdd-gate ignore_scripts input — monorepo prepare hook self-block 회피

### DIFF
--- a/.github/actions/tdd-gate/action.yml
+++ b/.github/actions/tdd-gate/action.yml
@@ -17,6 +17,14 @@ inputs:
     description: 'Go version'
     required: false
     default: 'stable'
+  ignore_scripts:
+    description: |
+      node install 시 prepare/postinstall/preinstall 같은 lifecycle scripts 무시 여부.
+      monorepo 의 workspace prepare hook (`"prepare": "npm run build"` 등) 이
+      tdd-gate self-block 일으키는 경우 'true' 옵트인. 디폴트 false (사용자 monorepo 의
+      의도된 빌드 진행).
+    required: false
+    default: 'false'
 runs:
   using: composite
   steps:
@@ -114,11 +122,19 @@ runs:
       if: steps.detect.outputs.has_node == 'true'
       shell: bash
       run: |
+        # ignore_scripts 옵트인 시 prepare/postinstall/preinstall lifecycle scripts 무시
+        # — monorepo workspace prepare hook self-block 회피 (예: jajang mobile-qa-tour)
+        if [ "${{ inputs.ignore_scripts }}" = "true" ]; then
+          IGNORE_FLAG="--ignore-scripts"
+          echo "[tdd-gate] ignore_scripts=true — lifecycle scripts 무시"
+        else
+          IGNORE_FLAG=""
+        fi
         case "${{ steps.pm.outputs.pm }}" in
-          pnpm) pnpm install --frozen-lockfile ;;
-          yarn) yarn install --frozen-lockfile ;;
-          bun)  bun install --frozen-lockfile ;;
-          *)    npm ci ;;
+          pnpm) pnpm install --frozen-lockfile $IGNORE_FLAG ;;
+          yarn) yarn install --frozen-lockfile $IGNORE_FLAG ;;
+          bun)  bun install --frozen-lockfile $IGNORE_FLAG ;;
+          *)    npm ci $IGNORE_FLAG ;;
         esac
 
     - name: Run node tests (affected)

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -436,12 +436,17 @@ fi
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
+          with:
+            fetch-depth: 0  # branch diff (PR base sha) 추출 위해 full history 필요
         - uses: alruminum/dcNess/.github/actions/tdd-gate@main
+          # with:
+          #   ignore_scripts: true  # monorepo prepare/postinstall hook self-block 시 옵트인
   ```
 
   - 사용자 repo 에 검증 로직 cp 0 — package manager 검출 / install / test 실행 전부 dcNess composite action 안.
   - 사용자가 `@main` 대신 `@v1.2.3` 등 tag pin 으로 버전 고정 가능.
   - 머지 후 push → 다음 PR 부터 CI 자동 발화.
+  - **monorepo prepare/postinstall self-block 회피**: workspace 안 `"prepare": "npm run build"` 같은 hook 이 root install 시 발화 → tsc 빌드 실패 → tdd-gate self-block. 이런 경우 `ignore_scripts: true` 옵트인.
 
 - **n**: skip. 로컬 hook + 사용자 자율로만 테스트 enforce. CI 우회 가능 — 회귀 위험 ↑.
 


### PR DESCRIPTION
## 변경 요약

### [issue-320] tdd-gate ignore_scripts input
- **What**: composite action 에 `ignore_scripts` input 추가 (default false). true 시 npm/pnpm/yarn/bun install 단에 `--ignore-scripts` 적용.
- **Why**: jajang 인프라 PR (#248) 머지 시 mobile-qa-tour 의 `"prepare": "npm run build"` workspace hook 이 root install 단에 발화 → tsc 빌드 실패 → tdd-gate self-block. 일반화: 어떤 monorepo 도 prepare/postinstall hook 가질 수 있음. dcness composite action 차원 escape hatch 부재 = design flaw.

## 동작

```yaml
# 사용자 thin yml — 옵트인
- uses: alruminum/dcNess/.github/actions/tdd-gate@main
  with:
    ignore_scripts: true
```

→ composite action 안:
```bash
case ${pm} in
  pnpm) pnpm install --frozen-lockfile --ignore-scripts ;;
  yarn) yarn install --frozen-lockfile --ignore-scripts ;;
  bun)  bun install --frozen-lockfile --ignore-scripts ;;
  *)    npm ci --ignore-scripts ;;
esac
```

## 사용자 적용 (jajang)

1. `claude plugin update dcness@dcness`
2. `cd ~/project/jajang && /init-dcness` 재실행 (Step 2.9 새 thin yml 옵트인 주석 포함)
3. `.github/workflows/tdd-gate.yml` 의 composite action 호출에 `with: { ignore_scripts: true }` 박음
4. 재시도 → workspace prepare hook 무시 → 통과

## 관련 이슈

Part of #320

Document-Exception-PR-Close: 사용자 jajang 실측 사례 대응 — 별도 sub-issue 없음.

## 결정 근거

대안 검토:
- ❌ `npm ci --workspaces=false`: workspace dependency 자체 install 안 됨 → test 단에서 import 실패
- ❌ `gh pr merge --admin`: 임시 — 다음 PR 마다 재발. design flaw 잔존
- ❌ jajang 측 mobile-qa-tour fix: 사용자 측 작업 누적 + 다른 monorepo 도 같은 함정
- ✅ dcness 측 `--ignore-scripts` input: escape hatch + 사용자 디폴트 행동 안 바뀜 (default false)

trade-off:
- true 옵트인 시 사용자 monorepo 의 *진짜 필요한 빌드 스크립트* (native module compile, 워크스페이스 빌드 등) 도 무시 — 사용자가 trade-off 인지 + 옵트인 결정

## 배포 경로 검증 (CLAUDE.md §0.5)

- (1) plug-in 본체: `.github/actions/tdd-gate/action.yml` — plug-in 업데이트 자동
- (2) init-dcness 배포: Step 2.9 thin yml 안내문 갱신 — 기존 활성 프로젝트는 `/init-dcness` 재실행 시 새 안내문 받음. 단 사용자가 직접 `with: { ignore_scripts: true }` 박아야 (thin yml 의 *주석* 으로 안내, 자동 enable 안 함 — default false 유지)
- (3) SSOT 문서: N/A

## 참고

- `fetch-depth: 0` 도 thin yml 템플릿에 명시 추가 — branch diff (PR base sha) 추출 시 full history 필요. 누락 시 affected detection 부정확. 기존 사용자는 thin yml 재배포 받아야 효과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)