### PR TITLE
[issue-320] pr-finalize.sh — 머지 + CI 대기 + main sync 한 명령 통합

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,15 +131,15 @@ python3 -m unittest tests.test_signal_io -v   # 단일 모듈
 4. git commit -m "..."                      # hook 자동 게이트 (main-block + pytest)
 5. git push -u origin {브랜치명}
 6. gh pr create --title "..." --body "..."  # git-naming-spec §4~§5 템플릿
-7. gh pr merge --auto                       # regular merge (squash 금지) — CI PASS 후 자동 머지
-   gh pr checks <PR_NUMBER> --watch         # MUST: CI 완료까지 대기, 결과 확인 후 다음 진행
-8. git checkout main && git pull
+7. bash scripts/pr-finalize.sh              # 머지 + CI 대기 + main sync 자동 (한 명령)
 ```
 
 - **main 직접 commit/push 금지**. 항상 branch → PR → regular merge.
 - **squash merge 금지** — 커밋별 히스토리 보존 목적.
 - **branch 는 merge 후에도 삭제하지 않는다**.
-- **CI 대기 MUST**: `gh pr merge --auto` 직후 반드시 `gh pr checks <PR_NUMBER> --watch` 실행 — CI 결과 확인 전 다음 작업 진행 금지. CI FAIL 시 머지 취소 후 원인 수정.
+- **pr-finalize 사용 권장** — 내부에서 `gh pr merge --auto --merge` + `gh pr checks --watch` + auto-merge 완료 대기 + `git checkout main && git pull` 자동. 메인 Claude 가 main sync 까먹는 회귀 차단.
+- **argument 없이 호출 시** current branch 의 open PR 자동 검출. 명시 시 `pr-finalize.sh <PR_NUMBER>`.
+- **CI FAIL** 시 pr-finalize 가 exit 1 + 안내. 원인 수정 후 재시도.
 
 ## 6. 환경변수
 

--- a/docs/plugin/git-naming-spec.md
+++ b/docs/plugin/git-naming-spec.md
@@ -97,11 +97,17 @@ Part of #N
 2. (작업 + 커밋)
 3. git push -u origin {브랜치명}
 4. gh pr create --title "..." --body "..."
-5. gh pr merge --auto                      # regular merge (squash 금지) — CI PASS 후 자동 머지
-   gh pr checks <PR_NUMBER> --watch        # MUST: CI 완료까지 대기, 결과 확인 후 다음 진행
-6. git checkout main && git pull
+5. "$PLUGIN_ROOT/scripts/pr-finalize.sh"   # 머지 + CI 대기 + main sync 자동 (한 명령)
 ```
 
-- **CI 대기 MUST**: `gh pr merge --auto` 직후 반드시 `gh pr checks <PR_NUMBER> --watch` 실행.
-  CI 결과 확인 전 다음 작업 진행 금지. `<PR_NUMBER>` 는 `gh pr create` 출력에서 확인.
-- **CI FAIL 시**: 머지 취소 — 원인 파악 후 수정 커밋 → 재검증.
+`pr-finalize.sh` 내부:
+- `gh pr merge --auto --merge` (auto-merge 토글)
+- `gh pr checks --watch` (CI 결과 대기)
+- auto-merge 완료 대기 (GitHub 백그라운드 lag)
+- `git checkout main && git pull` (자동 sync)
+
+argument 없이 호출 시 current branch 의 open PR 자동 검출. 명시 시 `pr-finalize.sh <PR_NUMBER>`.
+
+- **CI FAIL 시**: pr-finalize 가 exit 1 + 안내. 원인 파악 후 수정 커밋 → 재검증.
+- **working tree dirty**: pr-finalize 가 사용자 확인 후 main sync skip 옵션.
+- **레거시 패턴** (수동 4 명령) 도 작동 — 단 권장 X (메인 Claude 가 까먹어 main sync 누락 사례).

--- a/scripts/pr-finalize.sh
+++ b/scripts/pr-finalize.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# dcness pr-finalize — PR 머지 + CI 대기 + main sync 자동
+#
+# 한 명령으로 머지 절차 끝:
+#   1. gh pr merge --auto --merge (auto-merge 토글 ON)
+#   2. gh pr checks --watch (CI 결과 대기)
+#   3. auto-merge 완료 대기 (GitHub 백그라운드 lag)
+#   4. git checkout main + git pull
+#
+# 사용:
+#   pr-finalize.sh                # current branch 의 open PR 자동 검출
+#   pr-finalize.sh <PR_NUMBER>    # 명시 PR 번호
+#
+# 안전:
+#   - 현재 working tree dirty 면 abort (git pull 충돌 회피)
+#   - CI FAIL 시 main sync skip + 에러 코드
+#   - 머지 안 됐으면 main sync skip + 사용자 안내
+
+set -e
+
+PR="$1"
+
+# PR 번호 자동 검출 — current branch
+if [ -z "$PR" ]; then
+  BRANCH=$(git rev-parse --abbrev-ref HEAD)
+  if [ "$BRANCH" = "main" ]; then
+    echo "[pr-finalize] ERROR: current branch = main. PR 번호 인자 박거나 feature branch 에서 호출" >&2
+    exit 1
+  fi
+  PR=$(gh pr list --head "$BRANCH" --json number -q '.[0].number' 2>/dev/null)
+  if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+    echo "[pr-finalize] ERROR: '$BRANCH' branch 의 open PR 없음. PR 먼저 생성 (gh pr create)" >&2
+    exit 1
+  fi
+  echo "[pr-finalize] current branch '$BRANCH' → PR #$PR 자동 검출"
+fi
+
+# working tree dirty check
+if [ -n "$(git status --porcelain)" ]; then
+  echo "[pr-finalize] WARN: working tree dirty — main sync 시 충돌 위험" >&2
+  git status --short >&2
+  echo "[pr-finalize] 계속 진행 (auto-merge 만, main sync skip) Y/n? "
+  read -r reply
+  if [ "$reply" != "Y" ] && [ "$reply" != "y" ]; then
+    exit 1
+  fi
+  SKIP_SYNC=true
+fi
+
+# Step 1: auto-merge 토글
+echo "[pr-finalize] PR #$PR — auto-merge 토글 ON"
+gh pr merge "$PR" --auto --merge
+
+# Step 2: CI 결과 대기
+echo "[pr-finalize] CI 결과 대기 (gh pr checks --watch)"
+if ! gh pr checks "$PR" --watch; then
+  echo "[pr-finalize] ERROR: CI FAIL — 머지 안 됨. main sync skip" >&2
+  exit 1
+fi
+
+# Step 3: auto-merge 완료 대기 (GitHub 백그라운드)
+echo "[pr-finalize] auto-merge 완료 대기"
+STATE=""
+for i in 1 2 3 4 5 6 7 8; do
+  STATE=$(gh pr view "$PR" --json state -q .state 2>/dev/null)
+  if [ "$STATE" = "MERGED" ]; then
+    break
+  fi
+  sleep 3
+done
+
+if [ "$STATE" != "MERGED" ]; then
+  echo "[pr-finalize] WARN: PR #$PR 머지 안 됐음 (state=$STATE). branch protection 미충족 또는 review 필요 가능. 수동 확인:" >&2
+  echo "  gh pr view $PR" >&2
+  exit 1
+fi
+
+# Step 4: main sync
+if [ "${SKIP_SYNC:-}" = "true" ]; then
+  echo "[pr-finalize] main sync skip (working tree dirty)"
+  exit 0
+fi
+
+echo "[pr-finalize] main sync"
+git checkout main
+git pull --quiet
+
+echo "[pr-finalize] 완료 — PR #$PR 머지 + main 동기화"


### PR DESCRIPTION
## 변경 요약

### [issue-320] pr-finalize.sh — 머지 절차 한 명령 통합
- **What**: `scripts/pr-finalize.sh` 신규 + `git-naming-spec.md §6` + `CLAUDE.md §5` 머지 절차 갱신. 5 명령 → 1 명령.
- **Why**: 사용자 피드백 — "머지되면 main 으로 다시 되돌아가고 pull 까지 했으면 좋겠어서". 메인 Claude 가 5 명령 박는 동안 main sync 까먹는 회귀 빈번.

## 동작

```sh
bash scripts/pr-finalize.sh           # current branch 의 open PR 자동 검출
bash scripts/pr-finalize.sh 123       # 명시 PR
```

내부:
```
1. gh pr merge --auto --merge   (auto-merge 토글)
2. gh pr checks --watch          (CI 결과 대기)
3. auto-merge 완료 대기          (GitHub 백그라운드 lag)
4. git checkout main + git pull  (자동 sync)
```

## 안전 설계

- **working tree dirty 검사**: 사용자 확인 후 sync skip
- **CI FAIL**: exit 1 + 안내, sync skip
- **머지 안 됨** (branch protection 미충족 등): exit 1 + 안내

## 관련 이슈

Part of #320

Document-Exception-PR-Close: 사용자 명시 피드백 대응 — 별도 sub-issue 없음.

## 배포 경로 검증 (CLAUDE.md §0.5)

- (1) plug-in 본체: `scripts/pr-finalize.sh` 신규 — plug-in 업데이트 자동
- (2) init-dcness 배포: 현재 plug-in SSOT 호출 — 사용자 repo 에 cp 안 함. 향후 결정 (사용자 repo `scripts/` 에 cp 할지)
- (3) SSOT 문서: `git-naming-spec.md` §6 + `CLAUDE.md` §5 갱신

🤖 Generated with [Claude Code](https://claude.com/claude-code)