### PR TITLE
[docs] enum 통일 잔재 정리 (PR B-5)

### DIFF
--- a/scripts/research/enum_roi_baseline.mjs
+++ b/scripts/research/enum_roi_baseline.mjs
@@ -14,6 +14,10 @@
  *
  * agent 분류는 allowed enum 셋 시그니처 기반 (record 에 agent name 부재).
  * 매트릭스와 drift 가 있으면 "unclassified:..." 로 표시 — 그 자체가 발견.
+
+ * [역사 baseline] agent enum 통일 (PR #361 / B-3, 2026-05-11) *이전* 의
+ * 분류 함수. 새 enum (PASS/FAIL/ESCALATE) 통일 후엔 agent 추정 불가능 —
+ * 본 baseline 은 다이어트 *이전* run 의 회고 분석용.
  */
 import { readFileSync, existsSync } from 'node:fs';
 

--- a/tests/eval_agentevals.py
+++ b/tests/eval_agentevals.py
@@ -71,20 +71,20 @@ def _make_cases() -> list[EnumCase]:
     """agent × mode 별 합성 prose 케이스 생성."""
     specs = [
         # (agent, mode, allowed, happy_enum)
-        ("architect",     "MODULE_PLAN",      ["READY_FOR_IMPL", "SPEC_GAP_FOUND"],   "READY_FOR_IMPL"),
-        ("architect",     "SYSTEM_DESIGN",    ["SYSTEM_DESIGN_READY", "SPEC_GAP_FOUND"], "SYSTEM_DESIGN_READY"),
-        ("architect",     "LIGHT_PLAN",       ["LIGHT_PLAN_READY", "SPEC_GAP_FOUND"], "LIGHT_PLAN_READY"),
-        ("architect",     "SPEC_GAP",         ["SPEC_GAP_RESOLVED", "PRODUCT_PLANNER_ESCALATION_NEEDED"], "SPEC_GAP_RESOLVED"),
-        ("architect",     "DOCS_SYNC",        ["DOCS_SYNCED"],                        "DOCS_SYNCED"),
+        ("module-architect",    None         ,      ["PASS", "SPEC_GAP_FOUND"],   "PASS"),
+        ("system-architect",    None         ,    ["PASS", "SPEC_GAP_FOUND"], "PASS"),
+        ("module-architect",    None         ,       ["PASS", "SPEC_GAP_FOUND"], "PASS"),
+        ("module-architect",    None         ,         ["PASS", "ESCALATE"], "PASS"),
+        ("module-architect",    None         ,        ["PASS"],                        "PASS"),
         ("engineer",      "IMPL",             ["IMPL_DONE", "SPEC_GAP_FOUND", "TESTS_FAIL"], "IMPL_DONE"),
         ("engineer",      "POLISH",           ["POLISH_DONE"],                        "POLISH_DONE"),
-        ("test-engineer", None,               ["TESTS_WRITTEN", "SPEC_GAP_FOUND"],    "TESTS_WRITTEN"),
+        ("test-engineer", None,               ["PASS", "SPEC_GAP_FOUND"],    "PASS"),
         ("validator",     "CODE_VALIDATION",  ["PASS", "FAIL", "SPEC_MISSING"],       "PASS"),
         ("validator",     "BUGFIX_VALIDATION",["BUGFIX_PASS", "BUGFIX_FAIL"],         "BUGFIX_PASS"),
         ("validator",     "PLAN_VALIDATION",  ["PLAN_VALIDATION_PASS", "PLAN_VALIDATION_FAIL"], "PLAN_VALIDATION_PASS"),
         ("validator",     "UX_VALIDATION",    ["UX_REVIEW_PASS", "UX_REVIEW_FAIL"],   "UX_REVIEW_PASS"),
-        ("pr-reviewer",   None,               ["LGTM", "CHANGES_REQUESTED"],          "LGTM"),
-        ("plan-reviewer", None,               ["PLAN_REVIEW_PASS", "PLAN_REVIEW_FAIL", "PLAN_REVIEW_ESCALATE"], "PLAN_REVIEW_PASS"),
+        ("pr-reviewer",   None,               ["PASS", "FAIL"],          "PASS"),
+        ("plan-reviewer", None,               ["PASS", "FAIL", "ESCALATE"], "PASS"),
     ]
 
     cases: list[EnumCase] = []
@@ -336,19 +336,19 @@ def _make_trajectory(steps: list[tuple[str, Optional[str], str]]) -> list[ChatCo
 # 레퍼런스 시퀀스 정의 (루프별 happy-path)
 _REFERENCE_TRAJECTORIES: dict[str, list[tuple[str, Optional[str], str]]] = {
     "impl_task_loop": [
-        ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
-        ("test-engineer", None,               "TESTS_WRITTEN"),
+        ("module-architect",    None         ,      "PASS"),
+        ("test-engineer", None,               "PASS"),
         ("engineer",      "IMPL",             "IMPL_DONE"),
         ("validator",     "CODE_VALIDATION",  "PASS"),
-        ("pr-reviewer",   None,               "LGTM"),
+        ("pr-reviewer",   None,               "PASS"),
     ],
     "feature_build_fragment": [
-        ("architect",      "SYSTEM_DESIGN",   "SYSTEM_DESIGN_READY"),
-        ("architect",      "MODULE_PLAN",     "READY_FOR_IMPL"),
+        ("system-architect",    None         ,   "PASS"),
+        ("module-architect",    None         ,     "PASS"),
     ],
     "polish_loop": [
         ("engineer",      "POLISH",           "POLISH_DONE"),
-        ("pr-reviewer",   None,               "LGTM"),
+        ("pr-reviewer",   None,               "PASS"),
     ],
 }
 
@@ -361,11 +361,11 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "name": "impl_happy_path",
         "reference": "impl_task_loop",
         "actual": [
-            ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
-            ("test-engineer", None,               "TESTS_WRITTEN"),
+            ("module-architect",    None         ,      "PASS"),
+            ("test-engineer", None,               "PASS"),
             ("engineer",      "IMPL",             "IMPL_DONE"),
             ("validator",     "CODE_VALIDATION",  "PASS"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict":    True,   # 순서/내용 완전 일치
         "expect_superset":  True,   # 필수 단계 모두 있음
@@ -375,11 +375,11 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "name": "impl_missing_test_engineer",
         "reference": "impl_task_loop",
         "actual": [
-            ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
+            ("module-architect",    None         ,      "PASS"),
             # test-engineer 누락
             ("engineer",      "IMPL",             "IMPL_DONE"),
             ("validator",     "CODE_VALIDATION",  "PASS"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict":    False,  # 단계 누락
         "expect_superset":  False,  # test-engineer 없어서 필수 단계 미충족
@@ -389,13 +389,13 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "name": "impl_with_spec_gap_retry",
         "reference": "impl_task_loop",
         "actual": [
-            ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
-            ("test-engineer", None,               "TESTS_WRITTEN"),
+            ("module-architect",    None         ,      "PASS"),
+            ("test-engineer", None,               "PASS"),
             ("engineer",      "IMPL",             "SPEC_GAP_FOUND"),  # spec gap 발생
-            ("architect",     "SPEC_GAP",         "SPEC_GAP_RESOLVED"),  # reference 외 단계
+            ("module-architect",    None         ,         "PASS"),  # reference 외 단계
             ("engineer",      "IMPL",             "IMPL_DONE"),
             ("validator",     "CODE_VALIDATION",  "PASS"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict":    False,  # 추가 step 있어서 순서 불일치
         "expect_superset":  True,   # reference 필수 단계 모두 포함
@@ -406,7 +406,7 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "reference": "polish_loop",
         "actual": [
             ("engineer",      "POLISH",           "POLISH_DONE"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict":    True,
         "expect_superset":  True,

--- a/tests/eval_deepeval.py
+++ b/tests/eval_deepeval.py
@@ -138,20 +138,20 @@ _PADDING = (
 def _make_cases() -> list[EnumCase]:
     """agent × mode 별 합성 prose 케이스 생성."""
     specs = [
-        ("architect",     "MODULE_PLAN",      ["READY_FOR_IMPL", "SPEC_GAP_FOUND"],   "READY_FOR_IMPL"),
-        ("architect",     "SYSTEM_DESIGN",    ["SYSTEM_DESIGN_READY", "SPEC_GAP_FOUND"], "SYSTEM_DESIGN_READY"),
-        ("architect",     "LIGHT_PLAN",       ["LIGHT_PLAN_READY", "SPEC_GAP_FOUND"], "LIGHT_PLAN_READY"),
-        ("architect",     "SPEC_GAP",         ["SPEC_GAP_RESOLVED", "PRODUCT_PLANNER_ESCALATION_NEEDED"], "SPEC_GAP_RESOLVED"),
-        ("architect",     "DOCS_SYNC",        ["DOCS_SYNCED"],                        "DOCS_SYNCED"),
+        ("module-architect",    None         ,      ["PASS", "SPEC_GAP_FOUND"],   "PASS"),
+        ("system-architect",    None         ,    ["PASS", "SPEC_GAP_FOUND"], "PASS"),
+        ("module-architect",    None         ,       ["PASS", "SPEC_GAP_FOUND"], "PASS"),
+        ("module-architect",    None         ,         ["PASS", "ESCALATE"], "PASS"),
+        ("module-architect",    None         ,        ["PASS"],                        "PASS"),
         ("engineer",      "IMPL",             ["IMPL_DONE", "SPEC_GAP_FOUND", "TESTS_FAIL"], "IMPL_DONE"),
         ("engineer",      "POLISH",           ["POLISH_DONE"],                        "POLISH_DONE"),
-        ("test-engineer", None,               ["TESTS_WRITTEN", "SPEC_GAP_FOUND"],    "TESTS_WRITTEN"),
+        ("test-engineer", None,               ["PASS", "SPEC_GAP_FOUND"],    "PASS"),
         ("validator",     "CODE_VALIDATION",  ["PASS", "FAIL", "SPEC_MISSING"],       "PASS"),
         ("validator",     "BUGFIX_VALIDATION",["BUGFIX_PASS", "BUGFIX_FAIL"],         "BUGFIX_PASS"),
         ("validator",     "PLAN_VALIDATION",  ["PLAN_VALIDATION_PASS", "PLAN_VALIDATION_FAIL"], "PLAN_VALIDATION_PASS"),
         ("validator",     "UX_VALIDATION",    ["UX_REVIEW_PASS", "UX_REVIEW_FAIL"],   "UX_REVIEW_PASS"),
-        ("pr-reviewer",   None,               ["LGTM", "CHANGES_REQUESTED"],          "LGTM"),
-        ("plan-reviewer", None,               ["PLAN_REVIEW_PASS", "PLAN_REVIEW_FAIL", "PLAN_REVIEW_ESCALATE"], "PLAN_REVIEW_PASS"),
+        ("pr-reviewer",   None,               ["PASS", "FAIL"],          "PASS"),
+        ("plan-reviewer", None,               ["PASS", "FAIL", "ESCALATE"], "PASS"),
     ]
 
     cases: list[EnumCase] = []
@@ -349,19 +349,19 @@ def run_real_data_eval(harness_root: Path) -> dict:
 
 _REFERENCE_TRAJECTORIES: dict[str, list[tuple[str, Optional[str], str]]] = {
     "impl_task_loop": [
-        ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
-        ("test-engineer", None,               "TESTS_WRITTEN"),
+        ("module-architect",    None         ,      "PASS"),
+        ("test-engineer", None,               "PASS"),
         ("engineer",      "IMPL",             "IMPL_DONE"),
         ("validator",     "CODE_VALIDATION",  "PASS"),
-        ("pr-reviewer",   None,               "LGTM"),
+        ("pr-reviewer",   None,               "PASS"),
     ],
     "feature_build_fragment": [
-        ("architect",      "SYSTEM_DESIGN",   "SYSTEM_DESIGN_READY"),
-        ("architect",      "MODULE_PLAN",     "READY_FOR_IMPL"),
+        ("system-architect",    None         ,   "PASS"),
+        ("module-architect",    None         ,     "PASS"),
     ],
     "polish_loop": [
         ("engineer",      "POLISH",           "POLISH_DONE"),
-        ("pr-reviewer",   None,               "LGTM"),
+        ("pr-reviewer",   None,               "PASS"),
     ],
 }
 
@@ -370,11 +370,11 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "name": "impl_happy_path",
         "reference": "impl_task_loop",
         "actual": [
-            ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
-            ("test-engineer", None,               "TESTS_WRITTEN"),
+            ("module-architect",    None         ,      "PASS"),
+            ("test-engineer", None,               "PASS"),
             ("engineer",      "IMPL",             "IMPL_DONE"),
             ("validator",     "CODE_VALIDATION",  "PASS"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict": True, "expect_superset": True, "expect_subset": True,
     },
@@ -382,10 +382,10 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "name": "impl_missing_test_engineer",
         "reference": "impl_task_loop",
         "actual": [
-            ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
+            ("module-architect",    None         ,      "PASS"),
             ("engineer",      "IMPL",             "IMPL_DONE"),
             ("validator",     "CODE_VALIDATION",  "PASS"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict": False, "expect_superset": False, "expect_subset": True,
     },
@@ -393,13 +393,13 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "name": "impl_with_spec_gap_retry",
         "reference": "impl_task_loop",
         "actual": [
-            ("architect",     "MODULE_PLAN",      "READY_FOR_IMPL"),
-            ("test-engineer", None,               "TESTS_WRITTEN"),
+            ("module-architect",    None         ,      "PASS"),
+            ("test-engineer", None,               "PASS"),
             ("engineer",      "IMPL",             "SPEC_GAP_FOUND"),
-            ("architect",     "SPEC_GAP",         "SPEC_GAP_RESOLVED"),
+            ("module-architect",    None         ,         "PASS"),
             ("engineer",      "IMPL",             "IMPL_DONE"),
             ("validator",     "CODE_VALIDATION",  "PASS"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict": False, "expect_superset": True, "expect_subset": False,
     },
@@ -408,7 +408,7 @@ _ACTUAL_SCENARIOS: list[dict] = [
         "reference": "polish_loop",
         "actual": [
             ("engineer",      "POLISH",           "POLISH_DONE"),
-            ("pr-reviewer",   None,               "LGTM"),
+            ("pr-reviewer",   None,               "PASS"),
         ],
         "expect_strict": True, "expect_superset": True, "expect_subset": True,
     },

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1633,12 +1633,12 @@ class HelperAutomationTests(unittest.TestCase):
 복잡한 분석 줄2.
 
 ## 결론
-LIGHT_PLAN_READY — 빈 문자열 가드 추가.
+PASS — 빈 문자열 가드 추가.
 - src/greet.py:4 ValueError raise
 - 테스트 추가
 """
         out = _extract_prose_summary(prose)
-        self.assertIn("LIGHT_PLAN_READY", out)
+        self.assertIn("PASS", out)
         self.assertIn("ValueError raise", out)
         # `## 변경 분석` 섹션 본문은 안 들어와야 (결론 우선)
         self.assertNotIn("복잡한 분석", out)
@@ -1666,9 +1666,9 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
     def test_extract_prose_summary_fallback_when_no_section(self) -> None:
         """결론/요약 헤더 부재 → 첫 N 줄 fallback."""
         from harness.session_state import _extract_prose_summary
-        prose = "no headers\nLIGHT_PLAN_READY\nbody\n"
+        prose = "no headers\nPASS\nbody\n"
         out = _extract_prose_summary(prose)
-        self.assertIn("LIGHT_PLAN_READY", out)
+        self.assertIn("PASS", out)
 
     def test_extract_prose_summary_change_only_word_not_match(self) -> None:
         """`## 변경` 단독은 매칭 X (`## 변경 분석` 등 generic 헤더 회피)."""
@@ -1714,15 +1714,15 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         run_dir(sid, rid, create=True)
         _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "qa prose body", Path("/dev/null"))
         _append_step_status(
-            sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY",
-            "## 결론\nLIGHT_PLAN_READY\n## 변경\n무언가",
+            sid, rid, "module-architect", None, "PASS",
+            "## 결론\nPASS\n## 변경\n무언가",
             Path("/dev/null"),
         )
         records = _read_steps_jsonl(sid, rid)
         self.assertEqual(len(records), 2)
         self.assertEqual(records[0]["agent"], "qa")
         self.assertEqual(records[0]["enum"], "FUNCTIONAL_BUG")
-        self.assertEqual(records[1]["mode"], "LIGHT_PLAN")
+        self.assertIsNone(records[1]["mode"])
         self.assertFalse(records[0]["must_fix"])
 
     def test_append_step_status_detects_must_fix(self) -> None:
@@ -1837,7 +1837,7 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
 
         _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "ok", Path("/dev/null"))
         _append_step_status(
-            sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY", "ok", Path("/dev/null")
+            sid, rid, "module-architect", None, "PASS", "ok", Path("/dev/null")
         )
         _append_step_status(sid, rid, "engineer", "IMPL", "IMPL_DONE", "fix done", Path("/dev/null"))
         _append_step_status(
@@ -1887,7 +1887,7 @@ LIGHT_PLAN_READY — 빈 문자열 가드 추가.
         # engineer POLISH → pr-reviewer LGTM. 첫 pr-reviewer prose 에 MUST FIX 포함.
         _append_step_status(sid, rid, "qa", None, "FUNCTIONAL_BUG", "ok", Path("/dev/null"))
         _append_step_status(
-            sid, rid, "architect", "LIGHT_PLAN", "LIGHT_PLAN_READY", "ok", Path("/dev/null")
+            sid, rid, "module-architect", None, "PASS", "ok", Path("/dev/null")
         )
         _append_step_status(
             sid, rid, "engineer", "IMPL", "IMPL_DONE", "first attempt", Path("/dev/null")


### PR DESCRIPTION
## 변경 요약

issue #358 그릴미 최종 follow-up — PR B-1~B-4 후 활성 코드/테스트에 남아있던 옛 enum 잔재 정합. 활성 잔재 = 0.

## 변경 (4 files)

### 테스트 (3)
- `tests/eval_deepeval.py` / `tests/eval_agentevals.py` — 옛 agent="architect" + 6 mode 시절 fixtures
  - agent: `architect` → `system-architect` / `module-architect`
  - mode: `MODULE_PLAN` / `SYSTEM_DESIGN` / `LIGHT_PLAN` / `SPEC_GAP` / `DOCS_SYNC` → `None` (mode 평탄화)
  - enum: `READY_FOR_IMPL` / `SYSTEM_DESIGN_READY` / `LIGHT_PLAN_READY` / `SPEC_GAP_RESOLVED` / `DOCS_SYNCED` / `TESTS_WRITTEN` / `LGTM` / `PLAN_REVIEW_PASS` / `DESIGN_READY_FOR_REVIEW` → `PASS`
  - enum: `CHANGES_REQUESTED` → `FAIL`
  - enum: `DESIGN_LOOP_ESCALATE` / `PLAN_REVIEW_ESCALATE` / `PRODUCT_PLANNER_ESCALATION_NEEDED` → `ESCALATE`
- `tests/test_session_state.py` — `_append_step_status` 테스트 fixtures (`architect`/`LIGHT_PLAN`/`LIGHT_PLAN_READY` → `module-architect`/None/`PASS`)

### Research 도구 (1)
- `scripts/research/enum_roi_baseline.mjs` — 헤더에 *역사 baseline* 명시 추가. 함수 본문 옛 enum 분류는 보존 (다이어트 *이전* run 회고용)

## 역사 자료 보존 (수정 X — 의도적)

- `PROGRESS.md` / `docs/archive/**` — 변경 로그 + 역사 자료
- `docs/internal/enum-roi-baseline.md` — research baseline 분석 (옛 enum 기록)
- `scripts/setup_branch_protection.mjs` — proposal §5 코멘트 안 옛 LGTM 인용
- `docs/plugin/handoff-matrix.md` §1.4b Note — 다이어트 컨텍스트 ("이전 6 mode → 2 agent 통합") 보존

## Test plan
- [x] 415/415 unittest PASS
- [x] git-naming gate PASS
- [x] pytest-gate PASS

Document-Exception-PR-Close: issue #358 그릴미 결정 8 + 후속 잔재 정리 모두 처리 완료. issue close 추천.

🤖 Generated with [Claude Code](https://claude.com/claude-code)