### PR TITLE
[docs] enum 현행화 잔재 정리 (PR-0, SSOT 다이어트 전치)

### DIFF
--- a/agents/architecture-validator.md
+++ b/agents/architecture-validator.md
@@ -32,11 +32,11 @@ prose 마지막 단락에 자기 언어로 명시. 권장 표현:
 - **FAIL** — system-architect 재진입 권고 (cycle 한도 2). 본문에 (placeholder 위치 / 어느 PRD Must 기능 직결 / spike 권고) 명시.
 - **ESCALATE** — 사용자 위임. system-architect 재설계 (max 1 회) 후에도 동일 FAIL, 또는 본 에이전트 권한·정보 부족. 본문에 *사유* 명시.
 
-호출자가 prompt 로 전달하는 정보: system-architect READY 문서 경로, 실행 식별자.
+호출자가 prompt 로 전달하는 정보: system-architect PASS 산출물 경로, 실행 식별자.
 
 ## 작업 흐름
 
-1. system-architect READY 문서 (`docs/architecture.md` 또는 impl 목차 포함 산출물) 읽기
+1. system-architect PASS 산출물 (`docs/architecture.md` 또는 impl 목차 포함 산출물) 읽기
 2. PRD 읽기 (`docs/prd.md`) — Must / Should / Could 분류 확인
 3. SD 가 참조하는 SDK / API 명세 문서 읽기 (`docs/sdk.md`, `docs/reference.md`)
 4. 2 항목 체크리스트 적용
@@ -64,7 +64,7 @@ prose 마지막 단락에 자기 언어로 명시. 권장 표현:
 
 ### 2. Spike Gate
 
-> 추상 인터페이스 (ABC / Protocol) + Mock 구현만으로 system-architect READY 통과 금지. PRD Must 기능 핵심 가치 직결 외부 의존 (모델·SDK·API) 은 *실제 1개 spike* 실측 후 통과.
+> 추상 인터페이스 (ABC / Protocol) + Mock 구현만으로 system-architect PASS 통과 금지. PRD Must 기능 핵심 가치 직결 외부 의존 (모델·SDK·API) 은 *실제 1개 spike* 실측 후 통과.
 
 **적용 대상** (모두 해당 시 spike 의무):
 

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -22,7 +22,7 @@ UI 디자인 mid-loop 필요 시 → `impl-ui-design-loop` (orchestration §4.4)
 ## 진입 모드 — default vs fallback (위치 도장)
 - task 경로 매치 + 정식 위치 (`docs/milestones/v\d+/epics/epic-\d+-*/impl/\d+-*.md`) 파일 존재 → **default**: test-engineer 직진 (module-architect skip).
 - 매치 실패 / 파일 부재 → **fallback**: module-architect 1번 호출 후 test-engineer 진입.
-- 근거: architect-loop §4.2 의 Step 4 (module-architect × K) 가 정식 위치 impl 파일 본문 detail 까지 채움. 정식 경로 + 파일 존재 = 통과 보장. (옛 `MODULE_PLAN_READY` 마커 grep 룰 폐기 — 위치 자체가 도장.)
+- 근거: architect-loop §4.2 의 Step 4 (module-architect × K) 가 정식 위치 impl 파일 본문 detail 까지 채움. 정식 경로 + 파일 존재 = 통과 보장 (위치 자체가 도장).
 
 ## 후속 라우팅
 - 본 loop clean → 자동 commit/PR (branch prefix = orchestration §4.3 decision rule: feat/chore/fix)

--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -52,8 +52,6 @@ UX Flow 정의 / 변경 / refine. 산출 *전* 5 카테고리 self-check 의무 
   - 문서 동기화 케이스 = 후속 없음
 - **ESCALATE** — PRD 변경 필요 (`/product-plan` 재진입) / 기술 제약 충돌 (사용자) / 권한·도구 부족 (사용자).
 
-> Note: 이전 6 mode (SYSTEM_DESIGN / MODULE_PLAN / SPEC_GAP / LIGHT_PLAN / DOCS_SYNC / TECH_EPIC) → 2 agent 통합. 이전 mode 별 결론 enum (SYSTEM_DESIGN_READY / READY_FOR_IMPL / LIGHT_PLAN_READY / SPEC_GAP_RESOLVED / DOCS_SYNCED / TECH_CONSTRAINT_CONFLICT / PRODUCT_PLANNER_ESCALATION_NEEDED) → 단순 `PASS` / `ESCALATE` 2종. 옛 TASK_DECOMPOSE 의 가치 (Story → impl 매핑 / NN-slug 명명 / 의존 순서) 는 system-architect 의 `## impl 목차` 표로 흡수. impl 본문 detail 은 module-architect × N 가 채움.
-
 ### 1.5 engineer
 
 구현 hub. 결과 종류:
@@ -95,12 +93,6 @@ system-architect 산출물의 자가검증 사각지대 (Placeholder Leak + Spik
 - **PASS** → module-architect × N (impl 목차 첫 행부터 순차).
 - **FAIL** → system-architect 재진입 (cycle 한도 2). 본문에 placeholder 위치 / Must 기능 직결 / spike 권고 명시.
 - **ESCALATE** → system-architect 재설계 1 cycle 후에도 동일 FAIL → 사용자 위임.
-
-> Note: 옛 validator 5 모드 (CODE/DESIGN/UX/BUGFIX/PLAN) 폐기 (validator 단순화).
-> - PLAN_VALIDATION 은 컨베이어 task_list 에 *원래부터* 빠져있던 drift (issue #247) — 정합 회복.
-> - UX_VALIDATION 은 ux-architect self-check 흡수 (5 카테고리, FAIL 시 재고려).
-> - DESIGN_VALIDATION 의 자가검증 가능 항목 (인터페이스/에러/엣지케이스/리스크/성능) 은 system-architect self-check 흡수. *자가검증 사각지대* (Placeholder Leak + Spike Gate) 만 architecture-validator 가 외부 검증.
-> - BUGFIX_VALIDATION 은 code-validator 의 bugfix scope (impl 파일 경로 `docs/bugfix/`) 로 통합.
 
 ### 1.10 pr-reviewer
 

--- a/docs/plugin/orchestration.md
+++ b/docs/plugin/orchestration.md
@@ -272,7 +272,7 @@ FUNCTIONAL_BUG / CLEANUP 둘 다 `impl-task-loop` fallback path 진입 (impl 부
 | default | task 경로 매치 + 정식 위치 (`docs/milestones/v\d+/epics/epic-\d+-*/impl/\d+-*.md`) 파일 존재 | test-engineer | 4 |
 | fallback | 위 매치 실패 (즉석 task / direct-impl-loop / impl 부재) | module-architect | 5 |
 
-**근거**: architect-loop §4.2 의 Step 4 (module-architect × K) 가 정식 위치 impl 파일 본문 detail 까지 채움. 즉 정식 경로 + 파일 존재 = 본문 detail 보장 + architecture-validator PASS 통과물. module-architect 재호출 redundant. (이전 `MODULE_PLAN_READY` 마커 grep 룰 — DCN-30-13 — 폐기. 위치 자체가 도장.)
+**근거**: architect-loop §4.2 의 Step 4 (module-architect × K) 가 정식 위치 impl 파일 본문 detail 까지 채움. 즉 정식 경로 + 파일 존재 = 본문 detail 보장 + architecture-validator PASS 통과물. module-architect 재호출 redundant. 위치 자체가 도장.
 
 **commit 구조** ([`loop-procedure.md`](loop-procedure.md) §3.4):
 | stage | 시점 | 내용 |


### PR DESCRIPTION
## 변경 요약

### [docs] enum 현행화 잔재 정리 (PR #361/#363 후속)
- **What**: PR #361 (8 agent enum PASS/FAIL/ESCALATE 통일) + PR #363 (잔재 정리) 후 누락된 *옛 enum 표현* 4 파일 4 위치 정리
- **Why**: SSOT 다이어트 작업 (PR-1~PR-3) 진입 전 *현행화 기준* 100% 정합 필요. 사용자 의도 ("어제 에이전트 enum 정리 했으니 현행화 기준으로 잘 잡아야") 정합

## 결정 근거

| 위치 | 처리 | 사유 |
|---|---|---|
| `agents/architecture-validator.md` L35/L39/L67 | `system-architect READY` → `PASS` (3곳) | PR #361 enum 통일 시 본문 표현 누락 |
| `docs/plugin/handoff-matrix.md` §1.4b Note (옛 6 mode 폐기) | 단락 제거 | 역사 알림 — 진본 = commit log + `docs/archive/*` + `PROGRESS.md`. 현행 SSOT 안 보존 가치 X |
| `docs/plugin/handoff-matrix.md` §1.9 Note (옛 validator 5 모드 폐기) | 단락 제거 | 동일 |
| `docs/plugin/orchestration.md` L275 (옛 MODULE_PLAN_READY 마커) | "위치 자체가 도장" 만 유지 | 현행 룰 근거만 유지, 옛 enum 표현 제거 |
| `commands/impl.md` L25 (동일 표현) | 동일 압축 | 동일 |

## 배포 경로 검증

- `agents/architecture-validator.md` → plug-in 본체 (외부 사용자 plug-in update 시 자동 적용)
- `docs/plugin/*.md` → plug-in 본체
- `commands/impl.md` → plug-in 본체

외부 사용자 환경 자동 갱신. init-dcness 배포 경로 추가 갱신 없음.

## 검증

- 415/415 unittest PASS
- pre-commit hook (pytest-gate + git-naming) PASS
- `tests/test_session_state.py` / `tests/test_hooks.py` 등 코드 안 옛 enum (LGTM / CHANGES_REQUESTED / BUGFIX_VALIDATION 등) 은 **본 PR scope 밖** — heuristic interpreter backward compat 가능성 검증 후 별도 PR

## 관련 이슈

Document-Exception-PR-Close: SSOT 다이어트 작업의 전치 PR (PR-0). 이슈 등록 없이 진행.

## 참고

- PR-0 (현재) → PR-1 (`known-hallucinations.md` 폐기) → PR-2 (`orchestration.md` mermaid + 내부 다이어트) → PR-4 (작은 SSOT 다이어트) → PR-3 (`dcness-rules.md` 폐기 + 슬림 inject) 순으로 진행
- 본 PR 머지 후 PR-1 시작

🤖 Generated with [Claude Code](https://claude.com/claude-code)