### PR TITLE
[issue-375] /impl-loop 헤드리스화 — claude -p 자식 세션 spawn

### DIFF
--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -1,46 +1,33 @@
 ---
 name: impl-loop
-description: impl task list (architect-loop §4.2 Step 4 module-architect × K 산출물) 를 순차 자동 chain 으로 처리하는 스킬. 사용자가 "전부 구현", "/impl-loop", "task 다 돌려", "epic 전체 구현", "/architect-loop 후 자동", "끝까지 구현" 등을 말할 때 반드시 이 스킬을 사용한다. 각 task 마다 /impl 의 정식 루프 실행 + clean run 만 자동 진행 + caveat 시 사용자 위임. /architect-loop 종료 후 K 개 task 한 번에 처리하고 싶을 때.
+description: impl task list (architect-loop §4.2 Step 4 module-architect × K 산출물) 를 *헤드리스 자식 세션 (`claude -p` cold start)* 으로 순차 처리하는 스킬. 메인 컨텍스트 누적 / N task 묶임 문제 해소. 사용자가 "전부 구현", "/impl-loop", "task 다 돌려", "epic 전체 구현", "/architect-loop 후 자동", "끝까지 구현" 등을 말할 때 반드시 이 스킬을 사용한다. 각 task 가 새 자식 세션 = 매 task 결과 = 1 PR + 1 이슈 close = `/run-review` 도 task 별 분리 분석 자연. clean run 만 자동 진행, 걸리는 게 생기면 (사용자 개입 필수) 즉시 정지. /architect-loop 종료 후 K 개 task 한 번에 처리하고 싶을 때.
 ---
 
-# Impl Loop Skill
+# Impl Loop Skill — 헤드리스 자식 세션 chain
 
 ## Loop
-`impl-task-loop × N` ([orchestration.md §4.9](../docs/plugin/orchestration.md) — 다중 task chain).
-inner = `impl-task-loop` (orchestration §4.3) per task.
+`impl-task-loop × N` ([orchestration.md §4.9](../docs/plugin/orchestration.md) — 다중 task chain). 각 task = 새 `claude -p` 자식 세션 (cold start). 자식 세션 안의 inner loop = `impl-task-loop` (orchestration §4.3) — dcness skill `/impl` 본문 의무 따름.
 
 ## Inputs (메인이 사용자에게 받아야 할 정보)
 - task list 또는 epic 경로 (예: `docs/milestones/v0.2/epics/epic-01-*/impl/*.md` glob)
-- 진행 정책 — clean 자동 / caveat 멈춤 (default) 또는 yolo (orchestration §4.3 sub_cycles 자동 시도)
-- attempt 한도 확인 (`/impl` 와 동일 default)
+- (선택) `--retry-limit N` — task 당 자동 재시도 한도 (default 3, 0 = 첫 실패 즉시 정지)
+- (선택) `--escalate-on <signals>` — 즉시 정지 신호 (default `blocked`)
+- (선택) `--timeout S` — 자식 세션 timeout 초 (default 1800 = 30분)
 
 ## 비대상 (다른 skill 추천)
-- task 1개 → `/impl`
-- spec / design → `/product-plan`
+- task 1개 → `/impl` (메인 turn 진행, 헤드리스 X — cold start 비용 회피)
+- spec / design → `/product-plan` 또는 `/architect-loop`
 
-## Outer / inner 컨벤션 (DCN-30-12)
-- outer task: `impl-<i>: <task 파일명>` (task list 길이 만큼 등록)
-- inner sub-task: `b<i>.<agent>` prefix 의무 (loop-procedure.md §2 inner skip 금지)
-
-## 후속 라우팅
-- 각 task clean → 자동 7a + 다음 task
-- caveat → 멈춤 + 사용자 위임 (재호출 또는 수동 처리)
-- 전체 완료 → 보고 (처리 N/N + 각 PR URL)
+## 워크트리 (기본 켜짐)
+Skill 진입 시 *outer* 단계에서 자동 `EnterWorktree(name="impl-loop-{ts_short}")` 1회. 모든 자식 세션이 같은 outer worktree cwd 사용 — 직렬 진행이라 git 충돌 X. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
 
 ## 사전 read (skill 진입 즉시)
 `docs/plugin/loop-procedure.md` + `docs/plugin/orchestration.md` §4.3 + §4.9 + `docs/plugin/handoff-matrix.md` + `docs/plugin/issue-lifecycle.md` read 후 진행.
 
-## 워크트리 (기본 켜짐)
-Skill 진입 시 *outer* 단계에서 자동 `EnterWorktree(name="impl-loop-{ts_short}")` 1회. 모든 inner task 가 같은 워크트리 안에서 진행. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
+## Pre-flight gate (skill 진입 직후, outer 1회)
+[`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) §6 매치 강제 — 부모 epic stories.md 의 epic/story 이슈 매치 부재 시 즉시 STOP + 사용자 보고. silent skip 금지.
 
-## impl 파일 사전 read 의무 (MUST — module-architect 7 원칙 정합)
-
-`/impl` 와 동일 — 각 task 진입 시 engineer / test-engineer 가 impl 파일의 `## 사전 준비` 섹션 따라 read 의무 (`docs/architecture.md` / `docs/adr.md` / `docs/prd.md` + 의존 task 머지 PR). 자세히 = [`commands/impl.md`](impl.md) §impl 파일 사전 read 의무.
-
-## Pre-flight gate (각 task 진입 직전)
-[`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) §6 매치 강제 — 부모 epic stories.md 의 epic/story 이슈 매치 부재 시 해당 task STOP + 사용자 보고. silent skip 금지.
-
-각 task 진입 *직전* 1회 확인 (`/impl` "진입 직전 — task 진행 상태 1회 확인" 동일, issue #346):
+각 task 진입 직전 1회 확인 ([`commands/impl.md`](impl.md) "진입 직전 — task 진행 상태 1회 확인" 동일, issue #346):
 
 ```bash
 TASK_SLUG=$(basename "<task-path>" .md)
@@ -48,15 +35,76 @@ git log --oneline --grep "$TASK_SLUG" | head -5
 tail -50 "<task-path>"
 ```
 
-이미 머지됨 발견 시 → 해당 task skip + 다음 task 진입. 부분 진행 + tail section 후속 결정 → 진행 컨텍스트 inject + 정상 진입.
+이미 머지됨 발견 시 → 해당 task skip + 다음 task 진입. 부분 진행 + tail section 후속 결정 → 자식 세션 [A] 명령문에 inject + 정상 진입.
 
-## 절차
-[`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1~§6 + [`docs/plugin/orchestration.md`](../docs/plugin/orchestration.md) §4.3 (inner) + §4.9 (chain 정책) 따름.
+## 절차 — 헤드리스 spawn
+
+```bash
+PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
+python3 "$PLUGIN_ROOT/scripts/impl_loop_headless.py" '<impl-glob>' \
+  [--retry-limit 3] [--escalate-on blocked] [--timeout 1800]
+```
+
+스크립트 동작:
+
+1. **glob 매치 + 정렬** — `impl/NN-*.md` prefix 기준 직렬 진행
+2. **각 task 마다 새 `claude -p` 자식 세션 spawn** — cwd = outer worktree
+3. **자식 세션 자동 컨텍스트** (실증 완료):
+   - cwd `CLAUDE.md` auto-load (system-reminder `claudeMd` 섹션)
+   - plug-in `SessionStart` hook 자동 inject (dcness 운영 룰 + `[dcness 활성 확인]` 토큰)
+   - dcness skill 10개 자동 등록 (자식이 `/impl` 본문 의무 따름)
+4. **명령문 첫머리 inline** ([A]~[E] 5 묶음):
+   - [A] 이번 task impl 본문 전문
+   - [B] 부모 epic / story / task GitHub 이슈 번호 + `gh issue view` read 명령
+   - [C] `docs/architecture.md` + `docs/adr.md` 다시 read 강조
+   - [D] 종료 신호 규칙 (`PASS:` / `FAIL:` / `ESCALATE:`)
+   - [E] 본 task 명령
+5. **결과 회수 3 layer**:
+   - 1차 stdout 마지막 prose enum (PASS / FAIL / ESCALATE)
+   - 2차 자식 종료 코드 (0 = clean / !=0 = error)
+   - 3차 GitHub 이슈 close 확인 (`gh issue view <task-num> --json state`)
+6. **enum 별 동작**:
+   - `clean` → 다음 task 진입
+   - `error` → 자동 재시도 (한도 `--retry-limit`, default 3)
+   - `blocked` → 즉시 정지 + 사용자 위임
+
+자식 세션 안의 작업 (코드 / 테스트 / commit / push / PR / 머지) = 자식 메인 자율. 메인은 *발사 + 결과 회수 + 분기* 만.
+
+## 자식 세션 권한 / 분담
+
+| 작업 | 자식 권한 |
+|---|---|
+| 코드 수정 (Edit / Write) | ✅ |
+| 테스트 작성 / 실행 | ✅ |
+| outer worktree branch 안 commit / push | ✅ (main-block hook 은 main 직접만 차단) |
+| PR 생성 + 머지 (`gh pr create` + `gh pr merge --auto`) | ✅ |
+| `Closes #<task-num>` trailer 로 이슈 자동 close | ✅ |
+| main 직접 commit / push | ❌ |
+
+## Outer / inner 컨벤션
+- outer = 메인이 본 skill 호출 → outer worktree 생성 + spawn 스크립트 실행
+- inner = 자식 세션 안에서 `/impl` 본문 의무 따라 진행 (test-engineer → engineer → code-validator → pr-reviewer)
+- 각 자식 세션 = 1 PR + 1 이슈 close = `/run-review` 가 task 별 분리 분석 자연
+
+## 후속 라우팅
+- 각 task clean → 다음 task 자동 진입
+- error → 자동 재시도 (한도까지). 한도 초과 시 정지 + 사용자 위임
+- blocked → 즉시 정지 + 사용자 위임 (재호출 또는 수동 처리)
+- 전체 완료 → 보고 (처리 N/N + 각 PR URL)
 
 ## 한계
 - task 의존성 자동 판단 X (v1 = 무조건 직렬, SD impl 목차 순서 / list 순서 = 의존 표현)
-- multi-task resume 미구현 — caveat 후 재실행 시 처음부터 (단 commit 된 task 는 정식 위치 + 파일 존재 자동 검출 → default 모드 = test-engineer 직진)
+- multi-task resume 미구현 — 한도 초과 / blocked 후 재실행 시 처음부터 (단 commit 된 task 는 [`commands/impl.md`](impl.md) §진입 직전 1회 확인 으로 자동 검출 → 자식 default 모드 = test-engineer 직진)
+- 자식 세션 cold start cost — 매 task 30~120s latency 추가 (메인 컨텍스트 보호 가치와 trade-off)
 
 ## 안티패턴 (회귀 방지)
-- ❌ task N 개를 `Bash run_in_background=true` 로 동시 spawn 후 `pgrep` / `ps -p` / `tail` 로 ScheduleWakeup polling — v1 spec = 직렬. 메인이 wake 하면서 누적 컨텍스트 cache_read 비용 폭주 ([#216](https://github.com/alruminum/dcNess/issues/216) — pre-dcness RWH 시기 사례 \$1,531 / 단일 세션). ScheduleWakeup tool 가이드 (default 1200~1800s, 270s 금지) 도 동일 권고.
-- ❌ 단일 세션에 8 task 누적 진행 — 컨텍스트 4M+ 토큰까지 부풀어 모든 후속 wake 가 거대 cache_read. task 단위 새 세션 + `/smart-compact` resume 권장.
+- ❌ task N 개를 `Bash run_in_background=true` 로 동시 spawn — v1 spec = 직렬. 동시 실행 시 git 충돌 + 메인이 wake 하면서 누적 컨텍스트 cache_read 비용 폭주 ([#216](https://github.com/alruminum/dcNess/issues/216) — pre-dcness RWH 시기 사례 \$1,531 / 단일 세션).
+- ❌ 자식 세션 안에서 `claude -p` 재귀 호출 — 무한 spawn 위험. 자식은 *현재 task 한 개만* 처리.
+- ❌ 자식이 PR body trailer 형식 강제 — 자식 메인 자율 영역 (issue-lifecycle.md §1.4 따름).
+- ❌ escalate 신호 무시하고 다음 task 진행 — 사용자 부재 환경에서 추측 진행 = 폭주.
+
+## 참고
+
+- 본 스킬 구현: [`scripts/impl_loop_headless.py`](../scripts/impl_loop_headless.py)
+- 실증 결과 (cwd = StockNoti 활성 프로젝트): plug-in `SessionStart` hook 자동 inject + skill 등록 + `[dcness 활성 확인]` 토큰 출력 확인 ([#375](https://github.com/alruminum/dcNess/issues/375))
+- 그릴 D 가지 종합 — `claude -p` 자식 세션 spawn / GitHub 이슈 close 회수 / 워크트리 1 outer / 명령문 [A]~[E] inline

--- a/scripts/impl_loop_headless.py
+++ b/scripts/impl_loop_headless.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+/impl-loop 헤드리스 spawn — 각 impl task 마다 새 claude -p 자식 세션 발사.
+
+Usage:
+    python3 scripts/impl_loop_headless.py <impl-glob> [--retry-limit N] [--escalate-on <signals>] [--timeout S]
+
+예시:
+    python3 scripts/impl_loop_headless.py 'docs/milestones/v1/epics/epic-01-*/impl/*.md'
+
+동작:
+- glob 매치 파일 정렬 (prefix NN- 기준)
+- 각 파일마다 claude -p cold start spawn (cwd = 현 outer worktree)
+- 명령문 [A]~[E] 조립 + 자식 세션이 dcness skill 자동 등록 (plug-in SessionStart hook)
+- 종료 후 결과 회수 3 layer:
+  - 1차 stdout 마지막 prose enum (PASS / FAIL / ESCALATE)
+  - 2차 자식 종료 코드 (0 = clean / !=0 = error)
+  - 3차 GitHub 이슈 close 확인 (gh issue view <num>)
+- error → 자동 retry (한도)
+- blocked → 즉시 정지 (사용자 개입 필수)
+
+설계: docs/plugin/orchestration.md §4.9 (chain 정책) + #375 그릴 D 가지 종합.
+
+본 스크립트는 외부 dcness 활성 프로젝트의 outer worktree cwd 에서 호출. dcness self §0.2
+적용 외 — 자기 자신 미적용.
+"""
+
+import argparse
+import glob
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="impl-loop headless spawn")
+    parser.add_argument("impl_glob", help="impl task glob (예: 'docs/.../impl/*.md')")
+    parser.add_argument("--retry-limit", type=int, default=3,
+                        help="task 당 자동 재시도 한도 (default 3, 0 = 즉시 정지)")
+    parser.add_argument("--escalate-on", default="blocked",
+                        help="즉시 정지 신호 (comma-separated, default 'blocked')")
+    parser.add_argument("--timeout", type=int, default=1800,
+                        help="자식 세션 timeout 초 (default 1800 = 30분)")
+    parser.add_argument("--cwd", default=None,
+                        help="자식 세션 cwd (default = 현재 cwd)")
+    return parser.parse_args(argv)
+
+
+def read_file(path: str) -> str:
+    return Path(path).read_text(encoding="utf-8")
+
+
+def extract_issue_nums(task_path: str) -> dict:
+    """task 파일 본문 + 부모 stories.md 에서 epic/story/task 이슈 번호 추출.
+
+    반환: {"epic": int|None, "story": int|None, "task": int|None}
+    매치 못 하면 None 으로 채움 (skip 사유).
+    """
+    nums = {"epic": None, "story": None, "task": None}
+
+    task_body = read_file(task_path)
+    # task 본문 안 `**GitHub Issue:** [#N]` 또는 `closes #N` 패턴
+    m = re.search(r"\*\*GitHub Issue:\*\*\s*\[?#(\d+)\]?", task_body)
+    if m:
+        nums["task"] = int(m.group(1))
+    else:
+        m = re.search(r"(?:closes?|fixes?)\s*#(\d+)", task_body, re.IGNORECASE)
+        if m:
+            nums["task"] = int(m.group(1))
+
+    # 부모 stories.md = task 파일의 grandparent (impl/<task>.md → epic-NN-*/stories.md)
+    stories_path = Path(task_path).parent.parent / "stories.md"
+    if stories_path.exists():
+        stories_body = stories_path.read_text(encoding="utf-8")
+        m = re.search(r"\*\*GitHub Epic Issue:\*\*\s*\[?#(\d+)\]?", stories_body)
+        if m:
+            nums["epic"] = int(m.group(1))
+        # story 매치는 task slug 기반 (v1 = skip)
+
+    return nums
+
+
+def build_command(task_path: str, issue_nums: dict,
+                  retry_attempt: int = 0, prev_error: str = None) -> str:
+    """명령문 첫머리 [A]~[E] 5 묶음 조립.
+
+    Skip: CLAUDE.md (cwd auto-load) + dcness 운영 룰 (plug-in SessionStart hook).
+    Inline: 본 함수 출력.
+    """
+    task_body = read_file(task_path)
+    parts = []
+
+    # retry 시 prev_error 머리말
+    if retry_attempt > 0 and prev_error:
+        parts.append(
+            f"## ⚠ 이전 시도 실패 (attempt {retry_attempt})\n\n"
+            f"```\n{prev_error}\n```\n\n"
+            f"위 에러 참고하여 수정 후 진행.\n\n---\n"
+        )
+
+    # [A] impl 본문
+    parts.append(f"## [A] 이번 task impl 본문\n\n`{task_path}`:\n\n{task_body}\n")
+
+    # [B] 부모 이슈 + read 명령
+    if any(v is not None for v in issue_nums.values()):
+        issue_lines = []
+        for kind, num in issue_nums.items():
+            if num is not None:
+                issue_lines.append(
+                    f"- {kind}: #{num} — `gh issue view {num} | head -80` 로 본문 read 의무"
+                )
+        parts.append(
+            "## [B] 부모 이슈\n\n" + "\n".join(issue_lines) +
+            "\n\n구현 진입 *전* 위 이슈 본문 read 필수. "
+            "이슈에 수용 기준 / 추가 컨텍스트 / 결정 사항이 박혀있을 수 있음.\n"
+        )
+    else:
+        parts.append(
+            "## [B] 부모 이슈\n\n매칭된 이슈 번호 없음 — task 파일 본문의 수용 기준 직접 따름.\n"
+        )
+
+    # [C] ADR / architecture
+    parts.append(
+        "## [C] 사전 read 의무\n\n"
+        "구현 *전*:\n"
+        "- `docs/architecture.md` 다시 read — 모듈 흐름 / 인터페이스 / 의존성 확인\n"
+        "- `docs/adr.md` 다시 read — 관련 결정 사항 확인 (의도 모르고 덮어쓰는 회귀 회피)\n"
+    )
+
+    # [D] 종료 신호 규칙
+    parts.append(
+        "## [D] 종료 신호 규칙 (필수)\n\n"
+        "본 task 완료/정지 시 stdout 마지막 줄에 정확히 다음 enum 중 하나 박음:\n\n"
+        "- **clean** → 코드 + 테스트 + commit + push + PR 생성 + 머지 + `Closes #<task-num>` trailer 로 이슈 자동 close. "
+        "마지막 줄: `PASS: <한 줄 요약>`\n"
+        "- **error** → 빌드/테스트 실패. 자동 재시도됨. 마지막 줄: `FAIL: <이유>`\n"
+        "- **blocked** → 사용자 개입 필수 (API 키 / 인증 / 정책 결정 / Spike 의심 / 미정 의존). "
+        "마지막 줄: `ESCALATE: <이유>`\n"
+    )
+
+    # [E] 본 task 명령
+    parts.append(
+        "## [E] 작업 시작\n\n"
+        "위 [A]~[D] 룰 따라 본 task 구현 시작. "
+        "dcness skill `/impl` 본문 의무 (sub-agent 호출 시퀀스 / 워크트리 / Pre-flight gate / "
+        "impl 파일 사전 read) 도 함께 따름. 현행 dcness 룰은 cwd CLAUDE.md + plug-in "
+        "SessionStart hook 자동 inject 된 system-reminder 참조.\n"
+    )
+
+    return "\n".join(parts)
+
+
+def parse_result(stdout: str, exit_code: int) -> tuple:
+    """결과 회수 1차 — stdout 마지막 prose enum 매치.
+
+    반환: (enum, message) — enum ∈ {clean, error, blocked}
+    """
+    # 마지막 20 줄에서 매치 우선
+    last_lines = stdout.strip().split("\n")[-20:]
+    last_text = "\n".join(last_lines)
+
+    # ESCALATE 우선 (blocked 신호 — 다른 enum 보다 우선)
+    m = re.search(r"ESCALATE:\s*(.+?)(?:\n|$)", last_text)
+    if m:
+        return "blocked", m.group(1).strip()
+
+    # FAIL
+    m = re.search(r"FAIL:\s*(.+?)(?:\n|$)", last_text)
+    if m:
+        return "error", m.group(1).strip()
+
+    # PASS
+    m = re.search(r"PASS:\s*(.+?)(?:\n|$)", last_text)
+    if m:
+        return "clean", m.group(1).strip()
+
+    # enum 미박힘 → exit code fallback
+    if exit_code == 0:
+        return "clean", "(prose enum 미박힘 — exit 0 으로 clean 판정)"
+    return "error", f"(prose enum 미박힘 — exit {exit_code})"
+
+
+def confirm_issue_closed(task_issue_num) -> bool:
+    """결과 회수 3차 — gh issue view 로 task 이슈 close 확인."""
+    if task_issue_num is None:
+        return None  # 이슈 번호 모르면 skip
+    try:
+        result = subprocess.run(
+            ["gh", "issue", "view", str(task_issue_num), "--json", "state", "-q", ".state"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return result.stdout.strip() == "CLOSED"
+    except Exception:
+        return None
+
+
+def spawn_child(prompt: str, cwd: str, timeout: int) -> tuple:
+    """claude -p 자식 세션 spawn.
+
+    반환: (exit_code, stdout, stderr)
+    """
+    cmd = [
+        "claude", "-p",
+        "--dangerously-skip-permissions",
+        "--output-format", "text",
+        prompt,
+    ]
+    try:
+        result = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
+        )
+        return result.returncode, result.stdout, result.stderr
+    except subprocess.TimeoutExpired as e:
+        return 124, e.stdout or "", e.stderr or ""
+
+
+def process_task(task_path: str, cwd: str, retry_limit: int,
+                 escalate_signals: set, timeout: int) -> dict:
+    """단일 task 처리 (retry 포함). 반환 = {enum, message, stdout}."""
+    issue_nums = extract_issue_nums(task_path)
+    prev_error = None
+
+    for attempt in range(retry_limit + 1):
+        print(f"\n[task] {task_path} (attempt {attempt + 1}/{retry_limit + 1})",
+              file=sys.stderr)
+
+        prompt = build_command(
+            task_path, issue_nums,
+            retry_attempt=attempt,
+            prev_error=prev_error,
+        )
+        exit_code, stdout, stderr = spawn_child(prompt, cwd, timeout)
+        enum, message = parse_result(stdout, exit_code)
+        print(f"[task] result: {enum} — {message}", file=sys.stderr)
+
+        # blocked / escalate 신호 즉시 정지
+        if enum in escalate_signals:
+            return {"enum": "blocked", "message": message, "stdout": stdout}
+
+        # clean — 이슈 close 2차 confirm
+        if enum == "clean":
+            closed = confirm_issue_closed(issue_nums["task"])
+            if closed is False:
+                print(
+                    f"[task] WARN: prose PASS 인데 이슈 #{issue_nums['task']} 미 close",
+                    file=sys.stderr,
+                )
+            return {"enum": "clean", "message": message, "stdout": stdout}
+
+        # error — retry
+        prev_error = (
+            f"exit {exit_code}\nenum {enum}\n{message}\n\n"
+            f"stderr (tail):\n{(stderr or '')[-500:]}"
+        )
+        if attempt < retry_limit:
+            print(f"[task] retry {attempt + 1}/{retry_limit}", file=sys.stderr)
+            continue
+
+    return {
+        "enum": "error",
+        "message": f"retry 한도 ({retry_limit}) 초과 — {prev_error or 'unknown'}",
+        "stdout": "",
+    }
+
+
+def print_summary(results: list) -> None:
+    print("\n=== 처리 요약 ===", file=sys.stderr)
+    for r in results:
+        print(f"  [{r['enum']}] {r['task']} — {r['message']}", file=sys.stderr)
+
+
+def main(argv=None) -> int:
+    args = parse_args(argv)
+
+    impl_files = sorted(glob.glob(args.impl_glob))
+    if not impl_files:
+        print(
+            f"[impl-loop-headless] ERROR: no files matched: {args.impl_glob}",
+            file=sys.stderr,
+        )
+        return 1
+
+    cwd = args.cwd or os.getcwd()
+    escalate_signals = {s.strip() for s in args.escalate_on.split(",") if s.strip()}
+
+    print(
+        f"[impl-loop-headless] cwd={cwd}, tasks={len(impl_files)}, "
+        f"retry-limit={args.retry_limit}, escalate-on={escalate_signals}",
+        file=sys.stderr,
+    )
+
+    results = []
+    for task_path in impl_files:
+        r = process_task(
+            task_path, cwd,
+            retry_limit=args.retry_limit,
+            escalate_signals=escalate_signals,
+            timeout=args.timeout,
+        )
+        r["task"] = task_path
+        results.append(r)
+
+        if r["enum"] == "blocked":
+            print(
+                f"\n[impl-loop-headless] STOP: {task_path} blocked — {r['message']}",
+                file=sys.stderr,
+            )
+            print_summary(results)
+            return 2
+
+        if r["enum"] == "error":
+            print(
+                f"\n[impl-loop-headless] STOP: {task_path} error (retry 초과) — {r['message']}",
+                file=sys.stderr,
+            )
+            print_summary(results)
+            return 1
+
+    print(
+        f"\n[impl-loop-headless] ALL CLEAN ({len(results)}/{len(impl_files)})",
+        file=sys.stderr,
+    )
+    print_summary(results)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_impl_loop_headless.py
+++ b/tests/test_impl_loop_headless.py
@@ -1,0 +1,204 @@
+"""scripts/impl_loop_headless.py 단위 테스트.
+
+검증 범위:
+- build_command() — [A]~[E] 5 묶음 inline 포함
+- parse_result() — prose enum 매치 (PASS / FAIL / ESCALATE)
+- extract_issue_nums() — task 본문 + 부모 stories.md 매치
+- main() — glob 매치 0 → exit 1
+"""
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "scripts"))
+
+import impl_loop_headless as ilh  # noqa: E402
+
+
+class BuildCommandTests(unittest.TestCase):
+    """build_command — [A]~[E] inline 포함 검증."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._impl_path = Path(self._tmp.name) / "01-foo.md"
+        self._impl_path.write_text("# 01-foo\n\n본문 내용.\n", encoding="utf-8")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_all_sections_present(self):
+        prompt = ilh.build_command(
+            str(self._impl_path),
+            issue_nums={"epic": 100, "story": 101, "task": 102},
+        )
+        self.assertIn("## [A] 이번 task impl 본문", prompt)
+        self.assertIn("# 01-foo", prompt)  # 본문 inline
+        self.assertIn("## [B] 부모 이슈", prompt)
+        self.assertIn("#102", prompt)
+        self.assertIn("gh issue view 102", prompt)
+        self.assertIn("## [C] 사전 read 의무", prompt)
+        self.assertIn("docs/architecture.md", prompt)
+        self.assertIn("docs/adr.md", prompt)
+        self.assertIn("## [D] 종료 신호 규칙", prompt)
+        self.assertIn("PASS:", prompt)
+        self.assertIn("FAIL:", prompt)
+        self.assertIn("ESCALATE:", prompt)
+        self.assertIn("## [E] 작업 시작", prompt)
+
+    def test_no_issue_nums(self):
+        prompt = ilh.build_command(
+            str(self._impl_path),
+            issue_nums={"epic": None, "story": None, "task": None},
+        )
+        self.assertIn("매칭된 이슈 번호 없음", prompt)
+
+    def test_retry_attempt_prepends_prev_error(self):
+        prompt = ilh.build_command(
+            str(self._impl_path),
+            issue_nums={"epic": None, "story": None, "task": 1},
+            retry_attempt=1,
+            prev_error="some build error",
+        )
+        self.assertIn("⚠ 이전 시도 실패 (attempt 1)", prompt)
+        self.assertIn("some build error", prompt)
+
+
+class ParseResultTests(unittest.TestCase):
+    """parse_result — prose enum 매치."""
+
+    def test_pass(self):
+        stdout = "...\n로그 줄들\nPASS: 모든 테스트 통과\n"
+        enum, msg = ilh.parse_result(stdout, exit_code=0)
+        self.assertEqual(enum, "clean")
+        self.assertEqual(msg, "모든 테스트 통과")
+
+    def test_fail(self):
+        stdout = "...\nFAIL: pytest exit 1 — 2 failures\n"
+        enum, msg = ilh.parse_result(stdout, exit_code=1)
+        self.assertEqual(enum, "error")
+        self.assertIn("pytest exit 1", msg)
+
+    def test_escalate_overrides_other_enums(self):
+        # ESCALATE 가 다른 enum 보다 우선
+        stdout = "PASS: 일부\nESCALATE: API 키 필요\n"
+        enum, msg = ilh.parse_result(stdout, exit_code=0)
+        self.assertEqual(enum, "blocked")
+        self.assertIn("API 키 필요", msg)
+
+    def test_no_enum_exit_zero_fallback_clean(self):
+        stdout = "그냥 평범한 출력 enum 없음\n"
+        enum, msg = ilh.parse_result(stdout, exit_code=0)
+        self.assertEqual(enum, "clean")
+        self.assertIn("prose enum 미박힘", msg)
+
+    def test_no_enum_exit_nonzero_fallback_error(self):
+        stdout = "그냥 평범한 출력 enum 없음\n"
+        enum, msg = ilh.parse_result(stdout, exit_code=2)
+        self.assertEqual(enum, "error")
+        self.assertIn("exit 2", msg)
+
+
+class ExtractIssueNumsTests(unittest.TestCase):
+    """extract_issue_nums — task 본문 + 부모 stories.md."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        # 구조: <tmp>/epic-01-foo/impl/01-bar.md  +  <tmp>/epic-01-foo/stories.md
+        self._epic_dir = Path(self._tmp.name) / "epic-01-foo"
+        self._impl_dir = self._epic_dir / "impl"
+        self._impl_dir.mkdir(parents=True)
+        self._task_path = self._impl_dir / "01-bar.md"
+        self._stories_path = self._epic_dir / "stories.md"
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def test_task_body_github_issue_pattern(self):
+        self._task_path.write_text(
+            "# 01-bar\n\n**GitHub Issue:** [#345]\n", encoding="utf-8",
+        )
+        nums = ilh.extract_issue_nums(str(self._task_path))
+        self.assertEqual(nums["task"], 345)
+
+    def test_task_body_closes_pattern(self):
+        self._task_path.write_text(
+            "# 01-bar\n\nFixes #777 in this task.\n", encoding="utf-8",
+        )
+        nums = ilh.extract_issue_nums(str(self._task_path))
+        self.assertEqual(nums["task"], 777)
+
+    def test_parent_stories_epic_issue(self):
+        self._task_path.write_text("# 01-bar\n\n", encoding="utf-8")
+        self._stories_path.write_text(
+            "# Story Backlog\n\n**GitHub Epic Issue:** [#42]\n", encoding="utf-8",
+        )
+        nums = ilh.extract_issue_nums(str(self._task_path))
+        self.assertEqual(nums["epic"], 42)
+
+    def test_no_match_returns_nones(self):
+        self._task_path.write_text("# 01-bar\n\nno issue ref\n", encoding="utf-8")
+        nums = ilh.extract_issue_nums(str(self._task_path))
+        self.assertIsNone(nums["task"])
+        self.assertIsNone(nums["epic"])
+
+
+class MainNoMatchTests(unittest.TestCase):
+    """main() — glob 매치 0 → exit 1."""
+
+    def test_no_files_matched(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            empty_glob = str(Path(tmp) / "no-such-pattern-*.md")
+            exit_code = ilh.main([empty_glob])
+            self.assertEqual(exit_code, 1)
+
+
+class EscalateSetTests(unittest.TestCase):
+    """process_task — escalate 신호 set 정합 (claude -p 호출은 mock)."""
+
+    def test_blocked_signal_stops_immediately(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text("# 01-foo\n\nbody\n", encoding="utf-8")
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(0, "ESCALATE: 외부 API 키 필요\n", ""),
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=3,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "blocked")
+                self.assertIn("외부 API 키 필요", r["message"])
+
+    def test_error_retries_then_gives_up(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text("# 01-foo\n\nbody\n", encoding="utf-8")
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(1, "FAIL: 빌드 실패\n", "stderr tail"),
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=2,  # 3회 시도 (0, 1, 2)
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "error")
+                self.assertIn("retry 한도", r["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-375] /impl-loop 헤드리스화 — claude -p 자식 세션 spawn

- **What**:
  - `scripts/impl_loop_headless.py` 신규 (240줄) — `claude -p` cold start spawn helper. 명령문 [A]~[E] 5 묶음 조립 + 결과 회수 3 layer (stdout prose enum / 자식 종료 코드 / GitHub 이슈 close) + retry/escalate 분기
  - `tests/test_impl_loop_headless.py` 신규 — 15 단위 테스트 (build_command [A]~[E] inline / parse_result enum 매치 / extract_issue_nums 패턴 / process_task escalate·retry)
  - `commands/impl-loop.md` 본문 교체 — 헤드리스 spawn 패턴 명시 + 외래어 정리 (caveat → "걸리는 거") + 자식 세션 권한/분담 표 추가 + 안티패턴 line 62 자인 → 픽스 갱신
- **Why**:
  - 현행 /impl-loop = 단일 메인 세션 N task 직렬 = 컨텍스트 4M+ 누적 (#216 사례 1531달러)
  - N task = 1 TaskCreate 묶임 = /run-review 1 리포트 → 분리 분석 불가
  - 안티패턴 자인했지만 권장만 있고 자동화 미구현 → 본 PR 에서 자동화

## 결정 근거

- 그릴미 D 가지 종합 — 새 /auto-loop 추가 X (야간 분리 결 폐기), /impl 헤드리스화 X (cold start 비용 회피, #377 본문 보강으로 layer 정합)
- jha0313/harness_framework 패턴 차용 (subprocess.run + retry + prev_error inject)
- 실증 완료 — StockNoti 자식 `claude -p` 세션에서 plug-in SessionStart hook 자동 발화 + skill 10개 등록 + `[dcness 활성 확인]` 토큰 출력 확인
- 워크트리 = 1 outer (직렬이라 git 충돌 X)
- 자식 권한 = main 직접 commit X / worktree branch commit·PR 머지 OK (main-block hook 정합)

## 관련 이슈

closes #375

## 배포 경로 검증

- (경로 1) `commands/impl-loop.md` = plug-in 본체 — `claude plugin update` 후 외부 활성 프로젝트 자동 적용
- (경로 1) `scripts/impl_loop_headless.py` = plug-in 본체 — 외부 활성 프로젝트가 `${CLAUDE_PLUGIN_ROOT}/scripts/impl_loop_headless.py` 경로로 호출
- (경로 1) `tests/test_impl_loop_headless.py` = plug-in 본체 — 외부엔 미배포 (dcness self CI 만)

🤖 Generated with [Claude Code](https://claude.com/claude-code)