### PR TITLE
[issue-376] plug-in update 알림 — SessionStart hook 안 version 비교 + 24h 캐싱

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -23,11 +23,52 @@ CC_PID=$PPID
 # Python 으로 stdin 처리 + 핸들러 호출 (silent — stdout 안 씀)
 python3 -m harness.hooks session-start --cc-pid "$CC_PID"
 
+# === plug-in update 알림 (1회 / 일 캐싱, #376) ===
+# 외부 활성 프로젝트가 옛 dcness plug-in 버전 잔재로 운영 룰 drift 되는 문제 회피.
+# main branch 의 plugin.json version 과 비교 → 다르면 알림 박음.
+# gh CLI 부재 / API 실패 시 silent skip.
+DCNESS_UPDATE_MSG=""
+INSTALLED_VERSION=$(jq -r .version "${CLAUDE_PLUGIN_ROOT:-.}/.claude-plugin/plugin.json" 2>/dev/null || echo "")
+if [[ -n "$INSTALLED_VERSION" && "$INSTALLED_VERSION" != "null" ]]; then
+  CACHE_DIR="${HOME}/.claude/plugins/data/dcness-dcness"
+  CACHE_FILE="${CACHE_DIR}/last-update-check.txt"
+  CHECK_INTERVAL=86400  # 24h
+  NOW=$(date +%s 2>/dev/null || echo 0)
+  LAST_CHECK=0
+  LATEST_VERSION=""
+
+  if [[ -f "$CACHE_FILE" ]]; then
+    LAST_CHECK=$(awk '{print $1}' "$CACHE_FILE" 2>/dev/null || echo 0)
+    LATEST_VERSION=$(awk '{print $2}' "$CACHE_FILE" 2>/dev/null || echo "")
+  fi
+
+  # 캐시 stale (24h+) — gh api 로 main 의 plugin.json fetch
+  if (( NOW > 0 && NOW - LAST_CHECK > CHECK_INTERVAL )); then
+    FETCHED=$(gh api repos/alruminum/dcNess/contents/.claude-plugin/plugin.json --jq '.content' 2>/dev/null \
+              | base64 -d 2>/dev/null \
+              | jq -r '.version' 2>/dev/null \
+              || echo "")
+    if [[ -n "$FETCHED" && "$FETCHED" != "null" ]]; then
+      mkdir -p "$CACHE_DIR" 2>/dev/null
+      echo "$NOW $FETCHED" > "$CACHE_FILE" 2>/dev/null
+      LATEST_VERSION="$FETCHED"
+    fi
+  fi
+
+  # 버전 다르면 알림
+  if [[ -n "$LATEST_VERSION" && "$INSTALLED_VERSION" != "$LATEST_VERSION" ]]; then
+    DCNESS_UPDATE_MSG="[dcness update available: ${INSTALLED_VERSION} → ${LATEST_VERSION}. \`claude plugin update\` 권장 — 옛 운영 룰 잔재 회피]"
+  fi
+fi
+export DCNESS_UPDATE_MSG
+
 # 슬림 inject — dcness-rules.md 폐기 (PR-3). 매 세션 system-reminder 로 본문 자동 노출.
 # 외부 plug-in 사용자가 매 세션 강제 영역 + 메인 Claude 필수 + 진입 매트릭스 인지.
 python3 -c "
-import json
-msg = '''## [dcness 활성 환경]
+import json, os
+update_msg = os.environ.get('DCNESS_UPDATE_MSG', '').strip()
+header = (update_msg + '\n\n---\n\n') if update_msg else ''
+msg = header + '''## [dcness 활성 환경]
 
 첫 응답 첫 줄에 토큰 \`[dcness 활성 확인]\` 출력 의무 (사용자 즉시 룰 위반 확인 가능).
 


### PR DESCRIPTION
## 변경 요약

### [issue-376] plug-in update 알림 — SessionStart hook 안 version 비교 + 24h 캐싱

- **What**:
  - `hooks/session-start.sh` patch — `python3 -m harness.hooks session-start` 다음 새 블록:
    - `jq` 로 INSTALLED_VERSION 추출 (`${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`)
    - 캐시 파일 `~/.claude/plugins/data/dcness-dcness/last-update-check.txt` (24h TTL)
    - stale 시 `gh api` 로 main branch plugin.json 의 LATEST_VERSION fetch
    - 버전 다르면 `[dcness update available: X → Y. claude plugin update 권장]` 알림 박음
  - `export DCNESS_UPDATE_MSG` → 슬림 inject 의 python -c 안에서 `os.environ.get(...)` 으로 받아 첫 줄에 prepend
- **Why**:
  - 외부 활성 프로젝트 (StockNoti / jajang) 가 옛 plug-in 버전 잔재 시 사용자 인지 X → 운영 룰 drift
  - #375 그릴 D 가지 실증 중 발견 — StockNoti 첫 줄에 `[dcness-rules 로드 완료]` 옛 PR-3 이전 토큰 박힘
  - dcness 본 저장소 변경 → 외부 적용 latency 길어짐 (수동 `claude plugin update` 의무)

## 결정 근거

- release tag 부재 (dcness self) → release 기반 비교 작동 X → main branch plugin.json 직접 fetch 채택
- 1회/일 캐싱 = API rate limit 회피 (auth 5000/h, unauth 60/h — 1일 1회는 폭주 X)
- fail-safe — gh/jq/base64/API 호출 실패 시 silent skip (CC 동작 방해 X)
- `/dcness-doctor` 진단 skill (#376 본문 (다) 안) = 분리 별 PR (본 PR scope 최소화)
- 자동 update 적용 X (사용자 명시 `claude plugin update` 유지 — 동의 없는 plug-in body 변경 회피)

## 한계 (v1)

- gh CLI 부재 환경 = 알림 작동 X (대체 메커니즘 없음)
- release tag 시스템 부재 — main fetch 의존. 향후 release 워크플로우 도입 시 release 기반 전환 가능

## 관련 이슈

closes #376

## 배포 경로 검증

- (경로 1) `hooks/session-start.sh` = plug-in 본체 — `claude plugin update` 후 외부 활성 프로젝트 자동 적용
- 부트스트랩 가지 — *본 PR 머지 후* update 받은 외부 프로젝트만 알림 받음. 옛 plug-in 잔재 프로젝트는 한 번 *수동 update* 후 본 기능 작동

🤖 Generated with [Claude Code](https://claude.com/claude-code)