### PR TITLE
[issue-383] _CONCLUSION_ENUMS 12 매트릭스 확장 (follow-up)

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -278,11 +278,44 @@ def _parse_iso(ts: str) -> Optional[datetime]:
 # pr-reviewer 는 LGTM 도 사용. 마지막 N줄에서 단어 단위 매칭 — 부정문 (예: "FAIL 없음",
 # "0 FAIL") 회피 위해 같은 줄에 부정 마커 있으면 skip.
 _CONCLUSION_ENUMS: tuple[tuple[str, str], ...] = (
+    # issue #383 follow-up — agent 별 결론 enum 12개 매트릭스 (agents/*.md 실측):
+    #   engineer (IMPL): IMPL_DONE / IMPL_PARTIAL / TESTS_FAIL
+    #   engineer (POLISH): POLISH_DONE / IMPLEMENTATION_ESCALATE
+    #   test-engineer: TESTS_WRITTEN
+    #   code-validator / architecture-validator / module-architect / system-architect
+    #     / plan-reviewer: PASS / FAIL / ESCALATE
+    #   pr-reviewer: LGTM / FAIL / ESCALATE
+    #   ux-architect: UX_FLOW_DONE / UX_FLOW_ESCALATE
+    #   designer: PASS
+    # 우선순위 — 구체적 enum 먼저 (TESTS_FAIL 이 FAIL 보다 먼저 매칭).
+    # 일반 PASS/FAIL/ESCALATE 는 마지막 fallback.
     ("LGTM", re.compile(r"\bLGTM\b")),
+    # engineer IMPL
+    ("IMPL_DONE", re.compile(r"\bIMPL_DONE\b")),
+    ("IMPL_PARTIAL", re.compile(r"\bIMPL_PARTIAL\b")),
+    ("TESTS_FAIL", re.compile(r"\bTESTS_FAIL\b")),
+    # engineer POLISH
+    ("POLISH_DONE", re.compile(r"\bPOLISH_DONE\b")),
+    ("IMPLEMENTATION_ESCALATE", re.compile(r"\bIMPLEMENTATION_ESCALATE\b")),
+    # test-engineer
+    ("TESTS_WRITTEN", re.compile(r"\bTESTS_WRITTEN\b")),
+    # ux-architect
+    ("UX_FLOW_DONE", re.compile(r"\bUX_FLOW_DONE\b")),
+    ("UX_FLOW_ESCALATE", re.compile(r"\bUX_FLOW_ESCALATE\b")),
+    # 일반 (PR #361 enum 통일 — code/architecture-validator / system/module-architect
+    # / plan-reviewer / pr-reviewer / designer 공통)
     ("PASS", re.compile(r"\bPASS\b")),
     ("FAIL", re.compile(r"\bFAIL\b")),
     ("ESCALATE", re.compile(r"\bESCALATE\b")),
 )
+# 단독 결론 (negation 검사 skip 대상) — 단어 자체가 부정 형태 가질 수 없음.
+_STANDALONE_CONCLUSIONS: frozenset[str] = frozenset({
+    "LGTM",
+    "IMPL_DONE", "IMPL_PARTIAL",
+    "POLISH_DONE", "IMPLEMENTATION_ESCALATE",
+    "TESTS_WRITTEN", "TESTS_FAIL",
+    "UX_FLOW_DONE", "UX_FLOW_ESCALATE",
+})
 _NEGATION_RE = re.compile(
     r"(없|미발견|아님|아니|불필요|"           # 한글 부정
     r"\bno\b|\bnot\b|\bzero\b|\b0\s*\b|"     # 영어 부정
@@ -307,10 +340,11 @@ def _extract_conclusion_enum(prose: str) -> str:
     for label, pattern in _CONCLUSION_ENUMS:
         for line in tail:
             if pattern.search(line):
-                # 단독 LGTM 은 negation 검사 skip (보통 "LGTM —" 패턴)
-                if label == "LGTM":
+                # 단독 결론 enum (TESTS_WRITTEN / IMPL_DONE 등) 은 negation 검사 skip.
+                # 단어 자체가 부정 형태 가질 수 없음 — "TESTS_WRITTEN 없음" 어색.
+                if label in _STANDALONE_CONCLUSIONS:
                     return label
-                # 같은 줄에 부정 마커 있으면 skip
+                # 일반 PASS/FAIL/ESCALATE — 같은 줄에 부정 마커 있으면 skip
                 if _NEGATION_RE.search(line):
                     continue
                 return label

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -896,6 +896,53 @@ class ConclusionEnumExtractionTests(unittest.TestCase):
         self.assertEqual(_extract_conclusion_enum(""), "")
         self.assertEqual(_extract_conclusion_enum("아무 결론 없음"), "")
 
+    # issue #383 follow-up — agent 별 결론 enum 12 매트릭스 매핑 회귀 차단.
+    def test_extracts_tests_written(self):
+        # test-engineer 결론 (jajang run-459cce99 step 0 실측 케이스)
+        prose = "분석 완료.\n\n나머지 12 it 는 RED. TESTS_WRITTEN — engineer attempt 0 권고."
+        self.assertEqual(_extract_conclusion_enum(prose), "TESTS_WRITTEN")
+
+    def test_extracts_impl_done(self):
+        # engineer IMPL 결론
+        prose = "구현 완료.\n\nIMPL_DONE — code-validator 검증 권고."
+        self.assertEqual(_extract_conclusion_enum(prose), "IMPL_DONE")
+
+    def test_extracts_impl_partial(self):
+        prose = "분량 초과.\n\nIMPL_PARTIAL — 남은 작업: foo.ts §3.2 ~ §3.5"
+        self.assertEqual(_extract_conclusion_enum(prose), "IMPL_PARTIAL")
+
+    def test_extracts_polish_done(self):
+        prose = "POLISH 완료.\n\nN passed / 변경 범위 src/foo.ts. POLISH_DONE."
+        self.assertEqual(_extract_conclusion_enum(prose), "POLISH_DONE")
+
+    def test_extracts_implementation_escalate(self):
+        prose = "재시도 한도 초과.\n\nIMPLEMENTATION_ESCALATE — 사용자 위임."
+        self.assertEqual(_extract_conclusion_enum(prose), "IMPLEMENTATION_ESCALATE")
+
+    def test_extracts_tests_fail(self):
+        # TESTS_FAIL 이 FAIL 보다 우선 매칭
+        prose = "테스트 결과.\n\n3회 후에도 동일 FAIL — TESTS_FAIL 결론."
+        self.assertEqual(_extract_conclusion_enum(prose), "TESTS_FAIL")
+
+    def test_extracts_ux_flow_done(self):
+        prose = "UX_FLOW 작성 완료.\n\nself-check 5 카테고리 통과. UX_FLOW_DONE."
+        self.assertEqual(_extract_conclusion_enum(prose), "UX_FLOW_DONE")
+
+    def test_extracts_ux_flow_escalate(self):
+        prose = "self-check 2 cycle.\n\n카테고리 3 미해결. UX_FLOW_ESCALATE."
+        self.assertEqual(_extract_conclusion_enum(prose), "UX_FLOW_ESCALATE")
+
+    def test_standalone_enum_ignores_negation_marker_on_same_line(self):
+        # IMPL_DONE 같은 단독 enum 은 부정 마커 (예: "FAIL 없음") 있어도 추출.
+        # 단어 자체가 부정 형태 가질 수 없음.
+        prose = "임시 분석.\n\n빌드 통과, FAIL 없음. IMPL_DONE — 다음 단계 권고."
+        self.assertEqual(_extract_conclusion_enum(prose), "IMPL_DONE")
+
+    def test_priority_specific_over_generic(self):
+        # 같은 줄에 TESTS_FAIL 과 FAIL 둘 다 있으면 TESTS_FAIL 우선 매칭.
+        prose = "결과.\n\nTESTS_FAIL — 3회 FAIL 후 종료."
+        self.assertEqual(_extract_conclusion_enum(prose), "TESTS_FAIL")
+
     def test_parse_steps_populates_conclusion_enum(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)


### PR DESCRIPTION
## 변경 요약

### [issue-383] _CONCLUSION_ENUMS 12 매트릭스 확장 — engineer/test-engineer/ux-architect
- **What**: PR #384 의 B4 fix 후 jajang `run-459cce99` 재검증에서 test-engineer / engineer step enum 컬럼이 여전히 `PROSE_LOGGED`. `_CONCLUSION_ENUMS` 가 4 enum (33%) 만 매핑이라 부분 fix. 12 매트릭스 (engineer/test-engineer/ux-architect 8 enum 추가) 로 완성.
- **Why**: review 가독성 회복의 본 의도 = *agent prose 결론 enum 표시*. 4 enum 만 매핑 시 dcness 분리형 agent (engineer/test-engineer/ux-architect) prose 추출 미작동 → 사용자 가독성 회복 부분 미흡.

## 결정 근거
- **매핑 확장 vs 강제 단일화**: 매핑 채택. dcness PR #361 enum 통일이 *7 agent (validator/architect/reviewer 류)* 만 적용 — engineer/test-engineer/ux-architect 는 의도적 별도 enum 유지 (agents/engineer.md `IMPL_DONE`/`IMPL_PARTIAL`, agents/ux-architect.md `UX_FLOW_DONE`). 단일화는 agent 자율성 침해.
- **`_STANDALONE_CONCLUSIONS` 신설**: 단독 enum (TESTS_WRITTEN / IMPL_DONE 등) 은 단어 자체가 부정 형태 가질 수 없음 — negation 검사 skip 으로 false negative 회피.
- **우선순위 (구체적 → 일반)**: `TESTS_FAIL` 이 `FAIL` 보다 먼저 매칭. PR #361 통일 enum 매칭 시 더 구체적 enum 우선.

## 관련 이슈
- Closes #383 (B4 후속)
- Related: #361 (8 agent enum 통일), #284 (prose-only mode)

## 배포 경로 검증 (CLAUDE.md §0.5)
- `harness/run_review.py` — plug-in 본체
- `tests/test_run_review.py` — plug-in 본체

## 테스트
- 79 tests (69 기존 + 10 신규) all PASS
- jajang `run-459cce99` 재검증:
  - test-engineer step: `PROSE_LOGGED` → **`TESTS_WRITTEN`** ✅
  - engineer step: 여전히 `PROSE_LOGGED` (prose 자체 결론 enum 부재 = agent 룰 위반 케이스 — 별도 issue 후보)

## Test plan
- [x] 기존 69 tests PASS 보존
- [x] 10 신규 매핑 테스트 (TESTS_WRITTEN / IMPL_DONE / IMPL_PARTIAL / POLISH_DONE / IMPLEMENTATION_ESCALATE / TESTS_FAIL / UX_FLOW_DONE / UX_FLOW_ESCALATE / standalone negation skip / 구체→일반 우선순위)
- [x] jajang 실데이터 재검증
- [x] py_compile clean
- [x] git pre-commit hook PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)