### PR TITLE
[docs] /impl 종료 조건 (MUST) 단원 추가 — finalize-run + end-run 강제

### DIFF
--- a/commands/impl.md
+++ b/commands/impl.md
@@ -86,3 +86,22 @@ tail -50 "<task-path>"
 
 ## 절차
 [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1~§6 + [`docs/plugin/orchestration.md`](../docs/plugin/orchestration.md) §4.3 (`impl-task-loop` 풀스펙) 따름. UI 감지 시 §4.4 (`impl-ui-design-loop`).
+
+## 종료 조건 (MUST — 메인 Claude 의무)
+
+> ⚠️ **함정 경고**: §3.4 에서 PR merge 까지 자동 완료된다. 메인 본능 "merge = 작업 끝" 으로 *반드시* 다음 2개 명령을 skip 한다. skip = 자동 회고 + loop-insights 학습 누적 마비 → 다음 run 회귀 방지 기능 손실.
+
+PR merge 직후 *반드시* 다음 시퀀스 실행:
+
+```bash
+"$HELPER" finalize-run --expected-steps <N> --auto-review
+"$HELPER" end-run
+```
+
+- `<N>` = catalog 행 `expected_steps` 컬럼 (`impl-task-loop` 풀스펙 [`orchestration.md`](../docs/plugin/orchestration.md) §4.3 참조).
+- `--auto-review` 가 in-process `harness.run_review` 호출 → `<run_dir>/review.md` 저장 + stderr `[REVIEW_READY] <path>` 신호 emit.
+- **end-run 안전망** (`session_state.py:1001`): finalize-run 미호출 시 end-run 이 자동 보강. 단 end-run 자체 skip 은 보강 0.
+
+**REVIEW_READY 후속 — echo MUST**: stderr `[REVIEW_READY] <run_dir>/review.md` 감지 시 `review.md` 본문을 *character-for-character* 세션 응답에 복사 ([`loop-procedure.md`](../docs/plugin/loop-procedure.md) §6). 압축 / 요약 / 재배치 / 마크다운 테이블 → ASCII 변환 절대 금지. dcness echo 룰 MUST (DCN-30-15) — 토큰 절약 본능 차단.
+
+근거: §3.4 PR merge 자동 완료 후 메인이 Step 5 (finalize-run) + Step 6 (review echo) 를 skip 하는 회귀가 반복 발생. hook 미진입 영역이므로 본문 강제로 보완.


### PR DESCRIPTION
## 변경 요약

### [docs] /impl 종료 조건 (MUST) 단원 추가
- **What**: `commands/impl.md` 끝에 `## 종료 조건 (MUST)` 단원 신설. PR merge 후 `finalize-run --auto-review` + `end-run` 명령 강제 + REVIEW_READY echo MUST 명시.
- **Why**: `/impl` 명시 호출 후에도 메인 Claude 가 end-run 까먹는 회귀 반복 (jajang epic-12 task 06/08 사례). loop-procedure.md §5.1 강제는 prose 의무라 메인 본능 (= PR merge 자동 완료 후 "작업 끝" 인지) 으로 패배.

## 결정 근거
- 본문 강제 (처방 a) — 저비용, 즉시 적용. Stop hook 코드 강제 (#382) 는 별도 PR.

## 관련 이슈
Document-Exception-PR-Close: docs only — Stop hook (#382) 의 사전 처방. 별도 close 대상 이슈 없음 — #382 는 hook 코드 강제 (후속 PR) 가 close.

## 배포 경로 검증 (CLAUDE.md §0.5)
- `commands/impl.md` — plug-in 본체 (경로 1, `claude plugin update` 자동 적용)

## Test plan
- [x] 본문 강제 단원 추가 (docs only, code 변경 없음)
- [ ] 다음 1~2 /impl run 관찰 — 메인이 본문 따라 end-run 부르는지 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)