### PR TITLE
[issue-387] engineer prose 결론 enum 부재 검출 — MISSING_CONCLUSION_ENUM

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -528,6 +528,34 @@ def detect_wastes(
             fix=f"agents/{cur.agent}.md fail 전략 강화 또는 impl 보강",
         ))
 
+    # issue #387 — MISSING_CONCLUSION_ENUM. engineer prose 끝 결론 enum (IMPL_DONE
+    # / IMPL_PARTIAL / SPEC_GAP_FOUND / TESTS_FAIL / IMPLEMENTATION_ESCALATE
+    # / POLISH_DONE) 부재 검출. agents/engineer.md §21~32 명시 강제.
+    # validator/architect 류는 PR #361 enum 통일로 자율 영역 — 본 패턴 미적용.
+    for s in steps:
+        if s.agent != "engineer":
+            continue
+        if not s.prose_full:
+            continue  # prose 부재 시 검사 불가
+        if s.conclusion_enum:
+            continue  # 결론 enum 정상 박힘
+        findings.append(WasteFinding(
+            pattern="MISSING_CONCLUSION_ENUM",
+            severity="MEDIUM",
+            step_idx=s.idx,
+            agent=s.agent,
+            detail=(
+                f"engineer step {s.idx} prose 끝 결론 enum 부재 — "
+                "agents/engineer.md §21~32 명시 의무 위반 "
+                "(IMPL_DONE / IMPL_PARTIAL / SPEC_GAP_FOUND / TESTS_FAIL / "
+                "IMPLEMENTATION_ESCALATE / POLISH_DONE 중 1)"
+            ),
+            fix=(
+                "engineer 재호출 시 prompt 에 결론 enum 강제 의무 명시 또는 "
+                "메인 Claude 가 prose routing 결정 시 enum 부재 인지 + 재호출"
+            ),
+        ))
+
     # ECHO_VIOLATION — prose 전체 줄 수 기준 (prose_full). prose_full 없는 레코드는 skip.
     for s in steps:
         if not s.prose_full:

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -967,5 +967,80 @@ class ConclusionEnumExtractionTests(unittest.TestCase):
             self.assertEqual(steps[0].enum, "PROSE_LOGGED")  # sentinel 그대로 보존
 
 
+class MissingConclusionEnumTests(unittest.TestCase):
+    """issue #387 — engineer prose 끝 결론 enum 부재 검출.
+
+    agents/engineer.md §21~32: IMPL/POLISH 모드 모두 prose 마지막 단락에
+    결론 enum (IMPL_DONE / IMPL_PARTIAL / SPEC_GAP_FOUND / TESTS_FAIL /
+    IMPLEMENTATION_ESCALATE / POLISH_DONE) 의무. jajang run-459cce99 step 1
+    engineer-IMPL prose 가 어떤 enum 도 박지 않은 caveat 케이스 직접 동기.
+    """
+
+    def test_missing_conclusion_enum_engineer_caveat(self):
+        # engineer prose 끝 = "사용자에게 요청하는 결정 사항" — 결론 enum 부재
+        prose = (
+            "구현 작업 중.\n\n"
+            "TypeScript 에러 발생.\n\n"
+            "**사용자에게 요청하는 결정 사항**\n"
+            "1. stub 파일 허용 여부\n"
+            "2. @theme/tokens 상대 경로 수정 허용 여부"
+        )
+        s = StepRecord(
+            idx=0, ts="2026-04-30T10:05:00+00:00",
+            agent="engineer", mode="IMPL",
+            enum="PROSE_LOGGED", must_fix=False,
+            prose_excerpt="x", prose_full=prose,
+            conclusion_enum="",  # 추출 실패
+        )
+        wastes = detect_wastes([s])
+        missing = [w for w in wastes if w.pattern == "MISSING_CONCLUSION_ENUM"]
+        self.assertEqual(len(missing), 1)
+        self.assertEqual(missing[0].severity, "MEDIUM")
+        self.assertEqual(missing[0].agent, "engineer")
+
+    def test_no_missing_when_enum_present(self):
+        prose = "구현 완료.\n\nIMPL_DONE — code-validator 권고."
+        s = StepRecord(
+            idx=0, ts="2026-04-30T10:05:00+00:00",
+            agent="engineer", mode="IMPL",
+            enum="PROSE_LOGGED", must_fix=False,
+            prose_excerpt="x", prose_full=prose,
+            conclusion_enum="IMPL_DONE",
+        )
+        wastes = detect_wastes([s])
+        missing = [w for w in wastes if w.pattern == "MISSING_CONCLUSION_ENUM"]
+        self.assertEqual(len(missing), 0)
+
+    def test_missing_skips_non_engineer(self):
+        # validator / pr-reviewer / architect 류는 자율 영역 — skip
+        prose = "검증 진행.\n\n특별한 enum 박지 않음."
+        steps = [
+            StepRecord(idx=0, ts="2026-04-30T10:05:00+00:00",
+                       agent="code-validator", mode="CODE_VALIDATION",
+                       enum="PROSE_LOGGED", must_fix=False,
+                       prose_excerpt="x", prose_full=prose, conclusion_enum=""),
+            StepRecord(idx=1, ts="2026-04-30T10:15:00+00:00",
+                       agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=False,
+                       prose_excerpt="y", prose_full=prose, conclusion_enum=""),
+        ]
+        wastes = detect_wastes(steps)
+        missing = [w for w in wastes if w.pattern == "MISSING_CONCLUSION_ENUM"]
+        self.assertEqual(len(missing), 0)
+
+    def test_missing_skips_no_prose_full(self):
+        # prose_full 부재 시 검사 불가 — skip
+        s = StepRecord(
+            idx=0, ts="2026-04-30T10:05:00+00:00",
+            agent="engineer", mode="IMPL",
+            enum="PROSE_LOGGED", must_fix=False,
+            prose_excerpt="x", prose_full="",
+            conclusion_enum="",
+        )
+        wastes = detect_wastes([s])
+        missing = [w for w in wastes if w.pattern == "MISSING_CONCLUSION_ENUM"]
+        self.assertEqual(len(missing), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-387] engineer prose 결론 enum 부재 검출
- **What**: `detect_wastes` 에 `MISSING_CONCLUSION_ENUM` 패턴 신규 (MEDIUM). engineer prose 끝 결론 enum (IMPL_DONE / IMPL_PARTIAL / SPEC_GAP_FOUND / TESTS_FAIL / IMPLEMENTATION_ESCALATE / POLISH_DONE) 부재 시 finding.
- **Why**: jajang `run-459cce99` step 1 engineer prose 가 *어떤 enum 도 박지 않은* caveat 케이스 — agent.md §21~32 룰 위반. 메인 routing 결정 어렵게 만듬.

## 결정 근거
- **engineer 만 적용 vs 전 agent 적용**: engineer 만 채택. PR #361 enum 통일로 validator/architect 류는 PASS/FAIL/ESCALATE 자율 — 결론 enum 부재 *agent 자율 영역*. engineer 는 agents/engineer.md §21~32 *명시 강제* 라 룰 위반 검출 정합.
- **MEDIUM vs HIGH**: MEDIUM 채택. 룰 위반은 맞지만 *caveat 분기 자체는 정상* (사용자 위임 가능) — 단지 enum 으로 의도 표현 안 한 것. HIGH = 차단성 위반.
- **MUST_FIX_LEAK 와 분리**: 다른 룰. LEAK = wastes 누락 회피 / MISSING_CONCLUSION_ENUM = agent 자가 룰 위반.

## 관련 이슈
- Closes #387

## 배포 경로 검증 (CLAUDE.md §0.5)
- `harness/run_review.py` — plug-in 본체
- `tests/test_run_review.py` — plug-in 본체

## 테스트
- 83 tests (79 기존 + 4 신규) all PASS
- jajang `run-459cce99` 검증: engineer step 1 MEDIUM `MISSING_CONCLUSION_ENUM` 정상 박힘

## Test plan
- [x] 4 신규 회귀 테스트 (caveat 검출 / enum 박힘 시 skip / 비-engineer skip / prose 부재 skip)
- [x] jajang 실데이터 검증
- [x] py_compile clean
- [x] git pre-commit hook PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)