### PR TITLE
[issue-382] Stop hook 자동 end-run — review.md 코드 강제 생성

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -48,6 +48,7 @@ __all__ = [
     "handle_pretooluse_file_op",
     "handle_posttooluse_agent",
     "handle_posttooluse_file_op",
+    "handle_stop",
 ]
 
 
@@ -764,6 +765,119 @@ def _module_architect_first_call(rd: Path) -> bool:
     return not (rd / "module-architect.md").exists()
 
 
+# ── Stop hook (issue #382) ────────────────────────────────────────────
+
+
+def handle_stop(
+    stdin_data: Optional[Dict[str, Any]] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """Stop hook — 메인 응답 종료 시 자동 end-run.
+
+    배경 (issue #382): /impl / /impl-loop / /architect-loop 등 컨베이어 루프
+    종료 후 메인 Claude 가 `end-run` 까먹는 회귀 반복 발생. loop-procedure.md §5.1
+    의 prose 의무로는 본능 (PR merge 후 "작업 끝" 인지) 패배.
+
+    Stop hook 으로 *코드 강제 승격*:
+    1. stop_hook_active=true → 무한 루프 방지, skip
+    2. active_runs[rid] 슬롯 부재 / finalized_at 박힘 → skip (이미 종료)
+    3. `.steps.jsonl` 마지막 row 의 (agent, mode) 가 live.json.current_step.
+       (agent, mode) 와 일치 → end-step 완료 상태 = 종료 후보 / 불일치 →
+       begin-step 후 end-step 미호출 진행 중 → skip (false positive 회피)
+    4. 위 모두 통과 → in-process `_cli_end_run` 호출.
+       session_state.py:1001 안전망 → finalize-run --auto-review 자동 →
+       `<run_dir>/review.md` 생성 + stderr `[REVIEW_READY]` 신호
+
+    Stop hook 자체는 메인 시야에 inject 안 함 (additionalContext 미지원).
+    review.md 본문 echo 는 *기존 prose 의무* (loop-procedure.md §6 +
+    run-review.md §51 + commands/impl.md §종료 조건) 에 의존.
+
+    return: 항상 0 (block 안 함, 정상 종료 허용).
+    """
+    if stdin_data is None:
+        try:
+            raw = sys.stdin.read()
+            stdin_data = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, OSError):
+            return 0
+
+    if not isinstance(stdin_data, dict):
+        return 0
+
+    # 무한 루프 가드 (Claude Code 공식 docs §"Stop hook runs forever")
+    if stdin_data.get("stop_hook_active"):
+        return 0
+
+    # 지연 import — session_state 가 무거움
+    try:
+        from harness.session_state import (
+            auto_detect_session_id,
+            auto_detect_run_id,
+            read_live,
+            _read_steps_jsonl,
+            _cli_end_run,
+        )
+    except Exception:
+        return 0
+
+    try:
+        sid = auto_detect_session_id(base_dir=base_dir) if base_dir else auto_detect_session_id()
+        rid = auto_detect_run_id(base_dir=base_dir) if base_dir else auto_detect_run_id()
+    except Exception:
+        return 0
+
+    if not (sid and rid):
+        return 0
+
+    # active_runs 슬롯 검사
+    try:
+        live = read_live(sid, base_dir=base_dir) if base_dir else read_live(sid)
+    except Exception:
+        return 0
+    if not live:
+        return 0
+    active = live.get("active_runs", {}) if isinstance(live, dict) else {}
+    slot = active.get(rid) if isinstance(active, dict) else None
+    if not isinstance(slot, dict):
+        return 0  # begin-run 미호출 — skip
+    if slot.get("finalized_at"):
+        return 0  # 이미 finalize-run 호출됨 — skip
+
+    # end-step 완료 매칭 검사 (false positive 회피)
+    # _read_steps_jsonl 마지막 row.(agent, mode) vs live.current_step.(agent, mode).
+    # 일치 = end-step 호출됨 (step 종료 상태) / 불일치 = begin-step 후 end-step
+    # 미호출 (sub-agent 진행 중 응답 종료 케이스 — end-run 발사 false positive).
+    try:
+        steps = _read_steps_jsonl(sid, rid)
+    except Exception:
+        return 0
+    if not steps:
+        return 0  # step 0개 — begin-step 안 부른 상태
+
+    last = steps[-1]
+    cur_step = slot.get("current_step") if isinstance(slot, dict) else None
+    if isinstance(cur_step, dict):
+        cur_agent = cur_step.get("agent")
+        cur_mode = cur_step.get("mode")
+        last_agent = last.get("agent")
+        last_mode = last.get("mode")
+        # 정확 일치 검사 (mode None 도 비교)
+        if cur_agent != last_agent or cur_mode != last_mode:
+            return 0  # begin-step 후 end-step 미호출 — 진행 중
+
+    # 모든 조건 충족 — end-run in-process 호출
+    try:
+        import argparse as _ap
+        _fake = _ap.Namespace()
+        _cli_end_run(_fake)
+        print("[stop-hook] end-run 자동 호출 — issue #382", file=sys.stderr)
+    except Exception as exc:
+        print(f"[stop-hook] end-run FAIL — {exc}", file=sys.stderr)
+
+    return 0
+
+
 # ── CLI 진입점 (bash 훅 → python -m harness.hooks <subcommand>) ─────
 
 
@@ -795,6 +909,10 @@ def _main(argv: Optional[list] = None) -> int:
                           help="PostToolUse Edit/Write/Read/Bash — agent-trace post append")
     p_pf.add_argument("--cc-pid", type=int, default=None)
 
+    p_st = sub.add_parser("stop",
+                          help="Stop 훅 — 메인 응답 종료 시 자동 end-run (issue #382)")
+    p_st.add_argument("--cc-pid", type=int, default=None)
+
     args = parser.parse_args(argv)
 
     # cc_pid 미명시 시 PPID 사용 (bash 훅 의 PPID = CC main)
@@ -810,6 +928,8 @@ def _main(argv: Optional[list] = None) -> int:
         return handle_posttooluse_agent(cc_pid=cc_pid)
     elif args.cmd == "posttooluse-file-op":
         return handle_posttooluse_file_op(cc_pid=cc_pid)
+    elif args.cmd == "stop":
+        return handle_stop()
     return 0
 
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,6 +1,17 @@
 {
-  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash/mcp__.* file-guard + PostToolUse Agent post-clear + PostToolUse Edit/Write/Read/Bash/mcp__.* post-file-op-trace)",
+  "description": "dcNess — 컨베이어 인프라 훅 (SessionStart sid + PreToolUse Agent catastrophic-gate + Edit/Write/Read/Bash/mcp__.* file-guard + PostToolUse Agent post-clear + PostToolUse Edit/Write/Read/Bash/mcp__.* post-file-op-trace + Stop auto-end-run)",
   "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-end-run.sh\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/hooks/stop-end-run.sh
+++ b/hooks/stop-end-run.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# dcNess Stop 훅 — 메인 응답 종료 시 자동 end-run (issue #382)
+#
+# 트리거: Claude Code Stop event (메인 Claude 응답 종료 시점)
+# stdin: CC payload (sessionId, stop_hook_active 포함)
+# 동작: harness/hooks.py 의 handle_stop 호출
+#   - stop_hook_active=true 시 즉시 skip (무한 루프 가드, 공식 docs §"Stop hook runs forever")
+#   - active_runs 슬롯 + end-step 완료 매칭 시 dcness-helper end-run 자동 호출
+#   - 부산물: <run_dir>/review.md 생성 + loop-insights 누적 + active_runs 정리
+#
+# 실패 시 silent (exit 0) — Stop hook 은 block 안 함 (정상 종료 허용).
+
+set -uo pipefail
+
+export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+
+# 활성화 게이트 — 현재 프로젝트가 dcness whitelist 에 없으면 pass-through.
+python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+
+CC_PID=$PPID
+
+# stderr 는 /tmp 보존 (디버그용). Stop hook 의 stderr 는 메인 시야에 직접 inject 안 됨.
+python3 -m harness.hooks stop --cc-pid "$CC_PID" 2>>/tmp/dcness-hook-stderr.log || true
+exit 0

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -39,6 +39,7 @@ from harness.hooks import (
     handle_pretooluse_agent,
     handle_pretooluse_file_op,
     handle_session_start,
+    handle_stop,
 )
 from harness.agent_trace import append as trace_append
 from harness.agent_trace import read_all as read_trace
@@ -1366,6 +1367,35 @@ class ExtractProseTextTests(unittest.TestCase):
         # depth 16 초과는 "" 반환 (crash X)
         result = _extract_prose_text(deep)
         self.assertIsInstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# handle_stop — issue #382 Stop hook (가드 로직 단위 테스트)
+# ---------------------------------------------------------------------------
+
+
+class StopHookGuardTests(unittest.TestCase):
+    """Stop hook 의 *조건 검사 가드* 만 단위 검증.
+
+    실제 end-run 발사 (in-process _cli_end_run) 는 integration 영역 —
+    jajang 같은 활성 프로젝트에서 round-trip 검증.
+    """
+
+    def test_stop_hook_active_skips_immediately(self):
+        # 무한 루프 가드 — Claude Code 공식 docs §"Stop hook runs forever"
+        rc = handle_stop(stdin_data={"stop_hook_active": True})
+        self.assertEqual(rc, 0)
+
+    def test_invalid_stdin_skips(self):
+        rc = handle_stop(stdin_data=None)
+        self.assertEqual(rc, 0)
+        rc = handle_stop(stdin_data="not a dict")  # type: ignore[arg-type]
+        self.assertEqual(rc, 0)
+
+    def test_empty_dict_no_sid_skips(self):
+        # sid/rid auto-detect 실패 → skip
+        rc = handle_stop(stdin_data={})
+        self.assertEqual(rc, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

### [issue-382] Stop hook 자동 end-run
- **What**: Claude Code Stop hook 신설 — 메인 응답 종료 시 active_runs 슬롯 + end-step 완료 매칭 검사 후 in-process `_cli_end_run` 자동 호출. session_state.py:1001 안전망 cascade 로 review.md 생성 + loop-insights 누적 + active_runs 정리.
- **Why**: end-run 까먹는 회귀가 PR #386 prose 강제만으론 본능 패배 우려. hook 코드 강제로 승격.

## 결정 근거
- **Stop hook 선택 (vs UserPromptSubmit)**: Stop hook = end-run *실행* 책무 (review.md *생성*). UserPromptSubmit 은 *시야 inject* 책무 — 본 PR scope 아님 (효과 관찰 후 결정).
- **block 안 함 (vs decision:block)**: Stop hook reason 은 사용자에게만 표시 (Claude inject X). exit 2 + stderr 는 error 형식 — 어색. block 없이 *코드 부산물 (review.md 파일 생성)* 만 박고 echo 는 prose 의무에 의존.
- **end-step 완료 매칭 가드**: `.steps.jsonl` last row (agent,mode) vs `live.json.current_step` (agent,mode) 일치 — sub-agent 진행 중 응답 종료 false positive 회피. PROSE_LOGGED 통일 후 enum 기반 가드 무의미 — 매칭 가드가 정확.

## 관련 이슈
- Closes #382
- Related: #383 (run-review fix — review.md 정확도 회복 의존), #386 (commands/impl.md §종료 조건 — prose 1차 강제)

## 배포 경로 검증 (CLAUDE.md §0.5)
- `harness/hooks.py` — plug-in 본체 (경로 1, `claude plugin update` 자동 적용)
- `hooks/stop-end-run.sh` — plug-in 본체
- `hooks/hooks.json` — plug-in 본체

## 테스트
- 456 tests (453 기존 + 3 신규 stop hook 가드) all PASS
- 실증 round-trip 검증은 jajang 등 활성 프로젝트 사용 후 다음 run 회고 발화 관찰

## Test plan
- [x] 가드 로직 단위 테스트 (stop_hook_active=true skip / invalid stdin skip / 빈 dict skip)
- [x] py_compile + hooks.json 유효성 검증
- [ ] 다음 /impl run (jajang) — Stop hook 발화 + review.md 자동 생성 확인
- [ ] 효과 미흡 시 UserPromptSubmit hook (review.md additionalContext inject) 추가 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)