### PR TITLE
[issue-396] insight CLI + FIFO 10 누적 + end-run 단일화

### DIFF
--- a/commands/impl.md
+++ b/commands/impl.md
@@ -89,19 +89,27 @@ tail -50 "<task-path>"
 
 ## 종료 조건 (MUST — 메인 Claude 의무)
 
-> ⚠️ **함정 경고**: §3.4 에서 PR merge 까지 자동 완료된다. 메인 본능 "merge = 작업 끝" 으로 *반드시* 다음 2개 명령을 skip 한다. skip = 자동 회고 + loop-insights 학습 누적 마비 → 다음 run 회귀 방지 기능 손실.
+> ⚠️ **함정 경고**: §3.4 에서 PR merge 까지 자동 완료된다. 메인 본능 "merge = 작업 끝" 으로 *반드시* 다음 명령을 skip 한다. skip = 자동 회고 마비 → 다음 run 회귀 방지 기능 손실.
 
-PR merge 직후 *반드시* 다음 시퀀스 실행:
+PR merge 직후 *반드시* 다음 1개 명령 실행 (issue #396 — 단일화):
 
 ```bash
-"$HELPER" finalize-run --expected-steps <N> --auto-review
 "$HELPER" end-run
 ```
 
-- `<N>` = catalog 행 `expected_steps` 컬럼 (`impl-task-loop` 풀스펙 [`orchestration.md`](../docs/plugin/orchestration.md) §4.3 참조).
-- `--auto-review` 가 in-process `harness.run_review` 호출 → `<run_dir>/review.md` 저장 + stderr `[REVIEW_READY] <path>` 신호 emit.
-- **end-run 안전망** (`session_state.py:1001`): finalize-run 미호출 시 end-run 이 자동 보강. 단 end-run 자체 skip 은 보강 0.
+- end-run 안전망 (`session_state.py:1001`) 이 finalize-run --auto-review 자동 발사 → `<run_dir>/review.md` 저장 + stderr `[REVIEW_READY] <path>` 신호 emit.
+- (예전 2개 명령 — `finalize-run --expected-steps <N> --auto-review` + `end-run` — 폐기. end-run 1개로 단순화)
 
-**REVIEW_READY 후속 — echo MUST**: stderr `[REVIEW_READY] <run_dir>/review.md` 감지 시 `review.md` 본문을 *character-for-character* 세션 응답에 복사 ([`loop-procedure.md`](../docs/plugin/loop-procedure.md) §6). 압축 / 요약 / 재배치 / 마크다운 테이블 → ASCII 변환 절대 금지. dcness echo 룰 MUST (DCN-30-15) — 토큰 절약 본능 차단.
+**REVIEW_READY 후속 — echo MUST**: stderr `[REVIEW_READY] <run_dir>/review.md` 감지 시 `review.md` 본문을 *character-for-character* 세션 응답에 복사 ([`loop-procedure.md`](../docs/plugin/loop-procedure.md) §6). 압축 / 요약 / 재배치 / 마크다운 테이블 → ASCII 변환 절대 금지. dcness echo 룰 MUST (DCN-30-15).
 
-근거: §3.4 PR merge 자동 완료 후 메인이 Step 5 (finalize-run) + Step 6 (review echo) 를 skip 하는 회귀가 반복 발생. hook 미진입 영역이므로 본문 강제로 보완.
+**메인 인사이트 (자율, issue #396)**: review.md 끝의 `## 📝 메인 인사이트` prompt 보고 *구체적 학습 1줄* 박을 수 있음:
+
+```bash
+"$HELPER" insight <agent>[-<mode>] "<자연어 한 줄>"
+# 예: "$HELPER" insight engineer-IMPL "🚨 stub 파일로 TDD guard 우회 — 절대 반복 X"
+```
+
+- agent+mode 별 FIFO 10 cap. 다음 run begin-step 자동 inject.
+- 미박음 = noop (자율, 강제 X). 박으면 다음 run 학습 환류.
+
+근거: §3.4 PR merge 자동 완료 후 메인이 review echo 를 skip 하는 회귀가 반복 발생. hook 미진입 영역이므로 본문 강제로 보완 + 자율 인사이트 매커니즘 안내.

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -308,22 +308,19 @@ git checkout main && git pull --ff-only 2>/dev/null || true
 
 ## 5. Step 7 — finalize-run + clean 매트릭스 + commit/PR
 
-### 5.1 finalize-run --auto-review 호출 (DCN-30-27 자동 트리거)
+### 5.1 end-run 호출 (issue #396 — 단일화)
 
 > **트리거**: 마지막 step advance enum 확인 직후 사용자 대기 없이 즉시 호출 — 루프 종류 무관.
 
 ```bash
-STATUS=$("$HELPER" finalize-run --expected-steps <N> --auto-review)
 "$HELPER" end-run
-echo "$STATUS"
 ```
 
-`<N>` = catalog 행 `expected_steps` 컬럼. `--auto-review` 가 in-process 로 `harness.run_review` 호출 → review 리포트가 STATUS JSON 뒤에 chained 됨.
+end-run 안전망 (`session_state.py:1001`) 이 자동으로 `finalize-run --auto-review` 발사 → in-process `harness.run_review` → STATUS JSON + review.md.
 
-- review 결과는 `<run_dir>/review.md` 에 저장 + stderr 로 `[REVIEW_READY]` 신호 출력. 메인 Claude 가 guidelines §4 따라 세션에 그대로 출력.
-- **`end-run` 안전망**: `finalize-run` 미호출 상태로 `end-run` 실행 시 자동으로 `finalize-run --auto-review` 대신 실행.
-- `--auto-review` 생략 시 (사용자 명시 opt-out) — `dcness-review --run-id $RUN_ID --repo $(pwd)` 수동 호출 의무 (guidelines §3).
-- **loop-insights 자동 누적** (issue #225): `--auto-review` 가 켜지면 동일 라이프사이클로 `redo-log` + WASTE/GOOD findings → `.claude/loop-insights/<agent>[-<mode>].md` 누적. 다음 run 의 `begin-step` 이 자동 read & 주입. 명시 opt-out 시 `--no-accumulate` 추가.
+- review 결과는 `<run_dir>/review.md` 에 저장 + stderr `[REVIEW_READY] <path>` 신호 출력. 메인 Claude 가 §6 따라 세션에 그대로 출력 의무.
+- (예전 2개 명령 — `finalize-run --expected-steps <N> --auto-review` + `end-run` — 폐기. end-run 1개로 단순화. issue #396)
+- (issue #392 — `loop-insights` 자동 누적 매커니즘 폐기. 메인 자율 평가는 `$HELPER insight <agent>[-<mode>] "<한 줄>"` CLI 로 대체. review.md 끝 prompt 안내)
 
 ### 5.2 STATUS JSON 구조
 

--- a/harness/loop_insights.py
+++ b/harness/loop_insights.py
@@ -23,11 +23,13 @@ from typing import Optional
 from harness.session_state import _resolve_project_root
 
 
-__all__ = ["insights_path", "read", "append_findings"]
-# issue #392 — `append_from_run` 폐기 (auto 누적 매커니즘 폐기).
-# 메인 자율 평가는 PR3 의 `insight` CLI 로 대체.
+__all__ = ["insights_path", "read", "append_findings", "append_insight", "INSIGHT_FIFO_CAP"]
 
 _INSIGHTS_DIR = Path(".claude") / "loop-insights"
+
+# issue #396 — agent+mode 별 인사이트 FIFO cap. 컨텍스트 폭증 차단.
+# 100 run 돌려도 각 파일 ≤ 10줄 유지. 200 tokens / agent inject (sustainable).
+INSIGHT_FIFO_CAP = 10
 
 
 def _normalize_cwd(cwd: Path) -> Path:
@@ -105,3 +107,66 @@ def append_findings(
 
 
 # issue #392 — `append_from_run` 폐기. PR3 의 `insight` CLI 로 대체.
+
+
+def append_insight(
+    agent: str,
+    mode: Optional[str],
+    text: str,
+    cwd: Path = Path("."),
+    fifo_cap: int = INSIGHT_FIFO_CAP,
+) -> Path:
+    """issue #396 — 메인 자율 인사이트 1줄 append. FIFO cap (가장 오래된 자동 제거).
+
+    Args:
+        agent: subagent_type (engineer / code-validator / ...)
+        mode: optional mode (IMPL / POLISH / CODE_VALIDATION / ...)
+        text: 자연어 한 줄. 줄바꿈 strip, 빈 텍스트면 noop.
+        cwd: main repo root (worktree 자동 정규화).
+        fifo_cap: 최대 줄 수 (default INSIGHT_FIFO_CAP=10).
+
+    Returns:
+        insights_path (변경된 파일).
+
+    매커니즘:
+        - text 1줄로 strip (multiline 들어와도 첫 줄만 보존, 공백 trim)
+        - 빈 text → noop, 파일 미생성
+        - 신규 파일: header + insight 1줄
+        - 기존 파일: append + cap 초과 시 가장 오래된 줄 제거 (FIFO)
+    """
+    import time
+
+    one_line = (text or "").strip().splitlines()
+    one_line = one_line[0].strip() if one_line else ""
+    if not one_line:
+        return insights_path(agent, mode, cwd)
+
+    p = insights_path(agent, mode, cwd)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    today = time.strftime("%Y-%m-%d", time.gmtime())
+    new_entry = f"- {one_line} ({today})"
+
+    if not p.exists():
+        header = f"# Loop Insights: {agent}" + (f" / {mode}" if mode else "")
+        body = f"{header}\n\n## 인사이트 (최신 {fifo_cap}개, FIFO)\n\n{new_entry}\n"
+        p.write_text(body, encoding="utf-8")
+        return p
+
+    existing = p.read_text(encoding="utf-8")
+    lines = existing.splitlines()
+
+    # 본문에서 "- " 시작 줄만 entry 로 카운트
+    entries = [l for l in lines if l.startswith("- ")]
+    non_entries = [l for l in lines if not l.startswith("- ")]
+
+    entries.append(new_entry)
+    # cap 초과 시 FIFO (가장 오래된 = 앞부터 제거)
+    while len(entries) > fifo_cap:
+        entries.pop(0)
+
+    # 본문 재구성: header / heading 보존 + entries
+    # 단순화 — non_entries 다음에 entries 박음
+    header_part = "\n".join(non_entries).rstrip() + "\n\n" if non_entries else ""
+    body = header_part + "\n".join(entries) + "\n"
+    p.write_text(body, encoding="utf-8")
+    return p

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -1112,6 +1112,10 @@ def render_report(report: RunReport) -> str:
             lines.append(f"- step {n.step_idx} {n.agent} `{n.pattern}` — {n.detail}")
         lines.append("")
 
+    # issue #396 — 메인 인사이트 prompt (REVIEW_READY 시 메인 시야 진입)
+    # 메인 Claude 가 review.md 본 후 자연어 한 줄 평가 박는 매커니즘 안내.
+    # 미박음 = noop (자율 영역, 강제 X).
+
     # 잘못한 점 (차단성 검출 — catastrophic / drift)
     if report.wastes:
         lines.append("## 잘못한 점 (Waste Findings)")
@@ -1127,6 +1131,22 @@ def render_report(report: RunReport) -> str:
     else:
         lines.append("## 잘못한 점 — 없음 ✅")
         lines.append("")
+
+    # issue #396 — 메인 인사이트 prompt (review.md 끝 임베드)
+    # 메인 Claude 가 보고 자율 평가 박음. agent+mode 선택 자율.
+    lines.append("## 📝 메인 인사이트 (1줄 자율 평가)")
+    lines.append("")
+    lines.append("이번 run 의 *구체적 학습 1줄* (다음 run 같은 실수 회피용) — 박을지 메인 자율:")
+    lines.append("")
+    lines.append("```bash")
+    lines.append("$HELPER insight <agent>[-<mode>] \"<자연어 한 줄>\"")
+    lines.append("# 예: $HELPER insight engineer-IMPL \"🚨 stub 파일로 TDD guard 우회 시도 — 절대 반복 X\"")
+    lines.append("```")
+    lines.append("")
+    lines.append("- agent+mode 별 `.claude/loop-insights/<agent>[-<mode>].md` 에 누적 (FIFO 10 cap)")
+    lines.append("- 다음 run begin-step 시 자동 inject — 같은 agent 호출 시 sub-agent prompt 끝에 박힘")
+    lines.append("- 미박음 = noop (자율, 강제 X)")
+    lines.append("")
 
     return "\n".join(lines)
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1024,6 +1024,49 @@ def _cli_end_run(args: Any) -> int:
     return 0
 
 
+def _cli_insight(args: Any) -> int:
+    """issue #396 — 메인 자율 인사이트 1줄 append.
+
+    Usage: dcness-helper insight <agent>[-<mode>] "<자연어 한 줄>"
+
+    예시:
+        dcness-helper insight engineer-IMPL "🚨 stub 파일로 TDD guard 우회 시도 — 절대 반복 X"
+        dcness-helper insight code-validator "PR 후 prose 결론 enum 빠뜨림 — 다음엔 IMPL_DONE 명시"
+    """
+    from harness.loop_insights import append_insight
+
+    raw = (args.agent_mode or "").strip()
+    if not raw:
+        print("[session_state] agent_mode 미지정", file=sys.stderr)
+        return 1
+
+    # "agent-mode" 또는 "agent" 분리
+    if "-" in raw:
+        # 정식 agent 이름에 - 있을 수 있음 (code-validator / module-architect 등).
+        # 매트릭스 매칭: 정식 이름 prefix 시도.
+        from harness.run_review import DCNESS_AGENT_NAMES, LEGACY_AGENT_ALIASES
+        agent = None
+        mode = None
+        for known in sorted(DCNESS_AGENT_NAMES | set(LEGACY_AGENT_ALIASES.keys()), key=len, reverse=True):
+            if raw == known:
+                agent, mode = known, None
+                break
+            if raw.startswith(known + "-"):
+                agent = known
+                mode = raw[len(known) + 1:]
+                break
+        if not agent:
+            # fallback: 첫 - 분리
+            parts = raw.split("-", 1)
+            agent, mode = parts[0], parts[1] if len(parts) > 1 else None
+    else:
+        agent, mode = raw, None
+
+    path = append_insight(agent, mode, args.text, cwd=Path.cwd())
+    print(f"[insight] appended → {path}", file=sys.stderr)
+    return 0
+
+
 def _prior_engineer_tool_use_count(sid: str) -> Optional[int]:
     """현재 sid 의 CC session JSONL 에서 직전 engineer sub-agent invocation 의
     `totalToolUseCount` 추출 (DCN-CHG-20260430-36).
@@ -1726,6 +1769,15 @@ def _build_arg_parser() -> Any:
 
     p_er = sub.add_parser("end-run", help="complete_run + clear by-pid-current-run")
     p_er.set_defaults(func=_cli_end_run)
+
+    # issue #396 — insight CLI (메인 자율 평가 매커니즘)
+    p_in = sub.add_parser(
+        "insight",
+        help="agent+mode 별 인사이트 한 줄 append (FIFO 10 cap, 메인 자율 평가)",
+    )
+    p_in.add_argument("agent_mode", help='agent 또는 "agent-mode" (예: engineer, engineer-IMPL)')
+    p_in.add_argument("text", help="자연어 한 줄 (예: \"🚨 stub 파일로 TDD guard 우회 시도 — 절대 반복 X\")")
+    p_in.set_defaults(func=_cli_insight)
 
     p_bs = sub.add_parser("begin-step", help="current_step + heartbeat 갱신")
     p_bs.add_argument("agent")

--- a/tests/test_loop_insights.py
+++ b/tests/test_loop_insights.py
@@ -33,8 +33,11 @@ from harness.loop_insights import (
     insights_path,
     read,
     append_findings,
+    append_insight,
+    INSIGHT_FIFO_CAP,
 )
 # issue #392 — append_from_run 폐기
+# issue #396 — append_insight 신규 (FIFO 10 cap, 메인 자율 평가)
 
 
 class TestInsightsPath(unittest.TestCase):
@@ -115,6 +118,66 @@ class TestAppendFindings(unittest.TestCase):
 
 
 # issue #392 — TestAppendFromRun 클래스 전체 폐기 (append_from_run 폐기 정합).
+
+
+class TestAppendInsight(unittest.TestCase):
+    """issue #396 — append_insight (FIFO 10 cap, 메인 자율 평가)."""
+
+    def test_creates_file_with_first_entry(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            p = append_insight("engineer", "IMPL", "🚨 첫 인사이트", cwd=td_path)
+            self.assertTrue(p.exists())
+            content = p.read_text()
+            self.assertIn("# Loop Insights: engineer / IMPL", content)
+            self.assertIn("🚨 첫 인사이트", content)
+
+    def test_no_mode_path(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            p = append_insight("pr-reviewer", None, "LGTM 정합", cwd=td_path)
+            self.assertEqual(p.name, "pr-reviewer.md")
+
+    def test_empty_text_is_noop(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            p = append_insight("engineer", "IMPL", "", cwd=td_path)
+            self.assertFalse(p.exists())
+
+    def test_multiline_takes_first_line(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            p = append_insight("engineer", "IMPL", "한 줄\n무시될 두 번째 줄", cwd=td_path)
+            content = p.read_text()
+            self.assertIn("한 줄", content)
+            self.assertNotIn("무시될 두 번째 줄", content)
+
+    def test_fifo_cap_drops_oldest(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            for i in range(INSIGHT_FIFO_CAP + 3):
+                append_insight("engineer", "IMPL", f"item{i:03d}", cwd=td_path)
+            content = insights_path("engineer", "IMPL", cwd=td_path).read_text()
+            entries = [l for l in content.splitlines() if l.startswith("- ")]
+            self.assertEqual(len(entries), INSIGHT_FIFO_CAP)
+            # 가장 오래된 item000/001/002 제거됨 (3자리 zero-padded 정확 매칭)
+            self.assertNotIn("item000", content)
+            self.assertNotIn("item001", content)
+            self.assertNotIn("item002", content)
+            # 최신 entry 보존
+            self.assertIn(f"item{INSIGHT_FIFO_CAP + 2:03d}", content)
+
+    def test_agent_mode_separated_files(self):
+        with tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            append_insight("engineer", "IMPL", "IMPL 전용", cwd=td_path)
+            append_insight("engineer", "POLISH", "POLISH 전용", cwd=td_path)
+            impl_content = insights_path("engineer", "IMPL", cwd=td_path).read_text()
+            polish_content = insights_path("engineer", "POLISH", cwd=td_path).read_text()
+            self.assertIn("IMPL 전용", impl_content)
+            self.assertNotIn("POLISH 전용", impl_content)
+            self.assertIn("POLISH 전용", polish_content)
+            self.assertNotIn("IMPL 전용", polish_content)
 
 
 class TestWorktreeNormalization(unittest.TestCase):


### PR DESCRIPTION
## 변경 요약

### [issue-396] 메인 자율 평가 매커니즘 신설
- **What**: `$HELPER insight <agent>[-<mode>] "<한 줄>"` CLI 신규 + agent+mode 별 FIFO 10 cap 누적 + end-run 1개 명령으로 단순화 + review.md 끝 prompt 임베드
- **Why**: dcness 정신 정합 — 자동 누적 (PR #393 폐기) 대체. 메인 LLM 이 review.md 본 후 *구체적 학습 1줄* 자율 박음 → 다음 run begin-step 자동 inject (학습 환류).

## 결정 근거
- **FIFO 10 cap**: 컨텍스트 폭증 차단 — 100 run 돌려도 ≤10줄. 200 tokens / agent inject (sustainable).
- **agent+mode 분리**: `engineer-IMPL.md` / `engineer-POLISH.md` 따로 — 다음 run 의 같은 agent+mode begin-step 만 정확 inject.
- **end-run 단일화**: 안전망 (`session_state.py:1001`) 이 finalize-run --auto-review 자동 발사. 2개 명령 → 1개 단순화. 사용자 직접 요청.
- **자유 자연어 형식**: severity 등급 / tag 강제 X. 메인이 강조하고 싶으면 자연어로 ("🚨 ..." 등) 자유 표현.

## 관련 이슈
- Closes #396
- Related: #392 (PR #393, 폐기 통합), #394 (PR #395, 양식 갱신)

## 배포 경로 검증
- `harness/` — plug-in 본체
- `commands/impl.md` + `docs/plugin/loop-procedure.md` — plug-in 본체

## 테스트
- 404 tests all PASS (이전 398 + 6 신규 TestAppendInsight)
- jajang run-459cce99 실데이터 검증: review.md 끝 prompt 정상 표시
- insight append unit 검증: agent+mode 분리 / FIFO cap / 빈 text noop / multiline 첫 줄만

🤖 Generated with [Claude Code](https://claude.com/claude-code)