### PR TITLE
[issue-404] hook 정상 통과 시 suppressOutput: true — attachment 숨김 시도

### DIFF
--- a/hooks/catastrophic-gate.sh
+++ b/hooks/catastrophic-gate.sh
@@ -19,11 +19,20 @@ set -uo pipefail
 # plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응.
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
 
-# 활성화 게이트 — 미활성 프로젝트는 즉시 통과 (Agent 호출 차단 0).
-python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+# 활성화 게이트 — 미활성 프로젝트는 즉시 통과 + suppressOutput.
+if ! python3 -m harness.session_state is-active >/dev/null 2>&1; then
+  echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+  exit 0
+fi
 
 # bash 의 PPID = CC main process
 CC_PID=$PPID
 
 python3 -m harness.hooks pretooluse-agent --cc-pid "$CC_PID"
-exit $?
+RC=$?
+
+# #404 — 정상 통과 시 suppressOutput: true 박아 transcript attachment 숨김 시도.
+if [ "$RC" = "0" ]; then
+  echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+fi
+exit $RC

--- a/hooks/file-guard.sh
+++ b/hooks/file-guard.sh
@@ -23,11 +23,21 @@ set -uo pipefail
 # plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응.
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
 
-# 활성화 게이트 — 미활성 프로젝트는 즉시 통과.
-python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
+# 활성화 게이트 — 미활성 프로젝트는 즉시 통과 + suppressOutput.
+if ! python3 -m harness.session_state is-active >/dev/null 2>&1; then
+  echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+  exit 0
+fi
 
 # bash 의 PPID = CC main process
 CC_PID=$PPID
 
 python3 -m harness.hooks pretooluse-file-op --cc-pid "$CC_PID"
-exit $?
+RC=$?
+
+# #404 — 정상 통과 시 suppressOutput: true 박아 transcript attachment 숨김 시도.
+# CC 본체 알려진 버그 (anthropics/claude-code#34859) 회피 가설. 차단 path 는 기존 (stderr + exit 1) 유지.
+if [ "$RC" = "0" ]; then
+  echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+fi
+exit $RC

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -11,8 +11,14 @@
 
 set -u
 
+# #404 — 정상 통과 시 suppressOutput: true 박아 transcript attachment 숨김 시도.
+allow() {
+  echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+  exit 0
+}
+
 INPUT=$(cat)
-[ -z "$INPUT" ] && exit 0
+[ -z "$INPUT" ] && allow
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -47,31 +53,31 @@ for key in ("file_path", "path", "filename"):
 PY
 )
 
-[ -z "$FILE_PATH" ] && exit 0
+[ -z "$FILE_PATH" ] && allow
 
 # 자동 skip — test 파일 자체
 case "$FILE_PATH" in
-  *test*|*spec*|*.test.*|*.spec.*|*__tests__*) exit 0 ;;
+  *test*|*spec*|*.test.*|*.spec.*|*__tests__*) allow ;;
 esac
 
 # 자동 skip — 설정 / 비-코드 / 타입 / Next.js 특수
 case "$FILE_PATH" in
-  *.json|*.css|*.scss|*.md|*.yml|*.yaml|*.env*|*.config.*|*tailwind*|*postcss*|*next.config*|*tsconfig*) exit 0 ;;
-  */types/*|*/types.ts|*/types.d.ts|*.d.ts) exit 0 ;;
-  */layout.tsx|*/layout.ts|*/page.tsx|*/page.ts|*/loading.tsx|*/error.tsx|*/not-found.tsx|*/globals.css) exit 0 ;;
+  *.json|*.css|*.scss|*.md|*.yml|*.yaml|*.env*|*.config.*|*tailwind*|*postcss*|*next.config*|*tsconfig*) allow ;;
+  */types/*|*/types.ts|*/types.d.ts|*.d.ts) allow ;;
+  */layout.tsx|*/layout.ts|*/page.tsx|*/page.ts|*/loading.tsx|*/error.tsx|*/not-found.tsx|*/globals.css) allow ;;
 esac
 
 # 자동 skip — plug-in 시드 boilerplate / 디자인 시안 폴더
 # templates/ = dcness self repo 의 사용자 프로젝트 배포용 시드 (cp 후 활성화)
 # design-variants/ = 활성화 프로젝트의 디자인 시안 폴더 (UI prototype, production 테스트 의무 X)
 case "$FILE_PATH" in
-  */templates/*|*/design-variants/*) exit 0 ;;
+  */templates/*|*/design-variants/*) allow ;;
 esac
 
 # TS/JS 한정 — 그 외 silent skip
 case "$FILE_PATH" in
   *.ts|*.tsx|*.js|*.jsx) ;;
-  *) exit 0 ;;
+  *) allow ;;
 esac
 
 # 매칭 test 파일 존재 검사
@@ -108,4 +114,4 @@ if ! has_test_for "$FILE_PATH"; then
   exit 0
 fi
 
-exit 0
+allow


### PR DESCRIPTION
## Summary
Closes #404. CC 본체 알려진 버그 (anthropics/claude-code#34859, #34713) 회피 가설. 3 PreToolUse hook 정상 통과 path 에서 \`suppressOutput: true\` JSON emit — transcript attachment 숨김 시도.

## 배경

CC hook exit 0 + 빈 stdout 정석 따라도 transcript 에 \`Output truncated (0KB total)\` 165자 wrapper attachment 박힘. 그 attachment 가 메인 cache_read 누적의 leak source.

dcness 비활성 환경에서도 동일 패턴 = CC 본체 영역 = dcness matcher 좁히기 효과 0.

## 처방

CC 공식 docs:
- \`suppressOutput: false\` (기본값) — 훅 output transcript 표시
- \`suppressOutput: true\` — 훅 output 사용자에게 숨김

3 PreToolUse hook 정상 통과 path 에서 다음 JSON emit:

\`\`\`json
{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
\`\`\`

- \`catastrophic-gate.sh\` — 활성 게이트 통과 + harness exit 0 시
- \`file-guard.sh\` — 활성 게이트 통과 + harness exit 0 시
- \`tdd-guard.sh\` — 모든 skip path + has_test 통과 시

차단 path (deny / exit 1) 는 기존 동작 유지.

## 실증 필요

본 PR 머지 후 사용자 jajang 다음 /impl 1 회 → transcript jsonl 의 attachment 165자 wrapper 박혔는지 확인. 효과 0~큰 가능성 범위.

## 리스크

- JSON 박는 것 자체 무해
- 차단 path 미영향 (기존 동작 유지)
- 회귀 없음

## 정합

PR #401 (skill docs lazy) + #403 (SessionStart cost-aware) 누적 처방의 마지막 lever.

## Test plan

- [x] python3 -m unittest discover → 404/404 PASS
- [x] bash 문법 검사: 3 hook 모두 OK
- [x] hook 직접 호출 검증: tdd-guard 정상 통과 4 path 모두 suppressOutput JSON emit, deny path 기존 패턴 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)