### PR TITLE
[issue-408] _summarize_input cwd 기준 relative path 단축

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -58,6 +58,23 @@ __all__ = [
 _TRACE_INPUT_MAX = 200  # entry size cap (POSIX append atomic = 4096 bytes 이내)
 
 
+def _shorten_path(s: str) -> str:
+    """absolute path → cwd 기준 relative path. cwd 외부 또는 absolute 아니면 그대로.
+
+    #408 — PostToolUse:Agent histogram 본문 cache_read 감축.
+    예: '/Users/foo/proj/src/x.ts' (cwd='/Users/foo/proj') → 'src/x.ts'
+    """
+    if not s or not s.startswith("/"):
+        return s
+    try:
+        cwd_str = str(Path.cwd().resolve())
+        if s.startswith(cwd_str + "/"):
+            return s[len(cwd_str) + 1:]
+    except (OSError, ValueError):
+        pass
+    return s
+
+
 def _summarize_input(tool_name: str, tool_input: Dict[str, Any]) -> str:
     """tool_input 핵심을 _TRACE_INPUT_MAX bytes 이하로 요약."""
     if not isinstance(tool_input, dict):
@@ -65,7 +82,7 @@ def _summarize_input(tool_name: str, tool_input: Dict[str, Any]) -> str:
     if tool_name == "Bash":
         s = str(tool_input.get("command", ""))
     elif tool_name in ("Edit", "Write", "NotebookEdit", "Read"):
-        s = str(tool_input.get("file_path", "") or tool_input.get("path", ""))
+        s = _shorten_path(str(tool_input.get("file_path", "") or tool_input.get("path", "")))
     elif tool_name in ("Glob", "Grep"):
         s = str(tool_input.get("pattern", ""))
     else:

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1330,5 +1330,45 @@ class StopHookGuardTests(unittest.TestCase):
         self.assertEqual(rc, 0)
 
 
+# ---------------------------------------------------------------------------
+# _shorten_path / _summarize_input path 단축 — issue #408
+# ---------------------------------------------------------------------------
+
+
+class ShortenPathTests(unittest.TestCase):
+    """#408 — absolute path → cwd 기준 relative 단축."""
+
+    def test_cwd_path_shortened(self):
+        from harness.hooks import _shorten_path
+        cwd = str(Path.cwd().resolve())
+        self.assertEqual(_shorten_path(cwd + "/src/foo.ts"), "src/foo.ts")
+
+    def test_outside_cwd_preserved(self):
+        from harness.hooks import _shorten_path
+        self.assertEqual(_shorten_path("/tmp/outside.txt"), "/tmp/outside.txt")
+
+    def test_relative_path_preserved(self):
+        from harness.hooks import _shorten_path
+        self.assertEqual(_shorten_path("relative.ts"), "relative.ts")
+
+    def test_empty_preserved(self):
+        from harness.hooks import _shorten_path
+        self.assertEqual(_shorten_path(""), "")
+
+    def test_summarize_input_read_uses_shortened(self):
+        from harness.hooks import _summarize_input
+        cwd = str(Path.cwd().resolve())
+        result = _summarize_input("Read", {"file_path": cwd + "/harness/hooks.py"})
+        self.assertEqual(result, "harness/hooks.py")
+
+    def test_summarize_input_bash_not_shortened(self):
+        # Bash command 안 path 는 command 전체 의미라 단축 X
+        from harness.hooks import _summarize_input
+        cwd = str(Path.cwd().resolve())
+        result = _summarize_input("Bash", {"command": f"cat {cwd}/foo.ts"})
+        # command 그대로 — Bash 는 _shorten_path 미적용
+        self.assertIn(cwd, result)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Closes #408. PostToolUse:Agent histogram 본문의 \`같은 input 반복\` 영역 cache_read 감축.

이전:
\`\`\`
같은 input 반복: /Users/dc.kim/project/jajang/.claude/worktrees/impl-issue259/src/foo.ts ×3
\`\`\`

후:
\`\`\`
같은 input 반복: src/foo.ts ×3
\`\`\`

## 처방

- \`_shorten_path\` 함수 신규 — absolute path 가 cwd 안 이면 relative 로 단축
- \`_summarize_input\` Read/Edit/Write/NotebookEdit 의 file_path/path 영역만 적용
- Bash command 는 단축 X (command 전체 의미 보존)
- cwd 외부 path 는 그대로 (절대 path 보존)

## 효과

- ~6k chars / 세션 cache_read 감축 (~1.5k tok)
- 의미 손실 X — 상대 path 가 더 읽기 쉬움 (사용자 인지 향상)

## 정합

#400 + #402 + #404 (v0.2.19) 의 후속 마이크로 lever.

## Test plan

- [x] 6 신규 unit tests (\`tests.test_hooks.ShortenPathTests\`)
- [x] python3 -m unittest discover → 410/410 PASS
- [x] cwd 안 / cwd 외부 / 빈 path / 상대 path 4 분기 검증
- [x] Bash command 비단축 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)