### PR TITLE
[issue-415] _build_tool_histogram_table 마지막 step 누락 fix

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -999,17 +999,18 @@ def _build_tool_histogram_table(report: RunReport) -> list[str]:
     lines.append("|---|---|---|---|---|---|---|---|---|---|")
 
     for i, s in enumerate(report.steps):
-        # 현 step 종료 ts ~ 다음 step 시작 ts 사이의 pre entry 카운트
-        start_ts = s.ts
-        end_ts = report.steps[i + 1].ts if i + 1 < len(report.steps) else None
+        # #415 — step.ts = end-step 시각. sub-agent 도구 호출 ts < step.ts.
+        # 윈도우 = 이전 step end ~ 현재 step end (i=0 은 빈 string = 모두 포함).
+        start_ts = report.steps[i - 1].ts if i > 0 else ""
+        end_ts = s.ts
 
         from collections import Counter
         hist: Counter = Counter()
         for e in pre_entries:
             e_ts = e.get("ts", "")
-            if e_ts < start_ts:
+            if start_ts and e_ts <= start_ts:
                 continue
-            if end_ts and e_ts >= end_ts:
+            if e_ts > end_ts:
                 continue
             tool = e.get("tool", "?")
             hist[tool] += 1

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -843,5 +843,78 @@ class MissingConclusionEnumTests(unittest.TestCase):
         self.assertEqual(len(missing), 0)
 
 
+class ToolHistogramTableTests(unittest.TestCase):
+    """#415 — _build_tool_histogram_table step 윈도우 fix.
+
+    step.ts = end-step 시각. sub-agent 도구 호출 ts < step.ts.
+    윈도우 = 이전 step end ~ 현재 step end.
+    """
+
+    def _make_run_with_trace(self, td: Path, step_records: list[dict], trace_entries: list[dict]) -> Path:
+        sid = "00000000-0000-4000-8000-000000000415"
+        rid = "run-00000415"
+        rd = _make_run_dir(td, sid, rid, step_records)
+        # agent-trace.jsonl 추가
+        trace_path = rd / "agent-trace.jsonl"
+        with open(trace_path, "w", encoding="utf-8") as f:
+            for e in trace_entries:
+                f.write(json.dumps(e, ensure_ascii=False) + "\n")
+        return rd
+
+    def test_last_step_included(self):
+        """마지막 step 의 sub-agent trace 가 히스토그램에 포함된다."""
+        from harness.run_review import _build_tool_histogram_table
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            # step 2개 — 마지막은 pr-reviewer
+            rd = self._make_run_with_trace(tmp, [
+                {"ts": "2026-05-12T14:54:00+00:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "x"},
+                {"ts": "2026-05-12T14:59:00+00:00", "agent": "pr-reviewer", "mode": None,
+                 "enum": "LGTM", "must_fix": False, "prose_excerpt": "y"},
+            ], [
+                # engineer trace (step 0 윈도우 = ~ 14:54:00)
+                {"phase": "pre", "agent": "engineer", "ts": "2026-05-12T14:53:00+00:00", "tool": "Edit"},
+                {"phase": "pre", "agent": "engineer", "ts": "2026-05-12T14:53:30+00:00", "tool": "Edit"},
+                # pr-reviewer trace (step 1 윈도우 = 14:54:00 ~ 14:59:00)
+                {"phase": "pre", "agent": "pr-reviewer", "ts": "2026-05-12T14:57:00+00:00", "tool": "Read"},
+                {"phase": "pre", "agent": "pr-reviewer", "ts": "2026-05-12T14:58:00+00:00", "tool": "Read"},
+            ])
+            report = build_report(rd, tmp)
+            lines = _build_tool_histogram_table(report)
+            # 표 lines: header(2) + step0 + step1
+            self.assertGreater(len(lines), 2)
+            joined = "\n".join(lines)
+            # step 1 (pr-reviewer) 가 표에 포함 — last step 누락 회귀 차단
+            pr_line = [ln for ln in lines if "pr-reviewer" in ln]
+            self.assertEqual(len(pr_line), 1)
+            # Read 2 박힘
+            self.assertIn(" 2 ", pr_line[0])
+
+    def test_step_window_uses_previous_end_to_current_end(self):
+        """윈도우 = 이전 step.ts ~ 현재 step.ts. trace 가 정확히 배정."""
+        from harness.run_review import _build_tool_histogram_table
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = self._make_run_with_trace(tmp, [
+                {"ts": "2026-05-12T10:00:00+00:00", "agent": "test-engineer", "mode": None,
+                 "enum": "TESTS_WRITTEN", "must_fix": False, "prose_excerpt": "x"},
+                {"ts": "2026-05-12T10:10:00+00:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False, "prose_excerpt": "y"},
+            ], [
+                # test-engineer 영역 (~ 10:00:00 까지)
+                {"phase": "pre", "agent": "test-engineer", "ts": "2026-05-12T09:55:00+00:00", "tool": "Read"},
+                {"phase": "pre", "agent": "test-engineer", "ts": "2026-05-12T09:56:00+00:00", "tool": "Write"},
+                # engineer 영역 (10:00:00 ~ 10:10:00)
+                {"phase": "pre", "agent": "engineer", "ts": "2026-05-12T10:05:00+00:00", "tool": "Edit"},
+            ])
+            report = build_report(rd, tmp)
+            lines = _build_tool_histogram_table(report)
+            joined = "\n".join(lines)
+            # 두 step 모두 표에 박힘
+            self.assertIn("test-engineer", joined)
+            self.assertIn("engineer", joined)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
Closes #415. \`_build_tool_histogram_table\` 가 마지막 step 을 누락하던 버그 fix. step.ts = end-step 시각 이라는 사실에 맞춰 윈도우 방향 정정.

## 원인

\`step.ts\` = end-step 호출 시각인데 line 1003 이 begin-step 가정:
\`\`\`python
start_ts = s.ts
end_ts = report.steps[i + 1].ts if i + 1 < len(report.steps) else None
\`\`\`

마지막 step 만 \`end_ts = None\` 으로 노출 — 다른 step 은 다음 step end ts 까지 윈도우라 우연히 정합 (한 칸 밀려있었음).

## 처방

윈도우 = 이전 step end ~ 현재 step end:
\`\`\`python
start_ts = report.steps[i - 1].ts if i > 0 else ""
end_ts = s.ts
\`\`\`

## 실측 (jajang run-d20947f2 재분석)

| step | agent | 이전 | 이후 |
|---|---|---|---|
| 0 | test-engineer | Read 4 Edit 3 Bash 4 | **Read 21 Write 2 Edit 2 Bash 1 기타 1** |
| 1 | engineer | Read 7 | **Read 4 Edit 3 Bash 4** |
| 2 | code-validator | Read 10 | **Read 7** |
| 3 | pr-reviewer | **누락** | **Read 10** ✅ |

이전엔 trace 가 한 칸 밀려있었음.

## Test plan

- [x] 2 신규 unit tests (\`ToolHistogramTableTests\`)
- [x] python3 -m unittest discover → 412/412 PASS
- [x] jajang run-d20947f2 helper 재호출 검증 — step 0~3 모두 박힘

🤖 Generated with [Claude Code](https://claude.com/claude-code)