### PR TITLE
[docs] release 0.2.21 — 통합 브랜치 패턴 지원

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론 + 메타 LLM 해석 + 함정 회피 5원칙. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.2.17"
+    "version": "0.2.21"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "description": "Lightweight harness — status-JSON-mutate determinism + 4-pillar fitness (CLAUDE.md / CI gates / tool boundaries / feedback loops). parse_marker ladder eliminated.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,60 @@
 
 ---
 
+## v0.2.21 (2026-05-13)
+
+**커밋 범위**: `v0.2.20..v0.2.21`
+**핵심 변경**: 통합 브랜치 패턴 지원 — git-naming + product-plan + scripts auto-detect (#413 + #414)
+
+### 1. git-naming regex 완화 (#413)
+
+`scripts/check_git_naming.mjs`:
+- BRANCH_RE 에 `feature/<desc>` 패턴 추가 (자유 feature / 통합 브랜치 — 예: `feature/local_dsp`)
+- 4 패턴 통일 기본 제약: 소문자 + `[a-z0-9_-]` + 최소 3자
+- TITLE_RE 에 `[epic{N}]` (epic-only, 통합 → main 머지) + `[feature]` (자유 feature) 추가
+
+`docs/plugin/git-naming-spec.md` §1 / §2 / §4 / §6 표 갱신 + base 분기 룰 명시.
+
+배경: jajang Epic 19 (#262) 통합 브랜치 `feature/local-dsp` push 시 hook 차단 → `--no-verify` 우회. 본 release 로 차단 해소.
+
+### 2. 통합 브랜치 모드 (`commands/product-plan.md`) (#414 problem A)
+
+- §Step 6.5 신설 — 메인 → 사용자 그릴 (a) 일반 / (b) 통합 브랜치
+- §Step 7 (a) trunk / (b) integration 분기
+- (b) 흐름: `stories.md` 상단 `**Base Branch:** feature/<slug>` 마커 + 통합 브랜치 생성 + PRD sub-PR (`docs/<slug>_prd` from `feature/<slug>`)
+
+mode 코드 분기 도입 X — 자연어 마커만으로 분기 (메인 Claude 의 stories.md grep 인식).
+
+### 3. scripts/create_epic_story_issues.sh 헤더 양식 auto-detect + 마커 미러링 (#414 problem B)
+
+- 헤더 양식 auto-detect: `## Epic — ...` (h2+h3, product-plan 양식) / `# Epic NN — ...` (h1+h2, jajang 양식)
+- `**Base Branch:**` 마커 자동 epic issue body 미러링
+
+배경: jajang stories.md (h1+h2) parse 실패 → 메인이 4 직접 호출로 우회. 본 release 로 양식 통일 흡수.
+
+### 4. commands × 3 base 분기 체크리스트
+
+`commands/impl.md` / `commands/impl-loop.md` / `commands/architect-loop.md` 의 PR 생성 직전 절차에 stories.md `**Base Branch:**` grep → `--base` 박는 룰 1줄 추가.
+
+### 5. docs/plugin/issue-lifecycle.md §1.4 명문화
+
+통합 브랜치 케이스 — base ≠ main sub-PR 의 GitHub auto-close 한계 + 마지막 통합 → main 머지 PR body 에 bulk close (`Closes #<story1...N>` + `Closes #<epic>`) 패턴 명문화. GitHub default branch 제약 (linking-a-pull-request-to-an-issue) 인용.
+
+### 사용자 업데이트 가이드
+
+```sh
+claude plugin update dcness@dcness
+```
+
+문제 발생 시:
+```sh
+claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness
+```
+
+업데이트 후 `feature/<desc>` 같은 자유 슬러그 브랜치명 + `[feature] / [epic{N}]` PR 제목 형식이 즉시 통과한다.
+
+---
+
 ## v0.2.20 (2026-05-13)
 
 **커밋 범위**: `v0.2.19..v0.2.20`


### PR DESCRIPTION
## 변경 요약

### [docs] release 0.2.21 — 통합 브랜치 패턴 지원
- **What**: `.claude-plugin/plugin.json` 0.2.20 → 0.2.21 + `marketplace.json` 0.2.17 → 0.2.21 + release-notes.md v0.2.21 섹션 추가.
- **Why**: 선행 PR #417 (이미 머지) 본체를 사용자 cache 에 도달시키기 위한 version bump.

## 결정 근거

- 본 release 자체엔 코드 변경 X — version bump + release notes 만.
- `marketplace.json` 의 metadata.version 이 0.2.17 까지만 올라가있던 drift 도 정정 (0.2.18~0.2.20 release 들이 marketplace.json 안 올린 흔적).

## 관련 이슈

Closes #413
Closes #414

> 본 release 의 #413 / #414 close 는 *cache 도달 보장* 의미. 실제 변경은 선행 PR #417 에 박혀있고 이미 머지됨.

## 참고

- 사용자 업데이트: `claude plugin update dcness@dcness`
- 문제 시: `claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness`
- 업데이트 후 새 BRANCH_RE / TITLE_RE 즉시 적용 — `feature/<desc>` 자유 슬러그 + `[feature] / [epic{N}]` 형식 통과.