### PR TITLE
[issue-419] cc-pre-commit.sh — git-naming script resolve 우선순위 뒤집기

### DIFF
--- a/scripts/hooks/cc-pre-commit.sh
+++ b/scripts/hooks/cc-pre-commit.sh
@@ -27,6 +27,14 @@ else
 fi
 
 resolve_naming_script() {
+  # 우선순위 (이슈 #419):
+  # 1. git toplevel 의 scripts — 본 저장소 안 작업 시 항상 본 저장소의 최신 룰 우선.
+  #    cc-pre-commit.sh 는 .claude/settings.json 통해 dcness self 작업용으로 등록되므로
+  #    plug-in cache 의 구 룰이 자기 저장소를 검증하던 회귀 차단.
+  # 2. CLAUDE_PLUGIN_ROOT — 외부 활성 프로젝트가 본 hook 를 별도로 등록한 경우 대비 (현재 미사용).
+  # 3. plug-in cache — 위 둘 다 부재 시 최후 fallback.
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null || echo "${CLAUDE_PROJECT_DIR:-}")/scripts/check_git_naming.mjs"
+  [ -f "$legacy" ] && echo "$legacy" && return 0
   if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs" ]; then
     echo "${CLAUDE_PLUGIN_ROOT}/scripts/check_git_naming.mjs"; return 0
   fi
@@ -37,8 +45,6 @@ resolve_naming_script() {
       echo "$cache_dir/$latest/scripts/check_git_naming.mjs"; return 0
     fi
   fi
-  legacy="$(git rev-parse --show-toplevel 2>/dev/null || echo "${CLAUDE_PROJECT_DIR:-}")/scripts/check_git_naming.mjs"
-  [ -f "$legacy" ] && echo "$legacy" && return 0
   return 1
 }
 


### PR DESCRIPTION
## 변경 요약

### [issue-419] cc-pre-commit.sh — git-naming script resolve 우선순위 뒤집기
- **What**: `scripts/hooks/cc-pre-commit.sh` 의 `resolve_naming_script()` 우선순위를 git toplevel (legacy) 1순위, `CLAUDE_PLUGIN_ROOT` 2순위, plug-in cache 3순위 순으로 뒤집음.
- **Why**: cc-pre-commit.sh 는 `.claude/settings.json` 통해 dcness 본 저장소 작업용으로만 등록되는데, resolve 우선순위가 잘못돼서 plug-in 캐시의 *구* git-naming script 로 본 저장소를 검증하던 회귀. dcness self 가 자기 저장소의 최신 룰을 못 읽는 모순 상태.

## 결정 근거

- 1차 분석에선 "whitelist gate 부재" 로 진단 → cc-pre-commit.sh 발화 자체를 dcness self 에서 차단하려 함. 그러나 본 hook 의 3 기능 (main 직접 commit 차단 / pytest 게이트 / git-naming 검증) 은 dcness self 에도 *적용되어야 정합* (CLAUDE.md §1 + §3). whitelist 차단은 보호 기능까지 cancel 시켜 부적합.
- 진짜 원인 = git-naming script *resolve 순서*. cache 우선이면 본 저장소의 최신 룰이 항상 가려짐. legacy (git toplevel) 우선이면 dcness self 가 자기 룰을 즉시 적용.
- 외부 활성 프로젝트는 본 hook 미적용 (cc-pre-commit.sh 가 plug-in 본체 `hooks/hooks.json` 에 등록 0건). 따라서 우선순위 뒤집기의 영향 범위 = dcness self 만.

## 관련 이슈

Closes #419

## 배포 경로 검증

- `scripts/hooks/cc-pre-commit.sh` = 카테고리 1 (plug-in 본체 자동 적용) 같은 위치지만, 본 hook 는 *외부 활성 프로젝트엔 미적용* (settings.json 등록 없음). 따라서 본 변경의 사용자 도달 = **0** — dcness self 작업자만 영향.
- 별도 배포 단계 불필요.

## Test Plan

- [x] dcness self, `feature/{desc}` 자유 패턴 통과 — `feature/framing_guard` PASS 확인
- [x] dcness self, `fix/issue{N}_{desc}` 단일 이슈 패턴 통과 — `fix/issue419_hook_resolve_order` PASS 확인
- [x] dcness self, 잘못된 브랜치명 거부 — `BadName` FAIL 확인
- [x] CI plugin-manifest / PR body / git-naming-validation 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)