### PR TITLE
[issue-422] impl_loop_headless 자식 conveyor cycle 명시 + false-clean 강등

### DIFF
--- a/scripts/impl_loop_headless.py
+++ b/scripts/impl_loop_headless.py
@@ -140,13 +140,38 @@ def build_command(task_path: str, issue_nums: dict,
         "마지막 줄: `ESCALATE: <이유>`\n"
     )
 
-    # [E] 본 task 명령
+    # [E] 본 task 명령 — 명시 conveyor cycle + enum 의무 강화 (#422)
+    task_num = issue_nums.get("task")
+    issue_arg = f" --issue-num {task_num}" if task_num else ""
+    helper_resolve = (
+        'HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} '
+        '2>/dev/null | sort -V | tail -1)/scripts/dcness-helper"'
+    )
     parts.append(
         "## [E] 작업 시작\n\n"
         "위 [A]~[D] 룰 따라 본 task 구현 시작. "
         "dcness skill `/impl` 본문 의무 (sub-agent 호출 시퀀스 / 워크트리 / Pre-flight gate / "
         "impl 파일 사전 read) 도 함께 따름. 현행 dcness 룰은 cwd CLAUDE.md + plug-in "
-        "SessionStart hook 자동 inject 된 system-reminder 참조.\n"
+        "SessionStart hook 자동 inject 된 system-reminder 참조.\n\n"
+        "### MUST — conveyor cycle 명시 호출 (silent-fail 회피, #422)\n\n"
+        "헤드리스 자식 세션이 `/impl` chain 을 자율 따라가다 begin-run / begin-step / end-step / "
+        "end-run 호출을 빠뜨리면 `.steps.jsonl` 미작성 → 사후 분석 불가 + Stop hook 선행 조건 "
+        "(active_runs 슬롯 + end-step 매칭) 미충족 → noop → 외부 헤드리스 parent 가 "
+        "silent-fail 감지 불가. 따라서 다음 4 호출 **명시 의무**:\n\n"
+        "```bash\n"
+        f"{helper_resolve}\n"
+        f'RUN_ID=$("$HELPER" begin-run impl{issue_arg})\n'
+        "# 각 sub-agent 호출 직전:  \"$HELPER\" begin-step <agent> [<MODE>]\n"
+        "# 각 sub-agent 호출 직후:  \"$HELPER\" end-step <agent> [<MODE>]\n"
+        "# PR merge 직후:           \"$HELPER\" end-run\n"
+        "```\n\n"
+        "agent 인자 예시: `test-engineer` / `engineer IMPL` / `code-validator` / `pr-reviewer` "
+        "(기본 시퀀스 — `commands/impl.md` 참조).\n\n"
+        "### MUST — 종료 prose enum 박음 (false-clean 회피, #422)\n\n"
+        "위 [D] 룰 재강조 — enum 누락 + exit 0 = 헤드리스 parent 의 fallback 분기가 "
+        "**잘못 clean 판정** → 다음 task silent 진행 → 사용자 개입 시점 놓침. "
+        "사용자 위임 / 결정 불가 / 측정 환경 부재 시 반드시 마지막 줄 `ESCALATE: <위임 내용>` "
+        "박을 것.\n"
     )
 
     return "\n".join(parts)
@@ -239,14 +264,41 @@ def process_task(task_path: str, cwd: str, retry_limit: int,
         if enum in escalate_signals:
             return {"enum": "blocked", "message": message, "stdout": stdout}
 
-        # clean — 이슈 close 2차 confirm
+        # clean — 이슈 close 2차 confirm (#422 강화: WARN → blocked 강등)
         if enum == "clean":
-            closed = confirm_issue_closed(issue_nums["task"])
-            if closed is False:
-                print(
-                    f"[task] WARN: prose PASS 인데 이슈 #{issue_nums['task']} 미 close",
-                    file=sys.stderr,
-                )
+            task_issue = issue_nums.get("task")
+            if task_issue is not None:
+                closed = confirm_issue_closed(task_issue)
+                if closed is False:
+                    # PASS prose / exit 0 fallback 인데 이슈 미 close = false-clean.
+                    # 사용자 위임 prose + enum 누락 + 미머지 (#422 NS2 케이스) 잡힘.
+                    return {
+                        "enum": "blocked",
+                        "message": (
+                            f"prose PASS / exit 0 인데 이슈 #{task_issue} 미 close — "
+                            f"false-clean 의심 (자식이 enum 누락 + PR 미머지 상태로 종료 가능성)"
+                        ),
+                        "stdout": stdout,
+                    }
+            else:
+                # 이슈 번호 부재 → cwd uncommitted files 로 fallback 검사.
+                # cwd 자체에 잔존하는 케이스만 잡힘 (worktree 안 잔존은 미검출 — 한계).
+                try:
+                    res = subprocess.run(
+                        ["git", "status", "--porcelain"],
+                        cwd=cwd, capture_output=True, text=True, timeout=10,
+                    )
+                    if res.stdout.strip():
+                        return {
+                            "enum": "blocked",
+                            "message": (
+                                "prose PASS / exit 0 인데 cwd uncommitted files 잔존 — "
+                                "false-clean 의심"
+                            ),
+                            "stdout": stdout,
+                        }
+                except Exception:
+                    pass
             return {"enum": "clean", "message": message, "stdout": stdout}
 
         # error — retry

--- a/tests/test_impl_loop_headless.py
+++ b/tests/test_impl_loop_headless.py
@@ -51,6 +51,26 @@ class BuildCommandTests(unittest.TestCase):
         self.assertIn("ESCALATE:", prompt)
         self.assertIn("## [E] 작업 시작", prompt)
 
+    def test_e_section_includes_conveyor_cycle_commands(self):
+        """#422: [E] 가 begin-run / begin-step / end-step / end-run 명시 호출 박음."""
+        prompt = ilh.build_command(
+            str(self._impl_path),
+            issue_nums={"epic": None, "story": None, "task": 102},
+        )
+        self.assertIn("begin-run impl --issue-num 102", prompt)
+        self.assertIn("begin-step <agent>", prompt)
+        self.assertIn("end-step <agent>", prompt)
+        self.assertIn("end-run", prompt)
+
+    def test_e_section_conveyor_without_issue_num(self):
+        """#422: task 이슈 번호 부재 시 begin-run impl (--issue-num 없음)."""
+        prompt = ilh.build_command(
+            str(self._impl_path),
+            issue_nums={"epic": None, "story": None, "task": None},
+        )
+        self.assertIn('"$HELPER" begin-run impl)', prompt)
+        self.assertNotIn("begin-run impl --issue-num", prompt)
+
     def test_no_issue_nums(self):
         prompt = ilh.build_command(
             str(self._impl_path),
@@ -198,6 +218,127 @@ class EscalateSetTests(unittest.TestCase):
                 )
                 self.assertEqual(r["enum"], "error")
                 self.assertIn("retry 한도", r["message"])
+
+
+class FalseCleanDowngradeTests(unittest.TestCase):
+    """process_task — #422 false-clean 강등 검증."""
+
+    def test_pass_prose_but_issue_open_downgrades_to_blocked(self):
+        """PASS prose + task 이슈 OPEN → clean 아닌 blocked 강등."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text(
+                "# 01-foo\n\n**GitHub Issue:** [#999]\n", encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(0, "...\nPASS: 머지 완료\n", ""),
+            ), mock.patch.object(
+                ilh, "confirm_issue_closed", return_value=False,
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "blocked")
+                self.assertIn("false-clean", r["message"])
+                self.assertIn("#999", r["message"])
+
+    def test_exit_zero_fallback_with_open_issue_downgrades(self):
+        """enum 누락 + exit 0 fallback clean + 이슈 OPEN → blocked 강등 (NS2 케이스)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text(
+                "# 01-foo\n\n**GitHub Issue:** [#888]\n", encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(0, "사용자에게 위임합니다 enum 없음\n", ""),
+            ), mock.patch.object(
+                ilh, "confirm_issue_closed", return_value=False,
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "blocked")
+                self.assertIn("#888", r["message"])
+
+    def test_pass_with_closed_issue_stays_clean(self):
+        """PASS prose + task 이슈 CLOSED → 정상 clean (회귀 방지)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text(
+                "# 01-foo\n\n**GitHub Issue:** [#777]\n", encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(0, "PASS: 정상 머지\n", ""),
+            ), mock.patch.object(
+                ilh, "confirm_issue_closed", return_value=True,
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "clean")
+
+    def test_no_issue_num_with_uncommitted_files_downgrades(self):
+        """task 이슈 번호 부재 + cwd uncommitted files → blocked 강등."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text("# 01-foo\n\nno issue ref\n", encoding="utf-8")
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(0, "PASS: 완료\n", ""),
+            ), mock.patch.object(
+                ilh.subprocess, "run",
+                return_value=mock.Mock(stdout=" M some_file.py\n"),
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "blocked")
+                self.assertIn("uncommitted", r["message"])
+
+    def test_no_issue_num_clean_cwd_stays_clean(self):
+        """task 이슈 번호 부재 + cwd clean → 정상 clean (회귀 방지)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text("# 01-foo\n\nno issue ref\n", encoding="utf-8")
+
+            with mock.patch.object(
+                ilh, "spawn_child",
+                return_value=(0, "PASS: 완료\n", ""),
+            ), mock.patch.object(
+                ilh.subprocess, "run",
+                return_value=mock.Mock(stdout=""),
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "clean")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 변경 요약

### [issue-422] impl_loop_headless 자식 conveyor cycle 명시 + false-clean 강등

- **What**:
  - `scripts/impl_loop_headless.py` `build_command()` `[E]` 단락에 명시 conveyor cycle 4 호출 (begin-run impl / begin-step / end-step / end-run) + enum 누락 시 false-clean 위험 경고 추가
  - `process_task()`: `confirm_issue_closed is False` 시 WARN 만 하던 것을 `blocked` 강등으로 격상
  - 이슈 번호 부재 시 cwd `git status --porcelain` fallback 검사 추가 (잔존 시 blocked 강등)
  - 테스트 6개 추가 (E 단락 conveyor / false-clean downgrade / 회귀 가드)
- **Why**:
  - 자식 `claude -p` 세션이 `/impl` chain 위임을 자율적으로 안 따라가면 `.steps.jsonl` 미작성 → 사후 분석 불가 + Stop hook noop
  - `parse_result()` exit 0 fallback 이 enum 누락 시 clean 판정 → 자식이 사용자 위임 prose 박고 PR 미머지 상태로 exit 0 종료 시 `ALL CLEAN` 잘못 보고
  - 실측 evidence: jajang Epic 19 Story 1 (2026-05-13) NS2 자식 사단

## 결정 근거

- 이슈 본문의 Fix A 제안 (`begin-run impl-loop`) → `impl` 로 정정. 각 자식 = 1 task = `/impl` 1 사이클이지 outer loop conveyor 가 아님.
- 이슈 본문의 Fix B 제안 (`gh pr list --head <task-branch>` cross-check) → branch 명을 parent 가 보유 X 라서 실현 불가. 대신 이미 존재하는 `confirm_issue_closed` 신호를 격상하는 게 1줄짜리 더 가성비 높음.
- worktree 안 잔존 파일은 본 fix 로 미검출 (한계 명시). cwd 자체 잔존만 잡힘.

## 관련 이슈

Closes #422

## 참고

- `commands/impl.md` §종료 조건 — end-run 의무 (line 102-106) 정합
- `docs/plugin/loop-procedure.md` §1.2 begin-run + §3.1 begin-step/end-step 시퀀스 정합
- `hooks/stop-end-run.sh` — `active_runs 슬롯 + end-step 완료 매칭` 선행 조건. 본 fix 가 자식 prompt 강제로 이 선행 조건 충족 보장

🤖 Generated with [Claude Code](https://claude.com/claude-code)