### PR TITLE
[feature] 헤드리스 자식 슬래시 직호출 + impl 형제 PR 환기 + 단발 헤드리스 옵션

### DIFF
--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -35,7 +35,7 @@ git log --oneline --grep "$TASK_SLUG" | head -5
 tail -50 "<task-path>"
 ```
 
-이미 머지됨 발견 시 → 해당 task skip + 다음 task 진입. 부분 진행 + tail section 후속 결정 → 자식 세션 [A] 명령문에 inject + 정상 진입.
+이미 머지됨 발견 시 → 해당 task skip + 다음 task 진입. 부분 진행 + tail section 후속 결정 → 자식 세션이 `/dcness:impl <path>` 슬래시 직호출 받으면 `commands/impl.md` §진입 직전 task 진행 상태 1회 확인 룰 따라 자체 inject + 정상 진입.
 
 ## 절차 — 헤드리스 spawn
 
@@ -53,12 +53,14 @@ python3 "$PLUGIN_ROOT/scripts/impl_loop_headless.py" '<impl-glob>' \
    - cwd `CLAUDE.md` auto-load (system-reminder `claudeMd` 섹션)
    - plug-in `SessionStart` hook 자동 inject (dcness 운영 룰 + `[dcness 활성 확인]` 토큰)
    - dcness skill 10개 자동 등록 (자식이 `/impl` 본문 의무 따름)
-4. **명령문 첫머리 inline** ([A]~[E] 5 묶음):
-   - [A] 이번 task impl 본문 전문
-   - [B] 부모 epic / story / task GitHub 이슈 번호 + `gh issue view` read 명령
-   - [C] `docs/architecture.md` + `docs/adr.md` 다시 read 강조
-   - [D] 종료 신호 규칙 (`PASS:` / `FAIL:` / `ESCALATE:`)
-   - [E] 본 task 명령
+4. **자식 prompt = 슬래시 직호출** (#422 follow-up — chain 깊이 0):
+   - 자식이 받는 user message = `/dcness:impl <task-path>` 1줄
+   - CC 가 슬래시 파싱 → `commands/impl.md` 본문이 자식 system-reminder 에 자동 inject
+   - 사전 read 의무 (architecture.md / adr.md / prd.md / 의존 task PR / 형제 story PR) /
+     conveyor cycle (begin-run / begin-step / end-step / end-run) / enum 규칙
+     모두 자식 instruction 으로 1st-class 도달
+   - retry 시 `--append-system-prompt` 로 이전 에러 컨텍스트만 추가
+   - 옛 [A]~[E] 5 묶음 자연어 본문 폐기 — 중복 + chain 3 단계 누락 위험
 5. **결과 회수 3 layer**:
    - 1차 stdout 마지막 prose enum (PASS / FAIL / ESCALATE)
    - 2차 자식 종료 코드 (0 = clean / !=0 = error)
@@ -92,7 +94,7 @@ python3 "$PLUGIN_ROOT/scripts/impl_loop_headless.py" '<impl-glob>' \
 - 매치 → `gh pr create --base <매치 값>` (통합 브랜치 케이스)
 - 매치 없음 → `gh pr create --base main` (default, trunk-based)
 
-명령문 [A] 묶음 (이번 task impl 본문 전문) 에 자식 세션이 [`commands/impl.md`](impl.md) §"PR 생성 직전 — base 분기 체크" 본문을 따르도록 안내. 메인 outer 단계는 base 분기 결정 X — 자식 세션의 자율 영역.
+슬래시 직호출 시 자식이 [`commands/impl.md`](impl.md) §"PR 생성 직전 — base 분기 체크" 본문을 자동 instruction 으로 받음. 메인 outer 단계는 base 분기 결정 X — 자식 세션의 자율 영역.
 
 ## 후속 라우팅
 - 각 task clean → 다음 task 자동 진입

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -35,6 +35,19 @@ UI 디자인 mid-loop 필요 시 → `impl-ui-design-loop` (orchestration §4.4)
 ## 워크트리 (기본 켜짐)
 Step 0 진입 시 자동 `EnterWorktree(name="impl-{ts_short}")`. 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시에만 건너뜀. 자세히 = [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.
 
+## 헤드리스 실행 옵션 (단발 task, #422)
+
+사용자 발화에 정규식 `헤드리스|headless` 매치 시 메인 Claude 가 본 skill 본문 직접 진행 대신 **헤드리스 자식 세션** 으로 위임. 메인 컨텍스트 누적 회피 + 단발 task 도 `/run-review` 사후 분석 자연 분리.
+
+```bash
+PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
+python3 "$PLUGIN_ROOT/scripts/impl_loop_headless.py" '<task-path>'
+```
+
+스크립트가 1 task glob 도 처리 — task 1개도 자식 세션 cold start 로 처리하고 결과만 메인에 회수. 메인은 결과 회수 + 사용자 보고만. 자세히 = [`commands/impl-loop.md`](impl-loop.md) §절차.
+
+trade-off: 매 task 30~120s cold start latency 추가. 컨텍스트 누적 보호 + 사후 분석 자연 분리 가치와 trade-off.
+
 ## Pre-flight gate (Step 0 직후)
 [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) §6 매치 강제 — 부모 epic stories.md 상단 `**GitHub Epic Issue:** [#\d+]` 또는 `미등록 (사유: …)` 매치 0건 시 즉시 STOP + 사용자 보고. silent skip 금지.
 
@@ -60,6 +73,7 @@ gh issue view <task-num> | head -80
 2. `docs/adr.md` — 핵심 설계 결정 (부재 시 silent skip)
 3. `docs/prd.md` — 비즈니스 요구사항
 4. (의존 task 있을 시) 이전 step 머지 PR — impl 파일의 *의존 task slug* 따라 `gh pr list --search "<slug>" --state merged --json url --jq '.[0].url'` 호출 후 read
+5. (같은 epic 내) 이전 머지된 형제 story / task PR 환기 — `gh pr list --search "[epic<N>]" --state merged --limit 10 --json title,url` 로 본 task 보다 앞선 머지 항목 본문 1회 훑음. 형제 PR 의 *후속 결정 사항* (옵션 채택 / 인터페이스 변경 / 시드 데이터 등) 이 본 task 영향 미칠 수 있음. 부재 / 첫 task 시 silent skip.
 
 → agent prompt 에 impl 파일 경로 박으면 agent 가 자체 read. *메인 Claude 가 사전 inject* 불필요 (impl 파일 안 진입 prompt 가 강제).
 

--- a/scripts/impl_loop_headless.py
+++ b/scripts/impl_loop_headless.py
@@ -7,19 +7,24 @@ Usage:
 
 예시:
     python3 scripts/impl_loop_headless.py 'docs/milestones/v1/epics/epic-01-*/impl/*.md'
+    python3 scripts/impl_loop_headless.py 'docs/.../impl/01-foo.md'  # 단발 task 동일 처리
 
 동작:
 - glob 매치 파일 정렬 (prefix NN- 기준)
 - 각 파일마다 claude -p cold start spawn (cwd = 현 outer worktree)
-- 명령문 [A]~[E] 조립 + 자식 세션이 dcness skill 자동 등록 (plug-in SessionStart hook)
+- 자식 prompt = `/dcness:impl <task-path>` 슬래시 직호출 (chain 깊이 0)
+  → 자식 CC 가 슬래시 파싱 후 commands/impl.md 본문을 system-reminder 로 자동 inject
+  → 사전 read 의무 / conveyor cycle / enum 룰 등 정식 instruction 으로 자식에 도달
+- retry 시 `--append-system-prompt` 로 이전 에러 컨텍스트 inject
 - 종료 후 결과 회수 3 layer:
-  - 1차 stdout 마지막 prose enum (PASS / FAIL / ESCALATE)
+  - 1차 stdout 마지막 enum (PASS / FAIL / ESCALATE)
   - 2차 자식 종료 코드 (0 = clean / !=0 = error)
-  - 3차 GitHub 이슈 close 확인 (gh issue view <num>)
+  - 3차 GitHub 이슈 close 확인 (gh issue view <num>) — false-clean 안전망
 - error → 자동 retry (한도)
 - blocked → 즉시 정지 (사용자 개입 필수)
 
-설계: docs/plugin/orchestration.md §4.9 (chain 정책) + #375 그릴 D 가지 종합.
+설계: #422 = 자식 conveyor cycle 누락 + false-clean → 안전망 추가 + 슬래시 직호출
+리팩토링으로 chain 깊이 0 단축. #375 그릴 D 가지 종합 후속.
 
 본 스크립트는 외부 dcness 활성 프로젝트의 outer worktree cwd 에서 호출. dcness self §0.2
 적용 외 — 자기 자신 미적용.
@@ -82,99 +87,34 @@ def extract_issue_nums(task_path: str) -> dict:
     return nums
 
 
-def build_command(task_path: str, issue_nums: dict,
-                  retry_attempt: int = 0, prev_error: str = None) -> str:
-    """명령문 첫머리 [A]~[E] 5 묶음 조립.
+def build_invocation(task_path: str,
+                     retry_attempt: int = 0,
+                     prev_error: str = None) -> tuple:
+    """슬래시 직호출 invocation 조립 (#425 follow-up — chain 깊이 0).
 
-    Skip: CLAUDE.md (cwd auto-load) + dcness 운영 룰 (plug-in SessionStart hook).
-    Inline: 본 함수 출력.
+    반환: (extra_cli_args, user_prompt)
+    - user_prompt = `/dcness:impl <task-path>` — CC 가 슬래시 파싱 후
+      commands/impl.md 스킬 본문을 system-reminder 로 자식 세션에 자동 inject
+    - extra_cli_args = retry 시 `--append-system-prompt <prev_error>` 추가
+
+    이전 `[A]~[E]` 5 묶음 자연어 본문 폐기. 사유 = chain 깊이 3 → 0 단축:
+    - 옛: 자식이 본문 [E] → /impl 스킬 결정 → loop-procedure.md 결정 → 명령 호출
+    - 신: 자식이 슬래시 = 스킬 본문 직접 instruction → 명령 호출 (1 단계)
+
+    부수 정보 ([A] task 본문 inline / [B] 부모 이슈 read / [C] ADR 사전 read /
+    [D] enum 규칙) 은 commands/impl.md 본문이 이미 강제. 중복 제거.
     """
-    task_body = read_file(task_path)
-    parts = []
-
-    # retry 시 prev_error 머리말
+    extra_args = []
     if retry_attempt > 0 and prev_error:
-        parts.append(
-            f"## ⚠ 이전 시도 실패 (attempt {retry_attempt})\n\n"
-            f"```\n{prev_error}\n```\n\n"
-            f"위 에러 참고하여 수정 후 진행.\n\n---\n"
+        retry_context = (
+            f"이전 시도 실패 (attempt {retry_attempt}):\n\n"
+            f"{prev_error}\n\n"
+            "위 에러 참고하여 수정 후 진행. /dcness:impl 본문 룰 따름."
         )
+        extra_args = ["--append-system-prompt", retry_context]
 
-    # [A] impl 본문
-    parts.append(f"## [A] 이번 task impl 본문\n\n`{task_path}`:\n\n{task_body}\n")
-
-    # [B] 부모 이슈 + read 명령
-    if any(v is not None for v in issue_nums.values()):
-        issue_lines = []
-        for kind, num in issue_nums.items():
-            if num is not None:
-                issue_lines.append(
-                    f"- {kind}: #{num} — `gh issue view {num} | head -80` 로 본문 read 의무"
-                )
-        parts.append(
-            "## [B] 부모 이슈\n\n" + "\n".join(issue_lines) +
-            "\n\n구현 진입 *전* 위 이슈 본문 read 필수. "
-            "이슈에 수용 기준 / 추가 컨텍스트 / 결정 사항이 박혀있을 수 있음.\n"
-        )
-    else:
-        parts.append(
-            "## [B] 부모 이슈\n\n매칭된 이슈 번호 없음 — task 파일 본문의 수용 기준 직접 따름.\n"
-        )
-
-    # [C] ADR / architecture
-    parts.append(
-        "## [C] 사전 read 의무\n\n"
-        "구현 *전*:\n"
-        "- `docs/architecture.md` 다시 read — 모듈 흐름 / 인터페이스 / 의존성 확인\n"
-        "- `docs/adr.md` 다시 read — 관련 결정 사항 확인 (의도 모르고 덮어쓰는 회귀 회피)\n"
-    )
-
-    # [D] 종료 신호 규칙
-    parts.append(
-        "## [D] 종료 신호 규칙 (필수)\n\n"
-        "본 task 완료/정지 시 stdout 마지막 줄에 정확히 다음 enum 중 하나 박음:\n\n"
-        "- **clean** → 코드 + 테스트 + commit + push + PR 생성 + 머지 + `Closes #<task-num>` trailer 로 이슈 자동 close. "
-        "마지막 줄: `PASS: <한 줄 요약>`\n"
-        "- **error** → 빌드/테스트 실패. 자동 재시도됨. 마지막 줄: `FAIL: <이유>`\n"
-        "- **blocked** → 사용자 개입 필수 (API 키 / 인증 / 정책 결정 / Spike 의심 / 미정 의존). "
-        "마지막 줄: `ESCALATE: <이유>`\n"
-    )
-
-    # [E] 본 task 명령 — 명시 conveyor cycle + enum 의무 강화 (#422)
-    task_num = issue_nums.get("task")
-    issue_arg = f" --issue-num {task_num}" if task_num else ""
-    helper_resolve = (
-        'HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} '
-        '2>/dev/null | sort -V | tail -1)/scripts/dcness-helper"'
-    )
-    parts.append(
-        "## [E] 작업 시작\n\n"
-        "위 [A]~[D] 룰 따라 본 task 구현 시작. "
-        "dcness skill `/impl` 본문 의무 (sub-agent 호출 시퀀스 / 워크트리 / Pre-flight gate / "
-        "impl 파일 사전 read) 도 함께 따름. 현행 dcness 룰은 cwd CLAUDE.md + plug-in "
-        "SessionStart hook 자동 inject 된 system-reminder 참조.\n\n"
-        "### MUST — conveyor cycle 명시 호출 (silent-fail 회피, #422)\n\n"
-        "헤드리스 자식 세션이 `/impl` chain 을 자율 따라가다 begin-run / begin-step / end-step / "
-        "end-run 호출을 빠뜨리면 `.steps.jsonl` 미작성 → 사후 분석 불가 + Stop hook 선행 조건 "
-        "(active_runs 슬롯 + end-step 매칭) 미충족 → noop → 외부 헤드리스 parent 가 "
-        "silent-fail 감지 불가. 따라서 다음 4 호출 **명시 의무**:\n\n"
-        "```bash\n"
-        f"{helper_resolve}\n"
-        f'RUN_ID=$("$HELPER" begin-run impl{issue_arg})\n'
-        "# 각 sub-agent 호출 직전:  \"$HELPER\" begin-step <agent> [<MODE>]\n"
-        "# 각 sub-agent 호출 직후:  \"$HELPER\" end-step <agent> [<MODE>]\n"
-        "# PR merge 직후:           \"$HELPER\" end-run\n"
-        "```\n\n"
-        "agent 인자 예시: `test-engineer` / `engineer IMPL` / `code-validator` / `pr-reviewer` "
-        "(기본 시퀀스 — `commands/impl.md` 참조).\n\n"
-        "### MUST — 종료 prose enum 박음 (false-clean 회피, #422)\n\n"
-        "위 [D] 룰 재강조 — enum 누락 + exit 0 = 헤드리스 parent 의 fallback 분기가 "
-        "**잘못 clean 판정** → 다음 task silent 진행 → 사용자 개입 시점 놓침. "
-        "사용자 위임 / 결정 불가 / 측정 환경 부재 시 반드시 마지막 줄 `ESCALATE: <위임 내용>` "
-        "박을 것.\n"
-    )
-
-    return "\n".join(parts)
+    user_prompt = f"/dcness:impl {task_path}"
+    return extra_args, user_prompt
 
 
 def parse_result(stdout: str, exit_code: int) -> tuple:
@@ -221,17 +161,21 @@ def confirm_issue_closed(task_issue_num) -> bool:
         return None
 
 
-def spawn_child(prompt: str, cwd: str, timeout: int) -> tuple:
-    """claude -p 자식 세션 spawn.
+def spawn_child(prompt: str, cwd: str, timeout: int,
+                extra_args: list = None) -> tuple:
+    """claude -p 자식 세션 spawn — 슬래시 직호출 지원.
 
+    extra_args = `--append-system-prompt <retry_context>` 등 추가 CLI 인자.
     반환: (exit_code, stdout, stderr)
     """
     cmd = [
         "claude", "-p",
         "--dangerously-skip-permissions",
         "--output-format", "text",
-        prompt,
     ]
+    if extra_args:
+        cmd.extend(extra_args)
+    cmd.append(prompt)
     try:
         result = subprocess.run(
             cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
@@ -251,12 +195,12 @@ def process_task(task_path: str, cwd: str, retry_limit: int,
         print(f"\n[task] {task_path} (attempt {attempt + 1}/{retry_limit + 1})",
               file=sys.stderr)
 
-        prompt = build_command(
-            task_path, issue_nums,
+        extra_args, prompt = build_invocation(
+            task_path,
             retry_attempt=attempt,
             prev_error=prev_error,
         )
-        exit_code, stdout, stderr = spawn_child(prompt, cwd, timeout)
+        exit_code, stdout, stderr = spawn_child(prompt, cwd, timeout, extra_args=extra_args)
         enum, message = parse_result(stdout, exit_code)
         print(f"[task] result: {enum} — {message}", file=sys.stderr)
 

--- a/tests/test_impl_loop_headless.py
+++ b/tests/test_impl_loop_headless.py
@@ -1,9 +1,10 @@
 """scripts/impl_loop_headless.py 단위 테스트.
 
 검증 범위:
-- build_command() — [A]~[E] 5 묶음 inline 포함
-- parse_result() — prose enum 매치 (PASS / FAIL / ESCALATE)
+- build_invocation() — 슬래시 직호출 (`/dcness:impl <path>`) + retry → --append-system-prompt
+- parse_result() — enum 매치 (PASS / FAIL / ESCALATE)
 - extract_issue_nums() — task 본문 + 부모 stories.md 매치
+- process_task() — #422 false-clean 강등 안전망
 - main() — glob 매치 0 → exit 1
 """
 
@@ -21,72 +22,35 @@ sys.path.insert(0, str(ROOT / "scripts"))
 import impl_loop_headless as ilh  # noqa: E402
 
 
-class BuildCommandTests(unittest.TestCase):
-    """build_command — [A]~[E] inline 포함 검증."""
+class BuildInvocationTests(unittest.TestCase):
+    """build_invocation — 슬래시 직호출 + retry context 안전성."""
 
-    def setUp(self):
-        self._tmp = tempfile.TemporaryDirectory()
-        self._impl_path = Path(self._tmp.name) / "01-foo.md"
-        self._impl_path.write_text("# 01-foo\n\n본문 내용.\n", encoding="utf-8")
+    def test_first_attempt_slash_only(self):
+        """첫 시도: prompt = `/dcness:impl <path>`, extra_args = 빈 리스트."""
+        extra_args, prompt = ilh.build_invocation("docs/impl/01-foo.md")
+        self.assertEqual(extra_args, [])
+        self.assertEqual(prompt, "/dcness:impl docs/impl/01-foo.md")
 
-    def tearDown(self):
-        self._tmp.cleanup()
-
-    def test_all_sections_present(self):
-        prompt = ilh.build_command(
-            str(self._impl_path),
-            issue_nums={"epic": 100, "story": 101, "task": 102},
-        )
-        self.assertIn("## [A] 이번 task impl 본문", prompt)
-        self.assertIn("# 01-foo", prompt)  # 본문 inline
-        self.assertIn("## [B] 부모 이슈", prompt)
-        self.assertIn("#102", prompt)
-        self.assertIn("gh issue view 102", prompt)
-        self.assertIn("## [C] 사전 read 의무", prompt)
-        self.assertIn("docs/architecture.md", prompt)
-        self.assertIn("docs/adr.md", prompt)
-        self.assertIn("## [D] 종료 신호 규칙", prompt)
-        self.assertIn("PASS:", prompt)
-        self.assertIn("FAIL:", prompt)
-        self.assertIn("ESCALATE:", prompt)
-        self.assertIn("## [E] 작업 시작", prompt)
-
-    def test_e_section_includes_conveyor_cycle_commands(self):
-        """#422: [E] 가 begin-run / begin-step / end-step / end-run 명시 호출 박음."""
-        prompt = ilh.build_command(
-            str(self._impl_path),
-            issue_nums={"epic": None, "story": None, "task": 102},
-        )
-        self.assertIn("begin-run impl --issue-num 102", prompt)
-        self.assertIn("begin-step <agent>", prompt)
-        self.assertIn("end-step <agent>", prompt)
-        self.assertIn("end-run", prompt)
-
-    def test_e_section_conveyor_without_issue_num(self):
-        """#422: task 이슈 번호 부재 시 begin-run impl (--issue-num 없음)."""
-        prompt = ilh.build_command(
-            str(self._impl_path),
-            issue_nums={"epic": None, "story": None, "task": None},
-        )
-        self.assertIn('"$HELPER" begin-run impl)', prompt)
-        self.assertNotIn("begin-run impl --issue-num", prompt)
-
-    def test_no_issue_nums(self):
-        prompt = ilh.build_command(
-            str(self._impl_path),
-            issue_nums={"epic": None, "story": None, "task": None},
-        )
-        self.assertIn("매칭된 이슈 번호 없음", prompt)
-
-    def test_retry_attempt_prepends_prev_error(self):
-        prompt = ilh.build_command(
-            str(self._impl_path),
-            issue_nums={"epic": None, "story": None, "task": 1},
+    def test_retry_appends_system_prompt(self):
+        """retry: extra_args 에 --append-system-prompt + 이전 에러 inject."""
+        extra_args, prompt = ilh.build_invocation(
+            "docs/impl/01-foo.md",
             retry_attempt=1,
-            prev_error="some build error",
+            prev_error="exit 1\npytest 실패",
         )
-        self.assertIn("⚠ 이전 시도 실패 (attempt 1)", prompt)
-        self.assertIn("some build error", prompt)
+        self.assertEqual(extra_args[0], "--append-system-prompt")
+        self.assertIn("이전 시도 실패 (attempt 1)", extra_args[1])
+        self.assertIn("pytest 실패", extra_args[1])
+        self.assertEqual(prompt, "/dcness:impl docs/impl/01-foo.md")
+
+    def test_retry_attempt_zero_no_extra_args(self):
+        """attempt 0 + prev_error 있어도 retry 머리말 inject 안 함 (첫 시도)."""
+        extra_args, _ = ilh.build_invocation(
+            "docs/impl/01-foo.md",
+            retry_attempt=0,
+            prev_error="should be ignored",
+        )
+        self.assertEqual(extra_args, [])
 
 
 class ParseResultTests(unittest.TestCase):


### PR DESCRIPTION
## 변경 요약

### [feature] 헤드리스 자식 슬래시 직호출 + impl 형제 PR 환기 + 단발 헤드리스 옵션

- **What**:
  - 헤드리스 자식 prompt 를 `/dcness:impl <task-path>` 슬래시 직호출로 단순화 (chain 깊이 3 → 0)
  - retry context = `--append-system-prompt` 로 inject
  - `commands/impl.md` §사전 read 의무에 5번 항목 추가 (같은 epic 형제 머지 PR 환기)
  - `commands/impl.md` §헤드리스 실행 옵션 추가 — 단발 task 도 사용자 발화 `헤드리스|headless` 매치 시 헤드리스로 위임
  - 옛 `build_command()` ([A]~[E] 5 묶음 자연어 본문) → `build_invocation()` 으로 폐기
  - 테스트 갱신 (BuildCommandTests → BuildInvocationTests 3 case)
- **Why**:
  - [A]~[E] 5 묶음 자연어 = chain 깊이 3 (자식 → /impl 결정 → loop-procedure.md 결정 → 명령). 단계마다 누락 위험 누적 → #422 NS2 사단
  - [B][C][D] 묶음이 `commands/impl.md` 본문과 *중복*. 슬래시 호출 시 스킬 본문이 system-reminder 로 자동 inject 됨 → 자연어 재박음 불필요
  - 같은 epic 형제 story 의 후속 결정 (옵션 채택 / 인터페이스 변경 등) 이 본 task 영향 미쳐도 자식이 인지 못 함
  - 단발 task 도 메인 컨텍스트 누적 회피 + `/run-review` 사후 분석 분리 가치 챙기고 싶음

## 결정 근거

- `claude -p` 슬래시 + `--append-system-prompt` 동작 실증 완료: `claude -p ... --append-system-prompt "..." "/dcness:impl ..."` → "BOTH_LOADED" 응답 확인
- `claude --disable-slash-commands` flag 존재 = 기본 활성. `--bare` 모드도 "Skills still resolve via /skill-name"
- #422 fix 의 process_task 강등 + Stop hook 자동 end-run 안전망 위에 chain 단축 = 다중 안전망
- 옛 build_command 의 task 본문 inline 도 폐기 — 자식이 task 경로 받아 자체 read (commands/impl.md §부모 이슈 본문 read 의무 + §impl 파일 사전 read 의무 가 강제)

## 관련 이슈

Document-Exception-PR-Close: #422 의 follow-up 리팩토링 (안전망 위에 chain 단축). 본 PR 자체는 close 할 신규 이슈 없음 — #422 는 #425 에서 이미 close됨.

## 참고

- `commands/impl.md` 라인 55-66 — 사전 read 의무 (형제 PR 5번 항목 추가)
- `scripts/impl_loop_headless.py` `build_invocation()` — 슬래시 직호출 entry
- 인터랙티브 `/impl` 과 헤드리스 `/dcness:impl` 가 동일 system-reminder 본문 받음 = 동일 conveyor cycle 정확도

🤖 Generated with [Claude Code](https://claude.com/claude-code)