### PR TITLE
[issue-423] TDD GUARD entry-file false-positive 해소

### DIFF
--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -74,11 +74,34 @@ case "$FILE_PATH" in
   */templates/*|*/design-variants/*) allow ;;
 esac
 
+# 자동 skip — entry-file path heuristic (#423)
+# registerRootComponent / AppRegistry.registerComponent 같은 entry 정의 파일은
+# 비즈니스 로직 없는 boilerplate. test 의무 X. 컨벤션 path 만 좁게 매치.
+# - */App.{ts,tsx,js,jsx}      = RN / Expo entry shell
+# - */_layout.{ts,tsx,js,jsx}  = expo-router layout (Next.js layout.tsx 는 라인 67에서 별도 cover)
+# - */apps/*/index.{ts,tsx,js,jsx} = monorepo apps/<name>/ entry (일반 index.* 는 너무 광범위라 제외)
+# - */src/main.{ts,tsx,js,jsx}     = Vue/Vite main entry
+case "$FILE_PATH" in
+  */App.ts|*/App.tsx|*/App.js|*/App.jsx) allow ;;
+  */_layout.ts|*/_layout.tsx|*/_layout.js|*/_layout.jsx) allow ;;
+  */apps/*/index.ts|*/apps/*/index.tsx|*/apps/*/index.js|*/apps/*/index.jsx) allow ;;
+  */src/main.ts|*/src/main.tsx|*/src/main.js|*/src/main.jsx) allow ;;
+esac
+
 # TS/JS 한정 — 그 외 silent skip
 case "$FILE_PATH" in
   *.ts|*.tsx|*.js|*.jsx) ;;
   *) allow ;;
 esac
+
+# 자동 skip — 파일 내용 시그니처 매치 (#423)
+# entry-file 가 path heuristic 못 잡은 위치에 있어도 내용으로 detection.
+# 단 Edit 케이스만 cover (파일 이미 존재). 최초 Write 시는 path heuristic 의존.
+if [ -f "$FILE_PATH" ]; then
+  if grep -qE 'registerRootComponent\(|AppRegistry\.registerComponent\(' "$FILE_PATH" 2>/dev/null; then
+    allow
+  fi
+fi
 
 # 매칭 test 파일 존재 검사
 has_test_for() {

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -1,0 +1,186 @@
+"""hooks/tdd-guard.sh 단위 테스트 — entry-file false-positive 회피 (#423).
+
+검증 범위:
+- 기존 skip 룰 (test/spec 파일 자체 / config / 타입 / Next.js 특수) — 회귀 방지
+- entry-file path heuristic (#423): App.{ts,tsx,js,jsx} / _layout.* / apps/*/index.* / src/main.*
+- 파일 내용 시그니처 grep (#423): registerRootComponent / AppRegistry.registerComponent
+- 일반 src 파일 + 테스트 부재 → deny (기존 동작 보존)
+- 매칭 테스트 파일 존재 → allow
+
+호출 메커니즘: hook 은 bash. stdin 으로 JSON payload 받고 stdout 으로 JSON 결정 반환.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HOOK_PATH = ROOT / "hooks" / "tdd-guard.sh"
+
+
+def run_hook(file_path: str, cwd: str, tool_name: str = "Edit") -> dict:
+    """tdd-guard.sh 호출 → 결정 JSON 반환."""
+    payload = {
+        "tool_name": tool_name,
+        "tool_input": {"file_path": file_path},
+    }
+    result = subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, cwd=cwd, timeout=10,
+    )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+
+
+def decision(out: dict) -> str:
+    """allow / deny 추출."""
+    spec = out.get("hookSpecificOutput", {})
+    return spec.get("permissionDecision", "unknown")
+
+
+class TestEntryFileHeuristic(unittest.TestCase):
+    """#423 — entry-file path heuristic skip."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str = "// stub\n") -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_app_tsx_skipped(self):
+        path = self._touch("apps/mobile/App.tsx")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_app_js_skipped(self):
+        path = self._touch("apps/mobile/App.js")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_expo_router_layout_skipped(self):
+        path = self._touch("apps/mobile/app/_layout.tsx")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_expo_router_group_layout_skipped(self):
+        path = self._touch("apps/mobile/app/(tabs)/_layout.tsx")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_monorepo_apps_index_js_skipped(self):
+        path = self._touch("apps/mobile/index.js")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_monorepo_apps_index_ts_skipped(self):
+        path = self._touch("apps/web/index.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_vue_vite_main_skipped(self):
+        path = self._touch("src/main.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
+class TestSignatureGrep(unittest.TestCase):
+    """#423 — 파일 내용 시그니처 grep skip."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _write(self, rel: str, content: str) -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_registerRootComponent_skipped(self):
+        """비-컨벤션 path 라도 registerRootComponent 시그니처 → allow."""
+        path = self._write(
+            "src/some-non-conventional-entry.tsx",
+            "import { registerRootComponent } from 'expo';\nregisterRootComponent(App);\n",
+        )
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_AppRegistry_registerComponent_skipped(self):
+        """Bare RN AppRegistry.registerComponent → allow."""
+        path = self._write(
+            "src/rn-bare-entry.js",
+            "import { AppRegistry } from 'react-native';\nAppRegistry.registerComponent('app', () => App);\n",
+        )
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
+class TestRegressionPreserved(unittest.TestCase):
+    """기존 skip 룰 + deny 동작 회귀 방지."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str = "// stub\n") -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_test_file_self_skipped(self):
+        path = self._touch("src/foo.test.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_config_skipped(self):
+        path = self._touch("babel.config.js")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_metro_config_skipped(self):
+        path = self._touch("metro.config.js")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_app_config_ts_skipped(self):
+        path = self._touch("app.config.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_types_skipped(self):
+        path = self._touch("src/types/foo.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_non_ts_js_skipped(self):
+        path = self._touch("src/foo.py")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_src_business_logic_without_test_denied(self):
+        """일반 비즈니스 로직 + 테스트 부재 → deny (기존 동작 보존)."""
+        path = self._touch(
+            "src/business-logic.ts",
+            "export function calculatePrice(qty, unit) { return qty * unit; }\n",
+        )
+        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+
+    def test_src_business_logic_with_test_allowed(self):
+        """일반 비즈니스 로직 + 매칭 테스트 존재 → allow."""
+        self._touch(
+            "src/biz.ts",
+            "export function calc() { return 1; }\n",
+        )
+        self._touch("src/biz.test.ts", "test('ok', () => {})\n")
+        path = str(Path(self._tmp) / "src/biz.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-423] TDD GUARD entry-file false-positive 해소 — path heuristic + 시그니처 grep

- **What**:
  - `hooks/tdd-guard.sh` 에 entry-file path heuristic 4 패턴 + 파일 내용 시그니처 grep 추가
  - `tests/test_tdd_guard.py` 신규 — 17 테스트 (entry-file 7 / 시그니처 grep 2 / 회귀 방지 8)
- **Why**:
  - Expo `apps/mobile/index.js` / RN `App.tsx` / expo-router `_layout.tsx` = entry boilerplate (registerRootComponent / AppRegistry.registerComponent 만, 비즈니스 로직 X). 본질적으로 test 의무 없음
  - 기존 skip 룰이 Next.js `*/layout.tsx` 만 cover. underscore prefix 인 expo-router `_layout` / Expo entry `index.js` / RN `App.tsx` 미커버
  - jajang Epic 19 Story 1 NS2 (2026-05-13) 측정 진입 시 false-positive deny → 사용자 수동 우회 = 인프라 마찰
  - engineer agent 의 빈 stub 회피 안티패턴 강화 위험 (jajang `feedback_dcness_tdd_guard_theme_infix_false_positive` 누적)

## 결정 근거

- 이슈 본문 권장 = Option A + C 조합. 본 PR 채택:
  - Option C (path heuristic): 좁은 컨벤션 path 만 매치 (`App.{ts,tsx,js,jsx}` / `_layout.*` / `apps/*/index.*` / `src/main.*`). `index.*` 일반 패턴은 `src/components/Button/index.tsx` 같은 모듈 false-skip 위험으로 제외
  - Option A (시그니처 grep): `registerRootComponent\(` / `AppRegistry\.registerComponent\(` 매치. Edit 케이스 (파일 이미 존재) 만 cover. 최초 Write 는 path heuristic 의존
- Option B (`.tdd-ignore`) 보류 — escape hatch 필요해지면 별도 이슈
- 모든 실증 검증 후 진행 (`*.config.*` 가 babel/metro/app.config 다 cover 함을 확인 — 이슈 본문 제안에 중복 있었음)

## 관련 이슈

Closes #423

## 참고

- `hooks/tdd-guard.sh` 라인 78-88 — 새 path heuristic
- `hooks/tdd-guard.sh` 라인 97-103 — 새 시그니처 grep
- 회귀 방지: 일반 비즈니스 로직 (`src/business-logic.ts`) + 테스트 부재 → 여전히 deny

🤖 Generated with [Claude Code](https://claude.com/claude-code)