### PR TITLE
[issue-431] 헤드리스 자식 conveyor + inner 4-step 부분 호출 차단 (3 결함 묶음)

### DIFF
--- a/commands/impl.md
+++ b/commands/impl.md
@@ -24,6 +24,22 @@ UI 디자인 mid-loop 필요 시 → `impl-ui-design-loop` (orchestration §4.4)
 - 매치 실패 / 파일 부재 → **fallback**: module-architect 1번 호출 후 test-engineer 진입.
 - 근거: architect-loop §4.2 의 Step 4 (module-architect × K) 가 정식 위치 impl 파일 본문 detail 까지 채움. 정식 경로 + 파일 존재 = 통과 보장 (위치 자체가 도장).
 
+## Inner loop 4-step 모두 호출 (MUST — false-clean 차단, #431)
+
+default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → pr-reviewer**. 4 단계 *모두 호출* 의무.
+
+❌ 안티패턴 (jajang epic 19 task 06 사단, #431 결함 3): test-engineer + engineer 만 호출하고 commit/push/PR 안 만들고 prose "PASS" 박고 종료. 자식 spawn 의 핵심 보장 (1 자식 = 1 PR + 1 이슈 close) 깨짐 + 메인이 수동 commit/push/PR 강요됨.
+
+✅ 정상 흐름:
+1. test-engineer (TESTS_WRITTEN) → 테스트 선작성
+2. engineer:IMPL (IMPL_DONE) → 구현 + 테스트 PASS
+3. **code-validator (PASS)** — impl 계획 ↔ 구현 정합 검증
+4. **pr-reviewer (LGTM)** — 코드 품질·보안 + commit/push/PR 생성·머지
+
+후반 2 단계 (3+4) skip 차단:
+- `scripts/impl_loop_headless.py:process_task` 가 자식 stdout text 에 `code-validator` / `pr-reviewer` 흔적 부재 시 → false-clean 의심 → blocked 강등 (#431)
+- 헤드리스 parent 가 메인에 `ESCALATE` 보고 → 사용자 개입
+
 ## 후속 라우팅
 - 본 loop clean → 자동 commit/PR (branch prefix = orchestration §4.3 decision rule: feat/chore/fix)
 - caveat → 사용자 결정 (수동 7b)

--- a/scripts/impl_loop_headless.py
+++ b/scripts/impl_loop_headless.py
@@ -88,31 +88,90 @@ def extract_issue_nums(task_path: str) -> dict:
 
 
 def build_invocation(task_path: str,
+                     issue_nums: dict = None,
                      retry_attempt: int = 0,
                      prev_error: str = None) -> tuple:
-    """슬래시 직호출 invocation 조립 (#425 follow-up — chain 깊이 0).
+    """슬래시 직호출 invocation 조립 (#425 follow-up + #431 강화).
 
     반환: (extra_cli_args, user_prompt)
     - user_prompt = `/dcness:impl <task-path>` — CC 가 슬래시 파싱 후
       commands/impl.md 스킬 본문을 system-reminder 로 자식 세션에 자동 inject
-    - extra_cli_args = retry 시 `--append-system-prompt <prev_error>` 추가
+    - extra_cli_args = `--append-system-prompt <mandate + (retry context)>` —
+      자식이 system prompt 로 받는 1st-class 의무. commands/impl.md 본문보다
+      *우선* (#431 자식이 본문만으론 conveyor + inner 4-step 자율 미호출 사단)
 
-    이전 `[A]~[E]` 5 묶음 자연어 본문 폐기. 사유 = chain 깊이 3 → 0 단축:
-    - 옛: 자식이 본문 [E] → /impl 스킬 결정 → loop-procedure.md 결정 → 명령 호출
-    - 신: 자식이 슬래시 = 스킬 본문 직접 instruction → 명령 호출 (1 단계)
-
-    부수 정보 ([A] task 본문 inline / [B] 부모 이슈 read / [C] ADR 사전 read /
-    [D] enum 규칙) 은 commands/impl.md 본문이 이미 강제. 중복 제거.
+    의무 4 카테고리:
+    - 진입 즉시 begin-run 호출 (없으면 `.steps.jsonl` 미작성 → dcness-review --latest
+      자식 run 못 찾고 메인 history 무관 run 반환, #431 결함 1+2)
+    - inner 4-step 모두 호출 — test-engineer → engineer → code-validator → pr-reviewer.
+      test-engineer + engineer 만 호출하고 PASS 박는 false-clean 차단 (#431 결함 3)
+    - PR merge 직후 end-run 호출 — Stop hook 안전망 위 1차 명시
+    - 종료 prose enum (PASS/FAIL/ESCALATE) 박음 — false-clean fallback 차단
     """
-    extra_args = []
-    if retry_attempt > 0 and prev_error:
-        retry_context = (
-            f"이전 시도 실패 (attempt {retry_attempt}):\n\n"
-            f"{prev_error}\n\n"
-            "위 에러 참고하여 수정 후 진행. /dcness:impl 본문 룰 따름."
-        )
-        extra_args = ["--append-system-prompt", retry_context]
+    issue_nums = issue_nums or {}
+    task_num = issue_nums.get("task")
+    issue_arg = f" --issue-num {task_num}" if task_num else ""
 
+    helper_resolve = (
+        'HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} '
+        '2>/dev/null | sort -V | tail -1)/scripts/dcness-helper"'
+    )
+
+    mandate_parts = [
+        "## 헤드리스 자식 세션 의무 (MUST — system prompt 1st-class, #431)",
+        "",
+        "본 세션은 `scripts/impl_loop_headless.py` 가 spawn 한 headless 자식. "
+        "commands/impl.md 본문보다 *우선* 적용되는 의무 4 항목:",
+        "",
+        "### 1. 진입 즉시 conveyor begin-run (필수)",
+        "",
+        "task 진행 *전* 다음 Bash 명령 1회 실행:",
+        "",
+        "```bash",
+        helper_resolve,
+        f'RUN_ID=$("$HELPER" begin-run impl{issue_arg})',
+        "```",
+        "",
+        "누락 시 자식 sid 의 `runs/<rid>/.steps.jsonl` 미작성 → `dcness-review --latest` "
+        "가 자식 run 못 찾고 메인 history 의 무관 run 반환 (#431 결함 1+2).",
+        "",
+        "### 2. inner 4-step 모두 호출 (필수)",
+        "",
+        "`commands/impl.md` default 시퀀스 = test-engineer → engineer → "
+        "**code-validator → pr-reviewer**. 각 sub-agent 호출 전후 `begin-step` / "
+        "`end-step` 명시 (loop-procedure.md §3.1).",
+        "",
+        "test-engineer + engineer 만 호출하고 commit/push/PR 안 만들고 PASS 박는 "
+        "false-clean 안티패턴 = 본 자식 spawn 의 핵심 보장 (1 자식 = 1 PR + 1 이슈 close) "
+        "을 깨뜨림. headless parent 가 stdout text fragility 검사로 차단 (#431 결함 3).",
+        "",
+        "### 3. PR merge 직후 conveyor end-run (필수)",
+        "",
+        "```bash",
+        '"$HELPER" end-run',
+        "```",
+        "",
+        "Stop hook 안전망 (`hooks/stop-end-run.sh`) 이 누락 보완하지만 *명시 호출* 우선.",
+        "",
+        "### 4. 종료 prose enum 박음 (필수)",
+        "",
+        "- 코드 + 테스트 + commit + push + PR 머지 + `Closes #<task-num>` → "
+        "stdout 마지막 줄: `PASS: <한 줄 요약>`",
+        "- 빌드/테스트 실패 → `FAIL: <원인>`",
+        "- 사용자 협업 필요 / 측정 환경 부재 / blocked → `ESCALATE: <위임 내용>`",
+        "",
+        "enum 누락 + exit 0 = headless parent 가 false-clean fallback 판정 → "
+        "다음 task silent 진행 (#422 NS2 사단).",
+    ]
+    mandate = "\n".join(mandate_parts)
+
+    if retry_attempt > 0 and prev_error:
+        mandate = (
+            f"이전 시도 실패 (attempt {retry_attempt}):\n\n{prev_error}\n\n"
+            "위 에러 참고하여 수정 후 진행.\n\n---\n\n"
+        ) + mandate
+
+    extra_args = ["--append-system-prompt", mandate]
     user_prompt = f"/dcness:impl {task_path}"
     return extra_args, user_prompt
 
@@ -249,6 +308,7 @@ def process_task(task_path: str, cwd: str, retry_limit: int,
 
         extra_args, prompt = build_invocation(
             task_path,
+            issue_nums=issue_nums,
             retry_attempt=attempt,
             prev_error=prev_error,
         )
@@ -259,6 +319,31 @@ def process_task(task_path: str, cwd: str, retry_limit: int,
         # blocked / escalate 신호 즉시 정지
         if enum in escalate_signals:
             return {"enum": "blocked", "message": message, "stdout": stdout}
+
+        # clean — inner 4-step 호출 trace 검사 (#431 결함 3)
+        # default 시퀀스 = test-engineer → engineer → code-validator → pr-reviewer.
+        # 자식 stdout 에 후반 2 단계 (code-validator / pr-reviewer) 흔적 부재 시 false-clean.
+        # echo 룰 (commands/impl.md / loop-procedure.md §3.1) 따라 sub-agent 결과가
+        # `[<task>.<agent>] echo` 또는 agent 이름 prose 로 stdout 에 흐름.
+        if enum == "clean":
+            stdout_lower = stdout.lower()
+            has_validator = "code-validator" in stdout_lower
+            has_reviewer = "pr-reviewer" in stdout_lower
+            if not (has_validator and has_reviewer):
+                missing = []
+                if not has_validator:
+                    missing.append("code-validator")
+                if not has_reviewer:
+                    missing.append("pr-reviewer")
+                return {
+                    "enum": "blocked",
+                    "message": (
+                        f"prose PASS / exit 0 인데 inner 4-step 부분 호출 흔적 "
+                        f"(누락: {', '.join(missing)}) — false-clean 의심 (#431 결함 3, "
+                        f"자식이 test-engineer + engineer 만 호출하고 commit/push/PR 안 만들고 종료)"
+                    ),
+                    "stdout": stdout,
+                }
 
         # clean — 이슈 close 2차 confirm (#422 강화: WARN → blocked 강등)
         if enum == "clean":

--- a/tests/test_impl_loop_headless.py
+++ b/tests/test_impl_loop_headless.py
@@ -23,34 +23,63 @@ import impl_loop_headless as ilh  # noqa: E402
 
 
 class BuildInvocationTests(unittest.TestCase):
-    """build_invocation — 슬래시 직호출 + retry context 안전성."""
+    """build_invocation — 슬래시 직호출 + system prompt 의무 (#431)."""
 
-    def test_first_attempt_slash_only(self):
-        """첫 시도: prompt = `/dcness:impl <path>`, extra_args = 빈 리스트."""
-        extra_args, prompt = ilh.build_invocation("docs/impl/01-foo.md")
-        self.assertEqual(extra_args, [])
-        self.assertEqual(prompt, "/dcness:impl docs/impl/01-foo.md")
-
-    def test_retry_appends_system_prompt(self):
-        """retry: extra_args 에 --append-system-prompt + 이전 에러 inject."""
+    def test_first_attempt_slash_with_mandate(self):
+        """첫 시도: prompt = `/dcness:impl <path>`, extra_args 에 의무 system prompt."""
         extra_args, prompt = ilh.build_invocation(
             "docs/impl/01-foo.md",
+            issue_nums={"task": 272},
+        )
+        self.assertEqual(prompt, "/dcness:impl docs/impl/01-foo.md")
+        # system prompt 의무 박힘
+        self.assertEqual(extra_args[0], "--append-system-prompt")
+        mandate = extra_args[1]
+        # 의무 4 항목
+        self.assertIn("begin-run impl --issue-num 272", mandate)
+        self.assertIn("end-run", mandate)
+        self.assertIn("test-engineer", mandate)
+        self.assertIn("engineer", mandate)
+        self.assertIn("code-validator", mandate)
+        self.assertIn("pr-reviewer", mandate)
+        # enum 의무
+        self.assertIn("PASS:", mandate)
+        self.assertIn("FAIL:", mandate)
+        self.assertIn("ESCALATE:", mandate)
+
+    def test_no_issue_num_omits_arg(self):
+        """task 이슈 번호 부재 시 begin-run impl (no --issue-num)."""
+        extra_args, _ = ilh.build_invocation(
+            "docs/impl/01-foo.md",
+            issue_nums={"task": None},
+        )
+        mandate = extra_args[1]
+        self.assertIn("begin-run impl)", mandate)
+        self.assertNotIn("begin-run impl --issue-num", mandate)
+
+    def test_retry_prepends_prev_error(self):
+        """retry: 이전 에러가 의무 앞에 prepend."""
+        extra_args, _ = ilh.build_invocation(
+            "docs/impl/01-foo.md",
+            issue_nums={"task": 100},
             retry_attempt=1,
             prev_error="exit 1\npytest 실패",
         )
-        self.assertEqual(extra_args[0], "--append-system-prompt")
-        self.assertIn("이전 시도 실패 (attempt 1)", extra_args[1])
-        self.assertIn("pytest 실패", extra_args[1])
-        self.assertEqual(prompt, "/dcness:impl docs/impl/01-foo.md")
+        mandate = extra_args[1]
+        self.assertIn("이전 시도 실패 (attempt 1)", mandate)
+        self.assertIn("pytest 실패", mandate)
+        # 의무 본문 여전히 박힘
+        self.assertIn("begin-run impl", mandate)
 
-    def test_retry_attempt_zero_no_extra_args(self):
+    def test_retry_attempt_zero_no_prev_error_prepend(self):
         """attempt 0 + prev_error 있어도 retry 머리말 inject 안 함 (첫 시도)."""
         extra_args, _ = ilh.build_invocation(
             "docs/impl/01-foo.md",
+            issue_nums={},
             retry_attempt=0,
             prev_error="should be ignored",
         )
-        self.assertEqual(extra_args, [])
+        self.assertNotIn("이전 시도 실패", extra_args[1])
 
 
 class ParseResultTests(unittest.TestCase):
@@ -248,8 +277,16 @@ class SpawnChildStreamTests(unittest.TestCase):
 class FalseCleanDowngradeTests(unittest.TestCase):
     """process_task — #422 false-clean 강등 검증."""
 
+    # stdout fixture — inner 4-step 전부 완료 흔적 (enum 미포함). #431 검사 통과용.
+    _4STEP_ECHO = (
+        "[b1.test-engineer] echo TESTS_WRITTEN\n"
+        "[b2.engineer:IMPL] echo IMPL_DONE\n"
+        "[b3.code-validator] echo PASS\n"
+        "[b4.pr-reviewer] echo LGTM\n"
+    )
+
     def test_pass_prose_but_issue_open_downgrades_to_blocked(self):
-        """PASS prose + task 이슈 OPEN → clean 아닌 blocked 강등."""
+        """PASS prose + 4-step 전부 + task 이슈 OPEN → blocked 강등 (#422)."""
         with tempfile.TemporaryDirectory() as tmp:
             task_path = Path(tmp) / "01-foo.md"
             task_path.write_text(
@@ -258,7 +295,7 @@ class FalseCleanDowngradeTests(unittest.TestCase):
 
             with mock.patch.object(
                 ilh, "spawn_child",
-                return_value=(0, "...\nPASS: 머지 완료\n", ""),
+                return_value=(0, self._4STEP_ECHO + "PASS: 머지 완료\n", ""),
             ), mock.patch.object(
                 ilh, "confirm_issue_closed", return_value=False,
             ):
@@ -283,7 +320,7 @@ class FalseCleanDowngradeTests(unittest.TestCase):
 
             with mock.patch.object(
                 ilh, "spawn_child",
-                return_value=(0, "사용자에게 위임합니다 enum 없음\n", ""),
+                return_value=(0, self._4STEP_ECHO + "사용자 위임 enum 없음\n", ""),
             ), mock.patch.object(
                 ilh, "confirm_issue_closed", return_value=False,
             ):
@@ -298,7 +335,7 @@ class FalseCleanDowngradeTests(unittest.TestCase):
                 self.assertIn("#888", r["message"])
 
     def test_pass_with_closed_issue_stays_clean(self):
-        """PASS prose + task 이슈 CLOSED → 정상 clean (회귀 방지)."""
+        """PASS prose + 4-step + task 이슈 CLOSED → 정상 clean (회귀 방지)."""
         with tempfile.TemporaryDirectory() as tmp:
             task_path = Path(tmp) / "01-foo.md"
             task_path.write_text(
@@ -307,7 +344,7 @@ class FalseCleanDowngradeTests(unittest.TestCase):
 
             with mock.patch.object(
                 ilh, "spawn_child",
-                return_value=(0, "PASS: 정상 머지\n", ""),
+                return_value=(0, self._4STEP_ECHO + "PASS: 정상 머지\n", ""),
             ), mock.patch.object(
                 ilh, "confirm_issue_closed", return_value=True,
             ):
@@ -320,6 +357,63 @@ class FalseCleanDowngradeTests(unittest.TestCase):
                 )
                 self.assertEqual(r["enum"], "clean")
 
+    def test_inner_4step_partial_call_downgrades_to_blocked(self):
+        """#431: test-engineer + engineer 만 호출하고 PASS 박는 안티패턴 차단."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text(
+                "# 01-foo\n\n**GitHub Issue:** [#555]\n", encoding="utf-8",
+            )
+
+            # 4-step 중 test-engineer + engineer 만 호출 (#431 사단 재현)
+            partial_stdout = (
+                "[b1.test-engineer] echo TESTS_WRITTEN\n"
+                "[b2.engineer:IMPL] echo IMPL_DONE\n"
+                "PASS: 구현 완료\n"
+            )
+            with mock.patch.object(
+                ilh, "spawn_child", return_value=(0, partial_stdout, ""),
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "blocked")
+                self.assertIn("inner 4-step", r["message"])
+                self.assertIn("code-validator", r["message"])
+                self.assertIn("pr-reviewer", r["message"])
+                self.assertIn("#431", r["message"])
+
+    def test_inner_4step_only_validator_missing(self):
+        """#431: pr-reviewer 호출은 있는데 code-validator 만 누락 — 그래도 blocked."""
+        with tempfile.TemporaryDirectory() as tmp:
+            task_path = Path(tmp) / "01-foo.md"
+            task_path.write_text(
+                "# 01-foo\n\n**GitHub Issue:** [#556]\n", encoding="utf-8",
+            )
+
+            partial_stdout = (
+                "[b1.test-engineer] echo TESTS_WRITTEN\n"
+                "[b2.engineer:IMPL] echo IMPL_DONE\n"
+                "[b4.pr-reviewer] echo LGTM\n"  # code-validator skip
+                "PASS: 머지 완료\n"
+            )
+            with mock.patch.object(
+                ilh, "spawn_child", return_value=(0, partial_stdout, ""),
+            ):
+                r = ilh.process_task(
+                    str(task_path),
+                    cwd=tmp,
+                    retry_limit=0,
+                    escalate_signals={"blocked"},
+                    timeout=10,
+                )
+                self.assertEqual(r["enum"], "blocked")
+                self.assertIn("code-validator", r["message"])
+
     def test_no_issue_num_with_uncommitted_files_downgrades(self):
         """task 이슈 번호 부재 + cwd uncommitted files → blocked 강등."""
         with tempfile.TemporaryDirectory() as tmp:
@@ -328,7 +422,7 @@ class FalseCleanDowngradeTests(unittest.TestCase):
 
             with mock.patch.object(
                 ilh, "spawn_child",
-                return_value=(0, "PASS: 완료\n", ""),
+                return_value=(0, self._4STEP_ECHO + "PASS: 완료\n", ""),
             ), mock.patch.object(
                 ilh.subprocess, "run",
                 return_value=mock.Mock(stdout=" M some_file.py\n"),
@@ -351,7 +445,7 @@ class FalseCleanDowngradeTests(unittest.TestCase):
 
             with mock.patch.object(
                 ilh, "spawn_child",
-                return_value=(0, "PASS: 완료\n", ""),
+                return_value=(0, self._4STEP_ECHO + "PASS: 완료\n", ""),
             ), mock.patch.object(
                 ilh.subprocess, "run",
                 return_value=mock.Mock(stdout=""),


### PR DESCRIPTION
## 변경 요약

### [issue-431] 헤드리스 자식 conveyor + inner 4-step 부분 호출 차단 (3 결함 묶음)

- **What**:
  - `scripts/impl_loop_headless.py:build_invocation`:
    - `issue_nums` 파라미터 추가
    - `--append-system-prompt` 에 의무 4 항목 inject (begin-run / inner 4-step / end-run / enum)
    - retry context 의무 앞 prepend
  - `scripts/impl_loop_headless.py:process_task`:
    - 자식 stdout 에 `code-validator` / `pr-reviewer` 흔적 부재 시 → blocked 강등 (#431 결함 3)
  - `commands/impl.md` §Inner loop 4-step 모두 호출 (MUST) 섹션 신규 — 정상 흐름 + 안티패턴 + parent 검사 안내
  - 테스트 갱신 (BuildInvocationTests 4 → system prompt 의무 검증) + 신규 (FalseCleanDowngradeTests 2 → 4-step partial / code-validator only missing)
- **Why**:
  - jajang epic 19 task 06 (NS3 spike) 자식이 `dcness:test-engineer` + `dcness:engineer` 만 호출하고 commit/push/PR 안 만들고 prose "PASS" 박고 종료 → headless parent 가 false-clean 으로 판정 → 메인이 수동 commit/push/PR 강요됨
  - 자식 conveyor begin-run 미발화 → `.steps.jsonl` 영구 손실 → `dcness-review --latest` 가 자식 run 못 찾고 메인 history 5/12 epic-12 무관 run 반환
  - 자식 cost \$15~20/1회 실측인데 review 에 \$0 표시 — 측정 거버넌스 catastrophic 결함

## 결정 근거

- 결함 1 (dcness-review --latest) = 결함 2 (자식 begin-run 미호출) 의 종속 결함 — fix 결함 2 만으로 자동 해소. `list_runs` mtime 정렬 + `_resolve_state_root_for_cwd` git common-dir 단일 source 검증
- 결함 2 fix = system prompt 1st-class 의무 inject (commands/impl.md 본문보다 우선). 자식 자율 본능 의존 100% 해소 X — 추가 안전망 (Stop hook 자동 begin-run, SessionStart env trigger) 은 별도 이슈 영역
- 결함 3 fix = parent 의 stdout text fragility 검사. `process_task` 가 `code-validator` / `pr-reviewer` keyword 부재 시 blocked. echo 룰 (commands/impl.md / loop-procedure.md §3.1) 따라 자식이 정상이면 둘 다 stdout 흐름 보장
- ToolSearch / 코드 실증 검증 후 진행 — `harness/session_state.py:_resolve_state_root_for_cwd` 가 git common-dir 사용 = worktree cwd 라도 main repo `.sessions/` 단일 source 확인

## 관련 이슈

Closes #431

## 참고

- jajang 자식 실측 \$15~20/1회 → 4-step 누락 회귀 = 사용자 수동 후속 + cost 손실. fix 가성비 매우 높음
- 자식 jsonl: `~/.claude/projects/-Users-dc-kim-project-jajang--claude-worktrees-impl-loop-epic19-task67/a5dc830d-cc85-4fc3-9169-0756e7ad4be2.jsonl`
- 관련 PR: #425 (#422 안전망 1차) → #426 (슬래시 직호출) → **#XXX (본 PR, #431 의무 + 4-step 검사)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)