### PR TITLE
[feature] 헤드리스 자식 stream-json 파서 — 사람 친화 progress view

### DIFF
--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -41,19 +41,21 @@ tail -50 "<task-path>"
 
 ## 절차 — 헤드리스 spawn
 
-**메인 Claude 가 호출하는 방식 (MUST — 실시간 진행 가시화)**:
-
-Bash tool 의 `run_in_background=true` 로 spawn 후 Monitor tool 로 stdout line stream 받음. 메인 세션 UI 에 자식 진행 (`[child] ...` 접두) 이 line-by-line notification 으로 흐름. foreground (`run_in_background=false`) 호출 시 자식 종료까지 외부 progress (`Running... · 11m 42s`) 만 보이고 자식 prose 안 보임 (회귀 케이스).
-
 ```bash
 PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
 python3 "$PLUGIN_ROOT/scripts/impl_loop_headless.py" '<impl-glob>' \
   [--retry-limit 3] [--escalate-on blocked] [--timeout 1800]
 ```
 
-- Bash 호출 시 `run_in_background=true` 권장 (multi-task 또는 단일이라도 5분+ 예상 시)
-- Monitor tool 로 위 background 호출 stream — 메인이 line-by-line notification 받음 → 자식 sub-agent prose / Bash log 등 실시간 echo
-- 자식 stdout line 은 헤드리스 script 가 `  [child] <line>` 접두 박아 stderr 로 stream (옛 buffer-until-end 폐기)
+**실시간 진행 가시화 (#431 follow-up)**:
+- 스크립트가 자식 `claude -p` 를 `--output-format stream-json --verbose` 로 spawn
+- parent 가 stream-json event 파싱 → **간결한 progress line** 만 stderr emit:
+  - sub-agent 호출 → `  ㄴ <subagent_type> — <description>`
+  - conveyor lifecycle Bash → `  ㄴ "$HELPER" begin-run impl ...`
+  - 최종 결과 → `  [result] <첫 줄>`
+- 다른 도구 호출 (Edit/Read/Glob 등) + 메시지 텍스트는 progress 에서 skip (noise 차단)
+- Bash tool foreground 호출 시 CC UI 의 ⎿ 들여쓰기로 자식 진행 자연 표시 (raw line 흐름 아닌 *filter 후* 1 line per marker → CC Bash layer 가 stream 잘 표시)
+- Background + Monitor 패턴 옵션은 미권장 — Monitor notification 이 메인 Claude 해석 layer 거쳐 사용자 시야 도달이라 자식 line 직접 stream 효과 X
 
 스크립트 동작:
 

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -62,7 +62,8 @@ PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dc
 python3 "$PLUGIN_ROOT/scripts/impl_loop_headless.py" '<task-path>'
 ```
 
-- Bash tool `run_in_background=true` + Monitor stream 권장 — 메인 세션 UI 에 자식 진행 (`[child] ...` 접두) line-by-line notification. foreground 호출 시 자식 종료까지 외부 progress 만 보이고 자식 prose 안 보임 (회귀)
+- 스크립트가 자식 `claude -p` 를 stream-json + 사람 친화 progress 로 spawn — sub-agent 호출 / conveyor Bash / 최종 result 만 1 line per marker 로 stderr emit (#431 follow-up)
+- Bash tool foreground 호출 시 CC UI 의 ⎿ 들여쓰기로 자식 진행 자연 표시
 - 스크립트가 1 task glob 도 처리 — task 1개도 자식 세션 cold start 로 처리하고 결과만 메인에 회수. 메인은 결과 회수 + 사용자 보고만. 자세히 = [`commands/impl-loop.md`](impl-loop.md) §절차
 
 trade-off: 매 task 30~120s cold start latency 추가. 컨텍스트 누적 보호 + 사후 분석 자연 분리 + 실시간 가시화 가치와 trade-off.

--- a/scripts/impl_loop_headless.py
+++ b/scripts/impl_loop_headless.py
@@ -32,6 +32,7 @@ Usage:
 
 import argparse
 import glob
+import json
 import os
 import re
 import subprocess
@@ -220,25 +221,101 @@ def confirm_issue_closed(task_issue_num) -> bool:
         return None
 
 
+def format_progress_event(ev: dict) -> "str | None":
+    """stream-json event → 간결한 사람 친화 progress line.
+
+    None 반환 = 해당 event skip (raw line stream noise 회피).
+    """
+    t = ev.get("type")
+
+    # assistant tool_use → 도구 호출 시작
+    if t == "assistant":
+        msg = ev.get("message", {}) or {}
+        for c in msg.get("content", []) or []:
+            if not isinstance(c, dict):
+                continue
+            if c.get("type") == "tool_use":
+                name = c.get("name", "")
+                inp = c.get("input", {}) or {}
+                if name == "Task":
+                    sub = inp.get("subagent_type", "?")
+                    desc = (inp.get("description", "") or "")[:50]
+                    return f"  ㄴ {sub} — {desc}"
+                if name == "Bash":
+                    cmd = (inp.get("command", "") or "").splitlines()[0][:80]
+                    # conveyor lifecycle 명령만 echo (begin-run / begin-step / end-step / end-run)
+                    if any(kw in cmd for kw in (
+                        "begin-run", "begin-step", "end-step", "end-run",
+                    )):
+                        return f"  ㄴ {cmd}"
+                    # 그 외 일반 Bash 는 skip (verbose noise)
+                    return None
+                # 그 외 도구 (Edit/Read/Glob/Grep 등) 는 skip
+                return None
+
+    # result → 최종 메시지
+    if t == "result":
+        res = (ev.get("result", "") or "").strip()
+        if res:
+            short = res.splitlines()[0][:120]
+            return f"  [result] {short}"
+
+    return None
+
+
+def extract_event_text(ev: dict) -> "str | None":
+    """parse_result / 4-step 검사가 사용할 text 추출.
+
+    assistant text + tool_use 의 subagent_type / Bash command 도 함께 누적
+    (4-step keyword 매칭 + parse_result enum 매칭 양쪽 대응).
+    """
+    t = ev.get("type")
+    if t == "assistant":
+        msg = ev.get("message", {}) or {}
+        parts = []
+        for c in msg.get("content", []) or []:
+            if not isinstance(c, dict):
+                continue
+            if c.get("type") == "text":
+                parts.append(c.get("text", "") or "")
+            elif c.get("type") == "tool_use":
+                inp = c.get("input", {}) or {}
+                if c.get("name") == "Task":
+                    sub = inp.get("subagent_type", "")
+                    if sub:
+                        parts.append(f"[tool_use:Task subagent_type={sub}]")
+                elif c.get("name") == "Bash":
+                    cmd = (inp.get("command", "") or "").splitlines()[0][:200]
+                    parts.append(f"[tool_use:Bash {cmd}]")
+        return "\n".join(parts) if parts else None
+    if t == "result":
+        return ev.get("result", "") or None
+    return None
+
+
 def spawn_child(prompt: str, cwd: str, timeout: int,
                 extra_args: list = None,
                 stream_to: "io.TextIOBase | None" = None) -> tuple:
-    """claude -p 자식 세션 spawn — 슬래시 직호출 + 실시간 stdout stream.
+    """claude -p 자식 세션 spawn — stream-json 파서 + 간결 progress (#431 follow-up).
 
     extra_args = `--append-system-prompt <retry_context>` 등 추가 CLI 인자.
-    stream_to = 자식 stdout line 실시간 echo 대상 (default sys.stderr).
+    stream_to = 사람 친화 progress line 출력 대상 (default sys.stderr).
                 None 박으면 echo skip (capture only).
-    반환: (exit_code, stdout, stderr)
+    반환: (exit_code, aggregated_text, stderr)
 
-    옛 `subprocess.run(capture_output=True)` (전체 buffer) → `Popen + line stream`
-    으로 교체 (#429 follow-up — 사용자 메인 세션에서 자식 진행 실시간 가시화).
-    헤드리스 parent 가 `run_in_background=true` 로 호출되면 Monitor tool 이
-    stdout line stream 을 메인 Claude 로 notification 으로 전달.
+    옛 `--output-format text` (raw line stream) → `stream-json --verbose` 로 교체.
+    parent 가 각 JSON event 파싱 → Task tool 호출 (sub-agent 진입) + conveyor
+    lifecycle Bash 명령 + 최종 result 만 사람 친화 1-line 으로 stream_to emit.
+    raw event 노이즈 차단 → CC Bash foreground 진행 중 ⎿ 들여쓰기 자연 표시.
+
+    aggregated_text = parse_result + 4-step 검사용 — assistant text + tool_use
+    의 subagent_type / Bash command 누적.
     """
     cmd = [
         "claude", "-p",
         "--dangerously-skip-permissions",
-        "--output-format", "text",
+        "--output-format", "stream-json",
+        "--verbose",  # stream-json 은 verbose 페어링 필수 (CC CLI 강제)
     ]
     if extra_args:
         cmd.extend(extra_args)
@@ -247,7 +324,7 @@ def spawn_child(prompt: str, cwd: str, timeout: int,
     if stream_to is None:
         stream_to = sys.stderr
 
-    captured_stdout = []
+    captured_text = []
     captured_stderr = []
 
     try:
@@ -262,24 +339,47 @@ def spawn_child(prompt: str, cwd: str, timeout: int,
 
     import threading
 
-    def _drain(pipe, sink, prefix):
+    def _drain_stdout():
         try:
-            for line in iter(pipe.readline, ""):
-                sink.append(line)
+            for line in iter(proc.stdout.readline, ""):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
+                    # 가끔 non-JSON 줄 (CC 디버그 등) → raw echo + skip
+                    if stream_to is not None:
+                        stream_to.write(f"  [child:raw] {line}\n")
+                        stream_to.flush()
+                    continue
+
+                # progress line emit
                 if stream_to is not None:
-                    stream_to.write(f"{prefix}{line}")
+                    progress = format_progress_event(ev)
+                    if progress:
+                        stream_to.write(progress + "\n")
+                        stream_to.flush()
+
+                # text aggregation
+                text = extract_event_text(ev)
+                if text:
+                    captured_text.append(text)
+        finally:
+            proc.stdout.close()
+
+    def _drain_stderr():
+        try:
+            for line in iter(proc.stderr.readline, ""):
+                captured_stderr.append(line)
+                if stream_to is not None:
+                    stream_to.write(f"  [child:err] {line}")
                     stream_to.flush()
         finally:
-            pipe.close()
+            proc.stderr.close()
 
-    t_out = threading.Thread(
-        target=_drain, args=(proc.stdout, captured_stdout, "  [child] "),
-        daemon=True,
-    )
-    t_err = threading.Thread(
-        target=_drain, args=(proc.stderr, captured_stderr, "  [child:err] "),
-        daemon=True,
-    )
+    t_out = threading.Thread(target=_drain_stdout, daemon=True)
+    t_err = threading.Thread(target=_drain_stderr, daemon=True)
     t_out.start()
     t_err.start()
 
@@ -289,11 +389,11 @@ def spawn_child(prompt: str, cwd: str, timeout: int,
         proc.kill()
         t_out.join(timeout=2)
         t_err.join(timeout=2)
-        return 124, "".join(captured_stdout), "".join(captured_stderr)
+        return 124, "\n".join(captured_text), "".join(captured_stderr)
 
     t_out.join(timeout=5)
     t_err.join(timeout=5)
-    return exit_code, "".join(captured_stdout), "".join(captured_stderr)
+    return exit_code, "\n".join(captured_text), "".join(captured_stderr)
 
 
 def process_task(task_path: str, cwd: str, retry_limit: int,

--- a/tests/test_impl_loop_headless.py
+++ b/tests/test_impl_loop_headless.py
@@ -214,23 +214,38 @@ class EscalateSetTests(unittest.TestCase):
 
 
 class SpawnChildStreamTests(unittest.TestCase):
-    """spawn_child line-buffered stream 동작 검증 (#429 follow-up).
+    """spawn_child stream-json 파서 + 간결 progress 검증 (#431 follow-up).
 
-    fake claude CLI 를 PATH 첫머리에 박아 실제 claude 호출 없이 검증.
-    fake CLI = 3 줄 stdout 출력 + 사이에 sleep → buffer-until-end 아닌
-    line-by-line 으로 즉시 stream_to 에 echo 되는지 확인.
+    fake claude CLI 가 stream-json 형식으로 4-step + result event emit.
+    parent 가 파싱 → Task tool_use marker + result 만 progress line 으로 echo.
     """
 
     def setUp(self):
         self._tmp = tempfile.mkdtemp()
-        # fake claude — 3 라인을 0.1s 간격으로 emit (line-buffered 검증)
+        # fake claude — stream-json events (assistant tool_use × 4 + result)
         fake_claude = Path(self._tmp) / "claude"
         fake_claude.write_text(
             "#!/usr/bin/env python3\n"
-            "import sys, time\n"
-            "sys.stdout.write('line1\\n'); sys.stdout.flush(); time.sleep(0.05)\n"
-            "sys.stdout.write('line2\\n'); sys.stdout.flush(); time.sleep(0.05)\n"
-            "sys.stdout.write('PASS: ok\\n'); sys.stdout.flush()\n"
+            "import json, sys, time\n"
+            "def emit(ev):\n"
+            "    sys.stdout.write(json.dumps(ev) + '\\n')\n"
+            "    sys.stdout.flush()\n"
+            "for agent, desc in [\n"
+            "    ('test-engineer', '테스트 작성'),\n"
+            "    ('engineer', '구현'),\n"
+            "    ('code-validator', '검증'),\n"
+            "    ('pr-reviewer', '리뷰'),\n"
+            "]:\n"
+            "    emit({'type': 'assistant', 'message': {'content': [\n"
+            "        {'type': 'tool_use', 'name': 'Task', 'input': {\n"
+            "            'subagent_type': agent, 'description': desc,\n"
+            "        }}\n"
+            "    ]}})\n"
+            "    time.sleep(0.02)\n"
+            "emit({'type': 'assistant', 'message': {'content': [\n"
+            "    {'type': 'text', 'text': 'PASS: 머지 완료'}\n"
+            "]}})\n"
+            "emit({'type': 'result', 'result': 'PASS: 머지 완료'})\n"
             "sys.exit(0)\n",
             encoding="utf-8",
         )
@@ -243,35 +258,34 @@ class SpawnChildStreamTests(unittest.TestCase):
         import shutil
         shutil.rmtree(self._tmp, ignore_errors=True)
 
-    def test_stream_to_receives_lines_with_prefix(self):
-        """stream_to 가 자식 stdout line 을 '[child] ' 접두 박아 받는지."""
+    def test_progress_emits_subagent_markers(self):
+        """stream_to 가 sub-agent 호출 marker 를 간결 progress 로 받는지."""
         import io
         sink = io.StringIO()
-        exit_code, stdout, stderr = ilh.spawn_child(
-            "/some-prompt", cwd=self._tmp, timeout=10,
-            stream_to=sink,
+        exit_code, stdout, _ = ilh.spawn_child(
+            "/x", cwd=self._tmp, timeout=10, stream_to=sink,
         )
         self.assertEqual(exit_code, 0)
-        # captured stdout 정합
-        self.assertIn("line1", stdout)
-        self.assertIn("line2", stdout)
-        self.assertIn("PASS: ok", stdout)
-        # stream sink 에 prefix 박힌 line stream 도착
         sink_content = sink.getvalue()
-        self.assertIn("[child] line1", sink_content)
-        self.assertIn("[child] line2", sink_content)
-        self.assertIn("[child] PASS: ok", sink_content)
+        # 4 sub-agent marker 모두 progress line 으로 emit
+        self.assertIn("ㄴ test-engineer — 테스트 작성", sink_content)
+        self.assertIn("ㄴ engineer — 구현", sink_content)
+        self.assertIn("ㄴ code-validator — 검증", sink_content)
+        self.assertIn("ㄴ pr-reviewer — 리뷰", sink_content)
+        # result line 도 emit
+        self.assertIn("[result] PASS: 머지 완료", sink_content)
 
-    def test_stream_to_none_skips_echo(self):
-        """stream_to=None 시 echo skip — capture 만."""
-        # spawn_child 시그니처상 None 전달 시 default sys.stderr 로 들어감.
-        # 따라서 stream skip 검증은 sink=io.StringIO() 빈 결과 확인이 아니라
-        # default 동작 회귀만 보장. 본 케이스는 capture 정합만 확인.
+    def test_aggregated_text_for_parse_result(self):
+        """aggregated_text 에 subagent_type keyword + assistant text 누적."""
         exit_code, stdout, _ = ilh.spawn_child(
             "/x", cwd=self._tmp, timeout=10, stream_to=None,
         )
         self.assertEqual(exit_code, 0)
-        self.assertIn("PASS: ok", stdout)
+        # 4-step 검사용 keyword
+        self.assertIn("code-validator", stdout)
+        self.assertIn("pr-reviewer", stdout)
+        # parse_result 용 enum text
+        self.assertIn("PASS: 머지 완료", stdout)
 
 
 class FalseCleanDowngradeTests(unittest.TestCase):


### PR DESCRIPTION
## 변경 요약

### [feature] 헤드리스 자식 stream-json 파서 — 사람 친화 progress view

- **What**:
  - `scripts/impl_loop_headless.py:spawn_child` `--output-format text` → `stream-json --verbose` 로 교체
  - `format_progress_event` / `extract_event_text` 신규 — JSON event filter + 사람 친화 1 line per marker
  - Sub-agent 호출 (`Task` tool) / conveyor lifecycle (Bash `begin-run` `begin-step` `end-step` `end-run`) / `result` 만 emit. 다른 도구 호출 (Edit/Read/Glob 등) skip
  - `commands/impl-loop.md` / `commands/impl.md` §절차 — stream-json + foreground Bash 자연 표시 명시, Bash background+Monitor 폐기
  - `SpawnChildStreamTests` 갱신 (2 케이스 — progress marker + aggregated text)
- **Why**:
  - v0.2.23 `[child] <raw line>` stream = verbose noise. 사용자 시연: 간결한 progress (sub-agent 진입/종료 marker 만) 필요
  - Bash background+Monitor 도 메인 Claude 해석 layer 거쳐 사용자 시야 도달 = 자식 line 직접 stream 효과 X
  - stream-json = CC CLI 의 권위 marker (`tool_use.name == "Task"` + `input.subagent_type`) → 패턴 fragility 0

## 결정 근거

- `claude -p --output-format stream-json --verbose` 실증 — Task tool 의 `subagent_type` 정확히 매치 확인
- foreground Bash 호출 시 CC UI ⎿ 자연 표시는 *간결한 progress* 일 때만 유효 — raw line 흐름은 buffering. filter 후 1 line per marker 박음
- aggregated_text 의 `[tool_use:Task subagent_type=<agent>]` 형태가 `process_task` 의 inner 4-step keyword 검사 (#432) 와 호환 — 회귀 없음
- 시뮬레이션 결과 사용자 의도 정확 매칭

## 관련 이슈

Document-Exception-PR-Close: #431 follow-up UX 보강 — 닫을 신규 이슈 없음

## 참고

- 시뮬레이션 출력:
  ```
  [task] .../impl/01-test.md (attempt 1/1)
    ㄴ "$HELPER" begin-run impl --issue-num 777
    ㄴ test-engineer — NS4 4 후보 perceptual 비교 테스트 작성
    ㄴ engineer — AudioEngine perceptual_score 측정 함수 구현
    ㄴ code-validator — impl 계획 ↔ 구현 정합 검증
    ㄴ pr-reviewer — 코드 품질·보안 + PR 생성·머지
    ㄴ "$HELPER" end-run
    [result] PASS: NS4 perceptual 비교 완료, PR 머지됨
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)