### PR TITLE
[docs] CLAUDE.md §0.4 영어 명사구·줄임말 함부로 사용 금지 규약 보강

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,21 @@
 
 - 외래어 (Caveats / Disclaimer / Note / TBD 등) 보다는 **명확한 한글** 사용. (예: "Caveats" → "주의사항" / "TBD" → "추후 결정")
 - 영어 약어가 더 정확한 곳(API / SDK / SSOT / PR / CI 등 산업 표준어)은 그대로 사용.
+- **영어 명사구·줄임말 함부로 사용 금지** — 사용자 응답 / PR 본문 / 커밋 메시지 / 문서 본문 모두 적용. 예시 대체:
+  - "cheap lever" → "저비용 절감 수단" / "가벼운 개선책"
+  - "knob" → "조작 지점" / "조정값"
+  - "follow-up" → "후속" / "후속 작업"
+  - "wrap-up" → "마무리"
+  - "polish" → "다듬기" (일반 문맥)
+  - "fallback" → "대체 경로" / "후보 경로"
+  - "fresh" → "새 / 갓 시작한"
+  - "in-session" → "한 세션 안에서" / "세션 내"
+  - 일반: 영어 명사구가 떠오르면 *우선 한글 풀이*, 정확도 위해 영어 병기 필요 시 `한글(영어)` 형식.
+- **예외 — 그대로 사용**:
+  - 산업 표준 약어 (API / SDK / SSOT / PR / CI / TDD / DRY / OWASP / MUST / IMPL / OAuth 등)
+  - dcness 코드 식별자·spec 키워드 (`POLISH` / `IMPL` / `SPEC_GAP_FOUND` / `PASS` / `FAIL` / `ESCALATE` / `Hybrid A` 등 agent·orchestration 에 박힌 정형 이름)
+  - 도구·라이브러리·인물 이름 (Claude / Anthropic / GitHub / vitest 등)
+  - 이슈·PR 본문 직접 인용
 - **`§` 기호는 명확하게 사용** — `§N`, `§N.M` 형식. 어디서 인용했는지 **반드시 명시** (예: `CLAUDE.md §2` / `orchestration.md §2.1`).
 - 단순히 "위 섹션" / "아래 참조" 같은 모호한 표현 X — 항상 `파일명 §번호` 박을 것.
 


### PR DESCRIPTION
## 변경 요약

### [docs] CLAUDE.md §0.4 영어 명사구·줄임말 함부로 사용 금지 규약 보강
- **What**: CLAUDE.md §0.4 작성 스타일 본문에 영어 명사구·줄임말 함부로 사용 금지 bullet 추가. 적용 범위 (사용자 응답 / PR 본문 / 커밋 메시지 / 문서 본문 모두) + 대체 예시 8건 + 예외 카탈로그 4종 명시.
- **Why**: 글로벌 메모리 (feedback_korean_first.md) 만으로는 dcness 자체 세션에서 강제력 약함. §0.4 가 추상 룰 ("쉬운 한글") 만 있고 구체 대체 예시·예외 카탈로그 부재 → 메인 Claude 가 "cheap lever" / "wrap-up" / "follow-up" / "fallback" / "in-session" 등 반복 사용. 사용자 직접 지시.

## 결정 근거

- **메모리 말고 CLAUDE.md** — 사용자 명시 (글로벌 메모리는 자동 컨텍스트라 강제력 약함, 본 저장소 작업 SSOT 에 박는 게 강제력 명확)
- **대체 예시 8건 구체화** — 추상 룰만 박으면 메인이 "어디까지 한글로?" 추측. 구체 예시 있으면 즉시 적용 가능
- **예외 카탈로그 명시** — 산업 표준 약어 (API/SSOT/PR/CI 등) + dcness 코드 식별자 (POLISH/IMPL/Hybrid A 등) + 도구·인물 이름 + 이슈·PR 직접 인용. 한글 강제로 가독성 떨어지는 영역 차단

## 관련 이슈

(자율 — 사용자 직접 피드백)

Document-Exception-PR-Close: dcness self 거버넌스 변경 — 이슈 close 없음.

## 참고

- 432/432 unittest PASS · git-naming hook PASS
- 사용자 직접 지시: "외래어 줄임말 금지" 메모리 말고 CLAUDE.md 에 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)