### PR TITLE
[issue-463] sub-agent CLAUDE.md 직접 수정 차단 + module-architect / system-architect ALLOW_MATRIX 키 명시

### DIFF
--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -186,7 +186,9 @@ merge 직전 코드 품질 + 보안 코드 패턴 심사:
 
 ### 4.3 인프라 패턴 (전 에이전트 공통 차단)
 
-전 sub-agent 의 인프라 path Write 차단 (`.claude/`, `hooks/`, `harness/*.py`, `docs/plugin/*.md`, `scripts/*.mjs` 등). 정확한 패턴 = **코드 SSOT [`harness/agent_boundary.py`](../../harness/agent_boundary.py) `DCNESS_INFRA_PATTERNS`**.
+전 sub-agent 의 인프라 path Write 차단 (`.claude/`, `hooks/`, `harness/*.py`, `docs/plugin/*.md`, `scripts/*.mjs`, repo root `CLAUDE.md` 등). 정확한 패턴 = **코드 SSOT [`harness/agent_boundary.py`](../../harness/agent_boundary.py) `DCNESS_INFRA_PATTERNS`**.
+
+> **`CLAUDE.md` 보호 (회귀 방지)**: 외부 활성 프로젝트의 repo root `CLAUDE.md` (메인 Claude 가 매 turn 자동 read 하는 SSOT) 는 본 패턴에 포함되어 sub-agent Write 차단. 메인 Claude 직접 편집 (active_agent 미설정 = 통과) 또는 `.no-dcness-guard` opt-out 마커로만 우회 가능.
 
 인프라 프로젝트(`is_infra_project()` True) 에선 위 패턴 해제 (dcness 자체 작업 시 본 SSOT 들도 편집 가능해야 함).
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -54,6 +54,7 @@ DCNESS_INFRA_PATTERNS: tuple[str, ...] = (
     r'(^|/)docs/plugin/loop-procedure\.md$',
     r'(^|/)docs/internal/governance\.md$',
     r'(^|/)scripts/(check_document_sync|check_task_id|setup_branch_protection|analyze_metrics)\.mjs$',
+    r'^CLAUDE\.md$',
 )
 
 
@@ -70,6 +71,18 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'(^|/)apps/[^/]+/[^/]+\.cfg$',
     ),
     "architect": (
+        r'(^|/)docs/',
+        r'(^|/)backlog\.md$',
+        r'(^|/)trd\.md$',
+    ),
+    # module-architect / system-architect — architect 변종. 키 명시 필수.
+    # 키 부재 시 "미정의 agent = 통과" fallback 으로 빠져 ALLOW 강제 자체가 무력화.
+    "module-architect": (
+        r'(^|/)docs/',
+        r'(^|/)backlog\.md$',
+        r'(^|/)trd\.md$',
+    ),
+    "system-architect": (
         r'(^|/)docs/',
         r'(^|/)backlog\.md$',
         r'(^|/)trd\.md$',

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -123,6 +123,37 @@ class WriteAllowedInfraPatternBlockTests(unittest.TestCase):
             )
             self.assertIsNotNone(reason)
 
+    def test_module_architect_blocked_on_claude_md(self):
+        # #463 회귀 — module-architect 가 외부 활성 프로젝트의 CLAUDE.md 직접 수정.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed(
+                "module-architect", "CLAUDE.md", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_engineer_blocked_on_claude_md(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed(
+                "engineer", "CLAUDE.md", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_subdir_claude_md_not_matched(self):
+        # repo root CLAUDE.md 만 차단. subdir 의 동명 파일은 매치 X.
+        # (단 ALLOW_MATRIX 미매칭으로 다른 차단은 가능 — 본 테스트는 INFRA 패턴 한정.)
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed(
+                "engineer", "node_modules/foo/CLAUDE.md", cwd=cwd
+            )
+            # INFRA 매칭은 아니어야 함 (root 직속만 매치).
+            if reason is not None:
+                self.assertNotIn("인프라", reason)
+
 
 class WriteAllowedAllowMatrixTests(unittest.TestCase):
     """user 프로젝트 — ALLOW_MATRIX 매칭/미매칭."""
@@ -171,6 +202,28 @@ class WriteAllowedAllowMatrixTests(unittest.TestCase):
             self.assertIsNotNone(reason)
             self.assertIn("ALLOW_MATRIX", reason)
 
+    def test_module_architect_docs_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("module-architect", "docs/impl/01-foo.md", cwd=cwd)
+            )
+
+    def test_module_architect_random_blocked(self):
+        # #463 — module-architect 키 명시 후 ALLOW 외 path 는 차단되어야 (silent pass 회귀 방지).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            reason = check_write_allowed("module-architect", "src/foo.ts", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("ALLOW_MATRIX", reason)
+
+    def test_system_architect_docs_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("system-architect", "docs/architecture.md", cwd=cwd)
+            )
+
     def test_unknown_agent_passes(self):
         # 미정의 agent → false positive 회피로 통과.
         with tempfile.TemporaryDirectory() as td:
@@ -200,6 +253,10 @@ class OptOutMarkerTests(unittest.TestCase):
             # 우회 — INFRA_PATTERN 매칭이지만 통과.
             self.assertIsNone(
                 check_write_allowed("engineer", "hooks/x.sh", cwd=cwd)
+            )
+            # CLAUDE.md 도 우회 (사용자 임시 우회 정합).
+            self.assertIsNone(
+                check_write_allowed("module-architect", "CLAUDE.md", cwd=cwd)
             )
 
     def test_no_marker_no_bypass(self):


### PR DESCRIPTION
## 변경 요약

### [issue-463] sub-agent CLAUDE.md 직접 수정 차단 + module-architect / system-architect ALLOW_MATRIX 키 명시
- **What**:
  - `harness/agent_boundary.py` — `DCNESS_INFRA_PATTERNS` 에 `^CLAUDE\.md$` (repo root 직속만) 추가 + `ALLOW_MATRIX` 에 `module-architect` / `system-architect` 키 명시 (architect 와 동일 영역)
  - `tests/test_agent_boundary.py` — 6 신규 케이스 (CLAUDE.md 차단 / subdir 매치 X / module-architect ALLOW 매칭·미매칭 / system-architect ALLOW / opt-out 마커 우회 정합)
  - `docs/plugin/handoff-matrix.md` §4.3 — 본문 예시에 `CLAUDE.md` 추가 + 보호 의도 / 우회 경로 1단락
- **Why**:
  - 2026-05-22 jajang 실측 사단 — `/impl-loop` 의 module-architect 3 병렬 spawn 중 1 spawn 이 본 task scope 외인 `CLAUDE.md` 의 모듈 표에 incomplete + 부정확 (Story 상태 IN PROGRESS 잘못 표기) + broken link (stories.md 부재 인지 X) 박음. CLAUDE.md 는 메인이 매 turn 자동 read 하는 SSOT — 잘못 박히면 누적 회귀.
  - 원인 ①: `DCNESS_INFRA_PATTERNS` 에 `CLAUDE.md` 패턴 부재.
  - 원인 ②: `module-architect` / `system-architect` 가 `ALLOW_MATRIX` 키 부재 → `check_write_allowed` 가 "미정의 agent = 통과" fallback 으로 빠져 ALLOW 자체 무력화.

## 결정 근거

- **CLAUDE.md 패턴 = repo root 직속만**: `^CLAUDE\.md$` 로 `_normalize` cwd-relative 정규화 후 매칭. cwd 밖 절대 path 의 동명 파일 (`/tmp/foo/CLAUDE.md` 등) 및 subdir (`node_modules/x/CLAUDE.md`) 은 매치 X — sub-agent 가 자기 영역 read 만 하면 안전. 이슈 본문 §보강 방향 1 정합.
- **module-architect / system-architect 키 = architect 와 동일 영역**: 두 변종 모두 docs/ + backlog/trd 작성이 정상 영역. 별도 좁힐 이유 부재. 이슈 본문 §보강 방향 2 option (a) 채택 — "ALLOW_MATRIX 키 부재 = deny all" fallback 변경은 미정의 agent 시나리오 (custom-agent 등) 까지 함께 깨므로 보수적으로 키 명시만.
- **opt-out 마커 정합**: `.no-dcness-guard` 가 이미 `check_write_allowed` line 208~209 에서 모든 룰 우회 → CLAUDE.md 차단도 자동 우회. 별도 조치 불필요. 이슈 본문 §보강 방향 3 자동 해소.

## 관련 이슈

Closes #463

## 배포 경로 검증

- **경로 1 (plug-in 본체)**: `harness/agent_boundary.py` + `docs/plugin/handoff-matrix.md` 모두 plug-in 본체 영역. 외부 활성 프로젝트가 `/plugin update dcness` 후 hook 실행 시 본 코드 호출되어 자동 적용.
- **경로 2 (init-dcness 복사)**: 본 변경 영역 미해당. `harness/` 코드는 경로 1 로 도달.
- **경로 3 (사용자 SSOT 문서)**: `docs/plugin/handoff-matrix.md` = plug-in 본체 docs/plugin/ 영역 — 외부 사용자가 직접 보는 SSOT 자동 갱신.

## Test Plan

- [x] `tests/test_agent_boundary.py` 6 신규 케이스 추가
- [x] `python3 -m unittest discover -s tests` 438 tests OK
- [x] 회귀 검증 — 기존 27 케이스 모두 PASS (CLAUDE.md 패턴 추가가 다른 영역 영향 X)

---
규칙 정의: [`CLAUDE.md`](../CLAUDE.md) (SSOT)