### PR TITLE
[issue-391] 메인 자율 insight CLI 호출 가이드 — 실수 환기 형태로만 박음 (잘 됐다 누적 차단)

### DIFF
--- a/commands/impl.md
+++ b/commands/impl.md
@@ -145,5 +145,6 @@ PR merge 직후 *반드시* 다음 1개 명령 실행 (issue #396 — 단일화)
 
 - agent+mode 별 FIFO 10 한도. 다음 run begin-step 자동 inject.
 - 미박음 = noop (자율, 강제 X). 박으면 다음 run 학습 환류.
+- **형식 가이드**: *실수 환기* 형태로만 박는다 (예: "🚨 X 실수 — 반복 X" / "Y 빠뜨림 — 다음엔 Z 명시"). "잘 됐던 케이스" 누적은 학습 가치 0 (issue #392 실측 — baseline good 노이즈). insight 1줄은 *다음 run 의 회귀 회피* 용도.
 
 근거: §3.4 PR merge 자동 완료 후 메인이 review echo 를 skip 하는 회귀가 반복 발생. hook 미진입 영역이므로 본문 강제로 보완 + 자율 인사이트 매커니즘 안내.

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -1147,6 +1147,7 @@ def render_report(report: RunReport) -> str:
     lines.append("- agent+mode 별 `.claude/loop-insights/<agent>[-<mode>].md` 에 누적 (FIFO 10 cap)")
     lines.append("- 다음 run begin-step 시 자동 inject — 같은 agent 호출 시 sub-agent prompt 끝에 박힘")
     lines.append("- 미박음 = noop (자율, 강제 X)")
+    lines.append("- **형식 가이드**: *실수 환기* 형태로만 (예: `🚨 X 실수 — 반복 X`). 잘 됐던 케이스 누적은 학습 가치 0 (issue #392 실측)")
     lines.append("")
 
     return "\n".join(lines)


### PR DESCRIPTION
## 변경 요약

### [issue-391] 메인 자율 insight CLI 호출 가이드 — 실수 환기 형태로만 박음
- **What**: `commands/impl.md` §메인 인사이트 + `harness/run_review.py` review.md 끝 prompt 2 곳에 "*실수 환기* 형태로만 박는다. 잘 됐던 케이스 누적은 학습 가치 0" 가이드 1줄 추가.
- **Why**: 이슈 #391 본문 (옛 자동 누적 매커니즘 분석) 은 이미 stale — `detect_goods` + `append_from_run` 매커니즘은 이슈 #392 로 폐기됨 (`run_review.py:736~743` 주석 + `loop_insights.py:109`). 현재 누적 경로는 메인 자율 `dcness-helper insight` CLI 만 남음. 다만 사용자 의도 ("잘됐다는 큰 의미 없음, 이전 실수 환기만 의미") 가 명시적 가이드로 박혀있지 않아 메인이 자율 호출 시 good 형태 박을 자유 잔존.

## 결정 근거

- **이슈 본문 = stale**: #391 본문의 처방 (BASELINE_GOOD_PATTERNS 필터) 은 매커니즘 자체가 폐기됐으므로 의미 0.
- **A + B 옵션 채택** (사용자 추천): #391 close (stale) + agent 가이드 보강.
- **C (코드 강제) 미채택**: `append_insight` 시그니처에 `type=Literal["bad"]` 강제 검토했으나 가끔 의미 있는 *교훈 형* 인사이트 (예: "X 방식이 N task 연속 회귀 방지함 — 계속 유지") 여지 남김. 자연어 가이드로 충분 + 회귀 발견 시 강제 승격 가능.
- **D (시스템 통째 폐기) 미채택**: 외부 활성 프로젝트의 실제 사용 빈도 미관측 상태에서 폐기 위험.

## 관련 이슈

Closes #391

## 배포 경로 검증

- **경로 1 (plug-in 본체)**: `commands/impl.md` + `harness/run_review.py` 모두 plug-in 본체 영역. `/plugin update dcness` 후 즉시 외부 활성 프로젝트에 반영.
- **경로 2 (init-dcness 복사)**: 미해당.
- **경로 3 (사용자 SSOT 문서)**: `commands/impl.md` = plug-in 본체 commands/ 영역, 외부 사용자가 직접 보는 가이드 자동 갱신.

## Test Plan

- [x] `python3 -m unittest discover -s tests` 438 tests OK
- [x] review.md render 출력의 가이드 텍스트는 테스트 covered X (`grep` 0 hit) → 회귀 X 확인
- [x] 가이드 1줄 추가만이라 동작 변경 0 (메인 자율 호출 자체 강제 X)

---
규칙 정의: [`CLAUDE.md`](../CLAUDE.md) (SSOT)