### PR TITLE
[issue-469] Stop hook continuation signal — 중간 step PASS 후 메인 turn 자동 발화 강제 (결함 A 단독 fix)

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -18,18 +18,20 @@ dcness 가 강제하는 영역은 단 2가지 ([`orchestration.md`](orchestratio
 
 ## 1. CC hook event 모델
 
-dcness 가 사용하는 CC hook event 3종:
+dcness 가 사용하는 CC hook event 4종:
 
 | Event | 시점 | 차단 권한 | dcness 사용 hook |
 |---|---|---|---|
 | `SessionStart` | CC 새 conversation 시작 시 (resume / `/clear` 포함). user 첫 prompt 처리 *전*. | X (inject 만) | session-start.sh |
 | `PreToolUse` | tool 호출 *직전*. matcher 매치 시 fire. | ✓ (`exit 1` 또는 `permissionDecision: deny` 로 차단) | catastrophic-gate / file-guard / tdd-guard |
 | `PostToolUse` | tool 호출 *직후* (결과 반환 후, 메인 다음 turn 시작 전). | X (inject 만) | post-agent-clear / post-file-op-trace |
+| `Stop` | 메인 응답 종료 시점. 무한 루프 방지 `stop_hook_active=true` 플래그 동반. | ✓ (`decision: "block"` JSON stdout 으로 메인 turn 재 발화 강제) | stop-end-run.sh |
 
-**미사용 event**: `UserPromptSubmit` / `PreCompact` / `Stop` / `SubagentStop` / `Notification` / `SessionEnd` — dcness 강제 백본은 PreToolUse + SessionStart + PostToolUse 3종으로 충족.
+**미사용 event**: `UserPromptSubmit` / `PreCompact` / `SubagentStop` / `Notification` / `SessionEnd` — dcness 강제 백본은 SessionStart + PreToolUse + PostToolUse + Stop 4종으로 충족.
 
 **차단 권한 비대칭**:
-- PreToolUse 만 *차단* 가능 → catastrophic-gate / file-guard / tdd-guard 가 실제 강제 백본.
+- PreToolUse 만 tool 호출 *차단* 가능 → catastrophic-gate / file-guard / tdd-guard 가 실제 강제 백본.
+- Stop 은 메인 종료 *차단* 가능 (`decision: "block"`) → stop-end-run.sh 가 중간 step PASS 후 메인 침묵 회귀 차단 (issue #469 결함 A).
 - SessionStart + PostToolUse 는 `hookSpecificOutput.additionalContext` 로 *컨텍스트 inject* — 메인 Claude 의 다음 turn 에 system reminder 로 보임.
 
 ---
@@ -62,7 +64,7 @@ python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
 
 ---
 
-## 3. 6 hook 상세
+## 3. 7 hook 상세
 
 ### 3.1 session-start.sh
 
@@ -178,6 +180,33 @@ python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
 
 ---
 
+### 3.7 stop-end-run.sh
+
+**Event**: `Stop`
+**시점**: 메인 Claude 응답 종료 시. `stop_hook_active=true` 동반 시 즉시 skip (무한 루프 가드).
+**도입**: issue #382 (자동 end-run) + issue #469 결함 A fix (continuation signal)
+
+**역할 1 — 자동 end-run (issue #382)**:
+- `active_runs[rid]` 슬롯 미finalized + 마지막 step end-step 호출 완료 매칭 시 in-process `_cli_end_run` 호출.
+- 부산물: `<run_dir>/review.md` 생성 + loop-insights 누적 + active_runs slot finalize.
+- 배경: `/impl` / `/impl-loop` / `/architect-loop` 종료 후 메인이 end-run 까먹는 회귀 차단.
+
+**역할 2 — continuation signal (issue #469 결함 A)**:
+- end-run 호출 *전* 마지막 step prose (`<run_dir>/<agent>[-<MODE>].md`) 결론 enum 추출.
+- 다음 step 진입 가능 enum (`PASS` / `IMPL_DONE` / `POLISH_DONE` / `TESTS_WRITTEN` / `UX_FLOW_DONE`) **AND** 마지막 step agent 가 종료 agent (`pr-reviewer`) 아닌 경우 → `{"decision": "block", "reason": "..."}` JSON stdout 박음.
+- CC 가 본 신호 인식 → 메인 turn 재 발화 강제. 메인이 reason 읽고 다음 sub-step 진입 (예: build-worker PASS → pr-reviewer 호출).
+- 무한 루프 가드: 같은 step 에서 block 박은 횟수 (`slot.stop_block_count[<agent>:<mode>]`) 가 `_STOP_BLOCK_COUNT_MAX = 2` 초과 시 skip — 메인이 reason 받고도 발화 안 하는 진짜 종료 의도 인정.
+- 배경: jajang Epic 20 multi-task `/impl-loop` 실측에서 build-worker tool_result 후 메인 turn 자동 발화 부재 = 9시간 16분 침묵 사례 ([issue #469](../../) 본문 참조).
+
+**차단 동작**:
+- 역할 1 분기 → `exit 0` + `_cli_end_run` 호출 (block 안 함, 정상 종료 허용).
+- 역할 2 분기 → `exit 0` + `decision:"block"` JSON stdout (메인 재 발화 강제).
+- 본 hook 의 차단 메커니즘 = stdout JSON 으로 CC 에 신호. stderr 는 `/tmp/dcness-hook-stderr.log` 보존 (디버그용).
+
+**코드 SSOT**: [`harness/hooks.py`](../../harness/hooks.py) `handle_stop` + `_maybe_emit_continuation_signal`.
+
+---
+
 ## 4. 등록 메커니즘
 
 **[`hooks/hooks.json`](../../hooks/hooks.json)**: CC plug-in 의 hook 등록 표준 형식. event 별 matcher + 실행 스크립트 정의.
@@ -194,7 +223,8 @@ python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
     "PostToolUse": [
       { "matcher": "Agent", "hooks": [...] },
       { "matcher": "Edit|Write|NotebookEdit|Read|Bash|mcp__.*", "hooks": [...] }
-    ]
+    ],
+    "Stop": [{ "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-end-run.sh\"" }] }]
   }
 }
 ```

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -777,11 +777,16 @@ def handle_stop(
        session_state.py:1001 안전망 → finalize-run --auto-review 자동 →
        `<run_dir>/review.md` 생성 + stderr `[REVIEW_READY]` 신호
 
-    Stop hook 자체는 메인 시야에 inject 안 함 (additionalContext 미지원).
+    issue #469 결함 A fix (DCN-CHG-20260522): 중간 step PASS 후 다음 step 미진입
+    상태로 Stop 받으면 `decision:"block"` JSON stdout 으로 메인 turn 자동 발화
+    강제 (build-worker PASS → 9시간 침묵 회귀 차단). `_maybe_emit_continuation_signal`
+    helper 가 `_CONTINUE_ENUMS` + `_TERMINAL_AGENTS` + `stop_block_count` 가드로
+    분기.
+
     review.md 본문 echo 는 *기존 prose 의무* (loop-procedure.md §6 +
     run-review.md §51 + commands/impl.md §종료 조건) 에 의존.
 
-    return: 항상 0 (block 안 함, 정상 종료 허용).
+    return: 항상 0 (block 박은 경우에도 0 — CC 가 stdout JSON 으로 block 분기 인식).
     """
     if stdin_data is None:
         try:
@@ -844,15 +849,27 @@ def handle_stop(
         return 0  # step 0개 — begin-step 안 부른 상태
 
     last = steps[-1]
+    last_agent = last.get("agent")
+    last_mode = last.get("mode")
     cur_step = slot.get("current_step") if isinstance(slot, dict) else None
     if isinstance(cur_step, dict):
         cur_agent = cur_step.get("agent")
         cur_mode = cur_step.get("mode")
-        last_agent = last.get("agent")
-        last_mode = last.get("mode")
         # 정확 일치 검사 (mode None 도 비교)
         if cur_agent != last_agent or cur_mode != last_mode:
             return 0  # begin-step 후 end-step 미호출 — 진행 중
+
+    # === issue #469 결함 A — 중간 step PASS 후 메인 turn 자동 발화 부재 fix ===
+    # build-worker / engineer / code-validator 같은 중간 step 종료 후 메인이
+    # 다음 step 진입 안 한 상태로 Stop 받으면 decision:block 으로 메인 turn
+    # 재 발화 강제. pr-reviewer 는 종료 agent (run 끝 = 정상 침묵).
+    if _maybe_emit_continuation_signal(
+        sid=sid, rid=rid, slot=slot, active=active,
+        last_agent=last_agent, last_mode=last_mode,
+        base_dir=base_dir,
+    ):
+        return 0
+    # === /issue #469 결함 A ============================================
 
     # 모든 조건 충족 — end-run in-process 호출
     try:
@@ -864,6 +881,97 @@ def handle_stop(
         print(f"[stop-hook] end-run FAIL — {exc}", file=sys.stderr)
 
     return 0
+
+
+# issue #469 결함 A — Stop hook continuation signal helper
+# 다음 step 진입 가능 결론 enum (단독 결론 + 일반 PASS).
+_CONTINUE_ENUMS: frozenset[str] = frozenset({
+    "PASS", "IMPL_DONE", "POLISH_DONE",
+    "TESTS_WRITTEN", "UX_FLOW_DONE",
+})
+# 종료 agent — 본 agent 의 PASS/LGTM 은 run 끝 = block 안 함.
+_TERMINAL_AGENTS: frozenset[str] = frozenset({"pr-reviewer"})
+# 무한 루프 가드 — 같은 step 에서 block 박은 횟수 상한.
+_STOP_BLOCK_COUNT_MAX = 2
+
+
+def _maybe_emit_continuation_signal(
+    *,
+    sid: str,
+    rid: str,
+    slot: Dict[str, Any],
+    active: Dict[str, Any],
+    last_agent: Optional[str],
+    last_mode: Optional[str],
+    base_dir: Optional[Path],
+) -> bool:
+    """issue #469 결함 A — 중간 step PASS 후 메인 turn 발화 강제 신호 박기.
+
+    조건:
+    1. 마지막 step agent 가 종료 agent (pr-reviewer) 아님
+    2. 마지막 step prose 파일 존재 + 결론 enum 이 다음 step 진입 가능 enum
+    3. stop_block_count[step_key] < _STOP_BLOCK_COUNT_MAX (무한 루프 가드)
+
+    반환:
+        True  — decision:block JSON stdout 박음 + 호출자는 return 0 해야 함
+        False — 조건 미충족, 호출자는 기존 분기 (end-run 자동 호출) 진행
+    """
+    if not last_agent or last_agent in _TERMINAL_AGENTS:
+        return False
+    rdir = slot.get("run_dir")
+    if not isinstance(rdir, str) or not rdir:
+        return False
+
+    mode_suffix = f"-{last_mode}" if last_mode else ""
+    prose_path = Path(rdir) / f"{last_agent}{mode_suffix}.md"
+    if not prose_path.is_file():
+        return False
+
+    # 결론 enum 추출 (run_review 의 패턴 재사용 — handle_stop 안 lazy import).
+    try:
+        from harness.run_review import _extract_conclusion_enum
+    except Exception:
+        return False
+    try:
+        prose = prose_path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    enum = _extract_conclusion_enum(prose)
+    if enum not in _CONTINUE_ENUMS:
+        return False
+
+    # 무한 루프 가드 — 같은 step 에서 block 박은 횟수 상한 검사.
+    step_key = f"{last_agent}:{last_mode or ''}"
+    block_counts = slot.get("stop_block_count")
+    if not isinstance(block_counts, dict):
+        block_counts = {}
+    try:
+        cur_count = int(block_counts.get(step_key, 0) or 0)
+    except (TypeError, ValueError):
+        cur_count = 0
+    if cur_count >= _STOP_BLOCK_COUNT_MAX:
+        return False  # 메인이 reason 받고도 발화 안 함 = 진짜 종료 — 기존 분기로
+
+    # count +1 persist
+    block_counts[step_key] = cur_count + 1
+    slot["stop_block_count"] = block_counts
+    active[rid] = slot
+    try:
+        update_live(sid, base_dir=base_dir, active_runs=active)
+    except Exception:
+        pass  # persist 실패해도 block 자체는 박음 (다음 호출 시 cur_count 만 미증가)
+
+    reason = (
+        f"[dcness Stop hook · issue #469 결함 A] sub-step "
+        f"'{last_agent}{mode_suffix}' 결론 '{enum}' — 다음 sub-step 진입 turn "
+        "필요. /impl-loop Hybrid A = build-worker PASS → pr-reviewer 영역 "
+        "(begin-step pr-reviewer + Agent pr-reviewer + end-step + PR 머지). "
+        "4-agent /impl 이면 정의된 다음 agent 호출. 사용자 의도로 정말 종료 "
+        f"하려면 메인 발화 → 다시 Stop trigger 시 본 가드가 {_STOP_BLOCK_COUNT_MAX}회 후 "
+        "skip 처리됨."
+    )
+    print(json.dumps({"decision": "block", "reason": reason}))
+    return True
 
 
 # ── CLI 진입점 (bash 훅 → python -m harness.hooks <subcommand>) ─────

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -27,11 +27,12 @@ Coverage matrix:
 """
 from __future__ import annotations
 
+import json
 import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from harness.hooks import (
     handle_posttooluse_agent,
@@ -1328,6 +1329,154 @@ class StopHookGuardTests(unittest.TestCase):
         # sid/rid auto-detect 실패 → skip
         rc = handle_stop(stdin_data={})
         self.assertEqual(rc, 0)
+
+
+# ---------------------------------------------------------------------------
+# _maybe_emit_continuation_signal — issue #469 결함 A
+# ---------------------------------------------------------------------------
+
+
+class StopHookContinuationSignalTests(unittest.TestCase):
+    """issue #469 결함 A — 중간 step PASS 후 메인 turn 자동 발화 신호.
+
+    `_maybe_emit_continuation_signal` 단위 검증. handle_stop 의 신규 분기는
+    본 helper 가 True 반환 시 즉시 return 0 + JSON 출력만 박음 — helper
+    단위로 충분.
+    """
+
+    SID = "12345678-1234-4321-abcd-1234567890ab"
+    RID = "run-deadbeef"
+
+    def setUp(self):
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        self.base_dir = Path(self._tmp.name)
+        self.run_dir_path = (
+            self.base_dir / "sessions" / self.SID / "runs" / self.RID
+        )
+        self.run_dir_path.mkdir(parents=True, exist_ok=True)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+
+    def _write_prose(self, agent: str, conclusion_line: str, mode: str = "") -> None:
+        suffix = f"-{mode}" if mode else ""
+        path = self.run_dir_path / f"{agent}{suffix}.md"
+        # 끝 15줄 안 결론 enum 매칭 위해 마지막 줄에 박음
+        path.write_text(
+            "## Prose\n\n작업 요약 prose.\n\n" + conclusion_line + "\n",
+            encoding="utf-8",
+        )
+
+    def _slot(self, *, run_dir: str = None, stop_block_count=None) -> Dict[str, Any]:
+        slot: Dict[str, Any] = {
+            "run_id": self.RID,
+            "started_at": "2026-05-22T00:00:00+00:00",
+            "run_dir": run_dir if run_dir is not None else str(self.run_dir_path),
+        }
+        if stop_block_count is not None:
+            slot["stop_block_count"] = stop_block_count
+        return slot
+
+    def _invoke(self, *, slot, last_agent, last_mode=None):
+        from harness.hooks import _maybe_emit_continuation_signal
+        active = {self.RID: slot}
+        # stdout capture
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            result = _maybe_emit_continuation_signal(
+                sid=self.SID, rid=self.RID, slot=slot, active=active,
+                last_agent=last_agent, last_mode=last_mode,
+                base_dir=self.base_dir,
+            )
+        return result, buf.getvalue()
+
+    def test_build_worker_pass_emits_block(self):
+        # PASS + 중간 agent → block decision JSON 박음
+        self._write_prose("build-worker", "[task1 · 01] PASS")
+        slot = self._slot()
+        result, stdout = self._invoke(slot=slot, last_agent="build-worker")
+        self.assertTrue(result)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["decision"], "block")
+        self.assertIn("build-worker", payload["reason"])
+        self.assertIn("PASS", payload["reason"])
+
+    def test_pr_reviewer_terminal_skips(self):
+        # pr-reviewer 는 종료 agent — PASS/LGTM 박혀있어도 block 안 박음
+        self._write_prose("pr-reviewer", "LGTM — merge 권고")
+        slot = self._slot()
+        result, stdout = self._invoke(slot=slot, last_agent="pr-reviewer")
+        self.assertFalse(result)
+        self.assertEqual(stdout, "")
+
+    def test_fail_enum_skips(self):
+        # FAIL → 메인 사용자 위임 영역 — block 안 박음
+        self._write_prose("code-validator", "전반적 FAIL — 4 항목 위반")
+        slot = self._slot()
+        result, stdout = self._invoke(slot=slot, last_agent="code-validator")
+        self.assertFalse(result)
+        self.assertEqual(stdout, "")
+
+    def test_no_conclusion_enum_skips(self):
+        # 결론 enum 부재 → block 안 박음
+        self._write_prose("build-worker", "작업 요약만 박음 — 결론 표기 없음")
+        slot = self._slot()
+        result, stdout = self._invoke(slot=slot, last_agent="build-worker")
+        self.assertFalse(result)
+        self.assertEqual(stdout, "")
+
+    def test_prose_file_missing_skips(self):
+        # prose file 자체 없음 → block 안 박음 (run_dir 만 박힘)
+        slot = self._slot()
+        result, stdout = self._invoke(slot=slot, last_agent="build-worker")
+        self.assertFalse(result)
+        self.assertEqual(stdout, "")
+
+    def test_block_count_max_skips(self):
+        # block count ≥ _STOP_BLOCK_COUNT_MAX (2) → 진짜 종료 의도 인정, skip
+        from harness.hooks import _STOP_BLOCK_COUNT_MAX
+        self._write_prose("build-worker", "[task1] PASS")
+        slot = self._slot(stop_block_count={"build-worker:": _STOP_BLOCK_COUNT_MAX})
+        result, stdout = self._invoke(slot=slot, last_agent="build-worker")
+        self.assertFalse(result)
+        self.assertEqual(stdout, "")
+
+    def test_block_count_increments_and_persists(self):
+        # 1차 호출 후 stop_block_count 가 live.json 에 +1 박힘
+        self._write_prose("engineer", "IMPL_DONE — 변경 완료", mode="IMPL")
+        slot = self._slot()
+        result, _ = self._invoke(slot=slot, last_agent="engineer", last_mode="IMPL")
+        self.assertTrue(result)
+
+        # live.json 에 persist 됐는지 확인
+        from harness.session_state import read_live
+        live = read_live(self.SID, base_dir=self.base_dir)
+        self.assertIsNotNone(live)
+        persisted_slot = live["active_runs"][self.RID]
+        self.assertEqual(
+            persisted_slot["stop_block_count"]["engineer:IMPL"], 1,
+        )
+
+    def test_engineer_impl_done_block(self):
+        # engineer mode 박힘 케이스 — prose path = engineer-IMPL.md
+        self._write_prose("engineer", "IMPL_DONE — 6 파일 변경", mode="IMPL")
+        slot = self._slot()
+        result, stdout = self._invoke(slot=slot, last_agent="engineer", last_mode="IMPL")
+        self.assertTrue(result)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["decision"], "block")
+        self.assertIn("engineer-IMPL", payload["reason"])
+        self.assertIn("IMPL_DONE", payload["reason"])
+
+    def test_missing_run_dir_skips(self):
+        # slot.run_dir 부재 → block 안 박음
+        slot = self._slot(run_dir="")  # 빈 문자열
+        result, stdout = self._invoke(slot=slot, last_agent="build-worker")
+        self.assertFalse(result)
+        self.assertEqual(stdout, "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 변경 요약

### [issue-469] Stop hook continuation signal — 중간 step PASS 후 메인 turn 자동 발화 강제 (결함 A 단독 fix)
- **What**: \`harness/hooks.py:handle_stop\` 에 \`_maybe_emit_continuation_signal\` helper 추가. 마지막 step prose 결론 enum 이 진행 가능 (\`PASS\` / \`IMPL_DONE\` / \`POLISH_DONE\` / \`TESTS_WRITTEN\` / \`UX_FLOW_DONE\`) **AND** agent 가 종료 agent (\`pr-reviewer\`) 아닌 경우 \`{"decision":"block","reason":"..."}\` JSON stdout 박아 메인 turn 재 발화 강제. 무한 루프 가드는 같은 step 의 block count ≤ 2 로 제한.
- **Why**: jajang Epic 20 multi-task \`/impl-loop\` 실측 (#469 결함 A) — build-worker tool_result 후 메인 turn 자동 발화 부재 = **9시간 16분 침묵** 사례. Stop hook 등록은 돼있으나 \`decision:"block"\` 신호 박지 않아 CC 가 메인 침묵 OK 판정. dcness 핵심 가치 (다중 task 자동 진행 + 메인 turn 비용 최소화) 가 깨지는 catastrophic 결함.

## 결정 근거

- **block 분기 vs PostToolUse:Agent inject 강화** — PostToolUse 의 \`additionalContext\` 는 *권고* 만, 메인 발화 자체 강제 X. Stop hook 의 \`decision:"block"\` 만 메인 turn 재 발화 *강제*. → 본 fix 영역은 Stop hook 단독.
- **block count 가드 (2회)** — 메인이 reason 받고도 발화 안 하면 = 진짜 종료 의도. 무한 루프 위험 회피 + 사용자 침묵 의도 인정. \`slot.stop_block_count[<agent>:<mode>]\` 에 live.json persist (다음 Stop 호출에서도 카운트 유지).
- **종료 agent (pr-reviewer) 예외** — pr-reviewer LGTM / PASS 는 run 끝 = 정상 침묵. block 박지 않음.
- **결함 A 단독 PR** — 결함 B (helper sid/rid 미해결) + C (tdd-guard hook path matcher) 는 별 PR. 본 fix 가 helper 정상 매핑 전제 (task1 시나리오) → 회수 확인 가능. multi-task (task2/3) 시나리오는 결함 B 미해결 영향 잔존.

## 관련 이슈

Part of #469

Document-Exception-PR-Close: 결함 A 단독 fix — issue #469 (3 결함 묶음 A/B/C) 자체 close 안 됨. 결함 B / C 별 PR 머지 후 #469 close 예정.

## 참고

- 결함 A round-trip 검증 = jajang 활성 프로젝트 다음 multi-task \`/impl-loop\` 실행 시 진행.
- 결함 B = #469 결함 B (별 PR 예정) — helper sid/rid 폴백 추가 (env var / live.json active_runs 최근 slot).
- 결함 C = #469 결함 C (별 PR 예정) — \`hooks/tdd-guard.sh\` path matcher 완화.
- 본 fix 후속 측정 : multi-task /impl-loop task당 메인 turn 평균 79 (#446 2차 측정) → 결함 A fix 후 사용자 인터럽트 응답 ~30 turn 회수 예상.
- 신규 unittest 9 케이스 (\`StopHookContinuationSignalTests\`) — block 분기 5 + 무한 루프 가드 2 + agent/run_dir 부재 가드 2. 전체 447 PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)