### PR TITLE
[issue-469] helper sid/rid 폴백 — env var + active_runs scan (결함 B 단독 fix)

### DIFF
--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -822,21 +822,128 @@ def get_cc_pid_via_ppid_chain() -> Optional[int]:
 
 
 def auto_detect_session_id(*, base_dir: Optional[Path] = None) -> str:
-    """helper 컨텍스트 — by-pid (멀티세션 정합) 우선, env/pointer 폴백."""
+    """helper 컨텍스트 — env > by-pid (멀티세션 정합) > pointer > active_runs scan 폴백.
+
+    issue #469 결함 B (DCN-CHG-20260522): PPID chain mismatch 시
+    (bash subprocess 재시작 / fork 등) sid 미해결 회귀 차단. env var 우선 +
+    active_runs scan 폴백 추가.
+    """
+    # (a) DCNESS_RUN_ID 동반 강제 — env var 통한 명시 매핑 우선
+    env_sid = os.environ.get("DCNESS_SESSION_ID", "")
+    if valid_session_id(env_sid):
+        return env_sid
+    # (b) PPID chain (기존 매커니즘)
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
         sid = read_pid_session(cc_pid, base_dir=base_dir)
         if sid:
             return sid
-    return current_session_id(base_dir=base_dir)
+    # (c) pointer 폴백 (기존 — current_session_id 가 env+pointer 2-tier)
+    sid = current_session_id(base_dir=base_dir)
+    if sid:
+        return sid
+    # (d) active_runs scan 폴백 — 가장 최근 미finalized run 의 session_id
+    slot_info = _scan_recent_active_run_slot(base_dir=base_dir)
+    if slot_info:
+        return slot_info[0]  # (sid, rid)
+    return ""
 
 
 def auto_detect_run_id(*, base_dir: Optional[Path] = None) -> str:
-    """helper 컨텍스트 — by-pid-current-run 에서 rid 추출."""
+    """helper 컨텍스트 — env > by-pid-current-run > active_runs scan 폴백.
+
+    issue #469 결함 B (DCN-CHG-20260522): rid 폴백 영역 신설. env var
+    `DCNESS_RUN_ID` 우선 + active_runs scan (`_scan_recent_active_run_slot`)
+    폴백 추가.
+    """
+    # (a) env var 우선 — 사용자 명시 매핑
+    env_rid = os.environ.get("DCNESS_RUN_ID", "")
+    if env_rid:
+        return env_rid
+    # (b) PPID chain (기존 매커니즘)
     cc_pid = get_cc_pid_via_ppid_chain()
-    if cc_pid is None:
-        return ""
-    return read_pid_current_run(cc_pid, base_dir=base_dir)
+    if cc_pid is not None:
+        rid = read_pid_current_run(cc_pid, base_dir=base_dir)
+        if rid:
+            return rid
+    # (c) active_runs scan 폴백 — 가장 최근 미finalized run 의 run_id
+    slot_info = _scan_recent_active_run_slot(base_dir=base_dir)
+    if slot_info:
+        return slot_info[1]
+    return ""
+
+
+def _scan_recent_active_run_slot(
+    *,
+    base_dir: Optional[Path] = None,
+    max_sessions: int = 5,
+) -> Optional[tuple[str, str]]:
+    """sessions/ 디렉토리 scan 후 가장 최근 미finalized active_run slot 의 (sid, rid).
+
+    issue #469 결함 B 의 best-effort 폴백 — PPID chain 미해결 시 사용.
+    다음 우선순위:
+    1. live.json mtime 최신 `max_sessions` 개만 검사 (비용 가드)
+    2. 각 live.json 의 `active_runs` 중 `finalized_at` 부재 + `started_at`
+       가장 최근 slot 박힌 (sid, rid) 반환
+
+    Returns:
+        (session_id, run_id) tuple — best-guess.
+        None — 매치 부재 (clean session 또는 모든 run finalized).
+
+    주의: multi-session 환경에서 잘못된 매핑 위험 있음. 본 폴백은 PPID chain
+    실패 케이스의 무대응 (= helper 동작 X) 대신 best-guess 제공. 정확 매핑 필요시
+    `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` env var 명시 권장.
+    """
+    base = _resolve_base(base_dir)
+    sessions_dir = base / "sessions"
+    if not sessions_dir.is_dir():
+        return None
+
+    # live.json mtime 최신 max_sessions 개만 추출 (비용 가드)
+    candidates: list[tuple[float, Path]] = []
+    try:
+        for entry in sessions_dir.iterdir():
+            if not entry.is_dir():
+                continue
+            live_file = entry / "live.json"
+            try:
+                stat = live_file.stat()
+            except OSError:
+                continue
+            candidates.append((stat.st_mtime, live_file))
+    except OSError:
+        return None
+    candidates.sort(key=lambda x: x[0], reverse=True)
+    candidates = candidates[:max_sessions]
+
+    # 각 live.json 의 미finalized active_run 중 started_at 최신 후보 수집
+    best: Optional[tuple[str, str, str]] = None  # (started_at, sid, rid)
+    for _, live_file in candidates:
+        try:
+            data = json.loads(live_file.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        sid = data.get("session_id")
+        if not isinstance(sid, str) or not valid_session_id(sid):
+            continue
+        active_runs = data.get("active_runs", {})
+        if not isinstance(active_runs, dict):
+            continue
+        for rid, slot in active_runs.items():
+            if not isinstance(slot, dict):
+                continue
+            if slot.get("finalized_at"):
+                continue
+            started = slot.get("started_at", "")
+            if not isinstance(started, str):
+                continue
+            if best is None or started > best[0]:
+                best = (started, sid, rid)
+    if best is None:
+        return None
+    return (best[1], best[2])
 
 
 # ── 프로젝트 활성화 (whitelist) ─────────────────────────────────────

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1951,5 +1951,150 @@ PASS — 빈 문자열 가드 추가.
         self.assertEqual(payload["action"], "unmapped")
 
 
+# ---------------------------------------------------------------------------
+# auto_detect_session_id / auto_detect_run_id 폴백 — issue #469 결함 B
+# ---------------------------------------------------------------------------
+
+
+class AutoDetectFallbackTests(unittest.TestCase):
+    """issue #469 결함 B — helper sid/rid 폴백 (env var + active_runs scan).
+
+    PPID chain mismatch (bash subprocess 재시작 / fork) 시 sid/rid 미해결
+    회귀 차단. env > PPID > pointer > active_runs scan 폴백 우선순위.
+    """
+
+    SID_A = "11111111-2222-4333-8444-555555555555"
+    SID_B = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+    RID_A = "run-aaaaaaaa"
+    RID_B = "run-bbbbbbbb"
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.base = Path(self._td.name)
+        # env var 영향 회피 — 각 테스트마다 clean
+        os.environ.pop("DCNESS_SESSION_ID", None)
+        os.environ.pop("DCNESS_RUN_ID", None)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+        os.environ.pop("DCNESS_SESSION_ID", None)
+        os.environ.pop("DCNESS_RUN_ID", None)
+
+    def _write_live(
+        self,
+        sid: str,
+        *,
+        runs: dict,
+    ) -> None:
+        """sessions/<sid>/live.json 작성 helper."""
+        sess_dir = self.base / "sessions" / sid
+        sess_dir.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "_meta": {"sessionId": sid, "version": 1, "writtenAt": "2026-05-22T00:00:00+00:00"},
+            "session_id": sid,
+            "active_runs": runs,
+        }
+        (sess_dir / "live.json").write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+
+    def test_env_var_takes_priority_for_session_id(self) -> None:
+        from harness.session_state import auto_detect_session_id
+        # env var = SID_A, 다른 active_runs = SID_B (env 가 우선)
+        os.environ["DCNESS_SESSION_ID"] = self.SID_A
+        self._write_live(
+            self.SID_B,
+            runs={self.RID_B: {"run_id": self.RID_B, "started_at": "2026-05-22T01:00:00+00:00"}},
+        )
+        sid = auto_detect_session_id(base_dir=self.base)
+        self.assertEqual(sid, self.SID_A)
+
+    def test_env_var_takes_priority_for_run_id(self) -> None:
+        from harness.session_state import auto_detect_run_id
+        os.environ["DCNESS_RUN_ID"] = self.RID_A
+        sid = auto_detect_run_id(base_dir=self.base)
+        self.assertEqual(sid, self.RID_A)
+
+    def test_invalid_env_sid_falls_through(self) -> None:
+        from harness.session_state import auto_detect_session_id
+        # path-traversal 문자 (valid_session_id regex fail) → 폴백 = active_runs scan
+        os.environ["DCNESS_SESSION_ID"] = "../escape"
+        self._write_live(
+            self.SID_B,
+            runs={self.RID_B: {"run_id": self.RID_B, "started_at": "2026-05-22T01:00:00+00:00"}},
+        )
+        sid = auto_detect_session_id(base_dir=self.base)
+        # env 무시 + PPID chain (실 환경 X) + pointer 부재 → active_runs scan 박힘
+        self.assertEqual(sid, self.SID_B)
+
+    def test_scan_picks_recent_unfinalized_run(self) -> None:
+        from harness.session_state import _scan_recent_active_run_slot
+        # session A 의 run A = 미finalized (오래된), session B 의 run B = 미finalized (최신)
+        self._write_live(
+            self.SID_A,
+            runs={self.RID_A: {"run_id": self.RID_A, "started_at": "2026-05-22T00:00:00+00:00"}},
+        )
+        self._write_live(
+            self.SID_B,
+            runs={self.RID_B: {"run_id": self.RID_B, "started_at": "2026-05-22T02:00:00+00:00"}},
+        )
+        result = _scan_recent_active_run_slot(base_dir=self.base)
+        self.assertEqual(result, (self.SID_B, self.RID_B))
+
+    def test_scan_skips_finalized_runs(self) -> None:
+        from harness.session_state import _scan_recent_active_run_slot
+        # session A: finalized run (skip 대상)
+        # session B: 미finalized run (선택 대상)
+        self._write_live(
+            self.SID_A,
+            runs={self.RID_A: {
+                "run_id": self.RID_A,
+                "started_at": "2026-05-22T02:00:00+00:00",  # 더 최신이지만
+                "finalized_at": "2026-05-22T02:30:00+00:00",  # finalized = skip
+            }},
+        )
+        self._write_live(
+            self.SID_B,
+            runs={self.RID_B: {
+                "run_id": self.RID_B,
+                "started_at": "2026-05-22T01:00:00+00:00",
+            }},
+        )
+        result = _scan_recent_active_run_slot(base_dir=self.base)
+        self.assertEqual(result, (self.SID_B, self.RID_B))
+
+    def test_scan_no_sessions_returns_none(self) -> None:
+        from harness.session_state import _scan_recent_active_run_slot
+        # sessions/ 디렉토리 자체 부재
+        result = _scan_recent_active_run_slot(base_dir=self.base)
+        self.assertIsNone(result)
+
+    def test_scan_all_finalized_returns_none(self) -> None:
+        from harness.session_state import _scan_recent_active_run_slot
+        # 모든 run finalized → None
+        self._write_live(
+            self.SID_A,
+            runs={self.RID_A: {
+                "run_id": self.RID_A,
+                "started_at": "2026-05-22T00:00:00+00:00",
+                "finalized_at": "2026-05-22T00:30:00+00:00",
+            }},
+        )
+        result = _scan_recent_active_run_slot(base_dir=self.base)
+        self.assertIsNone(result)
+
+    def test_auto_detect_run_id_uses_scan_when_no_env_no_ppid(self) -> None:
+        from harness.session_state import auto_detect_run_id
+        # env 없음, PPID chain 실 환경 X (테스트 환경에서는 None 반환 또는 unrelated PID)
+        # → active_runs scan 폴백 박힘
+        self._write_live(
+            self.SID_A,
+            runs={self.RID_A: {"run_id": self.RID_A, "started_at": "2026-05-22T01:00:00+00:00"}},
+        )
+        rid = auto_detect_run_id(base_dir=self.base)
+        self.assertEqual(rid, self.RID_A)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-469] helper sid/rid 폴백 — env var + active_runs scan (결함 B 단독 fix)
- **What**: \`harness/session_state.py:auto_detect_session_id\` / \`auto_detect_run_id\` 에 env var 폴백 (\`DCNESS_SESSION_ID\` / \`DCNESS_RUN_ID\`) + active_runs scan 폴백 (\`_scan_recent_active_run_slot\` 신규) 추가. PPID chain mismatch 시에도 helper 명령 정상 동작.
- **Why**: jajang multi-task \`/impl-loop\` 실측 (#469 결함 B) — task2 / task3 의 모든 helper 호출이 "sid/rid 미해결" 출력 → run-dir 디스크 등록 실패 → review.md / build-*.md / pr-reviewer.md 5개 phase prose 미보존. 측정 차원에서 review-based waste finding 분석 자체 불가.

## 결정 근거

- **env var 우선** — 사용자가 helper 호출 시 명시 매핑 가능 (\`DCNESS_SESSION_ID=<sid> DCNESS_RUN_ID=<rid> dcness-helper ...\`). PPID chain 보다 더 권위.
- **active_runs scan best-guess** — multi-session 환경에서 잘못된 매핑 위험 있음. 다만 PPID chain 실패의 무대응 (helper 동작 X) 대비 best-guess 가 훨씬 나은 회복. mtime 상위 5개 session 만 검사 (비용 가드).
- **결함 B 단독 PR** — 결함 A (#473 merged) + 본 결함 B 묶음 효과 = multi-task 시나리오에서 review.md 보존 + 결함 A continuation signal 정상 trigger. 결함 C (tdd-guard) 는 별 PR.

## 관련 이슈

Part of #469

Document-Exception-PR-Close: 결함 B 단독 fix — issue #469 (3 결함 묶음 A/B/C) 자체 close 안 됨. 결함 C 별 PR 머지 후 #469 close 예정.

## 참고

- 다중 session 환경에서 scan 폴백 = best-guess. 정확 매핑 필요시 \`DCNESS_SESSION_ID\` / \`DCNESS_RUN_ID\` env var 명시 권장 — helper docstring 에 명시.
- 신규 unittest 8 케이스 (\`AutoDetectFallbackTests\`): env var 우선 (sid + rid) / path-traversal fall-through / scan 최신 미finalized 선택 / scan finalized skip / sessions 부재 None / 모두 finalized None / scan 폴백 흐름. 전체 455 PASS.
- round-trip 검증: jajang 다음 multi-task \`/impl-loop\` 에서 task2 / task3 의 review.md 보존 + 결함 A continuation signal 정상 trigger 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)