### PR TITLE
[issue-469] tdd-guard path matcher 6-tier 확장 — grandparent + src_root monorepo cover (결함 C 단독 fix)

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -137,15 +137,19 @@ python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
 - 시드 / 시안 — `*/templates/*`, `*/design-variants/*`
 - 그 외 확장자 (`*.py`, `*.go` 등) — silent skip
 
-**매칭 test 파일 검사 8 location**:
+**매칭 test 파일 검사 6-tier 12 location** (DCN-CHG-20260522 — issue #469 결함 C 영역 확장):
 ```
-<dir>/<name>.{test,spec}.{ts,tsx,js,jsx}
-<dir>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-<parent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-<root>/src/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+Tier 1: <dir>/<name>.{test,spec}.{ts,tsx,js,jsx}
+Tier 2: <dir>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+Tier 3: <parent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+Tier 4: <grandparent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+Tier 5: <src_root>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+Tier 6: <PROJECT_ROOT>/src/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
 ```
 
-**차단 동작**: `permissionDecision: deny` + 한국어 안내 (테스트 부재 + 검사 위치 8곳). TDD 미이행 환경에선 plug-in 활성화 후 광범위한 deny 발생 가능.
+`<src_root>` = 파일 경로 안 `src/` 마디 직전까지 trim. monorepo `apps/<X>/src/...` / `packages/<X>/src/...` cover. trim 실패 (`src/` 부재) 시 `<PROJECT_ROOT>/src` fallback. Tier 4 (grandparent) + Tier 5 (src_root) = #469 결함 C 영역 확장 — build-worker 가 회피 stub 박는 안티패턴 차단.
+
+**차단 동작**: `permissionDecision: deny` + 한국어 안내 (테스트 부재 + 검사 위치 12곳 + 본 파일의 실측 `<dir>` / `<parent>` / `<grandparent>` / `<src_root>` / `<PROJECT_ROOT>` 값). TDD 미이행 환경에선 plug-in 활성화 후 광범위한 deny 발생 가능.
 
 ---
 

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -104,12 +104,21 @@ if [ -f "$FILE_PATH" ]; then
 fi
 
 # 매칭 test 파일 존재 검사
+# issue #469 결함 C — monorepo `apps/<X>/src/__tests__/<name>.test` 위치 cover.
+# `<src_root>` = 파일 경로 안 `src/` 마디 직전까지 trim. trim 실패 (src/ 부재) 시
+# `<PROJECT_ROOT>` fallback. 기존 4-tier (8 location) + grandparent 2 +
+# monorepo src_root 2 = 6-tier (12 location).
 has_test_for() {
   local fp="$1"
-  local dir base parent ext
+  local dir base parent grandparent src_root ext
   dir=$(dirname "$fp")
   base=$(basename "$fp" | sed -E 's/\.(ts|tsx|js|jsx)$//')
   parent=$(dirname "$dir")
+  grandparent=$(dirname "$parent")
+  case "$fp" in
+    */src/*) src_root="${fp%%/src/*}/src" ;;
+    *) src_root="${PROJECT_ROOT}/src" ;;
+  esac
   for ext in ts tsx js jsx; do
     [ -f "${dir}/${base}.test.${ext}" ] && return 0
     [ -f "${dir}/${base}.spec.${ext}" ] && return 0
@@ -117,6 +126,13 @@ has_test_for() {
     [ -f "${dir}/__tests__/${base}.spec.${ext}" ] && return 0
     [ -f "${parent}/__tests__/${base}.test.${ext}" ] && return 0
     [ -f "${parent}/__tests__/${base}.spec.${ext}" ] && return 0
+    # Tier 4: <grandparent>/__tests__/<name>.{test,spec}.<ext>  (issue #469 결함 C)
+    [ -f "${grandparent}/__tests__/${base}.test.${ext}" ] && return 0
+    [ -f "${grandparent}/__tests__/${base}.spec.${ext}" ] && return 0
+    # Tier 5: <src_root>/__tests__/<name>.{test,spec}.<ext>  (monorepo, issue #469 결함 C)
+    [ -f "${src_root}/__tests__/${base}.test.${ext}" ] && return 0
+    [ -f "${src_root}/__tests__/${base}.spec.${ext}" ] && return 0
+    # Tier 6: <PROJECT_ROOT>/src/__tests__/<name>.{test,spec}.<ext> (single-app fallback)
     [ -f "${PROJECT_ROOT}/src/__tests__/${base}.test.${ext}" ] && return 0
     [ -f "${PROJECT_ROOT}/src/__tests__/${base}.spec.${ext}" ] && return 0
   done
@@ -125,15 +141,36 @@ has_test_for() {
 
 if ! has_test_for "$FILE_PATH"; then
   BASE=$(basename "$FILE_PATH" | sed -E 's/\.(ts|tsx|js|jsx)$//')
+  DIR=$(dirname "$FILE_PATH")
+  PARENT=$(dirname "$DIR")
+  GP=$(dirname "$PARENT")
+  case "$FILE_PATH" in
+    */src/*) SRC_ROOT="${FILE_PATH%%/src/*}/src" ;;
+    *) SRC_ROOT="${PROJECT_ROOT}/src" ;;
+  esac
   deny "TDD GUARD: '${BASE}' 에 대한 테스트 파일이 존재하지 않습니다. 구현 코드를 작성하기 *전*에 테스트를 먼저 작성하세요.
 
-예: ${BASE}.test.ts 또는 __tests__/${BASE}.test.ts
+권장 위치 (먼저 시도):
+  ${DIR}/${BASE}.test.ts                또는 ${DIR}/${BASE}.spec.ts
+  ${DIR}/__tests__/${BASE}.test.ts
+  ${PARENT}/__tests__/${BASE}.test.ts
 
-이미 테스트 있는데 인식 안 됨 — dcness 가 검사하는 8 location:
-  <dir>/<name>.{test,spec}.{ts,tsx,js,jsx}
-  <dir>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-  <parent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-  <root>/src/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}"
+이미 테스트 박았는데 인식 안 됨 — dcness 가 검사하는 6-tier 12 location:
+  Tier 1: <dir>/<name>.{test,spec}.{ts,tsx,js,jsx}
+  Tier 2: <dir>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+  Tier 3: <parent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+  Tier 4: <grandparent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+  Tier 5: <src_root>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+  Tier 6: <PROJECT_ROOT>/src/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
+
+본 파일의 실측 위치:
+  <dir>         = ${DIR}
+  <parent>      = ${PARENT}
+  <grandparent> = ${GP}
+  <src_root>    = ${SRC_ROOT}
+  <PROJECT_ROOT>= ${PROJECT_ROOT}
+
+회피 안티패턴 금지: 위 location 외 다른 위치 (예: <parent>/__tests__/<subdir>/<name>.test.<ext>) 에 같은 본문 복사 박지 말 것. false negative 발견 시 본 hook 자체 fix (#469 결함 C 영역) 후속 PR 영역."
   exit 0
 fi
 

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -182,5 +182,113 @@ class TestRegressionPreserved(unittest.TestCase):
         self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
 
 
+class TestPathMatcherTier4_Grandparent(unittest.TestCase):
+    """issue #469 결함 C — Tier 4: <grandparent>/__tests__/<name>.{test,spec}.<ext>.
+
+    src 파일 hierarchy 가 2-tier 깊은 경우 (예: src/audio/decoder/X.ts) 의
+    `<grandparent>/__tests__/X.test.ts` (= src/__tests__/X.test.ts) 매치.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str = "// stub\n") -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_grandparent_tests_match(self):
+        # src 파일 = src/audio/decoder/X.ts
+        # grandparent = src
+        # 매치 위치 = src/__tests__/X.test.ts
+        self._touch("src/audio/decoder/X.ts", "export function go() { return 1; }\n")
+        self._touch("src/__tests__/X.test.ts", "test('ok', () => {})\n")
+        path = str(Path(self._tmp) / "src/audio/decoder/X.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_grandparent_spec_match(self):
+        self._touch("src/audio/decoder/Y.ts", "export const Y = 1;\n")
+        self._touch("src/__tests__/Y.spec.ts", "test('ok', () => {})\n")
+        path = str(Path(self._tmp) / "src/audio/decoder/Y.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
+class TestPathMatcherTier5_MonorepoSrcRoot(unittest.TestCase):
+    """issue #469 결함 C — Tier 5: <src_root>/__tests__/<name>.{test,spec}.<ext>.
+
+    monorepo `apps/<X>/src/...` 구조 cover. src_root = `apps/<X>/src`.
+    예: jajang `apps/mobile/src/audio/AudioEngine.ts` 의 `apps/mobile/src/__tests__/AudioEngine.test.ts`.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str = "// stub\n") -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_monorepo_apps_mobile_src_audio_match(self):
+        # src 파일 = apps/mobile/src/audio/AudioEngine.ts
+        # src_root = apps/mobile/src
+        # 매치 위치 = apps/mobile/src/__tests__/AudioEngine.test.ts
+        self._touch(
+            "apps/mobile/src/audio/AudioEngine.ts",
+            "export class AudioEngine { play() {} }\n",
+        )
+        self._touch(
+            "apps/mobile/src/__tests__/AudioEngine.test.ts",
+            "test('ok', () => {})\n",
+        )
+        path = str(Path(self._tmp) / "apps/mobile/src/audio/AudioEngine.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_monorepo_deep_hierarchy_match(self):
+        # src 파일 = apps/web/src/components/forms/LoginForm.ts (3-level deep)
+        # src_root = apps/web/src
+        self._touch(
+            "apps/web/src/components/forms/LoginForm.ts",
+            "export const LoginForm = () => null;\n",
+        )
+        self._touch(
+            "apps/web/src/__tests__/LoginForm.test.ts",
+            "test('login', () => {})\n",
+        )
+        path = str(Path(self._tmp) / "apps/web/src/components/forms/LoginForm.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_monorepo_no_test_denied(self):
+        # src 파일은 있는데 src_root 매치 test 부재 → deny
+        self._touch(
+            "apps/mobile/src/audio/AudioMixer.ts",
+            "export class AudioMixer {}\n",
+        )
+        path = str(Path(self._tmp) / "apps/mobile/src/audio/AudioMixer.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+
+    def test_packages_src_root_match(self):
+        # monorepo `packages/<X>/src/...` 패턴도 cover (src/ 마디 기준)
+        self._touch(
+            "packages/core/src/utils/format.ts",
+            "export const format = (s) => s;\n",
+        )
+        self._touch(
+            "packages/core/src/__tests__/format.test.ts",
+            "test('format', () => {})\n",
+        )
+        path = str(Path(self._tmp) / "packages/core/src/utils/format.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 변경 요약

### [issue-469] tdd-guard path matcher 6-tier 확장 (결함 C 단독 fix)
- **What**: \`hooks/tdd-guard.sh:has_test_for\` 의 매칭 영역 4-tier 8 → **6-tier 12 location** 확장. Tier 4 (\`<grandparent>/__tests__/<name>.test\`) + Tier 5 (\`<src_root>/__tests__/<name>.test\`, monorepo cover) 신규. deny 메시지에 본 파일 실측 위치 (\`<dir>\` / \`<parent>\` / \`<grandparent>\` / \`<src_root>\` / \`<PROJECT_ROOT>\`) 출력.
- **Why**: jajang multi-task \`/impl-loop\` 실측 (#469 결함 C) — task3 build-worker 가 \`apps/mobile/src/__tests__/AudioEngine.test.ts\` (진짜) + \`apps/mobile/src/__tests__/audio/AudioEngine.test.ts\` (회피 stub) 두 위치 복사 박음. 단순 prompt 보강만으론 회귀 확정. 본 hook 의 monorepo path matcher 가 \`<src_root>/__tests__/\` cover 안 한 영역.

## 결정 근거

- **src_root detection** — POSIX \`\${fp%%/src/*}/src\` 패턴. monorepo \`apps/<X>/src/...\` / \`packages/<X>/src/...\` 같은 sub-app 구조 cover. \`src/\` 마디 부재 시 \`<PROJECT_ROOT>/src\` fallback.
- **deny 메시지 보강** — 본 파일의 실측 위치 (\`<dir>\` / \`<parent>\` / \`<grandparent>\` / \`<src_root>\` / \`<PROJECT_ROOT>\`) 출력 + 회피 안티패턴 (위 12 location 외 동일 본문 stub 박지 말 것) 명시. build-worker 가 회피 stub 박지 않고 진짜 위치 박도록 유도.
- **결함 C 단독 PR** — 결함 A (#473 merged) + B (#475 merged) + 본 C = #469 3 결함 묶음 마지막. 본 머지 후 #469 close 후보.

## 관련 이슈

Closes #469

## 참고

- 신규 unittest 6 케이스 — Tier 4 (grandparent test/spec match) + Tier 5 (monorepo apps/mobile/src cover, deep hierarchy, 부재 deny, packages/<X>/src cover). 전체 461 PASS.
- 회피 안티패턴 (위 12 location 외 동일 본문 stub 복사) = deny 메시지에 명시 금지. 신규 false negative 발견 시 본 hook 자체 fix 후속 PR 영역.
- 본 PR 머지 후 #469 자동 close (3 결함 모두 fix 완료).

🤖 Generated with [Claude Code](https://claude.com/claude-code)