### PR TITLE
[feature] /impl + /impl-loop 정상 흐름 표현에 pr-reviewer 권한 경계 명확화 (commit/PR 주체 = 메인)

### DIFF
--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -173,7 +173,7 @@ impl 파일 부재로 module-architect 선두 진입한 경우 2번째 줄은 `m
 > `/impl` 단발 호출 (driver 부재) 은 review.md 원본 그대로 출력 MUST 유지 — rigor 우선. 본 재정의는 `/impl-loop` 한정.
 
 ## false-clean 차단 (MUST, #431)
-task 를 clean 으로 표기하기 *전*, code-validator 가 PASS 를 냈고 pr-reviewer 가 실행돼 PR 이 생성·머지됐는지 메인이 직접 확인한다. 둘 중 하나라도 흔적이 없으면 clean 아님 → `blocked` 강등 + 사용자 보고. (test-engineer + engineer 만 호출하고 commit/push/PR 없이 prose "PASS" 박고 종료하는 안티패턴 — 실측 회귀 사례.)
+task 를 clean 으로 표기하기 *전*, code-validator 가 PASS 를 냈고 pr-reviewer 가 실행된 뒤 *메인 Claude 가* PR 생성·머지까지 마쳤는지 메인이 직접 확인한다. 셋 중 하나라도 흔적이 없으면 clean 아님 → `blocked` 강등 + 사용자 보고. (pr-reviewer 자체는 `tools: Read, Glob, Grep` 만 — commit/push/PR 권한 없음. test-engineer + engineer 만 호출하고 commit/push/PR 없이 prose "PASS" 박고 종료하는 안티패턴 — 실측 회귀 사례.)
 
 ## compaction 중 진행 (안전망)
 긴 epic 진행 중 메인 컨텍스트가 auto-compaction 될 수 있다. 루프 진행 상태는 메인 컨텍스트가 아니라 conveyor state 파일 (`live.json` / `.by-pid-current-run/` / `run-NN` / `current_step`) 이 SSOT — compaction 돼도 진행 손실은 0. compaction 직후 자신이 impl-loop 도중이라고 판단되면 run state 를 재read 해서 현재 task index + step 을 식별하고 그 지점부터 재개한다.

--- a/commands/impl.md
+++ b/commands/impl.md
@@ -34,10 +34,11 @@ default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → p
 1. test-engineer (TESTS_WRITTEN) → 테스트 선작성
 2. engineer:IMPL (IMPL_DONE) → 구현 + 테스트 PASS
 3. **code-validator (PASS)** — impl 계획 ↔ 구현 정합 검증
-4. **pr-reviewer (LGTM)** — 코드 품질·보안 + commit/push/PR 생성·머지
+4. **pr-reviewer (LGTM, read-only)** — 코드 품질·보안 검토만. pr-reviewer 의 `tools: Read, Glob, Grep` — *commit/push/PR 생성·머지 권한 없음*
+5. **메인 Claude (git/PR 작업)** — pr-reviewer PASS 후 worker prose 의 commit message + PR 본문 *초안*을 받아 `scripts/pr-create.sh` 호출 → 후속으로 `scripts/pr-finalize.sh` 머지
 
-후반 2 단계 (3+4) skip 차단:
-- task 를 clean 으로 표기하기 *전*, code-validator 가 PASS 를 냈고 pr-reviewer 가 실행돼 PR 이 생성·머지됐는지 메인이 직접 확인. 흔적 부재 시 → false-clean 의심 → `blocked` 강등 + 사용자 개입 (#431)
+후반 3 단계 (3+4+5) skip 차단:
+- task 를 clean 으로 표기하기 *전*, code-validator 가 PASS 를 냈고 pr-reviewer 가 실행된 뒤 *메인 Claude 가* PR 생성·머지까지 마쳤는지 메인이 직접 확인. 흔적 부재 시 → false-clean 의심 → `blocked` 강등 + 사용자 개입 (#431)
 
 ## 후속 라우팅
 - 본 loop clean → 자동 commit/PR (branch prefix = orchestration §4.3 decision rule: feat/chore/fix)


### PR DESCRIPTION
## 변경 요약

### [feature] pr-reviewer 의 권한 경계 표현 명확화

`commands/impl.md` 의 정상 흐름 4번 항목 표현 (`**pr-reviewer (LGTM)** — 코드 품질·보안 + commit/push/PR 생성·머지`) 이 *pr-reviewer 가 commit/push/PR 까지 한다* 로 단독 읽혀, 외부 활성화 프로젝트의 Claude Code 가 \"pr-reviewer 가 해야 하는데 자기는 권한이 없다\" 며 혼란 호소.

**기술적 사실**: `agents/pr-reviewer.md` frontmatter `tools: Read, Glob, Grep` — Bash 부재로 `gh pr create` / `git commit` 실행 자체가 불가능. commit/push/PR 은 *메인 Claude 가 전담*. (`commands/impl-loop.md:182` 안 \"git 권한\" 절 + `agents/build-worker.md` §권한 경계 와 정합)

### 변경 항목 (2 파일)

**`commands/impl.md:37`** — 4번 항목을 read-only 검토 단계로 좁히고, 새 5번 항목으로 \"메인 Claude (git/PR 작업)\" 분리:
\`\`\`
4. **pr-reviewer (LGTM, read-only)** — 코드 품질·보안 검토만. pr-reviewer 의 \`tools: Read, Glob, Grep\` — *commit/push/PR 생성·머지 권한 없음*
5. **메인 Claude (git/PR 작업)** — pr-reviewer PASS 후 worker prose 의 commit message + PR 본문 *초안*을 받아 \`scripts/pr-create.sh\` 호출 → 후속으로 \`scripts/pr-finalize.sh\` 머지
\`\`\`
후반 skip 차단도 \"2 단계 (3+4)\" → \"3 단계 (3+4+5)\" 로 정합 갱신.

**`commands/impl-loop.md:176`** — false-clean 차단 절 주체 분리:
\`\`\`
... pr-reviewer 가 실행된 뒤 *메인 Claude 가* PR 생성·머지까지 마쳤는지 메인이 직접 확인 ... (pr-reviewer 자체는 \`tools: Read, Glob, Grep\` 만 — commit/push/PR 권한 없음. ...)
\`\`\`

## 결정 근거

- **표현 명확화만 — 동작 변화 0**: pr-reviewer 권한은 frontmatter `tools` 가 기술적 강제. 본 PR 은 *인지 비용* 만 절감.
- **다른 곳은 손 안 댐**: `agents/build-worker.md:6, 87, 117, 183` / `commands/impl-loop.md:76, 95, 182` / `docs/plugin/handoff-matrix.md:118` 는 이미 \"메인이 ...\" 명시 형태로 박혀있어 본 PR 범위 외.
- **SSOT 통합은 별도 PR 예정**: PR / commit / 이슈 등록 룰을 `docs/plugin/git-spec.md` 단일 SSOT 로 통합하는 작업은 분리 PR 로 진행 (issue-lifecycle.md 축소 + PULL_REQUEST_TEMPLATE 참조화 + git-naming-spec.md 리네임).

## 관련 이슈

Document-Exception-PR-Close: skill-prose-clarify — 사용자 구두 보고로 발견한 회귀 (외부 CC 혼란) 대응. 별도 GitHub 이슈 없음.

## 배포 경로 검증 (CLAUDE.md §0.5)

- 경로 1 (plug-in 본체): `commands/impl.md` + `commands/impl-loop.md` 변경 → plug-in 업데이트 시 외부 활성화 프로젝트에 자동 적용 ✅
- 경로 2 (init-dcness 복사): N/A — skill 본문은 plug-in 본체에서 직접 read
- 경로 3 (사용자 SSOT): N/A — 외부 사용자가 따라야 하는 문서 변경 아님

## Test Plan

- [x] 표현 변경만 — 코드 변경 없음, 실행 영향 없음
- [x] commands/impl.md 변경 후 흐름 자체 정합 (4번 → 5번 신설, skip 차단 \"2 단계\" → \"3 단계\" 갱신) 시각 검토
- [x] commands/impl-loop.md 의 line 182 \"git 권한\" 절과 신규 표현 충돌 없음 확인
- [ ] CI (plugin-manifest / pr-body / git-naming-validation) PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)