### PR TITLE
[issue-484] must_fix 부정 regex 보강 — 한국어 라벨 형태 흡수 (`**MUST FIX 항목**: 없음`)

### DIFF
--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1655,9 +1655,12 @@ def _cli_end_step(args: Any) -> int:
 _MUST_FIX_RE = re.compile(r"\bMUST[\s_-]?FIX\b", re.IGNORECASE)
 
 # 같은 줄 부정 패턴 — "MUST FIX 0" / "MUST FIX 없음" / "no must fix"
+# DCN-CHG-20260523 (#484 Case 2): between 영역 `[\s:=]*` → `[^\n]{0,30}?` 로 일반화.
+# jajang `**MUST FIX 항목**: 없음` 패턴 (한국어 라벨 + markdown bold + 콜론 끼임)
+# 회귀 차단. 30자 한도 = `MUST FIX` 직후 같은 라인 안 짧은 라벨 + 부정 어휘만 흡수.
 _MUST_FIX_NEGATION_RE = re.compile(
-    r"\bMUST[\s_-]?FIX\b[\s:=]*"
-    r"(?:0(?!\s*\d)|없[음다])"
+    r"\bMUST[\s_-]?FIX\b[^\n]{0,30}?"
+    r"(?:\b0(?!\s*\d)|없[음다]|해당\s*없[음다])"
     r"|\bno\s+MUST[\s_-]?FIX\b",
     re.IGNORECASE,
 )

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1707,6 +1707,53 @@ PASS — 빈 문자열 가드 추가.
         for r in records:
             self.assertFalse(r["must_fix"], f"false positive: {r['prose_excerpt'][:60]}")
 
+    def test_must_fix_negation_kr_label_form(self) -> None:
+        """DCN-CHG-20260523 (#484 Case 2) — `**MUST FIX 항목**: 없음` 한국어 라벨 형태 부정 인식.
+
+        jajang run-e630af3a pr-reviewer 회귀 — `**MUST FIX 항목**: 없음`
+        라인이 `[\\s:=]*` between 영역에 `**`, `항목`, `:` 가 끼어 못 매치 →
+        `_has_positive_must_fix` 가 True 반환 → MUST_FIX_LEAK false positive.
+        """
+        from harness.session_state import (
+            _append_step_status, _read_steps_jsonl, run_dir,
+            _clear_default_base_cache,
+        )
+        repo = Path(self._tmp.name) / "repo"
+        repo.mkdir()
+        os.chdir(repo)
+        _clear_default_base_cache()
+        run_dir("sid", "run-dddd4444", create=True)
+        # 자장 task2 pr-reviewer 실 prose 형태
+        _append_step_status(
+            "sid", "run-dddd4444", "pr-reviewer", None, "LGTM",
+            "**MUST FIX 항목**: 없음\n**NICE TO HAVE 항목**:\n- D 데드코드\n",
+            Path("/dev/null"),
+        )
+        # 변형 — 라벨 + 콜론 + 부정
+        _append_step_status(
+            "sid", "run-dddd4444", "pr-reviewer", None, "LGTM",
+            "MUST FIX 항목: 없음\nNICE TO HAVE: 3건\n",
+            Path("/dev/null"),
+        )
+        # 변형 — 해당 없음
+        _append_step_status(
+            "sid", "run-dddd4444", "pr-reviewer", None, "LGTM",
+            "MUST FIX: 해당 없음\n",
+            Path("/dev/null"),
+        )
+        # 변형 — bold + `:` 없이 직접 부정
+        _append_step_status(
+            "sid", "run-dddd4444", "pr-reviewer", None, "LGTM",
+            "**MUST FIX** 없음\n",
+            Path("/dev/null"),
+        )
+        records = _read_steps_jsonl("sid", "run-dddd4444")
+        for r in records:
+            self.assertFalse(
+                r["must_fix"],
+                f"false positive (kr label form): {r['prose_excerpt'][:80]}",
+            )
+
     def test_must_fix_positive_still_detected(self) -> None:
         """negation regex 가 *진짜* MUST FIX 케이스는 정확히 검출."""
         from harness.session_state import (


### PR DESCRIPTION
## 변경 요약

### [issue-484] must_fix 부정 regex 보강 — 한국어 라벨 형태 흡수 (`**MUST FIX 항목**: 없음`)
- **What**: `_MUST_FIX_NEGATION_RE` 의 MUST FIX 와 부정 어휘 사이 영역을 `[\s:=]*` (whitespace/`:`/`=` 만) → `[^\n]{0,30}?` (같은 라인 안 30자 이내 임의 문자) 로 일반화
- **Why**: jajang run-e630af3a pr-reviewer prose `**MUST FIX 항목**: 없음` 패턴이 `**`, `항목`, `:` 가 끼어 between 영역 못 매치 → `_has_positive_must_fix` 가 True 반환 → `MUST_FIX_LEAK` HIGH false positive 박힘 ([issue #484](https://github.com/alruminum/dcNess/issues/484) Case 2)

## 결정 근거

- 대안 1 (between 영역에 `[\s:=*항목건개\)\(\[\]]*` 한국어 라벨 토큰 명시 흡수) — fragile, 새 라벨 형태마다 추가 필요
- 대안 2 (`_LINE_NEGATION_TOKENS` 별 regex 추가 + 라인 단위 후속 검사) — `_has_positive_must_fix` 본문 분기 늘어남, 테스트 영역도 분기
- **선택 3 (between 영역 일반화 `[^\n]{0,30}?`)** — 단일 regex 수정으로 한국어 라벨 + bold + 콜론 + 임의 라벨 변형 다 흡수. 30자 한도 = `MUST FIX` 직후 같은 라인 안 짧은 라벨 + 부정 어휘만 허용 (long 콜론 뒤 진짜 finding 은 30자 초과). non-greedy `?` 로 첫 부정 어휘 매치 우선.

## 관련 이슈

Part of #484

Document-Exception-PR-Close: multi-PR track — #484 Case 2 단독 fix. Case 1 (Bash 반복 finding) 은 별 PR 예정, 둘 다 머지 후 #484 close.

## 배포 경로 검증

- **경로 1 (plug-in 본체)**: `harness/session_state.py` 는 plug-in 본체 파일 — `claude plugin update dcness@dcness` 시 사용자 자동 적용

## Test Plan

- [x] `tests/test_session_state.py::test_must_fix_negation_kr_label_form` 신규 4 케이스 (Case 2 본 케이스 + 변형 3)
- [x] 회귀 검증: 468/468 unittest PASS — 기존 `test_must_fix_negation_no_false_positive` / `test_must_fix_positive_still_detected` 무영향

🤖 Generated with [Claude Code](https://claude.com/claude-code)
