### PR TITLE
[issue-484] review heuristic TOOL_REPEAT_HIGH 신규 — agent-trace 기반 동일 입력 반복 검출

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -499,7 +499,10 @@ def detect_wastes(
     invocations: Optional[list[dict]] = None,
     repo_path: Optional[Path] = None,
     window: Optional[tuple] = None,
+    run_dir: Optional[Path] = None,
 ) -> list[WasteFinding]:
+    # run_dir 신규 (DCN-CHG-20260523, #484 Case 1) — agent-trace.jsonl 기반
+    # TOOL_REPEAT_HIGH 검출용. None 이면 trace 검사 skip.
     findings: list[WasteFinding] = []
 
     # RETRY_SAME_FAIL — 연속 동일 FAIL enum
@@ -678,6 +681,95 @@ def detect_wastes(
     # issue #392 — MISSING_SELF_VERIFY 폐기 (agent 자율 영역 침해).
     # issue #392 — MAIN_SED_MISDIAGNOSIS 폐기 (메인 자율 영역 + 검출 모호함).
 
+    # issue #484 Case 1 — agent-trace 기반 TOOL_REPEAT_HIGH (동일 input 반복).
+    if run_dir is not None:
+        findings.extend(_detect_tool_repeat_findings(steps, run_dir))
+
+    return findings
+
+
+def _detect_tool_repeat_findings(
+    steps: list[StepRecord], run_dir: Path
+) -> list[WasteFinding]:
+    """agent-trace.jsonl 기반 동일 (tool, input) ≥ N 회 반복 finding.
+
+    issue #484 Case 1 (DCN-CHG-20260523): jajang run-545513a1 build-worker 가
+    같은 Bash command 6회 반복 호출 + Bash 40회 폭증한 안티패턴을 review heuristic
+    이 못 잡아 "잘못한 점 — 없음 ✅" 통과시킨 회귀 차단. PostToolUse hook 의
+    감시자 신호와 동일 영역 — review 와 hook 의 단일 SSOT 통합.
+
+    임계:
+    - Bash: 같은 input ≥ 5 회
+    - Read: 같은 input ≥ 4 회 (정상 단순 재read 2~3 회 면제)
+    - 기타 도구: ≥ 5 회
+
+    step 별 윈도우 (전 step end ~ 현 step end) 적용. input 200자 초과 truncate.
+    """
+    from collections import Counter
+
+    findings: list[WasteFinding] = []
+    trace_path = run_dir / "agent-trace.jsonl"
+    if not trace_path.exists():
+        return findings
+
+    entries: list[dict] = []
+    try:
+        for line in trace_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    except OSError:
+        return findings
+
+    pre_entries = [e for e in entries if e.get("phase") == "pre"]
+    if not pre_entries:
+        return findings
+
+    thresholds = {"Bash": 5, "Read": 4}
+    default_threshold = 5
+
+    for i, s in enumerate(steps):
+        start_ts = steps[i - 1].ts if i > 0 else ""
+        end_ts = s.ts
+        window_entries = [
+            e for e in pre_entries
+            if (not start_ts or e.get("ts", "") > start_ts)
+            and (not end_ts or e.get("ts", "") <= end_ts)
+        ]
+        if not window_entries:
+            continue
+        key_count: Counter = Counter()
+        for e in window_entries:
+            tool = e.get("tool", "?")
+            inp = e.get("input", "")
+            if not isinstance(inp, str) or not inp:
+                continue
+            key_count[(tool, inp[:200])] += 1
+        for (tool, inp), cnt in sorted(
+            key_count.items(), key=lambda kv: (-kv[1], kv[0][0])
+        ):
+            threshold = thresholds.get(tool, default_threshold)
+            if cnt < threshold:
+                continue
+            inp_disp = inp[:80].replace("\n", " ") + ("…" if len(inp) > 80 else "")
+            findings.append(WasteFinding(
+                pattern="TOOL_REPEAT_HIGH",
+                severity="MEDIUM",
+                step_idx=i,
+                agent=s.agent,
+                detail=(
+                    f"step {i} ({s.agent}) {tool} 동일 input {cnt}회 반복 "
+                    f"(임계 {threshold}회): `{inp_disp}`"
+                ),
+                fix=(
+                    f"sub-agent prompt 에 동일 {tool} 호출 반복 금지 가드 추가 "
+                    f"또는 작업 분해 ({tool} 결과 활용 권장)"
+                ),
+            ))
     return findings
 
 
@@ -1176,7 +1268,11 @@ def build_report(run_dir: Path, repo_path: Path) -> RunReport:
 
     # DCN-CHG-20260430-37: detect_wastes 에 invocations + repo_path + window 전달
     # (END_STEP_SKIP / MAIN_SED_MISDIAGNOSIS run-level 패턴 검출 위해).
-    wastes = detect_wastes(steps, invocations=invocations, repo_path=repo_path, window=window)
+    # DCN-CHG-20260523 (#484 Case 1): run_dir 추가 — agent-trace 기반 TOOL_REPEAT_HIGH.
+    wastes = detect_wastes(
+        steps, invocations=invocations, repo_path=repo_path,
+        window=window, run_dir=run_dir,
+    )
     notes = detect_notes(steps)  # issue #394 — TOOL_USE_OVERFLOW / THINKING_LOOP raw 알림
     # issue #392 — detect_goods 호출 폐기.
     cost, in_tok, out_tok = compute_run_cost(run_dir, repo_path)

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -249,6 +249,122 @@ class WasteDetectionTests(unittest.TestCase):
 
     # issue #392 — test_external_verified_missing 폐기 (EXTERNAL_VERIFIED_MISSING 패턴 폐기 정합).
 
+    def test_tool_repeat_high_bash(self):
+        """issue #484 Case 1 — Bash 동일 input ≥ 5회 반복 = TOOL_REPEAT_HIGH MEDIUM.
+
+        jajang run-545513a1 build-worker 가 같은 `cd ... npm test ...` 6회 호출했는데
+        review heuristic 이 못 잡은 회귀 직접 재현 테스트.
+        """
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = tmp / "runs" / "rid1"
+            rd.mkdir(parents=True)
+            # agent-trace.jsonl 박기
+            trace = rd / "agent-trace.jsonl"
+            cmd = "cd apps/mobile && npm test -- --testPathPattern S11"
+            entries = []
+            for i in range(6):
+                entries.append({
+                    "ts": f"2026-05-23T02:1{i}:00Z", "phase": "pre",
+                    "agent": "build-worker", "tool": "Bash", "input": cmd,
+                })
+            trace.write_text("\n".join(json.dumps(e) for e in entries))
+            steps = [
+                StepRecord(idx=0, ts="2026-05-23T02:20:00Z", agent="build-worker",
+                           mode=None, enum="PASS", must_fix=False, prose_excerpt="x"),
+            ]
+            wastes = detect_wastes(steps, run_dir=rd)
+            repeats = [w for w in wastes if w.pattern == "TOOL_REPEAT_HIGH"]
+            self.assertEqual(len(repeats), 1)
+            self.assertEqual(repeats[0].severity, "MEDIUM")
+            self.assertIn("6회 반복", repeats[0].detail)
+            self.assertIn("Bash", repeats[0].detail)
+
+    def test_tool_repeat_below_threshold_skip(self):
+        """Bash 동일 input ≤ 4회 = 임계 미만 → skip (정상 단순 재시도)."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = tmp / "runs" / "rid2"
+            rd.mkdir(parents=True)
+            trace = rd / "agent-trace.jsonl"
+            cmd = "npm test"
+            entries = [
+                {"ts": f"2026-05-23T02:1{i}:00Z", "phase": "pre",
+                 "agent": "build-worker", "tool": "Bash", "input": cmd}
+                for i in range(4)
+            ]
+            trace.write_text("\n".join(json.dumps(e) for e in entries))
+            steps = [
+                StepRecord(idx=0, ts="2026-05-23T02:20:00Z", agent="build-worker",
+                           mode=None, enum="PASS", must_fix=False, prose_excerpt="x"),
+            ]
+            wastes = detect_wastes(steps, run_dir=rd)
+            self.assertFalse(any(w.pattern == "TOOL_REPEAT_HIGH" for w in wastes))
+
+    def test_tool_repeat_read_lower_threshold(self):
+        """Read 는 임계 4회 — 동일 파일 4회 read = finding."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = tmp / "runs" / "rid3"
+            rd.mkdir(parents=True)
+            trace = rd / "agent-trace.jsonl"
+            entries = [
+                {"ts": f"2026-05-23T02:1{i}:00Z", "phase": "pre",
+                 "agent": "pr-reviewer", "tool": "Read",
+                 "input": "apps/mobile/src/screens/S11PreviewScreen.tsx"}
+                for i in range(4)
+            ]
+            trace.write_text("\n".join(json.dumps(e) for e in entries))
+            steps = [
+                StepRecord(idx=0, ts="2026-05-23T02:20:00Z", agent="pr-reviewer",
+                           mode=None, enum="PASS", must_fix=False, prose_excerpt="x"),
+            ]
+            wastes = detect_wastes(steps, run_dir=rd)
+            repeats = [w for w in wastes if w.pattern == "TOOL_REPEAT_HIGH"]
+            self.assertEqual(len(repeats), 1)
+            self.assertIn("4회 반복", repeats[0].detail)
+
+    def test_tool_repeat_no_trace_skip(self):
+        """agent-trace.jsonl 부재 / run_dir=None 시 silent skip — 기존 동작 영향 X."""
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False, prose_excerpt="x"),
+        ]
+        wastes = detect_wastes(steps)  # run_dir 미전달
+        self.assertFalse(any(w.pattern == "TOOL_REPEAT_HIGH" for w in wastes))
+
+    def test_tool_repeat_window_split_by_step(self):
+        """step 별 윈도우 분리 — task1 와 task2 의 같은 input 은 별개 카운트."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = tmp / "runs" / "rid4"
+            rd.mkdir(parents=True)
+            trace = rd / "agent-trace.jsonl"
+            cmd = "npm test"
+            entries = []
+            # step 0 윈도우 안 3회
+            for i in range(3):
+                entries.append({
+                    "ts": f"2026-05-23T02:0{i}:00Z", "phase": "pre",
+                    "agent": "build-worker", "tool": "Bash", "input": cmd,
+                })
+            # step 1 윈도우 안 3회
+            for i in range(3):
+                entries.append({
+                    "ts": f"2026-05-23T02:1{i}:00Z", "phase": "pre",
+                    "agent": "build-worker", "tool": "Bash", "input": cmd,
+                })
+            trace.write_text("\n".join(json.dumps(e) for e in entries))
+            steps = [
+                StepRecord(idx=0, ts="2026-05-23T02:05:00Z", agent="build-worker",
+                           mode=None, enum="PASS", must_fix=False, prose_excerpt="x"),
+                StepRecord(idx=1, ts="2026-05-23T02:20:00Z", agent="build-worker",
+                           mode=None, enum="PASS", must_fix=False, prose_excerpt="x"),
+            ]
+            wastes = detect_wastes(steps, run_dir=rd)
+            # 각 step 3회씩 — 임계 5회 미달 → 둘 다 skip
+            self.assertFalse(any(w.pattern == "TOOL_REPEAT_HIGH" for w in wastes))
+
 
 # issue #392 — GoodDetectionTests 전체 폐기. detect_goods 함수 폐기와 정합.
 


### PR DESCRIPTION
## 변경 요약

### [issue-484] review heuristic TOOL_REPEAT_HIGH 신규 — agent-trace 기반 동일 입력 반복 검출
- **What**: `harness/run_review.py` 에 `_detect_tool_repeat_findings` 신규. agent-trace.jsonl 의 (tool, input) 카운트 ≥ 임계 시 `TOOL_REPEAT_HIGH` MEDIUM finding emit. 임계: Bash 5+ / Read 4+ / 기타 5+. step 별 윈도우 분리
- **Why**: jajang run-545513a1 build-worker 가 같은 Bash command (`cd /Users/.../impl-loop-fix307-309/apps/mobi…`) 6회 반복 호출한 안티패턴을 review heuristic 이 못 잡아 "잘못한 점 없음 ✅" 통과시킨 회귀 차단 ([issue #484](https://github.com/alruminum/dcNess/issues/484) Case 1). PostToolUse hook 의 감시자 신호와 동일 영역 — review heuristic 으로 흡수해 단일 SSOT

## 결정 근거

- 대안 1 (PostToolUse hook 의 감시자 결과를 별 파일에 저장 + review 가 읽기) — hook 출력 파일 신규 + 파싱 영역 추가, 영역 분산
- 대안 2 (`detect_wastes` 시그니처 무변경 + build_report 안에서 직접 trace 분석 후 wastes extend) — 호출 영역 분기, 테스트 가독성 ↓
- **선택 3 (`detect_wastes` 시그니처에 `run_dir` keyword 추가 + 본문 안 별 helper 호출)** — 기존 호출 영향 0 (nullable), 모든 영역 단일 함수, 테스트 자연

임계값 근거:
- Bash 5+ = jajang run-545513a1 의 6회 케이스 ≥ 5 임계 통과. 정상 진단/검증 흐름의 3-4회 호출은 면제
- Read 4+ = 동일 파일 4회+ read = 메모리/요약 활용 권장 신호. 2-3회는 정상 review 패턴

## 관련 이슈

Closes #484

## 배포 경로 검증

- **경로 1 (plug-in 본체)**: `harness/run_review.py` 는 plug-in 본체 — `claude plugin update dcness@dcness` 시 사용자 자동 적용. 다음 `/impl-loop` 부터 review.md 의 "잘못한 점" 표에 TOOL_REPEAT_HIGH finding 박힘

## Test Plan

- [x] `test_tool_repeat_high_bash` — Bash 동일 input 6회 → finding 1건
- [x] `test_tool_repeat_below_threshold_skip` — 4회 임계 미만 → skip
- [x] `test_tool_repeat_read_lower_threshold` — Read 4회 → finding 1건
- [x] `test_tool_repeat_no_trace_skip` — agent-trace.jsonl 부재 / run_dir=None → silent skip
- [x] `test_tool_repeat_window_split_by_step` — step 별 윈도우 분리 (task1 3 + task2 3 ≠ 합산 6)
- [x] 실측 검증: jajang run-545513a1 → `TOOL_REPEAT_HIGH MEDIUM build-worker Bash 6회 반복` 정확히 잡힘
- [x] 회귀: 473/473 unittest PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)