### PR TITLE
[feature] PR body 게이트 over-firing 해소 — Part of 트레일러도 valid 트레일러로 인정

### DIFF
--- a/.github/actions/pr-body/action.yml
+++ b/.github/actions/pr-body/action.yml
@@ -1,5 +1,5 @@
-name: 'dcness pr-body close-keyword validation'
-description: 'Validate PR body contains issue auto-close keyword (Closes/Fixes/Resolves #N) or explicit Document-Exception-PR-Close marker.'
+name: 'dcness pr-body trailer validation'
+description: 'Validate PR body contains issue trailer (Closes/Fixes/Resolves/Part of #N) or explicit Document-Exception-PR-Close marker.'
 inputs:
   body:
     description: 'PR body text to validate'
@@ -12,7 +12,7 @@ runs:
       with:
         node-version: '20'
 
-    - name: Validate PR body close keyword
+    - name: Validate PR body trailer
       shell: bash
       env:
         PR_BODY: ${{ inputs.body }}

--- a/scripts/check_pr_body.mjs
+++ b/scripts/check_pr_body.mjs
@@ -1,17 +1,22 @@
 #!/usr/bin/env node
 /**
- * PR body 안 issue auto-close 키워드 (`Closes #N` / `Fixes #N` / `Resolves #N`) 검증 게이트.
+ * PR body 안 issue 트레일러 (`Closes #N` / `Fixes #N` / `Resolves #N` / `Part of #N`) 검증 게이트.
  * 규칙 정의: docs/plugin/git-spec.md §8.1 (SSOT)
  *
  * 본 프로젝트(및 dcness 활성 프로젝트) 는 regular merge 채택 (squash 금지).
  * regular merge 시 GitHub auto-close 는 *PR body* 또는 *squash merge commit message* 만 인식.
  * 따라서 commit message 안 `Closes #N` 만으론 issue 자동 close 안 됨 — PR body 에 반드시 써야 함.
  *
+ * 트레일러 종류:
+ *   - Closes #N / Fixes #N / Resolves #N — auto-close 발동 (story / epic 마지막 task PR)
+ *   - Part of #N                          — 단순 언급, auto-close 발동 X (중간 task PR default)
+ * 게이트 의미 = "이슈 트레일러 1+ 강제" (이슈 추적 누락 차단). close-keyword 단독 강제는 over-firing.
+ *
  * 사용:
  *   node scripts/check_pr_body.mjs --body "<PR body 전체>"
  *   echo "<PR body>" | node scripts/check_pr_body.mjs --stdin
  *
- * exit 0: 통과 (close 키워드 1+ 매치 OR 명시적 예외 마커 1+ 매치)
+ * exit 0: 통과 (트레일러 1+ 매치 OR 명시적 예외 마커 1+ 매치)
  * exit 1: 위반 (둘 다 0 매치)
  *
  * 예외 우회 — body 안에 다음 line 쓰면 통과:
@@ -19,7 +24,7 @@
  *   사유 예) "infra-only — issue 없음", "follow-up split — close 별도 PR"
  */
 
-const CLOSE_RE = /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s*#\d+/i;
+const TRAILER_RE = /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?|part\s+of)\s*#\d+/i;
 const EXCEPTION_RE = /^\s*Document-Exception-PR-Close:\s*\S+/im;
 
 function readStdin() {
@@ -47,26 +52,27 @@ async function main() {
   }
 
   if (typeof body !== 'string' || body.length === 0) {
-    console.error('[pr-body] FAIL — PR body 가 비어있음. 최소 close 키워드 1건 또는 Document-Exception-PR-Close 마커 쓸 것.');
+    console.error('[pr-body] FAIL — PR body 가 비어있음. 최소 트레일러 1건 또는 Document-Exception-PR-Close 마커 쓸 것.');
     process.exit(1);
   }
 
   if (EXCEPTION_RE.test(body)) {
-    console.log('[pr-body] PASS — Document-Exception-PR-Close 마커 매치 (close 키워드 검사 우회).');
+    console.log('[pr-body] PASS — Document-Exception-PR-Close 마커 매치 (트레일러 검사 우회).');
     process.exit(0);
   }
 
-  if (CLOSE_RE.test(body)) {
-    const match = body.match(CLOSE_RE)[0];
-    console.log(`[pr-body] PASS — close 키워드 매치: "${match}"`);
+  if (TRAILER_RE.test(body)) {
+    const match = body.match(TRAILER_RE)[0];
+    console.log(`[pr-body] PASS — 트레일러 매치: "${match}"`);
     process.exit(0);
   }
 
-  console.error('[pr-body] FAIL — PR body 에 issue auto-close 키워드 부재.');
+  console.error('[pr-body] FAIL — PR body 에 issue 트레일러 부재.');
   console.error('  허용 패턴 (대소문자 무관, 1+ 매치):');
-  console.error('    Closes #N   |  Close #N   |  Closed #N');
-  console.error('    Fixes #N    |  Fix #N     |  Fixed #N');
-  console.error('    Resolves #N |  Resolve #N |  Resolved #N');
+  console.error('    Closes #N   |  Close #N   |  Closed #N        ← auto-close 발동 (마지막 task PR)');
+  console.error('    Fixes #N    |  Fix #N     |  Fixed #N         ← auto-close 발동');
+  console.error('    Resolves #N |  Resolve #N |  Resolved #N      ← auto-close 발동');
+  console.error('    Part of #N                                     ← 단순 언급 (중간 task PR default)');
   console.error('');
   console.error('  근거: 본 프로젝트는 regular merge 채택 — GitHub auto-close 는 *PR body* 만 인식.');
   console.error('       commit message 안 Closes #N 만으론 issue 자동 close 안 됨.');


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: gate-overfiring-fix — 사용자 보고 (반복적인 pr-body-validation 실패 메일) 대응. 별도 GitHub 이슈 없음.

## 배경 및 문제

사용자가 PR body 게이트 실패 메일이 반복적으로 발송된다고 보고. 직전 fail run [#26323709721](https://github.com/alruminum/dcNess/actions/runs/26323709721) 분석 결과 — `Part of #484` 트레일러 박힌 PR 인데 게이트가 fail. 게이트는 close 키워드 (`Closes/Fixes/Resolves #N`) 1+ 강제하는데, dcness 의 워크플로우상 *중간 task PR* 은 [`docs/plugin/git-spec.md`](../blob/main/docs/plugin/git-spec.md) §8.1 룰로 `Part of #N` 박는 게 정상.

→ 모든 중간 task PR 마다 게이트 fail 발화 → 사용자가 매번 `Document-Exception-PR-Close:` 우회 마커 박거나 PR body 수정해서 회복하는 패턴 누적. 직전 PR 들의 fail → success 반복 패턴 (예: #484 의 26323709721 fail → 26323722731 success) 이 본 회귀의 실측 증거.

**룰 모순 본질**: 게이트 의도 = \"머지 시 issue auto-close 누락 차단\" (regular merge 환경에서 PR body 의 close 키워드 강제). 그러나 dcness 패턴 = 중간 task PR 빈도 압도적 — close 키워드만 강제 시 *해당 목적과 무관한 케이스* 에 over-firing.

## 작업내용

- \`scripts/check_pr_body.mjs\` 의 \`CLOSE_RE\` → \`TRAILER_RE\` 로 변수명·정규식 의미 진화:
  - 기존: \`/(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s*#\d+/i\`
  - 갱신: \`/(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?|part\s+of)\s*#\d+/i\`
- 파일 상단 주석 + 통과/실패 메시지 + 허용 패턴 목록 의미 진화 반영. 각 패턴 우측에 \"auto-close 발동\" / \"단순 언급\" 표기.
- \`.github/actions/pr-body/action.yml\` 의 action name + step name + description 갱신 (\"close-keyword validation\" → \"trailer validation\").
- 게이트 이름 \`PR body close-keyword gate\` 자체는 historical name 으로 보존 — 기존 활성 프로젝트의 branch protection rule required status check 호환 (직전 SSOT 통합 PR [#491](https://github.com/alruminum/dcNess/pull/491) 의 \`git-naming-spec gate\` 보존과 동일 정신).

## 결정 근거

직전 사용자 옵션 선택 (A·B·C 중) — A 채택:

- **A (정규식 확장)**: 게이트 가치 보존 (이슈 트레일러 누락 차단) + over-firing 해소. 단점 = story 마지막 task PR 에서 close 누락하고 \`Part of\` 만 박아도 통과 (auto-close 누락 catch X). 단 이 영역은 메인 Claude 가 PR 생성 직전 git-spec §8.3 bash one-liner 로 자동 결정하므로 실측 회귀 빈도 낮음.
- B (게이트 폐기): 매번 fail 메일 0건 but auto-close 누락 catch 못 함. 거절.
- C (현 상태 유지): 사용자 부담 누적. 거절.

## 배포 경로 검증 (CLAUDE.md §0.5)

- **경로 1 (plug-in 본체)**: \`.github/actions/pr-body/action.yml\` + \`scripts/check_pr_body.mjs\` 변경 → plug-in 업데이트 시 자동 적용 ✅
- **경로 2 (init-dcness 복사)**: N/A — 외부 활성 프로젝트의 thin yml 은 \`uses: alruminum/dcNess/.github/actions/pr-body@main\` 으로 dcness self 의 composite action 호출. composite action 은 dcness self 의 \`scripts/check_pr_body.mjs\` 를 상대경로로 호출. **외부 사용자 재배포 불필요** — 본 PR 머지 후 모든 활성 프로젝트의 다음 PR 부터 즉시 새 룰 적용.
- **경로 3 (사용자 SSOT)**: [`docs/plugin/git-spec.md`](../blob/main/docs/plugin/git-spec.md) §8.1 룰 자체는 변경 없음 — 게이트 구현이 spec 룰 정합으로 진화한 것.

## Test Plan

- [x] sanity check 4 케이스 (Part of #N PASS / Closes #N PASS / Document-Exception PASS / 트레일러 없음 FAIL) — \`node scripts/check_pr_body.mjs --body \"...\"\` 직접 호출 검증
- [x] pytest 477 OK (mjs 변경은 Python tests 무관)
- [x] 본 PR body 자체가 \`Document-Exception-PR-Close: gate-overfiring-fix\` 박혀 통과 예정 (변경 전 룰로 게이트 발화)
- [ ] CI (pr-body-validation / git-naming-spec / plugin-manifest) PASS

## 참고

본 변경 머지 후 효과:
- 중간 task PR 작성자가 \`Part of #N\` 만 박아도 게이트 통과 → \`Document-Exception-PR-Close:\` 우회 마커 빈도 급감
- 외부 활성 프로젝트의 fail 메일 알림 누적 자연 해소

🤖 Generated with [Claude Code](https://claude.com/claude-code)