### PR TITLE
[docs] SSOT M1 — 외부 배포물 안 archive 인용 9건 정리 + 본문 자족화

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -662,7 +662,6 @@ inactive 로 회귀. 재설치 후엔 각 활성 프로젝트마다 `/init-dcnes
 
 ## 참조
 
-- `harness/session_state.py` — `is_project_active` / `enable_project` / `disable_project` / CLI subcommands
+- `harness/session_state.py` — `is_project_active` / `enable_project` / `disable_project` / CLI subcommands + `_default_base` (worktree γ resolution — 활성화 상태도 main repo 기준 sid)
 - `hooks/session-start.sh` / `hooks/catastrophic-gate.sh` — 첫 줄에 `is-active` 게이트
-- `docs/archive/conveyor-design.md` §13 — worktree γ resolution (활성화도 main repo 기준)
 - 이전 하네스 패턴 대비: whitelist 위치가 글로벌 `~/.claude/harness-projects.json` 대신 plugin-scoped `~/.claude/plugins/data/dcness-dcness/projects.json`

--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -210,7 +210,6 @@ RWHarness 4 신호 OR 정합:
 - [`orchestration.md`](orchestration.md) — 시퀀스 catalog (§2 게이트 + §3 진입 경로 + §4 8 loop 행별 풀스펙)
 - [`loop-procedure.md`](loop-procedure.md) — Step 0~8 mechanics
 - [`orchestration.md`](orchestration.md) §0 — 강제 영역 2가지 (대 원칙)
-- [`../archive/status-json-mutate-pattern.md`](../archive/status-json-mutate-pattern.md) — Prose-Only 원전 proposal (역사 자료)
 - `agents/*.md` — 각 agent 의 결론 prose 표현 가이드
 - `harness/signal_io.py` / `harness/interpret_strategy.py` — 옛 enum 추출 인프라 (이슈 #284 폐기 진행 중)
 - (issue #392 — `harness/routing_telemetry.py` 폐기. baseline 비교 끝남 + cascade marker 실측 0건)

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -71,7 +71,7 @@ else
 fi
 ```
 
-자세히 = [`../archive/conveyor-design.md`](../archive/conveyor-design.md) §13.
+위 squash 흡수 검사 + ExitWorktree 자동 분기 패턴은 본 SSOT 본문이 자족. (역사 설계 컨텍스트는 [`../../README.md`](../../README.md) "참조 문서" 표 참고.)
 
 ### 1.2 begin-run
 
@@ -507,7 +507,6 @@ review 리포트의 must-fix / waste finding / per-Agent metric 즉시 인지 + 
 - [`orchestration.md`](orchestration.md) §2~§4 — 시퀀스 mini-graph / 8 loop 행별 풀스펙 / handoff cross-ref
 - [`hooks.md`](hooks.md) — 6 hook (catastrophic-gate / file-guard / tdd-guard / stop-end-run / session-start / post-*) 시점·차단·우회 SSOT
 - 본 문서 §3.1 + §6 — echo / 자가점검 / REDO 분류 / 개선점 코멘트 (옛 dcness-rules §3/§4 흡수)
-- [`../archive/conveyor-design.md`](../archive/conveyor-design.md) §2 / §3 / §7 — 컨베이어 디자인 + catastrophic gate (역사 자료)
 - `harness/session_state.py` — helper CLI (`begin-run` / `end-run` / `begin-step` / `end-step` / `finalize-run` / `run-dir` / `auto-resolve`)
 - `harness/run_review.py` — review 엔진 (`--auto-review` 호출 대상)
 - `commands/<skill>.md` — skill 진입점 (input 정형화 + Loop 추천)

--- a/docs/plugin/orchestration.md
+++ b/docs/plugin/orchestration.md
@@ -351,7 +351,7 @@ default 진입 = test-engineer (architect-loop 통과물). fallback (즉석 task
 
 ## 6. 코드 Driver
 
-§2.1 catastrophic = `hooks/catastrophic-gate.sh` (PreToolUse Agent) 강제. 메인 Claude = 시퀀스 결정자. **6 hook 전체 시점·차단·우회 메커니즘 SSOT** = [`hooks.md`](hooks.md). 상세 설계 history = [`../archive/conveyor-design.md`](../archive/conveyor-design.md).
+§2.1 catastrophic = `hooks/catastrophic-gate.sh` (PreToolUse Agent) 강제. 메인 Claude = 시퀀스 결정자. **6 hook 전체 시점·차단·우회 메커니즘 SSOT** = [`hooks.md`](hooks.md).
 
 ---
 
@@ -361,12 +361,10 @@ default 진입 = test-engineer (architect-loop 통과물). fallback (즉석 task
 - [`loop-procedure.md`](loop-procedure.md) — 루프 실행 Step 0~8 mechanics
 - [`hooks.md`](hooks.md) — 6 hook (catastrophic-gate / file-guard / tdd-guard / stop-end-run / session-start / post-*) 시점·차단·우회 SSOT (코드 강제 백본)
 - 본 문서 §0 — 강제 영역 2가지 + 안티패턴 4건 (옛 dcness-rules.md §1 흡수)
-- [`../archive/status-json-mutate-pattern.md`](../archive/status-json-mutate-pattern.md) — Prose-Only 원전 proposal (Phase 분할 / §11.4 도입 기준 / Risks) (역사 자료)
-- [`../archive/conveyor-design.md`](../archive/conveyor-design.md) — 코드 driver 디자인 + 폐기된 옵션 카탈로그 (역사 자료)
 - [`loop-procedure.md`](loop-procedure.md) §3 — cross-cutting 룰 (echo / 자가점검 / REDO 분류 / yolo)
 - [`../../CLAUDE.md`](../../CLAUDE.md) — 작업 절차 + 게이트 SSOT
-- [`../archive/plugin-dryrun-guide.md`](../archive/plugin-dryrun-guide.md) — plugin 배포 dry-run (역사 자료)
-- [`../archive/migration-decisions.md`](../archive/migration-decisions.md) §2.1 — RWHarness 모듈 분류 (impl_loop.py DISCARD) (역사 자료)
+
+> 역사 자료 (Prose-Only 원전 proposal / 코드 driver 디자인 / plugin 배포 dry-run / RWHarness 모듈 분류 등) 는 [`../../README.md`](../../README.md) 의 "참조 문서" 표 (`docs/archive/` 영역) 참조.
 - `agents/*.md` — 각 agent prose writing guide + 결론 enum 출처 (system-architect / module-architect / engineer / test-engineer / code-validator / architecture-validator / designer / ux-architect / plan-reviewer / pr-reviewer / qa)
 - `harness/signal_io.py` / `harness/interpret_strategy.py` — interpret_signal + heuristic
 - `scripts/analyze_metrics.mjs` — fitness 측정


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: SSOT audit (`tmp/ssot-audit-20260523.html`) 후속 M1 정리, 자가 발의 (PR #495 H1~H3 의 follow-up)

## 배경 및 문제

PR #495 (H1~H3) 머지 후, audit Section 4 의 archive 인용 잔존 10건 정리. 외부 배포 SSOT (plugin/commands) 본문에 `docs/archive/` 인용이 박혀 있으면 plugin 사용자가 본문 읽다가 역사 자료로 이탈 → 본문 자족 원칙 위배 + `CLAUDE.md §0.3` 정신 (내부 추적 표현을 외부 배포물 본문에 박지 마라) 충돌.

**9건 정리** + **1건 scope 제외** (`commands/smart-compact.md:177` — resume prompt sample 코드블록 안 historical 예시, 부분 갱신 시 sample 안 다른 옛 인용과 inconsistent. 별 PR 후보).

## 작업내용

- `docs/plugin/orchestration.md` §6 본문 — "상세 설계 history = `conveyor-design.md`" 제거. `hooks.md` cross-ref 로 본문 자족
- `docs/plugin/orchestration.md` §7 참조 — 4 archive 인용 제거 (status-json-mutate / conveyor-design / plugin-dryrun / migration-decisions) + 끝에 1줄 안내 ("역사 자료는 `README.md` 참조 문서 표 참고") 통합
- `docs/plugin/handoff-matrix.md` §5 참조 — status-json-mutate-pattern 인용 제거
- `docs/plugin/loop-procedure.md` §1.1 본문 — "자세히 = `conveyor-design.md` §13" 제거 (ExitWorktree squash 흡수 검사 스크립트로 본문 자족)
- `docs/plugin/loop-procedure.md` §8 참조 — conveyor-design.md §2/§3/§7 인용 제거
- `commands/init-dcness.md` §참조 — conveyor-design.md §13 인용 → `harness/session_state.py:_default_base` 구현 코드 직접 인용 (worktree γ resolution 본문 자족)

## 결정 근거

- **plugin 사용자 본문 자족 원칙** — 외부 사용자가 본문 자체로 다음 행동을 결정할 수 있어야 함. archive 클릭 의존성을 끊음
- **역사 자료 통합 노출** — orchestration §7 끝의 안내 1줄이 모든 archive 자료를 `README.md` "참조 문서" 표로 일괄 정리. 외부 사용자가 역사 컨텍스트 원할 때 1 hop
- **scope 제외 (smart-compact.md:177)** — `line 142-182` 의 resume prompt sample 코드블록 안 — DCN-CHG 옛 PR 번호 / 옛 SSOT 파일명 다수 포함 historical 예시. 본 영역의 archive 인용 1건만 부분 갱신 시 sample 내 다른 historical 인용과 inconsistent. sample 전체 generic 화는 별 PR 후보

## 배포 경로 검증 (plug-in 영향 시)

- **영향 경로**: `docs/plugin/` 3개 + `commands/init-dcness.md` (plug-in cache 자동 갱신, plugin update 시 사용자 환경 적용)
- **`agents/**` / `hooks/**`** 변경 0건. init-dcness 복사 파일 (scripts/hooks/* / templates/*) 변경 0건 — 사용자 repo 에 직접 cp 작업 없음
- **외부 사용자 영향**: 본문 자족화로 archive 이탈 0. 역사 컨텍스트 필요한 사용자는 README 1 hop

## Test Plan

- [x] Python path resolver 재실측 — dead link **0 유지**
- [x] 외부 배포 archive 인용 재실측 — **9 → 0** (orchestration §7 끝 안내 텍스트만 잔존, 실제 인용 0)
- [x] git-naming hook PASS
- [ ] CI: PR body gate + git-naming + plugin-manifest 통과 대기

## 참고

- 분석 보고서: `tmp/ssot-audit-20260523.html` (Section 4)
- 직전 PR: #495 (H1~H3)
- 다음 후보:
  - **M2** — `handoff-matrix.md §1` ↔ `orchestration.md §4` 양방향 cross-ref 강제 룰
  - **L1** — `git-spec.md` ↔ `issue-lifecycle.md` 통합 검토
  - **L2** — cross-ref 검증 스크립트 CI 통합