### PR TITLE
[docs] SSOT M2 — handoff-matrix §1 ↔ orchestration §4 양방향 drift 룰 박기

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,8 +81,8 @@
 | 파일 | 언제 읽나 |
 |---|---|
 | [`docs/plugin/git-spec.md`](docs/plugin/git-spec.md) | 브랜치·커밋·PR 네이밍 규칙 SSOT — 모든 커밋 작업에 적용 |
-| [`docs/plugin/orchestration.md`](docs/plugin/orchestration.md) | 시퀀스 mini-graph + 8 loop 풀스펙 — 루프 진입 경로·분기 수정 시 |
-| [`docs/plugin/handoff-matrix.md`](docs/plugin/handoff-matrix.md) | agent 호출 분기 / retry / escalate 한도 / 접근 권한 경계 수정 시 |
+| [`docs/plugin/orchestration.md`](docs/plugin/orchestration.md) | 시퀀스 mini-graph + 8 loop 풀스펙 — 루프 진입 경로·분기 수정 시. **§4 갱신 시 `handoff-matrix.md` §1 동시 갱신 의무** (drift 룰, 본문 callout 정합) |
+| [`docs/plugin/handoff-matrix.md`](docs/plugin/handoff-matrix.md) | agent 호출 분기 / retry / escalate 한도 / 접근 권한 경계 수정 시. **§1 갱신 시 `orchestration.md` §4 동시 갱신 의무** (drift 룰, 본문 callout 정합) |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md) | Step 0~8 mechanics (begin-run → begin-step → Agent → end-step → finalize-run) 수정 시 |
 | [`docs/plugin/hooks.md`](docs/plugin/hooks.md) | hook 시스템 (PreToolUse / SessionStart / cc-pre-commit) 수정 시 SSOT |
 | [`docs/plugin/issue-lifecycle.md`](docs/plugin/issue-lifecycle.md) | 외부 활성 프로젝트의 epic / story / impl 흐름 변경 시 SSOT (본 저장소 자체엔 미적용 — §0.2 참조) |

--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -15,6 +15,8 @@
 > - 메인은 prose + 본 §1 가이드만으로 routing 결정. enum 형식 검증 없음.
 > - prose 가 모호하거나 결론을 추출 못 하면 메인이 사용자에게 위임 (prose 본문 "결정 불가" 명시, issue #392 — routing_telemetry cascade marker 폐기).
 
+> 🔴 **Drift 룰 (양방향 cross-ref 강제)** — 본 §1 의 agent 결론 → 다음 호출 매핑 갱신 시 [`orchestration.md`](orchestration.md) §4 의 해당 loop 시퀀스도 동시 갱신 의무. 같은 enum→destination 매핑이 두 시각 (agent 단위 vs loop 단위) 에 분리 박혀 있어 한쪽만 갱신하면 drift 위험. 신 agent 추가 / 기존 enum 추가 / cycle 한도 변경 3 케이스 적용.
+
 ### 1.1 plan-reviewer
 
 PRD 외부 검증 (`FULL` 모드 default / `PRE_CHECK` 모드 — `/product-plan` 스킬의 Spike Pre-Check 단계). 세 가지 결과:

--- a/docs/plugin/orchestration.md
+++ b/docs/plugin/orchestration.md
@@ -129,6 +129,8 @@ default 진입 = test-engineer (architect-loop 통과물). fallback (즉석 task
 > *행별 풀스펙* SSOT (entry_point / task_list / advance / clean_enum / branch_prefix / Step 별 allowed_enums / 분기 / sub_cycles).
 > 시퀀스 = §2. 실행 절차 = [`loop-procedure.md`](loop-procedure.md).
 
+> 🔴 **Drift 룰 (양방향 cross-ref 강제)** — 본 §4 의 loop 시퀀스 안 agent 결론 → 다음 호출 매핑 갱신 시 [`handoff-matrix.md`](handoff-matrix.md) §1 의 해당 agent sub-section 도 동시 갱신 의무. 같은 enum→destination 매핑이 두 시각 (loop 단위 vs agent 단위) 에 분리 박혀 있어 한쪽만 갱신하면 drift 위험. 신 agent 추가 / 기존 enum 추가 / cycle 한도 변경 3 케이스 적용.
+
 ### 4.1 한눈 인덱스
 
 | loop | entry_point | task_list (Step 1) | advance | clean_enum | expected_steps |


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: SSOT audit (`tmp/ssot-audit-20260523.html`) 후속 M2 정리, 자가 발의 (PR #495 H1~H3 + PR #496 M1 의 follow-up)

## 배경 및 문제

audit Section 5 Drift Hot-Spot 의 (B) 항목 — `docs/plugin/handoff-matrix.md §1` (agent 단위 시각) 과 `docs/plugin/orchestration.md §4` (loop 단위 시각) 에 같은 *agent 결론 → 다음 호출 매핑* 이 분리 박혀 있음. 두 시각은 직교지만 정보는 겹침. 신 agent 추가 / 기존 enum 추가 / cycle 한도 변경 3 케이스에서 양쪽 동시 갱신 의무지만 코드 강제 없음 = drift 위험.

### 구체 예시
- `module-architect` 의 `ESCALATE` destination 매핑 — handoff §1.4 본문 (`PRD 변경 필요 → /product-plan` 등) + orchestration §4.3 (`module-architect ESCALATE → 사용자 위임`) 양쪽 박힘
- `engineer` 의 `IMPL_PARTIAL` enum / cycle 한도 — handoff §1.5 + orchestration §4.3 양쪽

## 작업내용

- `docs/plugin/handoff-matrix.md` §1 — "이슈 #280 정착 후 작동 모델" callout 직후에 **🔴 Drift 룰** callout 1줄 신규. `orchestration.md` §4 동시 갱신 의무 명시 + 3 적용 케이스
- `docs/plugin/orchestration.md` §4 — §4.1 인덱스 직전에 동일 callout 1줄 신규. `handoff-matrix.md` §1 동시 갱신 의무 명시 + 동일 3 케이스
- `CLAUDE.md` §3 문서 지도 — 두 SSOT 행에 "**§N 갱신 시 짝 SSOT §M 동시 갱신 의무** (drift 룰, 본문 callout 정합)" annotation 추가

## 결정 근거

### 옵션 A (룰 메모) 선택 이유
- **옵션 B (한 곳 통합)**: 두 시각 (agent / loop) 모두 필요한 사용자에게 inefficient + orchestration §4 비대화 (215 + 118 = 333줄+)
- **옵션 C (자동 검증 스크립트)**: 자연어 parsing 의 false positive 위험 + L2 (cross-ref 검증 스크립트 CI 통합) 와 묶어 별 진행이 비용 효율
- **옵션 A**: 비용 0 (1 PR / 5분) + 효과 보통 (사람 의존). M2 단독으로 충분, L2 follow-up 으로 코드 강제 강화

### 양방향 cross-ref
- 한쪽에만 박으면 반대 방향 진입자가 룰 발견 못 함. 사람 의존 강제이므로 양방향 가시성 필수

### CLAUDE.md §3 annotation
- dcness self 메인 Claude 가 문서 지도 보고 SSOT 갱신 진입 시 짝 SSOT 인지 자연 유도. 외부 사용자엔 영향 X (CLAUDE.md 는 dcness self 작업 룰)

### dcness 강제 원칙 정합
- 강제는 *룰 메모 가시성* 만 — 코드 강제 X. dcness 의 강제 영역 = 작업 순서 + 접근 영역만 (`orchestration.md §0` 정합). 사람 의존 한계는 인정

## 배포 경로 검증 (plug-in 영향 시)

- **영향 경로**: `docs/plugin/handoff-matrix.md` + `docs/plugin/orchestration.md` — plug-in cache 자동 갱신 (사용자 plugin update 후 적용)
- **`CLAUDE.md`**: dcness self 작업 룰. 외부 배포 X (사용자 plugin 활성화 시 사용자 자기 CLAUDE.md 가 진본). dcness 메인 Claude 작업 시 인지 채널만 영향
- **`agents/**` / `hooks/**` / init-dcness 복사 파일** 변경 0건

## Test Plan

- [x] Python path resolver 재실측 — **dead link 0 유지**
- [x] git-naming hook PASS
- [ ] CI: PR body gate + git-naming + plugin-manifest 통과 대기

## 참고

- 분석 보고서: `tmp/ssot-audit-20260523.html` (Section 5 Drift Hot-Spot, (B) MODERATE 항목)
- 직전 PR: #495 (H1~H3) + #496 (M1)
- 후속 옵션:
  - **L1** — `git-spec.md` ↔ `issue-lifecycle.md` 통합 검토 (#491 안정화 후)
  - **L2** — cross-ref 검증 스크립트 CI 통합 (자연어 routing 매핑 diff 자동화 = 본 M2 룰의 코드 강제 형태)
  - **(별)** `commands/smart-compact.md` sample generic 화