### PR TITLE
[docs] SSOT L2 — cross-ref CI 게이트 추가 (dead link / dead anchor / 옛 명칭 회귀 차단)

### DIFF
--- a/.github/workflows/cross-ref-validation.yml
+++ b/.github/workflows/cross-ref-validation.yml
@@ -1,0 +1,50 @@
+# GitHub Actions — Cross-Ref 무결성 검증
+#
+# 검증 범위:
+# - markdown link 파일 실존 (`[text](path)` / `[text](path#anchor)`)
+# - anchor → target heading slug 매칭 (GitHub-flavored slug 단순 모사)
+# - 옛 명칭 deny-list (외부 배포 영역 한정 — docs/plugin/, commands/, agents/, hooks/, .claude-plugin/)
+#
+# Scope 외 (별 PR 후보):
+# - prose `<file>.md §N.M` heuristic 인용 (false positive 분류 부담)
+#
+# SSOT: docs/plugin/git-spec.md §3.3 (cross-ref 룰)
+#
+# 도입 배경 (SSOT audit L2):
+# - H1 (Dead Link 7→0) / N (옛 명칭 12→0) 정리 후 회귀 자동 차단 필요
+# - 기존 게이트 4개 (main-block / git-naming / pytest / plugin-manifest / pr-body) 와 같은 패턴
+
+name: cross-ref-validation
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/check_cross_refs.mjs'
+      - '.github/workflows/cross-ref-validation.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/*.md'
+      - 'scripts/check_cross_refs.mjs'
+      - '.github/workflows/cross-ref-validation.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: validate cross-refs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run cross-ref check
+        run: node scripts/check_cross_refs.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@
 - **pytest**: `scripts/check_python_tests.sh` — harness/tests/agents 변경 시만
 - **plugin-manifest**: `scripts/check_plugin_manifest.mjs` (CI `plugin-manifest.yml`) — `.claude-plugin/plugin.json` version / manifest 정합 검증
 - **pr-body**: `scripts/check_pr_body.mjs` (CI `pr-body-validation.yml`) — PR 본문 템플릿 충족 검증
+- **cross-ref**: `scripts/check_cross_refs.mjs` (CI `cross-ref-validation.yml`) — markdown link 파일/anchor 실존 + 옛 명칭 deny-list (외부 배포 영역 한정) 회귀 차단
 
 > ⚠️ **금지**: `--no-verify` 등 hook 우회. main 직접 push.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Donghan Kim
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -159,4 +159,4 @@ PR 절차: [`CLAUDE.md`](CLAUDE.md) §5.
 
 ## License
 
-MIT — see [`LICENSE`](LICENSE) (TBD).
+MIT — see [`LICENSE`](LICENSE).

--- a/docs/internal/enum-roi-baseline.md
+++ b/docs/internal/enum-roi-baseline.md
@@ -164,4 +164,4 @@
 - [`harness/signal_io.py`](../../harness/signal_io.py) `_heuristic_interpret` (line 232-264) — 추출 휴리스틱
 - [`docs/plugin/handoff-matrix.md`](../plugin/handoff-matrix.md) `§1` — drift 발견된 매트릭스
 - [`docs/plugin/orchestration.md`](../plugin/orchestration.md) `§0` — LLM 자율 + 최소 가이드레일 (강제 영역 2 + 안티패턴 4, dcness-rules.md 폐기 후 흡수처)
-- 분석 스크립트: [`scripts/research/enum_roi_baseline.mjs`](../../scripts/research/enum_roi_baseline.mjs) — 본 보고서 재현용
+- 분석 방식: manual — 본 보고서는 telemetry 샘플 + heuristic 룰 매핑을 수동으로 정리. 재현용 스크립트는 미작성 (필요 시 별 PR).

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -1,0 +1,305 @@
+#!/usr/bin/env node
+/**
+ * dcNess cross-ref validator (CI 게이트).
+ *
+ * 검증 A — markdown link 무결성
+ *   - `[text](path)`             → path 파일 실존
+ *   - `[text](path#anchor)`      → 파일 실존 + target 파일 heading slug 매칭
+ *   - `[text](#same-doc-anchor)` → 자기 파일 heading slug 매칭
+ *   - 외부 URL (http(s)/mailto/tel/ftp) → skip
+ *   - .md 외 파일의 #anchor (예: harness/foo.py#L10) → skip
+ *
+ * 검증 B — 옛 명칭 deny-list (외부 배포 영역 한정)
+ *   - 폐기 명령어 / 옛 loop 명 / 옛 SSOT 파일명
+ *   - 외부 배포 영역: docs/plugin/, commands/, agents/, hooks/, .claude-plugin/
+ *   - 예외 파일: commands/smart-compact.md (sample 코드블록 안 historical 인용 — M1/N 동일 사유)
+ *
+ * Scope 외 (별 PR 후보):
+ *   - prose `<filename>.md §N.M` heuristic 인용 (false positive 분류 부담)
+ *
+ * 사용:
+ *   node scripts/check_cross_refs.mjs
+ *
+ * exit 0: PASS
+ * exit 1: FAIL — dead link / dead anchor / 옛 명칭 매치
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { dirname, resolve, join, relative } from 'node:path';
+
+const REPO_ROOT = process.cwd();
+
+// ─── 검사 대상 ─────────────────────────────────────────────────
+const SCAN_DIRS = ['docs/plugin', 'docs/internal', 'commands', 'agents'];
+const SCAN_ROOTS = ['README.md', 'AGENTS.md', 'PROGRESS.md', 'CLAUDE.md'];
+
+// ─── 옛 명칭 deny-list ────────────────────────────────────────
+// historical annotation (navigation hint) 은 통과:
+//   keyword "옛|폐기|history|deprecated|legacy" 가 동일 라인에 있으면 valid context
+const HISTORICAL_CTX_RE = /(옛|폐기|history|deprecated|legacy)/i;
+
+const DENY_LIST = [
+  {
+    pattern: /(?<![\w/])\/auto-loop\b/,
+    label: '폐기 명령어 `/auto-loop` — 현존 X (`/impl` / `/impl-loop` 만)',
+  },
+  {
+    pattern: /\bdirect-impl-loop\b/,
+    label: '폐기 loop 명 `direct-impl-loop` — 현재 `impl-task-loop` / `impl-ui-design-loop` 만',
+  },
+  {
+    pattern: /prose-only-principle\.md/,
+    label: '폐기 SSOT `prose-only-principle.md` — `orchestration.md §0` 로 흡수',
+  },
+  {
+    pattern: /dcness-rules\.md/,
+    label: '폐기 SSOT `dcness-rules.md` — `orchestration.md §0` 안티패턴 1+3 로 흡수',
+  },
+];
+
+const EXTERNAL_DIRS = ['docs/plugin', 'commands', 'agents', 'hooks', '.claude-plugin'];
+
+const DENY_EXCLUDE = new Set([
+  'commands/smart-compact.md',
+]);
+
+// ─── 헬퍼 ────────────────────────────────────────────────────
+function walkMd(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkMd(p));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function collectFiles() {
+  const out = [];
+  for (const d of SCAN_DIRS) {
+    if (existsSync(d)) out.push(...walkMd(d));
+  }
+  for (const f of SCAN_ROOTS) {
+    if (existsSync(f)) out.push(f);
+  }
+  return out.sort();
+}
+
+const fileCache = new Map();
+function getContent(filePath) {
+  if (!fileCache.has(filePath)) {
+    fileCache.set(filePath, readFileSync(filePath, 'utf8'));
+  }
+  return fileCache.get(filePath);
+}
+
+// GitHub-flavored anchor slug (단순 모사)
+//   - lowercase
+//   - 영숫자/공백/dash/한글/한글자모 유지, 나머지 제거
+//   - 공백 → dash (연속 공백도 단일 dash)
+function slugify(text) {
+  return text
+    .toLowerCase()
+    .replace(/[^\w\s\-가-힣ㄱ-ㅎㅏ-ㅣ]/gu, '')
+    .trim()
+    .replace(/\s+/g, '-');
+}
+
+const anchorCache = new Map();
+function getAnchors(filePath) {
+  if (anchorCache.has(filePath)) return anchorCache.get(filePath);
+  const content = getContent(filePath);
+  const slugs = new Set();
+  let inCodeBlock = false;
+  for (const line of content.split('\n')) {
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+    const m = line.match(/^(#{1,6})\s+(.+?)\s*$/);
+    if (m) slugs.add(slugify(m[2]));
+  }
+  anchorCache.set(filePath, slugs);
+  return slugs;
+}
+
+// inline code 영역 mask out — 백틱 안 [text](url) 은 placeholder 예시일 가능성 높음
+// `` ` `` ~ `` ` `` 사이 영역을 공백으로 치환 (라인 길이 보존, 정규식 위치 유지)
+function maskInlineCode(line) {
+  // 백틱 1개 (또는 2개) 로 둘러싼 영역. ``` (3개) 는 code fence 라 별도 처리.
+  // 짝수 번째 백틱까지의 영역을 같은 길이 공백으로 치환.
+  let out = '';
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '`') {
+      // 백틱 시작 — 닫는 백틱까지 찾아 mask
+      const close = line.indexOf('`', i + 1);
+      if (close === -1) {
+        out += line.slice(i);
+        break;
+      }
+      out += ' '.repeat(close - i + 1);
+      i = close + 1;
+    } else {
+      out += line[i];
+      i++;
+    }
+  }
+  return out;
+}
+
+function extractLinks(filePath) {
+  const content = getContent(filePath);
+  const links = [];
+  let lineNo = 0;
+  let inCodeBlock = false;
+  for (const line of content.split('\n')) {
+    lineNo++;
+    if (line.trim().startsWith('```')) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (inCodeBlock) continue;
+    const masked = maskInlineCode(line);
+    const re = /\[([^\]]+)\]\(([^)\s]+)\)/g;
+    let m;
+    while ((m = re.exec(masked)) !== null) {
+      links.push({ text: m[1], url: m[2], lineNo });
+    }
+  }
+  return links;
+}
+
+function isExternalUrl(url) {
+  return /^(https?:|mailto:|tel:|ftp:|#?$)/i.test(url);
+}
+
+function validateLinks(filePath) {
+  const violations = [];
+  const sourceDir = dirname(filePath);
+
+  for (const { url, lineNo } of extractLinks(filePath)) {
+    if (isExternalUrl(url)) continue;
+
+    const hashIdx = url.indexOf('#');
+    const pathPart = hashIdx === -1 ? url : url.slice(0, hashIdx);
+    const anchor = hashIdx === -1 ? '' : url.slice(hashIdx + 1);
+
+    if (!pathPart) {
+      // same-doc anchor
+      if (anchor && !getAnchors(filePath).has(anchor)) {
+        violations.push({
+          file: filePath,
+          lineNo,
+          url,
+          reason: `same-doc anchor #${anchor} not found in heading slugs`,
+        });
+      }
+      continue;
+    }
+
+    const target = resolve(sourceDir, pathPart);
+    if (!existsSync(target)) {
+      violations.push({
+        file: filePath,
+        lineNo,
+        url,
+        reason: `file not found at ${relative(REPO_ROOT, target)}`,
+      });
+      continue;
+    }
+
+    if (anchor && target.endsWith('.md')) {
+      if (!getAnchors(target).has(anchor)) {
+        violations.push({
+          file: filePath,
+          lineNo,
+          url,
+          reason: `anchor #${anchor} not found in ${relative(REPO_ROOT, target)}`,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+function isExternalFile(filePath) {
+  return EXTERNAL_DIRS.some(
+    (d) => filePath === d || filePath.startsWith(d + '/')
+  );
+}
+
+function validateDenyList(filePath) {
+  if (!isExternalFile(filePath)) return [];
+  if (DENY_EXCLUDE.has(filePath)) return [];
+
+  const violations = [];
+  const lines = getContent(filePath).split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // historical annotation 은 통과 (옛/폐기/history 키워드 동반)
+    if (HISTORICAL_CTX_RE.test(line)) continue;
+    for (const { pattern, label } of DENY_LIST) {
+      if (pattern.test(line)) {
+        violations.push({
+          file: filePath,
+          lineNo: i + 1,
+          snippet: line.trim().slice(0, 120),
+          label,
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+// ─── main ────────────────────────────────────────────────────
+function main() {
+  const files = collectFiles();
+  const linkViolations = [];
+  const denyViolations = [];
+
+  for (const f of files) {
+    linkViolations.push(...validateLinks(f));
+    denyViolations.push(...validateDenyList(f));
+  }
+
+  console.log(`[cross-ref] 검사 대상: ${files.length} 파일`);
+
+  if (linkViolations.length === 0 && denyViolations.length === 0) {
+    console.log('[cross-ref] PASS — dead link / dead anchor / 옛 명칭 0건');
+    process.exit(0);
+  }
+
+  if (linkViolations.length > 0) {
+    console.error(`\n[cross-ref] FAIL — dead link / dead anchor ${linkViolations.length} 건:`);
+    for (const v of linkViolations) {
+      console.error(`  ${v.file}:${v.lineNo}  [${v.url}]`);
+      console.error(`    → ${v.reason}`);
+    }
+  }
+
+  if (denyViolations.length > 0) {
+    console.error(`\n[cross-ref] FAIL — 옛 명칭 deny-list ${denyViolations.length} 건:`);
+    for (const v of denyViolations) {
+      console.error(`  ${v.file}:${v.lineNo}  ${v.snippet}`);
+      console.error(`    → ${v.label}`);
+    }
+  }
+
+  console.error('');
+  console.error('  Scope:');
+  console.error('    - 검증 A (link)   : markdown link 형식만 (`[text](path)` / `[text](#anchor)`).');
+  console.error('                       prose `<file>.md §N.M` heuristic 인용은 별 PR 후보.');
+  console.error('    - 검증 B (deny)   : 외부 배포 영역 (docs/plugin/, commands/, agents/, hooks/, .claude-plugin/) 한정.');
+  console.error('                       예외: commands/smart-compact.md (sample 코드블록 안 historical).');
+  console.error('  SSOT: 본 스크립트 헤더 주석 + .github/workflows/cross-ref-validation.yml 헤더.');
+
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## 관련 이슈 번호
Document-Exception-PR-Close: SSOT audit 후속 L2 (cross-ref 검증 CI 통합), 자가 발의

## 배경 및 문제
- 직전 PR #495~#498 (H1~H3 + M1 + M2 + N) — Dead Link 7→0 / 옛 명칭 + dead anchor 12→0 정리 완료
- **회귀 방어 부재** — 다음 PR 에서 dead link / 옛 명칭 다시 들어가도 막을 자동 게이트 없음
- audit 보고서 (`tmp/ssot-audit-20260523.html`) Section 7 L2 항목: "cross-ref 검증 스크립트 CI 통합"

## 작업내용

### 1. cross-ref 게이트 추가
- `scripts/check_cross_refs.mjs` — Node.js native (기존 게이트 4개 패턴 정합, 외부 dep 0)
  - **검증 A** — markdown link `[text](path)` / `[text](path#anchor)` / `[text](#same-doc)` 무결성. anchor → GitHub-flavored slug 매칭
  - **검증 B** — 옛 명칭 deny-list (외부 배포 영역 한정): `/auto-loop`, `direct-impl-loop`, `prose-only-principle.md`, `dcness-rules.md`
  - inline code 안 placeholder (`[경로](경로)`, `[#MMM](url)`) 는 mask out — false positive 회피
  - historical annotation (`옛|폐기|history|deprecated|legacy` 동반 라인) 통과 — navigation hint 보호
  - `commands/smart-compact.md` deny 예외 (sample 코드블록 안 historical, M1/N 동일 사유)
- `.github/workflows/cross-ref-validation.yml` — `plugin-manifest.yml` 패턴 정합 (PR + push, paths 필터 `**/*.md`, Node 20)
- `CLAUDE.md` §2 게이트 요약 — 기존 4 게이트 (main-block / git-naming / pytest / plugin-manifest / pr-body) 에 cross-ref 추가 → **5 게이트**

### 2. 사전 실측에서 발견된 진짜 위반 2건 정리
- `LICENSE` (신규) — MIT 표준 텍스트 (저작권자: Donghan Kim, 2026). README 의 \`MIT — see [LICENSE] (TBD)\` 인용 정상화 — \`(TBD)\` 마크 제거
- `docs/internal/enum-roi-baseline.md`:167 — 부재 스크립트 \`scripts/research/enum_roi_baseline.mjs\` 인용 → "manual 분석 — 재현용 스크립트 미작성" 으로 정정

### 3. 사전 실측 false positive 4건 → resolver 개선
- inline code 안 example placeholder 3건 (`[경로](경로)` × 2, `[#MMM](url)` × 1) → `maskInlineCode()` 추가 (백틱 영역 mask, 라인 길이 보존)
- historical annotation 1건 (`옛 dcness-rules.md §1 흡수`) → `HISTORICAL_CTX_RE` 추가

## 결정 근거

### Scope = Phase 1 + 1.5
- **Phase 1** (markdown link 검증) — audit Section 3 Dead Link 회귀 100% 차단
- **Phase 1.5** (옛 명칭 deny-list) — N 작업 옛 명칭 12건 회귀 명시적 잠금. false positive 0
- **Phase 2** (prose \`<file>.md §N.M\` heuristic) = 별 PR 후보 — false positive 분류 부담 + heuristic 룰 튜닝 다른 성격

### 구현 선택
- **Node.js native** — 기존 게이트 4개 (`check_*.mjs`/`check_*.sh`) 패턴 정합. Python resolver 흔적 없어 새로 작성. 외부 dep 0 = CI 의존성 추가 X
- **inline code mask 룰** — 백틱 1개 짝(`` ` ... ` ``) 안 영역을 공백으로 mask. 라인 길이 보존 → 정규식 위치 유지 → lineNo 정확
- **historical annotation 예외** — 외부 사용자 navigation hint (\`옛 X.md → 현 Y.md 흡수\`) 는 valid info, 게이트가 잡으면 안 됨

## 배포 경로 검증
- **영향 경로**: dcness self 만 — `.github/workflows/`, `scripts/`, `CLAUDE.md`, `LICENSE`, `README.md`, `docs/internal/`
- plug-in 본체 (`agents/**`, `commands/**`, `hooks/**`) 변경 0건 → 외부 활성 프로젝트 plug-in cache 자동 갱신 없음 (의도적)
- `init-dcness` 가 사용자 프로젝트로 복사하는 파일 list — **본 PR 의 `check_cross_refs.mjs` / `cross-ref-validation.yml` 은 deploy 스텝에 추가하지 않음** (dcness self SSOT 보호 목적. 외부 활성 프로젝트는 SSOT 7개 부재 → 검사 대상 0 → 게이트 의미 없음). 외부 확장은 별 후속 PR (SCAN_DIRS 사용자 정의화 검토 필요)

## Test Plan
- [x] `node scripts/check_cross_refs.mjs` PASS — 검사 대상 35 파일, 위반 0
- [x] 사전 실측 → 위반 6건 (5 link + 1 deny) 분류 → resolver 개선 (FP 4) + 본문 정리 (real 2)
- [x] CLAUDE.md §2 정합 (5 게이트)
- [x] git-naming hook PASS
- [ ] CI: cross-ref-validation (신규) + git-naming + plugin-manifest + pr-body 통과 대기

## 참고
- audit 보고서: `tmp/ssot-audit-20260523.html` Section 7 L2
- 직전 PR: #495 (H1~H3) + #496 (M1) + #497 (M2) + #498 (N)
- 잔존 후보 (별 PR): smart-compact sample generic 화 / L1 git-spec ↔ issue-lifecycle 통합 / Phase 2 prose §N.M heuristic 게이트