### PR TITLE
[issue-501] create_epic_story_issues.sh: milestone title 추출로 정정 (gh CLI 정합)

### DIFF
--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -47,15 +47,26 @@ task 는 GitHub 이슈 X — [`git-spec.md`](git-spec.md) §8 PR 트레일러로
 
 `mcp__github__create_issue` 전: stories.md 의 `**GitHub Epic Issue:**` / `**GitHub Issue:**` 매치 검사. 링크 있으면 skip. stories.md 가 이슈 등록 상태의 SSOT.
 
-## 4. 마일스톤 number 조회
+## 4. 마일스톤 파라미터 — tool 별 타입 차이
 
-`mcp__github__create_issue` 의 `milestone` 파라미터는 **이름이 아닌 숫자(number)** 요구. 매 세션 1회 조회:
+**⚠️ tool 별 milestone 파라미터 타입이 다름** — 혼동 시 silent fail 또는 422 오류:
+
+| Tool | `milestone` 파라미터 | jq 추출 |
+|---|---|---|
+| `mcp__github__create_issue` | **number** (숫자) | `--jq '.[] | select(.title=="Epics") | .number'` |
+| `gh issue create --milestone <X>` | **name** (문자열 title) | `--jq '.[] | select(.title=="Epics") | .title'` |
+
+매 세션 1회 조회 (프로젝트별 number 다를 수 있음 — 캐싱 X):
 
 ```bash
 gh api repos/{owner}/{repo}/milestones --jq '.[] | {number, title}'
 ```
 
-프로젝트별 number 다를 수 있음 — 캐싱 X.
+근거:
+- `gh issue create --help` → `-m, --milestone name` (gh CLI v2.x 기준)
+- `mcp__github__create_issue` schema → `milestone: integer` (number 만)
+
+**스크립트 예** ([`scripts/create_epic_story_issues.sh`](../../scripts/create_epic_story_issues.sh)) 는 `gh issue create` 사용 → title 추출 필요. mcp tool 호출은 number 추출 필요.
 
 ## 5. mid-flow 누락 차단 (pre-flight gate)
 

--- a/scripts/create_epic_story_issues.sh
+++ b/scripts/create_epic_story_issues.sh
@@ -39,9 +39,11 @@ if grep -qE '^\*\*GitHub Epic Issue:\*\* \[#[0-9]+\]' "$STORIES"; then
   exit 0
 fi
 
-# 마일스톤 number 조회 (issue-lifecycle.md §5)
-EPICS_MS=$(gh api "repos/$REPO/milestones" --jq '.[] | select(.title=="Epics") | .number' 2>/dev/null)
-STORY_MS=$(gh api "repos/$REPO/milestones" --jq '.[] | select(.title=="Story") | .number' 2>/dev/null)
+# 마일스톤 title 조회 (issue-lifecycle.md §5)
+# 주의: gh CLI 의 `--milestone` 옵션은 *name* 만 받음 (number 거부). gh issue create --help → `-m, --milestone name`.
+# 따라서 milestone title 그대로 추출 + `--milestone "$EPICS_MS"` 에 전달 (line 127, 174).
+EPICS_MS=$(gh api "repos/$REPO/milestones" --jq '.[] | select(.title=="Epics") | .title' 2>/dev/null)
+STORY_MS=$(gh api "repos/$REPO/milestones" --jq '.[] | select(.title=="Story") | .title' 2>/dev/null)
 
 if [ -z "$EPICS_MS" ] || [ -z "$STORY_MS" ]; then
   echo "[issue-create] ERROR: 'Epics' 또는 'Story' 마일스톤 부재. GitHub repo 에 두 마일스톤 생성 후 재시도." >&2


### PR DESCRIPTION
## 관련 이슈 번호
Closes #501

## 배경 및 문제
외부 dcness 활성 프로젝트의 다른 Claude Code 세션에서 `bash scripts/create_epic_story_issues.sh` 실행 시 epic 이슈 생성 첫 호출에서 실패 보고. test 이슈 1건 후 stop. 외부 세션이 본 dcness self 저장소에 진단·fix 가능 여부 확인 → 진짜 dcness 버그 확정.

## 원인
스크립트가 milestone *number* 추출해서 `gh issue create --milestone` 에 전달하지만, gh CLI 의 `--milestone` 옵션은 *name* 만 받음 (number 거부).

검증:
- `scripts/create_epic_story_issues.sh:43-44` — `gh api repos/.../milestones --jq '... .number'` 로 number 추출
- `scripts/create_epic_story_issues.sh:127, 174` — `--milestone "$EPICS_MS"` / `--milestone "$STORY_MS"` (= number) 전달
- gh CLI 실태 (v2.89.0): `gh issue create -m, --milestone name` (name 만 받음)

대조: `mcp__github__create_issue` 는 milestone parameter 가 number — 두 tool 이 같은 의미 parameter 에 다른 타입 요구. `docs/plugin/issue-lifecycle.md` §4 SSOT 가 mcp 만 다루고 gh CLI 안 다뤄서 본 갭 잔존.

## 작업내용
- `scripts/create_epic_story_issues.sh` line 43-46 — `.number` → `.title` 추출 + 변경 의도 주석 2 line 박음. 변수 `$EPICS_MS` / `$STORY_MS` 이름은 그대로 유지 (의미만 변경 — line 127, 174 호출부 비변경)
- `docs/plugin/issue-lifecycle.md` §4 본문 확장 — tool 별 타입 차이 표 (`mcp__github__create_issue` = number / `gh issue create --milestone` = name) + jq 추출 예 (`.number` vs `.title`) + 근거 (gh issue create --help / mcp schema) + 스크립트 예 cross-ref

## 결정 근거

### 옵션 비교
- **(a) `.number` → `.title` 추출 (채택)** — 최소 변경. 호출부 `--milestone "$EPICS_MS"` 그대로 작동
- (b) `EPICS_MS="Epics"` / `STORY_MS="Story"` 하드코딩 — milestone 존재 여부 검증 로직 (line 46) 무효화. 별 코드 필요
- (c) `gh api repos/.../issues` 로 milestone 우회 — issue 생성 + milestone 별도 patch. API 호출 2회 + 멱등성 메커니즘 복잡

(a) = 최소 변경 + 검증 로직 유지.

### SSOT 동시 갱신 (drift 룰 정합)
- `issue-lifecycle.md` §4 가 mcp 만 다뤄서 gh CLI 갭 잔존했음 (본 버그 의 근본 원인 중 하나)
- 본 PR 에서 §4 본문 확장으로 두 tool 정확히 다르게 안내 — 향후 재발 차단

## 배포 경로 검증
- **영향 경로**: dcness self — `scripts/create_epic_story_issues.sh` (init-dcness deploy 스텝의 복사 대상) + `docs/plugin/issue-lifecycle.md` (외부 배포 SSOT)
- **사용자 영향**: 다음 plugin update 받으면 외부 활성 프로젝트의 `bash scripts/create_epic_story_issues.sh` 작동 시작. 본 PR 의 외부 세션은 임시 패치로 즉시 진행 후 plugin update 받으면 임시 패치 제거 가능
- **init-dcness deploy**: 본 script 는 init-dcness 가 외부 프로젝트로 복사하는 대상 (deploy 스텝). 외부 *기존* 활성 프로젝트는 plugin update 만으로 자동 fix X — `/init-dcness` 재실행 또는 script 수동 복사 필요. 본 PR 본문 외부 사용자 안내 권고

## Test Plan
- [x] `node scripts/check_cross_refs.mjs` PASS (검사 대상 35 파일, 위반 0)
- [x] grep 재검증 — `--milestone "$EPICS_MS"` / `"$STORY_MS"` 호출부 비변경 (이제 title 전달)
- [x] git-naming hook PASS (`fix/issue501_milestone_title_not_number` 브랜치 + `[issue-501]` commit 제목)
- [ ] CI: cross-ref-validation + git-naming + plugin-manifest + pr-body 통과 대기
- [ ] 외부 활성 프로젝트 실측 권고 — dcness self 저장소엔 Epics / Story milestone 부재라 본 script 직접 실측 어려움

## 참고
- 본 진단은 dcness self 작업 세션 (audit 정리 PR #500 머지 후) 에서 외부 보고 전달 받고 검증
- 외부 세션 권고 (A) plugin update 효과 — main 에 fix 없어 무효 → 본 PR 머지 후 plugin 신 버전 배포 필요
- 외부 세션 권고 (B) 임시 패치 — 본 PR 머지 + plugin update 받으면 제거 가능 (1회성 임시방편)