### PR TITLE
[issue-508] pr-finalize + pr-create: origin/main ref-only fetch 정석 패턴 적용 (F1+F3+F14)

### DIFF
--- a/scripts/pr-create.sh
+++ b/scripts/pr-create.sh
@@ -78,29 +78,35 @@ fi
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 
-# Step 1: branch 처리
+# Step 1: branch 처리 — origin/$BASE 기반으로 만들어 worktree 환경에서도 stale base 회피
 if [ "$CURRENT_BRANCH" = "$BRANCH" ]; then
-  echo "[pr-create] 이미 '$BRANCH' 위에 있음 — checkout skip"
+  echo "[pr-create] 이미 '$BRANCH' 위에 있음 — checkout skip" >&2
 elif git rev-parse --verify --quiet "$BRANCH" >/dev/null; then
   echo "[pr-create] ERROR: '$BRANCH' branch 가 이미 존재 (다른 위치). 다른 이름 사용 또는 기존 branch 정리" >&2
   exit 1
 else
-  echo "[pr-create] git checkout -b $BRANCH $BASE"
-  git checkout -b "$BRANCH" "$BASE"
+  echo "[pr-create] git fetch origin $BASE + git checkout -b $BRANCH --no-track origin/$BASE" >&2
+  if ! git fetch origin "$BASE" --quiet; then
+    echo "[pr-create] WARN: git fetch origin $BASE 실패 — 로컬 origin/$BASE ref 사용 (stale 가능)" >&2
+  fi
+  # --no-track: 새 branch 가 origin/$BASE 를 upstream 으로 잡지 않도록 명시 차단
+  #             (사용자가 우연히 git push 만 호출했을 때 base branch 로 push 시도 방지).
+  #             이후 Step 4 의 `git push -u origin $BRANCH` 가 upstream 을 origin/$BRANCH 로 설정.
+  git checkout -b "$BRANCH" --no-track "origin/$BASE"
 fi
 
 # Step 2~3: add + commit
-echo "[pr-create] git add -A + commit"
+echo "[pr-create] git add -A + commit" >&2
 git add -A
-git commit -F "$COMMIT_MSG_FILE"
+git commit -F "$COMMIT_MSG_FILE" >&2
 
 # Step 4: push
-echo "[pr-create] git push -u origin $BRANCH"
-git push -u origin "$BRANCH"
+echo "[pr-create] git push -u origin $BRANCH" >&2
+git push -u origin "$BRANCH" >&2
 
 # Step 5: PR 생성
-echo "[pr-create] gh pr create --base $BASE"
+echo "[pr-create] gh pr create --base $BASE" >&2
 PR_URL=$(gh pr create --base "$BASE" --title "$TITLE" --body-file "$BODY_FILE")
 
-echo "[pr-create] 완료 — PR 생성: $PR_URL"
+echo "[pr-create] 완료 — PR 생성: $PR_URL" >&2
 echo "$PR_URL"

--- a/scripts/pr-finalize.sh
+++ b/scripts/pr-finalize.sh
@@ -57,8 +57,21 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 # Step 1: auto-merge 토글
+# PR 이 이미 clean status (CI 통과 + mergeable) 면 enablePullRequestAutoMerge mutation
+# 이 "Pull request is in clean status" 로 거부 → 즉시 머지 fallback.
 echo "[pr-finalize] PR #$PR — auto-merge 토글 ON" >&2
-gh pr merge "$PR" --auto --merge >&2
+MERGE_ERR=$(gh pr merge "$PR" --auto --merge 2>&1 >/dev/null) || {
+  if echo "$MERGE_ERR" | grep -q "clean status"; then
+    echo "[pr-finalize] PR 이미 clean status — auto-merge enable 의미 없음, 즉시 머지 fallback" >&2
+    gh pr merge "$PR" --merge >&2 || {
+      echo "[pr-finalize] ERROR: 즉시 머지 fallback 실패" >&2
+      exit 1
+    }
+  else
+    echo "[pr-finalize] ERROR: auto-merge 토글 실패: $MERGE_ERR" >&2
+    exit 1
+  fi
+}
 
 # Step 2: CI 결과 대기
 echo "[pr-finalize] CI 결과 대기 (gh pr checks --watch)" >&2

--- a/scripts/pr-finalize.sh
+++ b/scripts/pr-finalize.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
-# dcness pr-finalize — PR 머지 + CI 대기 + main sync 자동
+# dcness pr-finalize — PR 머지 + CI 대기 + origin/main ref 동기화 자동
 #
 # 한 명령으로 머지 절차 끝:
 #   1. gh pr merge --auto --merge (auto-merge 토글 ON)
 #   2. gh pr checks --watch (CI 결과 대기)
 #   3. auto-merge 완료 대기 (GitHub 백그라운드 lag)
-#   4. git checkout main + git pull
+#   4. git fetch origin main (origin/main remote-tracking 만 갱신, refspec 없이)
 #
 # 사용:
 #   pr-finalize.sh                # current branch 의 open PR 자동 검출
 #   pr-finalize.sh <PR_NUMBER>    # 명시 PR 번호
 #
 # 안전:
-#   - 현재 working tree dirty 면 abort (git pull 충돌 회피)
-#   - CI FAIL 시 main sync skip + 에러 코드
-#   - 머지 안 됐으면 main sync skip + 사용자 안내
+#   - 현재 working tree dirty 면 sync skip 옵션 (Y/n 물음)
+#   - CI FAIL 시 sync skip + 에러 코드
+#   - 머지 안 됐으면 sync skip + 사용자 안내
+#
+# 멀티 worktree 호환:
+#   - Step 4 는 `git fetch origin main` (refspec 없이) — 다른 worktree 가 main checkout 중이어도
+#     origin/main remote-tracking ref 만 갱신, 어느 worktree HEAD 와도 충돌 X.
+#   - 새 branch 생성은 `scripts/pr-create.sh` 가 `origin/$BASE` 기반으로 처리하므로 base 항상 최신.
+#
+# stdout / stderr 분리:
+#   - stdout = 최종 1줄 (PR URL + merged) — 메인 Claude / 사용자에게 필요한 정보.
+#   - stderr = 진행 표시 / WARN / ERROR — 사용자가 보고 싶으면 보면 됨, 메인 컨텍스트엔 안 들어감.
 
 set -e
 
@@ -32,14 +41,14 @@ if [ -z "$PR" ]; then
     echo "[pr-finalize] ERROR: '$BRANCH' branch 의 open PR 없음. PR 먼저 생성 (gh pr create)" >&2
     exit 1
   fi
-  echo "[pr-finalize] current branch '$BRANCH' → PR #$PR 자동 검출"
+  echo "[pr-finalize] current branch '$BRANCH' → PR #$PR 자동 검출" >&2
 fi
 
 # working tree dirty check
 if [ -n "$(git status --porcelain)" ]; then
-  echo "[pr-finalize] WARN: working tree dirty — main sync 시 충돌 위험" >&2
+  echo "[pr-finalize] WARN: working tree dirty — fetch sync 영향은 없지만 다음 작업 시 충돌 위험" >&2
   git status --short >&2
-  echo "[pr-finalize] 계속 진행 (auto-merge 만, main sync skip) Y/n? "
+  echo "[pr-finalize] 계속 진행 (auto-merge 만, sync skip) Y/n? " >&2
   read -r reply
   if [ "$reply" != "Y" ] && [ "$reply" != "y" ]; then
     exit 1
@@ -48,18 +57,18 @@ if [ -n "$(git status --porcelain)" ]; then
 fi
 
 # Step 1: auto-merge 토글
-echo "[pr-finalize] PR #$PR — auto-merge 토글 ON"
-gh pr merge "$PR" --auto --merge
+echo "[pr-finalize] PR #$PR — auto-merge 토글 ON" >&2
+gh pr merge "$PR" --auto --merge >&2
 
 # Step 2: CI 결과 대기
-echo "[pr-finalize] CI 결과 대기 (gh pr checks --watch)"
-if ! gh pr checks "$PR" --watch; then
-  echo "[pr-finalize] ERROR: CI FAIL — 머지 안 됨. main sync skip" >&2
+echo "[pr-finalize] CI 결과 대기 (gh pr checks --watch)" >&2
+if ! gh pr checks "$PR" --watch >&2; then
+  echo "[pr-finalize] ERROR: CI FAIL — 머지 안 됨. sync skip" >&2
   exit 1
 fi
 
 # Step 3: auto-merge 완료 대기 (GitHub 백그라운드)
-echo "[pr-finalize] auto-merge 완료 대기"
+echo "[pr-finalize] auto-merge 완료 대기" >&2
 STATE=""
 for i in 1 2 3 4 5 6 7 8; do
   STATE=$(gh pr view "$PR" --json state -q .state 2>/dev/null)
@@ -75,14 +84,19 @@ if [ "$STATE" != "MERGED" ]; then
   exit 1
 fi
 
-# Step 4: main sync
+# Step 4: origin/main ref 동기화 (refspec 없이 fetch — worktree 호환)
+PR_URL=$(gh pr view "$PR" --json url -q .url 2>/dev/null)
+
 if [ "${SKIP_SYNC:-}" = "true" ]; then
-  echo "[pr-finalize] main sync skip (working tree dirty)"
+  echo "[pr-finalize] origin/main 동기화 skip (working tree dirty)" >&2
+  echo "[pr-finalize] PR #$PR merged · $PR_URL"
   exit 0
 fi
 
-echo "[pr-finalize] main sync"
-git checkout main
-git pull --quiet
+echo "[pr-finalize] origin/main ref 동기화" >&2
+if ! git fetch origin main --quiet; then
+  echo "[pr-finalize] ERROR: git fetch origin main 실패 (네트워크 / 권한)" >&2
+  exit 1
+fi
 
-echo "[pr-finalize] 완료 — PR #$PR 머지 + main 동기화"
+echo "[pr-finalize] PR #$PR merged · $PR_URL"


### PR DESCRIPTION
## 관련 이슈 번호
Closes #508

## 배경 및 문제

외부 사용자가 dcness plugin v0.2.30 으로 youTubeGenerator 프로젝트에서 impl-loop 27 task 를 1 세션 안에 돌린 뒤 자체 분석한 리포트의 14 finding 중 HIGH 2건 + LOW 1건 처리.

- **F1** (HIGH, 27회 반복): `scripts/pr-finalize.sh` Step 4 의 `git checkout main + git pull` 이 멀티 worktree 환경에서 fatal — 메인 worktree (사용자 IDE 영역) 가 `main` HEAD 보유 중이라 작업 worktree 안에서 `git checkout main` 시도 시 `fatal: 'main' is already used by worktree at <path>`. PR 머지 자체는 성공이지만 작업 worktree 의 main ref stale → 다음 task 진입 시 매번 수동 회복. 27 task × ~1-2 turn = ~30 turn 손실.
- **F3** (HIGH, 명시 2회 + 잠재): 머지 직후 새 branch base 가 머지 *전* origin/main → 이전 task 의 `src/` import 시 ModuleNotFoundError. F1 의 결과로 로컬 main 이 stale 한 상태에서 `git checkout -b feature/<next> main` 하면 base 가 옛 commit.
- **F14** (LOW): 매 task 마다 pr-finalize 정상 path 출력 5줄 × 27 = ~120 lines 메인 컨텍스트 cache_read 누적.

## 의사결정 — 실측 + 웹 리서치 기반

### 잘못 시작한 안 (close 된 #503)

본래 안 = `git checkout main + git pull` → `git fetch origin main:main` (refspec) 교체. man page + git docs 의 refspec 정의만 보고 추론, 명령 직접 실행 검증 없음.

실제 작업 시작 시점 1차 실행 → fatal:
```
fatal: refusing to fetch into branch 'refs/heads/main' checked out at '/Users/dc.kim/project/dcNess'
```

git 의 fetch 안전장치는 *worktree-aware* — 현재 / 다른 worktree 어느 쪽이든 checkout 중인 branch 로 직접 fetch 거부. 옛 안은 fatal 메시지의 표면만 바꿔놓고 본질 동일.

### 정정된 안 (본 PR 채택)

`/tmp/dcness-worktree-test-*` 에 bare origin + 메인 worktree (main HEAD) + 작업 worktree (feature HEAD) 셋업, origin/main 에 새 commit push 시뮬 후 4 안 실측:

| 안 | 명령 | exit | origin/main | 로컬 main | 비고 |
|---|---|---|---|---|---|
| **A** ✅ | `git fetch origin main` (refspec 없이) | 0 | 갱신 | stale 유지 | **충돌 없음** |
| B ❌ | `git fetch origin main:main` (옛 안) | 128 | 갱신 | 안 됨 | fatal |
| C ⚠️ | `git fetch --update-head-ok origin main:main` | 0 | 갱신 | 갱신 | main-wt 의 HEAD ref advance + working tree 옛 상태 → IDE 환경 부수효과 |
| D ⚠️ | `git update-ref refs/heads/main origin/main` | 0 | (별 fetch) | 갱신 | 저수준 우회, 표준 패턴 아님 |

→ **안 A 만이 외부 worktree 의 working tree / HEAD 안 건드리는 진짜 안전 패턴.**

웹 리서치 (3개 검색) 모두 안 A 권장:
- [git ML — fetch protects branches checked out in all worktrees](https://public-inbox.org/git/xmqqo9saer9f.fsf@gitster.mtv.corp.google.com/t/)
- [DataCamp Git Worktree Tutorial](https://www.datacamp.com/tutorial/git-worktree-tutorial): "If you need to rebase or merge from main, you don't need to checkout main if you're in a worktree. Instead, stay in your current work tree and fetch, then rebase from origin main."
- [On Git worktrees by Kareem F.](https://kareemf.com/on-git-worktrees): "fetching in one updates remotes for all of them"

### F3 는 부산물 X — pr-create.sh 도 함께 수정

안 A 는 로컬 main 안 갱신 → 호출자가 `--base main` 박으면 stale base. 그래서 pr-create.sh 가 내부에서 `git fetch origin $BASE` + `git checkout -b $BRANCH --no-track origin/$BASE` 로 변경. 호출자 인터페이스 변경 없음.

`--no-track` 추가 이유 — 실측 중 발견: `git checkout -b new origin/main` default 는 새 branch 가 `origin/main` 을 upstream 으로 잡음. 그 사이 시간 (commit/push 전) 에 사용자가 우연히 `git push` 만 호출 시 main 으로 push 시도. dcness 룰 위반 가능성 차단.

## 변경 파일

| 파일 | 변경 요약 |
|---|---|
| `scripts/pr-finalize.sh` | Step 4 = `git fetch origin main` 1줄. 진행 echo stderr 분리. 정상 path stdout = PR URL + merged 1줄. |
| `scripts/pr-create.sh` | Step 1 = `git fetch origin $BASE` + `git checkout -b $BRANCH --no-track origin/$BASE`. 진행 echo stderr 분리. |

## 검증

- [x] **shell syntax**: `bash -n scripts/pr-finalize.sh` + `bash -n scripts/pr-create.sh` 둘 다 OK.
- [x] **단위 테스트**: `python3 -m unittest discover -s tests -v` → 477 tests OK.
- [x] **멀티 worktree 실측** (`/tmp/dcness-finalize-verify-*`): 안 A 의 `git fetch origin main` exit 0 + origin/main 갱신 + 로컬 main 미변경 + main-wt 미영향 확인.
- [x] **새 branch base 검증**: `git checkout -b feature/next origin/main` 결과 새 branch HEAD = origin/main 최신 commit.
- [x] **`--no-track` 검증**: `git config --get branch.<new>.remote` / `.merge` 둘 다 미설정.
- [ ] **dcness self CI 7 게이트**: PR 생성 후 자동 실행 (main-block / git-naming / pytest / plugin-manifest / pr-body / cross-ref).
- [ ] **dogfooding**: 본 PR 의 머지 단계가 새 `pr-finalize.sh` 호출 — 새 버전이 자기 PR 을 머지하면 회귀 검증 완료.

## 배포 경로 검증 (CLAUDE.md §0.5)

- 경로 1 (plug-in 본체 자동 갱신): `scripts/pr-finalize.sh` + `scripts/pr-create.sh` 모두 plug-in 본체. 사용자가 다음 plug-in 업데이트 받는 시점부터 자동 적용.
- 경로 2 (`init-dcness` deploy): 해당 없음 — scripts/ 는 사용자 프로젝트로 *복사 안 함*, plug-in cache 에서 직접 호출.
- 경로 3 (사용자용 SSOT): 해당 없음 — `docs/plugin/issue-lifecycle.md` / `docs/plugin/git-spec.md` 변경 없음.

→ **신규 활성화 프로젝트 + 기존 활성 사용자 모두** 다음 plug-in 버전 업 시 효과.

## 의존성 / 다음 단계

- 본 PR = 5 이슈 묶음 ([#504](https://github.com/alruminum/dcNess/issues/504), [#505](https://github.com/alruminum/dcNess/issues/505), [#506](https://github.com/alruminum/dcNess/issues/506), [#507](https://github.com/alruminum/dcNess/issues/507)) 중 PR 1 (#503 → #508 재설계). 외부 사용자 다음 impl-loop 세션 turn 절감 효과 가장 큼.
- 다음 PR (#504~#507) 와 코드 영역 다름 → 병렬 진행 가능.

## 부수 발견

- `git fetch origin main:main` 의 worktree-aware 거부는 *현재 worktree 가 main 가리키는 경우에도* 발동 — 옛 #503 안의 핵심 결함. 실측 없이 단정 위험.
- `git checkout -b <new> origin/<base>` default = autoSetupMerge 로 인해 새 branch 가 base 의 remote-tracking 을 upstream 으로 잡음. dcness 흐름에서는 `--no-track` 명시 차단이 안전.
