### PR TITLE
[issue-507] impl-loop: review 5줄 강제 + 다시 그리기 trade-off + 세션 분할 권장 (F8+F9+F13)

### DIFF
--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -140,6 +140,20 @@ prose 마지막 단락에 결론 + 메인의 다음 행동 권고 자연어로:
 - NICE TO HAVE 목록 (있는 경우)
 - 총평 1 줄
 
+### Hybrid A 모드 (`/impl-loop`) 한정 — last block 에 5줄 echo template 의무
+
+prose 마지막 영역에 메인이 chat 에 *그대로 echo 할 5줄 요약 template* 박는다 ([`commands/impl-loop.md`](../commands/impl-loop.md) §review 출력 재정의 정합). 메인이 자유 형식 단축 회귀 차단 목적 — 외부 사용자 [F8 실측](https://github.com/alruminum/dcNess/issues/507).
+
+```
+[task<i> · <slug>] <clean|error|blocked>
+build-worker: <N tests RED→GREEN · M files +X -Y · validate PASS|FAIL> · pr-reviewer: <LGTM|FAIL>
+finding: <PASS 시 "없음" / FAIL·NICE TO HAVE 시 1-2 문장>
+PR <#NNN> merged · closes #<MMM>
+next: <다음 task slug 진입 | 정지 사유>
+```
+
+`/impl` 단발 호출 (4-agent 모드) 은 본 template 불필요 — rigor 우선, 형식 자유 유지.
+
 ## 재검토 절차 (FAIL 후)
 
 1. 이전 리뷰의 MUST FIX 목록 확인

--- a/commands/impl-loop.md
+++ b/commands/impl-loop.md
@@ -140,13 +140,23 @@ impl 파일 부재 시 sub-step 3건 (`module-architect` / `build-worker` / `pr-
 
 **task i 진행 중 (MUST)** — 그 task 의 `impl` run 은 TaskCreate skip (sub-step task 이미 존재 — loop-procedure §2). conveyor 진행에 맞춰 sub-step 을 TaskUpdate (pending → in_progress → completed) 호출 의무. Hybrid A 경우 build-worker 안의 3 phase (build-test / build-impl / build-validate) 는 outer sub-step `build-worker` 하나로 묶임 — `activeForm` 에 phase 표시.
 
-**task i 완료 → task i+1 (다시 그리기)**:
+**task i 완료 → task i+1 (다시 그리기 — task 수 별 분기)**:
+
+| 총 task 수 | 절차 | 비용 (TaskCreate 호출) |
+|---|---|---|
+| **≤ 10** | 4 단계 완전 다시 그리기 (아래 1~4) — 가시성 우선 | 매 task ~N 호출 |
+| **11~20** | 3 단계 부분 다시 그리기 (1~3, 재생성 skip) — 다음 task 헤더만 in_progress 전환 | 매 task ~3 호출 |
+| **> 20** | 최소 갱신 — sub-step deleted + 다음 task 헤더 in_progress 만 | 매 task ~2 호출 |
+
+4 단계 (완전 다시 그리기):
 1. task i 의 sub-step 전부 `TaskUpdate(status=deleted)` — 완료 task 는 헤더 한 줄로 접음
 2. task i 헤더 `TaskUpdate(status=completed)`
 3. task i+1 ~ N 헤더 `TaskUpdate(status=deleted)`
 4. TaskCreate 를 이 순서로: `task(i+1) 헤더(in_progress)` → `task(i+1) sub × 2 (또는 × 5)` → `task(i+2) 헤더` → … → `taskN 헤더`
 
 생성순 = 표시순 + 중간삽입 불가 → 완료 헤더 뒤에 [현재 헤더 + sub-step + 남은 헤더] 를 다시 그려야 sub-step 이 부모 밑에 온다 (3·4 단계 = 다시 그리기 이유).
+
+> **trade-off 근거**: 외부 사용자 [F9 실측](https://github.com/alruminum/dcNess/issues/507) — task 27 에서 4 단계 매번 실행 시 TaskCreate ~27 × N 호출 = 무시 못 할 비용. task > 20 부터는 부모-자식 표시 어색해도 호출 비용 절감 우선. 사용자 가시성 (어디까지 진행했나) 은 task 헤더 in_progress / completed 표시만으로 충분. Task UI "after taskId" 옵션 (근본 fix) 은 Claude Code 시스템 영역 — dcness 영역 밖.
 
 **마지막 task 완료** — sub-step deleted + 헤더 completed. 전체가 `✓` 한 줄씩.
 
@@ -168,6 +178,8 @@ next: <다음 task slug 진입 | 정지 사유>
 
 impl 파일 부재로 module-architect 선두 진입한 경우 2번째 줄은 `module-architect: <PASS|ESCALATE> · build-worker: <N tests RED→GREEN · M files +X -Y · validate PASS|FAIL> · pr-reviewer: <LGTM|FAIL>`.
 
+**5줄 형식 강제 메커니즘** — pr-reviewer prose return 의 last block 에 본 5줄 template 그대로 박는 의무 ([`agents/pr-reviewer.md`](../agents/pr-reviewer.md) §산출물 정보 의무 정합). 메인은 prose 본 block 을 chat 에 *그대로 echo* — 자유 형식 단축 금지. 외부 사용자 [F8 실측](https://github.com/alruminum/dcNess/issues/507) 에서 메인이 자유 한 줄 출력 (예: "[task07] clean · PR #23 merged · LGTM") 회귀 — 사후 분석 시 어디까지 진행했는지 한눈에 안 들어옴 차단.
+
 **디스크** — `<run_dir>/review.md` 는 end-run 안전망이 이미 원본 그대로 저장 ([`commands/impl.md:134`](impl.md) 정합). `/run-review` 진단 / compaction 후 재진입 시 디스크에서 read.
 
 **메인 인사이트** ([`commands/impl.md`](impl.md) §종료 조건 의 자율 1줄 인사이트) 는 본 요약 뒤에 *선택* 1줄 쓸 수 있다 — 작성하면 누적 학습 신호, 생략해도 회귀 X.
@@ -179,6 +191,18 @@ task 를 clean 으로 표기하기 *전*, code-validator 가 PASS 를 냈고 pr-
 
 ## compaction 중 진행 (안전망)
 긴 epic 진행 중 메인 컨텍스트가 auto-compaction 될 수 있다. 루프 진행 상태는 메인 컨텍스트가 아니라 conveyor state 파일 (`live.json` / `.by-pid-current-run/` / `run-NN` / `current_step`) 이 SSOT — compaction 돼도 진행 손실은 0. compaction 직후 자신이 impl-loop 도중이라고 판단되면 run state 를 재read 해서 현재 task index + step 을 식별하고 그 지점부터 재개한다.
+
+### 세션 분할 권장 + 자동 /smart-compact 진입 (외부 사용자 [F13](https://github.com/alruminum/dcNess/issues/507) 영역)
+
+epic 크기에 따라 세션 분할 / compaction 발화 권고:
+
+| 총 task 수 | 권고 |
+|---|---|
+| ≤ 9 | single-session 진행. compaction 발화 가능성 낮음. |
+| 10~19 | single-session 가능, 단 task 절반 (5/10, 10/20) 진입 시점에 메인이 chat 으로 사용자에게 *"context 사용량 60%+ 추정 — /smart-compact 권장"* 1줄 안내 (사용자 명시 호출 트리거). |
+| ≥ 20 | **multi-session 진입 권장** — epic 을 절반/3분할 (예: task 1-10 / 11-20 / 21-27) 로 쪼개서 별 세션 진행. conveyor state SSOT 가 task 경계 재개를 보장. 메인이 impl-loop 진입 시점에 사용자에게 분할 안내. |
+
+**sub-agent prose 디스크 저장 + chat echo 분리**: build-worker / pr-reviewer prose 는 매 task `<run_dir>/build-{test,impl,validate}.md` + `<run_dir>/review.md` 디스크에 이미 저장됨. 메인 chat 에는 §"review 출력 재정의" 의 5줄 요약만 echo — sub-agent prose 본문 전수 echo 금지 (compaction trigger). 사용자 / 메인이 깊은 영역 필요 시 디스크에서 직접 Read (`/run-review` 진단).
 
 ## git 권한
 worktree branch 안 commit / push / PR 생성·머지 = **메인 Claude 전담**. engineer / build-worker / test-engineer 등 sub-agent 는 git commit/push/branch + `gh pr create/merge` 금지 — 코드 변경만 (worker 의 경우 PR 본문·commit message *초안* 만 prose return 에 작성, 실제 명령은 메인). main 직접 commit / push = ❌ (main-block hook 차단). 상세 = [`git-spec.md`](../docs/plugin/git-spec.md) §6 + [`loop-procedure.md`](../docs/plugin/loop-procedure.md) §3.4 + [`agents/build-worker.md`](../agents/build-worker.md) §권한 경계.


### PR DESCRIPTION
## 관련 이슈 번호
Closes #507

## 배경 및 문제

[harness-review HTML](file:///Users/dc.kim/project/youTubeGenerator/docs/dcness-harness-review.html) 의 14 finding 중 마지막 PR — F8 (LOW) + F9 (LOW) + F13 (MID) 3 건 처리. 외부 사용자 epic 1 = 27 task 실측 기반.

### F8 — review 5줄 형식 spec 미준수

impl-loop §"review 출력 재정의" 5줄 형식 (`[task N · slug] enum / build / pr-reviewer / finding / PR / next`) 이 spec 에 명시되어 있으나 메인이 자유 형식 한 줄로 회귀 (예: `[task07] clean · PR #23 merged · LGTM`). 사후 분석 시 어디까지 진행했는지 한눈에 안 들어옴. 강제 메커니즘 부재.

### F9 — 다시 그리기 4 단계 비용 vs 가시성 trade-off

impl-loop §진행 뷰 의 다시 그리기 4 단계 (sub deleted + i 헤더 completed + i+1~N 헤더 deleted + 재생성) 가 task 27 회 누적 시 TaskCreate ~27 × N 호출 = 무시 못 할 비용. 메인이 실제로는 1~2 단계만 실행. 부분 다시 그리기 허용 조건 명시 부재.

### F13 — 1 세션 27 task 컨텍스트 부담

epic 1 = 27 task = 메인 turn ~400+ 1 세션. dcness-helper next-task 가 task 경계를 1 turn 으로 압축 (#471) 했음에도 누적. compaction 자동 발동 위험. 진행 손실은 conveyor state SSOT 가 0 보장하지만 메인 재학습 비용. 자동 /smart-compact trigger / epic 크기 별 세션 분할 권장 명시 부재.

## 채택안

| Finding | 안 |
|---|---|
| F8 | pr-reviewer prose return 의 last block 에 5줄 template 박는 의무 추가 (agent-level 강제). 메인이 chat 에 그대로 echo. |
| F9 | 다시 그리기 절차를 *총 task 수 별 분기* 표로 재정의 — ≤ 10 (4 단계 완전) / 11~20 (3 단계 부분) / > 20 (최소 갱신). 사용자 가시성은 task 헤더 in_progress/completed 만으로 충분. |
| F13 | 세션 분할 권장 + 자동 /smart-compact 진입 sub-section 신설 — ≤ 9 single / 10~19 절반 시점 /smart-compact / ≥ 20 multi-session. sub-agent prose 디스크 저장 + chat echo 분리 1단락 추가. |

## 변경 파일

| 파일 | 변경 | finding |
|---|---|---|
| [`commands/impl-loop.md`](https://github.com/alruminum/dcNess/blob/main/commands/impl-loop.md) §진행 뷰 | 다시 그리기 task 수 별 분기 표 | F9 |
| [`commands/impl-loop.md`](https://github.com/alruminum/dcNess/blob/main/commands/impl-loop.md) §review 출력 재정의 | 5줄 형식 강제 메커니즘 1단락 (pr-reviewer prose cross-ref) | F8 |
| [`commands/impl-loop.md`](https://github.com/alruminum/dcNess/blob/main/commands/impl-loop.md) §compaction | 세션 분할 권장 + /smart-compact + sub-agent prose 분리 sub-section 신설 | F13 |
| [`agents/pr-reviewer.md`](https://github.com/alruminum/dcNess/blob/main/agents/pr-reviewer.md) §산출물 정보 의무 | Hybrid A 모드 한정 5줄 echo template 의무 단락 | F8 |

## Test Plan

- [x] `python3 -m unittest discover -s tests` → 477 tests OK.
- [x] `node scripts/check_cross_refs.mjs` → PASS (35 파일 dead link 0건).
- [ ] **실 효과 한계 (정직히 명시)**: dcness self 가 impl-loop 자기 자신 안 돌림 → 외부 활성화 프로젝트에서 다음 impl-loop 세션 (사용자 영역).
- [ ] dcness self CI 7 게이트.

## 배포 경로 ([CLAUDE.md §0.5](https://github.com/alruminum/dcNess/blob/main/CLAUDE.md))

- 경로 1 (plug-in 본체): 2 파일 모두 plug-in 본체 → 다음 plug-in 업데이트 시 외부 사용자 자동 적용.

## 의존성 / 다음 단계

- 본 PR = harness-review 14 finding 5 PR 묶음 중 **PR 5 (마지막)**. [PR 1 (#509)](https://github.com/alruminum/dcNess/pull/509) + [PR 2 (#510)](https://github.com/alruminum/dcNess/pull/510) + [PR 3 (#512)](https://github.com/alruminum/dcNess/pull/512) + [PR 4 (#513)](https://github.com/alruminum/dcNess/pull/513) 머지 완료.
- 본 PR 머지 후 [harness-review HTML F8 / F9 / F13 finding](file:///Users/dc.kim/project/youTubeGenerator/docs/dcness-harness-review.html) 영역에 ✅ FIX MERGED 박스 추가 예정.
- 14 finding 중 12 finding 처리 완료 (F2/F5 사전 fix + F1/F3/F14 PR #509 + F10 PR #510 + F6/F11 PR #512 + F4/F7/F12 PR #513 + F8/F9/F13 본 PR).
- 장기 — [issue #511](https://github.com/alruminum/dcNess/issues/511) (architect-loop 책임 구조 모듈 위임 전환) 별 plan turn.

## 부수

- F13 의 dcness-helper begin-run 자동 stderr 권장 메시지 / end-step 60%+ trigger 는 본 PR 범위 외 (spec 본문 가이드만, helper 자동화는 후속 issue 영역).
- F9 의 Task UI "after taskId" 옵션 = Claude Code 시스템 영역 (Anthropic feature request) — dcness 영역 밖.
