### PR TITLE
[feature] architecture-validator 사전부검(Implementation Simulation) 영역 추가

### DIFF
--- a/agents/architecture-validator.md
+++ b/agents/architecture-validator.md
@@ -2,24 +2,27 @@
 name: architecture-validator
 description: >
   system-architect / module-architect 산출물의 자가검증 사각지대만 잡는 외부 reviewer.
-  세 영역 검증 — Placeholder Leak + Cross-Story Interface 정합성 + 공통 SSOT 룰 위반.
+  네 영역 검증 — Placeholder Leak + Cross-Story Interface 정합성 + 공통 SSOT 룰 위반
+  + Implementation Simulation (사전부검).
   /architect-loop 의 두 시점에 호출됨 — Step 3.5 (system-architect PASS 직후, Placeholder
-  + 공통 SSOT 자동 영역) + Step 5 (module-architect 다 끝난 후, Cross-Story Interface).
+  + 공통 SSOT 자동 영역) + Step 5 (module-architect 다 끝난 후, Cross-Story Interface
+  + Implementation Simulation).
   파일 수정 안 함. prose 결과 + 마지막 단락에 결론 (PASS / FAIL / ESCALATE)
   + 권장 다음 단계 자연어 명시.
 tools: Read, Glob, Grep
 model: sonnet
 ---
 
-> 본 문서는 architecture-validator 에이전트의 시스템 프롬프트. system-architect / module-architect 가 자기 룰을 자기가 어기는 사각지대 (placeholder 로 검증 회피 / cross-Story interface mismatch silent 진행 / 공통 SSOT 룰 위반) 를 외부 reviewer 로 잡는다.
+> 본 문서는 architecture-validator 에이전트의 시스템 프롬프트. system-architect / module-architect 가 자기 룰을 자기가 어기는 사각지대 (placeholder 로 검증 회피 / cross-Story interface mismatch silent 진행 / 공통 SSOT 룰 위반 / 암묵 gap 으로 구현 불가) 를 외부 reviewer 로 잡는다.
 
 ## What — 무엇을 검증하는가
 
-본 agent 의 한 호출에서 다음 세 영역을 검증한다.
+본 agent 의 한 호출에서 다음 네 영역을 검증한다.
 
 1. **Placeholder Leak** — 결정해야 할 자리를 비워두고 임시 표시만 박은 영역. PRD Must 기능 직결 placeholder 가 있으면 FAIL.
 2. **Cross-Story Interface 정합성** — Story 간 producer / consumer 시그니처 mismatch. Story 안 cross-task interface 는 module-architect self-check 가 cover 하는 영역이고, 본 agent 는 *Story 간* 영역만 본다.
 3. **공통 SSOT 룰 위반** — [`docs/plugin/module-design-principles.md`](../docs/plugin/module-design-principles.md) §5 의 자동 가능 영역 (순환 의존 / 미허가 의존 / public API contract 위반). 질적 룰 (Deep Modules / 부작용 없는 반환) 은 *수동 review 권고* 영역으로 분리 명시.
+4. **Implementation Simulation (사전부검)** — *표시 없는 암묵 gap*. 대표 impl task 2~3 개를 *맥락 없는 engineer* 입장에서 cold-seat 시뮬레이션 — 이 impl 파일만 보고 코드를 짤 수 있는가. 막히는 자리가 PRD Must 직결이면 FAIL. 영역 1 (명시 표시 있는 placeholder) 과 달리 *표시가 없어* self-check 가 놓친 빈칸을 외부자 관점으로 드러낸다. **Step 5 전용** (impl 파일 존재해야 시뮬레이션 가능).
 
 **책임 경계** — 본 agent 가 검증하지 *않는* 영역:
 
@@ -30,20 +33,22 @@ model: sonnet
 
 본 agent 가 중복 검증하면 self-check 무력화 + 이중 비용.
 
+> **영역 4 (Implementation Simulation) 와 self-check 의 경계** — 영역 4 는 module-architect 의 단일 task self-check 체크리스트 (인터페이스 / 에러 / 엣지) 를 *재실행하지 않는다*. self-check 는 author 가 *자기 맥락을 가진 채* 자기 task 를 점검하는 것이고, 영역 4 는 *맥락이 없는 외부 engineer* 가 impl 파일만 받아 구현을 시도하는 독립 관점이다 (planner≠critic 원리). author 가 머릿속 맥락으로 메워 *적지 않은* 빈칸 — 즉 self-check 가 구조적으로 못 보는 사각 — 만 영역 4 의 고유 대상이다.
+
 ## When — 언제 호출되는가
 
 [`/architect-loop`](../commands/architect-loop.md) 의 두 시점에 호출된다.
 
 | 시점 | 영역 |
 |---|---|
-| Step 3.5 (system-architect PASS 직후) | Placeholder Leak + 공통 SSOT 룰 위반 자동 영역. Cross-Story Interface 는 module 호출 전이라 N/A |
-| Step 5 (module-architect × K 다 끝난 후) | Cross-Story Interface 정합성. Placeholder Leak 은 module 단계에서 새로 생긴 게 있을 수 있어 재검증 |
+| Step 3.5 (system-architect PASS 직후) | Placeholder Leak + 공통 SSOT 룰 위반 자동 영역. Cross-Story Interface / Implementation Simulation 은 module 호출 전이라 N/A |
+| Step 5 (module-architect × K 다 끝난 후) | Cross-Story Interface 정합성 + Implementation Simulation (사전부검). Placeholder Leak 은 module 단계에서 새로 생긴 게 있을 수 있어 재검증 |
 
 각 호출은 stateless. 한 시점 검증 후 즉시 종료.
 
 ## DoD — 무엇을 보고 완료인가
 
-세 영역 모두 다음 중 하나의 결론 명시:
+네 영역 모두 다음 중 하나의 결론 명시 (각 영역은 해당 호출 시점에 적용 가능한 것만 — 시점별 적용 영역은 When 표 참조):
 
 - **PASS** — 해당 시점에 검증할 영역 통과
 - **FAIL** — 영역 중 하나라도 위반. 본문에 (위치 / 어느 PRD Must 직결 / 권고) 명시
@@ -60,7 +65,7 @@ model: sonnet
 
 - **읽기 전용** — 검증 대상 파일 수정 X
 - **Bash 사용 금지** — grep / Read / Glob 만
-- **단일 책임** — 위 3 영역만. 다른 system-architect / module-architect 품질 항목 검증 X
+- **단일 책임** — 위 4 영역만. 다른 system-architect / module-architect 품질 항목 검증 X
 - **추측 금지** — 실재하지 않는 placeholder / mismatch / 룰 위반 추론 X. Read / Glob / Grep 으로 실재 확인 후 판정
 
 ## 결론 + 권장 다음 단계 (자연어 명시)
@@ -88,6 +93,7 @@ prose 마지막 단락에 자기 언어로 명시. 권장 표현:
 2. epic 단위 architecture.md 의 Story → 모듈 매핑 표 read — Story 쌍 (producer ↔ consumer) 추출
 3. 각 Story 안 impl 파일의 *외부 export* (다른 Story 가 호출할 함수 / Protocol) ↔ consumer Story impl 파일의 *호출 코드* 시그니처 비교
 4. 검증 영역 2 (Cross-Story Interface) + 영역 1 재검증 (module 단계 placeholder 발견 영역)
+5. 검증 영역 4 (Implementation Simulation) — PRD Must 직결 impl task 2~3 개 선정 후 각각 cold-seat 시뮬레이션 (체크리스트 4 절차)
 
 ## 체크리스트
 
@@ -155,11 +161,40 @@ validator prose 결론에 *자동 검증 통과 영역* + *수동 review 권고 
 - **PRD Should / Could 직결** → WARN
 - **부가 영역** → 통과 가능
 
+### 4. Implementation Simulation (사전부검)
+
+> 표시 없는 *암묵 gap* 검출. 대표 impl task 를 *맥락 없는 engineer* 입장에서 시뮬레이션 — "이 impl 파일(REQ 표 + 인터페이스 + 수용기준 + 의존)만 보고 막힘 없이 코드를 짤 수 있는가". gajae `ralplan` critic 의 "대표 task 2~3 개 구현 시뮬레이션" 차용. **Step 5 전용** (impl 파일 미작성 시점 = N/A).
+
+**검출 절차**:
+
+1. epic 단위 impl 파일 중 **PRD Must 직결 task 2~3 개 선정** (핵심 가치 직결 우선. epic 당 impl 이 적으면 전수, 많으면 PRD Must 커버리지가 가장 큰 것 우선)
+2. 각 task 에 대해 *맥락 없는 engineer* 시점으로 impl 파일 read — REQ 표 / 인터페이스 / 수용기준 / 의존만 근거로 "첫 줄부터 마지막 줄까지 임의 결정 없이 짤 수 있는가" 사고 시뮬레이션
+3. *막히는 자리* = gap 후보 추출. 단 영역 1 (명시 표시 있는 placeholder) / 영역 2 (Cross-Story 시그니처 mismatch) 에서 이미 잡힌 건 중복 계상 X — 영역 4 는 *표시 없는* 빈칸만
+
+**암묵 gap 패턴** (예시 — 더 다양한 형태 포함):
+
+| 형태 | 예시 |
+|---|---|
+| 분기 결정 누락 | "적절히 캐싱", "상황에 맞게 재시도" — *어느* 전략·정책인지 미명시 (placeholder 표시 없음) |
+| 에러/엣지 미정 | 인터페이스·happy path 는 있으나 실패·경계 입력 시 동작이 수용기준에 없음 → engineer 임의 결정 강요 |
+| 암묵 전제 | "이 데이터가 이미 존재한다고 가정" 하나, 그걸 만드는 선행 task / producer 가 impl 어디에도 없음 |
+| 검증 불가 수용기준 | "잘 동작" / "빠르게" 등 binary 판정 불가 → engineer 가 "됐다" 를 스스로 못 판정 |
+
+**판정**:
+
+- **PRD Must 기능 핵심 가치 직결 gap** → **FAIL** + 본문에 (impl 파일 위치 / 막힌 지점 / 어느 PRD Must 직결 / 권고)
+- **PRD Should / Could 직결** → WARN (본문 명시, 결론은 PASS 가능)
+- **부가 영역** → 통과 가능
+
+**검증 불가 케이스** (제외):
+
+- impl 파일이 아직 module-architect 작성 *전* (Step 3.5 시점) — 본 항목 N/A
+
 ## 판정 기준
 
 - **PASS** (Step 3.5) — Placeholder Leak 통과 + 공통 SSOT 룰 자동 영역 통과
-- **PASS** (Step 5) — 위 + Cross-Story Interface 정합성 통과
-- **FAIL** — 셋 중 하나라도 위반
+- **PASS** (Step 5) — 위 + Cross-Story Interface 정합성 통과 + Implementation Simulation 통과
+- **FAIL** — 넷 중 하나라도 위반
 - **ESCALATE** — system-architect / module-architect 재설계 (max 1 cycle) 후에도 동일 FAIL, 또는 본 에이전트 정보 부족
 - **PARTIAL 판정 금지**
 
@@ -174,7 +209,7 @@ validator prose 결론에 *자동 검증 통과 영역* + *수동 review 권고 
 
 - 검증 결과 prose
 - *자동 검증 통과 영역* + *수동 review 권고 영역* 분리 명시
-- FAIL 시: Fail Items 별 (Placeholder Leak / Cross-Story Interface / 공통 SSOT 룰 위반) + 위치 + 어느 PRD Must 직결
+- FAIL 시: Fail Items 별 (Placeholder Leak / Cross-Story Interface / 공통 SSOT 룰 위반 / Implementation Simulation) + 위치 + 어느 PRD Must 직결
 - ESCALATE 시: 사유 명시
 - (선택) 다음 행동 권고 (target / action / ref)
 

--- a/commands/architect-loop.md
+++ b/commands/architect-loop.md
@@ -59,7 +59,7 @@ K 의 의미: **Story 수 + 공통 호출 1 회 (공통 task 있으면) 또는 0
    - **Step 4.0 (공통 task 있으면)** — `mode=common` + 공통 task 목록 (system-architect 가 epic 단위 architecture.md 의 공통 task 섹션에 박은 영역) prompt 에 박고 호출. 산출 = 공통 task 의 impl 파일 N 개. → **commit 3**
    - **Step 4.1 ~ 4.N (Story 순차)** — Story 1 개씩 prompt 에 박고 호출. 산출 = Story 안 task 의 impl 파일 N 개. 각 호출 `READY` 직후 → **commit 4..N+3**
    - batch 모드 폐기 — Story 묶음 자체가 batch 의 본질 해결 (옛 batch 모드는 issue [#511](https://github.com/alruminum/dcNess/issues/511) 본질 해결로 자연 폐기)
-7. **Step 5 — architecture-validator 2차** — Cross-Story Interface 정합성 검증 (모든 impl 완성 후 producer ↔ consumer 시그니처 grep 비교) + Placeholder Leak 재검증 (module 단계 새로 생긴 영역) → `PASS` → **commit N+4** (검증 결과 메타)
+7. **Step 5 — architecture-validator 2차** — Cross-Story Interface 정합성 검증 (모든 impl 완성 후 producer ↔ consumer 시그니처 grep 비교) + Implementation Simulation (대표 impl task 2~3 개 cold-seat 시뮬레이션 — 표시 없는 암묵 gap 조기 포착) + Placeholder Leak 재검증 (module 단계 새로 생긴 영역) → `PASS` → **commit N+4** (검증 결과 메타)
 8. **Step 6 — PR + 머지** — `git push -u origin docs/<epic-slug>` + `gh pr create --base <BASE>` (body = 설계 산출물 요약 + `Part of #<epic-issue>`) + `bash scripts/pr-finalize.sh`
    - **base 분기 (MUST)**: `gh pr create` 직전 epic 단위 stories.md 상단 `**Base Branch:**` 줄 매치 → `--base <매치 값>` (통합 브랜치 케이스, base = `feature/<slug>`). 매치 없음 → `--base main` (default). Step 0 의 `EnterWorktree` branch (`docs/<epic-slug>`) 도 동일 base 기반 — 절차 [`docs/plugin/loop-procedure.md`](../docs/plugin/loop-procedure.md) §1.1.1.
 9. **Step 7 — ExitWorktree** + `end-run`
@@ -69,7 +69,7 @@ K 의 의미: **Story 수 + 공통 호출 1 회 (공통 task 있으면) 또는 0
 - ux-architect self-check FAIL → ux-architect 재진입 (cycle ≤ 2, prose 내부)
 - `UX_REFINE_READY` → designer 분기 (`/ux` 또는 `ux-refine-stage`)
 - architecture-validator 1차 `FAIL` (Step 3.5) → system-architect 재진입 (cycle ≤ 2). 보통 Placeholder Leak 또는 공통 SSOT 룰 위반 영역.
-- architecture-validator 2차 `FAIL` (Step 5) → 해당 module-architect 재진입 (Cross-Story Interface 영역, cycle ≤ 2). 또는 system-architect 재진입 (모듈 의존 그래프 영역).
+- architecture-validator 2차 `FAIL` (Step 5) → 해당 module-architect 재진입 (Cross-Story Interface 영역 또는 Implementation Simulation gap 보강, cycle ≤ 2). 또는 system-architect 재진입 (모듈 의존 그래프 영역).
 - module-architect `SPEC_GAP_FOUND` → module-architect (보강 케이스) cycle (≤ 2) → 신규 케이스 재진입
 - `*_ESCALATE` → 사용자 위임
 - cycle 발생 시 working tree only — commit X. PASS 후만 commit.

--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -94,19 +94,19 @@ impl 계획 ↔ 구현 코드 일치 검증. impl 파일 경로 (`docs/impl/NN-*
 
 ### 1.9 architecture-validator
 
-system-architect / module-architect 산출물의 자가검증 사각지대 외부 reviewer. 3 영역 — **Placeholder Leak + Cross-Story Interface 정합성 + 공통 SSOT 룰 위반**. Spike Gate 폐기 (이슈 [#511](https://github.com/alruminum/dcNess/issues/511)) — tech-reviewer 가 PRD 단계에서 외부 의존 검증 cover.
+system-architect / module-architect 산출물의 자가검증 사각지대 외부 reviewer. 4 영역 — **Placeholder Leak + Cross-Story Interface 정합성 + 공통 SSOT 룰 위반 + Implementation Simulation (사전부검)**. Spike Gate 폐기 (이슈 [#511](https://github.com/alruminum/dcNess/issues/511)) — tech-reviewer 가 PRD 단계에서 외부 의존 검증 cover.
 
 `/architect-loop` 안에서 두 시점에 호출:
 
-- **Step 3.5 (1차)** — system-architect PASS 직후. Placeholder Leak + 공통 SSOT 룰 자동 영역 검증. Cross-Story Interface 는 N/A (impl 파일 미작성).
-- **Step 5 (2차)** — module-architect × K 다 끝난 후. Cross-Story Interface 정합성 + Placeholder Leak 재검증.
+- **Step 3.5 (1차)** — system-architect PASS 직후. Placeholder Leak + 공통 SSOT 룰 자동 영역 검증. Cross-Story Interface / Implementation Simulation 은 N/A (impl 파일 미작성).
+- **Step 5 (2차)** — module-architect × K 다 끝난 후. Cross-Story Interface 정합성 + Implementation Simulation (대표 impl task 2~3 개 cold-seat 시뮬레이션 — 표시 없는 암묵 gap) + Placeholder Leak 재검증.
 
 결론 3종:
 
 - **PASS** (Step 3.5) → module-architect × K (공통 task 있으면 공통부터, 이후 Story 순차).
 - **PASS** (Step 5) → architect-loop Step 6 (PR + 머지).
 - **FAIL** (Step 3.5) → system-architect 재진입 (cycle 한도 2). 본문에 placeholder 위치 / Must 기능 직결 / 공통 SSOT 룰 위반 위치 명시.
-- **FAIL** (Step 5) → 해당 module-architect 재진입 (Cross-Story Interface 영역) 또는 system-architect 재진입 (모듈 의존 그래프 영역). cycle ≤ 2
+- **FAIL** (Step 5) → 해당 module-architect 재진입 (Cross-Story Interface 영역 또는 Implementation Simulation gap 보강) 또는 system-architect 재진입 (모듈 의존 그래프 영역). cycle ≤ 2
 - **ESCALATE** → 재설계 1 cycle 후에도 동일 FAIL → 사용자 위임.
 
 ### 1.10 pr-reviewer

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -243,7 +243,7 @@ phase prose 입자는 review.md 출력 재정의 (`commands/impl-loop.md §revie
 | `FAIL` | engineer POLISH cycle (≤2) |
 | `AMBIGUOUS` | 재호출 1회 (결론 enum 명시 요청) → 재호출도 AMBIGUOUS 시 사용자 위임 (enum 후보 + prose 발췌) |
 | architecture-validator 1차 `FAIL` (Step 3.5) | system-architect 재진입 (cycle ≤2). Placeholder Leak / 공통 SSOT 룰 위반 영역 |
-| architecture-validator 2차 `FAIL` (Step 5) | 해당 module-architect 재진입 (Cross-Story Interface 영역) 또는 system-architect 재진입 (모듈 의존 그래프). cycle ≤2 |
+| architecture-validator 2차 `FAIL` (Step 5) | 해당 module-architect 재진입 (Cross-Story Interface 영역 또는 Implementation Simulation gap 보강) 또는 system-architect 재진입 (모듈 의존 그래프). cycle ≤2 |
 | tech-reviewer `FAIL` | 메인이 사용자와 분기 토론 → (a) PRD patch + `/tech-review` 재호출 / (b) 격리 후보 격상 + 재호출 / (c) 항목 polish + 재호출. cycle 한도 X (단방향, 사용자 OK 까지) |
 | tech-reviewer `ESCALATE` | 사용자 위임 (WebFetch 차단 / 외부 API 인증 부재 / 권한 부족 / 사용자 환경 의존 도구 부재) |
 

--- a/docs/plugin/orchestration.md
+++ b/docs/plugin/orchestration.md
@@ -84,7 +84,7 @@ flowchart LR
     dv1 -->|FAIL| sd
     dv1 -->|ESCALATE| esc
     c2 --> mp[module-architect × K<br/>K = Story 수 + 공통 호출]
-    mp -->|PASS × K, 각 호출 후 commit| dv2[validator 2차<br/>Cross-Story Interface + Placeholder 재검증]
+    mp -->|PASS × K, 각 호출 후 commit| dv2[validator 2차<br/>Cross-Story Interface + Impl Simulation + Placeholder 재검증]
     mp -->|SPEC_GAP_FOUND / ESCALATE| esc
     dv2 -->|PASS| done[PR 생성/머지]
     dv2 -->|FAIL| mp
@@ -165,7 +165,7 @@ default 진입 = test-engineer (architect-loop 통과물). fallback (즉석 task
 | 3.5 | architecture-validator 1차 (Placeholder Leak + 공통 SSOT 룰 자동) | `PASS,FAIL,ESCALATE` | commit 2 (`[docs] architecture + adr + domain <epic-slug>`) — PASS 직후 |
 | 4.0 (공통 task 있을 시) | module-architect (mode=common) | `PASS,SPEC_GAP_FOUND,ESCALATE` | commit 3 (`[docs] impl 공통 task <epic-slug>`) — PASS 직후 |
 | 4.1 ~ 4.N | module-architect (Story 순차, occurrence 1..N) | `PASS,SPEC_GAP_FOUND,ESCALATE` | commit 4..N+3 (`[docs] impl <Story-slug>`) — 각 PASS 직후 |
-| 5 | architecture-validator 2차 (Cross-Story Interface + Placeholder 재검증) | `PASS,FAIL,ESCALATE` | commit N+4 (`[docs] validator 2차 결과`) — PASS 직후 |
+| 5 | architecture-validator 2차 (Cross-Story Interface + Implementation Simulation + Placeholder 재검증) | `PASS,FAIL,ESCALATE` | commit N+4 (`[docs] validator 2차 결과`) — PASS 직후 |
 
 **module-architect × K 단계 (Step 4)**:
 - K = Story 수 + 공통 호출 1 회 (공통 task 있으면) 또는 0 회 (없으면)
@@ -185,7 +185,7 @@ default 진입 = test-engineer (architect-loop 통과물). fallback (즉석 task
 - `UX_REFINE_READY` → designer 분기 (ux-design-stage / ux-refine-stage 권장)
 - `UX_FLOW_ESCALATE` → 사용자 위임
 - architecture-validator 1차 `FAIL` → system-architect 재진입 (cycle ≤ 2). Placeholder Leak 또는 공통 SSOT 룰 위반 영역.
-- architecture-validator 2차 `FAIL` → 해당 module-architect 재진입 (Cross-Story Interface 영역) 또는 system-architect 재진입 (모듈 의존 그래프 영역). cycle ≤ 2
+- architecture-validator 2차 `FAIL` → 해당 module-architect 재진입 (Cross-Story Interface 영역 또는 Implementation Simulation gap 보강) 또는 system-architect 재진입 (모듈 의존 그래프 영역). cycle ≤ 2
 - architecture-validator `ESCALATE` → 사용자 위임
 - module-architect `SPEC_GAP_FOUND` → module-architect (보강 케이스) cycle (≤ 2) → 신규 케이스 재진입
 - module-architect `ESCALATE` → 사용자 위임


### PR DESCRIPTION
## 관련 이슈 번호
Closes #529

## 배경 및 문제
[gajae-code](https://github.com/Yeachan-Heo/gajae-code) (Yeachan-Heo 의 '4 skills + 4 agents' 미니멀 하네스 PoC) 대조 결과, 헤드라인('4+4 압축', tmux 병렬 `team`)은 dcness 와 철학이 갈라져 차용 불가. 단, 글의 진짜 thesis — **"사전부검(pre-mortem)을 두껍게 → 사후부검(post-mortem) 반복 루프를 줄여라"** — 는 dcness 설계 방향과 일치.

dcness 는 현재 spec gap 을 *impl 단계*에서 늦게 잡는다 (code-validator `SPEC_GAP_FOUND` → 비싼 module-architect re-architect 사이클). gajae `ralplan` critic 의 "대표 task 2~3개 구현 시뮬레이션" 메커니즘을 차용해 이를 *plan 단계(Step 5)*로 당긴다.

## 원인 (해당 시)
-

## 작업내용
- **`agents/architecture-validator.md`**: 4번째 검증 영역 "Implementation Simulation (사전부검)" 신설. Step 5 에서 PRD Must 직결 impl task 2~3개를 *맥락 없는 engineer* 입장에서 cold-seat 시뮬레이션 → 표시 없는 암묵 gap(분기 결정 누락 / 에러·엣지 미정 / 암묵 전제 / 검증 불가 수용기준) 포착. 기존 3영역(Placeholder Leak / Cross-Story Interface / 공통 SSOT)과 경계 명시 — 영역 4 ≠ module-architect self-check 재실행(planner≠critic 원리).
- **drift 동시 갱신** (CLAUDE.md §3 orchestration §4 ↔ handoff-matrix §1 쌍 룰): handoff-matrix.md §1.9 / orchestration.md §4(mermaid + step 표 + FAIL 라우팅) / architect-loop.md Step 5 / loop-procedure.md Step 5 FAIL 라우팅.

## 배포 경로 검증 (§0.5)
- **기능 본체 = `agents/architecture-validator.md` (path 1)** — plugin 본체 파일이라 사용자가 plugin 버전 업 받으면 자동 적용. **init-dcness 복사/신규 스크립트 없음.**
- docs/plugin/** + commands/** 변경도 path 1(plugin 본체와 함께 배포). 누락 없음.

## Test Plan
- [x] pytest 게이트 PASS (490 tests OK)
- [x] cross-ref CI 게이트 PASS (37 파일, dead link/anchor/옛명칭 0건)
- [x] drift 정합 grep — "3 영역" 잔존 0건, Implementation Simulation 5개 파일 전파
- [x] 시나리오 워크스루 — 암묵 gap("적절히 캐싱") FAIL 포착 trace
- [x] 경계 회귀 점검 — 영역 4 가 self-check/Cross-Story 와 문구 중복 없음 재독

🤖 Generated with [Claude Code](https://claude.com/claude-code)