### PR TITLE
[docs] 폐기 묘비명 정리 — conveyor-design README 등록 + Step 4.5 슬림

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ PR 절차: [`CLAUDE.md`](CLAUDE.md) §5.
 | [`docs/archive/migration-decisions.md`](docs/archive/migration-decisions.md) | 모듈 PRESERVE / DISCARD / REFACTOR 분류 (역사 자료) |
 | [`docs/archive/document_update_record.md`](docs/archive/document_update_record.md) | (frozen) 옛 WHAT 로그 — 현재는 GitHub PR/issue/git log 가 SSOT |
 | [`docs/archive/change_rationale_history.md`](docs/archive/change_rationale_history.md) | (frozen) 옛 WHY 로그 — 현재는 PR description/이슈 thread/commit body 가 SSOT |
+| [`docs/archive/conveyor-design.md`](docs/archive/conveyor-design.md) | (frozen) Python 컨베이어 v1 폐기 설계 — Task tool 패턴 채택 사유 (역사 자료) |
 | [`PROGRESS.md`](PROGRESS.md) | 현재 상태 / TODO / Blockers |
 | [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 |
 | [`CLAUDE.md`](CLAUDE.md) | 메인 Claude 작업 지침 |

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -360,11 +360,7 @@ git checkout main && git pull --ff-only 2>/dev/null || true
 
 ## 4. Step 4.5 — 폐기 (2026-05-12)
 
-> **이전 정의**: `stories.md` task `[x]` 체크 + `backlog.md` epic `[x]` 체크 (engineer `IMPL_DONE` 직후, 메인 mechanical edit).
->
-> **폐기 사유**: stories.md 양식 단순화 (user story 만, task `[ ]` 쓰지 않음 — PR3-A) + `backlog.md` 자체 폐기. 진행 추적 SSOT = GitHub issue close 시스템 (PR body `Closes #N` / `Part of #N` 트레일러) 단일화. impl task PR diff 에는 stories.md / backlog.md 변경 0 (commit3 = src/** only).
->
-> **마이그레이션**: 기존 활성 프로젝트의 옛 stories.md (task `[ ]` 있는) 는 *그대로 잔재 허용* — backfill 강제 X. 새 작성만 새 양식 ([`commands/product-plan.md`](../../commands/product-plan.md) §stories.md 산출물). 자동 마이그레이션 원하는 사용자용 = `scripts/migrate_stories_to_new_format.sh`.
+> 옛 `stories.md` / `backlog.md` task 체크 동기화 step 폐기. 진행 추적 SSOT = GitHub issue close (PR body `Closes #N` / `Part of #N` 트레일러) 단일화 — impl task PR diff 는 `src/**` only. 새 stories.md 양식 = [`commands/product-plan.md`](../../commands/product-plan.md) §stories.md 산출물 (옛 양식 잔재 허용, backfill 강제 X). 폐기 상세는 git history.
 
 ---
 


### PR DESCRIPTION
## 관련 이슈 번호
Document-Exception-PR-Close: infra-only — 오케스트레이션 다이어트 PR1/4, issue 없음

## 배경 및 문제
오케스트레이션 코어 문서가 비대해졌다는 진단의 후속 작업(PR1/4). 폐기 묘비명 정리 — 순수 역사 기록이 코어 문서 본문을 점유하는 군살 제거.

## 작업내용
- `README.md` 참조 표: archive 에 실재하나 미등록이던 `docs/archive/conveyor-design.md` 1줄 추가
- `docs/plugin/loop-procedure.md` §4.5 "Step 4.5 — 폐기" 블록 21줄 → 1줄 요약. **제목은 유지**(`commands/issue-report.md` 가 "§4.5" 텍스트 참조). 폐기 상세 사유는 git history 로 충분

## 결정 근거
탐색 결과 코어 3문서의 폐기 서술 대부분이 현재 설계 근거와 얽혀 있어 순수 역사가 거의 없음 → 안전하게 옮길 수 있는 §4.5 블록 + orphan 등록만 정리. anchor 보존 위해 heading 유지.

## 배포 경로 검증 (CLAUDE.md §0.5)
- 경로 1 (plug-in 본체): `docs/plugin/loop-procedure.md` — plug-in 업데이트 시 자동 적용
- README 는 저장소 자체 문서 (배포 무관)
- 경로 2/3 해당 없음 (scripts/hook/SSOT 흐름 변경 없음)

## Test Plan
- [x] `node scripts/check_cross_refs.mjs` PASS (dead link/anchor/옛 명칭 0건)
- [ ] 회귀 검증

## 참고
오케스트레이션 다이어트 4-PR 시리즈 중 1번 (가장 안전, 먼저). 다음: PR2 3-way 중복 압축.