### PR TITLE
[docs] legacy enum 서술 축약 — dcness prose-only 단일 경로 명확화

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -107,7 +107,7 @@ TaskUpdate("<task>", in_progress)
 "$HELPER" begin-step <agent> [<MODE>]
 Agent(subagent_type="<agent>", mode="<MODE>", description="...")
 "$HELPER" end-step <agent> [<MODE>]   # prose-only mode (stdout=PROSE_LOGGED)
-# legacy compat: ENUM=$("$HELPER" end-step <agent> [<MODE>] --allowed-enums "<csv>")
+# (legacy: 외부 skill 이 --allowed-enums 전달 시에만 enum 반환. dcness 자신은 prose-only 만 사용)
 # 의무 echo (5~12 줄) — 아래 "결과 echo + 평가" 섹션
 TaskUpdate("<task>", completed)
 ```
@@ -165,7 +165,7 @@ REDO 판단 신호: 결과가 질문에 제대로 답하지 못함 / 같은 tool
 
 #### AMBIGUOUS 처리 (legacy enum mode 한정)
 
-`--allowed-enums` 쓴 legacy 호출에서 `end-step` stdout = `AMBIGUOUS` 시: 재호출 1회 (결론 enum 명시 요청) → 재호출도 AMBIGUOUS → 사용자 위임 (enum 후보 + prose 발췌). prose-only mode 는 AMBIGUOUS 자체 X — 결정 못 하면 prose 본문에 "결정 불가" 명시 후 사용자 위임 (issue #392).
+`AMBIGUOUS` 는 외부 skill 이 `--allowed-enums` 를 쓴 legacy 호출에서만 발생 (dcness 는 prose-only 라 미발생). 발생 시 재호출 1회 후에도 AMBIGUOUS 면 사용자 위임. prose-only mode 는 결정 못 하면 prose 본문에 "결정 불가" 명시 후 사용자 위임 (issue #392).
 
 #### helper 안전망 (자동 검출)
 
@@ -241,7 +241,7 @@ phase prose 입자는 review.md 출력 재정의 (`commands/impl-loop.md §revie
 | `*_ESCALATE` (hard) | 사용자 위임 (escalate) |
 | `*_ESCALATE` (soft) | 비-yolo: 사용자 위임 / yolo: `auto-resolve` |
 | `FAIL` | engineer POLISH cycle (≤2) |
-| `AMBIGUOUS` | 재호출 1회 (결론 enum 명시 요청) → 재호출도 AMBIGUOUS 시 사용자 위임 (enum 후보 + prose 발췌) |
+| `AMBIGUOUS` (legacy enum 한정) | 재호출 1회 → 또 AMBIGUOUS 면 사용자 위임 |
 | architecture-validator 1차 `FAIL` (Step 3.5) | system-architect 재진입 (cycle ≤2). Placeholder Leak / 공통 SSOT 룰 위반 영역 |
 | architecture-validator 2차 `FAIL` (Step 5) | 해당 module-architect 재진입 (Cross-Story Interface 영역 또는 Implementation Simulation gap 보강) 또는 system-architect 재진입 (모듈 의존 그래프). cycle ≤2 |
 | tech-reviewer `FAIL` | 메인이 사용자와 분기 토론 → (a) PRD patch + `/tech-review` 재호출 / (b) 격리 후보 격상 + 재호출 / (c) 항목 polish + 재호출. cycle 한도 X (단방향, 사용자 OK 까지) |


### PR DESCRIPTION
## 관련 이슈 번호
Document-Exception-PR-Close: infra-only — 오케스트레이션 다이어트 PR3/4, issue 없음

## 배경 및 문제
prose-only mode(이슈 #284)가 dcness 의 단일 실사용 경로인데, 옛 legacy enum(`--allowed-enums` / `AMBIGUOUS`) 서술이 본문에 단락으로 병기돼 있었다. `--allowed-enums` 실제 호출처는 dcness 배포물에 **0건** — 코드는 외부 skill 이 옛 방식으로 부를 때 crash 만 막는 방어 stub(`interpret_strategy.py:9` 주석 명시)이다.

## 작업내용
- `loop-procedure.md` §3.1 코드블록 legacy compat 주석 → "dcness 자신은 prose-only 만 사용" 명확화
- AMBIGUOUS 처리 단락 압축 — legacy enum mode(외부 skill `--allowed-enums`) 한정임을 명시
- §3.3 ENUM 분기 표 AMBIGUOUS 행 "(legacy enum 한정)" 표기 + 축약

## 결정 근거
코드 stub 은 crash 회피 가치가 있어 **유지**(제거 시 외부 skill 호환 깨짐) — 문서만 "legacy 한정·dcness 미사용" 으로 축약해 코드-동작 drift 없이 혼란 제거.

## 배포 경로 검증 (CLAUDE.md §0.5)
- 경로 1 (plug-in 본체): `docs/plugin/loop-procedure.md` — plug-in 업데이트 시 자동 적용
- 코드/scripts 무변경 → 경로 2/3 해당 없음

## Test Plan
- [x] `node scripts/check_cross_refs.mjs` PASS
- [ ] 회귀 검증

## 참고
오케스트레이션 다이어트 4-PR 시리즈 중 3번. 다음: PR4 loop 풀스펙 반복 축약.