### PR TITLE
[issue-523] is_infra_project cwd 신호를 repo 마커 기반으로 교체

### DIFF
--- a/docs/plugin/handoff-matrix.md
+++ b/docs/plugin/handoff-matrix.md
@@ -119,7 +119,7 @@ RWHarness 4 신호 OR 정합:
 1. `DCNESS_INFRA=1` 환경변수
 2. 마커 파일 `~/.claude/.dcness-infra` 존재
 3. `CLAUDE_PLUGIN_ROOT` 환경변수 non-empty
-4. `cwd.resolve() == Path("/Users/<user>/project/dcness")` (또는 화이트리스트 매칭)
+4. cwd 또는 그 상위에 dcness self repo 마커 `.claude-plugin/plugin.json` (`name == "dcness"`) 실재 (배포된 plugin 의 plugin.json 은 plugin cache 에만 있고 사용자 repo 엔 없으므로, 이 마커가 cwd 조상에 있으면 dcness self 저장소에서 작업 중이라는 뜻)
 
 > **코드 강제**: `harness/agent_boundary.py` 가 본 spec 의 SSOT 구현. `hooks/file-guard.sh` (PreToolUse Edit/Write/Read/Bash) + `hooks/post-agent-clear.sh` (PostToolUse Agent) 가 활성화. opt-out 마커 = `.no-dcness-guard` (cwd) — 사용자 임시 우회.
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -24,6 +24,7 @@
 """
 from __future__ import annotations
 
+import json
 import os
 import re
 from pathlib import Path
@@ -34,7 +35,6 @@ __all__ = [
     "DCNESS_INFRA_PATTERNS",
     "ALLOW_MATRIX",
     "READ_DENY_MATRIX",
-    "INFRA_PROJECT_CWD_WHITELIST",
     "is_infra_project",
     "is_opt_out",
     "check_write_allowed",
@@ -130,9 +130,27 @@ READ_DENY_MATRIX: dict[str, tuple[str, ...]] = {
 
 
 # ── §4.4 — is_infra_project() 4 OR 신호 ──────────────────────────────
-INFRA_PROJECT_CWD_WHITELIST: tuple[str, ...] = (
-    "/Users/dc.kim/project/dcNess",
-)
+def _is_dcness_self_repo(cwd: Path) -> bool:
+    """cwd 또는 그 상위에 dcness self repo 마커가 실재하나.
+
+    마커 = `.claude-plugin/plugin.json` 의 `name == "dcness"`.
+    배포된 plugin 의 plugin.json 은 plugin cache 에만 있고 *사용자 repo 에는 없으므로*,
+    이 마커가 cwd 조상에 실재한다는 것은 dcness self 저장소에서 작업 중이라는 뜻이다.
+    (옛 개인 절대경로 하드코딩 whitelist 대체 — 이슈 #523)
+    """
+    try:
+        cur = cwd.resolve()
+    except (OSError, RuntimeError):
+        return False
+    for d in (cur, *cur.parents):
+        manifest = d / ".claude-plugin" / "plugin.json"
+        if manifest.is_file():
+            try:
+                data = json.loads(manifest.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                return False
+            return data.get("name") == "dcness"
+    return False
 
 
 def is_infra_project(
@@ -146,7 +164,7 @@ def is_infra_project(
     1. DCNESS_INFRA=1 환경변수
     2. 마커 파일 ~/.claude/.dcness-infra 존재
     3. CLAUDE_PLUGIN_ROOT 환경변수 non-empty (dcness 개발 모드)
-    4. cwd.resolve() in INFRA_PROJECT_CWD_WHITELIST
+    4. cwd 조상에 dcness self repo 마커 (.claude-plugin/plugin.json name=dcness) 실재
     """
     e = env if env is not None else os.environ
     if e.get("DCNESS_INFRA") == "1":
@@ -158,11 +176,7 @@ def is_infra_project(
         return True
     if cwd is None:
         cwd = Path.cwd()
-    try:
-        resolved = str(cwd.resolve())
-    except (OSError, RuntimeError):
-        return False
-    return resolved in INFRA_PROJECT_CWD_WHITELIST
+    return _is_dcness_self_repo(cwd)
 
 
 def is_opt_out(cwd: Optional[Path] = None) -> bool:

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -48,17 +48,39 @@ class IsInfraProjectTests(unittest.TestCase):
             (home / ".claude" / ".dcness-infra").write_text("")
             self.assertTrue(is_infra_project(home, env={}, home=home))
 
-    def test_cwd_whitelist(self):
-        # 현 저장소 path = whitelist 멤버.
-        cwd = Path("/Users/dc.kim/project/dcNess")
-        if not cwd.exists():
-            self.skipTest("환경 외 — whitelist cwd 부재")
-        self.assertTrue(is_infra_project(cwd, env={}, home=Path("/tmp")))
+    def test_self_repo_marker(self):
+        # cwd 조상에 .claude-plugin/plugin.json (name=dcness) 실재 → infra.
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".claude-plugin").mkdir()
+            (root / ".claude-plugin" / "plugin.json").write_text(
+                json.dumps({"name": "dcness", "version": "0.3.0"})
+            )
+            self.assertTrue(is_infra_project(root, env={}, home=Path("/tmp")))
+            # 중첩 하위 디렉토리에서도 walk-up 으로 마커 발견.
+            nested = root / "harness" / "deep"
+            nested.mkdir(parents=True)
+            self.assertTrue(is_infra_project(nested, env={}, home=Path("/tmp")))
+
+    def test_self_repo_marker_wrong_name(self):
+        # name != dcness 매니페스트 → 오탐 방지 (외부 plugin 저장소).
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            (root / ".claude-plugin").mkdir()
+            (root / ".claude-plugin" / "plugin.json").write_text(
+                json.dumps({"name": "some-other-plugin"})
+            )
+            self.assertFalse(is_infra_project(root, env={}, home=Path("/tmp")))
 
     def test_user_project_not_infra(self):
         with tempfile.TemporaryDirectory() as td:
-            cwd = Path(td)  # /tmp/... — whitelist 외
+            cwd = Path(td)  # 마커 없음 — 외부 사용자 프로젝트
             self.assertFalse(is_infra_project(cwd, env={}, home=Path(td)))
+
+    def test_no_personal_path_hardcoded(self):
+        # 회귀 가드 (#523): 배포되는 agent_boundary.py 소스에 개인 절대경로 0건.
+        src = (REPO_ROOT / "harness" / "agent_boundary.py").read_text(encoding="utf-8")
+        self.assertNotIn("/Users/", src)
 
 
 class WriteAllowedMainBypassTests(unittest.TestCase):


### PR DESCRIPTION
## 관련 이슈 번호
Closes #523

## 배경 및 문제
`harness/agent_boundary.py` 의 `INFRA_PROJECT_CWD_WHITELIST` 에 작성자 개인 절대경로 `"/Users/dc.kim/project/dcNess"` 가 하드코딩돼 있었다. 이 파일은 plugin 본체로 외부 사용자에게 배포되므로:
1. **`CLAUDE.md §0.3` 위반** — 배포물에 개인 경로/내부 표현 포함 금지.
2. **외부 사용자에게 죽은 코드** — 그들 cwd 와 절대 매치 안 되며, 다른 홈디렉토리/Linux/monorepo 환경 portability 를 막는다.

`is_infra_project()` 는 dcness self repo 를 판정해 sub-agent path 가드를 해제하는 함수다. 이미 견고한 3개 마커 신호(`DCNESS_INFRA` env / `CLAUDE_PLUGIN_ROOT` env / `~/.claude/.dcness-infra`)가 있고, 4번째 cwd-whitelist 신호만 하드코딩이었다.

## 원인 (해당 시)
신호 4 가 개인 환경 1개를 절대경로 문자열로 박아둠. 초기 구현 편의 산물.

## 작업내용
- **harness/agent_boundary.py**: 하드코딩 `INFRA_PROJECT_CWD_WHITELIST` 삭제. `_is_dcness_self_repo()` 마커 헬퍼 추가 — cwd 와 그 조상을 walk-up 하며 `.claude-plugin/plugin.json` 의 `name == "dcness"` 확인. **배포된 plugin 의 plugin.json 은 plugin cache 에만 있고 사용자 repo 엔 없으므로**, 이 마커가 cwd 조상에 실재 = dcness self 저장소라는 신뢰 가능한 신호. `import json` + `__all__` + docstring 정합.
- **tests/test_agent_boundary.py**: 하드코딩 의존 `test_cwd_whitelist` 제거. `test_self_repo_marker`(중첩 walk-up) / `test_self_repo_marker_wrong_name`(오탐 방지) / `test_no_personal_path_hardcoded`(소스에 `/Users/` 0건 회귀 가드) 추가.
- **docs/plugin/handoff-matrix.md §4.4**: 신호 4 문구를 마커 기반으로 교체. (드리프트 룰 §1↔orchestration §4 와 무관한 §4.4 — orchestration 중복 보유 없음 확인, 동시갱신 불요.)

## 배포 경로 검증 (CLAUDE.md §0.5)
- `harness/agent_boundary.py` = **경로 1 (plugin 본체)** — 사용자가 plugin 업데이트 받으면 자동 적용. init-dcness 복사 대상 아님(경로 2 N/A).
- `docs/plugin/handoff-matrix.md` = 배포 docs — 개인 경로 제거라 개선 방향.
- 범위 밖: `commands/init-dcness.md` 의 username 노출은 예시 콘솔 출력 텍스트(기능 하드코딩 아님) — 별도 미용 정리로 분리.

## Test Plan
- [x] `tests.test_agent_boundary` 35 / `discover` 479 OK
- [x] 회귀 검증: 개인경로 grep 0건 · cross-ref PASS · 외부 cwd False · 기존 infra/main-bypass 무수정 통과
- [x] 수동: self repo 에서 env 없이 마커만으로 `is_infra_project()` True

🤖 Generated with [Claude Code](https://claude.com/claude-code)