### PR TITLE
[docs] README happy-path 교정 + 가독성/현재기준 정합

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # dcNess
 
-> **Status**: `0.3.0` — plugin 배포 채널(release 브랜치) 운영 중
 > **Origin**: [`alruminum/realworld-harness`](https://github.com/alruminum/realworld-harness) fork-and-refactor
 > **Spec(SSOT)**: [`docs/plugin/orchestration.md`](docs/plugin/orchestration.md) §0
 
-**dcNess 는 Claude Code 용 거버넌스 하네스 plugin 이다.** 코딩 에이전트가 혼자
-달릴 때 빠지는 함정 — 검증 건너뛰기, 권한 밖 파일 수정, 순서 뒤집기 — 을
-막는 데 집중한다. 강제하는 것은 단 두 가지: **(1) 작업 순서**, **(2) 접근 영역**.
+**dcNess 는 Claude Code 용 거버넌스 하네스 plugin 이다.**
+
+코딩 에이전트가 혼자 달릴 때 빠지는 함정 — 검증 건너뛰기, 권한 밖 파일 수정,
+순서 뒤집기 — 을 막는 데 집중한다.
+
+강제하는 것은 단 두 가지뿐이다.
+
+- **작업 순서** — 검증·구현·리뷰 시퀀스 보존
+- **접근 영역** — agent 별 파일 경계 + 외부 시스템 mutation 차단
+
 출력 형식·flag·schema 는 강제하지 않는다(agent 자율). 에이전트는 prose 를 자유롭게
-쓰고, 메인 Claude 가 그 prose 를 직접 읽어 다음 단계를 정한다 — 형식 강제 사다리도,
+쓰고, 메인 Claude 가 그 prose 를 직접 읽어 다음 단계를 정한다. 형식 강제 사다리도,
 메타 LLM 호출도 없는 **prose-only** 방식이다.
 
 ## 누구에게 맞나
@@ -19,49 +25,63 @@
 **안 맞다** — model/provider 라우팅이나 MCP 런타임 확장이 목적인 경우(그건 dcNess 의
 scope 가 아니다). 가벼운 단발 스크립팅만 원하는 경우엔 과할 수 있다.
 
-## 5분 Happy Path
+## 설치 & 활성화
 
 ```sh
-# 1. marketplace 등록 + plugin 설치 (Claude Code CLI)
+# marketplace 등록 + plugin 설치 (Claude Code CLI)
 claude plugin marketplace add alruminum/dcNess
 claude plugin install dcness@dcness
 ```
 
-설치만으로는 아무 hook 도 발화하지 않는다(디폴트 비활성 = pass-through). 적용할
-프로젝트에서 Claude Code 세션을 열고:
+설치만으로는 아무 hook 도 발화하지 않는다(디폴트 비활성 = pass-through).
+적용할 프로젝트에서 Claude Code 세션을 열고 활성화한다.
 
 ```
 /init-dcness        # 현 프로젝트를 활성 whitelist 에 등록 (+ Read 권한 / git hook 자동 셋업)
 ```
 
-활성화 확인:
+**활성화 성공 기준** — 아래처럼 `active: YES` 가 출력되면 정상이다.
 
 ```
 [dcness] active: YES
 ```
 
-이후 첫 구현 루프:
-
-```
-/impl <task>        # 단발 task — test-engineer → engineer → code-validator → pr-reviewer → PR
-/impl-loop          # 여러 task 를 순차 자동 처리
-/run-review         # 방금 run 의 step별 비용·차단 분석
-```
-
-**첫 성공 기준** — `/impl` 한 번이 PR 생성까지 도달하고, `/run-review` 로 그 run 의
-비용을 표로 확인할 수 있으면 정상 동작이다.
-
 > plugin 갱신: `claude plugin update dcness@dcness`
 > (문제 시 `claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness`)
 
-## 무엇이 다른가
+## 작업 흐름
 
-| 항목 | 선행 하네스 | dcNess |
-|---|---|---|
-| 결정론 메커니즘 | `parse_marker` regex + alias 사다리 (~180 LOC) | **prose-only** — agent 가 prose 자유 emit, 메인 Claude 가 prose 를 직접 읽고 routing (기계 enum 추출 / 메타 LLM 호출 0, 이슈 #280/#284) |
-| 형식 강제 | `---MARKER:X---` + alias 12변형 | **0** — 형식/flag/schema 모두 agent 자율. harness 강제 = 작업 순서 + 접근 영역만 |
-| 컨텍스트 layer | 5 layer | 2 layer (CLAUDE.md + agents) |
-| 게이트 | hook 다수 | 거버넌스 + 6 CI workflow (cross-ref / git-naming / plugin-manifest / pr-body / python-tests / release-sync) |
+dcNess 는 단계별 skill 로 작업을 끌고 간다. `/impl` 은 **설계 산출물(impl task 문서)이
+있어야** 동작하므로, 보통 아래 순서를 탄다.
+
+**새 기능**
+
+```
+/product-plan       # PRD + stories + tech-review 스켈레톤 (그릴미 대화)
+/architect-loop     # 1 epic 설계 — ux/system/module architect + validator → impl task 문서 생성
+/impl-loop          # 생성된 task 들을 순차 구현 (task 마다 1 PR)
+/run-review         # 방금 run 의 step별 비용·차단 분석
+```
+
+**버그 수정**
+
+```
+/issue-report       # 이슈 분류 → 라우팅 추천
+/impl <task>        # 분류 결과에 따라 fallback 경로로 구현
+```
+
+각 task 는 `test-engineer → engineer → code-validator → pr-reviewer → PR` 루프를 돈다.
+검증(code-validator)·리뷰(pr-reviewer) 를 건너뛴 채 다음 단계로 못 가는 것이 dcNess 의
+핵심이다.
+
+## 핵심 특징
+
+| 항목 | 내용 |
+|---|---|
+| 결정론 | **prose-only** — agent 가 prose 자유 emit, 메인 Claude 가 prose 를 직접 읽고 routing. 기계 enum 추출·메타 LLM 호출 0 |
+| 형식 강제 | **0** — 형식/flag/schema 모두 agent 자율. harness 강제 = 작업 순서 + 접근 영역만 |
+| 컨텍스트 layer | 2 layer (CLAUDE.md + agents) |
+| 게이트 | 거버넌스 + 6 CI workflow (cross-ref / git-naming / plugin-manifest / pr-body / python-tests / release-sync) |
 
 ## Skill (`commands/`, 10개)
 


### PR DESCRIPTION
## 관련 이슈 번호
Document-Exception-PR-Close: #519 머지(PR #550) 후 사용자 피드백 반영 follow-up — #519 는 이미 CLOSED.

## 배경 및 문제
#519 로 머지된 README 에 사용자가 4가지 정정을 요청. 핵심은 사실관계 오류와 가독성, "항상 현재 기준만" 원칙.

- **happy-path 오류**: 기존 README 가 활성화 직후 `/impl <task>` 를 첫 구현 루프로 제시했으나, `/impl` 은 task 경로(`docs/milestones/v*/epics/epic-*/impl/NN-*.md`)가 필수다(`commands/impl.md`). 설계 산출물(architect-loop) 없이는 동작하지 않음.
- 선행 하네스 비교 열은 "현재 기준만" 원칙에 어긋남.
- 맨 위 Status 줄은 계속 갱신 안 하면 stale.
- 인트로 단락이 한 덩어리라 가독성 낮음.

## 작업내용
- **happy-path 교정**: "설치 & 활성화"(성공 기준 = `active: YES`) + "작업 흐름"(새 기능 = `/product-plan → /architect-loop → /impl-loop`, 버그 = `/issue-report → /impl`) 2절로 분리. `/impl` 이 설계 산출물 선행 필요임을 명시.
- **"무엇이 다른가" → "핵심 특징"**: 선행 하네스 비교 열 삭제, 현재 기준 2열 표.
- **Status 줄 제거**: Origin / Spec 만 유지.
- **인트로 가독성**: 강제 2가지(작업 순서 / 접근 영역)를 불릿으로, 문단 줄바꿈.

## 작업내용 (게이트)
- `node scripts/check_cross_refs.mjs` → PASS (dead link / 옛 명칭 0건)
- 변경 파일 README.md 단일.

## Test Plan
- [x] cross-ref PASS
- [x] 회귀 검증: 선행 하네스/Status/틀린 첫루프 표현 0건

🤖 Generated with [Claude Code](https://claude.com/claude-code)