### PR TITLE
[issue-543] run-review INFRA_READ — build-worker 자기 run_dir 자기-참조 오탐 억제

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -626,9 +626,19 @@ def detect_wastes(
         ))
 
     # INFRA_READ — prose 안 인프라 경로 흔적
+    # issue #543: build-worker 등 driver 는 계약상 prose 끝에 자기 run_dir 의
+    # phase prose 경로 (runs/<run_id>/build-*.md) 를 메인 ls 검증용으로 나열한다.
+    # 그 경로는 리뷰 중인 run 자기 자신의 run_dir 아래라 인프라 *탐색* 이 아닌
+    # 자기-bookkeeping → 오탐. 매칭된 인프라 경로가 등장하는 line 단위로 보고,
+    # 자기 run_dir (`runs/<run_id>/`) 자기-참조 line 은 제외한다. 다른 세션/run
+    # 경로·harness-memory.md 등 진짜 leak 은 self marker 미포함 → 검출 유지.
+    self_run_marker = f"runs/{run_dir.name}/" if run_dir is not None else None
     for s in steps:
         for path in INFRA_PATH_PATTERNS:
-            if path in s.prose_full:
+            hit_lines = [ln for ln in s.prose_full.splitlines() if path in ln]
+            if self_run_marker is not None:
+                hit_lines = [ln for ln in hit_lines if self_run_marker not in ln]
+            if hit_lines:
                 findings.append(WasteFinding(
                     pattern="INFRA_READ",
                     severity="HIGH",

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -228,6 +228,66 @@ class WasteDetectionTests(unittest.TestCase):
 
     # issue #392 — test_placeholder_leak 폐기 (PLACEHOLDER_LEAK 패턴 폐기 정합).
 
+    def test_infra_read_self_rundir_bookkeeping_skipped(self):
+        """issue #543 — build-worker 가 자기 run_dir 의 phase prose 경로를
+        메인 ls 검증용으로 나열한 것은 인프라 탐색이 아니라 자기-bookkeeping →
+        INFRA_READ 오탐 X."""
+        rid = "run-abc123"
+        run_dir = Path(f"/repo/.claude/harness-state/.sessions/sid1/runs/{rid}")
+        prose = (
+            "phase 1/2/3 GREEN 확인 완료.\n"
+            "phase prose 파일 (메인 ls 검증용):\n"
+            f"- /repo/.claude/harness-state/.sessions/sid1/runs/{rid}/build-test.md\n"
+            f"- /repo/.claude/harness-state/.sessions/sid1/runs/{rid}/build-impl.md\n"
+            f"- /repo/.claude/harness-state/.sessions/sid1/runs/{rid}/build-validate.md\n"
+            "LGTM"
+        )
+        steps = [
+            StepRecord(idx=0, ts="t", agent="build-worker", mode="",
+                       enum="PASS", must_fix=False, prose_excerpt="x",
+                       prose_full=prose),
+        ]
+        wastes = detect_wastes(steps, run_dir=run_dir)
+        self.assertNotIn("INFRA_READ", {w.pattern for w in wastes})
+
+    def test_infra_read_other_run_path_detected(self):
+        """다른 run 의 harness-state 경로 참조는 자기-bookkeeping 아님 →
+        INFRA_READ 검출 유지."""
+        run_dir = Path("/repo/.claude/harness-state/.sessions/sid1/runs/run-abc123")
+        prose = (
+            "타 세션 산출물 확인:\n"
+            "/repo/.claude/harness-state/.sessions/sid1/runs/run-OTHER999/build-test.md\n"
+        )
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False, prose_excerpt="x",
+                       prose_full=prose),
+        ]
+        wastes = detect_wastes(steps, run_dir=run_dir)
+        infra = [w for w in wastes if w.pattern == "INFRA_READ"]
+        self.assertEqual(len(infra), 1)
+
+    def test_infra_read_harness_memory_detected_with_rundir(self):
+        """run_dir 가 있어도 harness-memory.md 등 self marker 무관 leak 은 검출 유지."""
+        run_dir = Path("/repo/.claude/harness-state/.sessions/sid1/runs/run-abc123")
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False, prose_excerpt="x",
+                       prose_full="설정 갱신 harness-memory.md 읽음"),
+        ]
+        wastes = detect_wastes(steps, run_dir=run_dir)
+        self.assertIn("INFRA_READ", {w.pattern for w in wastes})
+
+    def test_infra_read_no_rundir_falls_back_to_substring(self):
+        """run_dir 미전달 시 (None) self marker 필터 없이 기존 substring 검출 유지."""
+        steps = [
+            StepRecord(idx=0, ts="t", agent="engineer", mode="IMPL",
+                       enum="IMPL_DONE", must_fix=False, prose_excerpt="x",
+                       prose_full="경로 /repo/.claude/harness-state/.sessions/x/runs/y/z.md"),
+        ]
+        wastes = detect_wastes(steps)  # run_dir 미전달
+        self.assertIn("INFRA_READ", {w.pattern for w in wastes})
+
     def test_must_fix_ghost(self):
         steps = [
             StepRecord(idx=0, ts="t1", agent="validator", mode="CODE_VALIDATION",


### PR DESCRIPTION
## 관련 이슈 번호
Closes #543

## 배경 및 문제
`/run-review` 가 clean 하게 머지된 `/impl-loop` run 에서 `INFRA_READ` (HIGH) 를 거짓 발화한다. 외부 활성 프로젝트 impl-loop 실측: build-worker 스텝이 있는 run 전부 INFRA_READ HIGH 1건씩 검출 — 그러나 모두 정상 LGTM·머지였고 실제 권한 경계 위반은 없었다. 영향: build-worker 스텝당 오탐이 영구 누적 → 진짜 권한 경계 leak 신호가 noise 에 묻힌다.

## 원인
`harness/run_review.py` INFRA_READ 검출이 `s.prose_full` 전체를 substring 매칭한다. 그런데 build-worker 는 **계약상**(`agents/build-worker.md:180~186`) prose 끝에 자기 phase 산출물 경로(메인 ls 검증용)를 나열한다:

```
phase prose 파일 (메인 ls 검증용):
- <run_dir>/build-test.md   # = /repo/.claude/harness-state/.sessions/<sid>/runs/<rid>/build-test.md
- <run_dir>/build-impl.md
- <run_dir>/build-validate.md
```

이 경로들은 리뷰 중인 run **자기 자신의 run_dir** 아래라 `/.claude/harness-state/` 를 포함 → 인프라 *탐색* 이 아닌 자기-bookkeeping 인데 매번 매칭됐다.

## 작업내용
- INFRA_READ 검출을 line 단위로 변경. 매칭된 인프라 경로가 등장하는 line 중, 현재 리뷰 중인 run 자기 run_dir(`runs/<run_id>/`) 자기-참조 line 은 제외.
- `run_dir` 미전달(None) 시 기존 substring 동작으로 fallback.

## 결정 근거
- **run_dir self-reference 제외 채택** (이슈 제안 1안). build-worker 의 ls 검증 블록은 false-clean 차단용 의무 계약(`build-worker.md:186`)이라 그대로 유지하면서 리뷰어 쪽에서만 억제 → 계약 무손상.
- **진짜 leak 검출 유지**: 다른 세션/run 경로(`runs/<other_rid>/`)·`harness-memory.md`·`harness.config.json`·`/.claude/harness/` 등 self marker 무관 leak 은 self_run_marker 미포함 → 여전히 검출.

## 배포 경로 검증 (§0.5)
- `harness/run_review.py` = plugin 본체(경로 1) → 외부 활성 프로젝트는 plugin 버전 업데이트로 자동 수령. `scripts/dcness-review` 래퍼 호출 구조 불변. init-dcness 복사 스텝 변경 불필요.

## 스코프 밖 (이슈 명시)
- build-worker 가 `EXPECTED_AGENT_BUDGETS`/`DCNESS_AGENT_NAMES` 미포함이라 THINKING_LOOP·per-step metric 이 `-` 로 빠지는 가시성 문제 — 별도 이슈.

## Test Plan
- [x] `tests.test_run_review` → 72 OK (신규 INFRA_READ 회귀 4건: self bookkeeping skip / 다른 run 검출 / harness-memory 검출 / run_dir None fallback)
- [x] pre-commit pytest 게이트 전체 → 483 OK

## 참고
-

🤖 Generated with [Claude Code](https://claude.com/claude-code)