### PR TITLE
[feature] Codex validator skill prompt 주입

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ claude plugin install dcness@dcness
 > plugin 갱신: `claude plugin update dcness@dcness`
 > (문제 시 `claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness`)
 
-`/init-dcness` 재실행 시 기존 프로젝트도 Codex read-only validator route 를 opt-in 할 수 있다. 설치/갱신되는 Codex skills 는 `$CODEX_HOME/skills/dcness-*` 3개이며, route config 는 `~/.claude/plugins/data/dcness-dcness/routing.json` 에만 저장된다. 끄기:
+`/init-dcness` 재실행 시 기존 프로젝트도 Codex read-only validator route 를 opt-in 할 수 있다. 설치/갱신되는 Codex skills 는 `$CODEX_HOME/skills/dcness-*` 3개이며, wrapper 가 해당 `SKILL.md` 를 prompt 에 직접 포함한다. route config 는 `~/.claude/plugins/data/dcness-dcness/routing.json` 에만 저장된다. 끄기:
 
 ```sh
 dcness-helper routing disable-codex-validation

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -71,7 +71,7 @@ python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
 - wrapper: `scripts/dcness-codex-validator`
 - 대상: read-only validation 3종만. engineer / build-worker / module-architect 등 mutation agent 는 Claude route 고정.
 
-Codex wrapper 는 repo mutation 을 금지한다. 실행 전후 git status snapshot 이 달라지면 block 하고 자동 revert 하지 않는다.
+Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함하며 repo mutation 을 금지한다. 실행 전후 git status snapshot 이 달라지면 block 하고 자동 revert 하지 않는다.
 
 ---
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -129,7 +129,7 @@ else
 fi
 ```
 
-Codex wrapper 는 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행하고 마지막 응답을 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --prose-file ...` 를 호출한다. 따라서 Codex route 에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. 라우팅 config 는 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 이며, 비활성/미설정 기본값은 Claude 다.
+Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --prose-file ...` 로 저장한다. 따라서 Codex route 에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. 라우팅 config 는 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 이며, 비활성/미설정 기본값은 Claude 다.
 
 **호출 prompt 작성 — MUST**: 호출 직전 해당 `agent.md` §"호출자가 prompt 로 전달하는 정보" 항목 read 후 prompt 작성 (형식 자유, 정보 명시 의무).
 

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -5,7 +5,7 @@
 # 동작:
 #   1. staged 파일 목록 추출 (git diff --cached --name-only)
 #   2. harness/ | tests/ | agents/ | .github/workflows/python-tests.yml 매칭 시만 실행
-#   3. python3 -m unittest discover -s tests
+#   3. python3.11/python3 -m unittest discover -s tests
 #
 # 종료 코드:
 #   0 — 통과 (or 매칭 0)
@@ -36,6 +36,8 @@ echo "[pytest-gate] harness/tests/agents 변경 감지 — 단위 테스트 실�
 # GIT_WORK_TREE) 가 inherited 되어 자식 git worktree add 호출이 fail. unset 후 실행.
 PYTHON_BIN="${PYTHON_BIN:-}"
 if [ -z "$PYTHON_BIN" ]; then
+  # Tests use Python 3.10+ syntax (for example PEP 604 unions). Prefer 3.11
+  # when present so the local hook matches CI instead of macOS system python3.
   if command -v python3.11 >/dev/null 2>&1; then
     PYTHON_BIN="python3.11"
   else

--- a/scripts/dcness-codex-validator
+++ b/scripts/dcness-codex-validator
@@ -24,6 +24,9 @@ The wrapper runs Codex in read-only mode. On Codex CLI versions that expose
 approval flags, it also passes -a never:
   codex exec -C "$PROJECT_ROOT" -s read-only [-a never] --output-last-message "$TMP_PROSE"
 
+Before running Codex, it embeds the installed dcness Codex skill from
+$CODEX_HOME/skills or the plugin bundle when available.
+
 Then it stores the final prose with:
   dcness-helper end-step <agent> [MODE] --prose-file "$TMP_PROSE"
 USAGE
@@ -117,8 +120,37 @@ TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-${AGENT}.XXXXXX.md")"
 TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-prompt-${AGENT}.XXXXXX.md")"
 trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
 
+SKILL_NAME="dcness-${AGENT}"
+CODEX_HOME_DIR="${CODEX_HOME:-${HOME:-}/.codex}"
+SKILL_FILE=""
+SKILL_CANDIDATES=(
+  "$CODEX_HOME_DIR/skills/$SKILL_NAME/SKILL.md"
+  "$SCRIPT_DIR/../codex/skills/$SKILL_NAME/SKILL.md"
+)
+for CANDIDATE in "${SKILL_CANDIDATES[@]}"; do
+  if [ -f "$CANDIDATE" ]; then
+    SKILL_FILE="$CANDIDATE"
+    break
+  fi
+done
+
 {
-  echo "Use the dcness-${AGENT} Codex skill if it is installed."
+  echo "dcNess validation agent: $AGENT"
+  if [ -n "$MODE" ]; then
+    echo "dcNess validation mode: $MODE"
+  else
+    echo "dcNess validation mode: default"
+  fi
+  echo
+  if [ -n "$SKILL_FILE" ]; then
+    echo "Use these $SKILL_NAME Codex skill instructions:"
+    echo "----- BEGIN $SKILL_NAME SKILL.md -----"
+    cat "$SKILL_FILE"
+    echo "----- END $SKILL_NAME SKILL.md -----"
+  else
+    echo "Use the $SKILL_NAME Codex skill if it is installed."
+  fi
+  echo
   echo "You are running as a read-only dcNess validation agent."
   echo "Do not edit files, create files inside the repo, commit, push, or open PRs."
   echo "Return prose only. The final paragraph must contain exactly one conclusion word: PASS, FAIL, or ESCALATE."

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -1,0 +1,138 @@
+"""Smoke tests for the Codex validator wrapper."""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts" / "dcness-codex-validator"
+
+
+class CodexValidatorWrapperTests(unittest.TestCase):
+    def test_embeds_installed_skill_and_mode_before_prompt(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Review this implementation.\n", encoding="utf-8")
+
+            codex_home = tmp / "codex-home"
+            skill_dir = codex_home / "skills" / "dcness-architecture-validator"
+            skill_dir.mkdir(parents=True)
+            skill_dir.joinpath("SKILL.md").write_text(
+                "# Test Skill\n\nSPECIAL_SKILL_CHECKLIST\n",
+                encoding="utf-8",
+            )
+
+            prompt_capture = tmp / "captured-prompt.md"
+            prose_capture = tmp / "captured-prose.md"
+            helper_args = tmp / "helper-args.txt"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "exec" ] && [ "${2:-}" = "--help" ]; then
+                      echo "Usage: codex exec"
+                      exit 0
+                    fi
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat > "$PROMPT_CAPTURE"
+                    printf 'Codex prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" > "$HELPER_ARGS"
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --prose-file)
+                          cp "$2" "$PROSE_CAPTURE"
+                          exit 0
+                          ;;
+                      esac
+                      shift
+                    done
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "CODEX_HOME": str(codex_home),
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    "PROMPT_CAPTURE": str(prompt_capture),
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(WRAPPER),
+                    "architecture-validator",
+                    "SECOND",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            prompt = prompt_capture.read_text(encoding="utf-8")
+            self.assertIn("dcNess validation agent: architecture-validator", prompt)
+            self.assertIn("dcNess validation mode: SECOND", prompt)
+            self.assertIn("SPECIAL_SKILL_CHECKLIST", prompt)
+            self.assertIn("Review this implementation.", prompt)
+            self.assertTrue(
+                helper_args.read_text(encoding="utf-8")
+                .strip()
+                .startswith("end-step architecture-validator SECOND --prose-file "),
+            )
+            self.assertEqual(
+                prose_capture.read_text(encoding="utf-8"),
+                "Codex prose\n\nPASS\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: PR #556 review follow-up after merge

## 배경 및 문제

- PR #556 리뷰에서 Codex CLI가 `$CODEX_HOME/skills/dcness-*`를 `codex exec` 컨텍스트에 자동 주입하는지 미검증이라는 지적이 있었다.
- wrapper가 soft hint에 의존하면 skill 체크리스트가 실제 prompt에 들어가지 않을 수 있다.
- architecture-validator의 mode가 `end-step`에는 전달되지만 Codex prompt에는 명시되지 않았다.

## 원인 (해당 시)

- Codex skill 자동 로딩 여부를 wrapper 계약으로 고정하지 않았다.

## 작업내용

- `scripts/dcness-codex-validator`가 `$CODEX_HOME/skills/dcness-<agent>/SKILL.md`를 우선 읽고, 없으면 plugin bundle의 `codex/skills/.../SKILL.md`를 prompt에 직접 포함한다.
- wrapper prompt header에 validation agent와 mode를 명시한다.
- fake `codex`/`dcness-helper` 기반 wrapper smoke test를 추가했다.
- `scripts/check_python_tests.sh`에 Python 3.11 우선 선택 이유를 주석으로 남겼다.
- README와 plugin docs에 wrapper의 skill 직접 포함 동작을 반영했다.

## 결정 근거

- 실제 모델 호출로 자동 주입 여부를 한 번 확인하는 대신, wrapper가 skill 본문을 직접 포함하면 Codex CLI 내부 동작 변화와 무관하게 validator parity를 보장할 수 있다.
- begin-step 자동 호출은 기존 command 흐름과 중복될 수 있어 이번 변경에는 포함하지 않았다.

## 배포 경로 검증 (plug-in 영향 시)

- wrapper는 plugin bundle의 `scripts/dcness-codex-validator`로 배포된다.
- Codex skills는 기존 `/init-dcness` 경로로 `$CODEX_HOME/skills/dcness-*`에 설치/갱신된다.
- `$CODEX_HOME` skill이 없을 때도 plugin bundle의 `codex/skills/dcness-*`를 fallback으로 읽는다.
- 관련 사용자 문서: `README.md`, `docs/plugin/hooks.md`, `docs/plugin/loop-procedure.md` 갱신.

## Test Plan

- [x] `python3 -m unittest tests.test_codex_validator_wrapper -v`
- [x] `/Users/dc.kim/.local/bin/python3.11 -m unittest discover -s tests -v`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `bash -n scripts/dcness-codex-validator scripts/check_python_tests.sh`
- [x] `claude plugin validate .`
- [x] commit pre-commit hook: 493 tests PASS

## 참고

- Follow-up to #556.