### PR TITLE
[docs] av 1차 FAIL 재진입 대상 수정 (system-architect) — codex 회고 리뷰 반영

### DIFF
--- a/skills/architect-loop/architect-loop-routing.md
+++ b/skills/architect-loop/architect-loop-routing.md
@@ -63,7 +63,7 @@ flowchart TB
 | architecture-validator FAIL → architect 재진입 | 2 cycle | 사용자 위임 |
 | module-architect `SPEC_GAP_FOUND` → 보강 → 신규 케이스 재진입 | 2 cycle | 사용자 위임 |
 
-> **architecture-validator FAIL 재진입 대상 = 영역별** — Placeholder·공통 SSOT(1차) / Cross-Story Interface·Implementation Simulation·Origin Anchor(2차) → 해당 **module-architect** 재진입, 모듈 의존 그래프 영역 → **system-architect** 재진입.
+> **architecture-validator FAIL 재진입 대상 = 시점·영역별** — **1차**(Placeholder·공통 SSOT) → **system-architect** 재진입 (이 시점 module-architect 미실행 — 검증 대상이 system-architect 산출물이므로). **2차**(Cross-Story Interface·Implementation Simulation·Origin Anchor) → 해당 **module-architect** 재진입, 단 모듈 의존 그래프 영역이면 **system-architect** 재진입.
 > cycle 발생 시 **working tree only — commit X.** PASS 후에만 commit (cycle 도중 산출물은 덮어쓰기 전제).
 
 ## 4. escalate 처리


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: PR #562 hotfix — codex 회고 리뷰가 잡은 라우팅 버그 수정 (관련 이슈 없음)

## 배경 및 문제

PR #562 (architect-loop skill 전환) 검토 중 "정보 보존 검증" 명목으로 `architect-loop-routing.md §3` 에 av FAIL 재진입 대상 노트를 보강했는데, 1차/2차를 잘못 묶었다. `/codex:review` 회고 리뷰가 P2 로 포착:

> architecture-validator 1차 FAIL(Placeholder·공통 SSOT)을 module-architect 로 보내면, 그 시점엔 module-architect 가 아직 안 돌았고 검증 대상이 system-architect 산출물이라 틀린 agent 가 재시도하게 된다.

그래프 §1(`AV1 -->|FAIL ≤2| SA`)·원본(`commands/architect-loop.md:97` HEAD) 과도 모순이었다.

## 원인

검토 중 추가한 보강 노트가 "Placeholder·공통 SSOT(1차) → module-architect" 로 1차를 module-architect 에 잘못 귀속.

## 작업내용

- `architect-loop-routing.md §3` 노트 정정 — **1차(Placeholder·공통 SSOT) → system-architect 재진입**, 2차(Cross-Story·Impl Simulation·Origin Anchor) → module-architect 재진입(모듈 의존 그래프 영역이면 system-architect).

## 결정 근거

- 원본 `commands/architect-loop.md:97-98` + 그래프 §1 이 진본. 보강 노트를 그에 맞춤.
- codex 회고 리뷰의 P2 가 정확 — 채택. (P1 "command 유지" 는 skills/ 자동발견 실증으로 기우 판정 — apps-in-toss/claude-plugins-official plugin 이 SKILL.md 로 노출 중)

## 배포 경로 검증 (plug-in 영향 시)

경로 1 (plugin 본체 자동) — `skills/architect-loop/architect-loop-routing.md` 1줄 수정, plugin update 로 자동 반영.

## Test Plan

- [x] check_cross_refs PASS
- [x] 그래프 §1 (AV1 FAIL→SA / AV2 FAIL→MA) 과 §3 노트 정합

🤖 Generated with [Claude Code](https://claude.com/claude-code)