### PR TITLE
[docs] release 0.4.0 — commands→skills 전환

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — prose-only 결정론(메타 LLM 호출 0) + 작업 순서·접근 영역 강제. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.3.0"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Lightweight governance harness for Claude Code — prose-only determinism (no format-marker ladder, no meta-LLM) + enforced work-order and access boundaries.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,41 @@
 
 ---
 
+## v0.4.0 (2026-06-04)
+
+**커밋 범위**: `v0.3.0..v0.4.0`
+**핵심 변경**: `commands/*.md` → `skills/<name>/SKILL.md` 승격 (7 skill) + 라우팅을 각 skill 옆 `<name>-routing.md` 단일 진본으로 분산 + 전역 SSOT (`orchestration.md` / `handoff-matrix.md` / 전역 `routing.md`) 폐기. 부수 — Codex read-only validator skills 3종 신설 + harness 코드 다이어트 + agent 기능 강화 + 문서 컨벤션 SSOT 신설.
+
+### 무엇이 바뀌나
+
+1. **commands → skills 전환 (7 skill)** — `architect-loop` / `impl-loop` / `impl` / `issue-report` / `product-plan` / `tech-review` / `ux` 를 `commands/<name>.md` 단일 파일에서 `skills/<name>/SKILL.md` (진행 절차) + `skills/<name>/<name>-routing.md` (라우팅 SSOT — mermaid + 결론→다음 매핑 + retry 한도 + escalate) 디렉토리로 승격. SKILL.md 경량화. frontmatter `name` 동일 → 사용자 호출 방식 (`/architect-loop`·`/impl` 등) 그대로. plugin.json 무변경 (skills/ 자동 스캔, namespace `dcness:<name>`). 옛 `commands/<name>.md` 삭제 (동일 name 중복 등록 충돌 회피). 남은 commands = `efficiency` / `init-dcness` / `run-review` / `smart-compact`.
+
+2. **라우팅 SSOT 분산 + 전역 집계 파일 폐기** — `docs/plugin/orchestration.md` + `handoff-matrix.md` + 전역 `routing.md` 폐기. 통찰 = "라우팅은 skill 이 소유, agent 는 결론(enum)만 낸다". 런타임에 안 읽히던 전역 집계 view(중복)를 각 skill 옆 `<name>-routing.md` 단일 진본으로 이전.
+
+3. **Codex read-only validator skills 신설** — `code-validator` / `architecture-validator` / `pr-reviewer` 3종을 Codex read-only 실행으로 route 가능. `codex/skills/dcness-*/SKILL.md` + `scripts/dcness-codex-validator` wrapper (Codex read-only sandbox + prose 수집 + end-step 저장 + mutation guard) + `harness/agent_routing.py` (local routing). **사용자 repo 에 파일 안 만듦** — `~/.claude/plugins/data/dcness-dcness/routing.json` + `$CODEX_HOME/skills/` 에만. read-only 3종 한정(mutation agent migration 차단).
+
+4. **harness 코드 다이어트** — `harness/interpret_strategy.py` + `scripts/analyze_metrics.mjs` + `tests/eval_{deepeval,agentevals}.py` 삭제 (enum 추출 / 전략 해석 / 외부 eval 의존 제거). `harness/agent_routing.py` + `harness/prev_tasks.py` 신규.
+
+5. **agent 기능 강화** — architecture-validator premortem 시뮬레이션 + origin anchor provenance 검증 / tech-reviewer → system-architect signal 전달 / 신규 의존 경량 escalate (G3) / tech-stack grill checkpoint / UI-less 화면 ux skip gate / impl-loop prev-tasks 컨텍스트 inject + dry-run preview.
+
+6. **문서 컨벤션 SSOT + 정리** — `docs/internal/doc-conventions.md` 신규 (문서 작성 규약 단일 진본). anchor-ref 마이그레이션 (§N 참조 → 제목 자연어), codeblock/주석 stale-ref 자연어화, routing/loop 중복 다이어트, README·manifest sync, loop-procedure 단일 목적 슬림화.
+
+### 사용자 영향
+
+- **외부 활성 프로젝트: `claude plugin update dcness@dcness` 로 skills 전환 자동 반영** — 호출 방식 (`/architect-loop`·`/impl-loop`·`/impl`·`/issue-report`·`/product-plan`·`/tech-review`) 그대로. 옛 `commands/<name>.md` 는 삭제됐지만 같은 namespace 로 skills 가 등록돼 동작 동형. (런타임 트리거 100% 확인은 사용자 환경에서 한 번 호출.)
+- **Codex validator 쓰려면 `/init-dcness` 재실행** — plugin update 후 `/init-dcness` 재실행 시 Step 2.10 에서 `$CODEX_HOME/skills/dcness-*` 복사 + routing opt-in (Y/n). 끄기 = `dcness-helper routing disable-codex-validation`. opt-in 안 하면 기존 (메인 Claude in-session) validator 그대로.
+- **옛 전역 SSOT 앵커 참조** — `orchestration.md` / `handoff-matrix.md` / 전역 `routing.md` 의 §N 앵커 참조는 전부 각 skill routing.md 또는 제목 자연어로 마이그레이션됨. 외부 사용자가 직접 참조하던 링크 없으면 영향 없음.
+
+### 업데이트
+
+```sh
+claude plugin update dcness@dcness
+# Codex validator 까지 쓰려면:
+/init-dcness   # 재실행 → Step 2.10 routing opt-in
+```
+
+---
+
 ## v0.3.0 (2026-05-26)
 
 **커밋 범위**: `v0.2.34..v0.3.0`


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 릴리즈 버전 bump (v0.4.0) — 특정 이슈 없음 (v0.3.0..HEAD 누적 머지물 발행)

## 배경 및 문제

v0.3.0 (2026-05-26) 이후 40개 PR / 122 커밋이 머지됐으나 plug-in 버전 미발행 상태. 외부 활성 프로젝트가 `claude plugin update` 로 받을 버전 태그가 없어 누적 변경(commands→skills 전환 등)이 사용자 환경에 도달하지 못함.

## 원인 (해당 시)

-

## 작업내용

- `.claude-plugin/plugin.json` version 0.3.0 → 0.4.0
- `.claude-plugin/marketplace.json` metadata.version 0.3.0 → 0.4.0
- `docs/internal/release-notes.md` 최상단 v0.4.0 섹션 추가 (커밋 범위 `v0.3.0..v0.4.0`)

핵심 변경 요약:
- commands → skills 전환 (7 skill): architect-loop / impl-loop / impl / issue-report / product-plan / tech-review / ux
- 라우팅 SSOT 분산 + `orchestration.md` / `handoff-matrix.md` / 전역 `routing.md` 폐기
- Codex read-only validator skills 3종 신설 (code-validator / architecture-validator / pr-reviewer)
- harness 코드 다이어트 + agent 기능 강화 + 문서 컨벤션 SSOT 신설

## 결정 근거

- **minor bump (0.4.0)** — 0.x 에서 구조 큰 변경 = minor 관례 (0.2.34 → 0.3.0 동일 패턴). commands→skills 전환이 핵심 구조 변경.
- **브랜치명 `docs/release_0_4_0_...`** — git-naming 게이트가 `.`(점) 불허라 과거 최신 패턴(언더스코어 구분)대로.

## 배포 경로 검증 (plug-in 영향 시)

- 본 PR 은 버전 bump 전용 — 실제 기능 파일은 `v0.3.0..HEAD` 각 PR 에서 배포 경로 검증 완료 (경로 1: plug-in 본체 `agents/**`·`skills/**`·`hooks/**` 자동 / 경로 2: `init-dcness` Step 2.10 Codex skills + hook shim).
- 본 PR 머지 + `v0.4.0` 태그 후 외부 사용자 `claude plugin update dcness@dcness` 로 일괄 수령.

## Test Plan

- [x] plugin-manifest 게이트 로컬 PASS (`dcness@0.4.0`)
- [x] cross-ref 게이트 로컬 PASS (dead link / 옛 명칭 0건)
- [ ] CI 전체 게이트 PASS 후 머지

## 참고

- 릴리즈 절차: `docs/internal/plugin-release.md`
- 릴리즈 노트: `docs/internal/release-notes.md`
