### PR TITLE
[issue-593] session-start update-check semver 비교로 다운그레이드 오발화 차단

### DIFF
--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -55,9 +55,14 @@ if [[ -n "$INSTALLED_VERSION" && "$INSTALLED_VERSION" != "null" ]]; then
     fi
   fi
 
-  # 버전 다르면 알림
+  # LATEST 가 INSTALLED 보다 semver 상 높을 때만 알림.
+  # 단순 != 비교는 설치 버전이 더 높은 경우(update 직후 + stale 24h 캐시)에도
+  # "0.4.0 → 0.3.0" 처럼 다운그레이드 권유로 오발화 → semver 대소로 방향 강제 (#593).
   if [[ -n "$LATEST_VERSION" && "$INSTALLED_VERSION" != "$LATEST_VERSION" ]]; then
-    DCNESS_UPDATE_MSG="[dcness update available: ${INSTALLED_VERSION} → ${LATEST_VERSION}. \`claude plugin update\` 권장 — 옛 운영 룰 잔재 회피]"
+    HIGHER=$(printf '%s\n%s\n' "$INSTALLED_VERSION" "$LATEST_VERSION" | sort -V | tail -1)
+    if [[ "$HIGHER" == "$LATEST_VERSION" ]]; then
+      DCNESS_UPDATE_MSG="[dcness update available: ${INSTALLED_VERSION} → ${LATEST_VERSION}. \`claude plugin update\` 권장 — 옛 운영 룰 잔재 회피]"
+    fi
   fi
 fi
 export DCNESS_UPDATE_MSG


### PR DESCRIPTION
## 관련 이슈 번호

Closes #593

## 배경 및 문제

plugin v0.4.0 배포 후, 0.3.0 → 0.4.0 으로 `claude plugin update` 한 사용자가 24h 내 세션 시작 시 다음 알림(다운그레이드 권유처럼 보임)을 본다:

```
[dcness update available: 0.4.0 → 0.3.0]
```

## 원인

`hooks/session-start.sh:59` 의 update-체크가 `INSTALLED != LATEST` 단순 부등 비교. 설치 버전이 LATEST 보다 **더 높아도** 알림이 오발화한다. `LATEST` 는 `last-update-check.txt` 의 24h 캐시값(배포 전 fetch = 0.3.0)이라, update 직후 캐시가 아직 fresh 한 구간에서 `INSTALLED(0.4.0) != LATEST(0.3.0)` 이 참이 됨.

## 작업내용

- `hooks/session-start.sh`: update-체크 버전 비교를 단순 `!=` → **semver 대소(`sort -V`)** 로 변경. 둘 중 높은 버전을 구해 그게 `LATEST` 일 때만(= `INSTALLED < LATEST`) 알림 발화.

## 결정 근거

- `sort -V` = GNU coreutils + Apple/BSD sort 공통 지원(로컬 Apple sort 2.3 확인). semver 정렬 정확(0.10.0 > 0.4.0 — 사전식 비교 함정 회피).
- **릴리즈(버전 bump)는 본 PR 에 포함 안 함** — main 선반영만. 사용자 지시(수정은 지금, 릴리즈는 후속 변경과 묶어서)대로 다음 릴리즈에 함께 배포.

## 배포 경로 검증 (plug-in 영향 시)

- `hooks/session-start.sh` = 경로 1 (plug-in 본체). 다음 버전 bump + `claude plugin update` 시 외부 활성 프로젝트 전체 적용.
- 본 PR 단독으론 버전 동일(0.4.0)이라 외부 미도달 — **의도된 보류**. 즉시 정상화가 필요한 환경은 `last-update-check.txt` 캐시 갱신으로 별도 해소.

## Test Plan

- [x] `bash -n` 문법 검증
- [x] 전 케이스 시뮬레이션 (0.4.0→0.3.0 no-alert / 0.3.0→0.4.0 alert / 0.2.34→0.4.0 alert / 0.4.0→0.10.0 semver alert)
- [ ] CI 전체 게이트 PASS 후 머지

## 참고

- 이슈 #593
