### PR TITLE
[docs] risk-based workflow router 도입 — 리스크로 workflow 고르기

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@
 
 | 파일 | 언제 읽나 |
 |---|---|
+| [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md) | 자유 형식 작업 요청을 어떤 workflow 로 보낼지 (risk tier — gate 축 × shape 축) 판단 시 |
 | [`docs/plugin/git-spec.md`](docs/plugin/git-spec.md) | 브랜치·커밋·PR 네이밍 규칙 SSOT — 모든 커밋 작업에 적용 |
 | 각 skill 의 `<skill>-routing.md` ([`architect-loop`](skills/architect-loop/architect-loop-routing.md) / [`impl-loop`](skills/impl-loop/impl-loop-routing.md) 등) | 라우팅 진본 (mermaid + enum 표) + retry 한도 + escalate — agent 결론 → 다음 호출 매핑 수정 시 |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md) | Step 0~8 mechanics (begin-run → begin-step → Agent → end-step → finalize-run) 수정 시 |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dcness-helper routing disable-codex-validation
 
 | 리스크 신호 | 진입점 |
 |---|---|
-| 구체 파일 path · symbol · 이슈 번호 (high-risk 없음) | `/impl-loop` 또는 단발 구현 — 기획/설계 gate 만 skip (branch/PR/test/리뷰 유지) |
+| 구체 파일 path · symbol · 승인된 이슈/PR 번호 (high-risk 없음) | `/impl-loop` 또는 단발 구현 — 기획/설계 gate 만 skip (branch/PR/test/리뷰 유지) |
 | 목표·범위 모호 ("개선해줘 / 새 기능") | `/product-plan` 그릴미 |
 | 새 feature · 외부 의존(API/SDK/model) · auth/보안 · migration · public API breakage | `/product-plan → (외부 의존 시) /tech-review → /architect-loop → /impl-loop` |
 | (설계 완료 후) 여러 task/PR 로 분할 · 재개/handoff | `/impl-loop` chain |

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ dcness-helper routing disable-codex-validation
 |---|---|
 | 구체 파일 path · symbol · 이슈 번호 (high-risk 없음) | `/impl-loop` 또는 단발 구현 — 기획/설계 gate 만 skip (branch/PR/test/리뷰 유지) |
 | 목표·범위 모호 ("개선해줘 / 새 기능") | `/product-plan` 그릴미 |
-| 새 feature · 외부 의존(API/SDK/model) · auth/보안 · migration · public API breakage | `/product-plan → /tech-review → /architect-loop → /impl-loop` |
+| 새 feature · 외부 의존(API/SDK/model) · auth/보안 · migration · public API breakage | `/product-plan → (외부 의존 시) /tech-review → /architect-loop → /impl-loop` |
 | 여러 PR 로 분할 · 재개/handoff 필요 | `/impl-loop` chain |
 
 dcNess 는 단계별 skill 로 작업을 끌고 간다. `/impl-loop` 은 **설계 산출물(impl task 문서)이

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ dcness-helper routing disable-codex-validation
 | 구체 파일 path · symbol · 이슈 번호 (high-risk 없음) | `/impl-loop` 또는 단발 구현 — 기획/설계 gate 만 skip (branch/PR/test/리뷰 유지) |
 | 목표·범위 모호 ("개선해줘 / 새 기능") | `/product-plan` 그릴미 |
 | 새 feature · 외부 의존(API/SDK/model) · auth/보안 · migration · public API breakage | `/product-plan → (외부 의존 시) /tech-review → /architect-loop → /impl-loop` |
-| 여러 PR 로 분할 · 재개/handoff 필요 | `/impl-loop` chain |
+| (설계 완료 후) 여러 task/PR 로 분할 · 재개/handoff | `/impl-loop` chain |
 
 dcNess 는 단계별 skill 로 작업을 끌고 간다. `/impl-loop` 은 **설계 산출물(impl task 문서)이
 있어야** 동작하므로, 보통 아래 순서를 탄다.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,16 @@ dcness-helper routing disable-codex-validation
 
 ## 작업 흐름
 
+**명령을 외우지 말고 리스크로 고르기** — 작업 요청의 리스크 신호로 *가장 작은* workflow 를 고른다.
+상세 판정(gate 축 × shape 축)은 [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md).
+
+| 리스크 신호 | 진입점 |
+|---|---|
+| 구체 파일 path · symbol · 이슈 번호 (high-risk 없음) | `/impl-loop` 또는 단발 구현 — 기획/설계 gate 만 skip (branch/PR/test/리뷰 유지) |
+| 목표·범위 모호 ("개선해줘 / 새 기능") | `/product-plan` 그릴미 |
+| 새 feature · 외부 의존(API/SDK/model) · auth/보안 · migration · public API breakage | `/product-plan → /tech-review → /architect-loop → /impl-loop` |
+| 여러 PR 로 분할 · 재개/handoff 필요 | `/impl-loop` chain |
+
 dcNess 는 단계별 skill 로 작업을 끌고 간다. `/impl-loop` 은 **설계 산출물(impl task 문서)이
 있어야** 동작하므로, 보통 아래 순서를 탄다.
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -18,7 +18,7 @@ risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**
 세 문장으로 못 박는다:
 
 1. **concrete signal 은 direct impl 의 *필요조건*이지 *충분조건*이 아니다** — high-risk trigger 가 하나라도 있으면 direct impl 이 아니다. (예: "auth/payment 파일 X 고쳐 구독 SDK 붙여줘" 는 파일 path 가 있어도 high-risk 라 tier 3.)
-2. **direct impl 은 *절차 생략*이 아니라 *기획/설계 gate 생략*이다** — branch / PR / test / pr-reviewer / CI 게이트는 그대로 지킨다. 새 command/skill 이 아니라 메인이 직접 도는 단발 구현 경로다.
+2. **direct impl 은 *절차 생략*이 아니라 *기획/설계 gate 생략*이다** — branch / PR / test / pr-reviewer / CI 게이트는 그대로 지킨다. 새 command/skill 이 아니라 메인이 직접 도는 단발 구현 경로다. 단발 경로는 conveyor loop *밖*이라 code-validator(구현↔impl task 계획 정합 검증) 단계가 없다 — 검증할 impl task 계획 자체가 없는 케이스이기 때문. impl task 가 있으면 `/impl-loop` 로 가서 code-validator 를 포함한다. (catastrophic "src 변경 후 code-validator 없는 pr-reviewer 금지" 룰은 active run 안에서만 적용 — 단발 경로엔 해당 없음.)
 3. **high-risk 와 durable 은 합성된다** — 둘 다 맞으면 `/product-plan → (외부 의존 시) /tech-review → /architect-loop → /impl-loop chain`.
 
 **gate 축** (먼저 — *어느 workflow 로 진입*할지. 위에서 아래로):
@@ -31,13 +31,13 @@ risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**
 
 4. 구현이 여러 task/PR 로 나뉘나(resume/handoff/long-running 포함)? → `/impl-loop` **chain**, 아니면 single. chain 은 impl task list 가 있어야 시작하므로, **모호한 multi-PR 요청은 durable 로 직행하지 말고 먼저 gate(1~2)로** 보낸다.
 
-> 버그/이슈 신고는 gate 판정 *전*에 `/issue-report` 로 먼저 분류한다 ([issue-report 와의 경계](#issue-report-와의-경계)) — KNOWN_ISSUE / DESIGN_ISSUE / SCOPE_ESCALATE 를 건너뛰지 않기 위해. 분류 결과가 다시 위 tier 로 흐른다.
+> **아직 분류 안 된 새 버그/이슈 신고**("이거 안 돼 / 이상해")는 gate 판정 *전*에 `/issue-report` 로 먼저 분류한다 ([issue-report 와의 경계](#issue-report-와의-경계)) — KNOWN_ISSUE / DESIGN_ISSUE / SCOPE_ESCALATE 를 건너뛰지 않기 위해. 분류 결과가 다시 위 tier 로 흐른다. (반면 이미 분류·승인된 GitHub issue/PR 번호를 "구현/수정해줘"는 concrete signal 이므로 곧장 tier 1.)
 
 ## 라우팅 그래프
 
 ```mermaid
 flowchart TB
-  REQ["자유 형식 작업 요청"] --> BUG{"버그/이슈 신고?"}
+  REQ["자유 형식 작업 요청"] --> BUG{"새(미분류) 버그/이슈 신고?"}
   BUG -->|예| IR["/issue-report 분류 → 결과가 tier 로"]
   BUG -->|아니오| HR{"high-risk trigger?"}
   HR -->|예| T3["product-plan → (외부 의존 시) tech-review → architect-loop → impl-loop"]
@@ -66,7 +66,7 @@ flowchart TB
 
 | tier | 트리거 (signal) | 진입점 | 왜 이 tier |
 |---|---|---|---|
-| **1. direct impl** | concrete signal(파일 path · 함수/클래스/symbol · issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only · 이미 승인된 impl 파일) **1개 이상 AND high-risk trigger 0개**. (버그/이슈 신고는 tier 1 직행 X — 먼저 `/issue-report` 분류) | impl task/issue 있으면 `/impl-loop`, 없으면 **메인이 branch → PR → test → pr-reviewer → CI 를 지키는 단발 구현 경로** (새 skill 아님) | 의도·범위·수용 기준이 신호로 이미 명확 → 기획/설계 gate 만 비용. **검증·리뷰 게이트는 유지** |
+| **1. direct impl** | concrete signal(파일 path · 함수/클래스/symbol · **이미 분류·승인된** issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only · 이미 승인된 impl 파일) **1개 이상 AND high-risk trigger 0개**. (아직 분류 안 된 새 버그/이슈 신고는 tier 1 직행 X — 먼저 `/issue-report` 분류) | impl task/issue 있으면 `/impl-loop`, 없으면 **메인이 branch → PR → test → pr-reviewer → CI 를 지키는 단발 구현 경로** (새 skill 아님) | 의도·범위·수용 기준이 신호로 이미 명확 → 기획/설계 gate 만 비용. **검증·리뷰 게이트는 유지** |
 | **2. clarify** | 목표/사용자/성공 기준 모호 · "좋게 만들어줘 / 개선해줘 / 새 기능"처럼 범위 넓음 · 사용자가 "뭘 원하는지 모르겠다" | `/product-plan` 그릴미 (또는 메인이 명확화 질문) | shared understanding 부재 → 구현 전에 의도부터 |
 | **3. plan + review** | high-risk trigger 1개 이상 (아래 표) | `/product-plan` → (외부 의존 시) `/tech-review` → `/architect-loop` → `/impl-loop` | 되돌리기 비싼 결정 → 설계·검증 consensus 필요 |
 | **4. durable chain** | (gate 통과 후) 구현이 여러 task/PR 로 분할 · resume/handoff/audit · long-running · 병렬 후보 | `/impl-loop` chain 모드 — **impl task list 가 있어야 시작** (모호하면 먼저 tier 2/3) | **shape 축** — gate 가 아니라 실행 형태. 단일 PR 로 안 끝남 → task 경계 라우팅·재개 이득 |
@@ -87,10 +87,10 @@ flowchart TB
 
 본 router 와 [`issue-report`](../../skills/issue-report/issue-report-routing.md) 의 qa 분류는 **scope 가 다르다**:
 
-- **issue-report (qa 분류)** = *이미 발견된 버그/이슈* 를 분류한다.
+- **issue-report (qa 분류)** = *아직 분류 안 된 새 버그/이슈 신고* 를 분류한다 (KNOWN_ISSUE / DESIGN_ISSUE / SCOPE_ESCALATE 등).
 - **본 router** = *자유 형식 작업 요청* 을 사전 분류해 entrypoint 를 고른다.
 
-버그/이슈 신고는 먼저 `/issue-report` 로 분류하고, 그 결과가 다시 본 router 의 tier 로 흐른다 — 예: 기능 버그/정리 작업 → tier 1(direct impl) fallback, 큰 변경/다중 모듈 → tier 3(plan + review).
+아직 분류 안 된 새 버그/이슈 신고는 먼저 `/issue-report` 로 분류하고, 그 결과가 다시 본 router 의 tier 로 흐른다 — 예: 기능 버그/정리 작업 → tier 1(direct impl) fallback, 큰 변경/다중 모듈 → tier 3(plan + review). 반면 **이미 분류·승인된** GitHub issue/PR 번호를 "구현/수정해줘"는 그 자체가 concrete signal 이라 곧장 tier 1 (재분류 불필요).
 
 ## 하위 routing 과의 관계 (top-down 단방향)
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -25,7 +25,7 @@ risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**
 
 1. **high-risk trigger 가 있나?** → **plan + review** (tier 3)
 2. **목표/범위가 모호한가?** → **clarify** (tier 2)
-3. **high-risk 없고 concrete signal + impl task/issue 가 있나?** → **direct impl** (tier 1)
+3. **high-risk 없고 concrete signal 이 있나?** → **direct impl** (tier 1). impl task/issue 가 있으면 `/impl-loop`, 없으면 단발 구현 경로 — 이건 tier 1 *내부* 분기일 뿐, 진입 조건이 아니다.
 
 **shape 축** (gate 통과 *후* — *구현을 어떻게 실행*할지):
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -19,7 +19,7 @@ risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**
 
 1. **concrete signal 은 direct impl 의 *필요조건*이지 *충분조건*이 아니다** — high-risk trigger 가 하나라도 있으면 direct impl 이 아니다. (예: "auth/payment 파일 X 고쳐 구독 SDK 붙여줘" 는 파일 path 가 있어도 high-risk 라 tier 3.)
 2. **direct impl 은 *절차 생략*이 아니라 *기획/설계 gate 생략*이다** — branch / PR / test / pr-reviewer / CI 게이트는 그대로 지킨다. 새 command/skill 이 아니라 메인이 직접 도는 단발 구현 경로다.
-3. **high-risk 와 durable 은 합성된다** — 둘 다 맞으면 `/product-plan → /tech-review → /architect-loop → /impl-loop chain`.
+3. **high-risk 와 durable 은 합성된다** — 둘 다 맞으면 `/product-plan → (외부 의존 시) /tech-review → /architect-loop → /impl-loop chain`.
 
 판정은 위에서 아래로 본다:
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -21,47 +21,55 @@ risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**
 2. **direct impl 은 *절차 생략*이 아니라 *기획/설계 gate 생략*이다** — branch / PR / test / pr-reviewer / CI 게이트는 그대로 지킨다. 새 command/skill 이 아니라 메인이 직접 도는 단발 구현 경로다.
 3. **high-risk 와 durable 은 합성된다** — 둘 다 맞으면 `/product-plan → (외부 의존 시) /tech-review → /architect-loop → /impl-loop chain`.
 
-판정은 위에서 아래로 본다:
+**gate 축** (먼저 — *어느 workflow 로 진입*할지. 위에서 아래로):
 
-1. **high-risk trigger 가 있나?** → 있으면 **plan + review** (tier 3)
-2. **multi-PR / resume / handoff 가 있나?** → 있으면 impl 은 **durable chain** (tier 4)
-3. **목표/범위가 모호한가?** → 있으면 **clarify** (tier 2)
-4. **high-risk 없고 concrete signal 이 있나?** → **direct impl** (tier 1)
+1. **high-risk trigger 가 있나?** → **plan + review** (tier 3)
+2. **목표/범위가 모호한가?** → **clarify** (tier 2)
+3. **high-risk 없고 concrete signal + impl task/issue 가 있나?** → **direct impl** (tier 1)
+
+**shape 축** (gate 통과 *후* — *구현을 어떻게 실행*할지):
+
+4. 구현이 여러 task/PR 로 나뉘나(resume/handoff/long-running 포함)? → `/impl-loop` **chain**, 아니면 single. chain 은 impl task list 가 있어야 시작하므로, **모호한 multi-PR 요청은 durable 로 직행하지 말고 먼저 gate(1~2)로** 보낸다.
+
+> 버그/이슈 신고는 gate 판정 *전*에 `/issue-report` 로 먼저 분류한다 ([issue-report 와의 경계](#issue-report-와의-경계)) — KNOWN_ISSUE / DESIGN_ISSUE / SCOPE_ESCALATE 를 건너뛰지 않기 위해. 분류 결과가 다시 위 tier 로 흐른다.
 
 ## 라우팅 그래프
 
 ```mermaid
 flowchart TB
-  REQ["자유 형식 작업 요청"] --> HR{"high-risk trigger?"}
+  REQ["자유 형식 작업 요청"] --> BUG{"버그/이슈 신고?"}
+  BUG -->|예| IR["/issue-report 분류 → 결과가 tier 로"]
+  BUG -->|아니오| HR{"high-risk trigger?"}
   HR -->|예| T3["product-plan → (외부 의존 시) tech-review → architect-loop → impl-loop"]
-  HR -->|아니오| MP{"multi-PR / resume / handoff?"}
-  MP -->|예| T4["impl-loop chain"]
-  MP -->|아니오| AM{"목표·범위 모호?"}
+  HR -->|아니오| AM{"목표·범위 모호?"}
   AM -->|예| T2["product-plan 그릴미"]
   AM -->|아니오| CS{"concrete signal?"}
-  CS -->|예| T1["direct impl — impl task 있으면 impl-loop, 없으면 단발 PR"]
+  CS -->|예| T1["direct impl (impl task 있으면 impl-loop / 없으면 단발 PR)"]
   CS -->|아니오| T2
+  T3 -.->|구현 여러 task/PR| SHAPE["impl-loop chain (shape 축)"]
+  T1 -.->|구현 여러 task/PR| SHAPE
 
   classDef gate fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
   classDef shape fill:#fff3e0,stroke:#f57c00,color:#e65100
   classDef clar fill:#f3e5f5,stroke:#7b1fa2,color:#4a148c
   classDef direct fill:#e8f5e9,stroke:#388e3c,color:#1b5e20
   class T3 gate
-  class T4 shape
+  class SHAPE shape
   class T2 clar
+  class IR clar
   class T1 direct
 ```
 
-> high-risk 와 durable 이 둘 다면 tier 3 설계 후 tier 4 chain 으로 합성된다 (그래프는 첫 분기만 표시). tier 4 는 "더 높은 리스크"가 아니라 multi-PR 실행 형태(shape 축)일 뿐이다.
+> gate 축(high-risk / 모호 / direct)이 *어느 workflow 로 진입할지*를 정하고, shape 축(점선)은 진입 *후* 구현이 여러 task/PR 이면 `/impl-loop` chain 으로 실행한다. tier 4(durable chain)는 "더 높은 리스크"가 아니라 실행 형태일 뿐 — **gate 보다 먼저 판정하지 않는다.**
 
 ## tier 표
 
 | tier | 트리거 (signal) | 진입점 | 왜 이 tier |
 |---|---|---|---|
-| **1. direct impl** | concrete signal(파일 path · 함수/클래스/symbol · issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only · 단일 bug reproduction · 이미 승인된 impl 파일) **1개 이상 AND high-risk trigger 0개** | impl task/issue 있으면 `/impl-loop`, 없으면 **메인이 branch → PR → test → pr-reviewer → CI 를 지키는 단발 구현 경로** (새 skill 아님) | 의도·범위·수용 기준이 신호로 이미 명확 → 기획/설계 gate 만 비용. **검증·리뷰 게이트는 유지** |
+| **1. direct impl** | concrete signal(파일 path · 함수/클래스/symbol · issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only · 이미 승인된 impl 파일) **1개 이상 AND high-risk trigger 0개**. (버그/이슈 신고는 tier 1 직행 X — 먼저 `/issue-report` 분류) | impl task/issue 있으면 `/impl-loop`, 없으면 **메인이 branch → PR → test → pr-reviewer → CI 를 지키는 단발 구현 경로** (새 skill 아님) | 의도·범위·수용 기준이 신호로 이미 명확 → 기획/설계 gate 만 비용. **검증·리뷰 게이트는 유지** |
 | **2. clarify** | 목표/사용자/성공 기준 모호 · "좋게 만들어줘 / 개선해줘 / 새 기능"처럼 범위 넓음 · 사용자가 "뭘 원하는지 모르겠다" | `/product-plan` 그릴미 (또는 메인이 명확화 질문) | shared understanding 부재 → 구현 전에 의도부터 |
 | **3. plan + review** | high-risk trigger 1개 이상 (아래 표) | `/product-plan` → (외부 의존 시) `/tech-review` → `/architect-loop` → `/impl-loop` | 되돌리기 비싼 결정 → 설계·검증 consensus 필요 |
-| **4. durable chain** | task 가 여러 PR 로 분할 · resume/handoff/audit 필요 · long-running chain · 병렬 후보 | `/impl-loop` chain 모드 | **shape 축** — 더 높은 리스크가 아니라 multi-PR 실행 형태. 단일 PR 로 안 끝남 → task 경계 라우팅·재개 이득 |
+| **4. durable chain** | (gate 통과 후) 구현이 여러 task/PR 로 분할 · resume/handoff/audit · long-running · 병렬 후보 | `/impl-loop` chain 모드 — **impl task list 가 있어야 시작** (모호하면 먼저 tier 2/3) | **shape 축** — gate 가 아니라 실행 형태. 단일 PR 로 안 끝남 → task 경계 라우팅·재개 이득 |
 
 ### tier 3 (plan + review) 트리거 — 각각 왜 full chain 인가
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -33,7 +33,7 @@ risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**
 ```mermaid
 flowchart TB
   REQ["자유 형식 작업 요청"] --> HR{"high-risk trigger?"}
-  HR -->|예| T3["product-plan → tech-review → architect-loop → impl-loop"]
+  HR -->|예| T3["product-plan → (외부 의존 시) tech-review → architect-loop → impl-loop"]
   HR -->|아니오| MP{"multi-PR / resume / handoff?"}
   MP -->|예| T4["impl-loop chain"]
   MP -->|아니오| AM{"목표·범위 모호?"}

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -1,0 +1,96 @@
+# workflow-router 라우팅 SSOT
+
+> **Status**: ACTIVE
+> **Scope**: 자유 형식 작업 요청을 받았을 때 **어떤 workflow(skill)로 진입할지** 고르는 router 의 단일 진본. **entrypoint 선택(skill 진입 *전*) 전용** — skill 진입 *후* 의 agent 결론 → 다음 호출 라우팅은 각 `<skill>-routing.md` 영역이다. 본 문서는 그 하위 routing 을 *가리키되* 하위는 본 문서를 역참조하지 않는다 (top-down 단방향).
+> **Cross-ref**: 이슈 분류(이미 발견된 버그) = [`issue-report-routing.md`](../../skills/issue-report/issue-report-routing.md) · 강제 vs 권고 = [`CLAUDE.md`](../../CLAUDE.md).
+
+## 읽는 법
+
+라우팅은 **권고**다 — 강제 hook 이 아니다. 메인 Claude 가 자유 형식 작업 요청을 받으면, 먼저 이 표로 리스크를 판정해 *요청을 만족하는 가장 작은 workflow* 를 고른다. 최종 결정은 메인/사용자. 모호하면 tier 2(clarify) 가 기본. **명령명을 외우는 게 아니라 리스크로 고른다.**
+
+## 판정 규칙 — gate 축과 shape 축은 직교다
+
+risk tier 는 "더 무거운 하나"를 고르는 배타 선택이 **아니다**. 두 가지 서로 다른 질문에 답한다:
+
+- **high-risk = planning gate** 를 결정한다 (기획/기술검토/설계 루프가 필요한가).
+- **durable = implementation shape** 를 결정한다 (단일 PR 인가, 여러 PR chain 인가).
+
+세 문장으로 못 박는다:
+
+1. **concrete signal 은 direct impl 의 *필요조건*이지 *충분조건*이 아니다** — high-risk trigger 가 하나라도 있으면 direct impl 이 아니다. (예: "auth/payment 파일 X 고쳐 구독 SDK 붙여줘" 는 파일 path 가 있어도 high-risk 라 tier 3.)
+2. **direct impl 은 *절차 생략*이 아니라 *기획/설계 gate 생략*이다** — branch / PR / test / pr-reviewer / CI 게이트는 그대로 지킨다. 새 command/skill 이 아니라 메인이 직접 도는 단발 구현 경로다.
+3. **high-risk 와 durable 은 합성된다** — 둘 다 맞으면 `/product-plan → /tech-review → /architect-loop → /impl-loop chain`.
+
+판정은 위에서 아래로 본다:
+
+1. **high-risk trigger 가 있나?** → 있으면 **plan + review** (tier 3)
+2. **multi-PR / resume / handoff 가 있나?** → 있으면 impl 은 **durable chain** (tier 4)
+3. **목표/범위가 모호한가?** → 있으면 **clarify** (tier 2)
+4. **high-risk 없고 concrete signal 이 있나?** → **direct impl** (tier 1)
+
+## 라우팅 그래프
+
+```mermaid
+flowchart TB
+  REQ["자유 형식 작업 요청"] --> HR{"high-risk trigger?"}
+  HR -->|예| T3["product-plan → tech-review → architect-loop → impl-loop"]
+  HR -->|아니오| MP{"multi-PR / resume / handoff?"}
+  MP -->|예| T4["impl-loop chain"]
+  MP -->|아니오| AM{"목표·범위 모호?"}
+  AM -->|예| T2["product-plan 그릴미"]
+  AM -->|아니오| CS{"concrete signal?"}
+  CS -->|예| T1["direct impl — impl task 있으면 impl-loop, 없으면 단발 PR"]
+  CS -->|아니오| T2
+
+  classDef gate fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
+  classDef shape fill:#fff3e0,stroke:#f57c00,color:#e65100
+  classDef clar fill:#f3e5f5,stroke:#7b1fa2,color:#4a148c
+  classDef direct fill:#e8f5e9,stroke:#388e3c,color:#1b5e20
+  class T3 gate
+  class T4 shape
+  class T2 clar
+  class T1 direct
+```
+
+> high-risk 와 durable 이 둘 다면 tier 3 설계 후 tier 4 chain 으로 합성된다 (그래프는 첫 분기만 표시). tier 4 는 "더 높은 리스크"가 아니라 multi-PR 실행 형태(shape 축)일 뿐이다.
+
+## tier 표
+
+| tier | 트리거 (signal) | 진입점 | 왜 이 tier |
+|---|---|---|---|
+| **1. direct impl** | concrete signal(파일 path · 함수/클래스/symbol · issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only · 단일 bug reproduction · 이미 승인된 impl 파일) **1개 이상 AND high-risk trigger 0개** | impl task/issue 있으면 `/impl-loop`, 없으면 **메인이 branch → PR → test → pr-reviewer → CI 를 지키는 단발 구현 경로** (새 skill 아님) | 의도·범위·수용 기준이 신호로 이미 명확 → 기획/설계 gate 만 비용. **검증·리뷰 게이트는 유지** |
+| **2. clarify** | 목표/사용자/성공 기준 모호 · "좋게 만들어줘 / 개선해줘 / 새 기능"처럼 범위 넓음 · 사용자가 "뭘 원하는지 모르겠다" | `/product-plan` 그릴미 (또는 메인이 명확화 질문) | shared understanding 부재 → 구현 전에 의도부터 |
+| **3. plan + review** | high-risk trigger 1개 이상 (아래 표) | `/product-plan` → (외부 의존 시) `/tech-review` → `/architect-loop` → `/impl-loop` | 되돌리기 비싼 결정 → 설계·검증 consensus 필요 |
+| **4. durable chain** | task 가 여러 PR 로 분할 · resume/handoff/audit 필요 · long-running chain · 병렬 후보 | `/impl-loop` chain 모드 | **shape 축** — 더 높은 리스크가 아니라 multi-PR 실행 형태. 단일 PR 로 안 끝남 → task 경계 라우팅·재개 이득 |
+
+### tier 3 (plan + review) 트리거 — 각각 왜 full chain 인가
+
+| high-risk trigger | 왜 full chain |
+|---|---|
+| 새 product feature / epic | 사용자 가치·범위가 미확정 → 기획부터 |
+| 외부 dependency / API / SDK / model 선택 | 실현성·비용·라이선스 검증 필요 (`/tech-review`) |
+| auth / security / PII / compliance | 보안·규제 결함은 사후 회복 비용이 큼 → 설계 합의 |
+| migration / destructive change | 되돌리기 어려움 → 설계 단계에서 안전장치 |
+| public API breakage | 다운스트림 영향 → 인터페이스 합의 필요 |
+| cross-module / cross-story interface | 모듈 경계 정합 → architecture 검증 |
+| 비용 / 성능 / 운영 리스크 | 운영 영향 → 사전 설계·측정 |
+
+## issue-report 와의 경계
+
+본 router 와 [`issue-report`](../../skills/issue-report/issue-report-routing.md) 의 qa 분류는 **scope 가 다르다**:
+
+- **issue-report (qa 분류)** = *이미 발견된 버그/이슈* 를 분류한다.
+- **본 router** = *자유 형식 작업 요청* 을 사전 분류해 entrypoint 를 고른다.
+
+버그/이슈 신고는 먼저 `/issue-report` 로 분류하고, 그 결과가 다시 본 router 의 tier 로 흐른다 — 예: 기능 버그/정리 작업 → tier 1(direct impl) fallback, 큰 변경/다중 모듈 → tier 3(plan + review).
+
+## 하위 routing 과의 관계 (top-down 단방향)
+
+본 문서는 entrypoint 를 *고르는* 데서 끝난다. skill 진입 후의 agent 결론 → 다음 호출은 각 skill 의 `<skill>-routing.md` 가 진본이다:
+
+- `/product-plan` → [`product-plan-routing.md`](../../skills/product-plan/product-plan-routing.md)
+- `/impl-loop` → [`impl-loop-routing.md`](../../skills/impl-loop/impl-loop-routing.md)
+- `/architect-loop` → [`architect-loop-routing.md`](../../skills/architect-loop/architect-loop-routing.md)
+- `/issue-report` → [`issue-report-routing.md`](../../skills/issue-report/issue-report-routing.md)
+
+이 참조는 **단방향**이다 — 하위 routing 은 본 문서를 역참조하지 않는다. entrypoint 선택은 그들의 scope(skill 진입 후)가 아니기 때문이다.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -96,6 +96,7 @@ msg = header + '''## [dcness 활성 환경]
 ### 작업 진입 매트릭스 (lazy — 통째 read 폐기, #400)
 | 상황 | docs |
 |---|---|
+| 자유 형식 작업 요청 → 어떤 workflow (risk 분류) | \`workflow-router.md\` |
 | catastrophic / loop 진입 | \`hooks.md\` catastrophic-gate.sh + 해당 skill 의 \`## Loop\` + \`<skill>-routing.md\` |
 | Step 0~8 / echo / REDO | \`loop-procedure.md\` |
 | agent 결론 → 다음 (라우팅) | 호출 skill 의 \`<skill>-routing.md\` |
@@ -103,7 +104,7 @@ msg = header + '''## [dcness 활성 환경]
 | 이슈 lifecycle / PR | \`issue-lifecycle.md\` |
 | 브랜치/커밋 네이밍 | \`git-spec.md\` |
 
-skill 트리거 시 해당 skill 의 ## 사전 read 가 정확 경로 안내.
+자유 형식 작업 요청은 먼저 risk 분류 → 가장 작은 workflow 선택 (권고). skill 트리거 시 해당 skill 의 ## 사전 read 가 정확 경로 안내.
 '''
 print(json.dumps({
     'hookSpecificOutput': {


### PR DESCRIPTION
## 관련 이슈 번호
Closes #586

## 배경 및 문제
사용자(외부 활성 프로젝트)가 *어떤 entrypoint 를 써야 하는지를 외워야* 했다. low-risk 작업(구체 파일 path·symbol·이슈 번호)도 기획/설계 루프를 타야 하는 것처럼 느껴지고, high-risk 작업의 full chain 필요성이 "리스크 신호"가 아니라 명령명으로만 설명됐다. 메인 Claude 의 workflow 선택 기준도 문서마다 흩어져 있었다.

## 원인 (해당 시)
-

## 작업내용
- **신규** `docs/plugin/workflow-router.md` — risk tier 단일 진본(SSOT). 기존 routing 문서 형식(mermaid + 표).
  - **gate 축 × shape 축 직교** — high-risk = planning gate, durable = implementation shape. 둘 다면 `/product-plan → /tech-review → /architect-loop → /impl-loop chain` 으로 합성.
  - 4-tier: direct impl / clarify / plan+review / durable chain. (gajae-code 5번째 `team` 은 in-session 직렬 철학상 durable chain 에 흡수.)
  - 두 원칙 명문화: "concrete signal 은 필요조건이지 충분조건 아님", "direct impl 은 절차 생략이 아니라 기획/설계 gate 생략(branch/PR/test/리뷰/CI 유지, 새 skill 아님)".
- `hooks/session-start.sh` — inject 매트릭스에 workflow-router 행 + "risk 분류 먼저" 권고 1줄 (슬림 유지).
- `README.md` — 작업 흐름에 "명령 외우기보다 리스크로 고르기" 표.
- `CLAUDE.md` — 문서 지도(lazy)에 workflow-router 행.

## 결정 근거
- **SSOT 위치** = 새 문서(docs/plugin/). README 직접 삽입/issue-report-routing 확장 대비 SSOT 가 깔끔하고 routing 문서 형식과 일관.
- **AC #2 deviation (명시)** — 원 AC 는 `product-plan-routing.md`/`impl-loop-routing.md` 가 risk tier 를 *참조*하라고 했으나, **top-down 단방향**으로 대체. 하위 `*-routing.md` 는 skill *진입 후* agent 라우팅이 scope — entrypoint 선택(진입 전)은 그들 책임 밖이고, 역참조하면 (1) 읽는 시점에 이미 entry 가 끝나 늦고 (2) scope 침범 → "룰이 룰을 부르는" 안티패턴. 대신 router 의 "진입점" 칼럼이 product-plan/impl-loop 를 가리키고(router→하위), 메인 entry 판단은 SessionStart inject → router 로 연결. **하위 routing 두 파일 미수정.**
- **라우팅 = 권고** (CLAUDE.md 강제 vs 권고 원칙) — 강제 hook 아님.

## Test Plan
- [x] cross-ref PASS (44 파일, dead link/anchor/옛 명칭 0)
- [x] workflow-router.md 96줄 (300 cap 이내)
- [x] session-start inject JSON 유효성 (is-active 우회 tmpfile 검증 — workflow-router 행 + 권고 포함) + smoke test OK (8 tests)
- [x] 분류 시나리오 워크스루 — "auth 파일 고쳐 구독 SDK" 는 file path 있어도 precedence 1번(high-risk) → tier 3 로 정확히 라우팅
- [x] pytest 게이트는 자동 트리거 안 됨(`check_python_tests.sh` 패턴 밖: hooks/·docs/plugin/workflow-router.md·README·CLAUDE) → smoke test 수동 실행으로 검증 공백 보완

## 참고
**배포 경로 검증**: 전부 **경로 1 (plug-in 본체 자동 갱신)** — `docs/plugin/*.md` 는 사용자 repo 로 cp 안 하고 plugin SSOT 직접 read(#198). `cp` 배포·`init-dcness` deploy 스텝 수정 **불필요**. 사용자는 `claude plugin update` 로 자동 수신.

**비중복 범위** (router 본문엔 미포함 — 외부 배포물 내부 ID 금지): #520 doctor=설치/배포 검증 / #521 scenario test 와 달리 본 PR 은 policy/routing 계약 먼저 / #522 benchmark 와 연결 가능하나 본 PR 은 runtime/operator decision table / #524 provider-runtime 확장 무관.