### PR TITLE
[docs] README public launch surface 정리

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,28 +1,31 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "dcness",
-  "description": "Lightweight governance harness — prose-only determinism (no meta-LLM) + enforced work-order and access boundaries.",
+  "description": "Claude Code PR workflow guard that stops skipped tests, skipped reviews, and out-of-bound agent writes before PRs.",
   "owner": {
     "name": "alruminum",
     "email": "alruminum@gmail.com"
   },
   "metadata": {
-    "description": "dcNess — prose-only 결정론(메타 LLM 호출 0) + 작업 순서·접근 영역 강제. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
+    "description": "dcNess — Claude Code 가 테스트/리뷰/파일 경계를 건너뛰기 전에 막는 PR workflow guard. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
     "version": "0.4.0"
   },
   "plugins": [
     {
       "name": "dcness",
       "source": "./",
-      "description": "Prose-only governance harness — agent 가 prose 자유 emit, 메인 Claude 가 prose 를 직접 읽고 routing(메타 LLM 0). 형식 강제 사다리 폐기.",
+      "description": "Claude Code PR workflow guard — skipped tests, skipped reviews, and out-of-bound agent writes are blocked before PRs.",
       "category": "development",
       "tags": [
-        "agent",
+        "claude-code",
+        "claude-code-plugin",
+        "ai-agents",
+        "code-review",
+        "governance",
+        "hooks",
         "workflow",
-        "orchestration",
         "harness",
-        "prose-only",
-        "governance"
+        "prose-only"
       ]
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,20 +1,22 @@
 {
   "name": "dcness",
   "version": "0.4.0",
-  "description": "Lightweight governance harness for Claude Code — prose-only determinism (no format-marker ladder, no meta-LLM) + enforced work-order and access boundaries.",
+  "description": "Claude Code PR workflow guard that stops skipped tests, skipped reviews, and out-of-bound agent writes before PRs.",
   "author": {
     "name": "alruminum",
     "email": "alruminum@gmail.com"
   },
   "license": "MIT",
   "keywords": [
-    "agent",
-    "workflow",
-    "orchestration",
     "claude-code",
+    "claude-code-plugin",
+    "ai-agents",
+    "code-review",
+    "governance",
+    "hooks",
+    "workflow",
     "harness",
-    "prose-only",
-    "governance"
+    "prose-only"
   ],
   "homepage": "https://github.com/alruminum/dcNess",
   "repository": "https://github.com/alruminum/dcNess"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,9 +130,9 @@ cp scripts/hooks/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-
 cp scripts/hooks/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
 cp scripts/hooks/post-checkout .git/hooks/post-checkout && chmod +x .git/hooks/post-checkout
 
-# 하네스 단위 테스트 실행
-python3 -m unittest discover -s tests -v
-python3 -m unittest tests.test_signal_io -v   # 단일 모듈
+# 하네스 단위 테스트 실행 (Python 3.11 기준 — macOS system python3 는 3.9 일 수 있음)
+python3.11 -m unittest discover -s tests -v
+python3.11 -m unittest tests.test_signal_io -v   # 단일 모듈
 node scripts/check_public_surface.mjs
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # dcNess
 
+> Stop Claude Code from skipping tests, reviews, and file boundaries before PRs.
+> A Claude Code PR workflow guard that preserves test/review order and agent file boundaries.
+
 > **Origin**: [`alruminum/realworld-harness`](https://github.com/alruminum/realworld-harness) fork-and-refactor
 > **Spec(SSOT)**: [`CLAUDE.md`](CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)
 
-**dcNess 는 Claude Code 용 거버넌스 하네스 plugin 이다.**
+**dcNess 는 Claude Code 용 PR workflow guard plugin 이다.**
 
-코딩 에이전트가 혼자 달릴 때 빠지는 함정 — 검증 건너뛰기, 권한 밖 파일 수정,
-순서 뒤집기 — 을 막는 데 집중한다.
+Claude Code 가 혼자 달릴 때 가장 비싼 실수 — 테스트 생략, 리뷰 순서 뒤집기,
+권한 밖 파일 수정, PR 조기 생성 — 를 PR 전에 hook 으로 막고 복구 경로를 안내한다.
+Claude Code 기본 기능이 실행 능력을 준다면, dcNess 는 사용자가 정한 작업 순서와
+agent 파일 경계를 보존하는 얇은 안전장치다.
 
 dcNess 는 *모델을 불신해서 모든 사고를 대신하는* 하네스가 아니다. 모델이 좋아질수록
 절차를 없애는 게 아니라 **절차의 목적을 이해하고 더 적은 마찰로 지키게** 하는, 사용자의
@@ -24,8 +29,8 @@ risk 가 높을 때만 조건부로 부른다([`docs/plugin/workflow-router.md`]
 
 ## 누구에게 맞나
 
-**맞다** — Claude Code 로 실제 제품을 만들면서 PR/이슈/구현 루프에 **거버넌스**(검증
-순서 보존, 파일 경계, 재현 가능한 run-review)가 필요한 사람.
+**맞다** — Claude Code 로 실제 제품을 만들면서 `test → implement → review → PR`
+순서와 agent 파일 경계를 반복적으로 지키고 싶은 사람.
 
 **안 맞다** — 범용 model/provider 라우팅이나 MCP 런타임 확장이 목적인 경우(그건 dcNess 의
 scope 가 아니다). Codex route 는 read-only validator 3종 opt-in 에만 한정된다. 가벼운
@@ -60,6 +65,24 @@ claude plugin install dcness@dcness
 ```sh
 dcness-helper routing disable-codex-validation
 ```
+
+## 30초 데모: What It Catches
+
+가장 작은 데모는 "잘못된 순서 → hook block → 복구 → PR" 흐름이다. 전체 transcript 는
+[`docs/plugin/demo.md`](docs/plugin/demo.md) 에 있다.
+
+```text
+Claude tries to call pr-reviewer before code-validator PASS
+→ dcNess blocks the call: review cannot run before validation
+→ run code-validator read-only
+→ code-validator returns PASS
+→ pr-reviewer runs read-only
+→ tests pass
+→ branch → PR
+```
+
+이 흐름의 핵심은 절차를 늘리는 것이 아니라, 사고가 PR 로 번지기 전에 guard 가 멈추고
+복구 경로를 바로 보여주는 것이다.
 
 ## 작업 흐름
 
@@ -155,12 +178,16 @@ entrypoint 가 아니라 workflow 내부 gate/worker/reviewer 로 호출된다.
 
 ## 개발자 셋업 (dcNess 에 기여)
 
+검증 기준은 Python 3.11 이다. macOS 기본 `python3` 는 Python 3.9 일 수 있으므로
+로컬에서는 `python3.11` 을 명시한다. pre-commit hook 은 `python3.11` 을 우선 탐색하고,
+CI 는 GitHub Actions `setup-python` 으로 Python 3.11 을 고정한다.
+
 ```sh
 git clone https://github.com/alruminum/dcNess.git
 cd dcNess
 cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 
-python3 -m unittest discover -s tests -v   # 단위 테스트
+python3.11 -m unittest discover -s tests -v # 단위 테스트
 node scripts/check_plugin_manifest.mjs     # manifest 검증
 node scripts/check_public_surface.mjs      # public workflow surface 검증
 node scripts/check_cross_refs.mjs          # link/anchor + 옛 명칭 게이트
@@ -181,6 +208,16 @@ bash scripts/dcness-codex-validator --help # Codex validator wrapper smoke
 | [`PROGRESS.md`](PROGRESS.md) | 현재 상태 / TODO / Blockers |
 | [`CLAUDE.md`](CLAUDE.md) | 메인 Claude 작업 지침 |
 | [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 |
+
+## Public Launch Tracker
+
+현재 public launch surface 는 README / plugin manifest / GitHub About description 을 같은
+포지셔닝으로 맞추는 것이 기준이다. 후속 readiness 항목은 아래 이슈가 맡는다.
+
+- [`#520 /init-dcness doctor`](https://github.com/alruminum/dcNess/issues/520) — 활성화 실패를 사용자가 직접 진단할 수 있게 한다.
+- [`#521 agent/skill RED-GREEN 시나리오 테스트`](https://github.com/alruminum/dcNess/issues/521) — guard 동작을 예제 기반으로 검증한다.
+- [`#522 public benchmark`](https://github.com/alruminum/dcNess/issues/522) — 위 30초 데모의 block / recovery / PR 지점을 측정 포인트로 삼는다.
+- [`#524 runtime non-goal vs interop 포지셔닝`](https://github.com/alruminum/dcNess/issues/524) — provider router 가 아니라 PR workflow guard 라는 경계를 명확히 한다.
 
 ### 역사 자료 (archive)
 

--- a/docs/plugin/demo.md
+++ b/docs/plugin/demo.md
@@ -1,0 +1,39 @@
+# 30-Second Demo
+
+dcNess is easiest to understand as a PR workflow guard: it blocks a skipped gate,
+shows the recovery path, and lets the normal PR flow continue after validation.
+
+## Hook Block To Recovery
+
+```text
+Claude tries to call pr-reviewer before code-validator PASS
+→ dcNess blocks the call
+
+[dcness] BLOCK
+reason: pr-reviewer cannot run before validation PASS
+next: run code-validator read-only, then retry pr-reviewer
+
+Run code-validator
+→ code-validator returns PASS
+
+Retry pr-reviewer
+→ pr-reviewer runs read-only
+→ review passes
+
+Run tests
+→ tests pass
+
+Create PR
+→ branch → PR → merge gate
+```
+
+The useful part is not the number of steps. The useful part is that a skipped
+review cannot silently become a PR. The hook stops the unsafe action, names the
+missing gate, and points back to the shortest valid recovery path.
+
+## What This Shows
+
+- Work order is enforced before PR creation.
+- Review agents stay read-only.
+- Recovery is local and explicit.
+- The user-facing command surface stays small; `/impl` remains the default entrypoint.


### PR DESCRIPTION
## 관련 이슈 번호

Closes #619
Closes #620
Closes #621

## 배경 및 문제

public launch 관점에서 README 첫 화면, GitHub About description, plugin manifest 설명이 같은 가치를 말하지 않았다. README 검증 명령도 macOS system python3(3.9 가능성)와 Python 3.11 기준이 섞여 외부 사용자가 첫 검증에서 환경 차이로 실패할 수 있었다.

## 원인 (해당 시)

- README 의 첫 화면은 내부 철학 설명이 먼저 보여서 "무엇을 막는지"가 늦게 드러났다.
- plugin.json / marketplace.json 설명은 prose-only 중심이고 GitHub About description 은 stale status-JSON-mutate 표현을 포함했다.
- README / CLAUDE.md 개발 명령은 Python 3.11 기준을 명시하지 않았다.

## 작업내용

- README 첫 30줄 안에 영어 가치 제안과 한국어 guard 설명을 추가했다.
- README 와 docs/plugin/demo.md 에 hook block -> recovery -> PR transcript 를 추가했다.
- README 개발자 셋업과 CLAUDE.md 개발 명령을 python3.11 기준으로 고정하고 macOS python3 주의를 추가했다.
- .claude-plugin/plugin.json 과 .claude-plugin/marketplace.json description/tags 를 public launch 포지셔닝에 맞췄다.
- GitHub About description 을 같은 guard 문구로 갱신하고 topics 를 claude-code, claude-code-plugin, ai-agents, code-review, governance, hooks 로 추가했다.

## 결정 근거

README 에는 실제 사용자가 30초 안에 이해할 수 있는 transcript 를 두고, 자세한 데모는 docs/plugin/demo.md 로 분리했다. 새 command/agent/gate 를 만들지 않고 기존 public surface 를 유지하는 쪽이 dcNess 의 작은 기본 표면 원칙과 맞다.

## 배포 경로 검증 (plug-in 영향 시)

- README.md: public repository launch surface.
- .claude-plugin/plugin.json / .claude-plugin/marketplace.json: plugin metadata and marketplace metadata.
- docs/plugin/demo.md: plugin docs path included outside docs/internal and docs/archive.
- agents/** / commands/** / hooks/** / init-dcness copied files: 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] python3.11 --version -> Python 3.11.15
- [x] python3.11 -m unittest discover -s tests -v -> Ran 718 tests, OK
- [x] node scripts/check_plugin_manifest.mjs -> PASS
- [x] node scripts/check_public_surface.mjs -> PASS
- [x] node scripts/check_cross_refs.mjs -> PASS

## 참고

- GitHub repo metadata verified with gh repo view: stale status-JSON-mutate description removed; six launch topics present.
