### PR TITLE
[feature] optional parallel wave driver — worktree 격리 fan-in (#636)

### DIFF
--- a/agents/build-worker/build-worker-agent.md
+++ b/agents/build-worker/build-worker-agent.md
@@ -74,6 +74,15 @@
 - build-test phase에서는 구현 source를 읽지 않는다.
 - Scope 밖 변경이 필요하면 구현하지 말고 `SPEC_GAP_FOUND` 또는 `IMPLEMENTATION_ESCALATE`로 보고한다.
 
+### 병렬 wave 모드 (leader 가 격리 worktree 에서 호출한 경우 — #636)
+
+leader 가 opt-in 병렬 wave 의 한 worker 로 격리 worktree 에서 호출하면 **patch/evidence only** 만 반환한다 (정책 = `docs/plugin/parallel-policy.md` 의 권한 경계):
+
+- 반환: 격리 worktree 안 코드 diff/patch + 테스트·검증 결과 + evidence prose. transport 용 로컬 commit 은 허용(authoritative 아님).
+- 금지(위 금지에 더해): `git push`, issue close, `dcness-helper` 의 run/step/next-task/ledger/checkpoint 같은 leader-owned 이벤트. 병렬 worker 완료가 곧 task 완료가 아니다 — task 완료는 leader 의 PR merge + issue close 로만 성립한다.
+- 변경은 자기 task 의 `수정 허용` Scope 안에만 둔다 — fan-in 시 leader 가 scope 준수·cross-worker 충돌을 검증한다.
+- 외부 활성 프로젝트에서는 위 금지의 다수가 `harness/agent_boundary.py` 로 구조적으로도 차단된다(prompt + 코드 이중 경계).
+
 ## 결론과 보고
 
 마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다.

--- a/agents/build-worker/build-worker-agent.md
+++ b/agents/build-worker/build-worker-agent.md
@@ -79,7 +79,7 @@
 leader 가 opt-in 병렬 wave 의 한 worker 로 격리 worktree 에서 호출하면 **patch/evidence only** 만 반환한다 (정책 = `docs/plugin/parallel-policy.md` 의 권한 경계):
 
 - 반환: 격리 worktree 안 코드 diff/patch + 테스트·검증 결과 + evidence prose. transport 용 로컬 commit 은 허용(authoritative 아님).
-- 금지(위 금지에 더해): `git push`, issue close, `dcness-helper` 의 run/step/next-task/ledger/checkpoint 같은 leader-owned 이벤트. 병렬 worker 완료가 곧 task 완료가 아니다 — task 완료는 leader 의 PR merge + issue close 로만 성립한다.
+- 금지(위 금지에 더해): `git push`, issue close, leader 의 run 경계 이벤트(`dcness-helper` 의 begin-run/end-run/next-task/post-task-begin/finalize-run/ledger-event). 병렬 worker 완료가 곧 task 완료가 아니다 — task 완료는 leader 의 PR merge + issue close 로만 성립한다. (자기 phase 의 begin-step/end-step·prev-tasks-append 같은 build-worker 자체 메커니즘은 그대로 쓴다.)
 - 변경은 자기 task 의 `수정 허용` Scope 안에만 둔다 — fan-in 시 leader 가 scope 준수·cross-worker 충돌을 검증한다.
 - 외부 활성 프로젝트에서는 위 금지의 다수가 `harness/agent_boundary.py` 로 구조적으로도 차단된다(prompt + 코드 이중 경계).
 

--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -112,10 +112,11 @@ active conveyor run 안의 `Agent` 호출은 직전 `begin-step` 의 단일 `cur
 
 ## 9. agent_boundary 강제 (driver 구현으로 확정 — #636)
 
-[`agent_boundary.py`](../../harness/agent_boundary.py) 의 `check_bash_mutation` 은 sub-agent 의 `git push` / `gh` mutation 에 더해, **leader-owned run-lifecycle `dcness-helper` 서브커맨드**(`begin-run` / `end-run` / `next-task` / `post-task-begin` / `finalize-run` / `ledger-event` / `init-session`)를 차단한다. 호출 형태 3가지(wrapper 직접 / `bash <path>/dcness-helper` / `python -m harness.session_state`)를 모두 식별한다.
+[`agent_boundary.py`](../../harness/agent_boundary.py) 의 `check_bash_mutation` 은 sub-agent 의 `git push` / `gh` mutation 에 더해, **leader-owned run-lifecycle `dcness-helper` 서브커맨드**(`begin-run` / `end-run` / `next-task` / `post-task-begin` / `finalize-run` / `ledger-event` / `init-session` / `prev-tasks-reset`)를 차단한다. 호출 형태 3가지(wrapper 직접 / `bash <path>/dcness-helper` / `python -m harness.session_state`)를 모두 식별한다.
 
-- 차단 대상은 **run 시작/종료/경계/checkpoint** 한정이다 — 이들은 어떤 sub-agent 도 호출하지 않아(전수 확인) 차단해도 기존 흐름 회귀가 0이다.
-- **의도적 제외** — serial build-worker(sub-agent)가 정상적으로 호출하는 것은 구조 차단하지 않는다: `begin-step`/`end-step`(hybrid-A 가 phase 마다 직접 호출 — [`loop-procedure.md`](loop-procedure.md))과 `prev-tasks-append`(phase 3 산출 누적). agent_boundary 는 parallel-worker 와 serial-build-worker 를 구별할 신호가 없으므로, 이들은 막으면 직렬 conveyor 가 깨진다. 병렬 worker 의 step/prev-tasks 경계는 **prompt 경계**("권한 경계" + agent 지침)로 닫는다.
+- 차단 대상은 **run 시작/종료/경계/checkpoint + 파괴적 reset** 한정이다 — 이들은 어떤 sub-agent 도 호출하지 않아(전수 확인) 차단해도 기존 흐름 회귀가 0이다.
+- **의도적 제외** — serial build-worker(sub-agent)가 정상적으로 호출하는 것은 구조 차단하지 않는다: `begin-step`/`end-step`(hybrid-A 가 phase 마다 직접 호출 — [`loop-procedure.md`](loop-procedure.md))과 `prev-tasks-append`(phase 3 산출 누적). agent_boundary 는 parallel-worker 와 serial-build-worker 를 구별할 신호가 없으므로, 이들은 막으면 직렬 conveyor 가 깨진다. 병렬 worker 의 step/prev-tasks-append 경계는 **prompt 경계**("권한 경계" + agent 지침)로 닫는다.
+- **prev-tasks `append`(추가) 허용 / `reset`(삭제) 차단 비대칭** — append 는 build-worker 가 호출하지만, reset 은 메인 전담이고 메인 repo 의 handoff FIFO 를 *삭제*하는 파괴적 연산이라 병렬 worker 가 leader 컨텍스트를 못 지우게 차단한다.
 - 따라서 경계는 **run-lifecycle = 코드 차단**, **step/prev-tasks·기타 = prompt 경계** 의 조합이다. `git commit`(transport)·read-only helper(`run-dir` / `run-status` / `is-active` / `status` / `routing` / `wave-plan`)도 통과.
 - 한계: 변수 indirection(`"$HELPER" end-run`) 등은 미탐 — 본 guard 는 보안 경계가 아니라 best-effort denylist(기존 git/gh 차단과 동일 시맨틱).
 - dcness self repo 는 infra 라 이 guard 가 bypass 된다(기존 git-push 차단과 동일) — 강제는 *외부 활성 프로젝트* 에서 발화한다.

--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -2,7 +2,7 @@
 
 > impl chain 의 **opt-in 병렬 확장** 정책 SSOT. 기본은 직렬 chain 이고, 병렬은 독립 task 가 명확히 판정될 때만 켜지는 예외다. 상위 doctrine = [`CLAUDE.md` dcness 강제 원칙](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일). lane/shape 판정 = [`workflow-router.md`](workflow-router.md). chain mechanics = [`loop-procedure.md`](loop-procedure.md).
 >
-> 🔴 **범위 주의** — 본 문서는 *정책*(허용/금지 조건 · 권한 경계 · 판정 입력 스키마)을 고정한다. 병렬 wave 를 실제로 오케스트레이션하는 **driver 구현은 본 문서 범위 밖**이며 후속 작업이다. 현재 [`impl-loop`](../../skills/impl-loop/SKILL.md) chain 은 **직렬로만 동작**한다.
+> 🔴 **범위** — 본 문서는 *정책*(허용/금지 조건 · 권한 경계 · 판정 입력 스키마) SSOT 다. driver 구현(#636)은 이 정책을 다음으로 하강한다: 판정 코어 [`parallel_wave.py`](../../harness/parallel_wave.py) (`compute_waves` / `fan_in_check`) + `dcness-helper wave-plan` 헬퍼 + 오케스트레이션 절차 [`impl-loop` SKILL 병렬 wave 절](../../skills/impl-loop/SKILL.md#병렬-wave-opt-in-chain-한정-636). **기본은 여전히 직렬 chain 이고, 병렬은 독립 task 가 기계 판정으로 확신될 때만 opt-in 으로 켜진다.**
 
 ## 1. doctrine — 직렬이 기본, 병렬은 조건부 예외
 
@@ -108,19 +108,21 @@ active conveyor run 안의 `Agent` 호출은 직전 `begin-step` 의 단일 `cur
 - run-review / ROI marker 의 분석 단위는 **task 별 직렬 merge 단계** 기준으로 유지된다. build 가 병렬이어도 merge 가 직렬이라 `1 task = 1 run = 1 review` 단위가 깨지지 않는다.
 - ledger 가 wave 구조(어느 task 가 같은 wave 였는지)를 인지하도록 하는 확장은 후속이다.
 
-## 9. agent_boundary 검토 결론
+## 9. agent_boundary 강제 (driver 구현으로 확정 — #636)
 
-현재 [`agent_boundary.py`](../../harness/agent_boundary.py) 는 sub-agent 의 `git push` 와 `gh` mutation 만 차단하고, `git commit` / 내부 helper / ledger 이벤트는 통과시킨다.
+[`agent_boundary.py`](../../harness/agent_boundary.py) 의 `check_bash_mutation` 은 sub-agent 의 `git push` / `gh` mutation 에 더해, **leader-owned `dcness-helper` 서브커맨드**(`begin-run` / `end-run` / `next-task` / `begin-step` / `end-step` / `finalize-run` / `ledger-event` / `post-task-begin` / `insight` / `prev-tasks-*` / `auto-resolve` / `init-session`)를 차단한다. 호출 형태 3가지(wrapper 직접 / `bash <path>/dcness-helper` / `python -m harness.session_state`)를 모두 식별한다.
 
-- 위 "실행모델"에서 worker 는 **격리 worktree sub-agent** 라 leader 의 ledger helper 에 구조적으로 접근하기 어렵다 → 본 정책 단계에서는 **prompt-only 권한 명시**(agent 지침 + 본 문서 "권한 경계")로 1차 충분하다.
-- 다만 fallback 경로 등에서 worker 가 leader-owned mutation 을 호출할 수 있는 통로가 생기면, `agent_boundary.py` 에 worker→leader-mutation 차단을 추가할지 검토한다. 이 결정은 driver 의 실행모델 확정값에 종속되므로 **driver 구현 이슈에서 확정**한다.
+- 따라서 worker→leader-mutation 은 **prompt 경계(agent 지침 + 본 문서 "권한 경계") + 코드 경계(agent_boundary) 이중**으로 닫힌다.
+- `git commit` 은 통과시킨다 — worker 의 transport 용 로컬 commit 은 허용("권한 경계")이기 때문. read-only helper(`run-dir` / `run-status` / `is-active` / `status` / `routing` / `wave-plan`)도 통과.
+- 한계: 변수 indirection(`"$HELPER" end-run`) 등은 미탐 — 본 guard 는 보안 경계가 아니라 best-effort denylist(기존 git/gh 차단과 동일 시맨틱). 실제 경계는 "leader-owned 는 leader 영역" 시퀀스 규약 + 직접 호출 차단의 조합이다.
+- dcness self repo 는 infra 라 이 guard 가 bypass 된다(기존 git-push 차단과 동일) — 강제는 *외부 활성 프로젝트* 에서 발화한다.
 
-## 10. 범위 경계 — 본 정책 vs 후속
+## 10. 범위 경계 — 정책(#589) → driver(#636) → 후속
 
-| 본 정책(고정 완료) | 후속 이슈(범위 밖) |
-|---|---|
-| 병렬 허용/금지 조건 | 병렬 wave driver 오케스트레이션 구현 |
-| leader/worker 권한 목록 | wave-level integration validator 자동화 |
-| fan-in 검증 최소 절차 | ledger 의 wave 구조 인지 |
-| 판정 입력 스키마 (`depends_on` · Scope 파일집합) | `max_parallel_workers` 상한 상향 |
-| 직렬 chain default 명시 | `agent_boundary.py` worker 차단 코드(실행모델 확정 후) |
+| 정책 고정 (#589) | driver 구현 완료 (#636) | 후속 이슈(범위 밖) |
+|---|---|---|
+| 병렬 허용/금지 조건 | wave 후보 계산(`compute_waves`) + `wave-plan` 헬퍼 + dry preview opt-in | wave-level integration validator 자동화 |
+| leader/worker 권한 목록 | `agent_boundary.py` worker→leader-mutation 코드 차단 (agent_boundary 강제) | ledger 의 wave 구조 인지 |
+| fan-in 검증 최소 절차 | `fan_in_check`(scope 준수 + 충돌 + evidence) + leader aggregate test 절차 | `max_parallel_workers` 상한 상향 (실측 후) |
+| 판정 입력 스키마 (`depends_on` · Scope) | 3-state 파싱 + Scope 경로 정규화 파서 | run-review 의 wave 단위 집계 |
+| 직렬 chain default 명시 | 직렬 default 유지 + 병렬 opt-in 절차 (SKILL §병렬 wave) | 한 세션 병렬 Agent 실행모델 |

--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -73,6 +73,8 @@ active conveyor run 안의 `Agent` 호출은 직전 `begin-step` 의 단일 `cur
 - fan-in 검증(aggregate test / scope·conflict) 실패.
 - migration / destructive / security / 도메인 invariant 변경 같은 고위험 task.
 
+> **고위험 enforce 방식** — 고위험은 *의미* 판정이라 경로만으론 못 잡는다. (1) 메인 dry-preview 의 risk 열(`high-risk`)이 진본이며 그 slug 를 `wave-plan --high-risk` 로 driver 에 넘겨 직렬 강등한다. (2) 경로상 명백한 것(`migrations/`·`alembic/`·`.env`·`secrets`·`credentials`)은 parser 가 backstop 으로 자동 직렬화한다. (3) architect 가 impl frontmatter 에 `parallel: serial` 또는 `risk: high-risk` 를 적으면 그 task 는 무조건 직렬.
+
 ## 5. 권한 경계 — leader-owned vs worker
 
 | 행위 | leader (메인) | worker |

--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -110,11 +110,12 @@ active conveyor run 안의 `Agent` 호출은 직전 `begin-step` 의 단일 `cur
 
 ## 9. agent_boundary 강제 (driver 구현으로 확정 — #636)
 
-[`agent_boundary.py`](../../harness/agent_boundary.py) 의 `check_bash_mutation` 은 sub-agent 의 `git push` / `gh` mutation 에 더해, **leader-owned `dcness-helper` 서브커맨드**(`begin-run` / `end-run` / `next-task` / `begin-step` / `end-step` / `finalize-run` / `ledger-event` / `post-task-begin` / `insight` / `prev-tasks-*` / `auto-resolve` / `init-session`)를 차단한다. 호출 형태 3가지(wrapper 직접 / `bash <path>/dcness-helper` / `python -m harness.session_state`)를 모두 식별한다.
+[`agent_boundary.py`](../../harness/agent_boundary.py) 의 `check_bash_mutation` 은 sub-agent 의 `git push` / `gh` mutation 에 더해, **leader-owned run-lifecycle `dcness-helper` 서브커맨드**(`begin-run` / `end-run` / `next-task` / `post-task-begin` / `finalize-run` / `ledger-event` / `init-session`)를 차단한다. 호출 형태 3가지(wrapper 직접 / `bash <path>/dcness-helper` / `python -m harness.session_state`)를 모두 식별한다.
 
-- 따라서 worker→leader-mutation 은 **prompt 경계(agent 지침 + 본 문서 "권한 경계") + 코드 경계(agent_boundary) 이중**으로 닫힌다.
-- `git commit` 은 통과시킨다 — worker 의 transport 용 로컬 commit 은 허용("권한 경계")이기 때문. read-only helper(`run-dir` / `run-status` / `is-active` / `status` / `routing` / `wave-plan`)도 통과.
-- 한계: 변수 indirection(`"$HELPER" end-run`) 등은 미탐 — 본 guard 는 보안 경계가 아니라 best-effort denylist(기존 git/gh 차단과 동일 시맨틱). 실제 경계는 "leader-owned 는 leader 영역" 시퀀스 규약 + 직접 호출 차단의 조합이다.
+- 차단 대상은 **run 시작/종료/경계/checkpoint** 한정이다 — 이들은 어떤 sub-agent 도 호출하지 않아(전수 확인) 차단해도 기존 흐름 회귀가 0이다.
+- **의도적 제외** — serial build-worker(sub-agent)가 정상적으로 호출하는 것은 구조 차단하지 않는다: `begin-step`/`end-step`(hybrid-A 가 phase 마다 직접 호출 — [`loop-procedure.md`](loop-procedure.md))과 `prev-tasks-append`(phase 3 산출 누적). agent_boundary 는 parallel-worker 와 serial-build-worker 를 구별할 신호가 없으므로, 이들은 막으면 직렬 conveyor 가 깨진다. 병렬 worker 의 step/prev-tasks 경계는 **prompt 경계**("권한 경계" + agent 지침)로 닫는다.
+- 따라서 경계는 **run-lifecycle = 코드 차단**, **step/prev-tasks·기타 = prompt 경계** 의 조합이다. `git commit`(transport)·read-only helper(`run-dir` / `run-status` / `is-active` / `status` / `routing` / `wave-plan`)도 통과.
+- 한계: 변수 indirection(`"$HELPER" end-run`) 등은 미탐 — 본 guard 는 보안 경계가 아니라 best-effort denylist(기존 git/gh 차단과 동일 시맨틱).
 - dcness self repo 는 infra 라 이 guard 가 bypass 된다(기존 git-push 차단과 동일) — 강제는 *외부 활성 프로젝트* 에서 발화한다.
 
 ## 10. 범위 경계 — 정책(#589) → driver(#636) → 후속

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -504,13 +504,16 @@ _MUTATION_RECURSION_LIMIT = 3
 #   - `begin-step`/`end-step`: hybrid-A build-worker 가 phase(test/impl/validate)마다 직접
 #     호출 (loop-procedure.md). 막으면 기존 직렬 conveyor 가 깨진다.
 #   - `prev-tasks-append`: build-worker 가 phase 3 에서 자기 산출 누적 (#525). 막으면 다음
-#     task 의 [PREVIOUS_TASKS] 정합이 깨진다. (`prev-tasks-reset` 도 같은 subsystem → 제외.)
+#     task 의 [PREVIOUS_TASKS] 정합이 깨진다.
 #   이들은 agent_boundary 가 parallel-worker 와 serial-build-worker 를 구별할 신호가 없어
 #   구조 차단이 불가능 → 병렬 worker 에 대해서는 prompt 경계(정책 §5 + agent 지침)로 닫는다.
+# 단 `prev-tasks-reset` 은 **메인 전담 + 파괴적**(메인 repo 의 .prev-tasks.md FIFO 삭제)이고
+# 어떤 sub-agent 도 호출 안 하므로 차단한다 — 병렬 worker 가 leader 의 handoff 컨텍스트를
+# 지우지 못하게 (#636 F16). append(추가)는 허용, reset(삭제)은 차단으로 비대칭.
 # read-only (run-dir/run-status/is-active/status/routing/wave-plan) 도 비대상이라 통과.
 _HELPER_LEADER_SUBCOMMANDS = frozenset({
     "begin-run", "end-run", "next-task", "post-task-begin",
-    "finalize-run", "ledger-event", "init-session",
+    "finalize-run", "ledger-event", "init-session", "prev-tasks-reset",
 })
 # 호출 형태 식별 — script basename / `python -m` 모듈명.
 _HELPER_SCRIPT_NAMES = frozenset({"dcness-helper"})
@@ -748,10 +751,11 @@ def check_bash_mutation(command: str) -> Optional[str]:
     차단: `git push`, `gh pr (create|merge|...)`, `gh issue (create|edit|close|comment|...)`,
           `gh api` (mutating method / field flag), leader-owned run-lifecycle `dcness-helper`
           서브커맨드 (begin-run/end-run/next-task/post-task-begin/finalize-run/ledger-event/
-          init-session — 병렬 wave worker 금지, #636).
+          init-session/prev-tasks-reset — 병렬 wave worker 금지, #636).
     통과: read-only (`gh pr view`, `gh issue list`, `gh api` GET, `dcness-helper run-dir`,
           `dcness-helper wave-plan`), `git commit`(transport), serial build-worker 가 쓰는
           `begin-step`/`end-step`/`prev-tasks-append`(회귀 방지), 그 외 모든 명령.
+          (prev-tasks `append`(추가)=허용 / `reset`(삭제)=차단 비대칭.)
     절대 실행 경로(`/usr/bin/git`, `/opt/homebrew/bin/gh`)도 명령명으로 정규화해 식별한다.
     global flag (`git -C ...`, `gh -R ...`) 가 앞에 와도 noun/verb 를 정확히 식별 (codex P2).
     흔한 래퍼(`sudo`/`env`/subshell/쉘 키워드)도 벗겨 식별 (codex P2).

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -496,6 +496,19 @@ _SHELL_KEYWORDS = frozenset({
 _SHELL_COMMANDS = frozenset({"bash", "sh", "zsh"})
 _MUTATION_RECURSION_LIMIT = 3
 
+# leader-owned dcness helper 서브커맨드 — 병렬 wave worker(sub-agent) 금지 (#636, 정책 §5).
+# run ledger / step / checkpoint / lifecycle marker 는 leader(메인) 전담. worker 는
+# patch/evidence 만 반환한다. read-only (run-dir/run-status/is-active/status/routing/
+# wave-plan) 는 deny 목록에 없으므로 통과.
+_HELPER_LEADER_SUBCOMMANDS = frozenset({
+    "init-session", "begin-run", "end-run", "next-task", "post-task-begin",
+    "begin-step", "end-step", "finalize-run", "ledger-event", "insight",
+    "prev-tasks-append", "prev-tasks-reset", "auto-resolve",
+})
+# 호출 형태 식별 — script basename / `python -m` 모듈명.
+_HELPER_SCRIPT_NAMES = frozenset({"dcness-helper"})
+_HELPER_MODULE_NAMES = frozenset({"harness.session_state"})
+
 # GitHub MCP — read-only prefix (통과) / mutation verb prefix (차단).
 _MCP_GH_READ_PREFIXES = ("get_", "list_", "search_")
 _MCP_GH_MUTATION_PREFIXES = (
@@ -621,6 +634,39 @@ def _gh_api_mutation(toks: list[str]) -> Optional[str]:
     return None
 
 
+def _helper_leader_mutation(toks: list[str]) -> Optional[str]:
+    """leader-owned dcness helper 서브커맨드 호출인지 — block reason / None (#636).
+
+    식별 형태(셋 다):
+      - `<...>/dcness-helper <subcommand>`          (wrapper 직접 — basename 매칭)
+      - `bash <...>/dcness-helper <subcommand>`      (bash 로 스크립트 실행)
+      - `python -m harness.session_state <subcommand>` (모듈 직접)
+
+    helper 토큰을 찾은 뒤 *첫 positional* 토큰이 leader-owned 서브커맨드면 차단.
+    read-only (run-dir/run-status/.../wave-plan)는 deny 목록에 없어 통과.
+
+    한계(의도적): `"$HELPER" end-run` 처럼 변수 indirection 은 미탐 — 본 guard 는
+    보안 경계가 아니라 best-effort denylist (check_bash_mutation 한계와 동일).
+    """
+    helper_idx = None
+    for i, t in enumerate(toks):
+        if _command_basename(t) in _HELPER_SCRIPT_NAMES or t in _HELPER_MODULE_NAMES:
+            helper_idx = i
+            break
+    if helper_idx is None:
+        return None
+    for t in toks[helper_idx + 1:]:
+        if t.startswith("-"):
+            continue  # 옵션/플래그 skip
+        if t in _HELPER_LEADER_SUBCOMMANDS:
+            return (
+                f"dcness-helper {t} 차단 — run ledger / step / checkpoint 는 leader "
+                f"영역 (병렬 wave 정책 §5). worker 는 patch/evidence 만 반환."
+            )
+        return None  # 첫 positional 이 leader-owned 아님 (read-only 등) → 통과
+    return None
+
+
 def _check_bash_mutation(command: str, *, depth: int = 0) -> Optional[str]:
     if depth > _MUTATION_RECURSION_LIMIT:
         return None
@@ -638,6 +684,10 @@ def _check_bash_mutation(command: str, *, depth: int = 0) -> Optional[str]:
             if reason:
                 return f"{nested_source} nested command 차단 — {reason}"
             continue
+        # leader-owned dcness helper 서브커맨드 (병렬 wave worker 금지 — #636).
+        helper_reason = _helper_leader_mutation(toks)
+        if helper_reason:
+            return helper_reason
         cmd = _command_basename(toks[0])
         if cmd == "git":
             pos = _positional_args(toks[1:], _GIT_VALUE_FLAGS)
@@ -670,8 +720,11 @@ def check_bash_mutation(command: str) -> Optional[str]:
     """Bash command 안의 외부 시스템 mutation 차단 — block reason str / None=allow.
 
     차단: `git push`, `gh pr (create|merge|...)`, `gh issue (create|edit|close|comment|...)`,
-          `gh api` (mutating method / field flag).
-    통과: read-only (`gh pr view`, `gh issue list`, `gh api` GET, 그 외 모든 명령).
+          `gh api` (mutating method / field flag), leader-owned `dcness-helper` 서브커맨드
+          (begin-run/end-run/next-task/begin-step/end-step/ledger-event/... — 병렬 wave
+          worker 금지, #636).
+    통과: read-only (`gh pr view`, `gh issue list`, `gh api` GET, `dcness-helper run-dir`,
+          `dcness-helper wave-plan`, 그 외 모든 명령).
     절대 실행 경로(`/usr/bin/git`, `/opt/homebrew/bin/gh`)도 명령명으로 정규화해 식별한다.
     global flag (`git -C ...`, `gh -R ...`) 가 앞에 와도 noun/verb 를 정확히 식별 (codex P2).
     흔한 래퍼(`sudo`/`env`/subshell/쉘 키워드)도 벗겨 식별 (codex P2).

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -497,13 +497,20 @@ _SHELL_COMMANDS = frozenset({"bash", "sh", "zsh"})
 _MUTATION_RECURSION_LIMIT = 3
 
 # leader-owned dcness helper 서브커맨드 — 병렬 wave worker(sub-agent) 금지 (#636, 정책 §5).
-# run ledger / step / checkpoint / lifecycle marker 는 leader(메인) 전담. worker 는
-# patch/evidence 만 반환한다. read-only (run-dir/run-status/is-active/status/routing/
-# wave-plan) 는 deny 목록에 없으므로 통과.
+# **run-lifecycle 한정** — run 시작/종료/경계/checkpoint 는 leader(메인/훅) 전담이고
+# 어떤 sub-agent 도 호출하지 않는다(전수 grep 확인). 따라서 차단해도 회귀 0.
+#
+# ⚠️ 의도적 제외 — serial build-worker(sub-agent)가 정상적으로 호출하는 것들은 넣지 않는다:
+#   - `begin-step`/`end-step`: hybrid-A build-worker 가 phase(test/impl/validate)마다 직접
+#     호출 (loop-procedure.md). 막으면 기존 직렬 conveyor 가 깨진다.
+#   - `prev-tasks-append`: build-worker 가 phase 3 에서 자기 산출 누적 (#525). 막으면 다음
+#     task 의 [PREVIOUS_TASKS] 정합이 깨진다. (`prev-tasks-reset` 도 같은 subsystem → 제외.)
+#   이들은 agent_boundary 가 parallel-worker 와 serial-build-worker 를 구별할 신호가 없어
+#   구조 차단이 불가능 → 병렬 worker 에 대해서는 prompt 경계(정책 §5 + agent 지침)로 닫는다.
+# read-only (run-dir/run-status/is-active/status/routing/wave-plan) 도 비대상이라 통과.
 _HELPER_LEADER_SUBCOMMANDS = frozenset({
-    "init-session", "begin-run", "end-run", "next-task", "post-task-begin",
-    "begin-step", "end-step", "finalize-run", "ledger-event", "insight",
-    "prev-tasks-append", "prev-tasks-reset", "auto-resolve",
+    "begin-run", "end-run", "next-task", "post-task-begin",
+    "finalize-run", "ledger-event", "init-session",
 })
 # 호출 형태 식별 — script basename / `python -m` 모듈명.
 _HELPER_SCRIPT_NAMES = frozenset({"dcness-helper"})
@@ -660,8 +667,8 @@ def _helper_leader_mutation(toks: list[str]) -> Optional[str]:
             continue  # 옵션/플래그 skip
         if t in _HELPER_LEADER_SUBCOMMANDS:
             return (
-                f"dcness-helper {t} 차단 — run ledger / step / checkpoint 는 leader "
-                f"영역 (병렬 wave 정책 §5). worker 는 patch/evidence 만 반환."
+                f"dcness-helper {t} 차단 — run 시작/종료/경계/checkpoint 는 leader "
+                f"영역 (병렬 wave 정책 권한 경계). worker 는 patch/evidence 만 반환."
             )
         return None  # 첫 positional 이 leader-owned 아님 (read-only 등) → 통과
     return None
@@ -720,11 +727,12 @@ def check_bash_mutation(command: str) -> Optional[str]:
     """Bash command 안의 외부 시스템 mutation 차단 — block reason str / None=allow.
 
     차단: `git push`, `gh pr (create|merge|...)`, `gh issue (create|edit|close|comment|...)`,
-          `gh api` (mutating method / field flag), leader-owned `dcness-helper` 서브커맨드
-          (begin-run/end-run/next-task/begin-step/end-step/ledger-event/... — 병렬 wave
-          worker 금지, #636).
+          `gh api` (mutating method / field flag), leader-owned run-lifecycle `dcness-helper`
+          서브커맨드 (begin-run/end-run/next-task/post-task-begin/finalize-run/ledger-event/
+          init-session — 병렬 wave worker 금지, #636).
     통과: read-only (`gh pr view`, `gh issue list`, `gh api` GET, `dcness-helper run-dir`,
-          `dcness-helper wave-plan`, 그 외 모든 명령).
+          `dcness-helper wave-plan`), `git commit`(transport), serial build-worker 가 쓰는
+          `begin-step`/`end-step`/`prev-tasks-append`(회귀 방지), 그 외 모든 명령.
     절대 실행 경로(`/usr/bin/git`, `/opt/homebrew/bin/gh`)도 명령명으로 정규화해 식별한다.
     global flag (`git -C ...`, `gh -R ...`) 가 앞에 와도 noun/verb 를 정확히 식별 (codex P2).
     흔한 래퍼(`sudo`/`env`/subshell/쉘 키워드)도 벗겨 식별 (codex P2).

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -644,25 +644,44 @@ def _gh_api_mutation(toks: list[str]) -> Optional[str]:
 def _helper_leader_mutation(toks: list[str]) -> Optional[str]:
     """leader-owned dcness helper 서브커맨드 호출인지 — block reason / None (#636).
 
-    식별 형태(셋 다):
-      - `<...>/dcness-helper <subcommand>`          (wrapper 직접 — basename 매칭)
-      - `bash <...>/dcness-helper <subcommand>`      (bash 로 스크립트 실행)
-      - `python -m harness.session_state <subcommand>` (모듈 직접)
+    식별 형태(셋 다) — helper 가 **실제 실행 명령 위치(command position)** 일 때만:
+      - `<...>/dcness-helper <subcommand>`          (wrapper 직접 — toks[0] basename)
+      - `bash <...>/dcness-helper <subcommand>`      (shell 의 첫 positional = 스크립트)
+      - `python -m harness.session_state <subcommand>` (`-m` 모듈 직접)
 
-    helper 토큰을 찾은 뒤 *첫 positional* 토큰이 leader-owned 서브커맨드면 차단.
-    read-only (run-dir/run-status/.../wave-plan)는 deny 목록에 없어 통과.
+    그 뒤 *첫 positional* 토큰이 leader-owned 서브커맨드면 차단. read-only
+    (run-dir/run-status/.../wave-plan)는 deny 목록에 없어 통과.
+
+    data 위치 helper 토큰(`echo dcness-helper end-run`)은 명령이 아니므로 통과
+    (#636 codex F9 — false-positive 제거). `bash -c "..."` 의 payload 는 호출부
+    `_check_bash_mutation` 의 nested 재귀가 따로 처리한다.
 
     한계(의도적): `"$HELPER" end-run` 처럼 변수 indirection 은 미탐 — 본 guard 는
     보안 경계가 아니라 best-effort denylist (check_bash_mutation 한계와 동일).
     """
-    helper_idx = None
-    for i, t in enumerate(toks):
-        if _command_basename(t) in _HELPER_SCRIPT_NAMES or t in _HELPER_MODULE_NAMES:
-            helper_idx = i
-            break
-    if helper_idx is None:
+    if not toks:
         return None
-    for t in toks[helper_idx + 1:]:
+    cmd0 = _command_basename(toks[0])
+    sub_start: Optional[int] = None
+    if cmd0 in _HELPER_SCRIPT_NAMES:
+        sub_start = 1  # <helper> <sub>
+    elif cmd0 in _SHELL_COMMANDS:
+        # `bash <helper> <sub>` — 첫 positional(스크립트)이 helper 인 경우만.
+        for i in range(1, len(toks)):
+            if toks[i].startswith("-"):
+                continue
+            if _command_basename(toks[i]) in _HELPER_SCRIPT_NAMES:
+                sub_start = i + 1
+            break  # 첫 positional 만 본다 (그게 스크립트)
+    elif cmd0.startswith("python"):
+        # `python -m harness.session_state <sub>`
+        for i in range(1, len(toks) - 1):
+            if toks[i] == "-m" and toks[i + 1] in _HELPER_MODULE_NAMES:
+                sub_start = i + 2
+                break
+    if sub_start is None:
+        return None
+    for t in toks[sub_start:]:
         if t.startswith("-"):
             continue  # 옵션/플래그 skip
         if t in _HELPER_LEADER_SUBCOMMANDS:

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -277,9 +277,11 @@ def _parse_risk_marker(fm_lines: list[str]) -> bool:
 _INHERENT_HIGH_RISK_RE = re.compile(
     r"(^|/)migrations?(/|$)"
     r"|(^|/)alembic(/|$)"
-    r"|(^|/)\.env(\.[^/]*)?$"
-    r"|(^|/)secrets?(/|\.[^/]+|$)"
-    r"|(^|/)credentials?(/|\.[^/]+|$)"
+    # `.env` 계열 — `.env`, `.env.local`, `.env*`(glob), `.env-prod` 등. 뒤가
+    # `. / * -` 또는 끝일 때만 → `.environment` 같은 무관 경로 오탐 방지 (#636 F15).
+    r"|(^|/)\.env([./*\-]|$)"
+    r"|(^|/)secrets?([./*\-]|$)"
+    r"|(^|/)credentials?([./*\-]|$)"
 )
 
 

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -24,7 +24,7 @@
 """
 from __future__ import annotations
 
-import fnmatch
+import glob as _globmod
 import json
 import re
 import sys
@@ -335,17 +335,72 @@ def parse_impl_task(path: str | Path) -> ImplTask:
 # ── Scope 충돌 판정 ──────────────────────────────────────────
 
 
+def _has_glob(p: str) -> bool:
+    return "*" in p or "?" in p or "[" in p
+
+
+def _glob_to_regex(pattern: str) -> str:
+    """glob → regex. `*` 는 path segment 안에서만(`/` 안 넘음), `**` 는 `/` 넘음."""
+    out: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        ch = pattern[i]
+        if ch == "*":
+            if i + 1 < n and pattern[i + 1] == "*":
+                out.append(".*")  # ** → recursive (crosses /)
+                i += 2
+                continue
+            out.append("[^/]*")  # * → segment-local (no /)
+            i += 1
+            continue
+        if ch == "?":
+            out.append("[^/]")
+            i += 1
+            continue
+        out.append(re.escape(ch))
+        i += 1
+    return "".join(out)
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    """구체 path 가 glob pattern 에 full-match (segment-aware). glob 없으면 정확 비교.
+
+    `fnmatch` 와 달리 `*` 가 `/` 를 넘지 않는다 — `src/*.py` 는 `src/a.py` 만 매치하고
+    `src/sub/a.py` 는 매치 안 함 (fan-in scope gate 우회 차단, #636 codex F4).
+    """
+    if not _has_glob(pattern):
+        return path == pattern
+    return re.fullmatch(_glob_to_regex(pattern), path) is not None
+
+
+def _glob_dir_prefix(p: str) -> str:
+    """glob pattern 의 첫 `*`/`?`/`[` 이전 정적 디렉토리 prefix (trailing `/` 포함)."""
+    idx = len(p)
+    for ch in ("*", "?", "["):
+        j = p.find(ch)
+        if j >= 0:
+            idx = min(idx, j)
+    head = p[:idx]
+    slash = head.rfind("/")
+    return head[: slash + 1] if slash >= 0 else ""
+
+
 def _paths_overlap(a: str, b: str) -> bool:
-    """두 경로가 충돌(동일/디렉토리 포함/glob 매치)하는가."""
+    """두 경로가 충돌(동일/디렉토리 포함/segment-aware glob)하는가."""
     if a == b:
         return True
-    a_dir = a.rstrip("/") + "/"
-    b_dir = b.rstrip("/") + "/"
-    if b.startswith(a_dir) or a.startswith(b_dir):
+    if b.startswith(a.rstrip("/") + "/") or a.startswith(b.rstrip("/") + "/"):
         return True
-    if "*" in a or "*" in b:
-        if fnmatch.fnmatch(b, a) or fnmatch.fnmatch(a, b):
-            return True
+    a_glob, b_glob = _has_glob(a), _has_glob(b)
+    if a_glob and not b_glob:
+        return _glob_match(b, a)
+    if b_glob and not a_glob:
+        return _glob_match(a, b)
+    if a_glob and b_glob:
+        # glob-vs-glob: 정적 디렉토리 prefix 가 nested/equal 이면 보수적으로 충돌 가정.
+        pa, pb = _glob_dir_prefix(a), _glob_dir_prefix(b)
+        return pa == pb or pa.startswith(pb) or pb.startswith(pa)
     return False
 
 
@@ -454,13 +509,17 @@ def compute_waves(
 
 
 def _path_in_scope(path: str, scope: Iterable[str]) -> bool:
-    """changed path 가 declared scope 안인가."""
+    """changed path 가 declared scope 안인가 (fan-in scope gate).
+
+    glob entry 는 segment-aware 매칭 — `src/*.py` 는 `src/sub/a.py` 를 in-scope 로
+    오인하지 않는다 (#636 codex F4: fnmatch 가 `/` 를 안 가려 scope 우회되던 구멍).
+    """
     for entry in scope:
         if path == entry:
             return True
         if path.startswith(entry.rstrip("/") + "/"):
             return True
-        if "*" in entry and fnmatch.fnmatch(path, entry):
+        if _has_glob(entry) and _glob_match(path, entry):
             return True
     return False
 
@@ -523,8 +582,9 @@ def _resolve_impl_paths(raw_paths: list[str]) -> list[Path]:
         if p.is_dir():
             candidates = sorted(p.glob("*.md"))
         elif any(ch in raw for ch in "*?["):
-            base = Path(".")
-            candidates = sorted(base.glob(raw))
+            # glob 모듈은 절대/상대 패턴을 모두 처리 (Path.glob 은 절대 패턴에
+            # NotImplementedError — #636 codex F5). recursive `**` 도 지원.
+            candidates = sorted(Path(m) for m in _globmod.glob(raw, recursive=True))
         elif p.exists():
             candidates = [p]
         else:

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -260,6 +260,33 @@ def _parse_parallel_marker(fm_lines: list[str]) -> bool:
     return False
 
 
+def _parse_risk_marker(fm_lines: list[str]) -> bool:
+    """frontmatter `risk:` 가 high-risk 류면 강제 직렬 (architect 명시 시)."""
+    for line in fm_lines:
+        m = re.match(r"^risk\s*:\s*(.+)$", line)
+        if m:
+            val = _strip_inline_comment(m.group(1)).strip().strip("'\"").lower()
+            return val in {"high", "high-risk", "highrisk", "critical"}
+    return False
+
+
+# 정책 §4 — 경로만으로 명백히 고위험인 패턴 (DB 마이그레이션 / 비밀·자격증명).
+# 보수적·고정밀 safety net. 도메인 invariant·auth 로직 등 *의미* 기반 고위험은
+# 경로로 신뢰성 있게 못 잡으므로 메인 dry-preview 판정(compute_waves high_risk_slugs)이
+# 진본이고, 본 패턴은 메인이 놓쳐도 걸리는 backstop 이다.
+_INHERENT_HIGH_RISK_RE = re.compile(
+    r"(^|/)migrations?(/|$)"
+    r"|(^|/)alembic(/|$)"
+    r"|(^|/)\.env(\.[^/]*)?$"
+    r"|(^|/)secrets?(/|\.[^/]+|$)"
+    r"|(^|/)credentials?(/|\.[^/]+|$)"
+)
+
+
+def _scope_inherent_high_risk(scope_paths: Iterable[str]) -> bool:
+    return any(_INHERENT_HIGH_RISK_RE.search(p) for p in scope_paths)
+
+
 def _is_path_like(token: str) -> bool:
     """repo-relative 파일/디렉토리 경로처럼 보이는 단일 토큰인가."""
     if not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_./*-]*", token):
@@ -327,7 +354,11 @@ def parse_impl_task(path: str | Path) -> ImplTask:
     fm_lines = _extract_frontmatter_lines(text)
     depends_on = _parse_depends_on(fm_lines)
     scope_paths, scope_ambiguous = _parse_scope(text)
-    force_serial = _parse_parallel_marker(fm_lines)
+    force_serial = (
+        _parse_parallel_marker(fm_lines)
+        or _parse_risk_marker(fm_lines)
+        or _scope_inherent_high_risk(scope_paths)
+    )
     return ImplTask(
         slug=p.stem,
         path=str(p),
@@ -467,6 +498,7 @@ def _deps_satisfied(task: ImplTask, done: set[str], in_batch: set[str]) -> bool:
 def compute_waves(
     tasks: list[ImplTask],
     max_parallel_workers: int = DEFAULT_MAX_PARALLEL_WORKERS,
+    high_risk_slugs: Iterable[str] = (),
 ) -> WavePlan:
     """impl task 목록(직렬 순서)을 병렬 wave 계획으로.
 
@@ -474,9 +506,24 @@ def compute_waves(
         같은 wave 병렬 가능 = depends_on 위상상 선후 없음 AND Scope 파일집합 disjoint
     불명확(미상 / scope 자유서술 / force_serial)은 직렬 강등 (§4).
     동시성 상한 = max_parallel_workers (§7).
+
+    `high_risk_slugs` = 메인 dry-preview 가 고위험으로 판정한 slug 집합 (정책 §4
+    "migration/destructive/security/도메인 invariant → 직렬"의 *진본 판정*). 의미 기반
+    고위험은 경로로 신뢰성 있게 못 잡으므로 메인이 판정해 전달한다. parse_impl_task 의
+    inherent 경로 패턴(migrations/secrets 등)은 메인이 놓쳐도 걸리는 backstop.
     """
     if max_parallel_workers < 1:
         max_parallel_workers = 1
+    hr = frozenset(high_risk_slugs)
+
+    def _is_serial(t: ImplTask) -> bool:
+        return t.serial_only or t.slug in hr
+
+    def _serial_reason(t: ImplTask) -> str:
+        if t.slug in hr and not t.serial_only:
+            return "고위험 task (dry-preview 판정) → 직렬"
+        return t.serial_reason or "직렬"
+
     in_batch = {t.slug for t in tasks}
     remaining = list(tasks)
     done: set[str] = set()
@@ -498,25 +545,25 @@ def compute_waves(
 
         head = frontier[0]
 
-        if head.serial_only:
+        if _is_serial(head):
             step_index += 1
             steps.append(
-                WaveStep(step_index, "serial", (head,), head.serial_reason or "직렬")
+                WaveStep(step_index, "serial", (head,), _serial_reason(head))
             )
             remaining.remove(head)
             done.add(head.slug)
             continue
 
         # head 는 병렬 후보 — frontier 순서(NN/task_index)대로 *연속* 으로만 묶는다.
-        # join 불가한 task(serial_only / Scope 겹침)를 만나면 건너뛰지 않고 **멈춘다**.
+        # join 불가한 task(serial / Scope 겹침)를 만나면 건너뛰지 않고 **멈춘다**.
         # 건너뛰어 뒤 task 를 당기면 실행/머지 순서가 뒤집혀 task_index 기반 issue close
         # semantics(3/3 PR 이 story 를 닫음)가 깨진다 (#636 codex F10).
         wave = [head]
         for cand in frontier[1:]:
             if len(wave) >= max_parallel_workers:
                 break
-            if cand.serial_only:
-                break  # 순서 barrier
+            if _is_serial(cand):
+                break  # 순서 barrier (serial_only / 고위험)
             if all(scopes_disjoint(cand.scope_paths, w.scope_paths) for w in wave):
                 wave.append(cand)
             else:
@@ -552,14 +599,18 @@ def compute_waves(
 def _path_in_scope(path: str, scope: Iterable[str]) -> bool:
     """changed path 가 declared scope 안인가 (fan-in scope gate).
 
-    glob entry 는 segment-aware 매칭 — `src/*.py` 는 `src/sub/a.py` 를 in-scope 로
-    오인하지 않는다 (#636 codex F4: fnmatch 가 `/` 를 안 가려 scope 우회되던 구멍).
+    - exact 파일 매치.
+    - **명시적 디렉토리 scope(끝이 `/`)** 만 하위 파일을 허용. 확장자 없는 파일
+      scope(`scripts/tool`)를 디렉토리로 오인해 `scripts/tool/x.py` 를 통과시키던
+      구멍 차단 (#636 codex F12). 디렉토리 의도면 `scripts/tool/` 로 적는다.
+    - glob entry 는 segment-aware 매칭 — `src/*.py` 는 `src/sub/a.py` 를 in-scope 로
+      오인하지 않는다 (#636 codex F4: fnmatch 가 `/` 를 안 가려 scope 우회되던 구멍).
     """
     for entry in scope:
         if path == entry:
             return True
-        if path.startswith(entry.rstrip("/") + "/"):
-            return True
+        if entry.endswith("/") and path.startswith(entry):
+            return True  # 명시적 디렉토리 scope 만 하위 허용
         if _has_glob(entry) and _glob_match(path, entry):
             return True
     return False
@@ -638,12 +689,20 @@ def _resolve_impl_paths(raw_paths: list[str]) -> list[Path]:
     return sorted(found, key=lambda x: x.name)
 
 
+def _split_csv(value: Optional[str]) -> list[str]:
+    if not value:
+        return []
+    return [x.strip() for x in value.split(",") if x.strip()]
+
+
 def wave_plan_from_paths(
-    raw_paths: list[str], max_parallel_workers: int = DEFAULT_MAX_PARALLEL_WORKERS
+    raw_paths: list[str],
+    max_parallel_workers: int = DEFAULT_MAX_PARALLEL_WORKERS,
+    high_risk_slugs: Iterable[str] = (),
 ) -> WavePlan:
     paths = _resolve_impl_paths(raw_paths)
     tasks = [parse_impl_task(p) for p in paths]
-    return compute_waves(tasks, max_parallel_workers)
+    return compute_waves(tasks, max_parallel_workers, high_risk_slugs)
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -661,8 +720,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=DEFAULT_MAX_PARALLEL_WORKERS,
         help=f"동시성 상한 (default {DEFAULT_MAX_PARALLEL_WORKERS})",
     )
+    parser.add_argument(
+        "--high-risk",
+        default="",
+        help="메인 dry-preview 가 고위험으로 판정한 task slug (콤마 구분) → 직렬 강제",
+    )
     args = parser.parse_args(argv)
-    plan = wave_plan_from_paths(args.paths, args.max_parallel)
+    plan = wave_plan_from_paths(
+        args.paths, args.max_parallel, _split_csv(args.high_risk)
+    )
     print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
     return 0
 

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -1,0 +1,565 @@
+"""parallel_wave — impl chain 의 opt-in 병렬 wave 계산 (#636).
+
+정책 SSOT = `docs/plugin/parallel-policy.md` (모델 A: worktree 격리 fan-in).
+본 모듈은 그 정책의 *판정 로직* 만 코드로 하강한다. 오케스트레이션
+(worktree fan-out / git apply / aggregate test 실행 / PR·merge)은
+`skills/impl-loop/SKILL.md` 절차 영역이며 본 모듈은 결정 로직만 담는다.
+
+담는 것:
+
+- `parse_impl_task` — impl task frontmatter `depends_on` (3-state) +
+  `## Scope > 수정 허용` 파일 경로 집합 파싱.
+- `compute_waves` — depends_on DAG 위상 + Scope 파일집합 disjoint +
+  `max_parallel_workers` cap → 병렬 wave 후보. 불명확(미상 / scope 자유서술 /
+  force_serial)은 직렬 강등 (정책 §3.1 · §4).
+- `fan_in_check` — leader fan-in gate 의 최소 구조 판정 (scope 준수 +
+  cross-worker 파일 충돌 + evidence 존재). aggregate test 실행 PASS 는
+  이와 별개의 *절차적* 요건이라 leader 가 Bash 로 수행한다 (정책 §6).
+
+3-state `depends_on` (정책 §3.1):
+
+- `None`  = 미상(미작성 / placeholder 잔존) → 독립 확신 불가 → 직렬 강등.
+- `()`    = 명시적 `[]` = 선행 없음 선언 → Scope 도 disjoint 면 병렬 후보.
+- `(...)` = 그 선행 task 들에 의존.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+__all__ = [
+    "DEFAULT_MAX_PARALLEL_WORKERS",
+    "ImplTask",
+    "WaveStep",
+    "WavePlan",
+    "WorkerResult",
+    "FanInResult",
+    "parse_impl_task",
+    "compute_waves",
+    "fan_in_check",
+    "scopes_disjoint",
+]
+
+# 정책 §7 — 첫 버전 동시성 상한. 상향은 실측 후 별도 이슈.
+DEFAULT_MAX_PARALLEL_WORKERS = 2
+
+# 병렬 후보 wave 의 기본 사유.
+_PARALLEL_REASON = "독립 — depends_on 선후 없음 + Scope 파일집합 disjoint"
+
+
+# ── 데이터 모델 ──────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ImplTask:
+    """impl task 한 개의 병렬 판정 입력 (정규화 결과)."""
+
+    slug: str
+    path: str
+    # 3-state: None=미상 / ()=명시적 선행 없음 / (...)=목록
+    depends_on: Optional[tuple[str, ...]]
+    scope_paths: frozenset[str]
+    scope_ambiguous: bool
+    # frontmatter `parallel: serial|false` 또는 고위험 명시 → 강제 직렬.
+    force_serial: bool = False
+
+    @property
+    def serial_only(self) -> bool:
+        """병렬 불가(직렬 강등) 조건 — 정책 §4 fallback."""
+        return (
+            self.depends_on is None
+            or self.scope_ambiguous
+            or not self.scope_paths
+            or self.force_serial
+        )
+
+    @property
+    def serial_reason(self) -> Optional[str]:
+        """직렬 강등 사유 (병렬 불가일 때). 병렬 가능이면 None."""
+        if self.force_serial:
+            return "강제 직렬 (parallel: serial / 고위험)"
+        if self.depends_on is None:
+            return "depends_on 미상(미작성)"
+        if self.scope_ambiguous or not self.scope_paths:
+            return "Scope 파일 경로 미정규화(자유서술/빈값)"
+        return None
+
+
+@dataclass(frozen=True)
+class WaveStep:
+    """실행 계획의 한 단계 — 병렬 wave(≥2) 또는 직렬 단일(1)."""
+
+    index: int
+    mode: str  # "parallel" | "serial"
+    tasks: tuple[ImplTask, ...]
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "index": self.index,
+            "mode": self.mode,
+            "tasks": [t.slug for t in self.tasks],
+            "reason": self.reason,
+        }
+
+
+@dataclass(frozen=True)
+class WavePlan:
+    """compute_waves 결과 — 순서 있는 단계 목록."""
+
+    steps: tuple[WaveStep, ...]
+    max_parallel_workers: int
+
+    @property
+    def has_parallel(self) -> bool:
+        return any(s.mode == "parallel" for s in self.steps)
+
+    @property
+    def parallel_steps(self) -> tuple[WaveStep, ...]:
+        return tuple(s for s in self.steps if s.mode == "parallel")
+
+    def to_dict(self) -> dict:
+        return {
+            "max_parallel_workers": self.max_parallel_workers,
+            "has_parallel": self.has_parallel,
+            "steps": [s.to_dict() for s in self.steps],
+        }
+
+
+@dataclass(frozen=True)
+class WorkerResult:
+    """fan-in 시 worker 한 명이 반환한 산출물의 검증 입력."""
+
+    slug: str
+    changed_paths: frozenset[str]  # worker diff 가 실제로 건드린 파일
+    declared_scope: frozenset[str]  # 해당 task 의 `수정 허용`
+    evidence_present: bool = True
+
+
+@dataclass(frozen=True)
+class FanInResult:
+    """leader fan-in gate 의 최소 구조 판정 결과."""
+
+    verdict: str  # "PASS" | "FALLBACK"
+    scope_violations: tuple[tuple[str, str], ...]  # (slug, scope 밖 path)
+    conflicts: tuple[tuple[str, tuple[str, ...]], ...]  # (path, 그 path 건드린 slug 들)
+    missing_evidence: tuple[str, ...]  # evidence 없는 slug
+    reasons: tuple[str, ...]
+
+    @property
+    def passed(self) -> bool:
+        return self.verdict == "PASS"
+
+    def to_dict(self) -> dict:
+        return {
+            "verdict": self.verdict,
+            "passed": self.passed,
+            "scope_violations": [list(v) for v in self.scope_violations],
+            "conflicts": [[p, list(s)] for p, s in self.conflicts],
+            "missing_evidence": list(self.missing_evidence),
+            "reasons": list(self.reasons),
+        }
+
+
+# ── 파싱 ────────────────────────────────────────────────────
+
+
+def _strip_inline_comment(value: str) -> str:
+    """frontmatter 값에서 `#` 주석 제거. slug/경로는 `#` 미포함이라 안전."""
+    idx = value.find("#")
+    return value if idx < 0 else value[:idx]
+
+
+def _extract_frontmatter_lines(text: str) -> list[str]:
+    """첫 `---` … `---` 블록 안 줄 목록. 부재 시 빈 목록."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return []
+    out: list[str] = []
+    for line in lines[1:]:
+        if line.strip() == "---":
+            return out
+        out.append(line)
+    return []  # 닫는 --- 없음 → frontmatter 아님
+
+
+def _finalize_dep_items(items: Iterable[str]) -> Optional[tuple[str, ...]]:
+    """파싱한 depends_on 원소들을 정리. placeholder 잔존 시 미상(None)."""
+    cleaned: list[str] = []
+    for raw in items:
+        it = raw.strip().strip("'\"").strip("`").strip()
+        if not it:
+            continue
+        # placeholder 미충전 (`<NN-slug>`, `...`) → 미상으로 강등 (오판 방지).
+        if "<" in it or ">" in it or it == "...":
+            return None
+        cleaned.append(it)
+    if not cleaned:
+        return None
+    return tuple(cleaned)
+
+
+def _parse_depends_on(fm_lines: list[str]) -> Optional[tuple[str, ...]]:
+    """3-state depends_on 파싱 (정책 §3.1).
+
+    반환: None(미상) / ()(명시적 선행 없음) / (slug, ...)(목록).
+    """
+    idx = None
+    for i, line in enumerate(fm_lines):
+        if re.match(r"^depends_on\s*:", line):
+            idx = i
+            break
+    if idx is None:
+        return None  # 키 부재 → 미상
+
+    value = _strip_inline_comment(fm_lines[idx].split(":", 1)[1]).strip()
+
+    if value == "":
+        # same-line 값 없음 → 블록 리스트(`  - x`) 탐색.
+        items: list[str] = []
+        for j in range(idx + 1, len(fm_lines)):
+            m = re.match(r"^\s+-\s+(.+)$", fm_lines[j])
+            if m:
+                items.append(m.group(1))
+            elif fm_lines[j].strip() == "":
+                continue
+            else:
+                break  # 다음 key → 블록 종료
+        if not items:
+            return None  # 값도 블록도 없음 → 미상
+        return _finalize_dep_items(items)
+
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if inner == "":
+            return ()  # 명시적 [] → 선행 없음(독립 후보)
+        return _finalize_dep_items(inner.split(","))
+
+    # 스칼라/기타 malformed → 안전하게 미상.
+    return None
+
+
+def _parse_parallel_marker(fm_lines: list[str]) -> bool:
+    """frontmatter `parallel:` 가 serial/false/no 면 강제 직렬."""
+    for line in fm_lines:
+        m = re.match(r"^parallel\s*:\s*(.+)$", line)
+        if m:
+            val = _strip_inline_comment(m.group(1)).strip().strip("'\"").lower()
+            return val in {"serial", "false", "no", "off"}
+    return False
+
+
+def _is_path_like(token: str) -> bool:
+    """repo-relative 파일/디렉토리 경로처럼 보이는 단일 토큰인가."""
+    if not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_./*-]*", token):
+        return False
+    return ("/" in token) or bool(re.search(r"\.[A-Za-z0-9]+$", token))
+
+
+def _normalize_path(token: str) -> str:
+    """경로 정규화 — 선행 `./` 제거, 그 외 보존."""
+    t = token.strip()
+    while t.startswith("./"):
+        t = t[2:]
+    return t
+
+
+def _parse_scope(text: str) -> tuple[frozenset[str], bool]:
+    """`### 수정 허용` 섹션을 파일 경로 집합으로. (paths, ambiguous) 반환.
+
+    엄격 규칙(정책 §3 "자유 서술 금지"): bullet 내용이 **단일 path-like 토큰**일
+    때만 경로로 인정. 빈 bullet / 다중 토큰 / 산문 → ambiguous=True (직렬 강등).
+    섹션/경로 부재도 ambiguous.
+    """
+    lines = text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(r"^###\s+수정\s*허용\s*$", line.strip()):
+            start = i
+            break
+    if start is None:
+        return frozenset(), True  # 섹션 부재 → 미상
+
+    paths: list[str] = []
+    has_nonpath = False
+    for j in range(start + 1, len(lines)):
+        s = lines[j].strip()
+        if re.match(r"^#{2,4}\s", s):
+            break  # 다음 헤더
+        if s.startswith(">"):  # blockquote 안내문 무시
+            continue
+        if not s.startswith("-"):
+            continue
+        token = s[1:].strip()
+        if token.startswith("`") and token.endswith("`") and len(token) >= 2:
+            token = token[1:-1].strip()
+        parts = token.split()
+        if len(parts) == 1 and _is_path_like(parts[0]):
+            paths.append(_normalize_path(parts[0]))
+        else:
+            has_nonpath = True  # 빈/산문/다중토큰 bullet
+
+    if not paths:
+        return frozenset(), True
+    return frozenset(paths), has_nonpath
+
+
+def parse_impl_task(path: str | Path) -> ImplTask:
+    """impl task 파일을 ImplTask 로 파싱."""
+    p = Path(path)
+    text = p.read_text(encoding="utf-8")
+    fm_lines = _extract_frontmatter_lines(text)
+    depends_on = _parse_depends_on(fm_lines)
+    scope_paths, scope_ambiguous = _parse_scope(text)
+    force_serial = _parse_parallel_marker(fm_lines)
+    return ImplTask(
+        slug=p.stem,
+        path=str(p),
+        depends_on=depends_on,
+        scope_paths=scope_paths,
+        scope_ambiguous=scope_ambiguous,
+        force_serial=force_serial,
+    )
+
+
+# ── Scope 충돌 판정 ──────────────────────────────────────────
+
+
+def _paths_overlap(a: str, b: str) -> bool:
+    """두 경로가 충돌(동일/디렉토리 포함/glob 매치)하는가."""
+    if a == b:
+        return True
+    a_dir = a.rstrip("/") + "/"
+    b_dir = b.rstrip("/") + "/"
+    if b.startswith(a_dir) or a.startswith(b_dir):
+        return True
+    if "*" in a or "*" in b:
+        if fnmatch.fnmatch(b, a) or fnmatch.fnmatch(a, b):
+            return True
+    return False
+
+
+def scopes_disjoint(a: Iterable[str], b: Iterable[str]) -> bool:
+    """두 Scope 파일집합이 서로 충돌하지 않으면 True (병렬 가능)."""
+    a = list(a)
+    b = list(b)
+    for pa in a:
+        for pb in b:
+            if _paths_overlap(pa, pb):
+                return False
+    return True
+
+
+# ── wave 계산 ────────────────────────────────────────────────
+
+
+def _deps_satisfied(task: ImplTask, done: set[str], in_batch: set[str]) -> bool:
+    """task 의 batch 내 선행이 모두 done 인가 (batch 밖 선행은 머지됨으로 간주)."""
+    if not task.depends_on:  # None(미상) 또는 ()(선행 없음)
+        return True
+    for dep in task.depends_on:
+        if dep in in_batch and dep not in done:
+            return False
+    return True
+
+
+def compute_waves(
+    tasks: list[ImplTask],
+    max_parallel_workers: int = DEFAULT_MAX_PARALLEL_WORKERS,
+) -> WavePlan:
+    """impl task 목록(직렬 순서)을 병렬 wave 계획으로.
+
+    정책 §3 판정식:
+        같은 wave 병렬 가능 = depends_on 위상상 선후 없음 AND Scope 파일집합 disjoint
+    불명확(미상 / scope 자유서술 / force_serial)은 직렬 강등 (§4).
+    동시성 상한 = max_parallel_workers (§7).
+    """
+    if max_parallel_workers < 1:
+        max_parallel_workers = 1
+    in_batch = {t.slug for t in tasks}
+    remaining = list(tasks)
+    done: set[str] = set()
+    steps: list[WaveStep] = []
+    step_index = 0
+
+    while remaining:
+        frontier = [t for t in remaining if _deps_satisfied(t, done, in_batch)]
+        if not frontier:
+            # 순환/미해결 의존 → 안전하게 첫 항목 직렬.
+            head = remaining[0]
+            step_index += 1
+            steps.append(
+                WaveStep(step_index, "serial", (head,), "의존 미해결/순환 → 직렬")
+            )
+            remaining.remove(head)
+            done.add(head.slug)
+            continue
+
+        head = frontier[0]
+
+        if head.serial_only:
+            step_index += 1
+            steps.append(
+                WaveStep(step_index, "serial", (head,), head.serial_reason or "직렬")
+            )
+            remaining.remove(head)
+            done.add(head.slug)
+            continue
+
+        # head 는 병렬 후보 — 다른 후보와 Scope disjoint 한 wave 구성 (cap 까지).
+        wave = [head]
+        for cand in frontier[1:]:
+            if len(wave) >= max_parallel_workers:
+                break
+            if cand.serial_only:
+                continue
+            if all(scopes_disjoint(cand.scope_paths, w.scope_paths) for w in wave):
+                wave.append(cand)
+
+        step_index += 1
+        if len(wave) >= 2:
+            steps.append(
+                WaveStep(step_index, "parallel", tuple(wave), _PARALLEL_REASON)
+            )
+            for t in wave:
+                remaining.remove(t)
+                done.add(t.slug)
+        else:
+            # 짝 없음 → head 단독 직렬.
+            steps.append(
+                WaveStep(
+                    step_index,
+                    "serial",
+                    (head,),
+                    "동시 가능한 짝 없음 (Scope 중첩 등) → 직렬",
+                )
+            )
+            remaining.remove(head)
+            done.add(head.slug)
+
+    return WavePlan(tuple(steps), max_parallel_workers)
+
+
+# ── fan-in 검증 ──────────────────────────────────────────────
+
+
+def _path_in_scope(path: str, scope: Iterable[str]) -> bool:
+    """changed path 가 declared scope 안인가."""
+    for entry in scope:
+        if path == entry:
+            return True
+        if path.startswith(entry.rstrip("/") + "/"):
+            return True
+        if "*" in entry and fnmatch.fnmatch(path, entry):
+            return True
+    return False
+
+
+def fan_in_check(results: Iterable[WorkerResult]) -> FanInResult:
+    """fan-in gate 의 최소 구조 판정 (정책 §6).
+
+    PASS = 모든 worker diff 가 자기 Scope 안 + cross-worker 파일 충돌 없음 +
+    evidence 전부 존재. 하나라도 어기면 FALLBACK (직렬 강등 신호).
+
+    주의: aggregate tree 전체 테스트 PASS 는 별개의 절차적 요건이라 leader 가
+    Bash 로 수행한다 — 본 함수는 그 *전* 의 구조 게이트만 본다.
+    """
+    results = list(results)
+
+    scope_violations: list[tuple[str, str]] = []
+    for r in results:
+        for p in sorted(r.changed_paths):
+            if not _path_in_scope(p, r.declared_scope):
+                scope_violations.append((r.slug, p))
+
+    owners: dict[str, list[str]] = {}
+    for r in results:
+        for p in r.changed_paths:
+            owners.setdefault(p, []).append(r.slug)
+    conflicts = [
+        (p, tuple(sorted(s))) for p, s in sorted(owners.items()) if len(s) > 1
+    ]
+
+    missing = tuple(r.slug for r in results if not r.evidence_present)
+
+    reasons: list[str] = []
+    if scope_violations:
+        reasons.append(f"scope 이탈 {len(scope_violations)}건")
+    if conflicts:
+        reasons.append(f"cross-worker 파일 충돌 {len(conflicts)}건")
+    if missing:
+        reasons.append(f"evidence 누락 {len(missing)}건")
+
+    verdict = "PASS" if not reasons else "FALLBACK"
+    return FanInResult(
+        verdict=verdict,
+        scope_violations=tuple(scope_violations),
+        conflicts=tuple(conflicts),
+        missing_evidence=missing,
+        reasons=tuple(reasons),
+    )
+
+
+# ── CLI 보조 (wave-plan 서브커맨드에서 호출) ──────────────────
+
+
+def _resolve_impl_paths(raw_paths: list[str]) -> list[Path]:
+    """경로 인자(파일/디렉토리/glob)를 impl 파일 목록으로 전개 + NN- 순 정렬."""
+    found: list[Path] = []
+    seen: set[str] = set()
+    for raw in raw_paths:
+        p = Path(raw)
+        candidates: list[Path]
+        if p.is_dir():
+            candidates = sorted(p.glob("*.md"))
+        elif any(ch in raw for ch in "*?["):
+            base = Path(".")
+            candidates = sorted(base.glob(raw))
+        elif p.exists():
+            candidates = [p]
+        else:
+            candidates = []
+        for c in candidates:
+            key = str(c.resolve())
+            if key not in seen:
+                seen.add(key)
+                found.append(c)
+    return sorted(found, key=lambda x: x.name)
+
+
+def wave_plan_from_paths(
+    raw_paths: list[str], max_parallel_workers: int = DEFAULT_MAX_PARALLEL_WORKERS
+) -> WavePlan:
+    paths = _resolve_impl_paths(raw_paths)
+    tasks = [parse_impl_task(p) for p in paths]
+    return compute_waves(tasks, max_parallel_workers)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """`python -m harness.parallel_wave <paths...>` — wave plan JSON 출력."""
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="parallel_wave",
+        description="impl task 들의 병렬 wave 계획 계산 (#636)",
+    )
+    parser.add_argument("paths", nargs="+", help="impl 파일 / 디렉토리 / glob")
+    parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=DEFAULT_MAX_PARALLEL_WORKERS,
+        help=f"동시성 상한 (default {DEFAULT_MAX_PARALLEL_WORKERS})",
+    )
+    args = parser.parse_args(argv)
+    plan = wave_plan_from_paths(args.paths, args.max_parallel)
+    print(json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -305,7 +305,8 @@ def _parse_scope(text: str) -> tuple[frozenset[str], bool]:
             # bullet 아닌 자유서술 prose → 정규화 안 됨 → 미상(직렬) (#636 codex F7)
             has_nonpath = True
             continue
-        token = s[1:].strip()
+        # inline 주석 strip — depends_on 파싱과 일관 (`- src/a.py  # 핸들러` 허용).
+        token = _strip_inline_comment(s[1:]).strip()
         if token.startswith("`") and token.endswith("`") and len(token) >= 2:
             token = token[1:-1].strip()
         parts = token.split()
@@ -369,6 +370,26 @@ def _glob_to_regex(pattern: str) -> str:
             out.append("[^/]")
             i += 1
             continue
+        if ch == "[":
+            # char class `[abc]` / `[!abc]`(negation) — _has_glob 가 `[` 를 glob 으로
+            # 인식하므로 리터럴로 두면 비일관. 닫는 `]` 까지 regex char class 로 옮긴다.
+            j = i + 1
+            if j < n and pattern[j] in "!^":
+                j += 1
+            if j < n and pattern[j] == "]":
+                j += 1  # 첫 `]` 는 class 안 리터럴
+            while j < n and pattern[j] != "]":
+                j += 1
+            if j >= n:  # 닫는 `]` 없음 → 리터럴 `[`
+                out.append(re.escape("["))
+                i += 1
+                continue
+            inner = pattern[i + 1 : j]
+            if inner[:1] == "!":
+                inner = "^" + inner[1:]
+            out.append("[" + inner + "]")
+            i = j + 1
+            continue
         out.append(re.escape(ch))
         i += 1
     return "".join(out)
@@ -379,10 +400,14 @@ def _glob_match(path: str, pattern: str) -> bool:
 
     `fnmatch` 와 달리 `*` 가 `/` 를 넘지 않는다 — `src/*.py` 는 `src/a.py` 만 매치하고
     `src/sub/a.py` 는 매치 안 함 (fan-in scope gate 우회 차단, #636 codex F4).
+    `?`(단일 비-/ 문자)·`[...]`(char class)도 segment-aware.
     """
     if not _has_glob(pattern):
         return path == pattern
-    return re.fullmatch(_glob_to_regex(pattern), path) is not None
+    try:
+        return re.fullmatch(_glob_to_regex(pattern), path) is not None
+    except re.error:
+        return path == pattern  # 깨진 패턴 → 리터럴 비교 (안전)
 
 
 def _glob_dir_prefix(p: str) -> str:

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -288,8 +288,13 @@ def _scope_inherent_high_risk(scope_paths: Iterable[str]) -> bool:
 
 
 def _is_path_like(token: str) -> bool:
-    """repo-relative 파일/디렉토리 경로처럼 보이는 단일 토큰인가."""
-    if not re.fullmatch(r"[A-Za-z0-9_][A-Za-z0-9_./*-]*", token):
+    """repo-relative 파일/디렉토리 경로처럼 보이는 단일 토큰인가.
+
+    leading `.` 허용 — `./src/a.py`(상대), `.github/workflows/ci.yml`(dot-dir),
+    `.env`(dotfile) 같은 흔한 경로가 ambiguous 로 오판돼 직렬 강등되지 않게 (#636 F14).
+    bare `.`·`..`·`...` 는 `/` 도 확장자도 없어 아래 조건에서 걸러진다.
+    """
+    if not re.fullmatch(r"[A-Za-z0-9_.][A-Za-z0-9_./*-]*", token):
         return False
     return ("/" in token) or bool(re.search(r"\.[A-Za-z0-9]+$", token))
 
@@ -554,16 +559,22 @@ def compute_waves(
             done.add(head.slug)
             continue
 
-        # head 는 병렬 후보 — frontier 순서(NN/task_index)대로 *연속* 으로만 묶는다.
-        # join 불가한 task(serial / Scope 겹침)를 만나면 건너뛰지 않고 **멈춘다**.
-        # 건너뛰어 뒤 task 를 당기면 실행/머지 순서가 뒤집혀 task_index 기반 issue close
-        # semantics(3/3 PR 이 story 를 닫음)가 깨진다 (#636 codex F10).
+        # head 는 병렬 후보 — **remaining(NN/task_index) 순서의 *연속* prefix** 로만 묶는다.
+        # frontier(준비된 것만) 가 아니라 remaining 을 순회하는 이유: 사이에 *blocked*
+        # (아직 미준비) task 가 있으면 그것도 barrier 여야 한다. frontier 만 보면 blocked
+        # task 를 건너뛰고 뒤 독립 task 를 당겨 순서가 뒤집힌다 (#636 codex F13 — F10 의
+        # 미준비-intervening 변종). join 불가(blocked / serial·고위험 / Scope 겹침 / cap)를
+        # 만나면 멈춘다. 그래야 실행/머지 순서 = task_index 순서가 보존돼 3/3 PR 이 story 를
+        # 마지막에 닫는 invariant 가 유지된다.
+        head_idx = remaining.index(head)
         wave = [head]
-        for cand in frontier[1:]:
+        for cand in remaining[head_idx + 1:]:
             if len(wave) >= max_parallel_workers:
                 break
+            if not _deps_satisfied(cand, done, in_batch):
+                break  # blocked intervening task → 순서 barrier
             if _is_serial(cand):
-                break  # 순서 barrier (serial_only / 고위험)
+                break  # serial_only / 고위험 → 순서 barrier
             if all(scopes_disjoint(cand.scope_paths, w.scope_paths) for w in wave):
                 wave.append(cand)
             else:

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -482,15 +482,20 @@ def compute_waves(
             done.add(head.slug)
             continue
 
-        # head 는 병렬 후보 — 다른 후보와 Scope disjoint 한 wave 구성 (cap 까지).
+        # head 는 병렬 후보 — frontier 순서(NN/task_index)대로 *연속* 으로만 묶는다.
+        # join 불가한 task(serial_only / Scope 겹침)를 만나면 건너뛰지 않고 **멈춘다**.
+        # 건너뛰어 뒤 task 를 당기면 실행/머지 순서가 뒤집혀 task_index 기반 issue close
+        # semantics(3/3 PR 이 story 를 닫음)가 깨진다 (#636 codex F10).
         wave = [head]
         for cand in frontier[1:]:
             if len(wave) >= max_parallel_workers:
                 break
             if cand.serial_only:
-                continue
+                break  # 순서 barrier
             if all(scopes_disjoint(cand.scope_paths, w.scope_paths) for w in wave):
                 wave.append(cand)
+            else:
+                break  # Scope 겹침 → 순서 barrier
 
         step_index += 1
         if len(wave) >= 2:

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -189,10 +189,15 @@ def _extract_frontmatter_lines(text: str) -> list[str]:
 
 
 def _finalize_dep_items(items: Iterable[str]) -> Optional[tuple[str, ...]]:
-    """파싱한 depends_on 원소들을 정리. placeholder 잔존 시 미상(None)."""
+    """파싱한 depends_on 원소들을 정리. placeholder 잔존 시 미상(None).
+
+    block 리스트 원소의 inline 주석(`- 01-a  # produces X`)도 제거한다 — slug 는
+    `#` 를 포함하지 않으므로 안전. 안 떼면 주석이 slug 에 섞여 `_deps_satisfied`
+    가 선행 task 와 매칭 못 해 의존 task 를 같은 wave 로 잘못 올린다.
+    """
     cleaned: list[str] = []
     for raw in items:
-        it = raw.strip().strip("'\"").strip("`").strip()
+        it = _strip_inline_comment(raw).strip().strip("'\"").strip("`").strip()
         if not it:
             continue
         # placeholder 미충전 (`<NN-slug>`, `...`) → 미상으로 강등 (오판 방지).

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -228,11 +228,12 @@ def _parse_depends_on(fm_lines: list[str]) -> Optional[tuple[str, ...]]:
         # same-line 값 없음 → 블록 리스트(`  - x`) 탐색.
         items: list[str] = []
         for j in range(idx + 1, len(fm_lines)):
+            stripped = fm_lines[j].strip()
             m = re.match(r"^\s+-\s+(.+)$", fm_lines[j])
             if m:
                 items.append(m.group(1))
-            elif fm_lines[j].strip() == "":
-                continue
+            elif stripped == "" or stripped.startswith("#"):
+                continue  # 빈 줄·standalone 주석 → block 중간이라도 종료 X (#636 codex F6)
             else:
                 break  # 다음 key → 블록 종료
         if not items:
@@ -296,9 +297,13 @@ def _parse_scope(text: str) -> tuple[frozenset[str], bool]:
         s = lines[j].strip()
         if re.match(r"^#{2,4}\s", s):
             break  # 다음 헤더
+        if s == "":
+            continue
         if s.startswith(">"):  # blockquote 안내문 무시
             continue
         if not s.startswith("-"):
+            # bullet 아닌 자유서술 prose → 정규화 안 됨 → 미상(직렬) (#636 codex F7)
+            has_nonpath = True
             continue
         token = s[1:].strip()
         if token.startswith("`") and token.endswith("`") and len(token) >= 2:
@@ -348,7 +353,13 @@ def _glob_to_regex(pattern: str) -> str:
         ch = pattern[i]
         if ch == "*":
             if i + 1 < n and pattern[i + 1] == "*":
-                out.append(".*")  # ** → recursive (crosses /)
+                # globstar. `**/` 는 0개 이상 디렉토리 → `src/**/*.py` 가 `src/a.py`
+                # (중간 디렉토리 0개)도 매치하도록 slash 를 optional 로 (#636 codex F8).
+                if i + 2 < n and pattern[i + 2] == "/":
+                    out.append("(?:.*/)?")
+                    i += 3
+                    continue
+                out.append(".*")  # 끝의 ** → 나머지 전부
                 i += 2
                 continue
             out.append("[^/]*")  # * → segment-local (no /)

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1687,7 +1687,10 @@ def _cli_wave_plan(args: Any) -> int:
 
     from harness import parallel_wave
 
-    plan = parallel_wave.wave_plan_from_paths(args.paths, args.max_parallel)
+    high_risk = parallel_wave._split_csv(getattr(args, "high_risk", ""))
+    plan = parallel_wave.wave_plan_from_paths(
+        args.paths, args.max_parallel, high_risk
+    )
     print(_json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
     return 0
 
@@ -2445,6 +2448,12 @@ def _build_arg_parser() -> Any:
         default=parallel_wave.DEFAULT_MAX_PARALLEL_WORKERS,
         dest="max_parallel",
         help=f"동시성 상한 (default {parallel_wave.DEFAULT_MAX_PARALLEL_WORKERS})",
+    )
+    p_wp.add_argument(
+        "--high-risk",
+        default="",
+        dest="high_risk",
+        help="메인 dry-preview 고위험 판정 slug (콤마 구분) → 직렬 강제",
     )
     p_wp.set_defaults(func=_cli_wave_plan)
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1676,6 +1676,22 @@ def _cli_run_status(args: Any) -> int:
     return 0
 
 
+def _cli_wave_plan(args: Any) -> int:
+    """impl task 들의 opt-in 병렬 wave 계획 계산 → JSON stdout (#636).
+
+    `/impl-loop` chain dry preview 가 호출해 병렬 wave 후보를 표에 echo 한다.
+    정책 SSOT = docs/plugin/parallel-policy.md (모델 A: worktree 격리 fan-in).
+    내부 helper (run-dir / run-status 류) — 새 public surface 아님.
+    """
+    import json as _json
+
+    from harness import parallel_wave
+
+    plan = parallel_wave.wave_plan_from_paths(args.paths, args.max_parallel)
+    print(_json.dumps(plan.to_dict(), ensure_ascii=False, indent=2))
+    return 0
+
+
 def _cli_ledger_event(args: Any) -> int:
     """ledger 에 *수동* checkpoint event 한 줄 기록 (pr_created/pr_merged/task_completed/blocked 등 — 이슈 #587).
 
@@ -2326,6 +2342,8 @@ def _cli_routing(args: Any) -> int:
 def _build_arg_parser() -> Any:
     import argparse
 
+    from harness import parallel_wave
+
     parser = argparse.ArgumentParser(
         prog="python3 -m harness.session_state",
         description="dcNess 세션/run 격리 helper CLI",
@@ -2415,6 +2433,20 @@ def _build_arg_parser() -> Any:
     )
     p_rs.add_argument("--run-id", default=None, dest="run_id")
     p_rs.set_defaults(func=_cli_run_status)
+
+    p_wp = sub.add_parser(
+        "wave-plan",
+        help="impl task 들의 opt-in 병렬 wave 계획 JSON (chain dry preview — #636)",
+    )
+    p_wp.add_argument("paths", nargs="+", help="impl 파일 / 디렉토리 / glob")
+    p_wp.add_argument(
+        "--max-parallel",
+        type=int,
+        default=parallel_wave.DEFAULT_MAX_PARALLEL_WORKERS,
+        dest="max_parallel",
+        help=f"동시성 상한 (default {parallel_wave.DEFAULT_MAX_PARALLEL_WORKERS})",
+    )
+    p_wp.set_defaults(func=_cli_wave_plan)
 
     p_le = sub.add_parser(
         "ledger-event",

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -273,8 +273,12 @@ chain = 위 공통 골격 + 엔진을 **task 한 개씩** 반복. task N 이 완
 dry preview 표 echo *직후*, wave 후보를 계산한다 (판정은 harness 자동 — 사용자가 의존 사슬을 손으로 추적하지 않는다):
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" wave-plan <impl-glob-or-dir>
+# dry preview 표의 risk 열에서 high-risk 로 판정한 task slug 들을 --high-risk 로 넘긴다.
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" wave-plan <impl-glob-or-dir> \
+  --high-risk <high-risk-slug1,high-risk-slug2>   # 없으면 생략
 ```
+
+> 🔴 **고위험 판정 전달 (MUST)**: 정책의 "migration/destructive/security/도메인 invariant → 직렬" 은 *의미* 판정이라 경로만으론 못 잡는다. dry preview 의 risk 열(`high-risk`)이 진본이며, 그 slug 들을 `--high-risk` 로 넘겨야 driver 가 직렬로 강등한다. 경로상 명백한 것(migrations/·secrets·.env)은 harness 가 backstop 으로 자동 직렬화하지만, auth 로직·도메인 invariant 처럼 의미 기반 고위험은 메인이 넘기지 않으면 병렬로 샐 수 있다.
 
 - `has_parallel=false` → **전부 직렬** — 본 절 전체 skip, 기존 직렬 chain 그대로 (아무 것도 안 바뀜). 대부분의 chain 이 이 경로다.
 - `has_parallel=true` → 각 `parallel` step 의 task 묶음을 표에 한 줄 덧붙여 echo + **opt-in 1회 확인**: `wave: [taskX, taskY] 병렬로 갈까요? (Y/n)`.

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -266,6 +266,47 @@ chain = 위 공통 골격 + 엔진을 **task 한 개씩** 반복. task N 이 완
 - task **≥ 10** → 계획 표 echo + `진행할까요? (Y/n)` 1회 확인 후 진입.
 - **yolo 모드** (`yolo` / `auto` / `끝까지` / `막힘 없이` / `다 알아서`, [`loop-procedure.md`](../../docs/plugin/loop-procedure.md) yolo 키워드) → task 수 무관 자동 진입.
 
+### 병렬 wave (opt-in, chain 한정, #636)
+
+> 🔴 **기본은 직렬**. 병렬은 *독립 task 가 기계적으로 확신될 때만* opt-in 으로 켜진다. 정책 SSOT = [`parallel-policy.md`](../../docs/plugin/parallel-policy.md) (모델 A: worktree 격리 fan-in). 본 절은 그 정책의 *절차* 만 담는다.
+
+dry preview 표 echo *직후*, wave 후보를 계산한다 (판정은 harness 자동 — 사용자가 의존 사슬을 손으로 추적하지 않는다):
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" wave-plan <impl-glob-or-dir>
+```
+
+- `has_parallel=false` → **전부 직렬** — 본 절 전체 skip, 기존 직렬 chain 그대로 (아무 것도 안 바뀜). 대부분의 chain 이 이 경로다.
+- `has_parallel=true` → 각 `parallel` step 의 task 묶음을 표에 한 줄 덧붙여 echo + **opt-in 1회 확인**: `wave: [taskX, taskY] 병렬로 갈까요? (Y/n)`.
+  - **yolo 모드여도 병렬은 자동 ON 하지 않는다** — 병렬은 명시적 opt-in 한정 (직렬이 더 안전한 default). yolo 는 직렬 진입만 자동화.
+  - `n` / 무응답 / 모호 → 그 wave 직렬 fallback (각 task 를 순서대로 직렬 진행).
+  - `Y` → 아래 3단계 (build 병렬 → fan-in gate → merge 직렬) 실행.
+
+판정식·3-state `depends_on`·Scope 정규화·fallback 조건은 모두 `wave-plan` 이 [`parallel-policy.md`](../../docs/plugin/parallel-policy.md) 의 독립성 판정·병렬 금지 조건대로 계산한다. 메인은 결과 JSON 만 읽는다.
+
+**① build 병렬** — wave 의 각 task 마다 격리 worktree + worker:
+
+- task 별 별도 worktree: `git worktree add <wt_path> -b <task-branch> <base-ref>` (base = chain base; 통합 브랜치 모드면 그 integration branch).
+- 각 worktree 에서 build-worker 1명 호출. worker prompt 에 impl 경로 + task slug + **patch/evidence only 경계** 명시 ([`build-worker-agent.md` 병렬 wave 경계](../../agents/build-worker/build-worker-agent.md#권한-경계)): worker 는 코드 변경 + 테스트 결과 + evidence prose 만 반환. `git push` / PR 생성·머지 / issue close / `dcness-helper` run·ledger·checkpoint 금지. transport 용 로컬 commit 은 허용(authoritative 아님).
+- 동시성 상한 `max_parallel_workers=2` (정책 비용가드). 초과 task 는 다음 wave 또는 직렬.
+- 외부 활성 프로젝트에서는 worker(sub-agent)의 leader-owned helper/push/PR 가 [`agent_boundary.py`](../../harness/agent_boundary.py) 로 구조적 차단된다(prompt 경계 + 코드 경계 이중).
+
+**② fan-in gate (leader, 직렬 진입 허가만)** — 정책의 fan-in 검증 최소 절차:
+
+1. 각 worker worktree 의 변경 파일(`git -C <wt> diff --name-only <base>`) + evidence 수집.
+2. 별도 fan-in worktree 에 wave patch 들을 합친다 (`git -C <fanin> cherry-pick` 또는 `git apply`).
+3. **scope 준수**(각 변경 파일이 그 task `수정 허용` 안) + **cross-worker 파일 충돌**(두 worker 가 같은 파일) + **evidence 존재** 판정. 이 구조 게이트의 판정 로직 = [`parallel_wave.fan_in_check`](../../harness/parallel_wave.py) (PASS/FALLBACK).
+4. aggregate tree 전체 테스트를 1회 이상 돌린다 (이 *실행* 은 leader Bash — 구조 게이트와 별개의 절차 요건).
+5. **PASS** → ③ merge 단계 진입. **FAIL** → 충돌/실패 worker 산출물만 폐기하고 그 task 를 직렬 chain 으로 강등(나머지 wave 는 PASS 분만 진행 가능).
+
+**③ merge 직렬 (leader)** — fan-in PASS *후에도* 기존 규칙 그대로:
+
+- wave 의 task 를 **한 개씩 직렬**로 PR 생성 → pr-reviewer → merge → issue close. 병렬 worker 완료 ≠ task 완료. task 완료는 leader 의 PR merge + issue close 로만 성립.
+- `aggregate gate PASS 는 merge 단계 진입 허가일 뿐, PR 별 pr-reviewer·CI 검증을 생략하지 않는다`.
+- `1 task = 1 PR` 과 issue close semantics 유지. run-review / ROI marker 의 분석 단위는 task별 직렬 merge 기준이라 깨지지 않는다 (정책의 측정·분석 단위 보존).
+
+> wave 가 끝나면 그 build 용 worktree 들은 squash 흡수 후 정리한다 (fan-in worktree 포함). chain 의 다음 step(직렬 task 또는 다음 wave)으로 진행.
+
 ### task 경계 — next-task 통합 호출 (#471)
 
 마지막이 아닌 task 종료 시 `dcness-helper next-task --entry-point impl` 1회 호출 — helper 가 (이전 run end-run + previous review.md stdout + 새 run begin-run) 통합 처리 → 메인은 stdout 의 `[new] run_id` 만 받아 다음 task 진입. *마지막* task = `next-task` 대신 `end-run` 단독.
@@ -367,7 +408,7 @@ PR merge 직후 *반드시* 실행 (issue #396):
 ## 안티패턴 (회귀 방지)
 
 - ❌ task N 개를 한 sub-agent 호출에 묶어 한 번에 처리 — task 별 PR / 이슈 close 분리가 깨지고 `/run-review` 분석 단위 붕괴. 한 번에 한 task. (build-worker 는 1 task 통합 — 충돌 X)
-- ❌ task 동시 병렬 진행 — git 충돌 + cache_read 폭주 ([#216](https://github.com/alruminum/dcNess/issues/216) — \$1,531 / 단일 세션). 현재 chain 은 직렬만 동작. (독립 task 의 opt-in 병렬 wave 정책은 [`parallel-policy.md`](../../docs/plugin/parallel-policy.md) 에 정의 — driver 미구현이라 현 시점 동작은 직렬.)
+- ❌ **무분별한** task 동시 병렬 진행 — git 충돌 + cache_read 폭주 ([#216](https://github.com/alruminum/dcNess/issues/216) — \$1,531 / 단일 세션). 직렬이 default 이며, 병렬은 *독립 task 가 기계 판정으로 확신될 때만* opt-in 으로 켜진다 ([병렬 wave](#병렬-wave-opt-in-chain-한정-636) — worktree 격리 fan-in: build 만 병렬, merge 는 leader 직렬). 정책 = [`parallel-policy.md`](../../docs/plugin/parallel-policy.md). opt-in 없이/모호한데 병렬로 끌면 안티패턴 그대로.
 - ❌ 한 task 의 PR 머지 전 다음 task 진입 — task 간 의존 깨짐.
 - ❌ escalate 신호 무시하고 다음 task 진행 — 사용자 부재 환경 추측 진행 = 폭주.
 - ❌ chain 전체 완료 후 자율 작업 (이슈 등록 / cleanup / 분석) 진입 시 `post-task-begin` marker 누락 — task ROI 측정 왜곡 (#472).

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -765,7 +765,14 @@ class BashMutationTests(unittest.TestCase):
         self.assertIsNone(
             check_bash_mutation("bash scripts/dcness-helper prev-tasks-append --slug 01-x --summary y")
         )
-        self.assertIsNone(check_bash_mutation("dcness-helper prev-tasks-reset"))
+
+    def test_helper_prev_tasks_reset_blocked(self):
+        # codex F16 — append(추가)는 build-worker 호출이라 허용하지만, reset(삭제)은
+        # 메인 전담 + 파괴적(handoff FIFO 삭제)이라 차단. 비대칭.
+        self.assertIsNotNone(check_bash_mutation("dcness-helper prev-tasks-reset"))
+        self.assertIsNotNone(
+            check_bash_mutation("bash scripts/dcness-helper prev-tasks-reset")
+        )
 
     def test_helper_readonly_subcommand_passes(self):
         # read-only 서브커맨드는 통과 (worker 가 run_dir 등 조회는 무해)

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -726,6 +726,50 @@ class BashMutationTests(unittest.TestCase):
         self.assertIsNone(check_bash_mutation("eval 'git status'"))
         self.assertIsNone(check_bash_mutation("eval 'echo git push'"))
 
+    # ── #636 — leader-owned dcness helper 서브커맨드 (병렬 wave worker 금지) ──
+
+    def test_helper_leader_subcommand_blocked_direct(self):
+        # wrapper 직접 호출 (basename = dcness-helper)
+        self.assertIsNotNone(
+            check_bash_mutation("/x/scripts/dcness-helper end-run")
+        )
+        self.assertIsNotNone(
+            check_bash_mutation("scripts/dcness-helper begin-run impl")
+        )
+        self.assertIsNotNone(check_bash_mutation("dcness-helper next-task"))
+        self.assertIsNotNone(
+            check_bash_mutation("dcness-helper ledger-event pr_merged --pr 5")
+        )
+
+    def test_helper_leader_subcommand_blocked_via_bash(self):
+        # `bash <path>/dcness-helper end-run` — bash 가 toks[0] 여도 식별
+        self.assertIsNotNone(
+            check_bash_mutation("bash scripts/dcness-helper end-run")
+        )
+        self.assertIsNotNone(
+            check_bash_mutation('bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" begin-step build-worker')
+        )
+
+    def test_helper_leader_subcommand_blocked_via_module(self):
+        # python -m harness.session_state <subcommand>
+        self.assertIsNotNone(
+            check_bash_mutation("python3 -m harness.session_state finalize-run")
+        )
+
+    def test_helper_readonly_subcommand_passes(self):
+        # read-only 서브커맨드는 통과 (worker 가 run_dir 등 조회는 무해)
+        self.assertIsNone(check_bash_mutation("dcness-helper run-dir"))
+        self.assertIsNone(check_bash_mutation("dcness-helper run-status"))
+        self.assertIsNone(check_bash_mutation("dcness-helper is-active"))
+        self.assertIsNone(
+            check_bash_mutation("bash scripts/dcness-helper wave-plan docs/x/impl")
+        )
+
+    def test_helper_unrelated_command_passes(self):
+        # dcness-helper 아닌 명령은 무관 — end-run 같은 토큰이 있어도 false-positive 없음
+        self.assertIsNone(check_bash_mutation("echo end-run"))
+        self.assertIsNone(check_bash_mutation("ls scripts/dcness-helper"))
+
 
 class GithubMcpMutationTests(unittest.TestCase):
     """#597 커밋5 — check_github_mcp_mutation: PR/repo mutation 차단, read·issue mutation 통과."""

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -781,6 +781,15 @@ class BashMutationTests(unittest.TestCase):
         self.assertIsNone(check_bash_mutation("echo end-run"))
         self.assertIsNone(check_bash_mutation("ls scripts/dcness-helper"))
 
+    def test_helper_token_in_data_position_passes(self):
+        # codex F9 — helper 가 *명령 위치* 가 아니라 데이터일 땐 통과 (false-positive 제거).
+        self.assertIsNone(check_bash_mutation("echo dcness-helper end-run"))
+        self.assertIsNone(check_bash_mutation("echo 'run dcness-helper end-run later'"))
+        self.assertIsNone(check_bash_mutation("grep next-task scripts/dcness-helper"))
+        # 진짜 명령 위치는 여전히 차단 (회귀 아님 확인)
+        self.assertIsNotNone(check_bash_mutation("dcness-helper end-run"))
+        self.assertIsNotNone(check_bash_mutation("bash scripts/dcness-helper next-task"))
+
 
 class GithubMcpMutationTests(unittest.TestCase):
     """#597 커밋5 — check_github_mcp_mutation: PR/repo mutation 차단, read·issue mutation 통과."""

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -747,7 +747,7 @@ class BashMutationTests(unittest.TestCase):
             check_bash_mutation("bash scripts/dcness-helper end-run")
         )
         self.assertIsNotNone(
-            check_bash_mutation('bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" begin-step build-worker')
+            check_bash_mutation('bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" post-task-begin --reason x')
         )
 
     def test_helper_leader_subcommand_blocked_via_module(self):
@@ -755,6 +755,17 @@ class BashMutationTests(unittest.TestCase):
         self.assertIsNotNone(
             check_bash_mutation("python3 -m harness.session_state finalize-run")
         )
+
+    def test_helper_buildworker_subcommands_pass(self):
+        # #636 회귀 가드 — serial build-worker(sub-agent)가 정상 호출하는 것은 통과.
+        # begin-step/end-step: hybrid-A phase 직접 구동. prev-tasks-append: phase 3 누적.
+        # (deny set 에 넣으면 기존 직렬 conveyor 가 깨진다 — codex P2 F2.)
+        self.assertIsNone(check_bash_mutation("dcness-helper begin-step build-worker"))
+        self.assertIsNone(check_bash_mutation("dcness-helper end-step build-worker"))
+        self.assertIsNone(
+            check_bash_mutation("bash scripts/dcness-helper prev-tasks-append --slug 01-x --summary y")
+        )
+        self.assertIsNone(check_bash_mutation("dcness-helper prev-tasks-reset"))
 
     def test_helper_readonly_subcommand_passes(self):
         # read-only 서브커맨드는 통과 (worker 가 run_dir 등 조회는 무해)

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -225,6 +225,15 @@ class TestScopesDisjoint(unittest.TestCase):
     def test_glob_overlap(self):
         self.assertFalse(scopes_disjoint({"src/*.py"}, {"src/a.py"}))
 
+    def test_glob_segment_aware(self):
+        # codex F4 — `*` 는 `/` 를 넘지 않는다. src/*.py 는 src/sub/a.py 와 disjoint.
+        self.assertTrue(scopes_disjoint({"src/*.py"}, {"src/sub/a.py"}))
+        self.assertTrue(scopes_disjoint({"src/*.py"}, {"lib/*.js"}))
+
+    def test_glob_glob_same_dir_conservative_overlap(self):
+        # glob-vs-glob 같은 디렉토리 → 보수적으로 충돌(직렬) 가정.
+        self.assertFalse(scopes_disjoint({"src/*.py"}, {"src/a*"}))
+
 
 # ── compute_waves ───────────────────────────────────────────
 
@@ -444,6 +453,58 @@ class TestFanInCheck(unittest.TestCase):
         ]
         r = fan_in_check(results)
         self.assertTrue(r.passed)
+
+    def test_glob_scope_segment_aware_violation(self):
+        # codex F4 — glob scope `src/*.py` 선언했는데 src/sub/a.py 를 건드리면
+        # fnmatch 였다면 통과했을 것. segment-aware 라 scope 이탈로 잡아야 함.
+        violator = WorkerResult(
+            "01-a", frozenset({"src/sub/a.py"}), frozenset({"src/*.py"})
+        )
+        self.assertFalse(fan_in_check([violator]).passed)
+        # 같은 glob scope 의 직접 자식은 준수
+        ok = WorkerResult(
+            "02-b", frozenset({"src/a.py"}), frozenset({"src/*.py"})
+        )
+        self.assertTrue(fan_in_check([ok]).passed)
+
+
+class TestWavePlanFromPaths(unittest.TestCase):
+    """경로 인자 전개 — 디렉토리 / 절대 glob / 상대 glob (codex F5)."""
+
+    def _make_two(self, d):
+        _write_impl(
+            d, "01-a.md",
+            "---\ndepends_on: []\n---\n\n## Scope\n\n### 수정 허용\n\n- src/a.py\n",
+        )
+        _write_impl(
+            d, "02-b.md",
+            "---\ndepends_on: []\n---\n\n## Scope\n\n### 수정 허용\n\n- src/b.py\n",
+        )
+
+    def test_directory_arg(self):
+        from harness.parallel_wave import wave_plan_from_paths
+        with tempfile.TemporaryDirectory() as d:
+            self._make_two(d)
+            plan = wave_plan_from_paths([d])
+            self.assertTrue(plan.has_parallel)
+
+    def test_absolute_glob_does_not_crash(self):
+        # codex F5 — 절대경로 glob 은 Path('.').glob 에서 NotImplementedError 였음.
+        from harness.parallel_wave import wave_plan_from_paths
+        with tempfile.TemporaryDirectory() as d:
+            self._make_two(d)
+            plan = wave_plan_from_paths([str(Path(d) / "*.md")])
+            self.assertEqual(len(plan.steps), 1)
+            self.assertEqual(plan.steps[0].mode, "parallel")
+
+    def test_explicit_file_list(self):
+        from harness.parallel_wave import wave_plan_from_paths
+        with tempfile.TemporaryDirectory() as d:
+            self._make_two(d)
+            plan = wave_plan_from_paths(
+                [str(Path(d) / "01-a.md"), str(Path(d) / "02-b.md")]
+            )
+            self.assertTrue(plan.has_parallel)
 
 
 if __name__ == "__main__":

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -384,6 +384,35 @@ class TestComputeWaves(unittest.TestCase):
     def test_default_cap_is_two(self):
         self.assertEqual(DEFAULT_MAX_PARALLEL_WORKERS, 2)
 
+    def test_order_barrier_serial_task_between(self):
+        # codex F10 — 사이의 serial task(02)를 건너뛰고 01,03 을 같은 wave 로 당기면
+        # task_index 순서가 뒤집혀 issue close semantics 가 깨진다. 순서 보존 필수.
+        tasks = [
+            _task("01-a", (), {"a.py"}),
+            _task("02-b", (), {"b.py"}, force_serial=True),
+            _task("03-c", (), {"c.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertFalse(plan.has_parallel)  # [01,03] 병렬 금지
+        self.assertEqual(
+            [s.tasks[0].slug for s in plan.steps], ["01-a", "02-b", "03-c"]
+        )
+
+    def test_order_barrier_scope_overlap_between(self):
+        # 02 가 01 과 Scope 겹침 → 01 직렬 barrier, 그 다음 02‖03 (순서 보존).
+        tasks = [
+            _task("01-a", (), {"shared.py"}),
+            _task("02-b", (), {"shared.py"}),
+            _task("03-c", (), {"c.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertEqual(plan.steps[0].mode, "serial")
+        self.assertEqual(plan.steps[0].tasks[0].slug, "01-a")
+        self.assertEqual(plan.steps[1].mode, "parallel")
+        self.assertEqual(
+            [t.slug for t in plan.steps[1].tasks], ["02-b", "03-c"]
+        )
+
     def test_block_depends_on_comment_does_not_parallelize_dependent(self):
         # codex P2 F1 통합 — block depends_on 의 inline 주석이 slug 에 새면 의존이
         # 끊겨 의존 task 가 선행과 같은 wave 로 올라간다. parse→compute 로 방지 검증.

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -194,6 +194,23 @@ class TestParseScope(unittest.TestCase):
         self.assertEqual(t.scope_paths, frozenset({"src/feature/"}))
         self.assertFalse(t.scope_ambiguous)
 
+    def test_dot_prefixed_paths_accepted(self):
+        # codex F14 — leading dot 경로(dot-dir / 상대)가 ambiguous 로 오판되면 안 됨.
+        t = self._parse_scope(
+            "- .github/workflows/ci.yml\n- ./src/a.py\n"
+        )
+        self.assertEqual(
+            t.scope_paths,
+            frozenset({".github/workflows/ci.yml", "src/a.py"}),  # ./ 정규화
+        )
+        self.assertFalse(t.scope_ambiguous)
+
+    def test_dot_placeholder_tokens_still_ambiguous(self):
+        # bare . / .. / ... 는 경로가 아니므로 여전히 ambiguous
+        for tok in (".", "..", "..."):
+            t = self._parse_scope(f"- {tok}\n")
+            self.assertTrue(t.scope_ambiguous, f"{tok} 는 ambiguous 여야")
+
     def test_hyphenated_paths_accepted(self):
         # codex P2 F3 회귀 가드 — 하이픈 포함 경로는 흔함(parallel-policy.md / package-lock.json).
         # ambiguous 로 오판하면 독립 task 가 직렬로 강등돼 병렬 후보 과소탐지.
@@ -464,6 +481,24 @@ class TestComputeWaves(unittest.TestCase):
         self.assertEqual(
             [s.tasks[0].slug for s in plan.steps], ["01-a", "02-b", "03-c"]
         )
+
+    def test_order_barrier_blocked_intervening_task(self):
+        # codex F13 — 사이 task(02)가 *blocked*(미준비)면 frontier 에서 빠진다. 그래도
+        # 01,03 을 같은 wave 로 당기면 안 됨(03 이 02 앞서 머지 → 순서 위반). 01 단독 후
+        # 02 준비되면 진행.
+        tasks = [
+            _task("01-a", (), {"a.py"}),
+            _task("02-b", ("01-a",), {"b.py"}),  # 01-a 에 의존 → 처음엔 blocked
+            _task("03-c", (), {"c.py"}),
+        ]
+        plan = compute_waves(tasks)
+        # 첫 step 에 03-c 가 01-a 와 함께 들어가면 안 됨
+        first = {t.slug for t in plan.steps[0].tasks}
+        self.assertNotIn("03-c", first)
+        self.assertEqual(plan.steps[0].tasks[0].slug, "01-a")
+        # 03-c 는 02-b 보다 먼저/같이 머지되면 안 됨 — 03-c 의 step 이 02-b step 이후거나 동일 wave 의 뒤
+        order = [t.slug for s in plan.steps for t in s.tasks]
+        self.assertLess(order.index("02-b"), order.index("03-c"))
 
     def test_order_barrier_scope_overlap_between(self):
         # 02 가 01 과 Scope 겹침 → 01 직렬 barrier, 그 다음 02‖03 (순서 보존).

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -183,6 +183,12 @@ class TestParseScope(unittest.TestCase):
         self.assertTrue(t.scope_ambiguous)
         self.assertTrue(t.serial_only)
 
+    def test_scope_bullet_inline_comment_stripped(self):
+        # 사전 감사 — depends_on 처럼 Scope bullet 의 inline 주석도 strip (일관성).
+        t = self._parse_scope("- src/a.py  # 메인 핸들러\n- `src/b.py`  # 코멘트\n")
+        self.assertEqual(t.scope_paths, frozenset({"src/a.py", "src/b.py"}))
+        self.assertFalse(t.scope_ambiguous)
+
     def test_directory_scope(self):
         t = self._parse_scope("- src/feature/\n")
         self.assertEqual(t.scope_paths, frozenset({"src/feature/"}))
@@ -244,6 +250,17 @@ class TestScopesDisjoint(unittest.TestCase):
     def test_glob_glob_same_dir_conservative_overlap(self):
         # glob-vs-glob 같은 디렉토리 → 보수적으로 충돌(직렬) 가정.
         self.assertFalse(scopes_disjoint({"src/*.py"}, {"src/a*"}))
+
+    def test_glob_char_class(self):
+        # 사전 감사 — _has_glob 이 `[` 를 glob 으로 인식하므로 _glob_to_regex 도 char
+        # class 를 처리해야 함 (리터럴 취급 비일관 수정). segment-aware 유지.
+        from harness.parallel_wave import _glob_match
+        self.assertTrue(_glob_match("src/a.py", "src/[ab].py"))
+        self.assertFalse(_glob_match("src/c.py", "src/[ab].py"))
+        self.assertTrue(_glob_match("src/b.py", "src/[!a].py"))  # negation
+        self.assertFalse(_glob_match("src/sub/a.py", "src/[ab].py"))  # / 안 넘음
+        # 깨진 패턴은 리터럴 fallback (예외 안 남)
+        self.assertTrue(_glob_match("src/[x.py", "src/[x.py"))
 
     def test_globstar_zero_and_deep_dirs(self):
         # codex F8 — src/**/*.py 는 중간 디렉토리 0개(src/a.py)도 매치해야 함.

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -1,0 +1,405 @@
+"""test_parallel_wave — 병렬 wave 계산 코어 단위 테스트 (#636).
+
+정책 SSOT = docs/plugin/parallel-policy.md. 검증 축:
+
+    parse_impl_task:
+        - depends_on 3-state (미상 None / 명시적 [] () / 목록)
+        - placeholder 잔존 → 미상
+        - inline / block 리스트 둘 다
+        - Scope 파싱: 정규화 경로 / 자유서술 ambiguous / 빈값 / 디렉토리
+
+    compute_waves (AC: wave 후보 / scope 중첩 배제 / 미상 fallback / cap):
+        - 독립 2개 disjoint → 같은 병렬 wave
+        - Scope 중첩 → 같은 wave 배제(직렬)
+        - depends_on 사슬 → 직렬 순서
+        - depends_on 미상 → 직렬 fallback
+        - 명시적 [] + disjoint → 병렬
+        - max_parallel_workers=2 cap → 독립 3개 = wave(2)+직렬(1)
+        - force_serial(parallel: serial) → 직렬
+        - 디렉토리/파일 포함 충돌 → 직렬
+
+    fan_in_check (AC: fan-in PASS / FALLBACK):
+        - 깨끗한 wave → PASS
+        - scope 이탈 → FALLBACK
+        - cross-worker 파일 충돌 → FALLBACK
+        - evidence 누락 → FALLBACK
+"""
+import tempfile
+import unittest
+from pathlib import Path
+
+from harness.parallel_wave import (
+    DEFAULT_MAX_PARALLEL_WORKERS,
+    ImplTask,
+    WorkerResult,
+    compute_waves,
+    fan_in_check,
+    parse_impl_task,
+    scopes_disjoint,
+)
+
+
+def _task(
+    slug,
+    depends_on,
+    scope,
+    *,
+    scope_ambiguous=False,
+    force_serial=False,
+):
+    """ImplTask 빌더 — depends_on/scope 를 직접 지정."""
+    return ImplTask(
+        slug=slug,
+        path=f"{slug}.md",
+        depends_on=depends_on,
+        scope_paths=frozenset(scope),
+        scope_ambiguous=scope_ambiguous,
+        force_serial=force_serial,
+    )
+
+
+def _write_impl(dirpath, name, body):
+    p = Path(dirpath) / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ── parse_impl_task ─────────────────────────────────────────
+
+
+class TestParseDependsOn(unittest.TestCase):
+    def _parse(self, fm_depends, scope_block="- src/a.py\n"):
+        body = (
+            "---\n"
+            f"{fm_depends}\n"
+            "story: 1\n"
+            "---\n\n"
+            "## Scope\n\n### 수정 허용\n\n"
+            f"{scope_block}\n"
+            "### 수정 금지\n\n-\n"
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_impl(d, "01-foo.md", body)
+            return parse_impl_task(p)
+
+    def test_depends_on_absent_is_unknown(self):
+        # depends_on 키 자체가 없음 → 미상(None)
+        body = "---\nstory: 1\n---\n\n## Scope\n\n### 수정 허용\n\n- src/a.py\n"
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_impl(d, "01-foo.md", body)
+            t = parse_impl_task(p)
+        self.assertIsNone(t.depends_on)
+        self.assertTrue(t.serial_only)
+
+    def test_depends_on_empty_with_comment_is_unknown(self):
+        # 템플릿 기본형 — 값 없이 주석만 → 미상
+        t = self._parse("depends_on:             # [<NN-slug>, ...] 선행 task")
+        self.assertIsNone(t.depends_on)
+
+    def test_depends_on_explicit_empty_is_independent(self):
+        t = self._parse("depends_on: []")
+        self.assertEqual(t.depends_on, ())
+        self.assertFalse(t.serial_only)  # scope 정상이므로 병렬 후보
+
+    def test_depends_on_inline_list(self):
+        t = self._parse("depends_on: [01-foo, 02-bar]")
+        self.assertEqual(t.depends_on, ("01-foo", "02-bar"))
+
+    def test_depends_on_block_list(self):
+        t = self._parse("depends_on:\n  - 01-foo\n  - 02-bar")
+        self.assertEqual(t.depends_on, ("01-foo", "02-bar"))
+
+    def test_depends_on_placeholder_unfilled_is_unknown(self):
+        # [<NN-slug>] placeholder 가 값으로 남음 → 미상으로 강등
+        t = self._parse("depends_on: [<NN-slug>]")
+        self.assertIsNone(t.depends_on)
+
+    def test_depends_on_explicit_empty_with_comment(self):
+        t = self._parse("depends_on: []   # 선행 없음")
+        self.assertEqual(t.depends_on, ())
+
+
+class TestParseScope(unittest.TestCase):
+    def _parse_scope(self, scope_block):
+        body = (
+            "---\ndepends_on: []\n---\n\n"
+            "## Scope\n\n### 수정 허용\n\n"
+            f"{scope_block}\n"
+            "### 수정 금지\n\n-\n"
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_impl(d, "01-foo.md", body)
+            return parse_impl_task(p)
+
+    def test_clean_paths(self):
+        t = self._parse_scope("- src/a.py\n- harness/b.py\n")
+        self.assertEqual(t.scope_paths, frozenset({"src/a.py", "harness/b.py"}))
+        self.assertFalse(t.scope_ambiguous)
+
+    def test_backtick_paths(self):
+        t = self._parse_scope("- `src/a.py`\n")
+        self.assertEqual(t.scope_paths, frozenset({"src/a.py"}))
+        self.assertFalse(t.scope_ambiguous)
+
+    def test_blockquote_note_ignored(self):
+        t = self._parse_scope("> repo-relative 경로만 적는다\n\n- src/a.py\n")
+        self.assertEqual(t.scope_paths, frozenset({"src/a.py"}))
+        self.assertFalse(t.scope_ambiguous)
+
+    def test_empty_placeholder_is_ambiguous(self):
+        t = self._parse_scope("-\n")
+        self.assertEqual(t.scope_paths, frozenset())
+        self.assertTrue(t.scope_ambiguous)
+        self.assertTrue(t.serial_only)
+
+    def test_freeform_prose_is_ambiguous(self):
+        # 다중 토큰 산문 bullet → 정규화 안 됨 → ambiguous
+        t = self._parse_scope("- 사용자 입력 파서 전반\n")
+        self.assertTrue(t.scope_ambiguous)
+        self.assertTrue(t.serial_only)
+
+    def test_mixed_path_and_prose_is_ambiguous(self):
+        t = self._parse_scope("- src/a.py\n- 그리고 여러 곳\n")
+        self.assertTrue(t.scope_ambiguous)
+        self.assertTrue(t.serial_only)
+
+    def test_directory_scope(self):
+        t = self._parse_scope("- src/feature/\n")
+        self.assertEqual(t.scope_paths, frozenset({"src/feature/"}))
+        self.assertFalse(t.scope_ambiguous)
+
+
+class TestParseParallelMarker(unittest.TestCase):
+    def test_parallel_serial_forces_serial(self):
+        body = (
+            "---\ndepends_on: []\nparallel: serial\n---\n\n"
+            "## Scope\n\n### 수정 허용\n\n- src/a.py\n"
+        )
+        with tempfile.TemporaryDirectory() as d:
+            p = _write_impl(d, "01-foo.md", body)
+            t = parse_impl_task(p)
+        self.assertTrue(t.force_serial)
+        self.assertTrue(t.serial_only)
+
+
+# ── scopes_disjoint ─────────────────────────────────────────
+
+
+class TestScopesDisjoint(unittest.TestCase):
+    def test_disjoint_files(self):
+        self.assertTrue(scopes_disjoint({"a.py"}, {"b.py"}))
+
+    def test_same_file_overlap(self):
+        self.assertFalse(scopes_disjoint({"a.py"}, {"a.py"}))
+
+    def test_dir_contains_file_overlap(self):
+        self.assertFalse(scopes_disjoint({"src/"}, {"src/a.py"}))
+
+    def test_file_under_dir_overlap(self):
+        self.assertFalse(scopes_disjoint({"src/sub/a.py"}, {"src/"}))
+
+    def test_sibling_dirs_disjoint(self):
+        self.assertTrue(scopes_disjoint({"src/a/"}, {"src/b/"}))
+
+    def test_glob_overlap(self):
+        self.assertFalse(scopes_disjoint({"src/*.py"}, {"src/a.py"}))
+
+
+# ── compute_waves ───────────────────────────────────────────
+
+
+class TestComputeWaves(unittest.TestCase):
+    def test_two_independent_disjoint_parallel(self):
+        tasks = [
+            _task("01-a", (), {"src/a.py"}),
+            _task("02-b", (), {"src/b.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertTrue(plan.has_parallel)
+        self.assertEqual(len(plan.steps), 1)
+        self.assertEqual(plan.steps[0].mode, "parallel")
+        self.assertEqual(
+            {t.slug for t in plan.steps[0].tasks}, {"01-a", "02-b"}
+        )
+
+    def test_scope_overlap_serialized(self):
+        tasks = [
+            _task("01-a", (), {"src/shared.py"}),
+            _task("02-b", (), {"src/shared.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertFalse(plan.has_parallel)
+        self.assertEqual([s.mode for s in plan.steps], ["serial", "serial"])
+
+    def test_depends_on_chain_is_serial_order(self):
+        tasks = [
+            _task("01-a", (), {"src/a.py"}),
+            _task("02-b", ("01-a",), {"src/b.py"}),
+        ]
+        plan = compute_waves(tasks)
+        # 02-b 가 01-a 에 의존 → 같은 wave 불가 → 직렬 2단계
+        self.assertFalse(plan.has_parallel)
+        self.assertEqual(len(plan.steps), 2)
+        self.assertEqual(plan.steps[0].tasks[0].slug, "01-a")
+        self.assertEqual(plan.steps[1].tasks[0].slug, "02-b")
+
+    def test_unknown_depends_on_serial_fallback(self):
+        tasks = [
+            _task("01-a", None, {"src/a.py"}),  # 미상
+            _task("02-b", (), {"src/b.py"}),
+        ]
+        plan = compute_waves(tasks)
+        # 01-a 미상 → 직렬, 02-b 는 짝(01-a 직렬)이라 단독 → 직렬
+        self.assertFalse(plan.has_parallel)
+        self.assertEqual(plan.steps[0].mode, "serial")
+        self.assertIn("미상", plan.steps[0].reason)
+
+    def test_ambiguous_scope_serial_fallback(self):
+        tasks = [
+            _task("01-a", (), set(), scope_ambiguous=True),
+            _task("02-b", (), {"src/b.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertFalse(plan.has_parallel)
+
+    def test_max_parallel_cap_two(self):
+        # 독립 3개 disjoint, cap=2 → wave(2) + serial(1)
+        tasks = [
+            _task("01-a", (), {"src/a.py"}),
+            _task("02-b", (), {"src/b.py"}),
+            _task("03-c", (), {"src/c.py"}),
+        ]
+        plan = compute_waves(tasks, max_parallel_workers=2)
+        self.assertEqual(len(plan.steps), 2)
+        self.assertEqual(plan.steps[0].mode, "parallel")
+        self.assertEqual(len(plan.steps[0].tasks), 2)
+        self.assertEqual(plan.steps[1].mode, "serial")
+        self.assertEqual(plan.steps[1].tasks[0].slug, "03-c")
+
+    def test_higher_cap_three(self):
+        tasks = [
+            _task("01-a", (), {"src/a.py"}),
+            _task("02-b", (), {"src/b.py"}),
+            _task("03-c", (), {"src/c.py"}),
+        ]
+        plan = compute_waves(tasks, max_parallel_workers=3)
+        self.assertEqual(len(plan.steps), 1)
+        self.assertEqual(len(plan.steps[0].tasks), 3)
+
+    def test_force_serial_excluded_from_wave(self):
+        tasks = [
+            _task("01-a", (), {"src/a.py"}, force_serial=True),
+            _task("02-b", (), {"src/b.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertFalse(plan.has_parallel)
+        self.assertEqual(plan.steps[0].mode, "serial")
+
+    def test_directory_overlap_serialized(self):
+        tasks = [
+            _task("01-a", (), {"src/feature/"}),
+            _task("02-b", (), {"src/feature/x.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertFalse(plan.has_parallel)
+
+    def test_mixed_wave_then_dependent_serial(self):
+        # a,b 독립 병렬 → c 는 둘 다에 의존 → 다음 직렬
+        tasks = [
+            _task("01-a", (), {"src/a.py"}),
+            _task("02-b", (), {"src/b.py"}),
+            _task("03-c", ("01-a", "02-b"), {"src/c.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertEqual(len(plan.steps), 2)
+        self.assertEqual(plan.steps[0].mode, "parallel")
+        self.assertEqual(plan.steps[1].mode, "serial")
+        self.assertEqual(plan.steps[1].tasks[0].slug, "03-c")
+
+    def test_external_dependency_not_blocking(self):
+        # depends_on 이 batch 밖(이미 머지됨) → 차단 안 함
+        tasks = [
+            _task("02-a", ("00-merged",), {"src/a.py"}),
+            _task("03-b", ("00-merged",), {"src/b.py"}),
+        ]
+        plan = compute_waves(tasks)
+        self.assertTrue(plan.has_parallel)
+
+    def test_empty_task_list(self):
+        plan = compute_waves([])
+        self.assertEqual(plan.steps, ())
+        self.assertFalse(plan.has_parallel)
+
+    def test_default_cap_is_two(self):
+        self.assertEqual(DEFAULT_MAX_PARALLEL_WORKERS, 2)
+
+
+# ── fan_in_check ────────────────────────────────────────────
+
+
+class TestFanInCheck(unittest.TestCase):
+    def test_clean_wave_passes(self):
+        results = [
+            WorkerResult("01-a", frozenset({"src/a.py"}), frozenset({"src/a.py"})),
+            WorkerResult("02-b", frozenset({"src/b.py"}), frozenset({"src/b.py"})),
+        ]
+        r = fan_in_check(results)
+        self.assertTrue(r.passed)
+        self.assertEqual(r.verdict, "PASS")
+        self.assertEqual(r.reasons, ())
+
+    def test_scope_violation_fallback(self):
+        results = [
+            # a 가 선언 scope(src/a.py) 밖 src/other.py 를 건드림
+            WorkerResult(
+                "01-a",
+                frozenset({"src/a.py", "src/other.py"}),
+                frozenset({"src/a.py"}),
+            ),
+        ]
+        r = fan_in_check(results)
+        self.assertFalse(r.passed)
+        self.assertEqual(r.verdict, "FALLBACK")
+        self.assertIn(("01-a", "src/other.py"), r.scope_violations)
+
+    def test_cross_worker_conflict_fallback(self):
+        results = [
+            WorkerResult(
+                "01-a", frozenset({"src/shared.py"}), frozenset({"src/shared.py"})
+            ),
+            WorkerResult(
+                "02-b", frozenset({"src/shared.py"}), frozenset({"src/shared.py"})
+            ),
+        ]
+        r = fan_in_check(results)
+        self.assertFalse(r.passed)
+        self.assertEqual(len(r.conflicts), 1)
+        self.assertEqual(r.conflicts[0][0], "src/shared.py")
+        self.assertEqual(r.conflicts[0][1], ("01-a", "02-b"))
+
+    def test_missing_evidence_fallback(self):
+        results = [
+            WorkerResult(
+                "01-a",
+                frozenset({"src/a.py"}),
+                frozenset({"src/a.py"}),
+                evidence_present=False,
+            ),
+        ]
+        r = fan_in_check(results)
+        self.assertFalse(r.passed)
+        self.assertEqual(r.missing_evidence, ("01-a",))
+
+    def test_scope_dir_prefix_allowed(self):
+        # 선언 scope 가 디렉토리면 그 아래 파일 변경은 준수
+        results = [
+            WorkerResult(
+                "01-a", frozenset({"src/feature/x.py"}), frozenset({"src/feature/"})
+            ),
+        ]
+        r = fan_in_check(results)
+        self.assertTrue(r.passed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -254,11 +254,19 @@ class TestHighRisk(unittest.TestCase):
             "- migrations/0007_add.py",
             "- alembic/versions/x.py",
             "- config/.env",
+            "- config/.env*",          # codex F15 — glob 변종
+            "- config/.env.local",     # suffix 변종
             "- app/secrets/keys.json",
             "- src/credentials.py",
         ):
             t = self._parse("", scope)
             self.assertTrue(t.force_serial, f"{scope} 는 고위험이어야")
+
+    def test_inherent_high_risk_no_false_positive(self):
+        # codex F15 — `.environment`·`env_utils` 처럼 무관한 경로는 고위험 아님.
+        for scope in ("- .environment/conf.py", "- src/env_utils.py"):
+            t = self._parse("", scope)
+            self.assertFalse(t.force_serial, f"{scope} 는 고위험 아님")
 
     def test_risk_frontmatter_marker(self):
         t = self._parse("risk: high-risk\n", "- src/x.py")

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -220,6 +220,56 @@ class TestParseParallelMarker(unittest.TestCase):
         self.assertTrue(t.serial_only)
 
 
+class TestHighRisk(unittest.TestCase):
+    """codex F11 — 고위험 task 직렬 강제 (정책 §4)."""
+
+    def _parse(self, fm_extra, scope):
+        body = (
+            f"---\ndepends_on: []\n{fm_extra}---\n\n"
+            f"## Scope\n\n### 수정 허용\n\n{scope}\n"
+        )
+        with tempfile.TemporaryDirectory() as d:
+            return parse_impl_task(_write_impl(d, "01-foo.md", body))
+
+    def test_inherent_high_risk_scope_paths(self):
+        # 경로 backstop — migrations/alembic/.env/secrets/credentials
+        for scope in (
+            "- migrations/0007_add.py",
+            "- alembic/versions/x.py",
+            "- config/.env",
+            "- app/secrets/keys.json",
+            "- src/credentials.py",
+        ):
+            t = self._parse("", scope)
+            self.assertTrue(t.force_serial, f"{scope} 는 고위험이어야")
+
+    def test_risk_frontmatter_marker(self):
+        t = self._parse("risk: high-risk\n", "- src/x.py")
+        self.assertTrue(t.force_serial)
+
+    def test_ordinary_scope_not_high_risk(self):
+        t = self._parse("", "- src/feature/widget.py")
+        self.assertFalse(t.force_serial)
+
+    def test_compute_waves_high_risk_slugs_forces_serial(self):
+        # 메인 dry-preview 판정 전달 → 직렬
+        tasks = [
+            _task("01-a", (), {"a.py"}),
+            _task("02-b", (), {"b.py"}),
+        ]
+        plan = compute_waves(tasks, high_risk_slugs={"02-b"})
+        self.assertFalse(plan.has_parallel)
+        # 02-b 가 고위험 → 01-a 도 짝 못 찾아 직렬, 순서 보존
+        self.assertEqual(
+            [s.tasks[0].slug for s in plan.steps], ["01-a", "02-b"]
+        )
+
+    def test_high_risk_slug_serial_reason(self):
+        tasks = [_task("01-a", (), {"a.py"})]
+        plan = compute_waves(tasks, high_risk_slugs={"01-a"})
+        self.assertIn("고위험", plan.steps[0].reason)
+
+
 # ── scopes_disjoint ─────────────────────────────────────────
 
 
@@ -520,6 +570,23 @@ class TestFanInCheck(unittest.TestCase):
         ]
         r = fan_in_check(results)
         self.assertTrue(r.passed)
+
+    def test_file_scope_no_descendant(self):
+        # codex F12 — 확장자 없는 파일 scope(scripts/tool)를 디렉토리로 오인해
+        # scripts/tool/x.py 를 통과시키면 안 됨. 디렉토리는 끝에 / 를 적어야 함.
+        violator = WorkerResult(
+            "01-a", frozenset({"scripts/tool/x.py"}), frozenset({"scripts/tool"})
+        )
+        self.assertFalse(fan_in_check([violator]).passed)
+        exact = WorkerResult(
+            "02-b", frozenset({"scripts/tool"}), frozenset({"scripts/tool"})
+        )
+        self.assertTrue(fan_in_check([exact]).passed)
+        # 명시적 디렉토리 scope(끝 /)는 하위 허용
+        dir_ok = WorkerResult(
+            "03-c", frozenset({"scripts/tool/x.py"}), frozenset({"scripts/tool/"})
+        )
+        self.assertTrue(fan_in_check([dir_ok]).passed)
 
     def test_glob_scope_segment_aware_violation(self):
         # codex F4 — glob scope `src/*.py` 선언했는데 src/sub/a.py 를 건드리면

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -118,6 +118,15 @@ class TestParseDependsOn(unittest.TestCase):
         t = self._parse("depends_on: []   # 선행 없음")
         self.assertEqual(t.depends_on, ())
 
+    def test_depends_on_inline_list_with_comment(self):
+        t = self._parse("depends_on: [01-a, 02-b]   # 선행 둘")
+        self.assertEqual(t.depends_on, ("01-a", "02-b"))
+
+    def test_depends_on_block_list_with_inline_comment(self):
+        # codex P2 F1 회귀 가드 — block 원소의 inline 주석이 slug 에 새면 안 됨.
+        t = self._parse("depends_on:\n  - 01-a  # produces X\n  - 02-b")
+        self.assertEqual(t.depends_on, ("01-a", "02-b"))
+
 
 class TestParseScope(unittest.TestCase):
     def _parse_scope(self, scope_block):
@@ -166,6 +175,18 @@ class TestParseScope(unittest.TestCase):
     def test_directory_scope(self):
         t = self._parse_scope("- src/feature/\n")
         self.assertEqual(t.scope_paths, frozenset({"src/feature/"}))
+        self.assertFalse(t.scope_ambiguous)
+
+    def test_hyphenated_paths_accepted(self):
+        # codex P2 F3 회귀 가드 — 하이픈 포함 경로는 흔함(parallel-policy.md / package-lock.json).
+        # ambiguous 로 오판하면 독립 task 가 직렬로 강등돼 병렬 후보 과소탐지.
+        t = self._parse_scope(
+            "- docs/plugin/parallel-policy.md\n- package-lock.json\n"
+        )
+        self.assertEqual(
+            t.scope_paths,
+            frozenset({"docs/plugin/parallel-policy.md", "package-lock.json"}),
+        )
         self.assertFalse(t.scope_ambiguous)
 
 
@@ -332,6 +353,30 @@ class TestComputeWaves(unittest.TestCase):
 
     def test_default_cap_is_two(self):
         self.assertEqual(DEFAULT_MAX_PARALLEL_WORKERS, 2)
+
+    def test_block_depends_on_comment_does_not_parallelize_dependent(self):
+        # codex P2 F1 통합 — block depends_on 의 inline 주석이 slug 에 새면 의존이
+        # 끊겨 의존 task 가 선행과 같은 wave 로 올라간다. parse→compute 로 방지 검증.
+        with tempfile.TemporaryDirectory() as d:
+            _write_impl(
+                d,
+                "01-a.md",
+                "---\ndepends_on: []\n---\n\n## Scope\n\n### 수정 허용\n\n- src/a.py\n",
+            )
+            _write_impl(
+                d,
+                "02-b.md",
+                "---\ndepends_on:\n  - 01-a  # produces shared contract\n---\n\n"
+                "## Scope\n\n### 수정 허용\n\n- src/b.py\n",
+            )
+            a = parse_impl_task(Path(d) / "01-a.md")
+            b = parse_impl_task(Path(d) / "02-b.md")
+        self.assertEqual(b.depends_on, ("01-a",))
+        plan = compute_waves([a, b])
+        # 02-b 가 01-a 에 의존 → 절대 같은 wave 가 아니어야 함 (직렬 2단계).
+        self.assertFalse(plan.has_parallel)
+        self.assertEqual(plan.steps[0].tasks[0].slug, "01-a")
+        self.assertEqual(plan.steps[1].tasks[0].slug, "02-b")
 
 
 # ── fan_in_check ────────────────────────────────────────────

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -127,6 +127,11 @@ class TestParseDependsOn(unittest.TestCase):
         t = self._parse("depends_on:\n  - 01-a  # produces X\n  - 02-b")
         self.assertEqual(t.depends_on, ("01-a", "02-b"))
 
+    def test_depends_on_block_list_with_standalone_comment(self):
+        # codex F6 회귀 가드 — 원소 사이 standalone 주석 라인에서 끊겨 뒤 원소 누락 금지.
+        t = self._parse("depends_on:\n  - 01-a\n  # 02 는 forward dep\n  - 02-b")
+        self.assertEqual(t.depends_on, ("01-a", "02-b"))
+
 
 class TestParseScope(unittest.TestCase):
     def _parse_scope(self, scope_block):
@@ -169,6 +174,12 @@ class TestParseScope(unittest.TestCase):
 
     def test_mixed_path_and_prose_is_ambiguous(self):
         t = self._parse_scope("- src/a.py\n- 그리고 여러 곳\n")
+        self.assertTrue(t.scope_ambiguous)
+        self.assertTrue(t.serial_only)
+
+    def test_nonbullet_prose_plus_path_is_ambiguous(self):
+        # codex F7 — bullet 아닌 자유서술 산문 + 유효 path 가 섞이면 정규화 실패 → 미상.
+        t = self._parse_scope("핵심 파서 전반을 수정한다\n\n- src/a.py\n")
         self.assertTrue(t.scope_ambiguous)
         self.assertTrue(t.serial_only)
 
@@ -233,6 +244,16 @@ class TestScopesDisjoint(unittest.TestCase):
     def test_glob_glob_same_dir_conservative_overlap(self):
         # glob-vs-glob 같은 디렉토리 → 보수적으로 충돌(직렬) 가정.
         self.assertFalse(scopes_disjoint({"src/*.py"}, {"src/a*"}))
+
+    def test_globstar_zero_and_deep_dirs(self):
+        # codex F8 — src/**/*.py 는 중간 디렉토리 0개(src/a.py)도 매치해야 함.
+        from harness.parallel_wave import _path_in_scope
+        self.assertTrue(_path_in_scope("src/a.py", {"src/**/*.py"}))
+        self.assertTrue(_path_in_scope("src/x/a.py", {"src/**/*.py"}))
+        self.assertTrue(_path_in_scope("src/x/y/a.py", {"src/**/*.py"}))
+        self.assertFalse(_path_in_scope("lib/a.py", {"src/**/*.py"}))
+        # disjoint: src/**/*.py 는 src/a.py 와 겹침(둘 다 src 하위 .py)
+        self.assertFalse(scopes_disjoint({"src/**/*.py"}, {"src/a.py"}))
 
 
 # ── compute_waves ───────────────────────────────────────────


### PR DESCRIPTION
## 관련 이슈 번호

Closes #636

## 배경 및 문제

#636 은 #589(병렬 실행 정책 research) + PR #637(정책 SSOT `docs/plugin/parallel-policy.md` 작성) 의 후속이다. #637 은 정책(모델 A = worktree 격리 fan-in)만 고정하고 **driver 구현은 명시적으로 후속 분리**했다. 그 결과 정책은 있으나 `/impl-loop` chain 은 여전히 직렬로만 동작했고, 독립 task 가 명확한 epic 에서 처리량을 못 살렸다.

본 PR 은 그 driver 를 구현한다 — 정책을 코드(판정 코어 + helper)와 절차(SKILL)로 하강하되, 직렬 default·leader-owned governance·`1 task = 1 PR` invariant 를 전부 보존한다.

## 원인 (해당 시)

- (feature 추가 — RCA 비대상)

## 작업내용

- **wave 계산 코어** `harness/parallel_wave.py` (신규):
  - `parse_impl_task` — frontmatter `depends_on` 3-state(미상 `None` / 명시적 `[]` / 목록) + `## Scope > 수정 허용` 파일 경로 집합 파싱. placeholder 잔존·자유서술·빈값 = 미상 → 직렬 강등.
  - `compute_waves` — `depends_on` DAG 위상 + Scope 파일집합 disjoint + `max_parallel_workers=2` cap → 병렬 wave 후보. 불명확은 직렬 fallback.
  - `fan_in_check` — fan-in gate 최소 구조 판정(scope 준수 + cross-worker 파일 충돌 + evidence). aggregate test 실행은 별개의 절차 요건.
- **helper** `dcness-helper wave-plan` (session_state 서브커맨드) — chain dry preview 가 호출해 wave 후보를 JSON 으로 받음. 내부 helper(`run-dir` 류), 새 public surface 아님.
- **권한 경계** `harness/agent_boundary.py` — sub-agent 의 leader-owned `dcness-helper` 서브커맨드(run/step/ledger/checkpoint) 구조적 차단. 호출 형태 3가지(wrapper 직접 / `bash <path>` / `python -m`) 식별. `git commit`(transport)·read-only helper 는 통과. 정책 §9 가 driver 이슈로 미룬 결정 확정.
- **절차** `skills/impl-loop/SKILL.md` chain 모드 "병렬 wave (opt-in)" 절 신설 — wave 후보 echo → opt-in `(Y/n)` → build 병렬(격리 worktree, worker patch/evidence only) → leader fan-in gate → merge 직렬. yolo 여도 병렬 자동 ON 안 함.
- **문서** `parallel-policy.md`(driver 완료 반영 §9/§10) + `build-worker-agent.md`(병렬 wave worker 경계).
- **테스트** `tests/test_parallel_wave.py`(39) + `tests/test_agent_boundary.py`(helper 차단 케이스).

## 결정 근거

- **wave 계산을 Python 모듈로 분리**: AC 가 "wave 계산 단위 테스트 + fan-in PASS/FALLBACK 검증"을 요구 → main Claude prose 판정이 아닌 결정 로직을 코드로 내려 deterministic + testable 하게. dry preview 는 `wave-plan` JSON 만 읽음.
- **agent_boundary 구조 차단 채택(prompt-only 너머)**: 정책 §9 가 "worker→leader-mutation 차단은 driver 실행모델 확정 후"로 미뤘고, 본 driver 가 worktree 격리 모델을 확정 → sub-agent 가 `dcness-helper` 를 정상 호출하지 않음(grep 0건)을 근거로 전면 차단해도 무영향. prompt + 코드 이중 경계로 AC 5 를 구조적으로 닫음.
- **fan-in 충돌 판정 범위**: 실제 `git apply` 충돌은 leader 가 Bash 로 보지만, 그 전 cheap 구조 게이트(scope 준수 + 같은 파일을 두 worker 가 건드림 + evidence)는 순수 함수 `fan_in_check` 로 분리해 unit test 화. aggregate test 실행 PASS 는 별개 절차로 명시.
- **직렬 default 보존**: `has_parallel=false` 면 본 절차 전체 skip — 대부분 chain 은 동작 변화 0. 병렬은 명시 opt-in 한정(yolo 도 직렬만 자동화).

## 배포 경로 검증 (plug-in 영향 시)

전부 **경로 1 (plug-in 본체)**: `harness/parallel_wave.py` · `harness/session_state.py` · `harness/agent_boundary.py` · `skills/impl-loop/SKILL.md` · `agents/build-worker/**` · `docs/plugin/parallel-policy.md`. plug-in 버전 업으로 외부 활성 프로젝트에 자동 도달. init-dcness 가 사용자 repo 로 *복사*하는 파일(`scripts/check_*` / hooks / workflows) 변경 없음 → 별도 deploy 스텝·기존 사용자 재배포 고지 불필요.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public 발화 0. (1) 병렬은 기존 `/impl-loop` chain(shape 축)의 opt-in 변형으로 흡수됨. (2) 검증은 기존 pr-reviewer + 신규 fan-in gate 로 충족. (3) `wave-plan` 은 사용자-facing command 가 아니라 skill 내부에서 호출하는 helper 서브커맨드(`run-dir`/`run-status` 와 동급)다.

## Test Plan

- [x] `tests/test_parallel_wave.py` 39 PASS (3-state 파싱 / Scope 정규화 / wave 후보 / 중첩 배제 / 미상 fallback / cap / fan-in PASS·FALLBACK)
- [x] `tests/test_agent_boundary.py` helper 차단 케이스 추가 + 전체 PASS
- [x] 전체 pytest 762 PASS (회귀 0)
- [x] cross-ref / public-surface / plugin-manifest 게이트 PASS
- [x] `dcness-helper wave-plan` end-to-end 스모크 (cap=2 병렬+직렬 / cap=1 전부 직렬)
- [ ] driver 절차(SKILL)는 문서 — 런타임 wave 오케스트레이션 통합 테스트는 후속(정책 §10 의 wave integration validator 자동화 범위)

## 참고

- 정책 합의 경위: #589 코멘트(메인 Claude 정책 → Codex 리뷰 → 모델 A 확정) + PR #637(정책 SSOT).
- 비대상(이슈 명시): 한 세션 병렬 Agent / `current_step` multi-step 재설계 / wave-level integration validator 고급화 / `max_parallel_workers` 상한 상향.

## codex 리뷰 수렴 (8 라운드 — 7 fix + 1 clean, 모두 근본원인)

| R | findings (전부 근본원인 수정 + 회귀 테스트) |
|---|---|
| 1 | depends_on inline 주석 누수 · boundary deny set over-broad(serial build-worker 회귀) · 하이픈 경로(오탐→lock) |
| 2 | glob scope `/` 우회 구멍(fan-in gate) · 절대 glob crash |
| 3 | block 주석 절단 · Scope 산문 누락 · `**/` globstar 0-dir · helper guard data-position 오탐 |
| 4 | wave 순서 뒤집힘(task_index issue-close) — 순서 barrier |
| (자가감사) | Scope inline 주석 일관성 · glob char-class 일관성 (codex 전에 능동 발견) |
| 5 | 고위험 task 미강제(정책 §4) — 3중 강제 · 파일 scope 하위 우회 |
| 6 | blocked-intervening 순서 barrier(F10 변종) · dot 경로 오판 |
| 7 | `.env` glob backstop 미탐 · prev-tasks-reset 차단(파괴적·메인전담) |
| **8** | **clean — actionable issue 0** |

각 finding = 표면 패치 아님. 같은 클래스가 다른 위치에도 있는지 검토(예: glob 수정을 _path_in_scope+_paths_overlap 양쪽 / boundary deny set 을 caller 전수조사로 재설계). 전체 pytest 792 PASS, 전 게이트 PASS.
