### PR TITLE
[issue-636] fan-in gate fail-safe 보강

### DIFF
--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -94,7 +94,7 @@ active conveyor run 안의 `Agent` 호출은 직전 `begin-step` 의 단일 `cur
 
 1. 각 worker worktree 의 diff + evidence 를 수집한다.
 2. 별도 fan-in worktree 에서 wave 의 patch 들을 합친다.
-3. scope 준수(각 patch 가 자기 Scope 안인가)와 diff 충돌 여부를 확인한다. 구조 게이트는 wave 의 기대 task slug 전체를 함께 받아, worker 결과 record 자체가 누락된 경우도 evidence 누락으로 처리한다.
+3. scope 준수(각 patch 가 자기 Scope 안인가)와 diff 충돌 여부를 확인한다. 구조 게이트에는 wave 의 기대 task slug 전체를 `expected_slugs` 로 반드시 넘긴다. worker 결과 record 자체가 누락된 경우는 evidence 누락으로, 기대 slug 밖 worker 결과가 섞인 경우는 identity 오류로 강등한다.
 4. aggregate tree 전체 테스트를 1회 이상 돌린다.
 5. PASS → merge 단계 진입(각 task PR 은 기존 pr-reviewer·CI 그대로). FAIL → 충돌/실패 worker 산출물만 폐기하고 해당 task 직렬 fallback.
 

--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -94,7 +94,7 @@ active conveyor run 안의 `Agent` 호출은 직전 `begin-step` 의 단일 `cur
 
 1. 각 worker worktree 의 diff + evidence 를 수집한다.
 2. 별도 fan-in worktree 에서 wave 의 patch 들을 합친다.
-3. scope 준수(각 patch 가 자기 Scope 안인가)와 diff 충돌 여부를 확인한다.
+3. scope 준수(각 patch 가 자기 Scope 안인가)와 diff 충돌 여부를 확인한다. 구조 게이트는 wave 의 기대 task slug 전체를 함께 받아, worker 결과 record 자체가 누락된 경우도 evidence 누락으로 처리한다.
 4. aggregate tree 전체 테스트를 1회 이상 돌린다.
 5. PASS → merge 단계 진입(각 task PR 은 기존 pr-reviewer·CI 그대로). FAIL → 충돌/실패 worker 산출물만 폐기하고 해당 task 직렬 fallback.
 

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -149,6 +149,7 @@ class FanInResult:
     scope_violations: tuple[tuple[str, str], ...]  # (slug, scope 밖 path)
     conflicts: tuple[tuple[str, tuple[str, ...]], ...]  # (path, 그 path 건드린 slug 들)
     missing_evidence: tuple[str, ...]  # evidence 없는 slug
+    unexpected_workers: tuple[str, ...]  # wave 기대 slug 밖 worker 결과
     reasons: tuple[str, ...]
 
     @property
@@ -162,6 +163,7 @@ class FanInResult:
             "scope_violations": [list(v) for v in self.scope_violations],
             "conflicts": [[p, list(s)] for p, s in self.conflicts],
             "missing_evidence": list(self.missing_evidence),
+            "unexpected_workers": list(self.unexpected_workers),
             "reasons": list(self.reasons),
         }
 
@@ -632,20 +634,22 @@ def _path_in_scope(path: str, scope: Iterable[str]) -> bool:
 def fan_in_check(
     results: Iterable[WorkerResult],
     *,
-    expected_slugs: Iterable[str] = (),
+    expected_slugs: Iterable[str],
 ) -> FanInResult:
     """fan-in gate 의 최소 구조 판정 (정책 §6).
 
     PASS = 모든 worker diff 가 자기 Scope 안 + cross-worker 파일 충돌 없음 +
-    evidence 전부 존재. 하나라도 어기면 FALLBACK (직렬 강등 신호).
-    `expected_slugs` 를 주면 wave 에 있어야 하는 worker 결과가 통째로 누락된
-    경우도 evidence 누락으로 본다.
+    evidence 전부 존재 + 결과 slug 가 기대 wave 와 일치. 하나라도 어기면
+    FALLBACK (직렬 강등 신호). `expected_slugs` 는 필수 입력이다. caller 가
+    wave 에 있어야 하는 worker 전체를 넘기지 않으면 부분 누락을 알 수 없기
+    때문이다.
 
     주의: aggregate tree 전체 테스트 PASS 는 별개의 절차적 요건이라 leader 가
     Bash 로 수행한다 — 본 함수는 그 *전* 의 구조 게이트만 본다.
     """
     results = list(results)
     expected = tuple(dict.fromkeys(s for s in expected_slugs if s))
+    expected_set = set(expected)
     present = {r.slug for r in results}
 
     scope_violations: list[tuple[str, str]] = []
@@ -668,6 +672,9 @@ def fan_in_check(
             + [r.slug for r in results if not r.evidence_present]
         )
     )
+    unexpected = tuple(
+        dict.fromkeys(r.slug for r in results if r.slug not in expected_set)
+    )
 
     reasons: list[str] = []
     if not results and not expected:
@@ -678,6 +685,8 @@ def fan_in_check(
         reasons.append(f"cross-worker 파일 충돌 {len(conflicts)}건")
     if missing:
         reasons.append(f"evidence 누락 {len(missing)}건")
+    if unexpected:
+        reasons.append(f"예상 밖 worker {len(unexpected)}건")
 
     verdict = "PASS" if not reasons else "FALLBACK"
     return FanInResult(
@@ -685,6 +694,7 @@ def fan_in_check(
         scope_violations=tuple(scope_violations),
         conflicts=tuple(conflicts),
         missing_evidence=missing,
+        unexpected_workers=unexpected,
         reasons=tuple(reasons),
     )
 

--- a/harness/parallel_wave.py
+++ b/harness/parallel_wave.py
@@ -629,16 +629,24 @@ def _path_in_scope(path: str, scope: Iterable[str]) -> bool:
     return False
 
 
-def fan_in_check(results: Iterable[WorkerResult]) -> FanInResult:
+def fan_in_check(
+    results: Iterable[WorkerResult],
+    *,
+    expected_slugs: Iterable[str] = (),
+) -> FanInResult:
     """fan-in gate 의 최소 구조 판정 (정책 §6).
 
     PASS = 모든 worker diff 가 자기 Scope 안 + cross-worker 파일 충돌 없음 +
     evidence 전부 존재. 하나라도 어기면 FALLBACK (직렬 강등 신호).
+    `expected_slugs` 를 주면 wave 에 있어야 하는 worker 결과가 통째로 누락된
+    경우도 evidence 누락으로 본다.
 
     주의: aggregate tree 전체 테스트 PASS 는 별개의 절차적 요건이라 leader 가
     Bash 로 수행한다 — 본 함수는 그 *전* 의 구조 게이트만 본다.
     """
     results = list(results)
+    expected = tuple(dict.fromkeys(s for s in expected_slugs if s))
+    present = {r.slug for r in results}
 
     scope_violations: list[tuple[str, str]] = []
     for r in results:
@@ -654,9 +662,16 @@ def fan_in_check(results: Iterable[WorkerResult]) -> FanInResult:
         (p, tuple(sorted(s))) for p, s in sorted(owners.items()) if len(s) > 1
     ]
 
-    missing = tuple(r.slug for r in results if not r.evidence_present)
+    missing = tuple(
+        dict.fromkeys(
+            [s for s in expected if s not in present]
+            + [r.slug for r in results if not r.evidence_present]
+        )
+    )
 
     reasons: list[str] = []
+    if not results and not expected:
+        reasons.append("worker 결과 없음")
     if scope_violations:
         reasons.append(f"scope 이탈 {len(scope_violations)}건")
     if conflicts:

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -299,7 +299,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" wave-plan <impl-glob-or-dir> 
 
 1. 각 worker worktree 의 변경 파일(`git -C <wt> diff --name-only <base>`) + evidence 수집.
 2. 별도 fan-in worktree 에 wave patch 들을 합친다 (`git -C <fanin> cherry-pick` 또는 `git apply`).
-3. **scope 준수**(각 변경 파일이 그 task `수정 허용` 안) + **cross-worker 파일 충돌**(두 worker 가 같은 파일) + **evidence 존재** 판정. 이 구조 게이트의 판정 로직 = [`parallel_wave.fan_in_check`](../../harness/parallel_wave.py) (PASS/FALLBACK). 호출 시 wave 의 기대 task slug 전체를 `expected_slugs` 로 함께 넘겨, worker 결과 record 자체가 누락된 경우도 evidence 누락으로 강등한다.
+3. **scope 준수**(각 변경 파일이 그 task `수정 허용` 안) + **cross-worker 파일 충돌**(두 worker 가 같은 파일) + **evidence 존재** 판정. 이 구조 게이트의 판정 로직 = [`parallel_wave.fan_in_check`](../../harness/parallel_wave.py) (PASS/FALLBACK). 호출 시 wave 의 기대 task slug 전체를 `expected_slugs` 로 반드시 넘긴다. worker 결과 record 자체가 누락된 경우는 evidence 누락으로, 기대 slug 밖 worker 결과가 섞인 경우는 identity 오류로 강등한다.
 4. aggregate tree 전체 테스트를 1회 이상 돌린다 (이 *실행* 은 leader Bash — 구조 게이트와 별개의 절차 요건).
 5. **PASS** → ③ merge 단계 진입. **FAIL** → 충돌/실패 worker 산출물만 폐기하고 그 task 를 직렬 chain 으로 강등(나머지 wave 는 PASS 분만 진행 가능).
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -299,7 +299,7 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" wave-plan <impl-glob-or-dir> 
 
 1. 각 worker worktree 의 변경 파일(`git -C <wt> diff --name-only <base>`) + evidence 수집.
 2. 별도 fan-in worktree 에 wave patch 들을 합친다 (`git -C <fanin> cherry-pick` 또는 `git apply`).
-3. **scope 준수**(각 변경 파일이 그 task `수정 허용` 안) + **cross-worker 파일 충돌**(두 worker 가 같은 파일) + **evidence 존재** 판정. 이 구조 게이트의 판정 로직 = [`parallel_wave.fan_in_check`](../../harness/parallel_wave.py) (PASS/FALLBACK).
+3. **scope 준수**(각 변경 파일이 그 task `수정 허용` 안) + **cross-worker 파일 충돌**(두 worker 가 같은 파일) + **evidence 존재** 판정. 이 구조 게이트의 판정 로직 = [`parallel_wave.fan_in_check`](../../harness/parallel_wave.py) (PASS/FALLBACK). 호출 시 wave 의 기대 task slug 전체를 `expected_slugs` 로 함께 넘겨, worker 결과 record 자체가 누락된 경우도 evidence 누락으로 강등한다.
 4. aggregate tree 전체 테스트를 1회 이상 돌린다 (이 *실행* 은 leader Bash — 구조 게이트와 별개의 절차 요건).
 5. **PASS** → ③ merge 단계 진입. **FAIL** → 충돌/실패 worker 산출물만 폐기하고 그 task 를 직렬 chain 으로 강등(나머지 wave 는 PASS 분만 진행 가능).
 

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -552,12 +552,19 @@ class TestComputeWaves(unittest.TestCase):
 
 
 class TestFanInCheck(unittest.TestCase):
+    def test_expected_slugs_required(self):
+        results = [
+            WorkerResult("01-a", frozenset({"src/a.py"}), frozenset({"src/a.py"})),
+        ]
+        with self.assertRaises(TypeError):
+            fan_in_check(results)
+
     def test_clean_wave_passes(self):
         results = [
             WorkerResult("01-a", frozenset({"src/a.py"}), frozenset({"src/a.py"})),
             WorkerResult("02-b", frozenset({"src/b.py"}), frozenset({"src/b.py"})),
         ]
-        r = fan_in_check(results)
+        r = fan_in_check(results, expected_slugs=("01-a", "02-b"))
         self.assertTrue(r.passed)
         self.assertEqual(r.verdict, "PASS")
         self.assertEqual(r.reasons, ())
@@ -571,7 +578,7 @@ class TestFanInCheck(unittest.TestCase):
                 frozenset({"src/a.py"}),
             ),
         ]
-        r = fan_in_check(results)
+        r = fan_in_check(results, expected_slugs=("01-a",))
         self.assertFalse(r.passed)
         self.assertEqual(r.verdict, "FALLBACK")
         self.assertIn(("01-a", "src/other.py"), r.scope_violations)
@@ -585,7 +592,7 @@ class TestFanInCheck(unittest.TestCase):
                 "02-b", frozenset({"src/shared.py"}), frozenset({"src/shared.py"})
             ),
         ]
-        r = fan_in_check(results)
+        r = fan_in_check(results, expected_slugs=("01-a", "02-b"))
         self.assertFalse(r.passed)
         self.assertEqual(len(r.conflicts), 1)
         self.assertEqual(r.conflicts[0][0], "src/shared.py")
@@ -600,13 +607,13 @@ class TestFanInCheck(unittest.TestCase):
                 evidence_present=False,
             ),
         ]
-        r = fan_in_check(results)
+        r = fan_in_check(results, expected_slugs=("01-a",))
         self.assertFalse(r.passed)
         self.assertEqual(r.missing_evidence, ("01-a",))
 
     def test_empty_worker_results_fallback(self):
         # worker 결과 수집 자체가 실패했는데 빈 입력을 PASS 로 보면 안 됨.
-        r = fan_in_check([])
+        r = fan_in_check([], expected_slugs=())
         self.assertFalse(r.passed)
         self.assertEqual(r.verdict, "FALLBACK")
         self.assertIn("worker 결과 없음", r.reasons)
@@ -635,6 +642,18 @@ class TestFanInCheck(unittest.TestCase):
         self.assertFalse(r.passed)
         self.assertEqual(r.missing_evidence, ("01-a",))
 
+    def test_unexpected_worker_result_fallback(self):
+        # wave 밖 worker 결과가 섞이면 identity 오류라 fan-in 을 통과하면 안 됨.
+        results = [
+            WorkerResult("01-a", frozenset({"src/a.py"}), frozenset({"src/a.py"})),
+            WorkerResult("02-b", frozenset({"src/b.py"}), frozenset({"src/b.py"})),
+            WorkerResult("99-z", frozenset({"src/z.py"}), frozenset({"src/z.py"})),
+        ]
+        r = fan_in_check(results, expected_slugs=("01-a", "02-b"))
+        self.assertFalse(r.passed)
+        self.assertEqual(r.unexpected_workers, ("99-z",))
+        self.assertIn("예상 밖 worker 1건", r.reasons)
+
     def test_scope_dir_prefix_allowed(self):
         # 선언 scope 가 디렉토리면 그 아래 파일 변경은 준수
         results = [
@@ -642,7 +661,7 @@ class TestFanInCheck(unittest.TestCase):
                 "01-a", frozenset({"src/feature/x.py"}), frozenset({"src/feature/"})
             ),
         ]
-        r = fan_in_check(results)
+        r = fan_in_check(results, expected_slugs=("01-a",))
         self.assertTrue(r.passed)
 
     def test_file_scope_no_descendant(self):
@@ -651,16 +670,18 @@ class TestFanInCheck(unittest.TestCase):
         violator = WorkerResult(
             "01-a", frozenset({"scripts/tool/x.py"}), frozenset({"scripts/tool"})
         )
-        self.assertFalse(fan_in_check([violator]).passed)
+        self.assertFalse(
+            fan_in_check([violator], expected_slugs=("01-a",)).passed
+        )
         exact = WorkerResult(
             "02-b", frozenset({"scripts/tool"}), frozenset({"scripts/tool"})
         )
-        self.assertTrue(fan_in_check([exact]).passed)
+        self.assertTrue(fan_in_check([exact], expected_slugs=("02-b",)).passed)
         # 명시적 디렉토리 scope(끝 /)는 하위 허용
         dir_ok = WorkerResult(
             "03-c", frozenset({"scripts/tool/x.py"}), frozenset({"scripts/tool/"})
         )
-        self.assertTrue(fan_in_check([dir_ok]).passed)
+        self.assertTrue(fan_in_check([dir_ok], expected_slugs=("03-c",)).passed)
 
     def test_glob_scope_segment_aware_violation(self):
         # codex F4 — glob scope `src/*.py` 선언했는데 src/sub/a.py 를 건드리면
@@ -668,12 +689,14 @@ class TestFanInCheck(unittest.TestCase):
         violator = WorkerResult(
             "01-a", frozenset({"src/sub/a.py"}), frozenset({"src/*.py"})
         )
-        self.assertFalse(fan_in_check([violator]).passed)
+        self.assertFalse(
+            fan_in_check([violator], expected_slugs=("01-a",)).passed
+        )
         # 같은 glob scope 의 직접 자식은 준수
         ok = WorkerResult(
             "02-b", frozenset({"src/a.py"}), frozenset({"src/*.py"})
         )
-        self.assertTrue(fan_in_check([ok]).passed)
+        self.assertTrue(fan_in_check([ok], expected_slugs=("02-b",)).passed)
 
 
 class TestWavePlanFromPaths(unittest.TestCase):

--- a/tests/test_parallel_wave.py
+++ b/tests/test_parallel_wave.py
@@ -604,6 +604,37 @@ class TestFanInCheck(unittest.TestCase):
         self.assertFalse(r.passed)
         self.assertEqual(r.missing_evidence, ("01-a",))
 
+    def test_empty_worker_results_fallback(self):
+        # worker 결과 수집 자체가 실패했는데 빈 입력을 PASS 로 보면 안 됨.
+        r = fan_in_check([])
+        self.assertFalse(r.passed)
+        self.assertEqual(r.verdict, "FALLBACK")
+        self.assertIn("worker 결과 없음", r.reasons)
+
+    def test_missing_expected_worker_result_fallback(self):
+        # 2-worker wave 에서 한 worker 결과 record 가 통째로 누락된 경우도 evidence 누락.
+        results = [
+            WorkerResult("01-a", frozenset({"src/a.py"}), frozenset({"src/a.py"})),
+        ]
+        r = fan_in_check(results, expected_slugs=("01-a", "02-b"))
+        self.assertFalse(r.passed)
+        self.assertEqual(r.missing_evidence, ("02-b",))
+        self.assertIn("evidence 누락 1건", r.reasons)
+
+    def test_expected_worker_and_flagged_missing_deduped(self):
+        # expected 에도 있고 evidence_present=False 인 경우 missing_evidence 중복 방지.
+        results = [
+            WorkerResult(
+                "01-a",
+                frozenset({"src/a.py"}),
+                frozenset({"src/a.py"}),
+                evidence_present=False,
+            ),
+        ]
+        r = fan_in_check(results, expected_slugs=("01-a",))
+        self.assertFalse(r.passed)
+        self.assertEqual(r.missing_evidence, ("01-a",))
+
     def test_scope_dir_prefix_allowed(self):
         # 선언 scope 가 디렉토리면 그 아래 파일 변경은 준수
         results = [


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: PR #638 사후 리뷰 follow-up — #636은 #638에서 이미 처리된 후속 보정
Part of #636
Part of #640

## 배경 및 문제

PR #638 리뷰에서 `fan_in_check`가 제공된 `WorkerResult`만 검사해, 기대 worker 결과 레코드가 통째로 누락된 경우에도 PASS할 수 있는 문제가 확인됐다. 추가 확인 결과 `expected_slugs`를 caller가 빼먹으면 partial result가 여전히 PASS할 수 있고, expected wave 밖 worker 결과도 identity 오류로 잡지 못했다.

## 원인 (해당 시)

`fan_in_check`가 expected wave task slug 목록을 필수 입력으로 강제하지 않았고, `present - expected`에 해당하는 unexpected worker 결과를 별도 오류로 계산하지 않았다.

## 작업내용

- `fan_in_check`의 `expected_slugs`를 필수 keyword-only 인자로 변경해 caller가 기대 worker 목록을 빼먹을 수 없게 함
- 기대 worker 결과 레코드 누락을 `missing_evidence`로 판정
- expected wave slug 밖 worker 결과를 `unexpected_workers`로 노출하고 `FALLBACK` 처리
- 빈 worker result 입력을 PASS 대신 `FALLBACK` 처리
- partial no-expected / missing expected / unexpected worker / dedup 케이스 단위 테스트 추가
- impl-loop skill과 plugin parallel policy 문서에 필수 `expected_slugs` 전달 및 identity 오류 처리 규칙 반영

## 결정 근거

현재 실제 parallel wave driver caller는 아직 없으므로 API를 fail-safe 쪽으로 조일 수 있다. 향후 driver는 wave 전체 task slug를 fan-in gate에 반드시 넘겨야 하며, gate는 그 목록을 기준으로 missing worker와 unexpected worker를 모두 구조적으로 차단해야 한다. 실제 driver 구현 범위는 후속 #640으로 분리한다.

## 배포 경로 검증 (plug-in 영향 시)

`docs/plugin/parallel-policy.md`와 `skills/impl-loop/SKILL.md`에 동일 규칙을 반영했다. 새 public command/agent/surface는 추가하지 않았다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_parallel_wave -v`
- [x] `python3.11 -m unittest tests.test_agent_boundary -v`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`

## 참고

- PR #638 review finding follow-up
- 후속 실제 driver 구현: #640