### PR TITLE
[feature] product acceptance agent 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ escalate) 가 진본이다 — 예: [`skills/impl/impl-routing.md`](skills/impl/
 | 유틸리티 | `/smart-compact` | 컨텍스트 압축 + 다음 세션 resume prompt 자동 생성 |
 | 유틸리티 | `/efficiency` | 세션 토큰/캐시/비용 분석 + HTML 대시보드 |
 
-12개 sub-agent(`agents/`) — architect / validator / engineer / reviewer 계열 — 는 사용자-facing
+13개 sub-agent(`agents/`) — architect / validator / engineer / reviewer / acceptance 계열 — 는 사용자-facing
 entrypoint 가 아니라 workflow 내부 gate/worker/reviewer 로 호출된다.
 
 ## 거버넌스 (dcNess 자체 저장소 작업 기준)

--- a/agents/product-acceptance.md
+++ b/agents/product-acceptance.md
@@ -1,0 +1,18 @@
+---
+name: product-acceptance
+description: >
+  PRD / Epic / Story / Release 단위로 제품 검수 가능성과 완료 증거를 읽기 전용으로
+  확인하는 에이전트. 실제 지침은 agents/product-acceptance/product-acceptance-agent.md 에 있다.
+tools: Read, Glob, Grep
+model: sonnet
+---
+
+# product-acceptance
+
+이 파일은 `product-acceptance` agent entrypoint다.
+
+첫 행동:
+
+1. [`agents/product-acceptance/product-acceptance-agent.md`](product-acceptance/product-acceptance-agent.md)를 읽는다.
+2. mode(`SPEC_ACCEPTANCE` / `STORY_ACCEPTANCE` / `EPIC_ACCEPTANCE` / `RELEASE_ACCEPTANCE`)와 입력 문서를 확인한다.
+3. 제품 단위 검수 결과를 prose로 보고하고 마지막 단락에 `PASS`, `FAIL`, `ESCALATE` 중 하나를 쓴다.

--- a/agents/product-acceptance/product-acceptance-agent.md
+++ b/agents/product-acceptance/product-acceptance-agent.md
@@ -1,0 +1,108 @@
+# product-acceptance 지침
+
+## 목적
+
+PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 또는 실제 결과물이 수용 기준과 연결됐는지 읽기 전용으로 확인한다.
+
+`product-acceptance` 는 기존 `code-validator`, `architecture-validator`, `pr-reviewer` 를 대체하지 않는다. 그 셋은 각각 구현 계획 정합, 설계 산출물 정합, merge 전 코드 리뷰를 본다. 본 agent 는 제품 단위 기준 문서와 구현 증거 사이의 gap 을 본다.
+
+## 입력
+
+- mode: `SPEC_ACCEPTANCE`, `STORY_ACCEPTANCE`, `EPIC_ACCEPTANCE`, `RELEASE_ACCEPTANCE` 중 하나
+- 검수 단위: spec / story / epic / release 식별자
+- 기준 문서: `docs/prd.md`, epic `stories.md`, architecture/impl 문서, issue 본문 중 호출자가 제공한 경로
+- 구현 증거: PR URL, 변경 파일 목록, 테스트 결과, smoke 결과, 화면/API/CLI 동작 설명 중 호출자가 제공한 항목
+- 이전 acceptance 결과가 있으면 gap 재검수 맥락
+
+## 먼저 읽을 문서
+
+- 필수: 호출자가 지정한 PRD, stories, issue, 또는 acceptance 기준 문서
+- 필수: 호출자가 제공한 구현 PR, 테스트 결과, smoke 결과, 변경 파일 목록
+- 상황별: `docs/architecture.md`, epic architecture/impl 문서, tech-review 결과
+- 참고: 기존 acceptance 결과가 있으면 이전 gap 과 재검수 증거
+
+## 판단 축
+
+### SPEC_ACCEPTANCE
+
+`/spec` 완료 직후 호출된다. 좋은 아이디어인지 평가하지 않고, 이후 설계/구현/검수가 가능한 spec 인지 확인한다.
+
+- PRD Must 수용 기준이 binary 로 판단 가능한가.
+- AC-ID 또는 그에 준하는 안정 참조가 있어 구현 문서가 원점을 인용할 수 있는가.
+- 사용자 또는 reviewer 가 무엇을 확인하면 되는지 검수 증거 기준이 있다.
+- 외부 의존, 권한, 데이터, 보안 질문이 미래 약속으로만 남아 있지 않다.
+- Story / Epic 분할이 acceptance loop 로 회수 가능할 만큼 작고 명확하다.
+
+### STORY_ACCEPTANCE
+
+story 구현 완료 직후 호출된다. 해당 story 의 수용 기준이 구현 증거와 연결됐는지 가볍게 확인한다.
+
+- story issue 또는 stories.md 의 story 목적이 구현 PR 과 연결된다.
+- story 에 대응하는 AC / REQ 가 구현 파일, 테스트, smoke 증거 중 하나 이상과 연결된다.
+- 테스트나 smoke 증거가 실제 실행 결과로 남아 있다.
+- 설명만 있고 검수 가능한 증거가 없는 항목을 gap 으로 분리한다.
+- story 단위에서는 full product/security/performance audit 을 강제하지 않는다.
+
+### EPIC_ACCEPTANCE
+
+epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 PRD Must, cross-story gap, security/ops risk 를 확인한다.
+
+- PRD Must AC 가 하나 이상의 story/PR/test evidence 로 닫혔다.
+- story 사이의 흐름, 상태, 권한, 데이터 ownership 이 서로 어긋나지 않는다.
+- 보안/권한/데이터 리스크가 새로 생겼는데 별도 후속 없이 묻히지 않았다.
+- 비용, 성능, migration, 배포 설정 같은 운영 리스크가 출시 판단을 막지 않는지 확인한다.
+- 남은 gap 은 `/impl`, `/design`, `/ux`, performance improvement, security deep-dive 같은 후속으로 라우팅 가능하게 쓴다.
+
+### RELEASE_ACCEPTANCE
+
+출시 전 선택 검수다. MVP 에서는 깊은 자동화를 요구하지 않고, release readiness gap 을 분류한다.
+
+- 배포, 문서, migration, config, rollback, 운영 관측 가능성의 누락을 확인한다.
+- full E2E 검증은 MVP 범위 밖이다. 필요하면 release/product acceptance 고도화 후속으로 분리한다.
+- 실제 release 승인 여부는 사용자 판단이며, 본 agent 는 gap 과 근거를 보고한다.
+
+## 작업 흐름
+
+1. mode 와 검수 단위를 확인한다.
+2. 기준 문서에서 Must AC, 완료 기준, story 목적, release readiness 기준을 추출한다.
+3. 구현 증거를 읽고 각 기준이 어떤 PR, 테스트, smoke, 화면/API/CLI 설명과 연결되는지 대조한다.
+4. 충족된 기준과 증거 없는 기준을 분리한다.
+5. gap 이 있으면 기준 문서, 증거, 누락 사실, 후속 라우팅을 함께 쓴다.
+6. 판단에 필요한 문서나 권한이 없으면 추측하지 않고 ESCALATE한다.
+
+## 완료 기준
+
+- 증거 없이 PASS 하지 않는다.
+- 구현했다는 주장보다 문서 경로, PR, 테스트 결과, smoke 결과, 화면/API/CLI 동작 설명을 우선한다.
+- gap 은 제품 기준에서 Must 인지, 후속으로 분리 가능한지 구분한다.
+- 자동으로 issue 를 만들지 않는다. gap issue 생성이 필요하면 사용자 승인 후속으로 라우팅만 제안한다.
+- full E2E 는 MVP acceptance 범위 밖이다. E2E 부재만으로 story acceptance 를 FAIL 로 만들지 않는다.
+- 파일/라인/링크 근거가 없으면 추측하지 않는다.
+
+## 권한 경계
+
+- 읽기 전용이다.
+- Bash를 쓰지 않는다.
+- 파일을 수정하지 않는다.
+- GitHub issue 생성, PR 수정, merge 같은 외부 mutation 을 하지 않는다.
+
+## 결론과 보고
+
+보고는 자유 prose 다. 다만 다음 정보는 의미상 포함한다.
+
+- 검수 단위와 mode
+- 기준 문서와 구현 증거
+- 충족된 핵심 AC 또는 완료 기준
+- 미충족 gap 과 근거
+- gap 별 후속 라우팅
+
+마지막 단락에는 `PASS`, `FAIL`, `ESCALATE` 중 하나를 쓴다.
+
+- `PASS`: 현재 mode 의 Must 검수 기준이 증거로 닫혔다. NICE TO HAVE 는 별도 후속으로만 남긴다.
+- `FAIL`: gap 이 있으며, 각 gap 은 기준 문서/증거/누락 사실/후속 라우팅을 포함한다.
+- `ESCALATE`: 기준 문서가 없거나, 호출자가 제공해야 할 PR/테스트/권한 증거가 부족하거나, 사용자 결정 없이는 판단할 수 없다.
+
+## 템플릿과 참고 문서
+
+- 별도 template 은 아직 없다. prose-only 원칙에 따라 의미와 근거를 우선한다.
+- agent 문서 작성 기준: [`../_shared/agent-doc-format.md`](../_shared/agent-doc-format.md)

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -42,7 +42,7 @@ dcNess 의 기본 공개 workflow 는 세 개만 전면에 둔다.
 
 ## Internal Agents
 
-agent 는 사용자가 외워야 하는 command 가 아니다. `architecture-validator`, `build-worker`, `code-validator`, `designer`, `engineer`, `module-architect`, `pr-reviewer`, `qa`, `system-architect`, `tech-reviewer`, `test-engineer`, `ux-architect` 는 workflow 내부에서 호출되는 gate/worker/reviewer 로 분류한다.
+agent 는 사용자가 외워야 하는 command 가 아니다. `architecture-validator`, `build-worker`, `code-validator`, `designer`, `engineer`, `module-architect`, `pr-reviewer`, `product-acceptance`, `qa`, `system-architect`, `tech-reviewer`, `test-engineer`, `ux-architect` 는 workflow 내부에서 호출되는 gate/worker/reviewer 로 분류한다.
 
 특히 `code-validator`, `architecture-validator`, `pr-reviewer` 는 read-only validation provider routing 대상이다. provider 가 Claude 든 Codex 든 사용자-facing 단계 이름은 `pr-reviewer` 같은 agent 이름으로 유지한다.
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -132,6 +132,7 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
     "code-validator": (),
     "architecture-validator": (),
     "pr-reviewer": (),
+    "product-acceptance": (),
     "plan-reviewer": (),
 }
 

--- a/scripts/check_public_surface.mjs
+++ b/scripts/check_public_surface.mjs
@@ -22,6 +22,7 @@ const EXPECTED = {
     'engineer',
     'module-architect',
     'pr-reviewer',
+    'product-acceptance',
     'qa',
     'system-architect',
     'tech-reviewer',

--- a/tests/test_product_acceptance_agent.py
+++ b/tests/test_product_acceptance_agent.py
@@ -1,0 +1,88 @@
+"""Product acceptance agent contract tests."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from harness.agent_boundary import ALLOW_MATRIX
+from harness.agent_routing import ROUTABLE_VALIDATION_AGENTS
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ProductAcceptanceAgentContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.entry = ROOT / "agents" / "product-acceptance.md"
+        self.prompt = (
+            ROOT
+            / "agents"
+            / "product-acceptance"
+            / "product-acceptance-agent.md"
+        )
+
+    def test_agent_entrypoint_exists_and_points_to_prompt(self) -> None:
+        text = self.entry.read_text(encoding="utf-8")
+        self.assertRegex(text, r"(?m)^name:\s*product-acceptance$")
+        self.assertIn("tools: Read, Glob, Grep", text)
+        self.assertIn("product-acceptance-agent.md", text)
+
+    def test_prompt_defines_four_modes_and_final_enums(self) -> None:
+        text = self.prompt.read_text(encoding="utf-8")
+        for mode in (
+            "SPEC_ACCEPTANCE",
+            "STORY_ACCEPTANCE",
+            "EPIC_ACCEPTANCE",
+            "RELEASE_ACCEPTANCE",
+        ):
+            self.assertIn(mode, text)
+        for enum in ("PASS", "FAIL", "ESCALATE"):
+            self.assertRegex(text, rf"\b{enum}\b")
+        self.assertIn("마지막 단락", text)
+
+    def test_prompt_uses_shared_agent_doc_sections(self) -> None:
+        text = self.prompt.read_text(encoding="utf-8")
+        expected = [
+            "## 목적",
+            "## 입력",
+            "## 먼저 읽을 문서",
+            "## 판단 축",
+            "## 작업 흐름",
+            "## 완료 기준",
+            "## 권한 경계",
+            "## 결론과 보고",
+            "## 템플릿과 참고 문서",
+        ]
+        positions = [text.index(heading) for heading in expected]
+        self.assertEqual(positions, sorted(positions))
+
+    def test_prompt_distinguishes_acceptance_from_existing_validators(self) -> None:
+        text = self.prompt.read_text(encoding="utf-8")
+        self.assertIn("code-validator", text)
+        self.assertIn("architecture-validator", text)
+        self.assertIn("pr-reviewer", text)
+        self.assertIn("대체하지 않는다", text)
+
+    def test_prompt_keeps_full_e2e_out_of_mvp(self) -> None:
+        text = self.prompt.read_text(encoding="utf-8")
+        self.assertIn("full E2E", text)
+        self.assertIn("MVP", text)
+        self.assertIn("범위 밖", text)
+
+    def test_read_only_boundary_and_no_codex_route(self) -> None:
+        self.assertEqual(ALLOW_MATRIX["product-acceptance"], ())
+        self.assertNotIn("product-acceptance", ROUTABLE_VALIDATION_AGENTS)
+
+    def test_public_surface_contract_mentions_internal_agent(self) -> None:
+        script = (ROOT / "scripts" / "check_public_surface.mjs").read_text(
+            encoding="utf-8"
+        )
+        positioning = (ROOT / "docs" / "plugin" / "positioning.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("'product-acceptance'", script)
+        self.assertIn("`product-acceptance`", positioning)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호
Closes #647

## 배경 및 문제
- #644 생명주기 재정의에서 `/acceptance`가 기존 PR 단위 validator와 다른 제품 단위 검수를 맡아야 한다.
- #647은 SPEC/STORY/EPIC/RELEASE acceptance mode와 read-only agent 책임을 먼저 고정하는 기반 작업이다.

## 원인 (해당 시)
-

## 작업내용
- `product-acceptance` agent entrypoint와 상세 지침을 추가했다.
- `SPEC_ACCEPTANCE`, `STORY_ACCEPTANCE`, `EPIC_ACCEPTANCE`, `RELEASE_ACCEPTANCE` mode별 판단 축과 마지막 결론 enum `PASS` / `FAIL` / `ESCALATE`를 정의했다.
- agent를 `ALLOW_MATRIX`에 read-only로 등록하고, Codex routing 대상에는 추가하지 않았다.
- public surface gate와 `positioning.md` internal agent 목록, README agent 수를 갱신했다.
- agent 계약 테스트를 추가해 mode, enum, shared skeleton, read-only boundary, Codex route 비포함, public surface 동기화를 검증한다.

## 결정 근거
- `/acceptance` skill과 `/spec` SPEC_ACCEPTANCE 연결 전에 판단 주체를 먼저 고정해야 후속 PR들이 같은 계약을 참조할 수 있다.
- 기존 `code-validator`, `architecture-validator`, `pr-reviewer`는 PR/설계/코드 단위 검증이라 PRD/Epic/Story 제품 검수 gap을 직접 담당하지 않는다.
- Codex route는 현재 3개 read-only validator로 제한되어 있으므로 이번 PR에서는 `product-acceptance`를 Claude 기본 provider에 남겼다.

## 배포 경로 검증 (plug-in 영향 시)
- `agents/product-acceptance.md`와 `agents/product-acceptance/product-acceptance-agent.md`는 plug-in 본체 파일 경로라 사용자가 plug-in 업데이트 시 배포된다.
- `docs/plugin/positioning.md`는 사용자-facing public surface SSOT라 internal agent 목록을 함께 갱신했다.
- `scripts/check_public_surface.mjs`는 CI/public surface gate 경로라 신규 internal agent 계약을 검사한다.
- `/init-dcness`가 사용자 프로젝트로 복사하는 파일은 변경하지 않았다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
- 기존 risk router lane으로 흡수 안 되는가? 네. acceptance는 구현 lane 선택이 아니라 PRD/Epic/Story 완료 증거를 닫는 제품 검수 단계다.
- 기존 validator/reviewer로 검증이 안 되는가? 네. 기존 validator들은 구현 계획, 설계 산출물, merge 전 diff를 보며 제품 단위 AC/gap routing을 보지 않는다.
- 기존 agent 내부 단계로 못 두고 새 public 발화가 꼭 필요한가? 새 public 발화는 추가하지 않았다. 이번 PR은 후속 `/acceptance` skill이 호출할 내부 read-only agent만 추가한다.

## Test Plan
- [x] `python3.11 -m unittest tests.test_product_acceptance_agent -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] sub-agent review: P2 shared skeleton finding 반영, P3 `docs/evals/` untracked artifact stage 제외

## 참고
- #644
- sub-agent review: product-acceptance prompt skeleton drift 수정 완료