### PR TITLE
[feature] init-dcness 회귀 테스트 트리거 paths 보강

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,6 +7,7 @@
 # 트리거:
 # - PR / push to main 시 tests/ 또는 harness/ 또는 agents/ 또는 skills/ 변경 시
 #   (skills/ = test_loop_procedure_base_ref / test_impl_cost_aware 가 skills/<n>/SKILL.md 내용 단언)
+#   (commands/ = test_skill_scenarios / test_surface_docs_sync 가 commands/init-dcness.md deploy·문서 단언)
 # - scripts/check_git_naming.mjs / docs/plugin/git-spec.md 변경 시 (test_git_naming 게이트 회귀 차단)
 # - docs/plugin/loop-procedure.md 변경 시 (test_loop_procedure_base_ref base-ref 회귀 차단)
 # - paths 필터로 docs-only PR 에서 불필요 실행 회피
@@ -25,6 +26,7 @@ on:
       - 'tests/**'
       - 'agents/**'
       - 'skills/**'
+      - 'commands/**'
       - 'scripts/check_git_naming.mjs'
       - 'docs/plugin/git-spec.md'
       - 'docs/plugin/loop-procedure.md'
@@ -36,6 +38,7 @@ on:
       - 'tests/**'
       - 'agents/**'
       - 'skills/**'
+      - 'commands/**'
       - 'scripts/check_git_naming.mjs'
       - 'docs/plugin/git-spec.md'
       - 'docs/plugin/loop-procedure.md'

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -4,7 +4,7 @@
 #
 # 동작:
 #   1. staged 파일 목록 추출 (git diff --cached --name-only)
-#   2. harness/ | tests/ | agents/ | skills/ | .github/workflows/python-tests.yml 매칭 시만 실행
+#   2. harness/ | tests/ | agents/ | skills/ | commands/ | .github/workflows/python-tests.yml 매칭 시만 실행
 #   3. python3.11/python3 -m unittest discover -s tests
 #
 # 종료 코드:
@@ -26,7 +26,7 @@ if [ -z "$CHANGED" ]; then
   exit 0
 fi
 
-if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|skills/|scripts/check_git_naming\.mjs$|docs/plugin/git-spec\.md$|docs/plugin/loop-procedure\.md$|\.github/workflows/python-tests\.yml$)'; then
+if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|skills/|commands/|scripts/check_git_naming\.mjs$|docs/plugin/git-spec\.md$|docs/plugin/loop-procedure\.md$|\.github/workflows/python-tests\.yml$)'; then
   # 미매칭 — skip
   exit 0
 fi


### PR DESCRIPTION
## 관련 이슈 번호
Part of #521

## 배경 및 문제
#521 (PR #659) 머지 후 발견된 트리거 갭. `test_skill_scenarios` 시나리오 5(`/init-dcness` deploy source 실존) + 기존 `test_surface_docs_sync` 가 `commands/init-dcness.md` 를 단언하는데, `python-tests.yml` 의 `paths` 와 `check_python_tests.sh` 의 grep 패턴 어디에도 `commands/` 가 없어서 — `init-dcness.md` 만 바꾸는 변경은 두 게이트(로컬 pre-commit + CI)를 발화시키지 못하고 시나리오 5 회귀를 놓칠 수 있었다.

## 작업내용
- `.github/workflows/python-tests.yml`: `pull_request` + `push` 의 `paths` 에 `commands/**` 추가 (+ 주석)
- `scripts/check_python_tests.sh`: grep 매칭 패턴에 `commands/` 추가 (+ 주석)

로컬 hook 과 CI 트리거를 정합되게 보강.

## 결정 근거
- `commands/**` 로 넓게 — commands 디렉토리가 작아 부담 작고, 미래 commands 검증 테스트도 자동 커버. docs-only PR 불필요 실행 회피는 그대로 보존(`docs/prd.md` 미매칭 확인).
- 로컬+CI 양쪽을 같이 고쳐야 정합 (한쪽만 고치면 drift).

## Test Plan
- grep 패턴 단위: `echo commands/init-dcness.md | grep -qE '<패턴>'` → **MATCH** / `docs/prd.md` → **NO MATCH**
- `sh -n check_python_tests.sh` OK
- `python3.11 -m unittest discover -s tests` → **877 tests OK** (회귀 없음)

## 배포 경로 검증
`python-tests.yml` / `check_python_tests.sh` 는 dcness self CI·로컬 게이트 인프라다. `check_python_tests.sh` 는 `/init-dcness` 가 사용자 repo 로 배포하는 파일이 아니다(사용자 repo 는 plugin SSOT 직접 호출, #198) — dcness self 게이트 전용이라 외부 영향 없음.

## 잔여 (out of scope)
deploy source 파일(`scripts/hooks/*`)을 **rename-only** 하고 `init-dcness.md` 를 안 고치는 케이스는 여전히 미발화. 정상 작업이면 init-dcness.md 의 cp 경로 동반 수정으로 따라잡힌다. 완전 차단하려면 `scripts/hooks/**` 도 paths 에 넣어야 하나, 과한 트리거 확장이라 보류.

🤖 Generated with [Claude Code](https://claude.com/claude-code)