### PR TITLE
[issue-662] extract to-issue ssot template

### DIFF
--- a/skills/to-issue/SKILL.md
+++ b/skills/to-issue/SKILL.md
@@ -24,6 +24,12 @@ description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 
 - 큰 계획을 여러 issue 로 나누는 경우 horizontal layer 가 아니라 end-to-end vertical slice 로 나눈다. 완료된 slice 는 독립적으로 demo 또는 검증 가능해야 한다.
 - parent issue 가 있더라도 `/to-issue` 는 parent issue 를 닫거나 임의 수정하지 않는다.
 
+## 기준 파일
+
+- IssueType, Priority, repo label 매핑은 [`issue-fields.md`](issue-fields.md)를 SSOT 로 사용한다.
+- Issue Brief 본문 구조는 [`templates/issue-brief.md`](templates/issue-brief.md)를 템플릿으로 사용한다.
+- `SKILL.md` 에 필드 선택지 목록이나 Issue Brief 본문 템플릿을 다시 쓰지 않는다. 선택지나 템플릿을 바꿔야 하면 기준 파일을 먼저 바꾼다.
+
 ## 입력 확인
 
 이미 대화에 있는 정보를 우선 사용한다. 부족한 항목만 짧게 질문한다.
@@ -33,8 +39,8 @@ description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 
 - 원하는 동작 또는 만들 결과
 - 사용자가 보게 되는 command, API, 문서 surface, config shape, type/field 이름 같은 안정적인 계약
 - 독립적으로 검증 가능한 acceptance criteria
-- IssueType: `epic`, `feature`, `story`, `task`, `subTask`, `bug`
-- Priority: `blocker`, `critical`, `major`, `minor`, `trivial`
+- IssueType: [`issue-fields.md`](issue-fields.md)의 `IssueType` 값
+- Priority: [`issue-fields.md`](issue-fields.md)의 `Priority` 값
 - Blocked by: 없음 또는 blocking issue 링크
 - Out of scope
 - parent issue 여부
@@ -68,45 +74,9 @@ gh issue list --state open --search "<핵심 키워드>" --json number,title,lab
 
 ### Step 3 — Issue Brief 초안 작성
 
-issue 생성 전 아래 템플릿으로 초안을 보여준다.
+issue 생성 전 [`templates/issue-brief.md`](templates/issue-brief.md)를 읽고, [`issue-fields.md`](issue-fields.md)의 선택값으로 `{{IssueType}}`, `{{Priority}}` 를 채운 초안을 보여준다.
 
-```markdown
-## Issue Brief
-
-**IssueType:** epic / feature / story / task / subTask / bug
-**Priority:** blocker / critical / major / minor / trivial
-**Summary:**
-한 줄로 이 이슈가 달성해야 하는 결과를 쓴다.
-
-**Current behavior / Context:**
-지금 어떤 일이 벌어지는지 또는 어떤 배경 위에서 이 작업이 필요한지 쓴다.
-버그라면 깨진 동작과 관측 조건을 쓴다.
-기능/작업이라면 현재 없는 능력이나 현재 운영상의 gap 을 쓴다.
-
-**Desired behavior / What to build:**
-작업 완료 후 시스템, 사용자 경험, 문서, 하네스가 어떤 상태여야 하는지 쓴다.
-end-to-end behavior 를 설명하고 layer-by-layer 구현 계획을 쓰지 않는다.
-파일 경로, line number, 코드 조각, 특정 함수 수정 지시는 기본적으로 쓰지 않는다.
-예외적으로 prototype 의 state machine, schema, type shape 가 prose 보다 결정을 정확히 담는 경우만 짧게 포함하고 prototype 출처를 명시한다.
-
-**Key interfaces / Contracts:**
-- 사용자가 보게 되는 command, API, 문서 surface, config shape, type/field 이름 같은 안정적인 계약을 쓴다.
-- 현재 파일 위치가 아니라 바뀌어야 하는 인터페이스나 행동 계약을 쓴다.
-- 모르면 추측하지 말고 비워두거나 명확화 질문으로 남긴다.
-
-**Acceptance criteria:**
-- [ ] 독립적으로 검증 가능한 완료 조건 1
-- [ ] 독립적으로 검증 가능한 완료 조건 2
-- [ ] 독립적으로 검증 가능한 완료 조건 3
-
-**Blocked by:**
-None - can start immediately
-또는 blocking issue 링크 목록.
-
-**Out of scope:**
-- 이 이슈에서 하지 않을 것
-- 관련 있어 보이지만 별도 이슈로 둘 것
-```
+템플릿의 섹션 구조를 임의로 축약하지 않는다. 안정적인 계약을 모르면 추측하지 말고 비워두거나 명확화 질문으로 남긴다.
 
 ### Step 4 — 승인
 

--- a/skills/to-issue/issue-fields.md
+++ b/skills/to-issue/issue-fields.md
@@ -1,0 +1,33 @@
+# /to-issue Field SSOT
+
+This file is the single source of truth for `/to-issue` issue classification fields. `SKILL.md` must reference this file instead of duplicating these option lists.
+
+When GitHub Project field options or repo labels diverge from this file, stop before creating the issue and report the setup gap. Do not guess option ids or create labels implicitly.
+
+## IssueType
+
+| Value | Repo label | Meaning |
+| --- | --- | --- |
+| `epic` | `epic` | Large outcome that groups multiple features or stories. |
+| `feature` | `feature` | User-facing or operator-facing capability. |
+| `story` | `story` | End-to-end vertical slice that can be implemented and verified independently. |
+| `task` | `task` | Non-user-facing work item with a concrete completion condition. |
+| `subTask` | `subTask` | Child work item that only makes sense under a parent issue. |
+| `bug` | `bug` | Broken or regressed behavior that should be restored. |
+
+## Priority
+
+| Value | Meaning |
+| --- | --- |
+| `blocker` | Prevents dependent work or release from moving forward. |
+| `critical` | High-risk or time-sensitive issue that should be handled before normal major work. |
+| `major` | Normal important work with meaningful product, workflow, or maintenance value. |
+| `minor` | Useful but lower urgency work. |
+| `trivial` | Small cleanup or polish with limited impact. |
+
+## Usage Rules
+
+- Use the selected `IssueType` value as the repo label.
+- Set Project `IssueType` and Project `Priority` to the exact values above.
+- Set Project `Status` to `Todo` when registering the issue.
+- If a parent issue exists, reference it only. `/to-issue` does not close or rewrite the parent.

--- a/skills/to-issue/templates/issue-brief.md
+++ b/skills/to-issue/templates/issue-brief.md
@@ -1,0 +1,35 @@
+## Issue Brief
+
+**IssueType:** {{IssueType}}
+**Priority:** {{Priority}}
+**Summary:**
+{{한 줄로 이 이슈가 달성해야 하는 결과를 쓴다.}}
+
+**Current behavior / Context:**
+{{지금 어떤 일이 벌어지는지 또는 어떤 배경 위에서 이 작업이 필요한지 쓴다.}}
+{{버그라면 깨진 동작과 관측 조건을 쓴다.}}
+{{기능/작업이라면 현재 없는 능력이나 현재 운영상의 gap 을 쓴다.}}
+
+**Desired behavior / What to build:**
+{{작업 완료 후 시스템, 사용자 경험, 문서, 하네스가 어떤 상태여야 하는지 쓴다.}}
+{{end-to-end behavior 를 설명하고 layer-by-layer 구현 계획을 쓰지 않는다.}}
+{{구현 파일 경로, line number, 코드 조각, 특정 함수 수정 지시는 기본적으로 쓰지 않는다.}}
+{{예외적으로 prototype 의 state machine, schema, type shape 가 prose 보다 결정을 정확히 담는 경우만 짧게 포함하고 prototype 출처를 명시한다.}}
+
+**Key interfaces / Contracts:**
+- {{사용자가 보게 되는 command, API, 문서 surface, config shape, type/field 이름 같은 안정적인 계약을 쓴다.}}
+- {{현재 파일 위치가 아니라 바뀌어야 하는 인터페이스나 행동 계약을 쓴다.}}
+- {{모르면 추측하지 말고 비워두거나 명확화 질문으로 남긴다.}}
+
+**Acceptance criteria:**
+- [ ] {{독립적으로 검증 가능한 완료 조건 1}}
+- [ ] {{독립적으로 검증 가능한 완료 조건 2}}
+- [ ] {{독립적으로 검증 가능한 완료 조건 3}}
+
+**Blocked by:**
+None - can start immediately
+{{또는 blocking issue 링크 목록.}}
+
+**Out of scope:**
+- {{이 이슈에서 하지 않을 것}}
+- {{관련 있어 보이지만 별도 이슈로 둘 것}}

--- a/tests/test_to_issue_skill.py
+++ b/tests/test_to_issue_skill.py
@@ -12,6 +12,10 @@ ROOT = Path(__file__).resolve().parents[1]
 class ToIssueSkillTests(unittest.TestCase):
     def setUp(self) -> None:
         self.skill_path = ROOT / "skills" / "to-issue" / "SKILL.md"
+        self.field_ssot_path = ROOT / "skills" / "to-issue" / "issue-fields.md"
+        self.template_path = (
+            ROOT / "skills" / "to-issue" / "templates" / "issue-brief.md"
+        )
         self.workflow_router = (
             ROOT / "docs" / "plugin" / "workflow-router.md"
         ).read_text(encoding="utf-8")
@@ -27,7 +31,11 @@ class ToIssueSkillTests(unittest.TestCase):
         self.assertIn("승인 전에는 GitHub issue 를 만들지 않는다", text)
 
     def test_issue_brief_template_has_required_contract_sections(self) -> None:
-        text = self.skill_path.read_text(encoding="utf-8")
+        skill = self.skill_path.read_text(encoding="utf-8")
+        text = self.template_path.read_text(encoding="utf-8")
+
+        self.assertIn("[`templates/issue-brief.md`](templates/issue-brief.md)", skill)
+        self.assertNotIn("```markdown\n## Issue Brief", skill)
 
         required = (
             "IssueType",
@@ -47,6 +55,32 @@ class ToIssueSkillTests(unittest.TestCase):
         self.assertIn("구현 파일 경로", text)
         self.assertIn("line number", text)
         self.assertIn("layer-by-layer", text)
+        self.assertIn("{{IssueType}}", text)
+        self.assertIn("{{Priority}}", text)
+
+    def test_issue_field_options_are_defined_in_ssot_not_skill(self) -> None:
+        skill = self.skill_path.read_text(encoding="utf-8")
+        text = self.field_ssot_path.read_text(encoding="utf-8")
+
+        self.assertIn("[`issue-fields.md`](issue-fields.md)", skill)
+
+        for field in ("IssueType", "Priority"):
+            self.assertRegex(text, rf"(?m)^## {field}$")
+
+        for value in ("epic", "feature", "story", "task", "subTask", "bug"):
+            self.assertRegex(text, rf"(?m)^\|\s*`{re.escape(value)}`\s*\|")
+
+        for value in ("blocker", "critical", "major", "minor", "trivial"):
+            self.assertRegex(text, rf"(?m)^\|\s*`{re.escape(value)}`\s*\|")
+
+        forbidden_inline_lists = (
+            "IssueType: `epic`, `feature`, `story`, `task`, `subTask`, `bug`",
+            "Priority: `blocker`, `critical`, `major`, `minor`, `trivial`",
+            "**IssueType:** epic / feature / story / task / subTask / bug",
+            "**Priority:** blocker / critical / major / minor / trivial",
+        )
+        for inline_list in forbidden_inline_lists:
+            self.assertNotIn(inline_list, skill)
 
     def test_issue_creation_requires_user_confirmation_and_project_fields(self) -> None:
         text = self.skill_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## 관련 이슈 번호

Part of #662

## 배경 및 문제

- `/to-issue` 안에 `IssueType` / `Priority` 선택지와 Issue Brief 본문 템플릿이 직접 들어 있어, 필드 vocabulary 와 issue body contract 가 skill 절차문 안에서 drift 될 수 있었다.
- 참고한 triage-labels 패턴처럼 canonical 선택지는 별도 SSOT 에 두고, skill 은 그 기준 파일을 참조하는 구조가 더 맞다.

## 원인 (해당 시)

-

## 작업내용

- `skills/to-issue/issue-fields.md` 를 추가해 `IssueType`, `Priority`, repo label 매핑과 사용 규칙을 SSOT 로 분리했다.
- `skills/to-issue/templates/issue-brief.md` 를 추가해 Issue Brief 본문 구조를 별도 템플릿으로 분리했다.
- `skills/to-issue/SKILL.md` 에서 inline 선택지 목록과 embedded Issue Brief 본문을 제거하고 기준 파일 링크만 참조하게 했다.
- `/to-issue` 회귀 테스트를 갱신해 SSOT/템플릿 파일 존재, 필수 섹션, placeholder, inline 하드코딩 금지를 검증한다.

## 결정 근거

- 필드 옵션은 운영 vocabulary 이므로 한 파일에서 관리되어야 하고, `/to-issue` skill 은 대화/승인/등록 절차만 설명하는 편이 유지보수 범위가 명확하다.
- Issue Brief 는 작업 계약 템플릿이므로 skill 내부 설명문보다 별도 템플릿 파일로 리뷰되는 편이 변경 의도가 드러난다.

## 배포 경로 검증 (plug-in 영향 시)

- `/to-issue` 기존 public skill 의 내부 기준 파일과 템플릿 추가만 포함한다.
- 배포 대상 source path 는 `skills/to-issue/` 아래이며, 별도 generated copy path 나 init-dcness 복사 파일 변경은 없다.
- 새 relative link 는 `node scripts/check_cross_refs.mjs` 로 검증했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 를 추가하지 않았다. 기존 `/to-issue` surface 의 기준 파일과 템플릿만 분리했다.

## Test Plan

- [x] `python3 -m unittest tests.test_to_issue_skill`
- [x] `python3 -m unittest discover -s tests`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_git_naming.mjs --branch feature/to_issue_ssot_template`
- [x] `sh scripts/check_python_tests.sh`
- [x] commit pre-commit hook (`git commit -m "[issue-662] extract to-issue ssot template"`)

## 참고

- https://github.com/mattpocock/skills/blob/main/skills/engineering/setup-matt-pocock-skills/triage-labels.md
