### PR TITLE
[feature] GitHub Project lifecycle bootstrap

### DIFF
--- a/.github/actions/github-project-lifecycle/action.yml
+++ b/.github/actions/github-project-lifecycle/action.yml
@@ -1,0 +1,78 @@
+name: 'dcness GitHub Project lifecycle'
+description: 'Validate or update dcNess GitHub Project v2 Status, IssueType, Priority lifecycle.'
+inputs:
+  mode:
+    description: 'bootstrap, validate-issue, start-work, or pr-merged'
+    required: true
+  repo:
+    description: 'OWNER/REPO'
+    required: true
+  project-owner:
+    description: 'GitHub Project owner'
+    required: true
+  project-number:
+    description: 'GitHub Project number'
+    required: true
+  issue-number:
+    description: 'Issue number for validate-issue or start-work'
+    required: false
+    default: ''
+  pr-body:
+    description: 'PR body for pr-merged mode'
+    required: false
+    default: ''
+  expected-status:
+    description: 'Optional expected Status for validate-issue'
+    required: false
+    default: ''
+  expected-issue-type:
+    description: 'Optional expected IssueType for validate-issue'
+    required: false
+    default: ''
+  expected-priority:
+    description: 'Optional expected Priority for validate-issue'
+    required: false
+    default: ''
+  apply:
+    description: 'Set to true to create labels/fields or update Status'
+    required: false
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+
+    - name: Run Project lifecycle guard
+      shell: bash
+      env:
+        PR_BODY: ${{ inputs.pr-body }}
+      run: |
+        set -euo pipefail
+        ARGS=(
+          "${{ inputs.mode }}"
+          --repo "${{ inputs.repo }}"
+          --owner "${{ inputs.project-owner }}"
+          --project "${{ inputs.project-number }}"
+        )
+        if [ -n "${{ inputs.issue-number }}" ]; then
+          ARGS+=(--issue "${{ inputs.issue-number }}")
+        fi
+        if [ -n "${{ inputs.expected-status }}" ]; then
+          ARGS+=(--expected-status "${{ inputs.expected-status }}")
+        fi
+        if [ -n "${{ inputs.expected-issue-type }}" ]; then
+          ARGS+=(--expected-issue-type "${{ inputs.expected-issue-type }}")
+        fi
+        if [ -n "${{ inputs.expected-priority }}" ]; then
+          ARGS+=(--expected-priority "${{ inputs.expected-priority }}")
+        fi
+        if [ "${{ inputs.mode }}" = "pr-merged" ]; then
+          ARGS+=(--body-env PR_BODY)
+        fi
+        if [ "${{ inputs.apply }}" = "true" ]; then
+          ARGS+=(--apply)
+        fi
+        node "${{ github.action_path }}/../../../scripts/github_project_lifecycle.mjs" "${ARGS[@]}"

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -521,6 +521,115 @@ claude plugin uninstall dcness@dcness
 claude plugin install dcness@dcness
 ```
 
+### Step 2.10.5 — GitHub Project lifecycle bootstrap
+
+GitHub Project v2 `Status / IssueType / Priority` 축과 repo label 6종을 점검한다. 이 Step 은 `/to-issue` issue 등록, `/spec` / `/design` / `/impl` / `/ux` 시작 시 `Status=In progress`, PR merge 후 `Status=Done` 후처리가 같은 축을 쓰도록 만드는 bootstrap 이다.
+
+Project 축 SSOT 는 [`docs/plugin/github-project.md`](../docs/plugin/github-project.md) 이며, 실행 본체는 plug-in 의 `scripts/github_project_lifecycle.mjs` 이다. 사용자 repo 에 mjs 를 복사하지 않는다.
+
+dcNess self repo 안에서 직접 검증할 때는 `node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER` 형식으로 실행할 수 있다. 활성화한 다른 repo 에서는 아래 예시처럼 `$PLUGIN_ROOT` 안의 같은 스크립트를 호출한다.
+
+#### Project / label 점검
+
+```
+[dcness] GitHub Project lifecycle bootstrap 을 수행할까요?
+  - Project v2 field: Status / IssueType / Priority
+  - repo label 6종: epic / feature / story / task / subTask / bug
+  - /to-issue 등록 후 Status=Todo, IssueType/Priority, 동기 label 검증
+  - workflow 시작 시 Status=In progress 경로
+  - PR merge 후 Status=Done drift 검출/보정 경로
+(Y/n)
+```
+
+- **n**: skip. `/to-issue` 는 Project field 를 확인할 수 없으면 issue 생성 전 정지한다.
+- **Y**: Project owner 와 number 를 확인한다. 모르면 `gh project list --owner <owner>` 로 조회한다.
+
+```bash
+PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
+REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner)"
+OWNER="${REPO%%/*}"
+
+gh project list --owner "$OWNER"
+
+node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
+  --repo "$REPO" \
+  --owner "$OWNER" \
+  --project "$PROJECT_NUMBER"
+```
+
+Project가 없거나 필드가 부족하면 생성 또는 명확한 복구 안내를 제공한다.
+
+```bash
+gh project create --owner "$OWNER" --title "dcNess" --format json
+gh project link "$PROJECT_NUMBER" --owner "$OWNER" --repo "${REPO#*/}"
+node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
+  --repo "$REPO" \
+  --owner "$OWNER" \
+  --project "$PROJECT_NUMBER" \
+  --apply
+```
+
+repo label이 부족하면 같은 script 의 `--apply` 경로가 label 을 생성/갱신한다. 기존 Project field 의 option 이 부족한 경우는 GitHub CLI 가 option 추가를 직접 지원하지 않으므로 script 가 어떤 field/option 을 고쳐야 하는지 보고하고 멈춘다. 다른 repo 에서도 같은 명령을 `--repo other-owner/other-repo --owner other-owner --project <number>` 로 실행하면 같은 Project 축과 repo label 6종을 bootstrap 할 수 있다.
+
+#### lifecycle CI/CD workflow — 사용자 선택
+
+GitHub Actions 에서 Project lifecycle drift 검출과 PR merge 후 `Done` 보정을 수행할지 묻는다.
+
+```
+[dcness] GitHub Actions CI/CD 에서 Project lifecycle guard 를 활성화할까요?
+  - issue open/edit/label 변경 시 Project IssueType 과 repo label drift 검출
+  - PR closed+merged 시 Closes/Fixes/Resolves issue 의 Status=Done 보정
+  - Part of #N 만 있는 PR 은 Done 후보로 보지 않음
+  - Project v2 쓰기에는 project scope token 필요: secrets.DCNESS_PROJECT_TOKEN
+  - Project 번호/owner 는 vars.DCNESS_PROJECT_NUMBER / vars.DCNESS_PROJECT_OWNER 사용
+(Y/n)
+```
+
+- **Y**: 다음 thin yml 을 `$PROJECT_ROOT/.github/workflows/github-project-lifecycle.yml` 로 *always-overwrite*:
+
+  ```yaml
+  name: github-project-lifecycle
+  on:
+    issues:
+      types: [opened, edited, labeled, unlabeled]
+    pull_request:
+      types: [closed]
+  permissions:
+    contents: read
+    issues: read
+    pull-requests: read
+  jobs:
+    issue-drift:
+      if: ${{ github.event_name == 'issues' && vars.DCNESS_PROJECT_NUMBER != '' }}
+      runs-on: ubuntu-latest
+      steps:
+        - uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main
+          env:
+            GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
+          with:
+            mode: validate-issue
+            repo: ${{ github.repository }}
+            project-owner: ${{ vars.DCNESS_PROJECT_OWNER || github.repository_owner }}
+            project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
+            issue-number: ${{ github.event.issue.number }}
+    pr-merged:
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && vars.DCNESS_PROJECT_NUMBER != '' }}
+      runs-on: ubuntu-latest
+      steps:
+        - uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main
+          env:
+            GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
+          with:
+            mode: pr-merged
+            repo: ${{ github.repository }}
+            project-owner: ${{ vars.DCNESS_PROJECT_OWNER || github.repository_owner }}
+            project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
+            pr-body: ${{ github.event.pull_request.body }}
+            apply: "true"
+  ```
+
+- **n**: skip. 메인은 PR merge 후 `scripts/github_project_lifecycle.mjs pr-merged` 를 수동 실행해 drift 를 확인한다.
+
 ### Step 2.11 — 자동 commit + PR (인프라 머지 자동화)
 
 Step 2.6 ~ 2.9 까지 *깔린 파일들* (workflow yml 등) 은 working tree 변경 상태로 머무름 — 사용자가 git add / commit / push / PR 까지 직접 진행하지 않으면 main 머지 안 됨. 본 Step 이 그 부담을 자동화.
@@ -687,6 +796,12 @@ Codex validator routing (Step 2.10 — local opt-in):
 - route 대상은 read-only validation 3종만. build/engineer 계열은 Claude 유지
 - 상태 확인: `dcness-helper routing status`
 - 끄기: `dcness-helper routing disable-codex-validation`
+
+GitHub Project lifecycle bootstrap (Step 2.10.5 완료 시):
+- Project field: Status / IssueType / Priority 점검
+- repo label 6종: epic / feature / story / task / subTask / bug 점검/생성
+- optional CI/CD: issue drift 검출 + PR merge 후 Done 보정 workflow
+- 기존 활성 프로젝트는 plugin update 후 `/init-dcness` 재실행 필요
 
 자동 commit + PR (Step 2.11 완료 시):
 - Step 2.6 ~ 2.9 깔린 인프라 파일들 자동 stage + commit + push + PR

--- a/docs/plugin/github-project.md
+++ b/docs/plugin/github-project.md
@@ -1,0 +1,78 @@
+# GitHub Project Lifecycle
+
+> **Status**: ACTIVE
+> **Scope**: dcNess 표준 GitHub Project v2 축, repo label, lifecycle 상태 전이의 SSOT. 실행 메커니즘은 [`issue-lifecycle.md`](issue-lifecycle.md), git/PR trailer 룰은 [`git-spec.md`](git-spec.md), `/to-issue` 입력 필드 요약은 [`../../skills/to-issue/issue-fields.md`](../../skills/to-issue/issue-fields.md)를 함께 본다.
+
+dcNess 활성 repo 는 GitHub Project v2 에 `Status`, `IssueType`, `Priority` 세 축을 둔다. `/init-dcness` 는 이 축과 repo label 6종을 점검하고, `--apply` 경로에서는 부족한 repo label 과 새 Project field 를 만들 수 있다. 기존 Project field 에 option 이 빠진 경우는 GitHub CLI 가 option 추가를 직접 지원하지 않으므로 명확한 복구 안내를 낸다.
+
+## Status
+
+| Value | Meaning | Usage example |
+| --- | --- | --- |
+| `Todo` | issue 가 등록됐지만 아직 설계나 구현 흐름이 시작되지 않은 상태. | `/to-issue` 가 승인된 새 issue 를 Project item 으로 추가한 직후 설정한다. |
+| `In progress` | 대상 issue 를 두고 `/spec`, `/design`, `/impl`, `/ux` 같은 실제 작업 흐름이 시작된 상태. | `/impl #663` 처럼 특정 issue 구현을 시작하면 `start-work` 경로가 설정한다. |
+| `Done` | default branch 로 merge 된 PR 이 `Closes`, `Fixes`, `Resolves` 로 완료한 issue. | PR merge 후처리가 완료 후보 issue 를 찾아 설정하거나 drift 를 보고한다. |
+
+## IssueType
+
+| Value | Repo label | Meaning | Usage example |
+| --- | --- | --- | --- |
+| `epic` | `epic` | 여러 feature 또는 story 를 묶는 큰 outcome. | PRD epic 또는 여러 story 의 parent issue. |
+| `feature` | `feature` | 사용자 또는 운영자가 체감하는 capability. | 독립 기능 추가, workflow capability. |
+| `story` | `story` | end-to-end 로 독립 구현과 검증이 가능한 vertical slice. | epic 아래의 story issue. |
+| `task` | `task` | 사용자-facing 은 아니지만 완료 조건이 명확한 작업. | 인프라 보강, 도구 개선, 문서 sync. |
+| `subTask` | `subTask` | parent issue 아래에서만 의미가 있는 child work item. | 큰 issue 를 세부 실행 단위로 나눈 경우. |
+| `bug` | `bug` | 깨진 동작 또는 회귀를 복구해야 하는 issue. | 관측 가능한 실패와 복구 기대 동작이 있는 신고. |
+
+repo label 6종은 `epic`, `feature`, `story`, `task`, `subTask`, `bug` 이며 IssueType 축과 같은 의미로 쓴다. issue list, Project board, 검색/필터가 같은 분류 체계를 보도록 issue 는 Project `IssueType` 과 같은 repo label 을 정확히 하나 가진다.
+
+## Priority
+
+| Value | Meaning | Usage example |
+| --- | --- | --- |
+| `blocker` | 의존 작업 또는 release 진행을 막는 issue. | merge, release, production recovery 를 차단하는 상태. |
+| `critical` | 일반 major work 보다 먼저 다뤄야 하는 고위험 또는 시급 issue. | 보안, 데이터 손실, 매우 큰 운영 리스크. |
+| `major` | 정상 우선순위의 중요 작업. | 일반 feature, 중요한 workflow 개선. |
+| `minor` | 유용하지만 낮은 긴급도의 작업. | 작은 UX polish, 낮은 영향의 개선. |
+| `trivial` | 영향이 제한적인 작은 정리. | 문구, 소규모 cleanup. |
+
+## Lifecycle
+
+이슈 등록 직후 Project `Status=Todo` 이다. 특정 issue 를 대상으로 설계나 구현 흐름을 실제 시작하면 `Status=In progress` 로 이동한다. default branch 에 merge 된 PR 이 `Closes #N`, `Fixes #N`, `Resolves #N` 또는 GitHub 의 실제 closing issue reference 로 issue 를 완료하면 `Status=Done` 으로 이동한다.
+
+`Part of #N` 은 중간 연결일 뿐 완료 신호가 아니다. `Part of #N` 만 있는 PR 은 issue 를 `Done` 으로 옮기지 않는다.
+
+## Drift Messages
+
+status drift 는 어떤 issue 의 어떤 field 가 기대값과 실제값이 다른지 보여준다.
+
+예:
+
+```text
+issue #663: status drift on Project field Status. expected=Done, actual=In progress.
+```
+
+IssueType / repo label drift 는 어떤 issue 에서 어떤 값이 어긋났는지 보여준다.
+
+예:
+
+```text
+issue #663: Project IssueType=feature, repo label=bug. Set Project IssueType and exactly one matching repo label to the same value.
+```
+
+## Bootstrap Commands
+
+Project 번호를 아는 경우:
+
+```bash
+node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER
+node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER --apply
+```
+
+Project 가 없는 경우:
+
+```bash
+gh project create --owner OWNER --title "dcNess" --format json
+gh project link PROJECT_NUMBER --owner OWNER --repo REPO
+node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER --apply
+```

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -33,6 +33,72 @@ gh api -X POST repos/{owner}/{repo}/issues/{epic_number}/sub_issues \
 
 task 는 GitHub 이슈 X — [`git-spec.md`](git-spec.md#pr-트레일러-part-of-closes) PR 트레일러로만 추적.
 
+## GitHub Project Status lifecycle
+
+Project 축 정의의 SSOT 는 [`github-project.md`](github-project.md) 이다. 본 절은 `/spec`, `/design`, `/impl`, `/ux`, PR merge 후처리가 그 축을 어떻게 갱신하는지만 다룬다.
+
+### 작업 시작 — Status=In progress
+
+특정 GitHub issue 를 대상으로 `/spec`, `/design`, `/impl`, `/ux` 같은 설계나 구현 흐름을 실제 시작하면 메인은 시작 직전에 Project item 을 `Status=In progress` 로 이동한다. Project 번호와 owner 를 알 수 없으면 추측하지 말고 `/init-dcness` bootstrap 을 먼저 수행한다.
+
+```bash
+node scripts/github_project_lifecycle.mjs start-work \
+  --repo OWNER/REPO \
+  --owner OWNER \
+  --project PROJECT_NUMBER \
+  --issue ISSUE_NUMBER \
+  --apply
+```
+
+`--apply` 없이 실행하면 현재 Status 를 읽고 status drift 를 보고한다. 메시지는 어떤 issue 의 어떤 field 를 고쳐야 하는지 포함한다.
+
+```text
+issue #663: status drift on Project field Status. expected=In progress, actual=Todo.
+```
+
+### PR merge 후처리 — Status=Done
+
+default branch 로 PR merge 가 끝난 뒤 후처리 경로는 PR body 또는 GitHub closing issue reference 에서 완료 후보 issue 를 찾고 `Status=Done` 으로 이동한다.
+
+```bash
+node scripts/github_project_lifecycle.mjs pr-merged \
+  --repo OWNER/REPO \
+  --owner OWNER \
+  --project PROJECT_NUMBER \
+  --pr PR_NUMBER \
+  --apply
+```
+
+완료 후보는 `Closes #N`, `Fixes #N`, `Resolves #N` 또는 GitHub 가 실제 close 후보로 제공한 issue 뿐이다. `Part of #N` 은 완료 신호가 아니다. `Part of #N` 만 있는 PR 은 issue 를 `Done` 으로 옮기지 않는다.
+
+`--apply` 없이 실행하면 `Status=Done` 누락을 drift 로 보고한다. 메시지는 어떤 issue 와 어떤 field 를 고쳐야 하는지 포함한다.
+
+```text
+issue #663: status drift on Project field Status. expected=Done, actual=In progress.
+```
+
+### IssueType / repo label drift
+
+issue 는 Project `IssueType` 과 같은 repo label 을 정확히 하나 가져야 한다. 값이 어긋나면 어떤 issue 에서 어떤 값이 다른지 보고한다.
+
+```bash
+node scripts/github_project_lifecycle.mjs validate-issue \
+  --repo OWNER/REPO \
+  --owner OWNER \
+  --project PROJECT_NUMBER \
+  --issue ISSUE_NUMBER
+```
+
+예:
+
+```text
+issue #663: Project IssueType=feature, repo label=bug. Set Project IssueType and exactly one matching repo label to the same value.
+```
+
+### CI/CD harness
+
+`/init-dcness` 는 선택적으로 `github-project-lifecycle` thin workflow 를 활성 repo 에 설치한다. 이 workflow 는 본 repo 의 composite action 을 호출해 issue label/type drift 를 PR/issue 이벤트에서 검증하고, merge 된 PR 의 완료 후보 issue 를 `Done` 으로 보정한다. Project v2 쓰기에는 `project` scope 가 필요하므로 사용자 repo 는 `DCNESS_PROJECT_TOKEN` secret 과 `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` variables 를 설정해야 한다. token 이 없으면 workflow 는 drift 검출 중심으로 실패 메시지를 남긴다.
+
 ## 미등록 허용 모드
 
 프로젝트가 미등록 모드 (spike / 잡탕 epic 등) 채택 시 stories.md 상단:

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -1,0 +1,682 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+export const PROJECT_FIELDS = Object.freeze({
+  Status: Object.freeze(['Todo', 'In progress', 'Done']),
+  IssueType: Object.freeze(['epic', 'feature', 'story', 'task', 'subTask', 'bug']),
+  Priority: Object.freeze(['blocker', 'critical', 'major', 'minor', 'trivial']),
+});
+
+export const ISSUE_TYPE_LABEL_META = Object.freeze({
+  epic: ['7057ff', 'epic-level GitHub issue'],
+  feature: ['a2eeef', 'feature-level GitHub issue'],
+  story: ['0e8a16', 'story-level GitHub issue'],
+  task: ['c5def5', 'task-level GitHub issue'],
+  subTask: ['bfdadc', 'subTask-level GitHub issue'],
+  bug: ['d73a4a', 'bug-level GitHub issue'],
+});
+
+export const ISSUE_TYPE_LABELS = Object.freeze(PROJECT_FIELDS.IssueType);
+const COMPLETION_KEYWORD = String.raw`(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)`;
+const ISSUE_REFERENCE = String.raw`(?:([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+))?#(\d+)`;
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (Array.isArray(value?.fields)) return value.fields;
+  if (Array.isArray(value?.labels)) return value.labels;
+  if (Array.isArray(value?.items)) return value.items;
+  return [];
+}
+
+function optionNames(field) {
+  return asArray(field?.options).map((option) => String(option?.name ?? option));
+}
+
+function isSingleSelect(field) {
+  const dataType = String(field?.dataType ?? field?.type ?? '').toUpperCase();
+  return dataType === 'SINGLE_SELECT' || dataType === 'PROJECTV2SINGLESELECTFIELD';
+}
+
+function labelNames(labels) {
+  return asArray(labels).map((label) => String(label?.name ?? label));
+}
+
+export function validateProjectFields(fieldsInput) {
+  const fields = asArray(fieldsInput);
+  const byName = new Map(fields.map((field) => [String(field?.name ?? ''), field]));
+  const missingFields = [];
+  const wrongTypeFields = [];
+  const missingOptions = [];
+
+  for (const [fieldName, requiredOptions] of Object.entries(PROJECT_FIELDS)) {
+    const field = byName.get(fieldName);
+    if (!field) {
+      missingFields.push(fieldName);
+      continue;
+    }
+    if (!isSingleSelect(field)) {
+      wrongTypeFields.push(fieldName);
+    }
+    const actualOptions = new Set(optionNames(field));
+    for (const option of requiredOptions) {
+      if (!actualOptions.has(option)) {
+        missingOptions.push({ field: fieldName, option });
+      }
+    }
+  }
+
+  return {
+    ok: missingFields.length === 0
+      && wrongTypeFields.length === 0
+      && missingOptions.length === 0,
+    missingFields,
+    wrongTypeFields,
+    missingOptions,
+  };
+}
+
+export function validateIssueTypeLabels(labelsInput) {
+  const names = new Set(labelNames(labelsInput));
+  const missingLabels = ISSUE_TYPE_LABELS.filter((label) => !names.has(label));
+  return { ok: missingLabels.length === 0, missingLabels };
+}
+
+export function parseCompletionIssueNumbers(body) {
+  const refs = parseCompletionIssueRefs(body).refs;
+  const numbers = [];
+  const seen = new Set();
+  for (const ref of refs) {
+    if (!seen.has(ref.number)) {
+      seen.add(ref.number);
+      numbers.push(ref.number);
+    }
+  }
+  return { numbers };
+}
+
+export function parseCompletionIssueRefs(body, defaultRepo = null) {
+  const text = String(body ?? '');
+  const refs = [];
+  const seen = new Set();
+  const actionRegex = new RegExp(String.raw`\b(${COMPLETION_KEYWORD}|part\s+of)\b`, 'gi');
+  const completionRegex = new RegExp(String.raw`^${COMPLETION_KEYWORD}$`, 'i');
+  const referenceRegex = new RegExp(ISSUE_REFERENCE, 'g');
+
+  for (const line of text.split(/\r?\n/)) {
+    const actions = [...line.matchAll(actionRegex)];
+    for (let index = 0; index < actions.length; index += 1) {
+      const action = actions[index];
+      const keyword = action[1];
+      if (!completionRegex.test(keyword)) continue;
+
+      const segmentStart = action.index + action[0].length;
+      const segmentEnd = actions[index + 1]?.index ?? line.length;
+      const trailerText = line.slice(segmentStart, segmentEnd);
+      referenceRegex.lastIndex = 0;
+      for (const match of trailerText.matchAll(referenceRegex)) {
+        const repo = normalizeRepoName(match[1] || defaultRepo);
+        const number = Number(match[2]);
+        const key = `${repo ?? ''}#${number}`;
+        if (Number.isInteger(number) && !seen.has(key)) {
+          seen.add(key);
+          refs.push({ repo, number });
+        }
+      }
+    }
+  }
+
+  return { refs };
+}
+
+export function applyDefaultRepoToRefs(refs, defaultRepo) {
+  const repo = normalizeRepoName(defaultRepo);
+  return asArray(refs).map((ref) => ({
+    ...ref,
+    repo: normalizeRepoName(ref?.repo) ?? repo,
+  }));
+}
+
+export function resolveCompletionRefsForProject(body, cliRepo, detectedRepo) {
+  const refs = parseCompletionIssueRefs(body, cliRepo).refs;
+  return applyDefaultRepoToRefs(refs, detectedRepo ?? cliRepo);
+}
+
+export function prViewArgs({ pr, repo }) {
+  const args = ['pr', 'view', String(pr)];
+  if (repo) args.push('--repo', repo);
+  args.push('--json', 'body,closingIssuesReferences');
+  return args;
+}
+
+export function detectIssueTypeDrift({ issueNumber, projectIssueType, labels }) {
+  const issueTypeLabels = labelNames(labels).filter((label) => ISSUE_TYPE_LABELS.includes(label));
+  const issueRef = issueNumber ? `issue #${issueNumber}` : 'issue';
+  const projectValue = projectIssueType || '<unset>';
+  const labelValue = issueTypeLabels.length ? issueTypeLabels.join(',') : '<missing>';
+
+  if (
+    projectIssueType
+    && issueTypeLabels.length === 1
+    && issueTypeLabels[0] === projectIssueType
+  ) {
+    return { ok: true, message: `${issueRef}: IssueType and repo label match (${projectIssueType})` };
+  }
+
+  return {
+    ok: false,
+    message: `${issueRef}: Project IssueType=${projectValue}, repo label=${labelValue}. `
+      + 'Set Project IssueType and exactly one matching repo label to the same value.',
+  };
+}
+
+export function statusDriftMessage({ repo = null, issueNumber, field = 'Status', expected, actual }) {
+  const issueRef = repo ? `${repo}#${issueNumber}` : `#${issueNumber}`;
+  return `issue ${issueRef}: status drift on Project field ${field}. `
+    + `expected=${expected}, actual=${actual ?? '<unset>'}.`;
+}
+
+function issueRef({ repo = null, issueNumber }) {
+  return repo ? `${repo}#${issueNumber}` : `#${issueNumber}`;
+}
+
+function projectFieldDriftMessage({ repo = null, issueNumber, field, expected, actual }) {
+  return `issue ${issueRef({ repo, issueNumber })}: Project ${field}=${actual ?? '<unset>'}, `
+    + `expected=${expected}.`;
+}
+
+function validateExpectedValue({ fieldName, expected }) {
+  if (!expected || expected === 'any') return;
+  if (!PROJECT_FIELDS[fieldName].includes(expected)) {
+    throw new Error(`${fieldName}=${expected} is not a supported Project option.`);
+  }
+}
+
+export function validateIssueProjectRegistration({
+  repo = null,
+  issueNumber,
+  item,
+  labels,
+  expectedStatus = 'Todo',
+  expectedIssueType = null,
+  expectedPriority = null,
+}) {
+  validateExpectedValue({ fieldName: 'Status', expected: expectedStatus });
+  validateExpectedValue({ fieldName: 'IssueType', expected: expectedIssueType });
+  validateExpectedValue({ fieldName: 'Priority', expected: expectedPriority });
+
+  const messages = [];
+  let ok = true;
+  const projectIssueType = projectItemIssueType(item);
+  const issueTypeDrift = detectIssueTypeDrift({
+    issueNumber,
+    projectIssueType,
+    labels,
+  });
+  messages.push(issueTypeDrift.message);
+  if (!issueTypeDrift.ok) ok = false;
+
+  if (expectedIssueType && expectedIssueType !== 'any' && projectIssueType !== expectedIssueType) {
+    ok = false;
+    messages.push(projectFieldDriftMessage({
+      repo,
+      issueNumber,
+      field: 'IssueType',
+      expected: expectedIssueType,
+      actual: projectIssueType,
+    }));
+  }
+
+  if (expectedStatus && expectedStatus !== 'any') {
+    const actualStatus = projectItemFieldValue(item, 'Status');
+    if (actualStatus !== expectedStatus) {
+      ok = false;
+      messages.push(statusDriftMessage({
+        repo,
+        issueNumber,
+        expected: expectedStatus,
+        actual: actualStatus,
+      }));
+    }
+  }
+
+  const actualPriority = projectItemFieldValue(item, 'Priority');
+  if (expectedPriority && expectedPriority !== 'any') {
+    if (actualPriority !== expectedPriority) {
+      ok = false;
+      messages.push(projectFieldDriftMessage({
+        repo,
+        issueNumber,
+        field: 'Priority',
+        expected: expectedPriority,
+        actual: actualPriority,
+      }));
+    }
+  } else if (expectedPriority !== 'any' && !PROJECT_FIELDS.Priority.includes(actualPriority)) {
+    ok = false;
+    messages.push(projectFieldDriftMessage({
+      repo,
+      issueNumber,
+      field: 'Priority',
+      expected: PROJECT_FIELDS.Priority.join('|'),
+      actual: actualPriority,
+    }));
+  }
+
+  return { ok, messages };
+}
+
+function parseArgs(argv) {
+  const args = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      args._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    if (key === 'apply' || key === 'help') {
+      args[key] = true;
+      continue;
+    }
+    args[key] = argv[i + 1];
+    i += 1;
+  }
+  return args;
+}
+
+function gh(args, { json = false, allowFailure = false } = {}) {
+  try {
+    const output = execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+    if (!json) return output;
+    return output ? JSON.parse(output) : {};
+  } catch (error) {
+    if (allowFailure) return null;
+    const stderr = error.stderr ? String(error.stderr).trim() : error.message;
+    throw new Error(`gh ${args.join(' ')} failed: ${stderr}`);
+  }
+}
+
+function detectRepo(repoArg) {
+  if (repoArg) return repoArg;
+  const repo = gh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+    allowFailure: true,
+  });
+  if (!repo) {
+    throw new Error('repo not found. Pass --repo OWNER/REPO or run inside a GitHub repo.');
+  }
+  return repo;
+}
+
+function repoOwner(repo, ownerArg) {
+  return ownerArg || repo.split('/')[0];
+}
+
+function normalizeRepoName(value) {
+  if (!value) return null;
+  if (typeof value === 'object') {
+    return normalizeRepoName(
+      value.nameWithOwner
+        ?? value.fullName
+        ?? value.full_name
+        ?? value.url
+        ?? value.name,
+    );
+  }
+  const text = String(value);
+  const githubUrl = text.match(/^https:\/\/github\.com\/([^/]+\/[^/#?]+)/);
+  return githubUrl ? githubUrl[1] : text;
+}
+
+function ensureLabel(repo, name) {
+  const [color, description] = ISSUE_TYPE_LABEL_META[name];
+  const create = gh(
+    ['label', 'create', name, '--color', color, '--description', description, '--repo', repo],
+    { allowFailure: true },
+  );
+  if (create !== null) return;
+  gh(['label', 'edit', name, '--color', color, '--description', description, '--repo', repo]);
+}
+
+function fieldByName(fields, name) {
+  return asArray(fields).find((field) => field?.name === name);
+}
+
+function optionByName(field, name) {
+  return asArray(field?.options).find((option) => option?.name === name);
+}
+
+function itemRepositoryName(item) {
+  const content = item?.content ?? item;
+  const fromRepository = normalizeRepoName(content?.repository ?? item?.repository);
+  if (fromRepository) return fromRepository;
+
+  const url = content?.url ?? item?.url;
+  const match = typeof url === 'string'
+    ? url.match(/^https:\/\/github\.com\/([^/]+\/[^/]+)\/issues\/\d+/)
+    : null;
+  return match ? match[1] : null;
+}
+
+export function findProjectItem(itemsInput, target) {
+  const items = asArray(itemsInput);
+  const targetNumber = Number(typeof target === 'object' ? target.number : target);
+  const targetRepo = normalizeRepoName(typeof target === 'object' ? target.repo : null);
+  return items.find((item) => {
+    const content = item?.content ?? item;
+    const itemNumber = Number(content?.number ?? item?.number);
+    if (itemNumber !== targetNumber) return false;
+    if (!targetRepo) return true;
+    return itemRepositoryName(item) === targetRepo;
+  });
+}
+
+function scalarFieldValue(value) {
+  if (value && typeof value === 'object') {
+    return value.name ?? value.value ?? value.text ?? value.title ?? null;
+  }
+  return value ?? null;
+}
+
+export function projectItemFieldValue(item, fieldName) {
+  const topLevelKeys = {
+    Status: 'status',
+    IssueType: 'issueType',
+    Priority: 'priority',
+  };
+  const topLevelKey = topLevelKeys[fieldName];
+  if (topLevelKey && Object.prototype.hasOwnProperty.call(item ?? {}, topLevelKey)) {
+    return scalarFieldValue(item[topLevelKey]);
+  }
+  const fieldValues = asArray(item?.fieldValues ?? item?.field_values);
+  const value = fieldValues.find((entry) => entry?.field?.name === fieldName || entry?.name === fieldName);
+  return value?.name ?? value?.value ?? value?.text ?? value?.optionName ?? null;
+}
+
+function projectItemIssueType(item) {
+  return projectItemFieldValue(item, 'IssueType');
+}
+
+function setProjectSingleSelect({ projectId, itemId, fields, fieldName, optionName }) {
+  const field = fieldByName(fields, fieldName);
+  const option = optionByName(field, optionName);
+  if (!field?.id || !option?.id) {
+    throw new Error(`Project ${fieldName}=${optionName} option id not found.`);
+  }
+  gh([
+    'project',
+    'item-edit',
+    '--project-id',
+    field.projectId ?? projectId,
+    '--id',
+    itemId,
+    '--field-id',
+    field.id,
+    '--single-select-option-id',
+    option.id,
+  ]);
+}
+
+function printBootstrapRecovery({ repo, owner, project }) {
+  console.error('[dcness-project] recovery commands:');
+  console.error(`  gh project create --owner ${owner} --title "dcNess" --format json`);
+  console.error(`  gh project link ${project || '<project-number>'} --owner ${owner} --repo ${repo.split('/')[1]}`);
+  console.error(
+    `  node scripts/github_project_lifecycle.mjs bootstrap --repo ${repo} --owner ${owner} --project ${project || '<project-number>'} --apply`,
+  );
+}
+
+function commandBootstrap(args) {
+  const repo = detectRepo(args.repo);
+  const owner = repoOwner(repo, args.owner);
+  const apply = Boolean(args.apply);
+
+  const labels = gh(['label', 'list', '--repo', repo, '--limit', '200', '--json', 'name'], { json: true });
+  const labelValidation = validateIssueTypeLabels(labels);
+  if (!labelValidation.ok) {
+    console.error(`[dcness-project] missing repo labels: ${labelValidation.missingLabels.join(', ')}`);
+    if (apply) {
+      for (const label of labelValidation.missingLabels) ensureLabel(repo, label);
+      console.error('[dcness-project] repo labels created/updated.');
+    }
+  }
+
+  if (!args.project) {
+    console.error('[dcness-project] Project number is required for field validation.');
+    printBootstrapRecovery({ repo, owner, project: null });
+    return 1;
+  }
+
+  const fields = gh(
+    ['project', 'field-list', args.project, '--owner', owner, '--format', 'json'],
+    { json: true },
+  );
+  const fieldValidation = validateProjectFields(fields);
+  if (!fieldValidation.ok) {
+    console.error(`[dcness-project] missing fields: ${fieldValidation.missingFields.join(', ') || '-'}`);
+    for (const miss of fieldValidation.missingOptions) {
+      console.error(`[dcness-project] missing option: ${miss.field}=${miss.option}`);
+    }
+    if (apply) {
+      for (const fieldName of fieldValidation.missingFields) {
+        gh([
+          'project',
+          'field-create',
+          args.project,
+          '--owner',
+          owner,
+          '--name',
+          fieldName,
+          '--data-type',
+          'SINGLE_SELECT',
+          '--single-select-options',
+          PROJECT_FIELDS[fieldName].join(','),
+        ]);
+        console.error(`[dcness-project] created Project field: ${fieldName}`);
+      }
+      if (fieldValidation.missingOptions.length > 0) {
+        console.error('[dcness-project] existing Project fields with missing options need manual repair.');
+      }
+    } else {
+      printBootstrapRecovery({ repo, owner, project: args.project });
+    }
+  }
+
+  const finalLabels = apply
+    ? gh(['label', 'list', '--repo', repo, '--limit', '200', '--json', 'name'], { json: true })
+    : labels;
+  const finalFields = apply && fieldValidation.missingFields.length
+    ? gh(['project', 'field-list', args.project, '--owner', owner, '--format', 'json'], { json: true })
+    : fields;
+  const ok = validateIssueTypeLabels(finalLabels).ok && validateProjectFields(finalFields).ok;
+  console.log(ok ? '[dcness-project] bootstrap PASS' : '[dcness-project] bootstrap FAIL');
+  return ok ? 0 : 1;
+}
+
+function projectContext(args) {
+  const repo = detectRepo(args.repo);
+  const owner = repoOwner(repo, args.owner);
+  if (!args.project) throw new Error('--project <number> is required.');
+  const project = gh(['project', 'view', args.project, '--owner', owner, '--format', 'json'], { json: true });
+  const fields = gh(['project', 'field-list', args.project, '--owner', owner, '--format', 'json'], { json: true });
+  return { repo, owner, project, fields };
+}
+
+function getIssue(repo, issueNumber) {
+  return gh(['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'number,labels,url'], { json: true });
+}
+
+function getProjectItem({ owner, projectNumber, repo, issueNumber }) {
+  const items = gh(
+    ['project', 'item-list', String(projectNumber), '--owner', owner, '--format', 'json', '--limit', '1000'],
+    { json: true },
+  );
+  return findProjectItem(items, { repo, number: issueNumber });
+}
+
+function commandValidateIssue(args) {
+  if (!args.issue) throw new Error('--issue <number> is required.');
+  const { repo, owner } = projectContext(args);
+  const issue = getIssue(repo, args.issue);
+  const item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: args.issue });
+
+  if (!item) {
+    console.error(`issue #${args.issue}: Project item missing in Project ${args.project}.`);
+    return 1;
+  }
+
+  const validation = validateIssueProjectRegistration({
+    repo,
+    issueNumber: issue.number,
+    item,
+    labels: issue.labels,
+    expectedStatus: args['expected-status'] ?? 'any',
+    expectedIssueType: args['expected-issue-type'] ?? null,
+    expectedPriority: args['expected-priority'] ?? 'any',
+  });
+  for (const message of validation.messages) {
+    console.log(message);
+  }
+  return validation.ok ? 0 : 1;
+}
+
+function commandStartWork(args) {
+  if (!args.issue) throw new Error('--issue <number> is required.');
+  const { repo, owner, project, fields } = projectContext(args);
+  const item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: args.issue });
+  if (!item?.id) {
+    console.error(`issue #${args.issue}: Project item missing in Project ${args.project}.`);
+    return 1;
+  }
+  if (!args.apply) {
+    console.log(statusDriftMessage({
+      repo,
+      issueNumber: args.issue,
+      expected: 'In progress',
+      actual: projectItemFieldValue(item, 'Status'),
+    }));
+    console.log('Run again with --apply to set Status=In progress.');
+    return 1;
+  }
+  setProjectSingleSelect({
+    projectId: project.id,
+    itemId: item.id,
+    fields,
+    fieldName: 'Status',
+    optionName: 'In progress',
+  });
+  console.log(`issue #${args.issue}: Status=In progress`);
+  return 0;
+}
+
+function bodyFromArgs(args) {
+  if (args['body-file']) return readFileSync(args['body-file'], 'utf8');
+  if (args['body-env']) return process.env[args['body-env']] ?? '';
+  if (args.body) return args.body;
+  if (args.pr) {
+    const pr = gh(prViewArgs({ pr: args.pr, repo: args.repo }), { json: true });
+    const fromReferences = asArray(pr.closingIssuesReferences)
+      .map((issue) => ({
+        repo: normalizeRepoName(issue?.repository ?? issue?.repositoryNameWithOwner ?? args.repo),
+        number: Number(issue?.number),
+      }))
+      .filter((issue) => Number.isInteger(issue.number));
+    return `${pr.body ?? ''}\n${fromReferences.map((issue) => {
+      const repoPrefix = issue.repo ? `${issue.repo}` : '';
+      return `Closes ${repoPrefix}#${issue.number}`;
+    }).join('\n')}`;
+  }
+  return '';
+}
+
+function commandPrMerged(args) {
+  const body = bodyFromArgs(args);
+  const { refs } = parseCompletionIssueRefs(body, args.repo);
+  if (refs.length === 0) {
+    console.log('[dcness-project] no completion issue candidates. Part of #N is not a Done signal.');
+    return 0;
+  }
+  const { repo, owner, project, fields } = projectContext(args);
+  const resolvedRefs = resolveCompletionRefsForProject(body, args.repo, repo);
+
+  let failures = 0;
+  for (const ref of resolvedRefs) {
+    const item = getProjectItem({
+      owner,
+      projectNumber: args.project,
+      repo: ref.repo,
+      issueNumber: ref.number,
+    });
+    if (!item?.id) {
+      failures += 1;
+      console.error(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Project item missing in Project ${args.project}.`);
+      continue;
+    }
+    const actual = projectItemFieldValue(item, 'Status');
+    if (actual === 'Done') {
+      console.log(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Status=Done`);
+      continue;
+    }
+    if (!args.apply) {
+      failures += 1;
+      console.error(statusDriftMessage({
+        repo: ref.repo,
+        issueNumber: ref.number,
+        expected: 'Done',
+        actual,
+      }));
+      continue;
+    }
+    setProjectSingleSelect({
+      projectId: project.id,
+      itemId: item.id,
+      fields,
+      fieldName: 'Status',
+      optionName: 'Done',
+    });
+    console.log(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Status=Done`);
+  }
+  return failures === 0 ? 0 : 1;
+}
+
+function help() {
+  console.log(`Usage:
+  node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project N [--apply]
+  node scripts/github_project_lifecycle.mjs validate-issue --repo OWNER/REPO --owner OWNER --project N --issue N [--expected-status Todo|In progress|Done|any] [--expected-issue-type TYPE] [--expected-priority PRIORITY]
+  node scripts/github_project_lifecycle.mjs start-work --repo OWNER/REPO --owner OWNER --project N --issue N [--apply]
+  node scripts/github_project_lifecycle.mjs pr-merged --repo OWNER/REPO --owner OWNER --project N (--pr N | --body-file FILE | --body-env ENV) [--apply]
+`);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const [command] = args._;
+  if (!command || args.help) {
+    help();
+    return 0;
+  }
+  switch (command) {
+    case 'bootstrap':
+      return commandBootstrap(args);
+    case 'validate-issue':
+      return commandValidateIssue(args);
+    case 'start-work':
+      return commandStartWork(args);
+    case 'pr-merged':
+      return commandPrMerged(args);
+    default:
+      throw new Error(`unknown command: ${command}`);
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exitCode = main();
+  } catch (error) {
+    console.error(`[dcness-project] ${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/setup_labels.sh
+++ b/scripts/setup_labels.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# setup_labels.sh — dcNess 정적 GitHub 레이블 생성 (BugFix / UI / Docs)
-# 동적 레이블 (V0N / EPIC0N / Story0N) 은 agent 가 이슈 생성 시 자동 생성.
+# setup_labels.sh — dcNess IssueType 동기 GitHub label 생성
+# Project IssueType 과 repo label 이 같은 분류 체계를 쓰도록 표준 6종을 생성/갱신한다.
 #
 # 사용:
 #   bash scripts/setup_labels.sh [<owner/repo>]
@@ -28,8 +28,11 @@ _upsert_label() {
   fi
 }
 
-_upsert_label "BugFix" "d73a4a" "버그 수정"
-_upsert_label "UI"     "0075ca" "UI/Design 이슈 — designer 생성"
-_upsert_label "Docs"   "cfd3d7" "문서 변경"
+_upsert_label "epic"    "7057ff" "epic-level GitHub issue"
+_upsert_label "feature" "a2eeef" "feature-level GitHub issue"
+_upsert_label "story"   "0e8a16" "story-level GitHub issue"
+_upsert_label "task"    "c5def5" "task-level GitHub issue"
+_upsert_label "subTask" "bfdadc" "subTask-level GitHub issue"
+_upsert_label "bug"     "d73a4a" "bug-level GitHub issue"
 
-echo "[setup_labels] 완료 — BugFix / UI / Docs"
+echo "[setup_labels] 완료 — IssueType label 6종"

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -14,6 +14,7 @@ description: product/technical design 을 `/architect-loop` 호환 흐름으로 
 3. loop contract 의 `begin-run` 인자는 `begin-run architect-loop` 로 유지한다.
 4. entry_point = `architect-loop` 를 사용하고 `design` 으로 시작하지 않는다. `harness/hooks.py` 의 architect-loop gate 가 exact entry point 를 기준으로 동작하기 때문이다.
 5. 기존 `/architect-loop` 사용자는 그대로 호환된다. `/design` 추가가 `/architect-loop` 제거를 뜻하지 않는다.
+6. GitHub issue 번호가 대상이면 `/architect-loop` 진입 전 [`../../docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle)에 따라 Project `Status=In progress` 로 이동한다.
 
 ## 범위
 

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -44,6 +44,8 @@ concrete signal: 파일 path, 함수/클래스/symbol, 이미 분류·승인된 
 
 GitHub issue 등록이 목표인 요청이면 `/to-issue` 로 보내고, 수정/구현이 목표인 버그 신고는 아래 lane 판정으로 처리한다.
 
+GitHub issue 번호가 대상이면 lane 실행 전 [`docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle)에 따라 Project `Status=In progress` 로 이동한다. Project bootstrap 이 안 되어 있으면 `/init-dcness` 의 GitHub Project lifecycle bootstrap 을 먼저 수행한다.
+
 ## Step 1 — lane 판정
 
 판정 순서:

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -12,6 +12,7 @@ description: 새 기능 / PRD 변경 / 큰 기획을 시작하는 public entrypo
 1. [`../product-plan/SKILL.md`](../product-plan/SKILL.md)를 읽고 그 절차를 그대로 따른다.
 2. [`../product-plan/product-plan-routing.md`](../product-plan/product-plan-routing.md)를 라우팅 SSOT로 사용한다.
 3. `/spec` 완료 전 `product-acceptance:SPEC_ACCEPTANCE` 체크포인트를 수행한다.
+4. GitHub issue 번호가 대상이면 product-plan 진입 전 [`../../docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle)에 따라 Project `Status=In progress` 로 이동한다.
 
 ## 범위
 

--- a/skills/to-issue/SKILL.md
+++ b/skills/to-issue/SKILL.md
@@ -27,6 +27,7 @@ description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 
 ## 기준 파일
 
 - IssueType, Priority, repo label 매핑은 [`issue-fields.md`](issue-fields.md)를 SSOT 로 사용한다.
+- Project lifecycle 전체 축과 status 전이는 [`../../docs/plugin/github-project.md`](../../docs/plugin/github-project.md)를 SSOT 로 사용한다.
 - Issue Brief 본문 구조는 [`templates/issue-brief.md`](templates/issue-brief.md)를 템플릿으로 사용한다.
 - `SKILL.md` 에 필드 선택지 목록이나 Issue Brief 본문 템플릿을 다시 쓰지 않는다. 선택지나 템플릿을 바꿔야 하면 기준 파일을 먼저 바꾼다.
 
@@ -116,6 +117,14 @@ gh project item-edit --project-id "$PROJECT_ID" --id "$ITEM_ID" --field-id <Prio
 ```bash
 gh issue view <number> --json number,title,labels,url
 gh project item-list <number> --owner <owner> --format json
+node scripts/github_project_lifecycle.mjs validate-issue \
+  --repo <owner/repo> \
+  --owner <owner> \
+  --project <project-number> \
+  --issue <number> \
+  --expected-status Todo \
+  --expected-issue-type "<IssueType>" \
+  --expected-priority "<Priority>"
 ```
 
 등록된 issue 는 Project 에 추가되고 `Status=Todo`, 선택한 `IssueType`, 선택한 `Priority` 를 가져야 한다. 등록된 issue 는 Project `IssueType`과 같은 repo label 을 가져야 한다. 저장 실패나 Project field 반영 실패 상황에서 성공 안내를 하지 않는다. 이미 issue 는 생성됐지만 Project 반영이 실패했다면 partial state 를 명확히 말하고 필요한 후속 조치만 제안한다.

--- a/skills/to-issue/issue-fields.md
+++ b/skills/to-issue/issue-fields.md
@@ -1,8 +1,16 @@
 # /to-issue Field SSOT
 
-This file is the single source of truth for `/to-issue` issue classification fields. `SKILL.md` must reference this file instead of duplicating these option lists.
+This file is the single source of truth for `/to-issue` issue classification fields. `SKILL.md` must reference this file instead of duplicating these option lists. The broader Project lifecycle SSOT is [`../../docs/plugin/github-project.md`].
 
-When GitHub Project field options or repo labels diverge from this file, stop before creating the issue and report the setup gap. Do not guess option ids or create labels implicitly.
+When GitHub Project field options or repo labels diverge from this file, stop before creating the issue and report the setup gap. Do not guess option ids or create labels implicitly. repo label 6종은 IssueType 축과 같은 의미로 쓴다.
+
+## Status
+
+| Value | Meaning |
+| --- | --- |
+| `Todo` | Issue has been registered but no target workflow has started yet. |
+| `In progress` | A target workflow such as `/spec`, `/design`, `/impl`, or `/ux` has started for the issue. |
+| `Done` | The issue was completed by a merged PR that actually closes/fixes/resolves it. |
 
 ## IssueType
 
@@ -30,4 +38,6 @@ When GitHub Project field options or repo labels diverge from this file, stop be
 - Use the selected `IssueType` value as the repo label.
 - Set Project `IssueType` and Project `Priority` to the exact values above.
 - Set Project `Status` to `Todo` when registering the issue.
+- Move Project `Status` to `In progress` when a target workflow starts.
+- Move Project `Status` to `Done` only from `Closes`, `Fixes`, `Resolves`, or GitHub closing references after default-branch merge. `Part of #N` is not a Done signal.
 - If a parent issue exists, reference it only. `/to-issue` does not close or rewrite the parent.

--- a/skills/ux/SKILL.md
+++ b/skills/ux/SKILL.md
@@ -34,6 +34,7 @@ description: 화면 UX 플로우 정의 + 디자인 시안 핸드오프를 ux-ar
 - 대상 화면/플로우 (PRD 화면 인벤토리 또는 사용자 지정)
 - (UX_REFINE) 개선 대상 기존 화면 경로 (routes/screens 등)
 - (선택) design medium — 미지정 시 designer 가 `docs/design.md` frontmatter `medium` detect + 역질문
+- (선택) GitHub issue 번호 — 대상이 있으면 시작 전 [`../../docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle)에 따라 Project `Status=In progress` 로 이동한다.
 
 ## 비대상 (다른 skill 추천)
 

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -1,0 +1,444 @@
+"""Regression tests for GitHub Project lifecycle bootstrap (#663)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "github_project_lifecycle.mjs"
+
+
+def run_node(expression: str) -> dict:
+    code = textwrap.dedent(
+        f"""
+        import * as lifecycle from {json.dumps(SCRIPT.as_posix())};
+        const result = {expression};
+        console.log(JSON.stringify(result));
+        """
+    )
+    completed = subprocess.run(
+        ["node", "--input-type=module", "-e", code],
+        cwd=ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return json.loads(completed.stdout)
+
+
+class GithubProjectLifecycleScriptTests(unittest.TestCase):
+    def test_standard_project_fields_require_all_options(self) -> None:
+        fields = [
+            {
+                "name": "Status",
+                "dataType": "SINGLE_SELECT",
+                "options": [
+                    {"name": "Todo"},
+                    {"name": "In progress"},
+                    {"name": "Done"},
+                ],
+            },
+            {
+                "name": "IssueType",
+                "dataType": "SINGLE_SELECT",
+                "options": [
+                    {"name": "epic"},
+                    {"name": "feature"},
+                    {"name": "story"},
+                    {"name": "task"},
+                    {"name": "subTask"},
+                    {"name": "bug"},
+                ],
+            },
+            {
+                "name": "Priority",
+                "dataType": "SINGLE_SELECT",
+                "options": [
+                    {"name": "blocker"},
+                    {"name": "critical"},
+                    {"name": "major"},
+                    {"name": "minor"},
+                    {"name": "trivial"},
+                ],
+            },
+        ]
+
+        result = run_node(
+            f"lifecycle.validateProjectFields({json.dumps(fields)})"
+        )
+
+        self.assertEqual([], result["missingFields"])
+        self.assertEqual([], result["missingOptions"])
+        self.assertTrue(result["ok"])
+
+    def test_project_field_validation_accepts_gh_project_v2_type_names(self) -> None:
+        fields = [
+            {
+                "name": "Status",
+                "type": "ProjectV2SingleSelectField",
+                "options": [
+                    {"name": "Todo"},
+                    {"name": "In progress"},
+                    {"name": "Done"},
+                ],
+            },
+            {
+                "name": "IssueType",
+                "type": "ProjectV2SingleSelectField",
+                "options": [
+                    {"name": "epic"},
+                    {"name": "feature"},
+                    {"name": "story"},
+                    {"name": "task"},
+                    {"name": "subTask"},
+                    {"name": "bug"},
+                ],
+            },
+            {
+                "name": "Priority",
+                "type": "ProjectV2SingleSelectField",
+                "options": [
+                    {"name": "blocker"},
+                    {"name": "critical"},
+                    {"name": "major"},
+                    {"name": "minor"},
+                    {"name": "trivial"},
+                ],
+            },
+        ]
+
+        result = run_node(
+            f"lifecycle.validateProjectFields({json.dumps(fields)})"
+        )
+
+        self.assertTrue(result["ok"])
+        self.assertEqual([], result["wrongTypeFields"])
+
+    def test_project_field_validation_reports_missing_status_option(self) -> None:
+        fields = [
+            {
+                "name": "Status",
+                "dataType": "SINGLE_SELECT",
+                "options": [{"name": "Todo"}, {"name": "Done"}],
+            },
+        ]
+
+        result = run_node(
+            f"lifecycle.validateProjectFields({json.dumps(fields)})"
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("IssueType", result["missingFields"])
+        self.assertIn("Priority", result["missingFields"])
+        self.assertIn(
+            {"field": "Status", "option": "In progress"},
+            result["missingOptions"],
+        )
+
+    def test_issue_type_label_validation_uses_same_six_values(self) -> None:
+        labels = [
+            {"name": "epic"},
+            {"name": "feature"},
+            {"name": "story"},
+            {"name": "task"},
+            {"name": "subTask"},
+            {"name": "bug"},
+        ]
+
+        result = run_node(f"lifecycle.validateIssueTypeLabels({json.dumps(labels)})")
+
+        self.assertTrue(result["ok"])
+        self.assertEqual([], result["missingLabels"])
+
+    def test_completion_candidates_ignore_part_of_references(self) -> None:
+        body = """
+        ## 관련 이슈 번호
+        Part of #10
+        Closes #11
+        fixes alruminum/dcNess#12
+        Resolves #13, closes #14
+        """
+
+        result = run_node(
+            f"lifecycle.parseCompletionIssueNumbers({json.dumps(body)})"
+        )
+
+        self.assertEqual({"numbers": [11, 12, 13, 14]}, result)
+
+    def test_completion_candidates_include_comma_separated_issue_refs(self) -> None:
+        body = """
+        Closes #101, #102
+        Fixes #103 and #104
+        Resolves alruminum/dcNess#105, #106
+        """
+
+        result = run_node(
+            f"lifecycle.parseCompletionIssueNumbers({json.dumps(body)})"
+        )
+
+        self.assertEqual({"numbers": [101, 102, 103, 104, 105, 106]}, result)
+
+    def test_completion_refs_preserve_repo_identity(self) -> None:
+        body = """
+        Part of other/repo#100
+        Closes other/repo#101, #102
+        Fixes #103
+        """
+
+        result = run_node(
+            f"lifecycle.parseCompletionIssueRefs({json.dumps(body)}, 'alruminum/dcNess')"
+        )
+
+        self.assertEqual(
+            {
+                "refs": [
+                    {"repo": "other/repo", "number": 101},
+                    {"repo": "alruminum/dcNess", "number": 102},
+                    {"repo": "alruminum/dcNess", "number": 103},
+                ]
+            },
+            result,
+        )
+
+    def test_completion_refs_do_not_include_part_of_segment_on_same_line(self) -> None:
+        body = "Closes #663, Part of #662"
+
+        result = run_node(
+            f"lifecycle.parseCompletionIssueRefs({json.dumps(body)}, 'alruminum/dcNess')"
+        )
+
+        self.assertEqual(
+            {"refs": [{"repo": "alruminum/dcNess", "number": 663}]},
+            result,
+        )
+
+    def test_project_item_lookup_matches_repo_and_issue_number(self) -> None:
+        items = [
+            {
+                "id": "wrong",
+                "content": {"number": 663, "repository": "other/repo"},
+            },
+            {
+                "id": "right",
+                "content": {"number": 663, "repository": "alruminum/dcNess"},
+            },
+        ]
+
+        result = run_node(
+            f"lifecycle.findProjectItem({json.dumps(items)}, "
+            "{repo: 'alruminum/dcNess', number: 663})"
+        )
+
+        self.assertEqual("right", result["id"])
+
+    def test_completion_refs_can_apply_default_repo_after_context_load(self) -> None:
+        refs = [{"repo": None, "number": 663}]
+
+        result = run_node(
+            f"lifecycle.applyDefaultRepoToRefs({json.dumps(refs)}, 'alruminum/dcNess')"
+        )
+
+        self.assertEqual([{"repo": "alruminum/dcNess", "number": 663}], result)
+
+    def test_resolve_completion_refs_uses_detected_repo_when_cli_repo_missing(self) -> None:
+        result = run_node(
+            "lifecycle.resolveCompletionRefsForProject('Closes #663', null, 'alruminum/dcNess')"
+        )
+
+        self.assertEqual(
+            [{"repo": "alruminum/dcNess", "number": 663}],
+            result,
+        )
+
+    def test_pr_view_args_include_target_repo(self) -> None:
+        result = run_node(
+            "lifecycle.prViewArgs({pr: 17, repo: 'alruminum/dcNess'})"
+        )
+
+        self.assertEqual(
+            [
+                "pr",
+                "view",
+                "17",
+                "--repo",
+                "alruminum/dcNess",
+                "--json",
+                "body,closingIssuesReferences",
+            ],
+            result,
+        )
+
+    def test_issue_type_drift_message_names_issue_field_and_label(self) -> None:
+        result = run_node(
+            "lifecycle.detectIssueTypeDrift({"
+            "issueNumber: 42,"
+            "projectIssueType: 'feature',"
+            "labels: ['bug']"
+            "})"
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertIn("issue #42", result["message"])
+        self.assertIn("Project IssueType=feature", result["message"])
+        self.assertIn("repo label=bug", result["message"])
+
+    def test_status_drift_message_can_name_repo_scoped_issue(self) -> None:
+        result = run_node(
+            "lifecycle.statusDriftMessage({"
+            "repo: 'other/repo',"
+            "issueNumber: 42,"
+            "expected: 'Done',"
+            "actual: 'Todo'"
+            "})"
+        )
+
+        self.assertIn("issue other/repo#42", result)
+        self.assertIn("Project field Status", result)
+
+    def test_project_item_field_value_reads_gh_item_top_level_fields(self) -> None:
+        item = {
+            "status": "Todo",
+            "issueType": "feature",
+            "priority": "major",
+        }
+
+        result = run_node(
+            "{"
+            f"status: lifecycle.projectItemFieldValue({json.dumps(item)}, 'Status'),"
+            f"issueType: lifecycle.projectItemFieldValue({json.dumps(item)}, 'IssueType'),"
+            f"priority: lifecycle.projectItemFieldValue({json.dumps(item)}, 'Priority')"
+            "}"
+        )
+
+        self.assertEqual(
+            {"status": "Todo", "issueType": "feature", "priority": "major"},
+            result,
+        )
+
+    def test_registration_validation_requires_todo_status(self) -> None:
+        item = {
+            "status": "In progress",
+            "issueType": "feature",
+            "priority": "major",
+        }
+
+        result = run_node(
+            "lifecycle.validateIssueProjectRegistration({"
+            "repo: 'alruminum/dcNess',"
+            "issueNumber: 663,"
+            f"item: {json.dumps(item)},"
+            "labels: ['feature']"
+            "})"
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any(
+                "issue alruminum/dcNess#663" in message
+                and "expected=Todo" in message
+                and "actual=In progress" in message
+                for message in result["messages"]
+            )
+        )
+
+    def test_registration_validation_requires_priority_value(self) -> None:
+        item = {
+            "status": "Todo",
+            "issueType": "feature",
+            "priority": None,
+        }
+
+        result = run_node(
+            "lifecycle.validateIssueProjectRegistration({"
+            "issueNumber: 663,"
+            f"item: {json.dumps(item)},"
+            "labels: ['feature']"
+            "})"
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any(
+                "Project Priority=<unset>" in message
+                for message in result["messages"]
+            )
+        )
+
+    def test_registration_validation_can_pin_selected_issue_type_and_priority(self) -> None:
+        item = {
+            "status": "Todo",
+            "issueType": "bug",
+            "priority": "minor",
+        }
+
+        result = run_node(
+            "lifecycle.validateIssueProjectRegistration({"
+            "issueNumber: 663,"
+            f"item: {json.dumps(item)},"
+            "labels: ['bug'],"
+            "expectedIssueType: 'feature',"
+            "expectedPriority: 'major'"
+            "})"
+        )
+
+        self.assertFalse(result["ok"])
+        self.assertTrue(
+            any(
+                "Project IssueType=bug" in message
+                and "expected=feature" in message
+                for message in result["messages"]
+            )
+        )
+        self.assertTrue(
+            any(
+                "Project Priority=minor" in message
+                and "expected=major" in message
+                for message in result["messages"]
+            )
+        )
+
+    def test_registration_validation_accepts_expected_status_override(self) -> None:
+        item = {
+            "status": "In progress",
+            "issueType": "feature",
+            "priority": "major",
+        }
+
+        result = run_node(
+            "lifecycle.validateIssueProjectRegistration({"
+            "issueNumber: 663,"
+            f"item: {json.dumps(item)},"
+            "labels: ['feature'],"
+            "expectedStatus: 'In progress'"
+            "})"
+        )
+
+        self.assertTrue(result["ok"])
+
+    def test_registration_validation_can_skip_lifecycle_fields_for_drift_only(self) -> None:
+        item = {
+            "status": "In progress",
+            "issueType": "feature",
+            "priority": None,
+        }
+
+        result = run_node(
+            "lifecycle.validateIssueProjectRegistration({"
+            "issueNumber: 663,"
+            f"item: {json.dumps(item)},"
+            "labels: ['feature'],"
+            "expectedStatus: 'any',"
+            "expectedPriority: 'any'"
+            "})"
+        )
+
+        self.assertTrue(result["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_github_project_lifecycle_docs.py
+++ b/tests/test_github_project_lifecycle_docs.py
@@ -1,0 +1,95 @@
+"""Static contract tests for GitHub Project lifecycle docs (#663)."""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class GithubProjectLifecycleDocsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.project_doc = ROOT / "docs" / "plugin" / "github-project.md"
+        self.issue_lifecycle = (
+            ROOT / "docs" / "plugin" / "issue-lifecycle.md"
+        ).read_text(encoding="utf-8")
+        self.issue_fields = (
+            ROOT / "skills" / "to-issue" / "issue-fields.md"
+        ).read_text(encoding="utf-8")
+        self.to_issue = (
+            ROOT / "skills" / "to-issue" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+        self.init_dcness = (
+            ROOT / "commands" / "init-dcness.md"
+        ).read_text(encoding="utf-8")
+        self.setup_labels = (
+            ROOT / "scripts" / "setup_labels.sh"
+        ).read_text(encoding="utf-8")
+
+    def test_project_axes_ssot_documents_status_issue_type_priority(self) -> None:
+        text = self.project_doc.read_text(encoding="utf-8")
+
+        self.assertIn("# GitHub Project Lifecycle", text)
+        for field in ("Status", "IssueType", "Priority"):
+            self.assertRegex(text, rf"(?m)^## {field}$")
+            self.assertRegex(text, rf"(?ms)^## {field}$.+Usage example")
+
+        for value in ("Todo", "In progress", "Done"):
+            self.assertRegex(text, rf"(?m)^\|\s*`{re.escape(value)}`\s*\|")
+
+        for value in ("epic", "feature", "story", "task", "subTask", "bug"):
+            self.assertRegex(text, rf"(?m)^\|\s*`{re.escape(value)}`\s*\|")
+            self.assertRegex(text, rf"(?m)^\|\s*`{re.escape(value)}`\s*\|")
+
+        for value in ("blocker", "critical", "major", "minor", "trivial"):
+            self.assertRegex(text, rf"(?m)^\|\s*`{re.escape(value)}`\s*\|")
+
+    def test_repo_labels_match_issue_type_axis_and_are_bootstrapped(self) -> None:
+        for value in ("epic", "feature", "story", "task", "subTask", "bug"):
+            self.assertIn(f"`{value}`", self.issue_fields)
+            self.assertIn(f"_upsert_label \"{value}\"", self.setup_labels)
+
+        self.assertIn("repo label 6종", self.project_doc.read_text(encoding="utf-8"))
+        self.assertIn("IssueType 축과 같은 의미", self.issue_fields)
+
+    def test_init_dcness_checks_project_and_label_bootstrap(self) -> None:
+        text = self.init_dcness
+
+        self.assertIn("GitHub Project lifecycle bootstrap", text)
+        self.assertIn("scripts/github_project_lifecycle.mjs bootstrap", text)
+        self.assertIn("Status / IssueType / Priority", text)
+        self.assertIn("repo label 6종", text)
+        self.assertIn("Project가 없거나 필드가 부족", text)
+        self.assertIn("repo label이 부족", text)
+        self.assertIn("--apply", text)
+        self.assertIn("다른 repo", text)
+
+    def test_to_issue_contract_references_project_lifecycle_ssot(self) -> None:
+        self.assertIn("[`../../docs/plugin/github-project.md`]", self.issue_fields)
+        self.assertIn("Status=Todo", self.to_issue)
+        self.assertIn("scripts/github_project_lifecycle.mjs validate-issue", self.to_issue)
+        self.assertIn("--expected-status Todo", self.to_issue)
+        self.assertIn("--expected-issue-type", self.to_issue)
+        self.assertIn("--expected-priority", self.to_issue)
+        self.assertIn("Project `IssueType`과 같은 repo label", self.to_issue)
+
+    def test_work_start_and_pr_merge_lifecycle_are_documented(self) -> None:
+        text = self.issue_lifecycle
+
+        self.assertIn("Status=In progress", text)
+        self.assertIn("scripts/github_project_lifecycle.mjs start-work", text)
+        self.assertIn("/spec", text)
+        self.assertIn("/design", text)
+        self.assertIn("/impl", text)
+        self.assertIn("Status=Done", text)
+        self.assertIn("scripts/github_project_lifecycle.mjs pr-merged", text)
+        self.assertIn("Part of #N", text)
+        self.assertIn("완료 신호가 아니다", text)
+        self.assertRegex(text, r"(?s)status drift.+어떤 issue.+어떤 field")
+        self.assertRegex(text, r"(?s)IssueType.+repo label.+어떤 issue.+어떤 값")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #663

## 배경 및 문제

- #662 이후 `/to-issue` 는 Agent Brief 기반 issue 등록과 Project field 계약을 갖게 됐지만, `/init-dcness` 가 GitHub Project v2 축과 repo label 6종을 bootstrap/검증하는 공통 경로가 없었다.
- issue 등록, 작업 시작, PR merge 완료가 같은 `Status / IssueType / Priority` 축을 쓰도록 lifecycle SSOT 와 실행 경로가 필요했다.

## 원인 (해당 시)

-

## 작업내용

- GitHub Project lifecycle SSOT 문서와 helper script 를 추가해 `Status`, `IssueType`, `Priority` field/options 및 IssueType repo label 6종을 검증한다.
- `/init-dcness` 에 Project bootstrap, optional GitHub Actions workflow, recovery 안내를 추가했다.
- `/to-issue` post-create 검증을 `Status=Todo`, 선택한 `IssueType`, 선택한 `Priority`, matching repo label 까지 확인하도록 문서/스크립트 계약을 맞췄다.
- `/spec`, `/design`, `/impl`, `/ux` 시작 시 `Status=In progress`, PR merge 후 completion ref 기반 `Status=Done` 경로를 문서화했다.
- `Part of #N` 을 Done 신호에서 제외하고, comma-separated completion refs, repo-scoped refs, same-line `Closes #N, Part of #M` 케이스를 테스트했다.

## 결정 근거

- Project field/label 축은 `docs/plugin/github-project.md` 를 SSOT 로 두고, 실행 메커니즘은 `scripts/github_project_lifecycle.mjs` 하나로 모아 `/init-dcness`, `/to-issue`, CI workflow 가 같은 검증을 호출하게 했다.
- generic issue drift 검증은 later issue edit 에서 `Status=Todo` 를 강제하지 않도록 두고, `/to-issue` post-create 경로만 expected flag 로 생성 계약을 강하게 검증한다.
- PR completion 은 PR body parser 와 GitHub `closingIssuesReferences` 둘 다 수용하되, repo identity 를 유지해 multi-repo Project collision 을 피한다.

## 배포 경로 검증 (plug-in 영향 시)

- Plug-in 본체 경로: `scripts/github_project_lifecycle.mjs`, `.github/actions/github-project-lifecycle/action.yml`, `docs/plugin/github-project.md`, `docs/plugin/issue-lifecycle.md`, `skills/**`, `commands/init-dcness.md` 에 반영했다.
- `/init-dcness` 경로: 사용자 repo 에 helper script 를 복사하지 않고 plug-in root 의 script/action을 호출하도록 명시했다. optional thin workflow 는 `$PROJECT_ROOT/.github/workflows/github-project-lifecycle.yml` 로 배포된다.
- 기존 활성 프로젝트: plug-in update 후 `/init-dcness` 를 다시 실행하면 Project field/label 점검과 optional workflow 설치를 받을 수 있다. CI workflow 사용 시 `DCNESS_PROJECT_TOKEN`, `DCNESS_PROJECT_NUMBER`, `DCNESS_PROJECT_OWNER` 설정이 필요하다.
- dcNess self 확인: repo label 6종 중 누락됐던 `task`, `subTask` 를 bootstrap `--apply` 경로로 생성했고, #663 은 작업 시작 계약에 따라 Project `Status=In progress` 로 이동했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

- 기존 public command 는 늘리지 않았다. lifecycle은 기존 `/init-dcness`, `/to-issue`, `/spec`, `/design`, `/impl`, `/ux` 흐름 안에 흡수했다.
- prose validator/reviewer 만으로는 PR merge 이후 GitHub Project `Status=Done` 보정이 실행되지 않으므로, event 기반 composite action/script 가 필요하다.
- 새 agent 단계가 아니라 GitHub Project field/label drift 를 검증/보정하는 operational helper 이며, 사용자-facing 선택지는 `/init-dcness` bootstrap prompt 로 제한했다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v` — 909 tests OK
- [x] `node --check scripts/github_project_lifecycle.mjs`
- [x] `git diff --cached --check`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/github_project_lifecycle.mjs pr-merged --body 'Part of #663'`
- [x] dcness-code-validator subagent: PASS
- [x] dcness-pr-reviewer subagent: PASS
- [x] commit hook: pytest-gate PASS, git-naming PASS

## 참고

- #662 보호 계약 확인: qa subagent 미복구, 사용자 승인 전 issue 생성 금지, Issue Brief template 유지, parent issue 참조-only 유지.