### PR TITLE
[issue-669] 일괄 보드 백필이 기존 triage 상태 보존하도록 수정

### DIFF
--- a/scripts/create_epic_story_issues.sh
+++ b/scripts/create_epic_story_issues.sh
@@ -60,33 +60,41 @@ if [ -z "$PROJECT_OWNER" ]; then PROJECT_OWNER="${REPO%%/*}"; fi
 
 LIFECYCLE_MJS="$(dirname "$0")/github_project_lifecycle.mjs"
 
-# register_board — 생성/backfill 한 epic+story 이슈를 GitHub Project 보드에 등록.
-# epic → Status=Todo, IssueType=epic, Priority=major / story → Status=Todo, IssueType=story, Priority=major.
+# register_board [mode] — 생성/backfill 한 epic+story 이슈를 GitHub Project 보드에 등록.
+# epic → IssueType=epic / story → IssueType=story. 신규 등록 시 Status=Todo, Priority=major.
+# mode="backfill" (멱등 재실행) → --preserve-existing: 이미 보드에 있는 item 의 triage 상태
+#   (In progress/Done/바뀐 priority)를 Todo/major 로 되돌리지 않고 보존, 비어있는 필드만 채움 (#669).
+# mode="fresh" (기본, 새 이슈) → strict 등록 (Todo/major 강제 + 검증).
 # 좌표 없으면 skip (이슈는 이미 생성됨). register-issue 실패는 흡수 + partial 보고 (이슈를 막지 않는다).
 register_board() {
+  local mode="${1:-fresh}"
   if [ -z "$PROJECT_NUMBER" ]; then
     echo "[issue-create] Project 보드 미연결 (번호 없음) — 보드 등록 skip. 이슈는 생성됨."
     echo "  보드 연결 후 backfill: --project <N> --owner <O> 로 재실행 또는 'gh variable set DCNESS_PROJECT_NUMBER --body <N>'."
     return 0
   fi
-  local reg_ok=0 reg_total out failed=""
+  local reg_ok=0 reg_total out failed="" preserve_flag="" note="신규 Status=Todo, Priority=major"
+  if [ "$mode" = "backfill" ]; then
+    preserve_flag="--preserve-existing"
+    note="기존 triage 상태 보존, 빈 필드만 채움"
+  fi
   reg_total=$((1 + ${#STORY_NUMS[@]}))
-  echo "[issue-create] 보드 등록 — Project #$PROJECT_NUMBER (owner=$PROJECT_OWNER), 대상 ${reg_total}건"
-  if out=$(node "$LIFECYCLE_MJS" register-issue --repo "$REPO" --owner "$PROJECT_OWNER" --project "$PROJECT_NUMBER" --issue "$EPIC_NUM" --issue-type epic --apply 2>&1); then
+  echo "[issue-create] 보드 등록 ($mode) — Project #$PROJECT_NUMBER (owner=$PROJECT_OWNER), 대상 ${reg_total}건"
+  if out=$(node "$LIFECYCLE_MJS" register-issue --repo "$REPO" --owner "$PROJECT_OWNER" --project "$PROJECT_NUMBER" --issue "$EPIC_NUM" --issue-type epic $preserve_flag --apply 2>&1); then
     reg_ok=$((reg_ok+1))
   else
     failed="$failed epic#$EPIC_NUM"
     echo "  WARN: epic #$EPIC_NUM 보드 등록 실패 — $(echo "$out" | tail -1)"
   fi
   for sn in "${STORY_NUMS[@]}"; do
-    if out=$(node "$LIFECYCLE_MJS" register-issue --repo "$REPO" --owner "$PROJECT_OWNER" --project "$PROJECT_NUMBER" --issue "$sn" --issue-type story --apply 2>&1); then
+    if out=$(node "$LIFECYCLE_MJS" register-issue --repo "$REPO" --owner "$PROJECT_OWNER" --project "$PROJECT_NUMBER" --issue "$sn" --issue-type story $preserve_flag --apply 2>&1); then
       reg_ok=$((reg_ok+1))
     else
       failed="$failed story#$sn"
       echo "  WARN: story #$sn 보드 등록 실패 — $(echo "$out" | tail -1)"
     fi
   done
-  echo "[issue-create] 보드 등록 완료 — ${reg_ok}/${reg_total} 성공 (Status=Todo, Priority=major)"
+  echo "[issue-create] 보드 등록 완료 — ${reg_ok}/${reg_total} 성공 ($note)"
   if [ "$reg_ok" -lt "$reg_total" ]; then
     echo "[issue-create] WARN: partial state — 등록 실패:$failed. 이슈는 생성됨, 보드는 미반영."
     echo "  보드/field 셋업 확인 후 재실행으로 backfill (이슈 생성은 멱등 skip, 보드만 재시도)."
@@ -105,7 +113,7 @@ if grep -qE '^\*\*GitHub Epic Issue:\*\* \[#[0-9]+\]' "$STORIES"; then
     _n=$(echo "$_ln" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
     [ -n "$_n" ] && STORY_NUMS+=("$_n")
   done < <(grep -E '^\*\*GitHub Issue:\*\* \[#[0-9]+\]' "$STORIES")
-  register_board
+  register_board backfill
   exit 0
 fi
 

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -468,6 +468,26 @@ export function planRegistration({
   return { needsAdd: !item, sets };
 }
 
+// register-issue 검증 기대값을 *필드 단위*로 결정한다 (#669 백필).
+// preserve 모드라도, 완화('any')는 "원래 값이 있어 의도적으로 보존한 필드"에만 적용한다.
+// 원래 비어있던 필드는 채우기 대상이므로 strict 검증 유지 → apply 실패/부분 백필을 잡는다.
+// item 이 없으면(신규 add) 보존 대상이 없으니 전부 strict.
+export function resolveValidationExpectations({
+  item = null,
+  preserveExisting = false,
+  expectedStatus = 'Todo',
+  expectedPriority = 'major',
+}) {
+  const fieldWasSet = (fieldName) => {
+    const current = item ? projectItemFieldValue(item, fieldName) : null;
+    return !(current === null || current === undefined || current === '');
+  };
+  return {
+    validateStatus: (preserveExisting && fieldWasSet('Status')) ? 'any' : expectedStatus,
+    validatePriority: (preserveExisting && fieldWasSet('Priority')) ? 'any' : expectedPriority,
+  };
+}
+
 function printBootstrapRecovery({ repo, owner, project }) {
   console.error('[dcness-project] recovery commands:');
   console.error(`  gh project create --owner ${owner} --title "dcNess" --format json`);
@@ -632,13 +652,13 @@ function commandRegisterIssue(args) {
   const issue = getIssue(repo, args.issue);
 
   let item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: issue.number });
+  // 검증 완화는 *필드 단위* + *apply 전 원본 item* 기준 — 원래 값이 있던 필드만 보존('any'),
+  // 원래 비어있던 필드는 strict 로 두어 채우기 실패/부분 백필을 잡는다. IssueType 은 항상 strict.
+  const { validateStatus, validatePriority } = resolveValidationExpectations({
+    item, preserveExisting, expectedStatus, expectedPriority,
+  });
   // plan throws early if the board lacks a required field/option (incomplete board signal).
   const plan = planRegistration({ item, fields, issueType, expectedStatus, expectedPriority, preserveExisting });
-  // 기존 item 보존 모드면 Status/Priority 사후검증을 완화('any') — 보존한 값을 drift 로 오판하지 않는다.
-  // 새로 add 한 item 은 풀 등록되므로 strict 유지. IssueType(정체성)은 항상 검증.
-  const relaxLifecycle = preserveExisting && !plan.needsAdd;
-  const validateStatus = relaxLifecycle ? 'any' : expectedStatus;
-  const validatePriority = relaxLifecycle ? 'any' : expectedPriority;
 
   if (!args.apply) {
     if (!item) {
@@ -654,13 +674,9 @@ function commandRegisterIssue(args) {
       expectedPriority: validatePriority,
     });
     for (const message of validation.messages) console.log(message);
-    // preserve 완화로 검증은 'any' 라도, 채울 빈 필드(또는 drift)가 남아있으면 apply 가 item 을
-    // 바꾸므로 dry-run 은 pending 으로 보고한다 (완화가 "백필 불필요" 오보고를 내지 않게).
-    for (const entry of plan.sets) {
-      console.log(`issue #${issue.number}: Project ${entry.fieldName} needs set to ${entry.optionName} (run --apply).`);
-    }
     console.log('Run again with --apply to register the issue and set Project fields.');
-    return item && validation.ok && plan.sets.length === 0 ? 0 : 1;
+    // 채울 빈 필드는 strict 검증에서 drift 로 잡혀 validation.ok=false → pending 으로 보고된다.
+    return item && validation.ok ? 0 : 1;
   }
 
   if (plan.needsAdd) {

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -654,8 +654,13 @@ function commandRegisterIssue(args) {
       expectedPriority: validatePriority,
     });
     for (const message of validation.messages) console.log(message);
+    // preserve 완화로 검증은 'any' 라도, 채울 빈 필드(또는 drift)가 남아있으면 apply 가 item 을
+    // 바꾸므로 dry-run 은 pending 으로 보고한다 (완화가 "백필 불필요" 오보고를 내지 않게).
+    for (const entry of plan.sets) {
+      console.log(`issue #${issue.number}: Project ${entry.fieldName} needs set to ${entry.optionName} (run --apply).`);
+    }
     console.log('Run again with --apply to register the issue and set Project fields.');
-    return item && validation.ok ? 0 : 1;
+    return item && validation.ok && plan.sets.length === 0 ? 0 : 1;
   }
 
   if (plan.needsAdd) {

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -275,7 +275,7 @@ function parseArgs(argv) {
       continue;
     }
     const key = token.slice(2);
-    if (key === 'apply' || key === 'help') {
+    if (key === 'apply' || key === 'help' || key === 'preserve-existing') {
       args[key] = true;
       continue;
     }
@@ -426,6 +426,7 @@ export function planRegistration({
   issueType,
   expectedStatus = 'Todo',
   expectedPriority = 'major',
+  preserveExisting = false,
 }) {
   if (!issueType) {
     throw new Error('issueType is required for Project registration.');
@@ -434,21 +435,27 @@ export function planRegistration({
   validateExpectedValue({ fieldName: 'Status', expected: expectedStatus });
   validateExpectedValue({ fieldName: 'Priority', expected: expectedPriority });
 
+  // preservable: Status/Priority 는 사용자가 triage 하는 lifecycle 이라 백필 시 보존 대상.
+  // IssueType 은 이슈의 정체성(epic/story)이라 preserve 모드여도 항상 drift 교정.
   const desired = [
-    { fieldName: 'Status', optionName: expectedStatus },
-    { fieldName: 'IssueType', optionName: issueType },
-    { fieldName: 'Priority', optionName: expectedPriority },
+    { fieldName: 'Status', optionName: expectedStatus, preservable: true },
+    { fieldName: 'IssueType', optionName: issueType, preservable: false },
+    { fieldName: 'Priority', optionName: expectedPriority, preservable: true },
   ];
 
   const sets = [];
-  for (const { fieldName, optionName } of desired) {
+  for (const { fieldName, optionName, preservable } of desired) {
     const field = fieldByName(fields, fieldName);
     const option = field ? optionByName(field, optionName) : null;
     if (!field?.id || !option?.id) {
       throw new Error(`Project ${fieldName}=${optionName} option id not found.`);
     }
     const current = item ? projectItemFieldValue(item, fieldName) : null;
-    if (current !== optionName) {
+    const currentEmpty = current === null || current === undefined || current === '';
+    // preserveExisting (백필): 사용자가 triage 한 기존 값(In progress/Done/priority)은
+    // 덮지 않고, 비어있는 필드(부분 등록 실패 잔여)만 채운다. 기본(초기 등록)은 drift 교정.
+    const needsSet = (preserveExisting && preservable) ? currentEmpty : current !== optionName;
+    if (needsSet) {
       sets.push({
         fieldName,
         optionName,
@@ -620,11 +627,18 @@ function commandRegisterIssue(args) {
   const issueType = args['issue-type'];
   const expectedStatus = args.status ?? 'Todo';
   const expectedPriority = args.priority ?? 'major';
+  // --preserve-existing (백필): 보드에 이미 있는 item 의 triage 상태를 보존한다 (#669 회귀 가드).
+  const preserveExisting = Boolean(args['preserve-existing']);
   const issue = getIssue(repo, args.issue);
 
   let item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: issue.number });
   // plan throws early if the board lacks a required field/option (incomplete board signal).
-  const plan = planRegistration({ item, fields, issueType, expectedStatus, expectedPriority });
+  const plan = planRegistration({ item, fields, issueType, expectedStatus, expectedPriority, preserveExisting });
+  // 기존 item 보존 모드면 Status/Priority 사후검증을 완화('any') — 보존한 값을 drift 로 오판하지 않는다.
+  // 새로 add 한 item 은 풀 등록되므로 strict 유지. IssueType(정체성)은 항상 검증.
+  const relaxLifecycle = preserveExisting && !plan.needsAdd;
+  const validateStatus = relaxLifecycle ? 'any' : expectedStatus;
+  const validatePriority = relaxLifecycle ? 'any' : expectedPriority;
 
   if (!args.apply) {
     if (!item) {
@@ -635,9 +649,9 @@ function commandRegisterIssue(args) {
       issueNumber: issue.number,
       item: item ?? {},
       labels: issue.labels,
-      expectedStatus,
+      expectedStatus: validateStatus,
       expectedIssueType: issueType,
-      expectedPriority,
+      expectedPriority: validatePriority,
     });
     for (const message of validation.messages) console.log(message);
     console.log('Run again with --apply to register the issue and set Project fields.');
@@ -669,14 +683,17 @@ function commandRegisterIssue(args) {
     issueNumber: issue.number,
     item: verifyItem,
     labels: issue.labels,
-    expectedStatus,
+    expectedStatus: validateStatus,
     expectedIssueType: issueType,
-    expectedPriority,
+    expectedPriority: validatePriority,
   });
   for (const message of validation.messages) console.log(message);
   if (validation.ok) {
+    // preserve 모드에서 기존 값을 보존했을 수 있으므로 실제 보드 값을 보고한다.
+    const finalStatus = projectItemFieldValue(verifyItem, 'Status') ?? expectedStatus;
+    const finalPriority = projectItemFieldValue(verifyItem, 'Priority') ?? expectedPriority;
     console.log(
-      `issue #${issue.number}: Project registered (Status=${expectedStatus}, IssueType=${issueType}, Priority=${expectedPriority})`,
+      `issue #${issue.number}: Project registered (Status=${finalStatus}, IssueType=${issueType}, Priority=${finalPriority})`,
     );
   }
   return validation.ok ? 0 : 1;
@@ -757,7 +774,7 @@ function help() {
   node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project N [--apply]
   node scripts/github_project_lifecycle.mjs validate-issue --repo OWNER/REPO --owner OWNER --project N --issue N [--expected-status Todo|In progress|Done|any] [--expected-issue-type TYPE] [--expected-priority PRIORITY]
   node scripts/github_project_lifecycle.mjs start-work --repo OWNER/REPO --owner OWNER --project N --issue N [--apply]
-  node scripts/github_project_lifecycle.mjs register-issue --repo OWNER/REPO --owner OWNER --project N --issue N --issue-type epic|story|... [--status Todo] [--priority major] [--apply]
+  node scripts/github_project_lifecycle.mjs register-issue --repo OWNER/REPO --owner OWNER --project N --issue N --issue-type epic|story|... [--status Todo] [--priority major] [--preserve-existing] [--apply]
   node scripts/github_project_lifecycle.mjs pr-merged --repo OWNER/REPO --owner OWNER --project N (--pr N | --body-file FILE | --body-env ENV) [--apply]
 `);
 }

--- a/tests/test_create_epic_story_issues.py
+++ b/tests/test_create_epic_story_issues.py
@@ -152,6 +152,8 @@ class CreateEpicStoryBoardTests(unittest.TestCase):
         self.assertEqual(3, node_log.count("register-issue"))
         self.assertEqual(1, node_log.count("--issue-type epic"))
         self.assertEqual(2, node_log.count("--issue-type story"))
+        # fresh 경로(새 이슈)는 strict 등록 — preserve 안 함 (Todo/major 강제 + 검증).
+        self.assertEqual(0, node_log.count("--preserve-existing"))
 
     def test_skips_board_when_no_coords_but_still_creates_issues(self):
         result, gh_log, node_log, _ = self._run(STORIES_NEW, {})
@@ -181,6 +183,9 @@ class CreateEpicStoryBoardTests(unittest.TestCase):
         self.assertIn("--issue 100", node_log)
         self.assertIn("--issue 101", node_log)
         self.assertIn("--issue 102", node_log)
+        # 백필 회귀 가드 (#669): 기존 item 의 triage 상태(In progress/Done/priority)를
+        # 되돌리지 않도록 백필 경로는 register-issue 에 --preserve-existing 를 넘긴다.
+        self.assertEqual(3, node_log.count("--preserve-existing"))
 
 
 if __name__ == "__main__":

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -665,6 +665,58 @@ class GithubProjectLifecycleScriptTests(unittest.TestCase):
                 "})"
             )
 
+    def test_resolve_validation_relaxes_only_preserved_non_empty_field(self) -> None:
+        # preserve + 원래 값이 있던 필드 → 완화('any')로 보존값을 drift 오판 안 함.
+        item = {"status": "In progress", "priority": "minor"}
+        result = run_node(
+            "lifecycle.resolveValidationExpectations({"
+            f"item: {json.dumps(item)},"
+            "preserveExisting: true"
+            "})"
+        )
+        self.assertEqual(
+            {"validateStatus": "any", "validatePriority": "any"}, result
+        )
+
+    def test_resolve_validation_keeps_strict_for_blank_field(self) -> None:
+        # 백필 회귀 가드 (#669 round3): preserve 라도 원래 비어있던 Status 는 채우기 대상이라
+        # strict('Todo') 유지 → apply 가 실제로 채웠는지(부분 백필 실패) 검증한다.
+        item = {"priority": "major"}  # status 미설정 → 채움 대상
+        result = run_node(
+            "lifecycle.resolveValidationExpectations({"
+            f"item: {json.dumps(item)},"
+            "preserveExisting: true"
+            "})"
+        )
+        self.assertEqual(
+            {"validateStatus": "Todo", "validatePriority": "any"}, result
+        )
+
+    def test_resolve_validation_new_item_all_strict(self) -> None:
+        # 신규 add(item 없음)는 보존 대상 없음 → 전부 strict.
+        result = run_node(
+            "lifecycle.resolveValidationExpectations({"
+            "item: null,"
+            "preserveExisting: true"
+            "})"
+        )
+        self.assertEqual(
+            {"validateStatus": "Todo", "validatePriority": "major"}, result
+        )
+
+    def test_resolve_validation_non_preserve_all_strict(self) -> None:
+        # preserve 아님(fresh) → 기존 값 있어도 전부 strict (Todo/major 강제 검증).
+        item = {"status": "In progress", "priority": "minor"}
+        result = run_node(
+            "lifecycle.resolveValidationExpectations({"
+            f"item: {json.dumps(item)},"
+            "preserveExisting: false"
+            "})"
+        )
+        self.assertEqual(
+            {"validateStatus": "Todo", "validatePriority": "major"}, result
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -546,6 +546,75 @@ class GithubProjectLifecycleScriptTests(unittest.TestCase):
             result["sets"],
         )
 
+    def test_plan_registration_preserve_existing_keeps_triaged_state(self) -> None:
+        # 백필 회귀 가드 (#669): preserveExisting 이면 사용자가 옮긴 In progress /
+        # 바뀐 priority 를 Todo/major 로 되돌리지 않는다 (이미 값 있으면 보존).
+        item = {"status": "In progress", "issueType": "story", "priority": "minor"}
+
+        result = run_node(
+            "lifecycle.planRegistration({"
+            f"item: {json.dumps(item)},"
+            f"fields: {json.dumps(STANDARD_FIELDS)},"
+            "issueType: 'story',"
+            "preserveExisting: true"
+            "})"
+        )
+
+        self.assertFalse(result["needsAdd"])
+        self.assertEqual([], result["sets"])
+
+    def test_plan_registration_preserve_existing_fills_only_empty_field(self) -> None:
+        # preserveExisting 이라도 비어있는 필드(부분 등록 실패 잔여)는 채운다.
+        item = {"issueType": "story", "priority": "major"}  # status 미설정
+
+        result = run_node(
+            "lifecycle.planRegistration({"
+            f"item: {json.dumps(item)},"
+            f"fields: {json.dumps(STANDARD_FIELDS)},"
+            "issueType: 'story',"
+            "preserveExisting: true"
+            "})"
+        )
+
+        self.assertFalse(result["needsAdd"])
+        set_map = {entry["fieldName"]: entry["optionName"] for entry in result["sets"]}
+        self.assertEqual({"Status": "Todo"}, set_map)
+
+    def test_plan_registration_preserve_existing_new_item_sets_all(self) -> None:
+        # 보드에 없던 item 은 preserveExisting 여도 풀 등록 (Todo/story/major).
+        result = run_node(
+            "lifecycle.planRegistration({"
+            "item: null,"
+            f"fields: {json.dumps(STANDARD_FIELDS)},"
+            "issueType: 'story',"
+            "preserveExisting: true"
+            "})"
+        )
+
+        self.assertTrue(result["needsAdd"])
+        set_map = {entry["fieldName"]: entry["optionName"] for entry in result["sets"]}
+        self.assertEqual(
+            {"Status": "Todo", "IssueType": "story", "Priority": "major"},
+            set_map,
+        )
+
+    def test_plan_registration_preserve_existing_still_corrects_issue_type(self) -> None:
+        # IssueType 은 정체성이라 preserve 모드여도 drift 교정 (Status/Priority 만 보존).
+        item = {"status": "In progress", "issueType": "epic", "priority": "minor"}
+
+        result = run_node(
+            "lifecycle.planRegistration({"
+            f"item: {json.dumps(item)},"
+            f"fields: {json.dumps(STANDARD_FIELDS)},"
+            "issueType: 'story',"
+            "preserveExisting: true"
+            "})"
+        )
+
+        self.assertFalse(result["needsAdd"])
+        set_map = {entry["fieldName"]: entry["optionName"] for entry in result["sets"]}
+        self.assertEqual({"IssueType": "story"}, set_map)
+
     def test_plan_registration_rejects_unknown_issue_type(self) -> None:
         with self.assertRaises(subprocess.CalledProcessError):
             run_node(


### PR DESCRIPTION
## 관련 이슈 번호

Part of #669

<!-- #669/#670 은 이미 머지됨. 본 PR 은 머지 후 codex 리뷰에서 발견된 회귀를 고치는 follow-up 이라 정보용 Part of (auto-close 미발동). -->

## 배경 및 문제

PR #670 (이슈 #669) 머지 직후 누락했던 codex 리뷰를 머지된 6커밋(`b77ae21..6a40cd8`)에 돌린 결과 P2 회귀 1건이 발견됐다.

`create_epic_story_issues.sh` 의 멱등 백필 경로(`stories.md` 에 issue marker 가 이미 있고 보드가 연결된 상태에서 재실행)는 `register_board` 를 다시 돌린다. 그런데 `register-issue` 는 항상 `Status=Todo` / `Priority=major` 를 강제하므로, 사용자가 이미 보드에서 `In progress`/`Done` 으로 옮겼거나 priority 를 바꾼 스토리를 **재실행 한 번에 Todo/major 로 되돌려버린다**. 멱등 분리 이전(skip-only) 대비 명백한 회귀.

## 원인

`register-issue` 는 본질적으로 "이슈를 보드에 *초기* 배치" 하는 동사인데, 백필 경로가 이를 **이미 triage 된 기존 item 에도 그대로 재적용**했다. `planRegistration` 이 "현재값 ≠ 기대값이면 set" 규칙이라 `In progress`(≠Todo) 를 drift 로 보고 Todo 로 덮어쓴 것이 진원지. fresh 경로(새 이슈)는 항상 빈 필드라 무해 — 백필 경로만 문제.

## 작업내용

- `scripts/github_project_lifecycle.mjs`
  - `planRegistration` 에 `preserveExisting` 옵션 추가. preserve 모드에서 **Status/Priority 는 비어있을 때만 set**(사용자 triage 보존, 부분 등록 실패로 빈 필드는 채움). **IssueType(epic/story = 이슈 정체성)은 preserve 모드여도 항상 drift 교정** — preserve 대상에서 의도적으로 제외.
  - `commandRegisterIssue` 에 `--preserve-existing` 플래그. 기존 item 보존 시 Status/Priority 사후검증을 `'any'` 로 완화해 보존값을 drift 로 오판(false-fail)하지 않게 함. 새로 add 한 item 은 strict 유지. 성공 로그는 실제 보드 값을 출력.
  - `parseArgs` boolean 등록 + help 문구.
- `scripts/create_epic_story_issues.sh`
  - `register_board` 에 `mode` 인자. **백필 경로(멱등 재실행)만 `--preserve-existing` 전달**, fresh 경로(새 이슈)는 strict(Todo/major 강제) 유지.
- 테스트: `planRegistration` preserve 4 케이스(기존 triage 보존 / 빈 필드만 채움 / 신규 풀 등록 / IssueType 항상 교정) + 백필·fresh 의 `--preserve-existing` 전달 구분 검증.

## 결정 근거

codex 가 제시한 두 대안 — (a) 기존 lifecycle 보존, (b) 보드에 없는 item 에만 적용 — 중 **(a) 채택**. (b)(add-if-missing only)는 첫 실행에서 item-add 는 됐으나 field set 이 실패한 부분 등록 잔여를 못 메운다. (a) 의 "비어있을 때만 set" 은 그 갭까지 채우면서 triage 상태는 보존하므로 더 견고.

IssueType 을 preserve 에서 제외한 이유: IssueType 은 사용자가 triage 하는 lifecycle 이 아니라 이슈의 *정체성*이다. 이를 보존 대상에 넣으면 보드에 잘못 박힌 IssueType 을 못 고치고 검증 실패까지 유발 — 새 결함을 만들게 된다. Status/Priority(triage)만 보존, IssueType 은 항상 강제가 올바른 경계.

같은 클래스 결함 점검: `start-work`(→In progress) / `pr-merged`(→Done) 는 의도적 상태 전이라 무관, `/to-issue` 는 새 이슈라 빈 필드 → 안전. 회귀는 백필 경로 단 한 곳 → 국소 수정.

## 배포 경로 검증 (plug-in 영향 시)

- 변경 파일 `scripts/github_project_lifecycle.mjs`, `scripts/create_epic_story_issues.sh` 는 **plug-in 본체** 로, 외부 활성 프로젝트는 `$PLUGIN_ROOT/scripts/...` 로 직접 호출한다 (`commands/init-dcness.md:528` — "사용자 repo 에 mjs 를 복사하지 않는다"). init-dcness cp 스텝 불필요.
- 도달 경로 = **배포경로 1** (plug-in 버전업으로 자동 반영). PR #670 과 동일 경로 동일 파일이라 추가 배포 작업 없음.
- 사용자용 SSOT 문서(`docs/plugin/issue-lifecycle.md`, `github-project.md`)의 계약은 불변(보드 등록은 그대로, 백필이 기존 상태를 보존한다는 점만 강화) — 문서 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. 기존 `register-issue` 서브커맨드에 내부 플래그 1개 추가뿐.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 (937 OK, `python3.11 -m unittest discover -s tests`)
- [x] 회귀 검증 (백필이 `In progress`/`Done`/바뀐 priority 보존, IssueType 교정 + fresh strict 유지)
- [x] cross-ref / public-surface 게이트 PASS
- [x] `bash -n` / `node --check` 문법 PASS

## 참고

머지 후 누락했던 "꼼꼼구현" codex 리뷰 루프의 follow-up. round 1 결과(P2 1건)를 본 PR 로 수정 → 머지 전 codex round 2 로 #669 전체 그림(`--base b77ae21`) 재리뷰 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
