### PR TITLE
[docs] hooks.md 3-layer enforcement map + sync gate

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -1,319 +1,315 @@
-# Hooks SSOT — dcness 코드 강제 백본
+# Hooks SSOT — 3-layer enforcement map
 
 > **Status**: ACTIVE
-> **Scope**: dcness plug-in 이 활성 프로젝트에 적용하는 8 hook 의 시점 / 역할 / 차단 동작 / 우회 메커니즘 SSOT.
+> **Scope**: `/init-dcness` 로 활성화된 사용자 프로젝트에서 dcNess 가 어떤 시점에 무엇을 막는지 설명한다.
 > **Cross-ref**: [`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일) (대원칙), [`harness/agent_boundary.py`](../../harness/agent_boundary.py) (권한 매트릭스). catastrophic 시퀀스 진본 = 본 문서 [catastrophic-gate.sh](#catastrophic-gatesh).
 
----
+dcNess 의 강제 영역은 두 가지뿐이다.
 
-## 정체성 — hook 은 dcness 의 *유일한* 코드 강제 백본
+1. **작업 순서** — agent 시퀀스 + retry 전제
+2. **접근 영역** — 파일 경계 + 외부 시스템 mutation 차단
 
-dcness 가 강제하는 영역은 단 2가지 ([`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)):
-1. **작업 순서** — agent 시퀀스 + retry 정책
-2. **접근 영역** — 파일 경계 (ALLOW/READ_DENY) + 외부 시스템 mutation 차단
+그 외 prose 형식, handoff 형식, preamble, marker, status JSON, flag 는 agent 자율이다. 이 문서는 위 두 강제 영역이 실제 실행 환경에서 어느 레이어에 걸려 있는지 보여준다.
 
-그 *외* 모든 영역 = agent 자율 / 권고 / 측정. hook 은 위 2 영역의 *유일한 코드 구현*. 다른 모든 SSOT (routing / loop-procedure) 는 hook 동작을 *문서화* 한 자연어 spec 이며, 위반 시 실제로 *차단* 하는 주체는 본 문서가 다루는 8 hook.
+## 한눈 요약
 
----
+| Layer | 실행 주체 | 발화 시점 | 주 역할 | 대표 차단 |
+|---|---|---|---|---|
+| **1. CC hooks** | Claude Code plug-in hook | Claude 가 tool 을 쓰기 전/후, sub-agent 종료, 메인 응답 종료 | 작업 순서, 파일 경계, TDD, run state 보존 | 잘못된 agent 순서, out-of-bound file write, test 없는 TS/JS 구현 |
+| **2. git hooks** | local git | commit / checkout / push lifecycle | 로컬 git 조작 조기 차단 | 커밋 제목 위반, main 직접 push, 브랜치명 위반 |
+| **3. CI/CD workflows** | GitHub Actions | PR / issue / merge event | 로컬 우회와 원격 상태 drift 검증 | PR 제목/body 위반, Project lifecycle drift |
 
-## CC hook event 모델
+주의: CI workflow 파일이 설치되어 실행되는 것과 branch protection 또는 ruleset 의 required check 로 merge 를 막는 것은 별개다. 활성 프로젝트에서 hard merge gate 로 쓰려면 해당 repo 의 GitHub 설정에서 required check 로 연결해야 한다.
 
-dcness 가 사용하는 CC hook event 5종:
+## Layer 1 — CC hooks
 
-| Event | 시점 | 차단 권한 | dcness 사용 hook |
-|---|---|---|---|
-| `SessionStart` | CC 새 conversation 시작 시 (resume / `/clear` 포함). user 첫 prompt 처리 *전*. | X (inject 만) | session-start.sh |
-| `PreToolUse` | tool 호출 *직전*. matcher 매치 시 fire. | ✓ (`exit 2` + stderr 로 차단 — `exit 1` 은 non-blocking error 라 도구 그대로 진행) | catastrophic-gate / file-guard / tdd-guard |
-| `PostToolUse` | tool 호출 *직후* (결과 반환 후, 메인 다음 turn 시작 전). | X (inject 만) | post-agent-clear / post-file-op-trace |
-| `SubagentStop` | sub-agent 종료 직후 (sub 컨텍스트 종료 시점). `agent_id` + `agent_type` 동반. | ✓ (`exit 2` 가능하나 dcness 는 미사용 — state clear 만) | subagent-stop-clear.sh |
-| `Stop` | 메인 응답 종료 시점. 무한 루프 방지 `stop_hook_active=true` 플래그 동반. | ✓ (`decision: "block"` JSON stdout 으로 메인 turn 재 발화 강제) | stop-end-run.sh |
+등록 SSOT: [`hooks/hooks.json`](../../hooks/hooks.json). Claude Code 가 plug-in 활성 시 이 파일을 읽어 hook 을 등록한다. 모든 wrapper 는 `CLAUDE_PLUGIN_ROOT` 를 기준으로 plug-in 코드를 찾고, 현재 프로젝트가 dcNess 활성 whitelist 에 없으면 즉시 no-op 한다.
 
-**미사용 event**: `UserPromptSubmit` / `PreCompact` / `SubagentStart` / `Notification` / `SessionEnd` — dcness 가 쓰는 event 는 SessionStart + PreToolUse + PostToolUse + SubagentStop + Stop 5종.
+| Hook | Event / matcher | 언제 | 하는 일 | 차단 |
+|---|---|---|---|---|
+| `session-start.sh` | `SessionStart` | 새 세션, resume, `/clear` 직후 | sid/live state 초기화 + 활성 안내 inject | X |
+| `catastrophic-gate.sh` | `PreToolUse / Agent` | sub-agent 호출 직전 | catastrophic 시퀀스 + strict conveyor step 순서 검사 | O |
+| `file-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit|Read|Bash|mcp__.*` | file/bash/MCP tool 호출 직전 | agent 별 파일 경계 + 외부 mutation denylist 검사 | O |
+| `tdd-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit` | 파일 수정 직전 | TS/JS 구현 파일에 매칭 test 존재 확인 | O |
+| `post-agent-clear.sh` | `PostToolUse / Agent` | sub-agent 호출 직후 | active agent clear, prose 자동 staging, histogram inject | X |
+| `post-file-op-trace.sh` | `PostToolUse / Edit|Write|NotebookEdit|Read|Bash|mcp__.*` | file/bash/MCP tool 호출 직후 | agent trace append | X |
+| `subagent-stop-clear.sh` | `SubagentStop` | sub-agent 컨텍스트 종료 직후 | active agent clear 보강 | X |
+| `stop-end-run.sh` | `Stop` | 메인 응답 종료 시 | end-run 자동화 + 다음 step continuation signal | 조건부 재발화 |
 
-**차단 권한 비대칭**:
-- PreToolUse 만 tool 호출 *차단* 가능 → catastrophic-gate / file-guard / tdd-guard 가 실제 강제 백본. **차단은 반드시 `exit 2`** — CC docs 상 PreToolUse 의 `exit 1` 은 non-blocking error 라 도구가 그대로 진행한다. **정책 위반과 hook 크래시를 구분**하기 위해 Python CLI (`harness/hooks.py`) 가 *정책 위반* 만 `exit 2` 로 내보내고, wrapper 는 `RC==2` 만 차단으로 통과시킨다. import/문법 오류 등 파이썬 크래시는 `exit 1` → wrapper 가 **fail-open**(allow) — hook 버그가 모든 도구 호출을 과차단하지 않게 (#597 round5). exit 2 라야 stderr reason 이 Claude 에 피드백된다.
-- Stop 은 메인 종료 *차단* 가능 (`decision: "block"`) → stop-end-run.sh 가 중간 step PASS 후 메인 침묵 회귀 차단 (issue #469 결함 A).
-- SubagentStop 은 sub 종료 *차단* 가능 (`exit 2`) 하지만 dcness 는 쓰지 않는다 — `active_agent` 단일 슬롯 clear 만 수행하고 항상 `exit 0` (sub 종료 허용). file-op 권한/trace 는 payload 의 `agent_type` self-attribution 이 담당하므로 (issue #598) clear 는 보조 정리 역할.
-- SessionStart + PostToolUse 는 `hookSpecificOutput.additionalContext` 로 *컨텍스트 inject* — 메인 Claude 의 다음 turn 에 system reminder 로 보임.
-
----
-
-## 공통 패턴 (전 8 hook 공유)
-
-모든 hook 의 bash wrapper 가 동일한 부트스트랩 4 단계 수행:
+### CC hook 공통 실행 패턴
 
 ```bash
 set -uo pipefail
-
-# 1. plug-in root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
-
-# 2. 활성화 게이트 — dcness whitelist 외 프로젝트면 즉시 pass-through
 python3 -m harness.session_state is-active >/dev/null 2>&1 || exit 0
-
-# 3. CC PID 추출 (bash 의 PPID = CC main process)
 CC_PID=$PPID
-
-# 4. Python dispatch
 python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
 ```
 
-**활성화 게이트 메커니즘**:
-- `harness/session_state.py is-active` 가 현재 프로젝트가 dcness 활성 여부 판정 (`/init-dcness` 로 등록된 whitelist + marker 검사)
-- 미활성 프로젝트 → hook 즉시 `exit 0` (no-op). plug-in 설치만 했고 활성화 안 한 프로젝트엔 영향 X.
+PreToolUse 차단 hook 은 정책 위반만 `exit 2` 로 내보낸다. Claude Code 에서 `exit 2` 는 tool 호출을 막고 stderr 를 모델에게 보여준다. import 오류나 hook 자체 오류는 fail-open 쪽으로 처리해 hook 버그가 전체 작업을 과차단하지 않게 한다.
 
-**Python handler dispatch**: 모든 차단 / inject 로직은 [`harness/hooks.py`](../../harness/hooks.py) 안. bash wrapper 는 thin shim.
-
-### local provider routing 은 hook 이 아니다
-
-`code-validator` / `architecture-validator` / `pr-reviewer` 만 Codex read-only 실행으로 opt-in route 할 수 있다. 이는 hook 강제 백본이 아니라 메인 Claude 의 agent 호출 선택지다.
-
-- config: `~/.claude/plugins/data/dcness-dcness/routing.json`
-- CLI: `dcness-helper routing status|doctor|enable-codex-validation|disable-codex-validation|set|resolve`
-- wrapper: `scripts/dcness-codex-validator`
-- 대상: read-only validation 3종만. engineer / build-worker / module-architect 등 mutation agent 는 Claude route 고정.
-
-Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함하며 repo mutation 을 금지한다. 실행 전후 git status snapshot 이 달라지면 block 하고 자동 revert 하지 않는다.
-
----
-
-## 8 hook 상세
+Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision: "block"` JSON 을 stdout 으로 내보내 메인 turn 을 재발화시킨다.
 
 ### session-start.sh
 
-**Event**: `SessionStart`
-**시점**: CC 가 새 conversation 시작 시. user 첫 prompt 처리 *전*.
+**시점**: Claude Code 세션 시작, resume, `/clear` 직후.
 
 **역할**:
-- (a) sid 추출 + `.by-pid/<cc_pid>` 작성 + `live.json` 초기화 (state machine bootstrap). `.by-pid-current-run/<cc_pid>` 는 SessionStart 가 아니라 `begin-run` 이 작성한다 (run 시작 시점). `.session-id` pointer 는 legacy 폴백이라 SessionStart 가 쓰지 않는다 (멀티세션 정합은 `.by-pid` 가 담당).
-- (b) **슬림 inject (#596)** — `hookSpecificOutput.additionalContext` 로 *최소 활성 안내만* inject (~10줄): dcness 활성 사실 + 코드 강제 gate (catastrophic-gate / file-guard / tdd-guard / stop-end-run) 가 켜져 있다는 안내 + hook-first recovery 원칙. **문서 진입 매트릭스 / 안티패턴 / soft 필수 / cost-aware 행동은 inject 하지 않는다** — 절차·라우팅은 skill 진입 시 해당 skill 이 안내하고, 위반 복구 정보는 각 blocking hook 메시지가 그 자리에서 제공한다 (문서 선독 기반 compliance 가 아닌 hook-first recovery 모델).
-  - 메인 Claude 첫 응답 첫 줄에 토큰 `[dcness 활성 확인]` 출력 (활성 신호 — 토큰 부재 시 사용자가 룰 미적용 즉시 확인)
 
-**차단 동작**: SessionStart 는 차단 권한 X. `additionalContext` inject 만. 실패 시 silent (`exit 0`).
+- sid 추출, `.by-pid/<cc_pid>` 작성, `live.json` 초기화
+- `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
+- 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
 
----
+**차단**: 없음. 실패해도 세션 시작을 막지 않는다.
 
 ### catastrophic-gate.sh
 
-**Event**: `PreToolUse`
-**Matcher**: `Agent`
-**시점**: 메인 Claude 가 sub-agent 호출 (Task tool with `subagent_type`) *직전*.
+**시점**: 메인 Claude 가 `Agent` tool 로 sub-agent 를 호출하기 직전.
 
-**역할**: **catastrophic 시퀀스 + conveyor step 순서 강제** — 본 [catastrophic-gate.sh](#catastrophic-gatesh) = catastrophic 시퀀스 **진본 SSOT** 이자 active conveyor run 의 `begin-step → Agent → end-step` 물리 순서 gate. 다음 catastrophic 룰은 *어떤 동적 결정* 으로도 우회 금지. 원칙 — "흐름 강제는 catastrophic 시퀀스와 그 전제인 conveyor step 진입, 그 외 모든 시퀀스 = agent 자율".
+**역할**: catastrophic 시퀀스와 active conveyor run 의 `begin-step -> Agent -> end-step` 물리 순서를 강제한다.
 
-| 게이트 | 내용 | 강제 주체 |
-|---|---|---|
-| pr-reviewer 게이트 | engineer sub-agent 산출물(`engineer-IMPL.md` / `engineer-POLISH.md`) 존재 시 code-validator PASS 없이 pr-reviewer 호출 금지 | catastrophic-gate (코드) |
-| engineer 게이트 | engineer 가 module-architect `PASS` enum 발화 없이 src/ 작성 금지 (신규/보강/버그픽스 동일) | catastrophic-gate (코드) |
-| module-architect 게이트 | module-architect × K (architect-loop Step 4) 진입 직전 architecture-validator 1차 PASS 없이 진입 금지 | catastrophic-gate (코드) |
+| Gate | 차단 조건 |
+|---|---|
+| pr-reviewer gate | engineer 산출물이 있는데 code-validator PASS 없이 pr-reviewer 호출 |
+| engineer gate | module-architect PASS 없이 engineer 가 src 구현으로 진입 |
+| module-architect gate | architecture-validator 1차 PASS 없이 architect-loop 의 module-architect 반복 진입 |
+| strict conveyor gate | active run 안에서 직전 `begin-step` 과 다른 agent/mode 호출, `current_step` 부재, 이미 staged 된 stale step |
 
-> **게이트 강제 주체**: `harness/hooks.py` / `catastrophic-gate.sh` 가 위 3 게이트를 코드로 강제 — 에러 메시지에 `[catastrophic: <게이트>]` 노출. 옛 merge-gate (LGTM 없이 merge) / impl-task-loop 3-commit 룰은 자연어 폐기.
-> **Lite lane 정합**: `/impl` Lite 는 메인 직접 구현 경로라 engineer prose 가 없고 code-validator 를 호출하지 않는다. 이 경우에도 `begin-step pr-reviewer` 는 strict conveyor gate 를 통과해야 하며, pr-reviewer 가 local diff 와 테스트 증거를 리뷰한다.
-> **tech-review 자연어 관례 (코드 강제 아님)**: `/architect-loop` 진입 후 tech-reviewer 재호출은 *관례상 비권장* 이지만 *tech-reviewer 전용* 코드 강제로 차단하지 않는다 (forcing function 을 catastrophic 코드 강제하지 않는 대원칙 — [`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)). tech-review 는 architect-loop 진입 *전* 단방향 선행 단계라 재호출이 거의 필요 없을 뿐, 재호출 여부는 메인/사용자 자율 판단. *진입 gate* (PRD 변경 → 2차 tech-review 없이 진입 금지) 도 자연어 — `skills/tech-review/SKILL.md` / `skills/architect-loop/SKILL.md` 가 기능 참조. architect-loop 도중 tech-review 미검증 새 외부 의존 발견 시 처리 = `NEW_DEP_ESCALATE` 3안 (채택+수동검증 / 대안 우회 / 전체 회귀 — 어느 경우든 tech-reviewer 재호출 0). 라우팅 = [`../../skills/architect-loop/architect-loop-routing.md`](../../skills/architect-loop/architect-loop-routing.md#escalate-처리) escalate.
-> **strict conveyor gate 와의 관계**: 위 "재호출 비권장" 은 *tech-reviewer 전용 차단 제거* 를 뜻한다 — 자유 재호출은 active conveyor run *밖* (메인 루프 / 루프 finalize 후, run 부재라 게이트 미발화) 에서 일어난다. active conveyor run *안* 에서 tech-reviewer 를 부르면 strict conveyor gate 가 (tech-reviewer 특정이 아니라 *모든* off-sequence agent 에) `begin-step` 선언을 요구한다 — 이는 별개의 일반 conveyor 무결성 룰이고, 루프 도중 의존 검증 자체는 `NEW_DEP_ESCALATE` 로 간다.
+**strict conveyor 대상**: `entry_point=architect-loop|design|impl|ux`. 정상 `/design` 은 `begin-run architect-loop` 로 시작하지만, 실수로 `begin-run design` 한 run 도 같은 strict conveyor gate 와 module-architect gate 를 탄다.
 
-**strict conveyor gate** (#604): active conveyor run(`entry_point=architect-loop|design|impl|ux`) 안의 `Agent` 호출은 직전 `begin-step` 의 `current_step.agent/mode` 와 일치해야 한다. 정상 `/design` 은 `begin-run architect-loop` 로 시작하지만, 실수로 `begin-run design` 한 run 도 같은 strict conveyor gate 와 module-architect 게이트를 탄다. `current_step` 부재, agent/mode 불일치, 이미 staged 된 `current_step.prose_file`, 또는 `ledger.jsonl` 의 step_completed event 에 이미 기록된 stale current_step 은 PreToolUse 에서 차단한다. 복구 메시지는 `begin-step` 누락, `end-step` 필요, 다음 `begin-step` 필요 중 하나를 stderr 로 안내한다. `end-step` 성공 시 matching `current_step` 은 지워져 다음 Agent 호출이 새 `begin-step` 없이 통과하지 않는다.
+**tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. design/architect-loop 도중 미검증 새 외부 의존이 발견되면 architect-loop 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 
-**차단 동작**: handler 가 정책 위반 시 `1` 반환 → Python CLI 가 `exit 2` 로 내보냄 → wrapper 가 `RC==2` 를 그대로 통과 → CC 가 Agent 호출 거부 + stderr 메시지 노출. 메인이 회복 또는 사용자 위임. (파이썬 크래시 `exit 1` 은 wrapper 가 fail-open — hook 버그발 과차단 회피. tech-review 관련 자연어 관례는 메인 prose 가 자율 보존)
-
----
+**차단**: 위반 시 `exit 2` + stderr. 에러 메시지는 `[catastrophic: <gate>]` 형태를 포함한다.
 
 ### file-guard.sh
 
-**Event**: `PreToolUse`
-**Matcher**: `Edit|Write|NotebookEdit|Read|Bash|mcp__.*`
-**시점**: 모든 file / bash / mcp tool 호출 *직전* (sub-agent 활성 시 + 메인 직접 모두).
+**시점**: `Edit`, `Write`, `NotebookEdit`, `Read`, `Bash`, `mcp__.*` tool 호출 직전.
 
-**역할**: [`harness/agent_boundary.py`](../../harness/agent_boundary.py) 권한 매트릭스 강제
+**역할**: [`harness/agent_boundary.py`](../../harness/agent_boundary.py) 권한 매트릭스를 강제한다.
 
-| 룰 | 영향 |
+| Rule | 효과 |
 |---|---|
-| `DCNESS_INFRA_PATTERNS` | 전 sub-agent 의 인프라 path 차단 (`.claude/`, `hooks/`, `harness/*.py`, `docs/plugin/*.md`, `scripts/*.mjs`) |
-| `RUN_DIR_PROSE_ALLOW` | INFRA `.claude/` 의 좁은 예외 — `<run_dir>/*.md` (sub-agent step prose self-write, 예 build-worker `build-{test,impl,validate}.md`). INFRA/ALLOW 검사보다 먼저 적용 |
-| `ALLOW_MATRIX` | agent 별 Write 허용 path (예 engineer = `src/**`, designer = `design-variants/**`, build-worker = engineer ∪ test-engineer, tech-reviewer = `docs/tech-review.md` + `docs/tech-review/**`) |
-| `READ_DENY_MATRIX` | agent 별 Read 금지 (예 designer 는 `src/` 못 읽음) |
-| 외부 mutation denylist | sub-agent 의 `git push` / `gh pr (create\|merge\|review\|...)` / `gh api`(mutating method·field flag) / GitHub MCP **PR·repo** mutation(`merge_pull_request`/`push_files`/`create_pull_request`/`create_or_update_file` 등) 차단. **GitHub issue mutation 은 예외** — per-agent `tools:` 로 부여된 issue 작업 권한은 CC 가 gate (op 에 `issue` 포함 시 통과). read-only·메인 통과. 절대 실행 경로(`/usr/bin/git`, `/opt/homebrew/bin/gh`)는 명령명으로 정규화한다. 흔한 래퍼(`sudo`/`env`/subshell`)는 벗겨 식별하고, 단순 nested shell(`bash/sh/zsh -c "..."`)·`eval "..."` payload 는 재귀 검사한다. `$(...)`·backtick·문자열 조립·값-소비 래퍼 옵션 뒤 명령은 휴리스틱 한계 — *보안 경계 아닌 실수 방지* denylist (#597 커밋5, #601 보강) |
-| `is_infra_project()` | dcness 자체 작업 시 위 모두 해제 |
+| `DCNESS_INFRA_PATTERNS` | sub-agent 의 `.claude/`, `hooks/`, `harness/*.py`, `docs/plugin/*.md`, `scripts/*.mjs` 등 infra path 접근 차단 |
+| `RUN_DIR_PROSE_ALLOW` | build-worker 가 자기 run dir 의 `build-*.md` prose 를 쓰는 좁은 예외 |
+| `ALLOW_MATRIX` | agent 별 Write 허용 path 제한 |
+| `READ_DENY_MATRIX` | agent 별 Read 금지 path 제한 |
+| 외부 mutation denylist | sub-agent 의 `git push`, `gh pr create/merge/review`, mutating `gh api`, GitHub MCP PR/repo mutation 차단 |
 
-**메인 Claude turn** (sub-agent 비활성): pass-through. `mcp__.*` tool: `file_path` 부재 시 file path boundary skip — 단 `mcp__github__*` mutation 은 외부 mutation denylist 로 차단 (sub-agent 한정). 그 외 mcp tool 은 trace 만.
-**차단 동작**: handler 가 경계 위반 시 `1` 반환 → Python CLI 가 `exit 2` 로 내보냄 → wrapper 가 `RC==2` 통과 → tool 호출 거부 + stderr (파이썬 크래시 `exit 1` 은 fail-open). custom agent 추가 시 `ALLOW_MATRIX` 행 등록 의무 (미정의 agent 는 false-positive 회피로 통과 — 차단 아님).
+메인 Claude turn 은 file boundary 를 통과한다. GitHub issue mutation 은 agent tool 권한 설계에 맡기고 file-guard 에서는 예외로 둔다. PR/repo mutation 은 sub-agent 에서 차단한다.
 
-**코드 SSOT**: [`harness/agent_boundary.py`](../../harness/agent_boundary.py) — ALLOW / READ_DENY / DCNESS_INFRA_PATTERNS 권한 경계 (권한 진본).
-
----
+**차단**: 경계 위반 시 `exit 2` + stderr. `.no-dcness-guard` marker 는 file-guard 만 임시 우회한다.
 
 ### tdd-guard.sh
 
-**Event**: `PreToolUse`
-**Matcher**: `Edit|Write|NotebookEdit`
-**도입**: release 0.2.16 (PR #339 / #340)
-**시점**: Edit / Write tool 호출 *직전*.
+**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전.
 
-**역할**: TS / JS 파일 (`*.ts|*.tsx|*.js|*.jsx`) Edit / Write 시 매칭 test 파일 *존재* 검사. 없으면 deny.
+**역할**: TS/JS 구현 파일 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 에 대응하는 test/spec 파일이 있는지 확인한다. 없으면 구현 파일 작성을 막는다.
 
-**활성 게이트** (#597 커밋3): 다른 6 wrapper 와 동일하게 `is-active` 게이트를 가진다 — **미활성 프로젝트는 즉시 no-op(allow)**. 과거 tdd-guard 만 이 게이트가 없어, plug-in 설치만 하고 활성화 안 한 프로젝트에서도 deny 가 발동하던 결함을 수정.
+**skip 대상**:
 
-**skip 대상** (no-op, exit 0):
-- test 파일 자체 — `*test*`, `*spec*`, `*__tests__*`
-- 설정 / 비-코드 — `*.json`, `*.css`, `*.scss`, `*.md`, `*.yml`, `*.yaml`, `*.env*`, `*.config.*`, `*tailwind*`, `*postcss*`, `*next.config*`, `*tsconfig*`
-- 타입 — `*/types/*`, `*/types.ts`, `*/types.d.ts`, `*.d.ts`
-- Next.js 특수 — `*/layout.tsx`, `*/page.tsx`, `*/loading.tsx`, `*/error.tsx`, `*/not-found.tsx`, `*/globals.css`
-- 시드 / 시안 — `*/templates/*`, `*/design-variants/*`
-- 그 외 확장자 (`*.py`, `*.go` 등) — silent skip
+- test/spec 파일 자체, `__tests__`
+- 설정, markdown, yaml, env, css, 타입 선언
+- Next.js 특수 파일 (`layout`, `page`, `loading`, `error`, `not-found`, `globals.css`)
+- `templates/`, `design-variants/`
+- TS/JS 외 언어
 
-**매칭 test 파일 검사 6-tier 12 location** (DCN-CHG-20260522 — issue #469 결함 C 영역 확장):
-```
-Tier 1: <dir>/<name>.{test,spec}.{ts,tsx,js,jsx}
-Tier 2: <dir>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-Tier 3: <parent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-Tier 4: <grandparent>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-Tier 5: <src_root>/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-Tier 6: <PROJECT_ROOT>/src/__tests__/<name>.{test,spec}.{ts,tsx,js,jsx}
-```
+**매칭 위치**: 같은 디렉터리, 같은 디렉터리의 `__tests__`, 부모/조부모 `__tests__`, monorepo `src_root/__tests__`, 프로젝트 root `src/__tests__`.
 
-`<src_root>` = 파일 경로 안 `src/` 마디 직전까지 trim. monorepo `apps/<X>/src/...` / `packages/<X>/src/...` cover. trim 실패 (`src/` 부재) 시 `<PROJECT_ROOT>/src` fallback. Tier 4 (grandparent) + Tier 5 (src_root) = #469 결함 C 영역 확장 — build-worker 가 회피 stub 박는 안티패턴 차단.
-
-**차단 동작**: `exit 2` + stderr 로 한국어 안내 (테스트 부재 + 검사 위치 12곳 + 본 파일의 실측 `<dir>` / `<parent>` / `<grandparent>` / `<src_root>` / `<PROJECT_ROOT>` 값). 과거 `permissionDecision: deny` JSON 은 CC 본체 버그(anthropics/claude-code#37210) 영향이 가변이라 catastrophic-gate / file-guard 와 동일한 `exit 2` 로 통일. TDD 미이행 환경에선 plug-in 활성화 후 광범위한 deny 발생 가능.
-
----
+**차단**: test 부재 시 `exit 2` + 한국어 안내.
 
 ### post-agent-clear.sh
 
-**Event**: `PostToolUse`
-**Matcher**: `Agent`
-**시점**: sub-agent 호출 *직후* (Task tool 결과 반환 후, 메인 다음 turn 시작 전).
+**시점**: `Agent` tool 결과가 돌아온 직후.
 
 **역할**:
-- (a) `live.json.active_agent / active_mode` clear — 메인 Claude 복귀 표시
-- (b) **sub-agent prose 자동 저장** — `tool_response.text` → `<run_dir>/<agent>[-<MODE>].md` + `live.json.current_step.prose_file` 기록. 메인이 직접 Write 불필요.
-- (c) agent-trace 집계 → tool histogram + anomaly 검출
-- (d) **`additionalContext` inject** (`hookSpecificOutput` JSON) — 메인 다음 turn 의 Agent tool result 옆에 system reminder 로 보임. tool histogram 뿐 아니라 **prose staging 실패 진단**(`current_step` 부재 / extraction 실패 / `step_agent` 공백 등)도 함께 노출 — histogram 이 없어도 진단이 있으면 출력 (#597 커밋6). 기존 stderr→`/tmp` 로그는 유지.
-- (issue #392 — redo_log auto append + routing_telemetry.record_agent_call 폐기. baseline + 매커니즘 실측 0건)
 
-**차단 동작**: X (PostToolUse). stdout = JSON (`hookSpecificOutput`) inject. stderr = `/tmp/dcness-hook-stderr.log` 보존 (디버그용).
+- `live.json.active_agent / active_mode` clear
+- sub-agent prose 를 `<run_dir>/<agent>[-<MODE>].md` 로 자동 저장
+- `live.json.current_step.prose_file` 기록
+- tool histogram 과 staging 진단을 `hookSpecificOutput.additionalContext` 로 inject
 
----
+**차단**: 없음.
 
 ### post-file-op-trace.sh
 
-**Event**: `PostToolUse`
-**Matcher**: `Edit|Write|NotebookEdit|Read|Bash|mcp__.*`
-**시점**: file / bash / mcp tool 호출 *직후*.
+**시점**: file/bash/MCP tool 호출 직후.
 
-**역할**: 활성 sub-agent 가 있을 때만 `agent-trace.jsonl` 에 post phase 1줄 append.
-- 메인 Claude turn (active_agent 미설정) = noop
-- 비활성 프로젝트 = noop
+**역할**: 활성 sub-agent 가 있을 때 `agent-trace.jsonl` 에 post phase 1줄을 append 한다. 메인 Claude turn 이거나 비활성 프로젝트면 no-op 한다.
 
-**차단 동작**: X. agent 별 행동 trace 누적 → review report ([`harness/run_review.py`](../../harness/run_review.py)) 의 tool histogram + anomaly 검출 입력.
-
----
-
-### stop-end-run.sh
-
-**Event**: `Stop`
-**시점**: 메인 Claude 응답 종료 시. `stop_hook_active=true` 동반 시 즉시 skip (무한 루프 가드).
-**도입**: issue #382 (자동 end-run) + issue #469 결함 A fix (continuation signal)
-
-**역할 1 — 자동 end-run (issue #382)**:
-- `active_runs[rid]` 슬롯 미finalized + 마지막 step end-step 호출 완료 매칭 시 in-process `_cli_end_run` 호출.
-- 부산물: `<run_dir>/review.md` 생성 + loop-insights 누적 + active_runs slot finalize.
-- 배경: `/impl-loop` / `/architect-loop` 종료 후 메인이 end-run 까먹는 회귀 차단.
-
-**역할 2 — continuation signal (issue #469 결함 A)**:
-- end-run 호출 *전* 마지막 step prose (`<run_dir>/<agent>[-<MODE>].md`) 결론 enum 추출.
-- 다음 step 진입 가능 enum (`PASS` / `IMPL_DONE` / `POLISH_DONE` / `TESTS_WRITTEN` / `UX_FLOW_DONE`) **AND** 마지막 step agent 가 종료 agent (`pr-reviewer`) 아닌 경우 → `{"decision": "block", "reason": "..."}` JSON stdout 씀.
-- CC 가 본 신호 인식 → 메인 turn 재 발화 강제. 메인이 reason 읽고 다음 sub-step 진입 (예: build-worker PASS → pr-reviewer 호출).
-- 무한 루프 가드: 같은 step 에서 block 쓴 횟수 (`slot.stop_block_count[<agent>:<mode>]`) 가 `_STOP_BLOCK_COUNT_MAX = 2` 초과 시 skip — 메인이 reason 받고도 발화 안 하는 진짜 종료 의도 인정.
-- 배경: jajang Epic 20 multi-task `/impl-loop` 실측에서 build-worker tool_result 후 메인 turn 자동 발화 부재 = 9시간 16분 침묵 사례 ([issue #469](../../) 본문 참조).
-
-**차단 동작**:
-- 역할 1 분기 → `exit 0` + `_cli_end_run` 호출 (block 안 함, 정상 종료 허용).
-- 역할 2 분기 → `exit 0` + `decision:"block"` JSON stdout (메인 재 발화 강제).
-- 본 hook 의 차단 메커니즘 = stdout JSON 으로 CC 에 신호. stderr 는 `/tmp/dcness-hook-stderr.log` 보존 (디버그용).
-
-**코드 SSOT**: [`harness/hooks.py`](../../harness/hooks.py) `handle_stop` + `_maybe_emit_continuation_signal`.
-
----
+**차단**: 없음.
 
 ### subagent-stop-clear.sh
 
-**Event**: `SubagentStop`
-**시점**: sub-agent 종료 직후 (sub 컨텍스트 종료 시점). payload 에 `agent_id` + `agent_type` 동반.
-**도입**: issue #598 (병렬/백그라운드 sub-agent attribution)
+**시점**: sub-agent 컨텍스트 종료 직후.
 
-**역할**: `live.json.active_agent / active_mode` 단일 슬롯 clear 를 **PostToolUse Agent 매칭보다 신뢰도 높은 시점으로 승격**.
-- PostToolUse Agent clear 는 메인 컨텍스트에서 발화 + `agent_id` 가 없을 수 있어 취약. SubagentStop 은 sub 종료를 직접 신호하고 `agent_type` 을 동반한다.
-- **match-guard**: `active_agent == payload agent_type` 일 때만 clear → 동시 sub-agent 환경에서 다른 agent 의 슬롯을 오클리어하지 않음. `agent_type` 부재(구버전 CC) 시 best-effort 무조건 clear.
-- PostToolUse Agent 의 clear 는 그대로 유지 — 이중 안전망 (멱등).
+**역할**: `SubagentStop` payload 의 `agent_type` 을 사용해 active agent state 를 정리한다. PostToolUse Agent clear 보다 sub-agent 종료 시점에 더 가깝기 때문에 stale state 를 줄이는 보조 안전망이다.
 
-**왜 단일 슬롯 clear 만 하나**: 동시 sub-agent 의 권한/trace 정확 귀속은 file-op payload 의 `agent_type` self-attribution (`_resolve_acting_agent`) 이 담당한다 (issue #598). 따라서 `active_agent` 단일 슬롯은 구버전 폴백 + 보조 힌트 역할로 축소됐고, SubagentStop 은 그 잔여 상태를 신뢰성 있게 정리한다. sub 종료 lifecycle 추적용 multi-slot(`pending_agents`, `tool_use_id` 키)은 PreToolUse↔PostToolUse Agent 가 별도로 관리.
+**차단**: 없음. SubagentStop 은 차단 권한이 있지만 dcNess 는 state clear 만 수행하고 항상 종료를 허용한다.
 
-**차단 동작**: X (`exit 2` 차단 권한은 있으나 dcness 미사용). 항상 `exit 0` — sub 종료 허용. stderr = `/tmp/dcness-hook-stderr.log` 보존 (디버그용).
+### stop-end-run.sh
 
-**코드 SSOT**: [`harness/hooks.py`](../../harness/hooks.py) `handle_subagent_stop`.
+**시점**: 메인 Claude 응답 종료 시.
 
----
+**역할**:
+
+- 마지막 step 이 완료됐고 run 이 미finalized 상태면 `end-run` 을 자동 수행
+- 마지막 step 결론이 다음 step 으로 이어져야 하는 enum 이고 종료 agent 가 아니면 continuation signal 을 내보내 메인 turn 재발화
+- 같은 step 에서 반복 block 횟수가 한도를 넘으면 사용자/메인의 종료 의도를 존중하고 skip
+
+**차단**: tool 차단은 아니다. 필요 시 stdout JSON 으로 메인 turn 을 재발화한다.
+
+## Layer 2 — git hooks
+
+설치 경로: 사용자 repo 의 `.git/hooks/`. `/init-dcness` Step 2.6 이 plug-in 의 `scripts/hooks/*` thin shim 을 복사한다. 본체 검증 로직은 사용자 repo 에 복사하지 않고 plug-in SSOT 를 직접 호출한다.
+
+| Hook | Source | 언제 | 하는 일 | 차단 |
+|---|---|---|---|---|
+| `.git/hooks/commit-msg` | `scripts/hooks/commit-msg` | commit message 확정 전 | 커밋 제목 git-spec 검증 | O |
+| `.git/hooks/post-checkout` | `scripts/hooks/post-checkout` | branch checkout/switch 직후 | 브랜치명 위반 경고 + rename 안내 | X |
+| `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
+
+활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
+
+### .git/hooks/commit-msg
+
+**Source**: `scripts/hooks/commit-msg`
+
+**시점**: `git commit` 이 commit message 를 확정하기 직전.
+
+**역할**: commit title 을 읽고 `check_git_naming.mjs --title` 로 git-spec 제목 규칙을 검증한다. merge commit 제목은 면제한다.
+
+**차단**: 제목 위반 시 commit 실패.
+
+### .git/hooks/post-checkout
+
+**Source**: `scripts/hooks/post-checkout`
+
+**시점**: branch checkout/switch 직후.
+
+**역할**: 현재 브랜치명이 git-spec 을 어기면 경고와 `git branch -m <올바른-브랜치명>` 안내를 출력한다.
+
+**차단**: 없음. Git 이 post-checkout exit code 로 checkout 을 취소하지 않기 때문에 경고 전용이다.
+
+### .git/hooks/pre-push
+
+**Source**: `scripts/hooks/pre-push`
+
+**시점**: `git push` 직전.
+
+**역할**:
+
+- `refs/heads/main` 으로 직접 push 하는 경우 차단
+- push 대상 브랜치명이 git-spec 을 어기면 차단
+
+**차단**: main push 또는 브랜치명 위반 시 push 실패.
+
+## Layer 3 — CI/CD workflows
+
+설치 경로: 사용자 repo 의 `.github/workflows/`. `/init-dcness` 에서 사용자가 Y 를 선택한 경우 thin workflow 를 생성한다. workflow 본체는 `alruminum/dcNess` 의 composite action 을 호출한다.
+
+| Workflow | Trigger | 언제 | 하는 일 | 성격 |
+|---|---|---|---|---|
+| `.github/workflows/git-naming-validation.yml` | `pull_request` opened/synchronize/reopened/edited | PR 생성/수정/동기화 | 브랜치명 + PR 제목 git-spec 검증 | 선택형 CI gate |
+| `.github/workflows/pr-body-validation.yml` | `pull_request` opened/synchronize/reopened/edited | PR 생성/수정/동기화 | PR body issue trailer 검증 | 선택형 CI gate |
+| `.github/workflows/github-project-lifecycle.yml` | `issues`, `pull_request closed` | issue 변경 또는 PR merge | Project field/label drift 검출, merged PR Done 보정 | 선택형 CI/CD |
+
+### .github/workflows/git-naming-validation.yml
+
+**설치**: `/init-dcness` Step 2.6 에서 사용자가 CI git-naming 강제를 선택하면 생성한다.
+
+**시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때.
+
+**역할**: `alruminum/dcNess/.github/actions/git-naming@main` 을 호출해 `github.head_ref` 와 PR title 을 검증한다.
+
+**차단**: workflow 실패. hard merge gate 여부는 사용자 repo 의 branch protection/ruleset 설정에 달려 있다.
+
+### .github/workflows/pr-body-validation.yml
+
+**설치**: `/init-dcness` Step 2.6 에서 사용자가 PR body close-keyword gate 를 선택하면 생성한다.
+
+**시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때.
+
+**역할**: `alruminum/dcNess/.github/actions/pr-body@main` 을 호출해 PR body 에 issue trailer 가 있는지 확인한다.
+
+허용 패턴:
+
+- `Closes #N`, `Fixes #N`, `Resolves #N`
+- `Part of #N`
+- `Document-Exception-PR-Close: <사유>`
+
+**차단**: workflow 실패. hard merge gate 여부는 사용자 repo 의 branch protection/ruleset 설정에 달려 있다.
+
+### .github/workflows/github-project-lifecycle.yml
+
+**설치**: `/init-dcness` Step 2.10 에서 사용자가 Project lifecycle guard 를 선택하면 생성한다.
+
+**시점**:
+
+- issue opened/edited/labeled/unlabeled
+- PR closed, 단 merged PR 만 Done 보정 후보
+
+**역할**:
+
+- issue label 과 Project IssueType drift 검출
+- merged PR body 의 close keyword 대상 issue 를 Project Status `Done` 으로 보정
+- `Part of #N` 만 있는 PR 은 Done 후보로 보지 않음
+
+**필수 설정**: Project v2 쓰기에는 `secrets.DCNESS_PROJECT_TOKEN`, `vars.DCNESS_PROJECT_NUMBER`, `vars.DCNESS_PROJECT_OWNER` 가 필요하다.
+
+**차단/보정**: issue drift 는 workflow 실패로 드러나고, merged PR 보정은 `apply: "true"` 로 Project 상태를 수정한다.
+
+## 문서 동기화 게이트
+
+hook 또는 workflow 를 추가/삭제/이름 변경할 때 이 문서가 빠지지 않도록 `tests/test_surface_docs_sync.py` 가 다음을 검사한다.
+
+| Source | 문서에 있어야 하는 것 |
+|---|---|
+| `hooks/hooks.json` | 모든 CC hook script 의 `### <script>.sh` 상세 섹션 |
+| `commands/init-dcness.md` 의 `scripts/hooks/*` copy 목록 | 모든 사용자 repo git hook 의 `### .git/hooks/<name>` 상세 섹션 |
+| `commands/init-dcness.md` 의 선택형 `.github/workflows/*.yml` 목록 | 모든 workflow 의 `### .github/workflows/<name>.yml` 상세 섹션 |
+
+이 테스트는 hook 구현 변경의 의미까지 판정하지 않는다. 하지만 등록 surface 가 바뀌었는데 `hooks.md` 요약/상세가 누락되는 회귀는 CI에서 막는다.
 
 ## 등록 메커니즘
 
-**[`hooks/hooks.json`](../../hooks/hooks.json)**: CC plug-in 의 hook 등록 표준 형식. event 별 matcher + 실행 스크립트 정의.
+**CC hooks**: [`hooks/hooks.json`](../../hooks/hooks.json) 이 event, matcher, script command 를 정의한다. Claude Code 가 plug-in 활성 시 표준 경로를 자동 인식한다.
 
-```json
-{
-  "hooks": {
-    "SessionStart": [{ "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start.sh\"" }] }],
-    "PreToolUse": [
-      { "matcher": "Agent", "hooks": [...] },
-      { "matcher": "Edit|Write|NotebookEdit|Read|Bash|mcp__.*", "hooks": [...] },
-      { "matcher": "Edit|Write|NotebookEdit", "hooks": [...] }
-    ],
-    "PostToolUse": [
-      { "matcher": "Agent", "hooks": [...] },
-      { "matcher": "Edit|Write|NotebookEdit|Read|Bash|mcp__.*", "hooks": [...] }
-    ],
-    "SubagentStop": [{ "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/subagent-stop-clear.sh\"" }] }],
-    "Stop": [{ "hooks": [{ "type": "command", "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/stop-end-run.sh\"" }] }]
-  }
-}
-```
+**git hooks**: `/init-dcness` Step 2.6 이 사용자 repo 의 `.git/hooks/` 에 thin shim 을 always-overwrite 한다. hook 본체는 `CLAUDE_PLUGIN_ROOT`, plug-in cache, legacy repo script 순서로 검증 script 를 resolve 한다.
 
-**[`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json)**: plug-in 메타데이터 (`name`, `version`, `description`, `homepage`, `repository`). hook 등록은 본 파일에 없음 — `hooks/hooks.json` 가 별도 SSOT.
+**CI/CD workflows**: `/init-dcness` 가 사용자 선택에 따라 thin workflow 를 `.github/workflows/` 에 always-overwrite 한다. 사용자가 tag pin 을 원하면 `@main` 대신 release tag 로 바꿀 수 있다.
 
-**자동 로딩**: CC 가 plug-in 활성 시 `hooks/hooks.json` 표준 경로를 자동 인식해 등록.
-
-**`${CLAUDE_PLUGIN_ROOT}`**: CC 가 plug-in hook 실행 시 자동 설정하는 환경변수. plug-in 의 cache 경로 (`~/.claude/plugins/cache/dcness/dcness/<version>/`) 를 가리킴.
-
----
+`CLAUDE_PLUGIN_ROOT` 는 plug-in hook 실행 시 Claude Code 가 자동 설정하는 env 다. 이 값은 모든 활성 프로젝트 hook 에서 존재하므로 infra mode 신호로 쓰면 안 된다.
 
 ## 우회 / opt-out
 
-| 메커니즘 | 적용 범위 | 효과 |
+| Mechanism | Scope | Effect |
 |---|---|---|
-| **미활성 프로젝트** | 자동 | `is-active` 게이트 즉시 통과 — 모든 hook no-op |
-| **`.no-dcness-guard`** (cwd marker) | 임시 | file-guard 만 우회. cwd 에 빈 파일 |
-| **인프라 모드** (`DCNESS_INFRA=1` 환경변수 / `~/.claude/.dcness-infra` marker / cwd 조상의 dcness self repo 마커 `.claude-plugin/plugin.json name=dcness` 중 1+ = 3 OR 신호) | 영구 | dcness 자체 작업 — `DCNESS_INFRA_PATTERNS` 해제 |
+| 미활성 프로젝트 | 전체 CC hook | `is-active` 게이트에서 즉시 no-op |
+| `.no-dcness-guard` cwd marker | file-guard | file boundary / mutation denylist 임시 우회 |
+| `DCNESS_INFRA=1`, `~/.claude/.dcness-infra`, dcNess self repo marker | file boundary | dcNess 자체 작업에서 infra path 보호 해제 |
 
-> ⚠️ **`CLAUDE_PLUGIN_ROOT` 는 infra 신호가 아니다** (#597 P0-2). 이 env 는 *모든* plug-in hook 실행 시 CC 가 자동 set 하므로 외부 활성 프로젝트의 sub-agent 도 항상 가진다. 이를 신호로 쓰면 file-guard 가 외부 프로젝트서 전면 무력화되던 버그가 있었다. dcness self 저장소는 self repo 마커(신호 3)로 식별한다.
-
-**우회 불가**:
-- `--no-verify` 등 git hook bypass — [`CLAUDE.md`](../../CLAUDE.md#게이트-요약) 명시 금지
-- catastrophic-gate / tdd-guard 우회 marker 없음 (의도적 — 잘못된 시퀀스는 회복 비용 ↑)
-
----
+우회 marker 는 catastrophic-gate 와 tdd-guard 에 없다. git hook 의 `--no-verify` 우회는 가능하지만 dcNess 절차상 금지다. CI/CD workflow 는 GitHub 에 올라온 PR/issue 이벤트에서 다시 검증한다.
 
 ## 참조
 
-**자연어 SSOT (본 hook 들이 강제하는 룰의 spec)**:
-- [`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일) — 대원칙 (강제 영역 2가지)
-- 본 문서 [catastrophic-gate.sh](#catastrophic-gatesh) — catastrophic 시퀀스 진본 (catastrophic-gate 강제 대상)
-- [`harness/agent_boundary.py`](../../harness/agent_boundary.py) — 권한 매트릭스 (file-guard 강제 대상)
-- [`loop-procedure.md`](loop-procedure.md) — Step 0~8 mechanics (hook 시점이 절차 어디에 끼는지)
+자연어 SSOT:
 
-**코드 SSOT**:
-- [`harness/hooks.py`](../../harness/hooks.py) — 모든 hook handler dispatch
-- [`harness/session_state.py`](../../harness/session_state.py) — `is-active` 게이트 + run state machine
-- [`harness/agent_boundary.py`](../../harness/agent_boundary.py) — `DCNESS_INFRA_PATTERNS` + ALLOW/READ_DENY 코드 SSOT
+- [`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일) — 강제 영역 2가지
+- 본 문서 [catastrophic-gate.sh](#catastrophic-gatesh) — catastrophic 시퀀스 진본
+- [`git-spec.md`](git-spec.md) — branch / commit / PR naming + PR trailer
+- [`issue-lifecycle.md`](issue-lifecycle.md) — Project lifecycle workflow 의미
+- [`loop-procedure.md`](loop-procedure.md) — begin-run / begin-step / end-step / end-run mechanics
 
-**등록 manifest**:
-- [`hooks/hooks.json`](../../hooks/hooks.json) — hook 등록 표준 형식
-- [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) — plug-in 메타데이터
+코드 SSOT:
+
+- [`harness/hooks.py`](../../harness/hooks.py) — CC hook handler dispatch
+- [`harness/session_state.py`](../../harness/session_state.py) — 활성 프로젝트 판정 + run state machine
+- [`harness/agent_boundary.py`](../../harness/agent_boundary.py) — file boundary + external mutation denylist
+- [`scripts/check_git_naming.mjs`](../../scripts/check_git_naming.mjs) — git naming validator
+- [`scripts/check_pr_body.mjs`](../../scripts/check_pr_body.mjs) — PR body validator
+- [`scripts/github_project_lifecycle.mjs`](../../scripts/github_project_lifecycle.mjs) — Project lifecycle validator/applicator
+
+등록 manifest:
+
+- [`hooks/hooks.json`](../../hooks/hooks.json) — CC hook 등록
+- [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json) — plug-in metadata

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -1,6 +1,7 @@
 """Surface documentation sync tests for issues #644/#645."""
 from __future__ import annotations
 
+import json
 import re
 import unittest
 from pathlib import Path
@@ -180,6 +181,60 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("실수로 `begin-run design`", self.hooks_doc)
         self.assertNotIn("entry_point=architect-loop|design|impl|issue-report|ux", self.hooks_doc)
         self.assertNotIn("entry_point=architect-loop|design|impl|issue-report|ux", self.loop_procedure)
+
+    def test_hooks_doc_tracks_registered_enforcement_layers(self) -> None:
+        hooks_json = json.loads(
+            (ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8")
+        )
+        runtime_hooks: set[str] = set()
+        for entries in hooks_json["hooks"].values():
+            for entry in entries:
+                for hook in entry.get("hooks", []):
+                    command = hook.get("command", "")
+                    match = re.search(r"/hooks/([A-Za-z0-9_.-]+\.sh)", command)
+                    self.assertIsNotNone(match, command)
+                    runtime_hooks.add(match.group(1))
+
+        self.assertEqual(8, len(runtime_hooks))
+        for hook_name in sorted(runtime_hooks):
+            self.assertIn(f"### {hook_name}", self.hooks_doc)
+            self.assertRegex(
+                self.hooks_doc,
+                rf"\| `{re.escape(hook_name)}` \|",
+                msg=f"{hook_name} missing from CC hook summary table",
+            )
+
+        git_hooks = set(
+            re.findall(r'scripts/hooks/([A-Za-z0-9_.-]+)"', self.init_doc)
+        )
+        self.assertEqual({"commit-msg", "post-checkout", "pre-push"}, git_hooks)
+        for hook_name in sorted(git_hooks):
+            self.assertIn(f"### .git/hooks/{hook_name}", self.hooks_doc)
+            self.assertIn(f"`scripts/hooks/{hook_name}`", self.hooks_doc)
+
+        workflows = set(
+            re.findall(
+                r"다음 thin yml 을 `\$PROJECT_ROOT/\.github/workflows/"
+                r"([A-Za-z0-9_.-]+\.yml)`",
+                self.init_doc,
+            )
+        )
+        self.assertEqual(
+            {
+                "git-naming-validation.yml",
+                "github-project-lifecycle.yml",
+                "pr-body-validation.yml",
+            },
+            workflows,
+        )
+        for workflow_name in sorted(workflows):
+            workflow_path = f".github/workflows/{workflow_name}"
+            self.assertIn(f"### {workflow_path}", self.hooks_doc)
+            self.assertRegex(
+                self.hooks_doc,
+                rf"\| `{re.escape(workflow_path)}` \|",
+                msg=f"{workflow_path} missing from CI/CD summary table",
+            )
 
     def test_init_summary_uses_same_lifecycle_surface(self) -> None:
         default_block = self._section(


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: hooks 문서 구조 정리 및 문서 동기화 테스트 보강

## 배경 및 문제

hooks.md 가 활성 프로젝트 기준 강제 레이어를 바로 파악하기 어렵고, hook/workflow 추가·삭제 시 문서 누락을 막는 회귀 테스트가 부족했다.

## 원인 (해당 시)

-

## 작업내용

- hooks.md 를 활성 프로젝트 기준 3-layer enforcement map 으로 재구성
- CC hooks / git hooks / CI-CD workflows 요약표와 개별 상세 섹션 추가
- hooks/hooks.json, init-dcness 의 git hook 배포 목록, 선택형 workflow 목록이 hooks.md 상세 섹션과 동기화되는지 검사하는 테스트 추가

## 결정 근거

- 실행 주체와 발화 시점이 다른 hook 들을 같은 문맥에 섞지 않고, 레이어별로 먼저 읽히도록 구성
- 문서 누락은 cross-ref 만으로 잡기 어려워 등록 surface 기반 회귀 테스트로 보강

## 배포 경로 검증 (plug-in 영향 시)

- docs/plugin/hooks.md 는 plug-in 사용자에게 노출되는 SSOT 문서라 본 PR로 직접 배포 대상에 포함됨
- tests/test_surface_docs_sync.py 로 향후 hook/workflow 등록 surface 변경 시 hooks.md 누락을 CI에서 검출

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public skill/command/agent/gate 추가 없음. 기존 문서와 테스트 보강만 수행.

## Test Plan

- [x] python3.11 -m unittest tests.test_surface_docs_sync -v
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] python3.11 -m unittest discover -s tests -v
- [x] git diff --check
- [x] git commit hook: pre-commit unittest 948 tests PASS

## 참고

-
