### PR TITLE
[issue-681] TDD guard false negative 수정 + hooks 문서 정합

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -444,17 +444,21 @@ agent (메인 Claude / engineer / 등) 가 `Edit` / `Write` 시도 시 **PreTool
 #### 자동 skip 룰
 
 다음은 자동 통과 (TDD 강제 안 함):
-- 테스트 파일 자체 (`*.test.*` / `*.spec.*` / `__tests__/`)
+- 테스트 파일 자체 — basename 의 `.test.` / `.spec.` 접미 (`foo.test.ts` / `bar.spec.tsx`)
+- 표준 test 디렉터리 마디 — `__tests__/` / `__test__/` / `__mocks__/` / `test/` / `tests/` / `spec/` / `specs/` / `e2e/`
 - 설정 (`*.json` / `*.yml` / `*.yaml` / `*.env*` / `*.config.*` / `tailwind*` / `postcss*` / `next.config*` / `tsconfig*`)
 - 타입 (`types/` / `types.ts` / `types.d.ts`)
 - Next.js 특수 (`layout` / `page` / `loading` / `error` / `not-found` / `globals.css`)
+- entry-file (`App.*` / `_layout.*` / `apps/*/index.*` / `src/main.*` + `registerRootComponent(` / `AppRegistry.registerComponent(` 시그니처)
 - 비-코드 (`*.md` / `*.css` / `*.scss`)
+
+> basename 에 우연히 `test`/`spec` 이 든 **구현 파일** (`contest.ts` / `spectrum.ts` / `latest.ts`) 은 skip 하지 않음 — TDD 강제 대상. skip 은 `.test.`/`.spec.` 접미와 슬래시로 구분된 표준 test 디렉터리 마디에만 적용된다.
 
 #### 한계
 
 - TS / JS 한정 — 다른 언어는 phase 후속
 - *test 실행 X* — 존재만 확인. 실행은 사용자 개별 (vitest watch / CI 등)
-- agent 가 hook 우회 (예: `Bash` 으로 직접 파일 작성) 시 차단 X — 단 catastrophic-gate 등 다른 hook 이 잡음
+- `Bash` 로 직접 파일 작성 시 TDD guard 는 발화하지 않음 — TDD guard 는 `Edit`/`Write`/`NotebookEdit` 전용. Bash 쓰기는 file-guard 가 *경로 경계* 만 검사하고 매칭 test 존재는 검사하지 않으므로, Bash 경유 구현 파일은 현재 TDD 강제 범위 밖이다 (이 동작을 명시적으로 추가하지 않는 한)
 
 ### Step 2.10 — Codex validator skills + local routing opt-in
 
@@ -649,10 +653,10 @@ cd "$PROJECT_ROOT"
 
 # dcness 가 cp 한 파일만 명시 path — 사용자 다른 untracked 안 건드림
 NEW_FILES=$(git status --short \
-  .github/workflows/ .dcness/ 2>/dev/null \
+  .github/workflows/ 2>/dev/null \
   | grep -E '^\?\?' | awk '{print $2}')
 MODIFIED=$(git status --short \
-  .github/workflows/ .dcness/ 2>/dev/null \
+  .github/workflows/ 2>/dev/null \
   | grep -E '^.M' | awk '{print $2}')
 CHANGES="$NEW_FILES $MODIFIED"
 CHANGES_TRIM=$(echo $CHANGES | tr -s ' ')
@@ -685,8 +689,7 @@ fi
   변경 파일 (N개):
     .github/workflows/git-naming-validation.yml (신규)
     .github/workflows/pr-body-validation.yml (신규)
-    .github/workflows/tdd-gate.yml (신규)
-    .dcness/tdd-gate-enabled (신규)
+    .github/workflows/github-project-lifecycle.yml (신규)
   자동 진행 시:
     1. branch 생성: docs/dcness-init-{timestamp}
     2. 위 파일들 stage + commit (메시지 자동)
@@ -713,11 +716,10 @@ git commit -m "[docs] dcNess init — workflows + 마커 stage
 dcness plug-in 의 인프라 파일 main 등록:
 $(for f in $CHANGES; do echo "  - $f"; done)
 
-본 commit 머지 후 다음 PR 부터:
+본 commit 머지 후 다음 PR/issue 이벤트부터:
 - git-naming-validation 발화
 - pr-body-validation 발화
-- tdd-gate (CI affected) 발화
-- pre-commit TDD 게이트 (.dcness/tdd-gate-enabled 인지) 발화
+- github-project-lifecycle 발화 (issue/PR merge 이벤트)
 "
 
 git push -u origin "$BR"
@@ -739,8 +741,7 @@ Document-Exception-PR-Close: dcness init 인프라 PR — issue 매핑 없음. d
 
 - \`git-naming-validation\` CI 자동
 - \`pr-body-validation\` CI 자동
-- \`tdd-gate\` (CI affected) 자동
-- pre-commit TDD 게이트 (\`.dcness/tdd-gate-enabled\` 인지) 즉시 발화
+- \`github-project-lifecycle\` CI/CD 자동 (issue/PR merge 이벤트)
 EOF
 )"
 ```

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -93,29 +93,46 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 | `RUN_DIR_PROSE_ALLOW` | build-worker 가 자기 run dir 의 `build-*.md` prose 를 쓰는 좁은 예외 |
 | `ALLOW_MATRIX` | agent 별 Write 허용 path 제한 |
 | `READ_DENY_MATRIX` | agent 별 Read 금지 path 제한 |
-| 외부 mutation denylist | sub-agent 의 `git push`, `gh pr create/merge/review`, mutating `gh api`, GitHub MCP PR/repo mutation 차단 |
+| 외부 mutation denylist | sub-agent 의 `git push`, Bash `gh pr create/merge/review`, Bash `gh issue create/edit/close/comment`, mutating `gh api`, GitHub MCP PR/repo mutation 차단 |
 
-메인 Claude turn 은 file boundary 를 통과한다. GitHub issue mutation 은 agent tool 권한 설계에 맡기고 file-guard 에서는 예외로 둔다. PR/repo mutation 은 sub-agent 에서 차단한다.
+메인 Claude turn 은 file boundary 를 통과한다.
+
+GitHub issue mutation 은 경로에 따라 다르게 처리한다 — 같은 "issue 변경"이라도 차단 여부가 갈린다.
+
+| issue mutation 경로 | file-guard 동작 |
+|---|---|
+| Bash `gh issue create/edit/close/comment/...` | **차단** (Bash mutation denylist — `harness/agent_boundary.py` 의 `check_bash_mutation`) |
+| GitHub MCP issue 도구 (`mcp__github__create_issue`, `update_issue`, `add_issue_comment` 등) | **통과** (의도된 예외 — `check_github_mcp_mutation`). per-agent `tools:` 권한이 이미 gate 하므로 도구 미부여 agent 는 호출 자체 불가. designer 등 issue 도구를 가진 agent 의 설계된 흐름을 막지 않는다. |
+
+PR/repo mutation (`gh pr ...` / `merge_pull_request` / `push_files` / `create_or_update_file` 등) 은 Bash·MCP 양쪽 다 sub-agent 에서 차단한다.
 
 **차단**: 경계 위반 시 `exit 2` + stderr. `.no-dcness-guard` marker 는 file-guard 만 임시 우회한다.
 
 ### tdd-guard.sh
 
-**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전.
+**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. **`Bash` 로 만든 파일에는 발화하지 않는다** (아래 한계 참조).
 
-**역할**: TS/JS 구현 파일 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 에 대응하는 test/spec 파일이 있는지 확인한다. 없으면 구현 파일 작성을 막는다.
+**지원 언어**: TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`). 그 외 확장자는 silent skip — Python·Rust·Go 등 다른 ecosystem 의 TDD 강제는 현재 범위 밖이다.
+
+**역할**: 위 TS/JS 구현 파일에 대응하는 test/spec 파일이 *존재하는지* 확인한다. 없으면 구현 파일 작성을 막는다. **test 의 존재만 검사하고, test 를 실행하지는 않는다** — green/red 판정이 아니라 "작성 전 test 가 먼저 있는가" 강제다.
 
 **skip 대상**:
 
-- test/spec 파일 자체, `__tests__`
+- test/spec 파일 자체 — basename 의 `.test.` / `.spec.` 접미 컨벤션 (`foo.test.ts`, `bar.spec.tsx`)
+- 표준 test 디렉터리 마디 — `__tests__/`, `__test__/`, `__mocks__/`, `test/`, `tests/`, `spec/`, `specs/`, `e2e/`
 - 설정, markdown, yaml, env, css, 타입 선언
 - Next.js 특수 파일 (`layout`, `page`, `loading`, `error`, `not-found`, `globals.css`)
+- entry-file 예외 — path heuristic (`*/App.{ts,tsx,js,jsx}`, `*/_layout.*`, `*/apps/*/index.*`, `*/src/main.*`) + 내용 시그니처 (`registerRootComponent(`, `AppRegistry.registerComponent(`)
 - `templates/`, `design-variants/`
 - TS/JS 외 언어
+
+> basename 에 우연히 `test`/`spec` 이 든 **구현 파일** (`contest.ts`, `spectrum.ts`, `latest.ts`) 은 skip 하지 않는다 — TDD 강제 대상이다 (#681). skip 은 `.test.`/`.spec.` 접미와 슬래시로 구분된 표준 test 디렉터리 마디에만 적용된다.
 
 **매칭 위치**: 같은 디렉터리, 같은 디렉터리의 `__tests__`, 부모/조부모 `__tests__`, monorepo `src_root/__tests__`, 프로젝트 root `src/__tests__`.
 
 **차단**: test 부재 시 `exit 2` + 한국어 안내.
+
+**한계 (Bash write 는 범위 밖)**: TDD guard 는 `Edit`/`Write`/`NotebookEdit` 직접 파일 도구에서만 발화한다. `Bash` 로 작성한 구현 파일(`echo > foo.ts`, `cat <<EOF` 등)은 [file-guard.sh](#file-guardsh) 가 검사하지만, file-guard 는 *경로 경계*(agent 가 그 path 를 쓸 수 있는가)만 보고 *매칭 test 존재*는 보지 않는다. 즉 Bash 경유 구현 파일은 현재 TDD 강제가 닿지 않으며, 이 동작을 명시적으로 추가하지 않는 한 그대로다.
 
 ### post-agent-clear.sh
 

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -63,7 +63,12 @@ PY
 case "$(basename "$FILE_PATH")" in
   *.test.*|*.spec.*) allow ;;
 esac
-case "$FILE_PATH" in
+# 디렉터리 마디 매치는 절대/상대 경로 모두 대응 — 선두 슬래시를 1개로 정규화해
+# top-level 상대 경로 (`tests/helper.ts`, `__tests__/setup.ts`) 도 `*/tests/*` 로 잡는다.
+# 정규화 없이는 leading-slash 요구 패턴이 상대 top-level test 디렉터리를 놓쳐
+# 문서가 약속한 skip 과 어긋난다 (codex P2).
+_tdd_norm="/${FILE_PATH#/}"
+case "$_tdd_norm" in
   */__tests__/*|*/__test__/*|*/__mocks__/*) allow ;;
   */test/*|*/tests/*|*/spec/*|*/specs/*|*/e2e/*) allow ;;
 esac

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -55,9 +55,17 @@ PY
 
 [ -z "$FILE_PATH" ] && allow
 
-# 자동 skip — test 파일 자체
+# 자동 skip — test/spec 파일 자체 + 표준 test 디렉터리 (#681)
+# 주의: 단순 *test* / *spec* 광역 glob 은 contest.ts / spectrum.ts / latest.ts 같은
+# 구현 파일을 test 파일로 오인 skip → TDD 강제를 우회시킨다 (false negative).
+# 따라서 (1) basename 의 `.test.` / `.spec.` 접미 컨벤션, (2) 슬래시로 구분된 표준
+# test 디렉터리 마디만 매치한다. basename 에 우연히 test/spec 이 든 구현 파일은 skip 안 함.
+case "$(basename "$FILE_PATH")" in
+  *.test.*|*.spec.*) allow ;;
+esac
 case "$FILE_PATH" in
-  *test*|*spec*|*.test.*|*.spec.*|*__tests__*) allow ;;
+  */__tests__/*|*/__test__/*|*/__mocks__/*) allow ;;
+  */test/*|*/tests/*|*/spec/*|*/specs/*|*/e2e/*) allow ;;
 esac
 
 # 자동 skip — 설정 / 비-코드 / 타입 / Next.js 특수

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -63,12 +63,25 @@ PY
 case "$(basename "$FILE_PATH")" in
   *.test.*|*.spec.*) allow ;;
 esac
-# 디렉터리 마디 매치는 절대/상대 경로 모두 대응 — 선두 슬래시를 1개로 정규화해
-# top-level 상대 경로 (`tests/helper.ts`, `__tests__/setup.ts`) 도 `*/tests/*` 로 잡는다.
-# 정규화 없이는 leading-slash 요구 패턴이 상대 top-level test 디렉터리를 놓쳐
-# 문서가 약속한 skip 과 어긋난다 (codex P2).
-_tdd_norm="/${FILE_PATH#/}"
-case "$_tdd_norm" in
+# 디렉터리 마디 매치는 **repo-relative 경로 기준** — PROJECT_ROOT 바깥 조상
+# 디렉터리가 우연히 test 디렉터리명(e2e / __mocks__ 등)이어도 repo 내부 구현 파일을
+# 오인 skip 하지 않게 한다 (codex P2 round2: `.../e2e/app/src/foo.ts` 가 e2e 조상으로
+# TDD guard 가 무력화되던 결함). 절대/상대·심볼릭링크 경로 차이를 흡수하려 부모
+# 디렉터리를 물리경로(`pwd -P`)로 정규화한 뒤 PROJECT_ROOT 접두를 제거한다. 부모 dir 이
+# 아직 없으면(신규 중첩 경로) 원본을 그대로 쓴다. 선두 슬래시 1개로 정규화해 top-level
+# 상대 경로 (`tests/helper.ts`) 도 `*/tests/*` 로 잡는다.
+_tdd_pdir=$(cd "$(dirname "$FILE_PATH")" 2>/dev/null && pwd -P || true)
+if [ -n "$_tdd_pdir" ]; then
+  _tdd_abs="${_tdd_pdir}/$(basename "$FILE_PATH")"
+else
+  _tdd_abs="$FILE_PATH"
+fi
+_tdd_root=$(cd "$PROJECT_ROOT" 2>/dev/null && pwd -P || printf '%s' "$PROJECT_ROOT")
+case "$_tdd_abs" in
+  "$_tdd_root"/*) _tdd_rel="${_tdd_abs#"$_tdd_root"/}" ;;
+  *) _tdd_rel="$_tdd_abs" ;;
+esac
+case "/${_tdd_rel#/}" in
   */__tests__/*|*/__test__/*|*/__mocks__/*) allow ;;
   */test/*|*/tests/*|*/spec/*|*/specs/*|*/e2e/*) allow ;;
 esac

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -459,6 +459,35 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             self.issue_lifecycle,
         )
 
+    def test_init_doc_drops_removed_tdd_gate_references(self) -> None:
+        """#681 — /init-dcness 가 폐기된 TDD CI/pre-commit flow 를 더는 언급하지 않는다.
+
+        제거 대상: `tdd-gate.yml` workflow, `.dcness/tdd-gate-enabled` 마커,
+        pre-commit TDD 게이트 활성화 문구. (현재 setup/commit 예시에서 stale.)
+        """
+        for stale in ("tdd-gate.yml", ".dcness/tdd-gate-enabled", "pre-commit TDD", "TDD 게이트"):
+            self.assertNotIn(
+                stale,
+                self.init_doc,
+                msg=f"init-dcness.md 에 폐기된 TDD flow 참조 '{stale}' 잔존 (#681)",
+            )
+
+    def test_hooks_doc_distinguishes_issue_mutation_paths(self) -> None:
+        """#681 AC#4 — hooks.md 가 Bash `gh issue` 차단 vs GitHub MCP issue 통과를 구별한다."""
+        self.assertIn(
+            "Bash `gh issue create/edit/close/comment`",
+            self.hooks_doc,
+        )
+        self.assertIn("check_github_mcp_mutation", self.hooks_doc)
+        self.assertIn("per-agent `tools:` 권한", self.hooks_doc)
+
+    def test_hooks_doc_tdd_guard_scope_is_accurate(self) -> None:
+        """#681 AC#2/#3 — tdd-guard 문서가 존재-검사·entry-file·Bash 범위 밖을 명시한다."""
+        self.assertIn("test 의 존재만 검사하고, test 를 실행하지는 않는다", self.hooks_doc)
+        self.assertIn("registerRootComponent(", self.hooks_doc)
+        self.assertIn("Bash write 는 범위 밖", self.hooks_doc)
+        self.assertIn("contest.ts", self.hooks_doc)
+
     def _section(self, text: str, start: str, end: str) -> str:
         match = re.search(start + r"(?P<body>.*?)" + end, text, flags=re.S)
         self.assertIsNotNone(match)

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -273,6 +273,22 @@ class TestBasenameSubstringFalseNegative(unittest.TestCase):
         path = self._touch("src/contest/board.ts", "export const b = 1;\n")
         self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
 
+    def test_relative_top_level_tests_dir_skipped(self):
+        """상대 경로 top-level `tests/` 디렉터리 파일도 skip — codex P2 (선두 슬래시 정규화)."""
+        self._touch("tests/helper.ts", "export const h = 1;\n")
+        # 절대 경로가 아니라 cwd(tmp) 기준 상대 경로를 직접 전달.
+        self.assertEqual(decision(run_hook("tests/helper.ts", self._tmp)), "allow")
+
+    def test_relative_top_level_tests_underscore_dir_skipped(self):
+        """상대 경로 top-level `__tests__/` 디렉터리 파일도 skip — codex P2."""
+        self._touch("__tests__/setup.ts", "export const s = 1;\n")
+        self.assertEqual(decision(run_hook("__tests__/setup.ts", self._tmp)), "allow")
+
+    def test_relative_top_level_impl_still_denied(self):
+        """상대 경로라도 top-level 구현 파일(test 디렉터리 아님)은 여전히 deny — 정규화 오버매치 방지."""
+        self._touch("contest.ts", "export const c = 1;\n")
+        self.assertEqual(decision(run_hook("contest.ts", self._tmp)), "deny")
+
 
 class TestPathMatcherTier4_Grandparent(unittest.TestCase):
     """issue #469 결함 C — Tier 4: <grandparent>/__tests__/<name>.{test,spec}.<ext>.

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -289,6 +289,32 @@ class TestBasenameSubstringFalseNegative(unittest.TestCase):
         self._touch("contest.ts", "export const c = 1;\n")
         self.assertEqual(decision(run_hook("contest.ts", self._tmp)), "deny")
 
+    def test_repo_under_e2e_parent_does_not_skip_impl(self):
+        """repo 루트의 *조상* 디렉터리명이 test 디렉터리(e2e)여도 구현 파일은 skip 안 함 → deny.
+
+        codex P2 round2 — 디렉터리 마디 매치는 PROJECT_ROOT 상대 경로 기준이어야 한다.
+        체크아웃이 `.../e2e/app` 밑에 있으면 절대 경로의 `e2e` 조상 마디가 매치돼
+        TDD guard 가 무력화되던 결함.
+        """
+        repo = Path(self._tmp) / "e2e" / "app"
+        repo.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init"], cwd=str(repo), capture_output=True)
+        src = repo / "src" / "foo.ts"
+        src.parent.mkdir(parents=True, exist_ok=True)
+        src.write_text("export function foo() { return 1; }\n", encoding="utf-8")
+        # cwd = repo (PROJECT_ROOT 가 .../e2e/app 로 잡힘), 절대 경로 전달.
+        self.assertEqual(decision(run_hook(str(src), str(repo))), "deny")
+
+    def test_repo_internal_e2e_dir_still_skips(self):
+        """repo *내부* 의 e2e/ 디렉터리 파일은 계속 skip — 회귀 방지 (상대 경로 매치 보존)."""
+        repo = Path(self._tmp) / "e2e" / "app"
+        repo.mkdir(parents=True, exist_ok=True)
+        subprocess.run(["git", "init"], cwd=str(repo), capture_output=True)
+        f = repo / "src" / "e2e" / "flow.ts"
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text("export const flow = 1;\n", encoding="utf-8")
+        self.assertEqual(decision(run_hook(str(f), str(repo))), "allow")
+
 
 class TestPathMatcherTier4_Grandparent(unittest.TestCase):
     """issue #469 결함 C — Tier 4: <grandparent>/__tests__/<name>.{test,spec}.<ext>.

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -196,6 +196,84 @@ class TestRegressionPreserved(unittest.TestCase):
         self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
 
 
+class TestBasenameSubstringFalseNegative(unittest.TestCase):
+    """issue #681 — basename 에 우연히 'test'/'spec' 이 든 구현 파일은 skip 아님.
+
+    버그: 기존 skip 매처가 `*test*` / `*spec*` 광역 glob 이라 `contest.ts` / `spectrum.ts`
+    같은 구현 파일을 test 파일로 오인 → TDD 강제 우회. 매칭은 (1) basename 의
+    `.test.` / `.spec.` 접미 컨벤션, (2) 슬래시로 구분된 표준 test 디렉터리 마디만 해야 한다.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str = "// stub\n") -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_contest_impl_without_test_denied(self):
+        """contest.ts — basename 에 'test' 포함하나 구현 파일 → 테스트 부재면 deny."""
+        path = self._touch(
+            "src/contest.ts",
+            "export function joinContest(id) { return id; }\n",
+        )
+        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+
+    def test_spectrum_impl_without_test_denied(self):
+        """spectrum.ts — basename 에 'spec' 포함하나 구현 파일 → 테스트 부재면 deny."""
+        path = self._touch(
+            "src/spectrum.ts",
+            "export function analyzeSpectrum(buf) { return buf.length; }\n",
+        )
+        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+
+    def test_latest_impl_without_test_denied(self):
+        """latest.ts — basename 에 'test' 포함하나 구현 파일 → 테스트 부재면 deny."""
+        path = self._touch(
+            "src/latest.ts",
+            "export function latest(arr) { return arr[arr.length - 1]; }\n",
+        )
+        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+
+    def test_contest_with_matching_test_allowed(self):
+        """contest.ts + 매칭 contest.test.ts 존재 → allow (정상 TDD)."""
+        self._touch("src/contest.ts", "export const c = 1;\n")
+        self._touch("src/contest.test.ts", "test('ok', () => {})\n")
+        path = str(Path(self._tmp) / "src/contest.ts")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_real_test_file_still_skipped(self):
+        """진짜 test 파일 (.test. 접미) 은 계속 skip — 회귀 방지."""
+        path = self._touch("src/spectrum.test.ts", "test('x', () => {})\n")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_real_spec_file_still_skipped(self):
+        """진짜 spec 파일 (.spec. 접미) 은 계속 skip — 회귀 방지."""
+        path = self._touch("src/contest.spec.tsx", "test('x', () => {})\n")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_file_inside_tests_dir_skipped(self):
+        """표준 test 디렉터리(__tests__) 안 파일은 .test. 접미 없어도 skip."""
+        path = self._touch("src/__tests__/helper.ts", "export const h = 1;\n")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_file_inside_test_dir_segment_skipped(self):
+        """슬래시로 구분된 test/ 디렉터리 마디 안 파일은 skip."""
+        path = self._touch("src/test/fixtures.ts", "export const f = 1;\n")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_contest_dir_segment_not_skipped(self):
+        """디렉터리명이 'contest' (test 아님) 인 구현 파일은 skip 아님 → deny."""
+        path = self._touch("src/contest/board.ts", "export const b = 1;\n")
+        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+
+
 class TestPathMatcherTier4_Grandparent(unittest.TestCase):
     """issue #469 결함 C — Tier 4: <grandparent>/__tests__/<name>.{test,spec}.<ext>.
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #681

## 배경 및 문제

hooks SSOT 리뷰에서 문서 / `/init-dcness` 안내 / 실제 guard 동작 사이 불일치가 다수 발견됨.

- **TDD guard false negative**: `tdd-guard.sh` 의 skip 매처가 `*test*` / `*spec*` 광역 glob 이라, basename 에 우연히 `test`/`spec` 이 든 **구현 파일**(`contest.ts`, `spectrum.ts`, `latest.ts`)을 test 파일로 오인 skip → 매칭 test 없이도 작성 통과 (TDD 강제 우회).
- **문서 부정확**: hooks.md 가 Bash `gh issue` mutation 과 GitHub MCP issue mutation 을 구별하지 않음. tdd-guard 의 지원 언어 / entry-file 예외 / 존재-검사(실행 아님) 미명시.
- **Bash 우회 오기**: `/init-dcness` 가 "Bash 직접 작성은 catastrophic-gate 등 다른 hook 이 잡음"이라 적었으나, 실제로 Bash 쓰기는 file-guard 가 *경로 경계* 만 검사하고 매칭 test 존재는 보지 않음.
- **stale 참조**: `/init-dcness` 에 폐기된 `tdd-gate.yml` / `.dcness/tdd-gate-enabled` / pre-commit TDD 게이트 문구 잔존.

## 원인

skip 매처의 `*test*` / `*spec*` 는 path *어디든* 해당 substring 이 있으면 매치하는 광역 glob. 파일명 단위 컨벤션(`.test.`/`.spec.`)도, 디렉터리 마디 경계도 구분하지 않아 `contest`(con**test**) / `spectrum`(**spec**trum) 의 일부를 test 신호로 오독.

## 작업내용

- **`hooks/tdd-guard.sh`**: skip 을 (1) basename 의 `.test.`/`.spec.` 접미 컨벤션, (2) 슬래시로 구분된 표준 test 디렉터리 마디(`__tests__`/`__test__`/`__mocks__`/`test`/`tests`/`spec`/`specs`/`e2e`)로 한정. basename 에 우연히 test/spec 든 구현 파일은 더는 skip 안 함.
- **`docs/plugin/hooks.md`**:
  - file-guard — Bash `gh issue create/edit/close/comment` **차단** vs GitHub MCP issue 도구 **통과**(per-agent `tools:` gate) 표로 구별. (`harness/agent_boundary.py` 의 `check_bash_mutation` / `check_github_mcp_mutation` 실측 확인.)
  - tdd-guard — 지원 언어(TS/JS), 매칭 위치, entry-file 예외, **test 존재만 검사·실행 안 함**, Bash write 범위 밖 명시.
- **`commands/init-dcness.md`**: Bash 우회 오기 정정 + skip 룰/한계 정밀화 + 폐기된 `tdd-gate.yml`/`.dcness/tdd-gate-enabled`/pre-commit TDD 참조 제거 + dead `.dcness/` 스캔 정리(실제 생성 workflow 3종으로 예시 정합).
- **테스트**: `test_tdd_guard` +9건(contest/spectrum/latest deny, 매칭 test allow, 진짜 test/spec·표준 test 디렉터리 skip 보존, `contest/` 디렉터리는 skip 아님), `test_surface_docs_sync` +3건(stale-doc 가드 + hooks 문구 정합).

## 결정 근거

- 표면 패치(특정 두 파일명만 예외 처리)가 아니라 **매처 클래스 결함**을 근본 수정 — `.test.`/`.spec.` 접미 컨벤션 + 디렉터리 마디 경계는 JS/TS 생태계 표준이라 false positive(진짜 test 오차단) 위험 없이 false negative 를 닫음.
- 디렉터리 패턴은 슬래시 앵커(`*/test/*`)라 whole-segment 매치 → `contest/`·`latest/` 같은 비-test 디렉터리는 안 걸림.
- 문서는 추측 아닌 **실제 코드(`agent_boundary.py`) 실측** 후 기술.

## Test Plan

- `python3.11 -m unittest discover -s tests` → **960 passed** (신규 12건 포함).
- 신규 테스트 red→green 확인: 수정 전 contest/spectrum/latest deny 기대 4건 FAIL → 수정 후 전건 PASS.
- `node scripts/check_cross_refs.mjs` → PASS, `node scripts/check_plugin_manifest.mjs` → PASS.
- `bash -n hooks/tdd-guard.sh` → syntax OK.

## 배포 경로 검증

전부 **경로 1 (plug-in 본체)** — 사용자 plug-in 업데이트 시 자동 적용:
- `hooks/tdd-guard.sh` = `hooks/hooks.json` 에 등록된 PreToolUse hook (plug-in 설치본에서 실행, 사용자 repo 복사 X).
- `docs/plugin/hooks.md` = plug-in SSOT 문서.
- `commands/init-dcness.md` = plug-in 본체 스킬 본문.
- 별도 `/init-dcness` deploy 스텝 / `scripts/*` 복사 갱신 불필요 (배포 경로 2·3 무관).