### PR TITLE
[docs] hooks.md 차단 메시지 포맷 + session-start update-check 기술 정합

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -59,6 +59,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 - sid 추출, `.by-pid/<cc_pid>` 작성, `live.json` 초기화
 - `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
 - 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
+- 설치된 plug-in 버전과 `main` 의 최신 버전을 비교(하루 1회 캐시)해 더 높은 버전이 있을 때만 `claude plugin update` 알림을 함께 inject — 외부 활성 프로젝트가 옛 plug-in 버전 운영 룰에 묶이는 drift 회피
 
 **차단**: 없음. 실패해도 세션 시작을 막지 않는다.
 
@@ -79,7 +80,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 
 **tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. /design 도중 미검증 새 외부 의존이 발견되면 design 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 
-**차단**: 위반 시 `exit 2` + stderr. 에러 메시지는 `[catastrophic: <gate>]` 형태를 포함한다.
+**차단**: 위반 시 `exit 2` + stderr. engineer / pr-reviewer / module-architect 게이트 위반은 `[catastrophic: <gate>]`, strict conveyor 게이트 위반은 `[strict-conveyor]` 접두사를 포함한다.
 
 ### file-guard.sh
 


### PR DESCRIPTION
## 배경
hooks.md 감사 중 발견된 문서-구현 불일치 2건 정정 (코드 무변경, 강제 동작 변화 없음).

## 작업내용
1. **차단 메시지 포맷 정합** — catastrophic-gate.sh 차단 섹션이 모든 위반을 `[catastrophic: <gate>]` 로 기술했으나, strict conveyor 게이트는 실제로 `[strict-conveyor]` 접두사를 쓴다 (harness/hooks.py strict-conveyor 메시지 5종 실측). engineer/pr-reviewer/module-architect 와 strict conveyor 를 구분 기술.
2. **session-start update-check 누락 기술** — session-start.sh 가 설치 버전과 main 최신 버전을 비교(하루 1회 캐시)해 상위 버전 시 `claude plugin update` 알림을 inject 하는데 hooks.md 역할 목록에 빠져 있었음. 추가.

## 배포 경로 검증
- 변경 파일: `docs/plugin/hooks.md` (사용자가 따르는 SSOT 문서, 경로 1 = plug-in 본체). plug-in 업데이트 시 자동 반영. 코드/스크립트 무변경.

## Test Plan
- [x] cross-ref 검증 PASS (dead link/anchor/옛 명칭 0건)
- [x] test_surface_docs_sync 14건 PASS

Document-Exception-PR-Close: 문서 정합 PR (이슈 없음) — hooks.md 강제 메시지 포맷 오기 + session-start update-check 기술 누락 정정, 코드 무변경.