### PR TITLE
[issue-684] helper rid fallback 복구

### DIFF
--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -986,7 +986,18 @@ def auto_detect_run_id(*, base_dir: Optional[Path] = None) -> str:
         rid = read_pid_current_run(cc_pid, base_dir=base_dir)
         if rid:
             return rid
-    # (c) active_runs scan 폴백 — 가장 최근 미finalized run 의 run_id
+        sid = read_pid_session(cc_pid, base_dir=base_dir)
+        if sid:
+            slot_info = _scan_recent_active_run_slot(base_dir=base_dir, session_id=sid)
+            if slot_info:
+                return slot_info[1]
+    # (c) pointer/env sid 가 있으면 해당 세션 active_runs 를 먼저 scan
+    sid = current_session_id(base_dir=base_dir)
+    if sid:
+        slot_info = _scan_recent_active_run_slot(base_dir=base_dir, session_id=sid)
+        if slot_info:
+            return slot_info[1]
+    # (d) active_runs scan 폴백 — 가장 최근 미finalized run 의 run_id
     slot_info = _scan_recent_active_run_slot(base_dir=base_dir)
     if slot_info:
         return slot_info[1]
@@ -1011,6 +1022,7 @@ def diagnose_sid_rid_resolution(
     env_sid = os.environ.get("DCNESS_SESSION_ID", "")
     env_rid = os.environ.get("DCNESS_RUN_ID", "")
     cc_pid = get_cc_pid_via_ppid_chain()
+    sid_hint = env_sid if valid_session_id(env_sid) else ""
 
     lines: list[str] = []
     header = "sid/rid" if mode == "both" else mode
@@ -1032,8 +1044,10 @@ def diagnose_sid_rid_resolution(
         )
     else:
         lines.append(f"  (b) PPID chain cc_pid: {cc_pid}")
+        sid_from_pid = read_pid_session(cc_pid, base_dir=base_dir)
+        if sid_from_pid and not sid_hint:
+            sid_hint = sid_from_pid
         if mode in ("sid", "both"):
-            sid_from_pid = read_pid_session(cc_pid, base_dir=base_dir)
             lines.append(
                 f"  (b) by-pid/{cc_pid}: "
                 f"{'sid 있음' if sid_from_pid else 'sid 없음 (SessionStart 훅 미실행 또는 stale by-pid 파일)'}"
@@ -1046,7 +1060,12 @@ def diagnose_sid_rid_resolution(
             )
 
     # (c) active_runs scan layer (rid 영역만 의미 — sid 도 같이 매칭)
-    slot = _scan_recent_active_run_slot(base_dir=base_dir)
+    if not sid_hint:
+        sid_hint = current_session_id(base_dir=base_dir)
+    slot = _scan_recent_active_run_slot(
+        base_dir=base_dir,
+        session_id=sid_hint or None,
+    )
     if slot is None:
         lines.append("  (c) active_runs scan: 매치 없음 (모든 run finalized 또는 sessions dir 비어있음)")
     else:
@@ -1062,18 +1081,81 @@ def diagnose_sid_rid_resolution(
     return "\n".join(lines)
 
 
+def _is_open_active_run_slot(slot: Any) -> bool:
+    """active_runs 슬롯이 helper fallback 후보인지 판정."""
+    if not isinstance(slot, dict):
+        return False
+    if slot.get("finalized_at"):
+        return False
+    return slot.get("completed_at") is None
+
+
+def _scan_live_file_for_active_run(
+    live_file: Path,
+    *,
+    session_id: Optional[str] = None,
+) -> Optional[tuple[str, str, str]]:
+    """live.json 하나에서 최신 open active_run 후보 반환.
+
+    Returns:
+        (started_at, sid, rid) 또는 None.
+    """
+    try:
+        data = json.loads(live_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+
+    sid = data.get("session_id")
+    meta = data.get("_meta")
+    meta_sid = meta.get("sessionId") if isinstance(meta, dict) else None
+    if session_id:
+        if not valid_session_id(session_id):
+            return None
+        if isinstance(sid, str) and sid != session_id:
+            return None
+        if isinstance(meta_sid, str) and meta_sid != session_id:
+            return None
+        sid = session_id
+    else:
+        if isinstance(sid, str) and isinstance(meta_sid, str) and sid != meta_sid:
+            return None
+        sid = sid or meta_sid
+    if not isinstance(sid, str) or not valid_session_id(sid):
+        return None
+
+    active_runs = data.get("active_runs", {})
+    if not isinstance(active_runs, dict):
+        return None
+    best: Optional[tuple[str, str, str]] = None
+    for rid, slot in active_runs.items():
+        if not isinstance(rid, str) or not RUN_ID_RE.match(rid):
+            continue
+        if not _is_open_active_run_slot(slot):
+            continue
+        started = slot.get("started_at") or slot.get("last_confirmed_at") or ""
+        if not isinstance(started, str):
+            started = ""
+        if best is None or started > best[0]:
+            best = (started, sid, rid)
+    return best
+
+
 def _scan_recent_active_run_slot(
     *,
     base_dir: Optional[Path] = None,
     max_sessions: int = 5,
+    session_id: Optional[str] = None,
 ) -> Optional[tuple[str, str]]:
     """.sessions/ 디렉토리 scan 후 가장 최근 미finalized active_run slot 의 (sid, rid).
 
     issue #469 결함 B 의 best-effort 폴백 — PPID chain 미해결 시 사용.
     다음 우선순위:
-    1. live.json mtime 최신 `max_sessions` 개만 검사 (비용 가드)
-    2. 각 live.json 의 `active_runs` 중 `finalized_at` 부재 + `started_at`
-       가장 최근 slot 있는 (sid, rid) 반환
+    1. `session_id` 가 주어지면 그 세션 live.json 을 직접 검사 (#684)
+    2. live.json mtime 최신 `max_sessions` 개만 검사 (비용 가드)
+    3. 각 live.json 의 `active_runs` 중 `finalized_at`/`completed_at` 부재 +
+       `started_at` 가장 최근 slot 있는 (sid, rid) 반환
 
     Returns:
         (session_id, run_id) tuple — best-guess.
@@ -1088,6 +1170,19 @@ def _scan_recent_active_run_slot(
     session_roots = [p for p in session_roots if p.is_dir()]
     if not session_roots:
         return None
+
+    if session_id:
+        best: Optional[tuple[str, str, str]] = None
+        for sessions_dir in session_roots:
+            slot = _scan_live_file_for_active_run(
+                sessions_dir / session_id / "live.json",
+                session_id=session_id,
+            )
+            if slot and (best is None or slot[0] > best[0]):
+                best = slot
+        if best is None:
+            return None
+        return (best[1], best[2])
 
     # live.json mtime 최신 max_sessions 개만 추출 (비용 가드)
     candidates: list[tuple[float, Path]] = []
@@ -1110,28 +1205,9 @@ def _scan_recent_active_run_slot(
     # 각 live.json 의 미finalized active_run 중 started_at 최신 후보 수집
     best: Optional[tuple[str, str, str]] = None  # (started_at, sid, rid)
     for _, live_file in candidates:
-        try:
-            data = json.loads(live_file.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(data, dict):
-            continue
-        sid = data.get("session_id")
-        if not isinstance(sid, str) or not valid_session_id(sid):
-            continue
-        active_runs = data.get("active_runs", {})
-        if not isinstance(active_runs, dict):
-            continue
-        for rid, slot in active_runs.items():
-            if not isinstance(slot, dict):
-                continue
-            if slot.get("finalized_at"):
-                continue
-            started = slot.get("started_at", "")
-            if not isinstance(started, str):
-                continue
-            if best is None or started > best[0]:
-                best = (started, sid, rid)
+        slot = _scan_live_file_for_active_run(live_file)
+        if slot and (best is None or slot[0] > best[0]):
+            best = slot
     if best is None:
         return None
     return (best[1], best[2])

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -145,6 +145,7 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             )
 
     def test_resolves_sid_rid_without_caller_env(self) -> None:
+        """issue #625 — Codex subprocess PPID/env 단절 전 wrapper 가 sid/rid 를 export."""
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             project = tmp / "project"

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -859,6 +859,57 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         # path 가 .sessions/{sid}/runs/{rid} 끝남
         self.assertTrue(printed.endswith(f".sessions/{self.sid}/runs/{self.rid}"))
 
+    def test_cli_resolves_active_run_when_pid_current_run_pointer_missing(self) -> None:
+        """issue #684 — escape hatch 없이 helper CLI 가 sid-scoped active_runs 로 복구."""
+        from harness.session_state import (
+            _cli_begin_step,
+            _cli_end_step,
+            _cli_run_dir,
+            _cli_run_status,
+            clear_pid_current_run,
+            read_live,
+            run_dir,
+        )
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        clear_pid_current_run(self.cc_pid)
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_begin_step(SimpleNamespace(agent="validator", mode="CODE_VALIDATION"))
+        self.assertEqual(rc, 0)
+        self.assertIn("ok", out.getvalue())
+        live = read_live(self.sid)
+        slot = live["active_runs"][self.rid]
+        self.assertEqual(slot["current_step"]["agent"], "validator")
+        self.assertEqual(slot["current_step"]["mode"], "CODE_VALIDATION")
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_run_dir(SimpleNamespace())
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), str(run_dir(self.sid, self.rid)))
+
+        prose_path = self.base / "validator_prose.md"
+        prose_path.write_text("검증 결과 정상\n\nPASS\n", encoding="utf-8")
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="validator",
+                mode="CODE_VALIDATION",
+                prose_file=str(prose_path),
+            ))
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "PROSE_LOGGED")
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_run_status(SimpleNamespace(run_id=None))
+        self.assertEqual(rc, 0)
+        self.assertIn(self.rid, out.getvalue())
+
     def test_end_step_drift_warn_on_agent_mismatch(self) -> None:
         # DCN-30-25: end-step 호출 시 current_step 의 agent 와 args.agent 불일치
         # → stderr DRIFT WARN. 자동 보정 X (동작은 정상 진행).
@@ -2080,6 +2131,11 @@ class AutoDetectFallbackTests(unittest.TestCase):
 
     PPID chain mismatch (bash subprocess 재시작 / fork) 시 sid/rid 미해결
     회귀 차단. env > PPID > pointer > active_runs scan 폴백 우선순위.
+
+    회귀 계보:
+      - #469: impl-loop/helper 직접 호출의 PPID mismatch fallback
+      - #483: sid/rid 미해결 진단 출력
+      - #684: by-pid sid 는 있으나 current-run pointer 유실 + 전역 scan miss
     """
 
     SID_A = "11111111-2222-4333-8444-555555555555"
@@ -2104,19 +2160,22 @@ class AutoDetectFallbackTests(unittest.TestCase):
         sid: str,
         *,
         runs: dict,
-    ) -> None:
+        root: str = "sessions",
+    ) -> Path:
         """sessions/<sid>/live.json 작성 helper."""
-        sess_dir = self.base / "sessions" / sid
+        sess_dir = self.base / root / sid
         sess_dir.mkdir(parents=True, exist_ok=True)
         payload = {
             "_meta": {"sessionId": sid, "version": 1, "writtenAt": "2026-05-22T00:00:00+00:00"},
             "session_id": sid,
             "active_runs": runs,
         }
-        (sess_dir / "live.json").write_text(
+        live_file = sess_dir / "live.json"
+        live_file.write_text(
             json.dumps(payload, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        return live_file
 
     def test_env_var_takes_priority_for_session_id(self) -> None:
         from harness.session_state import auto_detect_session_id
@@ -2213,6 +2272,53 @@ class AutoDetectFallbackTests(unittest.TestCase):
         )
         rid = auto_detect_run_id(base_dir=self.base)
         self.assertEqual(rid, self.RID_A)
+
+    def test_auto_detect_run_id_uses_pid_sid_scoped_scan_when_current_run_pointer_missing(self) -> None:
+        """issue #684 — sid 는 by-pid 에 있으나 by-pid-current-run 만 유실된 장시간 run."""
+        from harness.session_state import (
+            auto_detect_run_id,
+            diagnose_sid_rid_resolution,
+            write_pid_session,
+        )
+
+        cc_pid = 12345
+        write_pid_session(cc_pid, self.SID_A, base_dir=self.base)
+        target_live = self._write_live(
+            self.SID_A,
+            root=".sessions",
+            runs={self.RID_A: {
+                "run_id": self.RID_A,
+                "started_at": "2026-05-22T01:00:00+00:00",
+                "completed_at": None,
+                "current_step": {"agent": "module-architect", "mode": None},
+            }},
+        )
+        os.utime(target_live, (1000, 1000))
+
+        # 전역 scan 의 live.json mtime 최신 5개가 모두 finalized 면 기존 fallback 은
+        # target sid 의 active_runs 를 보지 못하고 None 으로 떨어졌다.
+        for idx in range(6):
+            sid = f"noise-sid-{idx}"
+            rid = f"run-abc0000{idx}"
+            live_file = self._write_live(
+                sid,
+                root=".sessions",
+                runs={rid: {
+                    "run_id": rid,
+                    "started_at": "2026-05-22T02:00:00+00:00",
+                    "completed_at": None,
+                    "finalized_at": "2026-05-22T02:30:00+00:00",
+                }},
+            )
+            os.utime(live_file, (2000 + idx, 2000 + idx))
+
+        with patch("harness.session_state.get_cc_pid_via_ppid_chain", return_value=cc_pid):
+            rid = auto_detect_run_id(base_dir=self.base)
+            msg = diagnose_sid_rid_resolution(base_dir=self.base, mode="rid")
+        self.assertEqual(rid, self.RID_A)
+        self.assertIn("active_runs scan best-guess", msg)
+        self.assertIn(self.SID_A, msg)
+        self.assertIn(self.RID_A, msg)
 
     # ── issue #483 — diagnose_sid_rid_resolution 진단성 강화 ────────────
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #684

## 배경 및 문제

장시간 architect-loop run 에서 `.by-pid/{cc_pid}` sid 는 남아 있는데 `.by-pid-current-run/{cc_pid}` rid 포인터만 유실되면, helper 의 `begin-step` / `end-step` / `run-dir` / `run-status` 가 env escape hatch 없이는 sid/rid 를 복구하지 못했다. 기존 active_runs fallback 은 전역 live.json mtime 최신 5개만 scan 해서, 실제 sid 의 `active_runs` 에 run 이 살아 있어도 비용 가드 밖이면 `매치 없음`으로 떨어질 수 있었다.

## 원인 (해당 시)

`auto_detect_run_id()` 가 by-pid current-run 포인터를 못 찾은 뒤, 이미 by-pid 에서 확인 가능한 sid 를 활용하지 않고 `_scan_recent_active_run_slot()` 전역 scan 으로 바로 넘어갔다. 전역 scan 은 multi-session 비용 가드로 최신 live.json 5개만 보므로, 장시간 run 의 session live.json 이 그 후보 밖으로 밀리면 active run 을 누락했다.

## 작업내용

- `harness/session_state.py` 에 sid-scoped active_runs scan 경로를 추가했다.
- `auto_detect_run_id()` 는 by-pid sid 또는 env/pointer sid 가 있으면 해당 session live.json 을 먼저 직접 scan 한 뒤, 마지막에만 기존 전역 scan 으로 fallback 한다.
- `diagnose_sid_rid_resolution()` 도 같은 sid-scoped scan 을 사용해 `mode="both"` / `mode="rid"` 에서 실제 best-guess 를 보여준다.
- active run 후보 판정을 helper 함수로 분리하고, `finalized_at` 또는 `completed_at` 이 있는 슬롯은 fallback 후보에서 제외했다.
- #469 / #483 / #625 / #684 회귀 맥락을 테스트 이름과 docstring에 남겼다.

## 결정 근거

전역 scan 의 max_sessions 가드는 multi-session 비용 방어로 유지하되, 이미 sid 가 확인된 경우에는 multi-session ambiguity 가 없으므로 해당 sid 의 live.json 을 직접 읽는 것이 더 정확하다. 이 방식은 #625 처럼 sid 자체가 없는 subprocess 단절 케이스의 전역 fallback 을 유지하면서, #684 처럼 sid 는 살아 있고 rid 포인터만 유실된 케이스를 결정적으로 복구한다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 런타임 코드 경로: `harness/session_state.py` 변경으로 `scripts/dcness-helper` 및 `scripts/dcness-codex-validator` 가 import 하는 helper 자동해결 로직에 반영된다.
- `/init-dcness` 복사 파일, public command/skill/agent surface, 사용자 SSOT 문서 변경 없음.
- 기존 사용자는 plug-in 업데이트를 받으면 helper 런타임 변경을 그대로 받는다. 별도 프로젝트 재초기화는 필요하지 않다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_session_state.AutoDetectFallbackTests tests.test_session_state.CliBeginStepEndStepTests tests.test_codex_validator_wrapper -v`
- [x] `python3.11 -m unittest tests.test_session_state tests.test_hooks.RidResolutionTests tests.test_codex_validator_wrapper -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `git diff --check`
- [x] `scripts/check_python_tests.sh`
- [x] git pre-commit hook during `git commit`

## 참고

- 회귀 계보: #469 impl-loop/helper fallback, #483 진단성, #625 Codex subprocess env export, #684 current-run pointer 유실 + active_runs scan miss.
