### PR TITLE
[issue-684] completed_at scan 회귀 테스트

### DIFF
--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -2242,6 +2242,29 @@ class AutoDetectFallbackTests(unittest.TestCase):
         result = _scan_recent_active_run_slot(base_dir=self.base)
         self.assertEqual(result, (self.SID_B, self.RID_B))
 
+    def test_scan_skips_completed_runs_without_finalized_at(self) -> None:
+        """completed_at tombstone 만 있는 end-run 완료 슬롯도 fallback 후보에서 제외."""
+        from harness.session_state import _scan_recent_active_run_slot
+
+        self._write_live(
+            self.SID_A,
+            runs={self.RID_A: {
+                "run_id": self.RID_A,
+                "started_at": "2026-05-22T02:00:00+00:00",
+                "completed_at": "2026-05-22T02:30:00+00:00",
+            }},
+        )
+        self._write_live(
+            self.SID_B,
+            runs={self.RID_B: {
+                "run_id": self.RID_B,
+                "started_at": "2026-05-22T01:00:00+00:00",
+                "completed_at": None,
+            }},
+        )
+        result = _scan_recent_active_run_slot(base_dir=self.base)
+        self.assertEqual(result, (self.SID_B, self.RID_B))
+
     def test_scan_no_sessions_returns_none(self) -> None:
         from harness.session_state import _scan_recent_active_run_slot
         # sessions/ 디렉토리 자체 부재


### PR DESCRIPTION
## 관련 이슈 번호

Part of #684

## 배경 및 문제

PR #687 은 #684 본 수정 PR이며 merge 후 `pr-reviewer` post-check 에서 MUST FIX 없이 PASS 를 받았다. 다만 NICE TO HAVE 로 `finalized_at` 없이 `completed_at` 만 있는 완료 슬롯이 active_runs scan fallback 후보에서 제외되는지 좁은 테스트를 추가하라는 의견이 있었다.

## 원인 (해당 시)

구현은 이미 `completed_at` tombstone 을 fallback 후보에서 제외하지만, 기존 scan 테스트는 `finalized_at` 중심이었다. end-run 완료 슬롯의 primary tombstone 인 `completed_at` 단독 케이스를 테스트로 고정하지 않았다.

## 작업내용

- `tests/test_session_state.py` 에 `test_scan_skips_completed_runs_without_finalized_at` 추가.
- 더 최신 `completed_at` 완료 슬롯과 더 오래된 open 슬롯이 함께 있을 때, scan fallback 이 open 슬롯을 선택하는지 검증.

## 결정 근거

#684의 active_runs fallback은 "살아있는 run" 복구가 목적이다. `completed_at`만 있는 end-run 완료 슬롯은 `finalized_at`이 없더라도 살아있는 run 이 아니므로 후보에서 제외해야 한다. 이 동작을 명시 테스트로 고정한다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — 테스트 전용 보강. plug-in 런타임/commands/agents/hooks/init 복사 파일 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_session_state.AutoDetectFallbackTests -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `git diff --check`
- [x] `scripts/check_python_tests.sh`
- [x] git pre-commit hook during `git commit`

## 참고

- Follow-up to #687 post-merge `pr-reviewer` NICE TO HAVE.
