### PR TITLE
[feature] GitHub Project lifecycle CI 설치 (머지→Done 자동전이)

### DIFF
--- a/.github/workflows/github-project-lifecycle.yml
+++ b/.github/workflows/github-project-lifecycle.yml
@@ -1,0 +1,61 @@
+# GitHub Actions — GitHub Project v2 lifecycle 자동화 (issue drift 검출 + 머지→Done 보정)
+#
+# 모드/룰 정의: docs/plugin/github-project.md + scripts/github_project_lifecycle.mjs (SSOT)
+# 본 dcness self repo 는 자기 composite action (.github/actions/github-project-lifecycle) 을 dogfooding.
+# 외부 활성화 프로젝트는 init-dcness Step 2.10.5 가 묻고 Y 답변 시 thin yml 을 사용자 repo 에 배포 — 그 yml 은
+# `uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main` 1줄로 동일 검증.
+#
+# Project v2 쓰기에는 project scope token 필요: secrets.DCNESS_PROJECT_TOKEN
+#   (없으면 github.token 폴백 → Projects v2 쓰기 불가, drift 검출만 동작).
+# Project 좌표: vars.DCNESS_PROJECT_NUMBER / vars.DCNESS_PROJECT_OWNER.
+
+name: github-project-lifecycle
+
+on:
+  issues:
+    types: [opened, edited, labeled, unlabeled]
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  issue-drift:
+    if: ${{ github.event_name == 'issues' && vars.DCNESS_PROJECT_NUMBER != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate issue lifecycle via composite action
+        uses: ./.github/actions/github-project-lifecycle
+        env:
+          GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
+        with:
+          mode: validate-issue
+          repo: ${{ github.repository }}
+          project-owner: ${{ vars.DCNESS_PROJECT_OWNER || github.repository_owner }}
+          project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
+          issue-number: ${{ github.event.issue.number }}
+
+  pr-merged:
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && vars.DCNESS_PROJECT_NUMBER != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Correct Status=Done on merge via composite action
+        uses: ./.github/actions/github-project-lifecycle
+        env:
+          GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
+        with:
+          mode: pr-merged
+          repo: ${{ github.repository }}
+          project-owner: ${{ vars.DCNESS_PROJECT_OWNER || github.repository_owner }}
+          project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
+          pr-body: ${{ github.event.pull_request.body }}
+          apply: "true"


### PR DESCRIPTION
## 관련 이슈 번호
Document-Exception-PR-Close: self lifecycle CI 완성 — 2축 활성화 검토가 "self 단독 동기" 로 수렴해 별도 이슈 없이 진행. /init-dcness Step 2.10.5 가 외부 프로젝트에 배포하던 동일 workflow 의 self dogfooding.

## 배경 및 문제
self 는 이미 이슈관리(Issue Brief 포멧 + Project #3 + PR body Closes CI + git-naming)를 자체 hooks/CI/스킬로 운용 중이나, **Project Status 자동전이(머지→Done) 만 미설치**였다. composite action(`.github/actions/github-project-lifecycle`)·script(`scripts/github_project_lifecycle.mjs`)·repo vars(`DCNESS_PROJECT_NUMBER=3` / `DCNESS_PROJECT_OWNER`)는 이미 존재했으나, 이를 발화시킬 workflow yml 이 self repo 에 없었다.

## 원인 (해당 시)
-

## 작업내용
- `.github/workflows/github-project-lifecycle.yml` 신규.
  - `issue-drift` job: issue opened/edited/labeled/unlabeled → `validate-issue` (IssueType↔label drift 검출).
  - `pr-merged` job: PR closed+merged → `pr-merged` (PR body 의 Closes/Fixes/Resolves 대상 issue Status=Done 보정, `apply: true`).
  - self 컨벤션 정합: 로컬 composite action ref(`./.github/actions/github-project-lifecycle`) + `actions/checkout@v4` 선행 (git-naming/pr-body workflow 와 동형).

## 배포 경로 검증
- 본 변경은 **self repo 한정** (self CI dogfooding). 외부 활성화 프로젝트는 `/init-dcness` Step 2.10.5 가 동일 logic 의 thin yml(`alruminum/dcNess/.github/actions/github-project-lifecycle@main`)을 이미 배포 → **신규 배포 경로 추가 없음**.

## 후속 (out of scope)
- Project v2 쓰기에 `secrets.DCNESS_PROJECT_TOKEN`(project scope PAT) 필요. 미설정 시 `github.token` 폴백 → Done 보정 불가(drift 검출만). **토큰 등록은 별도 사용자 action.**
- `Todo→In progress` 자동전이(`start-work` 모드)는 표준 템플릿 미포함 — 필요 시 `issues: assigned` job 후속 배선.

## Test Plan
- [ ] 머지 후 다음 issue/PR 이벤트부터 workflow 발화
- [ ] `DCNESS_PROJECT_TOKEN` 설정 후 머지→Done 실동작 확인