### PR TITLE
[issue-694] ALLOW_MATRIX 언어 중립 확장 — 비-JS 외부 프로젝트 sub-agent write 회귀 수정

### DIFF
--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -94,13 +94,15 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'(^|/)packages/[^/]+/src/',
         r'(^|/)apps/[^/]+/[^/]+\.toml$',
         r'(^|/)apps/[^/]+/[^/]+\.cfg$',
-        # 언어 중립 소스 루트 레이아웃
-        r'(^|/)lib/',          # 다수 언어 라이브러리 소스
-        r'(^|/)app/',          # Rails/Phoenix 등 루트 app/
-        r'(^|/)cmd/',          # Go 엔트리포인트
-        r'(^|/)internal/',     # Go 내부 패키지
-        r'(^|/)pkg/',          # Go 공개 패키지
-        r'(^|/)remotion/',     # Remotion 비디오 소스 (youTubeGenerator 등) — #696 override 이관 후보
+        # 언어 중립 소스 루트 레이아웃 — 프로젝트 루트(^) 앵커. 위 src/ 는 monorepo 중첩
+        # (services/x/src 등)도 소스라 (^|/) 유지하지만, lib/cmd/pkg/internal 등은 모듈 루트
+        # 성격이라 중첩(node_modules/*/lib·.github/*/lib·vendor/*/pkg)을 소스로 오인하면 안 된다 (codex P2).
+        r'^lib/',          # 다수 언어 라이브러리 소스
+        r'^app/',          # Rails/Phoenix 등 루트 app/
+        r'^cmd/',          # Go 엔트리포인트
+        r'^internal/',     # Go 내부 패키지
+        r'^pkg/',          # Go 공개 패키지
+        r'^remotion/',     # Remotion 비디오 소스 (youTubeGenerator 등) — #696 override 이관 후보
     ),
     "architect": (
         r'(^|/)docs/',

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -77,9 +77,16 @@ RUN_DIR_PROSE_ALLOW: tuple[str, ...] = (
 
 
 # ── ALLOW_MATRIX (agent 별 Write 허용) ─────────────────────────
-# RWHarness agent-boundary.py:48~84 와 동일 패턴.
+# RWHarness agent-boundary.py:48~84 기반. engineer / test-engineer 는 #694 에서 언어·레이아웃
+# 중립으로 확장 (JS/TS 전용 → Python·Go·Ruby·JVM·C#·PHP·Elixir·remotion 등 비-JS 외부 프로젝트).
 ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
+    # engineer — 구현 소스. JS/TS·Python 모노레포(src/·apps/·packages/) + 언어 중립 소스 루트
+    # (lib/·app/·cmd/·internal/·pkg/) + Remotion 비디오 소스(remotion/). docs/ · 루트 비소스
+    # 문서(README 등)는 미매칭으로 차단 — 역할 격리 유지.
+    # ⚠️ remotion/ 같은 프로젝트 고유 디렉토리는 코어 기본값에 둔 임시 — 무한한 비표준 레이아웃은
+    #    프로젝트별 override 로 이관 예정(#696). 그때 코어 기본값 다이어트.
     "engineer": (
+        # JS/TS·Python 모노레포 관례
         r'(^|/)src/',
         r'(^|/)apps/[^/]+/src/',
         r'(^|/)apps/[^/]+/app/',
@@ -87,6 +94,13 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'(^|/)packages/[^/]+/src/',
         r'(^|/)apps/[^/]+/[^/]+\.toml$',
         r'(^|/)apps/[^/]+/[^/]+\.cfg$',
+        # 언어 중립 소스 루트 레이아웃
+        r'(^|/)lib/',          # 다수 언어 라이브러리 소스
+        r'(^|/)app/',          # Rails/Phoenix 등 루트 app/
+        r'(^|/)cmd/',          # Go 엔트리포인트
+        r'(^|/)internal/',     # Go 내부 패키지
+        r'(^|/)pkg/',          # Go 공개 패키지
+        r'(^|/)remotion/',     # Remotion 비디오 소스 (youTubeGenerator 등) — #696 override 이관 후보
     ),
     "architect": (
         r'(^|/)docs/',
@@ -109,15 +123,23 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'(^|/)design-variants/',
         r'(^|/)docs/ui-spec',
     ),
+    # test-engineer — 테스트만 (역할 격리: 구현 소스 write 금지). 언어 중립 테스트 컨벤션을
+    # 디렉토리(tests/·test/·spec/·__tests__/)와 파일명(test_*.py·*_test.{go,rb,..}·
+    # *.test.{ts,..}·*Test(s).{java,kt,cs,php}·*_spec.rb 등)으로 포괄.
+    # 기존 JS/TS 전용 패턴(src/__tests__/·apps/*/tests/ 등)은 아래 광범위 패턴에 흡수됨
+    # (test_test_engineer_js_ts_regression 회귀 가드가 보존 검증).
     "test-engineer": (
-        r'(^|/)src/__tests__/',
-        r'(^|/)src/.*\.test\.[jt]sx?$',
-        r'(^|/)src/.*\.spec\.[jt]sx?$',
-        r'(^|/)apps/[^/]+/tests/',
-        r'(^|/)apps/[^/]+/src/__tests__/',
-        r'(^|/)apps/[^/]+/src/.*\.test\.[jt]sx?$',
-        r'(^|/)apps/[^/]+/src/.*\.spec\.[jt]sx?$',
-        r'(^|/)packages/[^/]+/src/__tests__/',
+        # 테스트 디렉토리 — 안의 모든 파일이 테스트 (언어 다수)
+        r'(^|/)tests?/',           # tests/ · test/ — Python·Rust·PHP·JVM(src/test/)·JS·일반
+        r'(^|/)spec/',             # Ruby RSpec, JS Jasmine
+        r'(^|/)__tests__/',        # JS/TS jest — 어디든
+        # 테스트 파일명 — 디렉토리 밖 테스트 (언어별 컨벤션)
+        r'(^|/)test_[^/]+\.py$',                          # Python test_*.py
+        r'(^|/)[^/]+_test\.(py|go|rb|dart|exs?)$',        # Python·Go·Ruby·Dart·Elixir *_test.*
+        r'(^|/)[^/]+_spec\.rb$',                          # Ruby *_spec.rb
+        r'(^|/)[^/]+\.test\.[jt]sx?$',                    # JS/TS *.test.*
+        r'(^|/)[^/]+\.spec\.[jt]sx?$',                    # JS/TS *.spec.*
+        r'(^|/)[^/]+Tests?\.(java|kt|kts|scala|cs|php)$', # JVM·C#·PHP *Test(s).*
     ),
     "ux-architect": (
         r'(^|/)docs/ux-flow\.md$',

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -269,10 +269,14 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
             except ValueError:
                 # cwd 밖 — 그대로 반환 (외부 path 는 패턴 매칭에서 잡거나 통과)
                 return str(p)
-        # 상대 path — str(Path(...)) 로 정규화해 leading `./`·중복 separator 를 제거 (#694 codex P2).
-        # Edit/Write/Bash 가 `./lib/x` 처럼 넘겨도 루트 앵커(^lib/ 등) 패턴이 빗나가지 않게 하고,
-        # `./docs/x` 같은 prefix 우회도 docs deny 에 정상 매칭되게 한다.
-        return str(p)
+        # 상대 path — cwd 기준으로 결합·resolve 해 `.`/`..` 를 해소한 뒤 cwd 상대로 환원
+        # (#694 codex P1/P2). `./lib/x` 의 ./ 제거 + `lib/../README.md`·`tests/../src/x.py`
+        # 같은 .. 우회(매칭 위치 ≠ 실제 write 위치)를 차단한다. 절대 path 분기와 동일 정규화.
+        try:
+            return str((cwd / p).resolve().relative_to(cwd.resolve()))
+        except ValueError:
+            # ../ 로 cwd 상위 탈출 — 패턴 미매칭(ALLOW 미등재)으로 차단되도록 그대로 반환.
+            return str(p)
     except (OSError, ValueError):
         return file_path
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -177,8 +177,23 @@ _CODE_AGENTS: frozenset = frozenset({"engineer", "test-engineer", "build-worker"
 # 오인해 정상 소스를 막지 않도록 루트 docs 트리만 deny (#694 codex P2). _normalize 가
 # ./·.. 를 해소하므로 ^ 앵커가 안전(우회 prefix 없음).
 _CODE_AGENT_EXCLUSIVE_DENY: tuple[str, ...] = (
-    r'^docs/',            # architect / ux-architect / tech-reviewer 전용 (루트 docs 트리)
+    # 다른 역할 전용 산출 영역 — 루트(^) 앵커 (monorepo 동명 패키지 apps/docs/src 는 소스라 허용).
+    r'^docs/',            # architect / ux-architect / tech-reviewer 전용
     r'^design-variants/', # designer 전용
+    # 의존성 / 빌드 산출 트리 — 누구도 직접 write 하지 않는다. engineer 의 (^|/)src/ 와
+    # test-engineer 의 (^|/)tests?/·spec/ 가 이 트리 안 src/tests 를 *중첩* 매칭하던 우회를
+    # 차단 (codex P1/P2). monorepo 패키지별 중첩도 막도록 (^|/). 언어 전반의 보편 집합 —
+    # 프로젝트 고유 추가는 #696 override.
+    r'(^|/)node_modules/',   # JS/TS 의존성
+    r'(^|/)vendor/',          # Go·PHP·Ruby vendored
+    r'(^|/)third_party/',     # 일반 vendored
+    r'(^|/)\.venv/',          # Python 가상환경
+    r'(^|/)venv/',
+    r'(^|/)__pycache__/',     # Python 캐시
+    r'(^|/)dist/',            # 번들/패키지 산출물
+    r'(^|/)build/',           # 빌드 산출물
+    r'(^|/)target/',          # Rust·Java(Maven) 산출물
+    r'(^|/)out/',             # 일반 빌드 산출물
 )
 
 
@@ -261,25 +276,24 @@ def is_opt_out(cwd: Optional[Path] = None) -> bool:
 
 
 def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
-    """절대 path → cwd 상대 path. 외부 path 는 그대로 반환."""
+    """path 를 cwd 기준으로 resolve(`.`/`..`/심볼릭 해소) 후 cwd 상대로 환원.
+
+    절대/상대 동일 정규화. cwd 밖(상위 탈출·외부 절대)이면 *절대경로* 를 반환한다 —
+    호출부(check_write/read_allowed)의 cwd-밖 가드(`/` 시작)가 차단하게 (#694 codex P1).
+    원본 문자열을 돌려주면 `lib/../../lib/x` 같은 중첩 .. 탈출이 ALLOW 패턴에 매칭되는
+    우회가 생긴다.
+    """
     if cwd is None:
         cwd = Path.cwd()
     try:
         p = Path(file_path)
-        if p.is_absolute():
-            try:
-                return str(p.resolve().relative_to(cwd.resolve()))
-            except ValueError:
-                # cwd 밖 — 그대로 반환 (외부 path 는 패턴 매칭에서 잡거나 통과)
-                return str(p)
-        # 상대 path — cwd 기준으로 결합·resolve 해 `.`/`..` 를 해소한 뒤 cwd 상대로 환원
-        # (#694 codex P1/P2). `./lib/x` 의 ./ 제거 + `lib/../README.md`·`tests/../src/x.py`
-        # 같은 .. 우회(매칭 위치 ≠ 실제 write 위치)를 차단한다. 절대 path 분기와 동일 정규화.
+        base = p if p.is_absolute() else (cwd / p)
+        resolved = base.resolve()
         try:
-            return str((cwd / p).resolve().relative_to(cwd.resolve()))
+            return str(resolved.relative_to(cwd.resolve()))
         except ValueError:
-            # ../ 로 cwd 상위 탈출 — 패턴 미매칭(ALLOW 미등재)으로 차단되도록 그대로 반환.
-            return str(p)
+            # cwd 밖 — 절대경로 반환 (가드의 `/` 시작 체크가 차단).
+            return str(resolved)
     except (OSError, ValueError):
         return file_path
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -354,7 +355,8 @@ def check_write_allowed(
     # 사라져(→ `tests/x`) 셸가드를 우회하지만, 런타임엔 셸이 `$PWD` 를 확장해 프로젝트 밖에
     # write 한다 (#694 codex P2 r10). 원본 file_path 에 `$`/backtick 이 있으면 위치 미확정으로
     # 즉시 차단. Edit/Write 의 literal `$` 파일명(users.$id.tsx)은 shell_context=False 라 통과.
-    # (Bash 에서 literal `$` 파일은 따옴표로 써야 하고, 따옴표 토큰은 extract_bash_paths 가 제외.)
+    # Bash 는 shlex tokenization 뒤 quote 원형을 보존하지 않으므로, write target 에 `$`/backtick 이
+    # 남아 있으면 보수적으로 expansion risk 로 본다.
     if shell_context and ("$" in file_path or "`" in file_path):
         return (
             f"{agent} 셸 확장 경로 차단: `{file_path}` — Bash 의 $VAR/$()/backtick 은 hook 후 "
@@ -447,8 +449,9 @@ def check_read_allowed(
 
 # ── Bash heuristic ────────────────────────────────────────────────────
 
-# v1: 명시적 위반 패턴 (sed -i / awk -i / cp / mv / rm / 리다이렉션) 만 잡는다.
-# 정밀 path 추출 X — false negative 우선 (false positive 회피).
+# v1: 명시적 write 구문(sed/perl -i / cp / mv / rm / tee / 리다이렉션) 만 잡는다.
+# Bash 전체를 보안 파서처럼 해석하지 않는다. 단, 후보를 잡을 때는 "path처럼 보이는 모든
+# 토큰" 이 아니라 실제 write 대상만 추출해 read operand 오차단을 줄인다.
 _BASH_WRITE_INDICATORS: tuple[str, ...] = (
     r'\bsed\b\s+(?:[-]\w*i\w*|--in-place)',
     r'\bawk\b\s+(?:[-]\w*i\w*|--in-place)',
@@ -458,55 +461,272 @@ _BASH_WRITE_INDICATORS: tuple[str, ...] = (
     r'>>\s*\S',    # append redirect
     r'\btee\b',
 )
+_WRITE_REDIRECT_OPS = frozenset({">", ">>", ">|", "&>", ">&", "<>"})
+_READ_REDIRECT_OPS = frozenset({"<", "<<", "<<-"})
+_SHELL_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
+_CP_VALUE_FLAGS = frozenset({"-t", "--target-directory"})
+_SED_EXPR_FLAGS = frozenset({"-e", "--expression", "-f", "--file"})
+
+
+def _shell_tokens_for_paths(command: str) -> list[str]:
+    """Path 추출용 shell tokenization.
+
+    `shlex` 로 quote 를 해석하고 punctuation 을 분리한다. unmatched quote 등으로 실패하면
+    빈 list 를 반환한다. 이 hook 은 보안 경계가 아니라 실수 방지용 denylist 이므로
+    parse 불능 command 에서 억지 추출로 false positive 를 만들지 않는다.
+    """
+    try:
+        lexer = shlex.shlex(_strip_heredocs(command), posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
+    except ValueError:
+        return []
+
+
+def _split_shell_segments(tokens: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = []
+    cur: list[str] = []
+    for tok in tokens:
+        if tok in _SHELL_SEPARATORS:
+            if cur:
+                segments.append(cur)
+                cur = []
+        else:
+            cur.append(tok)
+    if cur:
+        segments.append(cur)
+    return segments
+
+
+def _strip_redirections_for_paths(tokens: list[str]) -> tuple[list[str], list[str]]:
+    """segment 에서 redirection write target 을 수집하고 command argv 만 반환."""
+    argv: list[str] = []
+    paths: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        # `2>err.log` 는 shlex 가 `2`, `>`, `err.log` 로 분리한다. fd 번호는 argv 에 넣지 않는다.
+        if tok.isdigit() and i + 1 < len(tokens) and tokens[i + 1] in (
+            _WRITE_REDIRECT_OPS | _READ_REDIRECT_OPS
+        ):
+            op = tokens[i + 1]
+            if i + 2 < len(tokens) and op in _WRITE_REDIRECT_OPS:
+                paths.append(tokens[i + 2])
+            i += 3 if i + 2 < len(tokens) else 2
+            continue
+        if tok in (_WRITE_REDIRECT_OPS | _READ_REDIRECT_OPS):
+            if i + 1 < len(tokens) and tok in _WRITE_REDIRECT_OPS:
+                paths.append(tokens[i + 1])
+            i += 2 if i + 1 < len(tokens) else 1
+            continue
+        argv.append(tok)
+        i += 1
+    return argv, paths
+
+
+def _command_positionals(args: list[str], value_flags: frozenset = frozenset()) -> list[str]:
+    out: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--":
+            out.extend(args[i + 1:])
+            break
+        if arg.startswith("-") and arg != "-":
+            base = arg.split("=", 1)[0]
+            if base in value_flags and "=" not in arg:
+                i += 2
+            else:
+                i += 1
+            continue
+        out.append(arg)
+        i += 1
+    return out
+
+
+def _target_directory_flag(args: list[str]) -> Optional[str]:
+    for i, arg in enumerate(args):
+        if arg.startswith("--target-directory="):
+            return arg.split("=", 1)[1]
+        if arg == "-t" and i + 1 < len(args):
+            return args[i + 1]
+        if arg == "--target-directory" and i + 1 < len(args):
+            return args[i + 1]
+    return None
+
+
+def _sed_in_place_targets(args: list[str]) -> list[str]:
+    in_place = False
+    expression_supplied = False
+    script_consumed = False
+    targets: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--":
+            targets.extend(p for p in args[i + 1:] if p and "://" not in p)
+            break
+        if arg in ("-i", "--in-place"):
+            in_place = True
+            # BSD sed: `sed -i '' 's/x/y/' file`
+            if i + 1 < len(args) and args[i + 1] == "":
+                i += 2
+            else:
+                i += 1
+            continue
+        if arg.startswith("-i") and arg != "-":
+            in_place = True
+            i += 1
+            continue
+        if arg.startswith("--in-place"):
+            in_place = True
+            i += 1
+            continue
+        if arg in _SED_EXPR_FLAGS:
+            expression_supplied = True
+            i += 2
+            continue
+        if (
+            arg.startswith("-e")
+            or arg.startswith("--expression=")
+            or arg.startswith("-f")
+            or arg.startswith("--file=")
+        ):
+            expression_supplied = True
+            i += 1
+            continue
+        if arg.startswith("-") and arg != "-":
+            i += 1
+            continue
+        if not expression_supplied and not script_consumed:
+            script_consumed = True
+            i += 1
+            continue
+        if arg and "://" not in arg:
+            targets.append(arg)
+        i += 1
+    return targets if in_place else []
+
+
+def _perl_in_place_targets(args: list[str]) -> list[str]:
+    in_place = False
+    targets: list[str] = []
+    skip_next_expr = False
+    for arg in args:
+        if skip_next_expr:
+            skip_next_expr = False
+            continue
+        if arg == "--":
+            continue
+        if arg.startswith("-") and arg != "-":
+            if "i" in arg.lstrip("-"):
+                in_place = True
+            # `-e 'script'`, `-pe 'script'`, `-E 'script'` 등은 다음 토큰이 program text.
+            opt = arg.lstrip("-")
+            if ("e" in opt or "E" in opt) and opt.lower().endswith(("e", "pe", "ne")):
+                skip_next_expr = True
+            continue
+        if arg and "://" not in arg:
+            targets.append(arg)
+    return targets if in_place else []
+
+
+def _awk_in_place_targets(args: list[str]) -> list[str]:
+    in_place = False
+    program_supplied = False
+    program_consumed = False
+    targets: list[str] = []
+    i = 0
+    while i < len(args):
+        arg = args[i]
+        if arg == "--":
+            targets.extend(p for p in args[i + 1:] if p and "://" not in p)
+            break
+        if arg == "-i":
+            if i + 1 < len(args) and args[i + 1] == "inplace":
+                in_place = True
+            i += 2
+            continue
+        if arg in ("-iinplace", "--include=inplace"):
+            in_place = True
+            i += 1
+            continue
+        if arg in ("-f", "--file"):
+            program_supplied = True
+            i += 2
+            continue
+        if arg.startswith("-f") or arg.startswith("--file="):
+            program_supplied = True
+            i += 1
+            continue
+        if arg in ("-v", "-F") and i + 1 < len(args):
+            i += 2
+            continue
+        if arg.startswith("-") and arg != "-":
+            i += 1
+            continue
+        if not program_supplied and not program_consumed:
+            program_consumed = True
+            i += 1
+            continue
+        # awk variable assignment arguments are not file operands.
+        if arg and "://" not in arg and not re.match(r"^[A-Za-z_][A-Za-z0-9_]*=", arg):
+            targets.append(arg)
+        i += 1
+    return targets if in_place else []
+
+
+def _command_write_targets(argv: list[str]) -> list[str]:
+    toks = _peel_wrappers(argv)
+    if not toks:
+        return []
+    cmd = _command_basename(toks[0])
+    args = toks[1:]
+    if cmd == "cp":
+        target_dir = _target_directory_flag(args)
+        if target_dir is not None:
+            return [target_dir]
+        pos = _command_positionals(args, _CP_VALUE_FLAGS)
+        return [pos[-1]] if len(pos) >= 2 else []
+    if cmd == "mv":
+        target_dir = _target_directory_flag(args)
+        pos = _command_positionals(args, _CP_VALUE_FLAGS)
+        return ([target_dir] if target_dir is not None else []) + pos
+    if cmd == "rm":
+        return _command_positionals(args)
+    if cmd == "tee":
+        return _command_positionals(args)
+    if cmd == "sed":
+        return _sed_in_place_targets(args)
+    if cmd == "perl":
+        return _perl_in_place_targets(args)
+    if cmd in ("awk", "gawk"):
+        return _awk_in_place_targets(args)
+    return []
 
 
 def extract_bash_paths(command: str) -> list[str]:
-    """Bash command 안의 의심 path 토큰 추출 (v1: 보수적).
+    """Bash command 안의 write target path 추출 (best-effort).
 
-    write 지표 (sed -i / cp / mv / rm / >) 가 보일 때만 토큰 분해 후
-    `/` 또는 `.md`/`.py`/`.json`/`.sh` 확장자 포함 토큰을 path 후보로 반환.
-    indicator 없으면 빈 list — false positive 회피.
+    이 함수는 file boundary 용이다. 따라서 `cat README.md > src/generated.ts` 에서
+    `README.md` 같은 read operand 는 후보가 아니고, 실제 write target 인
+    `src/generated.ts` 만 반환한다.
     """
     if not any(re.search(ind, command) for ind in _BASH_WRITE_INDICATORS):
         return []
-    # 토큰화 — quote 보존 (따옴표 친 토큰을 식별해 통째로 제외하기 위함).
-    tokens = re.findall(r"[\"'][^\"']*[\"']|\S+", command)
     paths: list[str] = []
-    for t in tokens:
-        # 따옴표로 감싼 토큰 처리 (codex P2 round10):
-        #   - 작은따옴표('…') = 셸 확장 없음 → 통째로 제외. sed/awk/perl 스크립트(`'s/foo/bar/'`)가
-        #     `/` 를 포함한다는 이유로 write path 로 오인돼 정상 편집(`sed -i 's/foo/bar/' src/main.ts`)이
-        #     차단되던 false positive 방지.
-        #   - 확장 토큰 없는 큰따옴표("…") = 동일하게 제외 (확장 없는 literal 인용).
-        #   - $/backtick 든 큰따옴표("$HOME/…", "`cmd`/…") = 셸이 hook 후 확장 → inner 를 *살려*
-        #     아래 path 후보 검사를 거쳐 반환한다. 그러면 check_write_allowed 의 셸확장 가드
-        #     (shell_context)가 위치 미확정으로 차단. 따옴표째 버리면 `echo x > "$HOME/tests/x"`
-        #     가 검사 미도달로 프로젝트 밖 write 우회가 된다 (codex P2 round10).
-        #     ($ 든 큰따옴표 안의 sed 치환 `"s/$old/$new/"` 은 inner 가 아래 sed 스크립트 제외
-        #      로직에 걸려 자연히 후보에서 빠진다 — false positive 안 생김.)
-        if len(t) >= 2 and t[0] in "\"'" and t[-1] == t[0]:
-            inner = t[1:-1]
-            if t[0] == '"' and ("$" in inner or "`" in inner):
-                t = inner   # 따옴표 벗긴 내용으로 후속 path/sed 검사 진행
-            else:
-                continue
-        if not t or t.startswith("-"):
-            continue
-        # URL/원격 스킴 토큰(`https://…`, `ssh://…`, `git://…`)은 로컬 write 대상이 아님 → 제외
-        # (codex P2 round9). `curl https://… > docs/…/x.json` 의 URL 이 `/` 를 포함한다는 이유로
-        # write path 후보로 오인돼 tech-reviewer 의 정상 evidence 수집이 차단되던 false positive 방지.
-        # shell `>` 리다이렉트 대상은 항상 로컬 path 이므로 URL 제외가 write 누락을 만들지 않는다.
-        if "://" in t:
-            continue
-        # 따옴표 없이 쓴 sed/awk 치환 스크립트(`s/foo/bar/`, `y/abc/def/`)도 명령 syntax → 제외
-        # (codex P2 round10). delimiter 가 2번 이상 등장하는 `[sy]<delim>…<delim>` 형태만 매칭해
-        # `src/main.ts` 같은 정상 path(`s` 다음이 delimiter 아님)는 보존.
-        if re.match(r"^[sy]([/|#@,!~]).+\1", t):
-            continue
-        # path 후보 — `/` 포함 또는 알려진 확장자.
-        if "/" in t or re.search(r"\.(md|py|json|sh|mjs|ts|tsx|js|jsx)$", t):
-            paths.append(t)
-    return paths
+    for segment in _split_shell_segments(_shell_tokens_for_paths(command)):
+        argv, redirect_paths = _strip_redirections_for_paths(segment)
+        paths.extend(redirect_paths)
+        paths.extend(_command_write_targets(argv))
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            deduped.append(path)
+    return deduped
 
 
 # ── 외부 시스템 mutation 차단 (#597 커밋5) ─────────────────────────────

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -173,9 +173,12 @@ ALLOW_MATRIX["build-worker"] = ALLOW_MATRIX["engineer"] + ALLOW_MATRIX["test-eng
 # design-variants/ 는 designer 전용이므로, 코드 agent 의 write 를 ALLOW 검사보다 *먼저*
 # 차단해 역할 경계를 지킨다. (기존 src/ 패턴의 docs/src/ 우회도 함께 닫힌다.)
 _CODE_AGENTS: frozenset = frozenset({"engineer", "test-engineer", "build-worker"})
+# 루트(^) 앵커 — monorepo 의 동명 app/package(apps/docs/src·packages/docs/src)를 문서로
+# 오인해 정상 소스를 막지 않도록 루트 docs 트리만 deny (#694 codex P2). _normalize 가
+# ./·.. 를 해소하므로 ^ 앵커가 안전(우회 prefix 없음).
 _CODE_AGENT_EXCLUSIVE_DENY: tuple[str, ...] = (
-    r'(^|/)docs/',            # architect / ux-architect / tech-reviewer 전용
-    r'(^|/)design-variants/', # designer 전용
+    r'^docs/',            # architect / ux-architect / tech-reviewer 전용 (루트 docs 트리)
+    r'^design-variants/', # designer 전용
 )
 
 
@@ -311,6 +314,15 @@ def check_write_allowed(
         return None
 
     norm = _normalize(file_path, cwd)
+
+    # cwd 밖 경로 차단 (#694 codex P2) — _normalize 가 cwd 상대화에 성공하면 항상 cwd-내
+    # 상대경로다. `/`(절대 외부) 또는 `../`(상위 탈출)로 시작하면 cwd 밖이며, 이때 원본을
+    # ALLOW 패턴에 먹이면 `../tests/x` 가 `(^|/)tests?/` 에 매칭되는 등 경계 우회가 생긴다.
+    if norm.startswith("/") or norm == ".." or norm.startswith("../"):
+        return (
+            f"{agent} cwd 밖 경로 차단: `{norm}` — 프로젝트 루트 밖 write 금지 "
+            f"(.. 상위 탈출 / 절대 외부 경로)."
+        )
 
     # 0. run_dir prose carve-out — build-worker 의 build-{test,impl,validate}.md self-write 한정.
     #    agent + 파일명 둘 다 좁혀 PASS 마커 위조를 차단 (codex P1). INFRA/ALLOW 검사보다 먼저.

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -269,7 +269,10 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
             except ValueError:
                 # cwd 밖 — 그대로 반환 (외부 path 는 패턴 매칭에서 잡거나 통과)
                 return str(p)
-        return file_path
+        # 상대 path — str(Path(...)) 로 정규화해 leading `./`·중복 separator 를 제거 (#694 codex P2).
+        # Edit/Write/Bash 가 `./lib/x` 처럼 넘겨도 루트 앵커(^lib/ 등) 패턴이 빗나가지 않게 하고,
+        # `./docs/x` 같은 prefix 우회도 docs deny 에 정상 매칭되게 한다.
+        return str(p)
     except (OSError, ValueError):
         return file_path
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -291,8 +291,11 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
     # 디렉토리 타깃(`cp x tests/`·`mv y apps/web/src/`)의 끝 구분자 보존 — resolve()가 끝 `/`를
     # 떼면 ALLOW 패턴(`tests?/`·`.../src/`)과 deny 패턴(`^docs/`·`(^|/)hooks/`)이 디렉토리 루트를
     # 미매칭해, 정당 in-bound write 가 오차단되고 보호 디렉토리 타깃이 누락된다 (#694 codex P2 r10).
-    # 끝 `/`를 정규화 결과에 다시 붙여 매칭 정합을 복원한다.
-    trailing = "/" if file_path.endswith(("/", os.sep)) else ""
+    # 끝 `/` 외에 `/.`(예 `cp x tests/.`)·`/./` 도 같은 디렉토리를 가리키는 흔한 스펠링이므로
+    # 동일하게 끝 `/`로 보존한다. resolve() 가 `/.` 를 떼어 `tests` 로 만드는 것을 보정 (codex P2 r10).
+    trailing = (
+        "/" if file_path.endswith(("/", os.sep, "/.", os.sep + ".")) else ""
+    )
     try:
         # ~ / ~user 는 셸이 hook 통과 *후* home 으로 확장하므로 미리 모사 — home 은 cwd 밖이라
         # 아래 resolve 가 절대경로화 → 호출부 cwd-밖 가드가 차단 (#694 codex P2).
@@ -346,6 +349,18 @@ def check_write_allowed(
     if is_opt_out(cwd):
         return None
 
+    # 셸 변수/명령치환 — Bash 출처(shell_context)만, *정규화 전 원본* 에 대해 검사한다.
+    # `$PWD/../tests/x` 처럼 `..` 가 `$` 세그먼트를 상쇄하면 _normalize 후 norm 에서 `$` 가
+    # 사라져(→ `tests/x`) 셸가드를 우회하지만, 런타임엔 셸이 `$PWD` 를 확장해 프로젝트 밖에
+    # write 한다 (#694 codex P2 r10). 원본 file_path 에 `$`/backtick 이 있으면 위치 미확정으로
+    # 즉시 차단. Edit/Write 의 literal `$` 파일명(users.$id.tsx)은 shell_context=False 라 통과.
+    # (Bash 에서 literal `$` 파일은 따옴표로 써야 하고, 따옴표 토큰은 extract_bash_paths 가 제외.)
+    if shell_context and ("$" in file_path or "`" in file_path):
+        return (
+            f"{agent} 셸 확장 경로 차단: `{file_path}` — Bash 의 $VAR/$()/backtick 은 hook 후 "
+            f"셸 확장돼 위치 미확정 (프로젝트 밖 write 우회 방지)."
+        )
+
     norm = _normalize(file_path, cwd)
 
     # cwd 밖 경로 차단 (#694 codex P2) — _normalize 가 cwd 상대화에 성공하면 항상 cwd-내
@@ -359,15 +374,6 @@ def check_write_allowed(
         return (
             f"{agent} 경계 밖 경로 차단: `{norm}` — 프로젝트 루트 밖 write 금지 "
             f"(.. 상위 탈출 / 절대 외부 / ~ home)."
-        )
-    # 셸 변수/명령치환 — Bash 출처(shell_context)만. Bash 의 $VAR/$()/backtick 은 hook 후 셸이
-    # 확장해 위치가 미확정이므로 차단 (#694 codex P2). Edit/Write 의 literal file_path 는
-    # shell_context=False 라 프레임워크 route 파일명(users.$id.tsx 등)의 literal `$` 를 허용.
-    # (Bash 에서 literal `$` 파일은 따옴표로 써야 하고, 따옴표 토큰은 extract_bash_paths 가 제외.)
-    if shell_context and ("$" in norm or "`" in norm):
-        return (
-            f"{agent} 셸 확장 경로 차단: `{norm}` — Bash 의 $VAR/$()/backtick 은 hook 후 "
-            f"셸 확장돼 위치 미확정 (프로젝트 밖 write 우회 방지)."
         )
 
     # 0. run_dir prose carve-out — build-worker 의 build-{test,impl,validate}.md self-write 한정.

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -288,6 +288,11 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
     """
     if cwd is None:
         cwd = Path.cwd()
+    # 디렉토리 타깃(`cp x tests/`·`mv y apps/web/src/`)의 끝 구분자 보존 — resolve()가 끝 `/`를
+    # 떼면 ALLOW 패턴(`tests?/`·`.../src/`)과 deny 패턴(`^docs/`·`(^|/)hooks/`)이 디렉토리 루트를
+    # 미매칭해, 정당 in-bound write 가 오차단되고 보호 디렉토리 타깃이 누락된다 (#694 codex P2 r10).
+    # 끝 `/`를 정규화 결과에 다시 붙여 매칭 정합을 복원한다.
+    trailing = "/" if file_path.endswith(("/", os.sep)) else ""
     try:
         # ~ / ~user 는 셸이 hook 통과 *후* home 으로 확장하므로 미리 모사 — home 은 cwd 밖이라
         # 아래 resolve 가 절대경로화 → 호출부 cwd-밖 가드가 차단 (#694 codex P2).
@@ -295,10 +300,13 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
         base = p if p.is_absolute() else (cwd / p)
         resolved = base.resolve()
         try:
-            return str(resolved.relative_to(cwd.resolve()))
+            rel = str(resolved.relative_to(cwd.resolve()))
+            # cwd 자기 자신(rel == ".")엔 `/`를 붙이지 않는다 — 루트는 어떤 ALLOW 도 아니며
+            # `./` 오매칭을 막는다. resolve() 결과는 끝 `/`가 없으므로 슬래시 중복 없음.
+            return rel + trailing if rel != "." else rel
         except ValueError:
-            # cwd 밖 — 절대경로 반환 (가드의 `/` 시작 체크가 차단).
-            return str(resolved)
+            # cwd 밖 — 절대경로 반환 (가드의 `/` 시작 체크가 차단). 끝 `/`는 무해(가드 우선).
+            return str(resolved) + trailing
     except (OSError, ValueError, RuntimeError):
         # expanduser 가 home 미해결 시 RuntimeError — 원본 반환(`~` 시작은 가드가 차단).
         return file_path

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -317,12 +317,17 @@ def check_write_allowed(
     file_path: str,
     *,
     cwd: Optional[Path] = None,
+    shell_context: bool = False,
 ) -> Optional[str]:
     """Write/Edit 검사 — block reason str / None=allow.
 
     메인 Claude (agent=None / 빈 문자열) = 통과. 메인 거버넌스는 Document Sync 가 강제.
     is_infra_project() True = 통과 — dcness 자체 SSOT 편집.
     `.no-dcness-guard` 마커 = 통과.
+
+    shell_context=True (Bash 추출 경로) — `$VAR`/`$()`/backtick 셸 확장 토큰을 추가 차단한다
+    (셸이 hook 후 확장 → 위치 미확정). Edit/Write 의 literal file_path 는 False(기본)라
+    프레임워크 route 파일명(users.$id.tsx 등)의 literal `$` 를 막지 않는다 (#694 codex P2).
     """
     if not agent:
         return None
@@ -336,22 +341,23 @@ def check_write_allowed(
     # cwd 밖 경로 차단 (#694 codex P2) — _normalize 가 cwd 상대화에 성공하면 항상 cwd-내
     # 상대경로다. `/`(절대 외부) 또는 `../`(상위 탈출)로 시작하면 cwd 밖이며, 이때 원본을
     # ALLOW 패턴에 먹이면 `../tests/x` 가 `(^|/)tests?/` 에 매칭되는 등 경계 우회가 생긴다.
-    # 셸 확장·변수·치환·상위탈출·절대외부 — hook 은 셸 확장 *전* 토큰을 보므로 위치가 미확정
-    # 이거나 cwd 밖이다 (#694 codex P2). ~ 는 _normalize expanduser 가 우선 모사하고, 잔존분과
-    # $VAR/${}/$()/backtick 은 여기서 막는다. Edit/Write 의 리터럴 경로엔 이 토큰이 없다.
-    # (참고: quoted "$VAR"·eval·문자열 조립은 extract_bash_paths 의 best-effort 한계 — 본 guard
-    #  는 보안 경계가 아니라 실수 방지 denylist. sub-agent 는 Bash 로 원천 우회 가능.)
-    if (
-        norm.startswith("/")
-        or norm == ".."
-        or norm.startswith("../")
-        or norm.startswith("~")
-        or "$" in norm        # $VAR · ${VAR} · $(cmd) 셸 변수/명령치환
-        or "`" in norm        # `cmd` 백틱 명령치환
-    ):
+    # 절대외부·상위탈출·~home — 출처 무관 공통 차단. _normalize 가 cwd 상대화에 성공하면 항상
+    # cwd-내 상대경로이므로, `/`(절대 외부)·`..`/`../`(상위 탈출)·`~`(home, expanduser 잔존)로
+    # 시작하면 프로젝트 루트 밖이다 (#694 codex P1/P2). 원본을 ALLOW 패턴에 먹이면 `../tests/x`
+    # 가 `(^|/)tests?/` 에 매칭되는 우회가 생긴다.
+    if norm.startswith("/") or norm == ".." or norm.startswith("../") or norm.startswith("~"):
         return (
-            f"{agent} 경계 밖/미확정 경로 차단: `{norm}` — 프로젝트 루트 밖이거나 셸 확장"
-            f"(~ $VAR $() ` / .. 상위 탈출 / 절대 외부)으로 위치 미확정."
+            f"{agent} 경계 밖 경로 차단: `{norm}` — 프로젝트 루트 밖 write 금지 "
+            f"(.. 상위 탈출 / 절대 외부 / ~ home)."
+        )
+    # 셸 변수/명령치환 — Bash 출처(shell_context)만. Bash 의 $VAR/$()/backtick 은 hook 후 셸이
+    # 확장해 위치가 미확정이므로 차단 (#694 codex P2). Edit/Write 의 literal file_path 는
+    # shell_context=False 라 프레임워크 route 파일명(users.$id.tsx 등)의 literal `$` 를 허용.
+    # (Bash 에서 literal `$` 파일은 따옴표로 써야 하고, 따옴표 토큰은 extract_bash_paths 가 제외.)
+    if shell_context and ("$" in norm or "`" in norm):
+        return (
+            f"{agent} 셸 확장 경로 차단: `{norm}` — Bash 의 $VAR/$()/backtick 은 hook 후 "
+            f"셸 확장돼 위치 미확정 (프로젝트 밖 write 우회 방지)."
         )
 
     # 0. run_dir prose carve-out — build-worker 의 build-{test,impl,validate}.md self-write 한정.

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -182,19 +182,21 @@ _CODE_AGENT_EXCLUSIVE_DENY: tuple[str, ...] = (
     r'^design-variants/', # designer 전용
     # 의존성 / 빌드 산출 트리 — 누구도 직접 write 하지 않는다. engineer 의 (^|/)src/ 와
     # test-engineer 의 (^|/)tests?/·spec/ 가 이 트리 안 src/tests 를 *중첩* 매칭하던 우회를
-    # 차단 (codex P1/P2). monorepo 패키지별 중첩도 막도록 (^|/). 언어 전반의 보편 집합 —
-    # 프로젝트 고유 추가는 #696 override.
+    # 차단 (codex P1/P2). 언어 전반의 보편 집합 — 프로젝트 고유 추가는 #696 override.
+    #
+    # 두 그룹으로 나눈다 (codex P2 round10):
+    #  A. 이름 충돌 없는 트리 — 디렉토리명이 소스 디렉토리·패키지명과 겹칠 일이 없어 어디서든
+    #     (^|/) deny 가 안전.
     r'(^|/)node_modules/',   # JS/TS 의존성
-    r'(^|/)vendor/',          # Go·PHP·Ruby vendored
-    r'(^|/)third_party/',     # 일반 vendored
     r'(^|/)\.venv/',          # Python 가상환경
     r'(^|/)venv/',
     r'(^|/)__pycache__/',     # Python 캐시 (항상 캐시 — 어디든)
-    # 빌드 산출물 — 루트 또는 monorepo 패키지 루트(apps/*·packages/*)에 위치. 의존성과 달리
-    # 이름(build·dist·out·target)이 소스 디렉토리명과 충돌할 수 있어, 허용된 src/ 트리 안의
-    # 동명 소스(src/build/ 등)를 막지 않도록 루트/패키지 루트만 앵커한다 (codex P2).
-    r'^(?:dist|build|target|out)/',
-    r'(^|/)(?:apps|packages)/[^/]+/(?:dist|build|target|out)/',
+    #  B. 이름 충돌 가능 트리 — vendor·third_party·dist·build·target·out 은 패키지명이나
+    #     소스 디렉토리명과 겹칠 수 있다 (예 monorepo 의 `apps/vendor/src/` 정상 패키지,
+    #     허용된 `src/build/`). 어디서든 (^|/) deny 하면 이런 정당 소스를 오차단하므로,
+    #     루트 또는 monorepo 패키지 루트(apps/*·packages/*)에만 앵커한다 (codex P2 round10).
+    r'^(?:vendor|third_party|dist|build|target|out)/',
+    r'(^|/)(?:apps|packages)/[^/]+/(?:vendor|third_party|dist|build|target|out)/',
 )
 
 
@@ -457,12 +459,23 @@ def extract_bash_paths(command: str) -> list[str]:
     tokens = re.findall(r"[\"'][^\"']*[\"']|\S+", command)
     paths: list[str] = []
     for t in tokens:
-        # 따옴표로 감싼 토큰은 path 후보에서 제외 (codex P2 round10). sed/awk/perl 스크립트
-        # (`'s/foo/bar/'`)가 `/` 를 포함한다는 이유로 write path 로 오인돼 정상 편집
-        # (`sed -i 's/foo/bar/' src/main.ts`)이 차단되던 false positive 방지. 따옴표 친 write
-        # 대상이 누락되는 것은 본 guard 의 "false negative 우선" 원칙 + nested-shell 한계와 정합.
+        # 따옴표로 감싼 토큰 처리 (codex P2 round10):
+        #   - 작은따옴표('…') = 셸 확장 없음 → 통째로 제외. sed/awk/perl 스크립트(`'s/foo/bar/'`)가
+        #     `/` 를 포함한다는 이유로 write path 로 오인돼 정상 편집(`sed -i 's/foo/bar/' src/main.ts`)이
+        #     차단되던 false positive 방지.
+        #   - 확장 토큰 없는 큰따옴표("…") = 동일하게 제외 (확장 없는 literal 인용).
+        #   - $/backtick 든 큰따옴표("$HOME/…", "`cmd`/…") = 셸이 hook 후 확장 → inner 를 *살려*
+        #     아래 path 후보 검사를 거쳐 반환한다. 그러면 check_write_allowed 의 셸확장 가드
+        #     (shell_context)가 위치 미확정으로 차단. 따옴표째 버리면 `echo x > "$HOME/tests/x"`
+        #     가 검사 미도달로 프로젝트 밖 write 우회가 된다 (codex P2 round10).
+        #     ($ 든 큰따옴표 안의 sed 치환 `"s/$old/$new/"` 은 inner 가 아래 sed 스크립트 제외
+        #      로직에 걸려 자연히 후보에서 빠진다 — false positive 안 생김.)
         if len(t) >= 2 and t[0] in "\"'" and t[-1] == t[0]:
-            continue
+            inner = t[1:-1]
+            if t[0] == '"' and ("$" in inner or "`" in inner):
+                t = inner   # 따옴표 벗긴 내용으로 후속 path/sed 검사 진행
+            else:
+                continue
         if not t or t.startswith("-"):
             continue
         # URL/원격 스킴 토큰(`https://…`, `ssh://…`, `git://…`)은 로컬 write 대상이 아님 → 제외

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -164,6 +164,19 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
 ALLOW_MATRIX["build-worker"] = ALLOW_MATRIX["engineer"] + ALLOW_MATRIX["test-engineer"]
 
 
+# ── 코드 agent 전용영역 deny (#694 codex P2) ───────────────────────
+# engineer / test-engineer / build-worker 의 언어 중립 ALLOW 패턴(lib/·internal/·cmd/·
+# tests?/·spec/·test_*.py 등)은 re.search 라 docs/ 하위 동명 디렉토리(docs/internal/·
+# docs/spec/·docs/tests/)나 docs 안 테스트 파일명을 *우회 허용* 한다. docs/ 는 architect,
+# design-variants/ 는 designer 전용이므로, 코드 agent 의 write 를 ALLOW 검사보다 *먼저*
+# 차단해 역할 경계를 지킨다. (기존 src/ 패턴의 docs/src/ 우회도 함께 닫힌다.)
+_CODE_AGENTS: frozenset = frozenset({"engineer", "test-engineer", "build-worker"})
+_CODE_AGENT_EXCLUSIVE_DENY: tuple[str, ...] = (
+    r'(^|/)docs/',            # architect / ux-architect / tech-reviewer 전용
+    r'(^|/)design-variants/', # designer 전용
+)
+
+
 # ── READ_DENY_MATRIX (agent 별 Read 금지) ──────────────────────
 READ_DENY_MATRIX: dict[str, tuple[str, ...]] = {
     "designer": (
@@ -300,7 +313,18 @@ def check_write_allowed(
     if matched:
         return f"인프라 path 보호: matched `{matched}` (DCNESS_INFRA_PATTERNS)"
 
-    # 2. ALLOW_MATRIX 미매칭 → 차단.
+    # 2. 코드 agent 전용영역 deny → ALLOW 검사보다 먼저 (#694 codex P2).
+    #    언어 중립 ALLOW 패턴이 docs/·design-variants/ 하위 동명 디렉토리/파일명을
+    #    re.search 로 우회 허용하는 것을 차단 — docs/ 는 architect, design-variants/ 는 designer.
+    if agent in _CODE_AGENTS:
+        matched = _matches_any(norm, _CODE_AGENT_EXCLUSIVE_DENY)
+        if matched:
+            return (
+                f"{agent} 전용영역 침범 차단: `{norm}` matched `{matched}` — "
+                f"docs/ 는 architect, design-variants/ 는 designer 전용 (코드 agent write 금지)."
+            )
+
+    # 3. ALLOW_MATRIX 미매칭 → 차단.
     allowed = ALLOW_MATRIX.get(agent)
     if allowed is None:
         # 미정의 agent — false positive 회피로 통과.

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -336,15 +336,22 @@ def check_write_allowed(
     # cwd 밖 경로 차단 (#694 codex P2) — _normalize 가 cwd 상대화에 성공하면 항상 cwd-내
     # 상대경로다. `/`(절대 외부) 또는 `../`(상위 탈출)로 시작하면 cwd 밖이며, 이때 원본을
     # ALLOW 패턴에 먹이면 `../tests/x` 가 `(^|/)tests?/` 에 매칭되는 등 경계 우회가 생긴다.
+    # 셸 확장·변수·치환·상위탈출·절대외부 — hook 은 셸 확장 *전* 토큰을 보므로 위치가 미확정
+    # 이거나 cwd 밖이다 (#694 codex P2). ~ 는 _normalize expanduser 가 우선 모사하고, 잔존분과
+    # $VAR/${}/$()/backtick 은 여기서 막는다. Edit/Write 의 리터럴 경로엔 이 토큰이 없다.
+    # (참고: quoted "$VAR"·eval·문자열 조립은 extract_bash_paths 의 best-effort 한계 — 본 guard
+    #  는 보안 경계가 아니라 실수 방지 denylist. sub-agent 는 Bash 로 원천 우회 가능.)
     if (
         norm.startswith("/")
         or norm == ".."
         or norm.startswith("../")
-        or norm.startswith("~")  # expanduser 가 home 미해결 시 잔존 — 셸 확장되면 cwd 밖
+        or norm.startswith("~")
+        or "$" in norm        # $VAR · ${VAR} · $(cmd) 셸 변수/명령치환
+        or "`" in norm        # `cmd` 백틱 명령치환
     ):
         return (
-            f"{agent} cwd 밖 경로 차단: `{norm}` — 프로젝트 루트 밖 write 금지 "
-            f"(.. 상위 탈출 / 절대 외부 / ~ home 경로)."
+            f"{agent} 경계 밖/미확정 경로 차단: `{norm}` — 프로젝트 루트 밖이거나 셸 확장"
+            f"(~ $VAR $() ` / .. 상위 탈출 / 절대 외부)으로 위치 미확정."
         )
 
     # 0. run_dir prose carve-out — build-worker 의 build-{test,impl,validate}.md self-write 한정.

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -189,11 +189,12 @@ _CODE_AGENT_EXCLUSIVE_DENY: tuple[str, ...] = (
     r'(^|/)third_party/',     # 일반 vendored
     r'(^|/)\.venv/',          # Python 가상환경
     r'(^|/)venv/',
-    r'(^|/)__pycache__/',     # Python 캐시
-    r'(^|/)dist/',            # 번들/패키지 산출물
-    r'(^|/)build/',           # 빌드 산출물
-    r'(^|/)target/',          # Rust·Java(Maven) 산출물
-    r'(^|/)out/',             # 일반 빌드 산출물
+    r'(^|/)__pycache__/',     # Python 캐시 (항상 캐시 — 어디든)
+    # 빌드 산출물 — 루트 또는 monorepo 패키지 루트(apps/*·packages/*)에 위치. 의존성과 달리
+    # 이름(build·dist·out·target)이 소스 디렉토리명과 충돌할 수 있어, 허용된 src/ 트리 안의
+    # 동명 소스(src/build/ 등)를 막지 않도록 루트/패키지 루트만 앵커한다 (codex P2).
+    r'^(?:dist|build|target|out)/',
+    r'(^|/)(?:apps|packages)/[^/]+/(?:dist|build|target|out)/',
 )
 
 
@@ -286,7 +287,9 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
     if cwd is None:
         cwd = Path.cwd()
     try:
-        p = Path(file_path)
+        # ~ / ~user 는 셸이 hook 통과 *후* home 으로 확장하므로 미리 모사 — home 은 cwd 밖이라
+        # 아래 resolve 가 절대경로화 → 호출부 cwd-밖 가드가 차단 (#694 codex P2).
+        p = Path(file_path).expanduser()
         base = p if p.is_absolute() else (cwd / p)
         resolved = base.resolve()
         try:
@@ -294,7 +297,8 @@ def _normalize(file_path: str, cwd: Optional[Path] = None) -> str:
         except ValueError:
             # cwd 밖 — 절대경로 반환 (가드의 `/` 시작 체크가 차단).
             return str(resolved)
-    except (OSError, ValueError):
+    except (OSError, ValueError, RuntimeError):
+        # expanduser 가 home 미해결 시 RuntimeError — 원본 반환(`~` 시작은 가드가 차단).
         return file_path
 
 
@@ -332,10 +336,15 @@ def check_write_allowed(
     # cwd 밖 경로 차단 (#694 codex P2) — _normalize 가 cwd 상대화에 성공하면 항상 cwd-내
     # 상대경로다. `/`(절대 외부) 또는 `../`(상위 탈출)로 시작하면 cwd 밖이며, 이때 원본을
     # ALLOW 패턴에 먹이면 `../tests/x` 가 `(^|/)tests?/` 에 매칭되는 등 경계 우회가 생긴다.
-    if norm.startswith("/") or norm == ".." or norm.startswith("../"):
+    if (
+        norm.startswith("/")
+        or norm == ".."
+        or norm.startswith("../")
+        or norm.startswith("~")  # expanduser 가 home 미해결 시 잔존 — 셸 확장되면 cwd 밖
+    ):
         return (
             f"{agent} cwd 밖 경로 차단: `{norm}` — 프로젝트 루트 밖 write 금지 "
-            f"(.. 상위 탈출 / 절대 외부 경로)."
+            f"(.. 상위 탈출 / 절대 외부 / ~ home 경로)."
         )
 
     # 0. run_dir prose carve-out — build-worker 의 build-{test,impl,validate}.md self-write 한정.

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -631,7 +631,9 @@ def handle_pretooluse_file_op(
                 print(f"[agent-boundary][Bash] {reason}", file=sys.stderr)
                 return 1
         for fp in extract_bash_paths(cmd):
-            reason = check_write_allowed(acting_agent, fp, cwd=cwd)
+            # shell_context=True — Bash 추출 경로의 $VAR/$()/backtick 셸 확장 토큰 차단
+            # (#694 codex P2). Edit/Write 의 literal 경로 검사(위)는 기본 False 라 영향 없음.
+            reason = check_write_allowed(acting_agent, fp, cwd=cwd, shell_context=True)
             if reason:
                 print(f"[agent-boundary][Bash] {reason}", file=sys.stderr)
                 return 1

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -301,6 +301,151 @@ class WriteAllowedAllowMatrixTests(unittest.TestCase):
             )
 
 
+class LanguageNeutralAllowMatrixTests(unittest.TestCase):
+    """#694 — ALLOW_MATRIX 언어 중립성.
+
+    test-engineer / engineer 의 write 경계가 JS/TS 모노레포 컨벤션에 묶여 비-JS 외부
+    프로젝트(Python·Go·Ruby·JVM·C#·PHP·Elixir·remotion 등)의 정상 산출물을 차단하던
+    회귀 수정. 역할 격리(test-engineer=테스트만, engineer=소스)는 유지하면서 언어·레이아웃만
+    중립화한다. 외부 프로젝트 시뮬레이션(DCNESS_INFRA="" + CLAUDE_PLUGIN_ROOT="").
+    """
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    # ── test-engineer: 언어 중립 테스트 경로 허용 ──
+    def test_test_engineer_python_tests_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in (
+                "tests/core/domain/test_shorts.py",   # tests/ 디렉토리 + test_ 파일명
+                "test_module.py",                      # 루트 test_*.py
+                "pkg/utils_test.py",                   # *_test.py (디렉토리 밖)
+            ):
+                self.assertIsNone(
+                    check_write_allowed("test-engineer", p, cwd=cwd),
+                    f"Python 테스트 {p} 가 허용되어야 함",
+                )
+
+    def test_test_engineer_go_test_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # *_test.go (디렉토리 무관 파일명 컨벤션).
+            self.assertIsNone(
+                check_write_allowed("test-engineer", "internal/svc/handler_test.go", cwd=cwd)
+            )
+
+    def test_test_engineer_ruby_spec_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("spec/models/user_spec.rb", "lib/foo_test.rb"):
+                self.assertIsNone(
+                    check_write_allowed("test-engineer", p, cwd=cwd),
+                    f"Ruby 테스트 {p} 허용",
+                )
+
+    def test_test_engineer_jvm_csharp_php_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in (
+                "src/test/java/com/foo/UserServiceTest.java",  # src/test/ 디렉토리
+                "src/test/kotlin/FooTests.kt",
+                "MyApp.Tests/CalculatorTests.cs",              # 파일명 패턴 (디렉토리 밖)
+                "app/Service/UserTest.php",
+            ):
+                self.assertIsNone(
+                    check_write_allowed("test-engineer", p, cwd=cwd),
+                    f"JVM/C#/PHP 테스트 {p} 허용",
+                )
+
+    def test_test_engineer_elixir_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("test-engineer", "test/foo_test.exs", cwd=cwd)
+            )
+
+    def test_test_engineer_js_ts_regression(self):
+        # 기존 JS/TS 패턴이 광범위 패턴에 흡수돼도 여전히 허용 (회귀 방지).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in (
+                "src/__tests__/a.test.ts",
+                "src/components/Button.spec.tsx",
+                "apps/web/tests/e2e.test.ts",
+                "packages/core/src/__tests__/x.test.ts",
+            ):
+                self.assertIsNone(
+                    check_write_allowed("test-engineer", p, cwd=cwd),
+                    f"기존 JS/TS 테스트 {p} 회귀",
+                )
+
+    def test_test_engineer_still_cannot_write_impl(self):
+        # 역할 격리 유지 — test-engineer 는 비-테스트 구현 코드를 쓰면 안 된다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("src/domain/shorts.py", "remotion/shorts-types.ts", "lib/core.go"):
+                reason = check_write_allowed("test-engineer", p, cwd=cwd)
+                self.assertIsNotNone(reason, f"test-engineer 가 구현 {p} 를 쓰면 안 됨")
+                self.assertIn("ALLOW_MATRIX", reason)
+
+    # ── engineer: 언어 중립 소스 레이아웃 허용 ──
+    def test_engineer_remotion_allowed(self):
+        # #694 핵심 — src/ 밖 소스 루트(remotion/) 허용 (youTubeGenerator task 04).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("engineer", "remotion/shorts-types.ts", cwd=cwd)
+            )
+
+    def test_engineer_common_source_layouts_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in (
+                "lib/parser.rb",
+                "app/models/user.rb",
+                "cmd/server/main.go",
+                "internal/svc/handler.go",
+                "pkg/util/strings.go",
+            ):
+                self.assertIsNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"흔한 소스 레이아웃 {p} 허용",
+                )
+
+    def test_engineer_invariant_still_blocks_docs_and_root(self):
+        # 회귀 가드 — engineer 가 docs / 루트 비소스 문서를 쓰면 안 된다 (기존 invariant 유지).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("README.md", "docs/storage-layout.md", "CHANGELOG.md"):
+                reason = check_write_allowed("engineer", p, cwd=cwd)
+                self.assertIsNotNone(reason, f"engineer 가 {p} 를 쓰면 안 됨")
+                self.assertIn("ALLOW_MATRIX", reason)
+
+    # ── build-worker: 합집합으로 둘 다 허용 (youTubeGenerator 통합 시나리오) ──
+    def test_build_worker_youtube_generator_scenario(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # 테스트 산출 (test-engineer 영역) — task 01·02·03·07
+            self.assertIsNone(
+                check_write_allowed("build-worker", "tests/core/domain/test_shorts.py", cwd=cwd)
+            )
+            # 소스 산출 (engineer 영역) — task 04
+            self.assertIsNone(
+                check_write_allowed("build-worker", "remotion/shorts-types.ts", cwd=cwd)
+            )
+            # remotion 디렉토리 안 테스트 (test 디렉토리 패턴)
+            self.assertIsNone(
+                check_write_allowed("build-worker", "remotion/test/render_test.ts", cwd=cwd)
+            )
+
+
 class AllowMatrixCoverageTests(unittest.TestCase):
     """#597 커밋4 — agents/*.md 전 agent 가 ALLOW_MATRIX key 로 등재 (누락 재발 차단).
 

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -439,6 +439,32 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
             self.assertIsNotNone(reason, "./docs/ 우회가 차단돼야 함")
             self.assertIn("docs", reason)
 
+    def test_dotdot_escape_blocked(self):
+        # #694 codex P1 — 상대 path 의 .. 세그먼트로 경계 밖(루트 문서·구현 코드)으로 탈출하는
+        # 우회 차단. _normalize 가 cwd 기준 resolve 로 실제 write 위치를 매칭 대상으로 삼는다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # lib/../README.md → 실제 README.md(루트 문서) → engineer 차단
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "lib/../README.md", cwd=cwd),
+                "lib/../README.md (.. 우회) 차단",
+            )
+            # tests/../src/main.py → 실제 src/main.py(구현) → test-engineer 차단
+            self.assertIsNotNone(
+                check_write_allowed("test-engineer", "tests/../src/main.py", cwd=cwd),
+                "tests/../src/main.py (.. 우회) 차단",
+            )
+            # ../ 상위 탈출 → 차단
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "../outside/x.ts", cwd=cwd),
+                "../ 상위 탈출 차단",
+            )
+            # 정상 .. 해소 후 유효 소스는 허용 (src/sub/../foo.ts → src/foo.ts)
+            self.assertIsNone(
+                check_write_allowed("engineer", "src/sub/../foo.ts", cwd=cwd),
+                "src/sub/../foo.ts → src/foo.ts 허용",
+            )
+
     def test_engineer_nested_common_names_not_matched(self):
         # #694 codex P2 (라운드2) — 루트 소스 레이아웃 패턴은 루트(^) 앵커. 중첩 동명
         # 디렉토리(node_modules/*/lib·.github/*/lib·vendor/*/pkg)는 소스 루트가 아니므로

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -419,6 +419,22 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                     f"흔한 소스 레이아웃 {p} 허용",
                 )
 
+    def test_engineer_nested_common_names_not_matched(self):
+        # #694 codex P2 (라운드2) — 루트 소스 레이아웃 패턴은 루트(^) 앵커. 중첩 동명
+        # 디렉토리(node_modules/*/lib·.github/*/lib·vendor/*/pkg)는 소스 루트가 아니므로
+        # engineer/build-worker 가 쓰면 안 된다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in (
+                "node_modules/some-lib/lib/index.js",
+                ".github/actions/foo/lib/action.yml",
+                "vendor/pkg/x.go",
+                "third_party/internal/y.go",
+            ):
+                reason = check_write_allowed("engineer", p, cwd=cwd)
+                self.assertIsNotNone(reason, f"engineer 가 중첩 {p} 를 쓰면 안 됨")
+                self.assertIn("ALLOW_MATRIX", reason)
+
     def test_engineer_invariant_still_blocks_docs_and_root(self):
         # 회귀 가드 — engineer 가 docs / 루트 비소스 문서를 쓰면 안 된다 (기존 invariant 유지).
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -972,8 +972,28 @@ class BashHeuristicTests(unittest.TestCase):
         paths = extract_bash_paths("cp src/a.ts hooks/b.sh")
         self.assertIn("hooks/b.sh", paths)
 
+    def test_read_operands_not_extracted_as_write_paths(self):
+        # write boundary 는 실제 write target 만 검사한다. read operand 를 섞으면
+        # `cat README.md > src/generated.ts` 같은 정상 생성이 README.md write 로 오차단된다.
+        self.assertEqual(
+            extract_bash_paths("cat README.md > src/generated.ts"),
+            ["src/generated.ts"],
+        )
+        self.assertEqual(
+            extract_bash_paths("cp README.md src/generated.ts"),
+            ["src/generated.ts"],
+        )
+        self.assertEqual(
+            extract_bash_paths("cat docs/prd.md | tee docs/tech-review/evidence/x.json"),
+            ["docs/tech-review/evidence/x.json"],
+        )
+
     def test_perl_in_place(self):
         paths = extract_bash_paths("perl -i -pe 's/a/b/' docs/x.md")
+        self.assertIn("docs/x.md", paths)
+
+    def test_awk_in_place(self):
+        paths = extract_bash_paths("awk -i inplace '{ print }' docs/x.md")
         self.assertIn("docs/x.md", paths)
 
     def test_url_not_extracted_as_write_path(self):
@@ -995,6 +1015,8 @@ class BashHeuristicTests(unittest.TestCase):
         paths2 = extract_bash_paths("sed -i s/foo/bar/ src/main.ts")
         self.assertNotIn("s/foo/bar/", paths2)
         self.assertIn("src/main.ts", paths2)
+        # 파일 operand 위치가 확정된 뒤에는 확장자 없는 파일도 write target 으로 본다.
+        self.assertIn("Makefile", extract_bash_paths("sed -i 's/a/b/' Makefile"))
 
     def test_quoted_shell_expansion_token_extracted(self):
         # codex P2 (round10) — 큰따옴표 안에 $/backtick 이 있는 토큰은 셸이 확장하므로 inner 를
@@ -1006,15 +1028,17 @@ class BashHeuristicTests(unittest.TestCase):
         paths_bt = extract_bash_paths('echo x > "`pwd`/lib/y.rb"')
         self.assertIn("`pwd`/lib/y.rb", paths_bt)
 
-    def test_quoted_literal_path_still_excluded(self):
-        # 확장 토큰 없는 따옴표(작은따옴표 전체 / $·backtick 없는 큰따옴표)는 제외 유지 —
-        # sed 스크립트 false positive 방지 원칙 보존.
+    def test_quoted_literal_write_target_extracted(self):
+        # sed script 는 quote 여부와 무관하게 command syntax 라 제외한다.
         self.assertNotIn(
             "s/foo/bar/", extract_bash_paths("sed -i 's/foo/bar/' src/main.ts")
         )
-        # $·backtick 없는 큰따옴표 literal 경로도 제외(false negative 우선 원칙).
-        self.assertNotIn(
+        # 하지만 실제 write target 이면 quote 된 literal path 도 검사 대상이다.
+        self.assertIn(
             "docs/x.md", extract_bash_paths('sed -i "s/a/b/" "docs/x.md"')
+        )
+        self.assertIn(
+            "hooks/evil.sh", extract_bash_paths('echo hi > "hooks/evil.sh"')
         )
 
     def test_quoted_sed_script_with_var_excluded(self):

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -464,6 +464,41 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 reason = check_write_allowed(agent, p, cwd=cwd)
                 self.assertIsNotNone(reason, f"{agent} cwd 밖 {p} 차단")
 
+    def test_nested_dotdot_escape_blocked(self):
+        # #694 codex P1 — 초기 허용 세그먼트 뒤 중첩 .. 로 cwd 밖 탈출(lib/../../lib/x·
+        # tests/../../tests/y)도 resolve 후 절대경로화되어 cwd-밖 가드로 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("engineer", "lib/../../lib/payload.rb"),
+                ("test-engineer", "tests/../../tests/test_x.py"),
+            ]:
+                reason = check_write_allowed(agent, p, cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} 중첩 .. 탈출 {p} 차단")
+
+    def test_code_agents_cannot_write_dependency_trees(self):
+        # #694 codex P2 — 의존성/vendored 트리는 test 패턴(tests?/·spec/)·src 패턴이 중첩
+        # 매칭해도 코드 agent write 금지 (node_modules·vendor·third_party·venv).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            cases = [
+                # 의존성/vendored — 안의 src/tests 가 중첩 매칭돼도 차단
+                ("test-engineer", "node_modules/pkg/tests/x.py"),
+                ("test-engineer", "vendor/foo/spec/bar_spec.rb"),
+                ("build-worker", "third_party/lib/foo_test.go"),
+                ("engineer", "node_modules/pkg/src/index.ts"),
+                ("engineer", ".venv/lib/python3.11/site.py"),
+                # 빌드 산출물 — 안의 src/tests 가 중첩 매칭돼도 차단
+                ("engineer", "dist/bundle/src/app.js"),
+                ("engineer", "build/gen/src/Main.java"),
+                ("engineer", "target/debug/build/foo/src/lib.rs"),
+                ("test-engineer", "out/tests/e2e.test.ts"),
+                ("engineer", "src/__pycache__/mod.cpython-311.pyc"),
+            ]
+            for agent, p in cases:
+                reason = check_write_allowed(agent, p, cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} 가 의존성/산출물 트리 {p} 를 쓰면 안 됨")
+
     def test_dotdot_escape_blocked(self):
         # #694 codex P1 — 상대 path 의 .. 세그먼트로 경계 밖(루트 문서·구현 코드)으로 탈출하는
         # 우회 차단. _normalize 가 cwd 기준 resolve 로 실제 write 위치를 매칭 대상으로 삼는다.
@@ -490,17 +525,16 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 "src/sub/../foo.ts → src/foo.ts 허용",
             )
 
-    def test_engineer_nested_common_names_not_matched(self):
-        # #694 codex P2 (라운드2) — 루트 소스 레이아웃 패턴은 루트(^) 앵커. 중첩 동명
-        # 디렉토리(node_modules/*/lib·.github/*/lib·vendor/*/pkg)는 소스 루트가 아니므로
-        # engineer/build-worker 가 쓰면 안 된다.
+    def test_engineer_nested_layout_names_not_matched(self):
+        # #694 codex P2 — 루트 소스 레이아웃(^lib/·^cmd/ 등)은 루트 앵커라, 의존성도 docs 도
+        # 아닌 일반 중첩 동명 디렉토리(.github/*/lib·services/*/lib·a/b/cmd)는 소스 루트가
+        # 아니므로 ALLOW 미매칭으로 차단된다 (의존성 트리는 별도 deny — 아래 테스트).
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
             for p in (
-                "node_modules/some-lib/lib/index.js",
                 ".github/actions/foo/lib/action.yml",
-                "vendor/pkg/x.go",
-                "third_party/internal/y.go",
+                "services/foo/lib/util.rb",
+                "a/b/cmd/run.go",
             ):
                 reason = check_write_allowed("engineer", p, cwd=cwd)
                 self.assertIsNotNone(reason, f"engineer 가 중첩 {p} 를 쓰면 안 됨")

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -551,6 +551,41 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                     f"{agent} 가 vendored 트리 {p} 를 쓰면 안 됨",
                 )
 
+    def test_directory_target_write_allowed(self):
+        # #694 codex P2 round10 — `cp x tests/`·`mv y apps/web/src/` 의 디렉토리 목적지 토큰은
+        # resolve() 가 끝 `/`를 떼면 ALLOW 패턴(`tests?/`·`.../src/`)에 미매칭돼 정당 in-bound
+        # write 가 오차단되던 결함. 끝 `/`를 보존해 디렉토리 루트 자체가 허용돼야 한다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("test-engineer", "tests/"),
+                ("engineer", "src/"),
+                ("engineer", "apps/web/src/"),
+                ("engineer", "lib/"),
+                ("engineer", "packages/core/src/"),
+            ]:
+                self.assertIsNone(
+                    check_write_allowed(agent, p, cwd=cwd, shell_context=True),
+                    f"{agent} 의 허용 디렉토리 타깃 {p} 허용",
+                )
+
+    def test_directory_target_role_and_deny_preserved(self):
+        # 디렉토리 타깃이라도 역할 격리(engineer 는 tests/ 못 씀)와 전용영역/인프라 deny 는 유지.
+        # 끝 `/` 보존이 보호를 뚫으면 안 됨 — 오히려 `docs/`·`hooks/` 디렉토리 타깃이 정확히 매칭.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("engineer", "tests/"),         # 역할 격리 — engineer ALLOW 미매칭
+                ("engineer", "docs/"),          # 전용영역 deny
+                ("engineer", "node_modules/"),  # 의존성 deny
+                ("engineer", "vendor/"),        # vendored deny (루트)
+                ("engineer", "hooks/"),         # 인프라 deny
+            ]:
+                self.assertIsNotNone(
+                    check_write_allowed(agent, p, cwd=cwd, shell_context=True),
+                    f"{agent} 의 보호 디렉토리 타깃 {p} 차단",
+                )
+
     def test_shell_expansion_path_blocked(self):
         # #694 codex P2 — Bash 출처(shell_context=True)의 $VAR/${}/$()/backtick 은 셸이 hook 후
         # 확장하므로 위치 미확정 → 차단. (literal Edit/Write 경로는 shell_context=False 라 허용.)
@@ -1391,6 +1426,26 @@ class BashIntegrationTests(unittest.TestCase):
                 any("$" in p for p in blocked),
                 f"quoted 셸확장 redirect 가 차단되지 않음: {paths}",
             )
+
+    def test_cp_mv_into_allowed_dir_not_blocked(self):
+        # codex P2 (round10) — `cp src/foo.ts apps/web/src/`·`mv test_helper.py tests/` 의
+        # 디렉토리 목적지가 끝 `/` 소실로 차단되던 false positive 수정 검증 (end-to-end).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            blocked_eng = [
+                p for p in extract_bash_paths("cp src/foo.ts apps/web/src/")
+                if check_write_allowed("engineer", p, cwd=cwd,
+                                       shell_context=True) is not None
+            ]
+            self.assertEqual(blocked_eng, [],
+                             f"engineer cp 디렉토리 타깃 차단됨: {blocked_eng}")
+            blocked_te = [
+                p for p in extract_bash_paths("mv test_helper.py tests/")
+                if check_write_allowed("test-engineer", p, cwd=cwd,
+                                       shell_context=True) is not None
+            ]
+            self.assertEqual(blocked_te, [],
+                             f"test-engineer mv 디렉토리 타깃 차단됨: {blocked_te}")
 
     def test_quoted_sed_with_var_legit_edit_not_blocked(self):
         # codex P2 (round10) — engineer 의 `sed -i "s/$old/$new/" src/main.ts` 가 따옴표 안

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -419,6 +419,26 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                     f"흔한 소스 레이아웃 {p} 허용",
                 )
 
+    def test_dot_slash_prefix_normalized(self):
+        # #694 codex P2 (라운드3) — Edit/Write/Bash 가 ./ prefix 로 넘긴 경로도 정규화되어
+        # 루트 앵커(^lib/ 등)가 빗나가지 않아야 하고, ./docs/ 우회는 여전히 차단돼야 한다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # ./ prefix 소스 — 허용
+            for p in ("./lib/parser.rb", "./remotion/shorts-types.ts", "./cmd/main.go"):
+                self.assertIsNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"./ prefix 소스 {p} 허용",
+                )
+            # ./ prefix 테스트 — 허용
+            self.assertIsNone(
+                check_write_allowed("test-engineer", "./tests/test_x.py", cwd=cwd)
+            )
+            # ./ prefix docs 우회 — 차단 유지
+            reason = check_write_allowed("engineer", "./docs/internal/x.md", cwd=cwd)
+            self.assertIsNotNone(reason, "./docs/ 우회가 차단돼야 함")
+            self.assertIn("docs", reason)
+
     def test_engineer_nested_common_names_not_matched(self):
         # #694 codex P2 (라운드2) — 루트 소스 레이아웃 패턴은 루트(^) 앵커. 중첩 동명
         # 디렉토리(node_modules/*/lib·.github/*/lib·vendor/*/pkg)는 소스 루트가 아니므로

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -524,8 +524,8 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 )
 
     def test_shell_expansion_path_blocked(self):
-        # #694 codex P2 — Bash 의 $VAR/${}/$()/backtick 은 셸이 hook 후 확장하므로 위치 미확정.
-        # ALLOW 매칭 전 차단 (Edit/Write 리터럴엔 이 토큰 없음). tilde 와 동일 클래스.
+        # #694 codex P2 — Bash 출처(shell_context=True)의 $VAR/${}/$()/backtick 은 셸이 hook 후
+        # 확장하므로 위치 미확정 → 차단. (literal Edit/Write 경로는 shell_context=False 라 허용.)
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
             for agent, p in [
@@ -534,8 +534,25 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 ("engineer", "$(pwd)/src/x.py"),
                 ("engineer", "`echo /etc`/src/x.py"),
             ]:
-                reason = check_write_allowed(agent, p, cwd=cwd)
-                self.assertIsNotNone(reason, f"{agent} 셸 확장 경로 {p} 차단")
+                reason = check_write_allowed(agent, p, cwd=cwd, shell_context=True)
+                self.assertIsNotNone(reason, f"{agent} Bash 셸 확장 경로 {p} 차단")
+
+    def test_literal_dollar_filename_allowed_for_edit_write(self):
+        # #694 codex P2 — Edit/Write 의 literal 파일명에 $ 가 있어도(Remix/React Router route
+        # users.$id.tsx) 허용 (shell_context=False 기본). 셸확장 검사는 Bash 출처에만 적용.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("src/routes/users.$userId.tsx", "app/routes/$slug.tsx"):
+                self.assertIsNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"literal $ 파일명 {p} 허용 (Edit/Write)",
+                )
+            # 동일 경로라도 Bash 출처(shell_context=True)면 셸 변수로 간주 차단
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "src/routes/users.$userId.tsx",
+                                    cwd=cwd, shell_context=True),
+                "Bash 출처의 $ 경로는 차단",
+            )
 
     def test_tilde_home_path_blocked(self):
         # #694 codex P2 — Bash 의 ~/... 는 셸이 hook 통과 후 home 으로 확장하므로 cwd 밖.

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -499,6 +499,43 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 reason = check_write_allowed(agent, p, cwd=cwd)
                 self.assertIsNotNone(reason, f"{agent} 가 의존성/산출물 트리 {p} 를 쓰면 안 됨")
 
+    def test_source_dir_named_like_output_allowed(self):
+        # #694 codex P2 — 빌드 산출물 deny 는 루트/패키지 루트 앵커. 허용된 src/ 트리 안의
+        # 동명 디렉토리(src/build·src/dist·.../src/out)는 정당 소스라 허용돼야 한다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("src/build/index.ts", "src/dist/util.ts",
+                      "packages/core/src/out/x.ts", "apps/web/src/build/m.ts"):
+                self.assertIsNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"src 트리 안 동명 디렉토리 {p} 허용",
+                )
+
+    def test_output_dirs_root_and_package_blocked(self):
+        # 루트(^build/) 및 monorepo 패키지 루트(apps/*/build·packages/*/dist) 산출물은 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("build/x.js", "dist/foo/src/a.js", "target/debug/x.rs",
+                      "out/index.html", "apps/web/build/foo/src/m.ts",
+                      "packages/core/dist/i.js"):
+                self.assertIsNotNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"산출물 루트 {p} 차단",
+                )
+
+    def test_tilde_home_path_blocked(self):
+        # #694 codex P2 — Bash 의 ~/... 는 셸이 hook 통과 후 home 으로 확장하므로 cwd 밖.
+        # _normalize expanduser + cwd-밖 가드로 차단 (tests?/ 등 ALLOW 매칭 우회 방지).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("test-engineer", "~/tests/test_x.py"),
+                ("engineer", "~/lib/x.rb"),
+                ("engineer", "~/src/main.py"),
+            ]:
+                reason = check_write_allowed(agent, p, cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} tilde 경로 {p} 차단")
+
     def test_dotdot_escape_blocked(self):
         # #694 codex P1 — 상대 path 의 .. 세그먼트로 경계 밖(루트 문서·구현 코드)으로 탈출하는
         # 우회 차단. _normalize 가 cwd 기준 resolve 로 실제 write 위치를 매칭 대상으로 삼는다.

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -439,6 +439,31 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
             self.assertIsNotNone(reason, "./docs/ 우회가 차단돼야 함")
             self.assertIn("docs", reason)
 
+    def test_code_agents_can_write_docs_named_package(self):
+        # #694 codex P2 — docs deny 는 루트 docs 트리(^docs/)만. monorepo 의 docs 이름
+        # app/package(apps/docs/src·packages/docs/src)는 정상 소스라 허용돼야 한다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("apps/docs/src/App.tsx", "packages/docs/src/index.ts"):
+                self.assertIsNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"docs 이름 패키지 소스 {p} 허용",
+                )
+
+    def test_dotdot_escape_via_allowed_dirname_blocked(self):
+        # #694 codex P2 — 부모 경로가 허용 디렉토리명(tests/spec/lib)이어도 cwd 밖 탈출은
+        # ALLOW 검사 전에 차단. `../tests/x` 가 (^|/)tests?/ 에 매칭되던 우회 봉쇄.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("test-engineer", "../tests/test_x.py"),
+                ("test-engineer", "../spec/foo_spec.rb"),
+                ("engineer", "../lib/x.rb"),
+                ("build-worker", "../src/main.py"),
+            ]:
+                reason = check_write_allowed(agent, p, cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} cwd 밖 {p} 차단")
+
     def test_dotdot_escape_blocked(self):
         # #694 codex P1 — 상대 path 의 .. 세그먼트로 경계 밖(루트 문서·구현 코드)으로 탈출하는
         # 우회 차단. _normalize 가 cwd 기준 resolve 로 실제 write 위치를 매칭 대상으로 삼는다.

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -563,6 +563,10 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 ("engineer", "apps/web/src/"),
                 ("engineer", "lib/"),
                 ("engineer", "packages/core/src/"),
+                # `/.`·`/./` 스펠링도 같은 디렉토리 타깃 (codex P2 r10).
+                ("test-engineer", "tests/."),
+                ("engineer", "apps/web/src/."),
+                ("engineer", "src/./"),
             ]:
                 self.assertIsNone(
                     check_write_allowed(agent, p, cwd=cwd, shell_context=True),
@@ -580,10 +584,31 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 ("engineer", "node_modules/"),  # 의존성 deny
                 ("engineer", "vendor/"),        # vendored deny (루트)
                 ("engineer", "hooks/"),         # 인프라 deny
+                # `/.` 스펠링도 동일하게 deny 매칭돼야 함 (보호 우회 방지).
+                ("engineer", "docs/."),
+                ("engineer", "node_modules/."),
+                ("engineer", "hooks/."),
             ]:
                 self.assertIsNotNone(
                     check_write_allowed(agent, p, cwd=cwd, shell_context=True),
                     f"{agent} 의 보호 디렉토리 타깃 {p} 차단",
+                )
+
+    def test_shell_expansion_collapsed_by_dotdot_blocked(self):
+        # #694 codex P2 round10 — `$PWD/../tests/x` 는 _normalize 가 `$PWD/..` 를 상쇄해 norm 에서
+        # `$` 가 사라지지만, 런타임엔 셸이 `$PWD` 를 확장해 프로젝트 밖에 write 한다. 셸확장 검사를
+        # 정규화 *전* 원본에 적용해 차단해야 한다 (norm 기반 검사의 우회 봉쇄).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("test-engineer", "$PWD/../tests/x.py"),
+                ("engineer", "$PWD/../../etc/src/x.py"),
+                ("engineer", "`pwd`/../src/x.py"),
+                ("engineer", "${PWD}/../app/x.rb"),
+            ]:
+                self.assertIsNotNone(
+                    check_write_allowed(agent, p, cwd=cwd, shell_context=True),
+                    f"{agent} 셸확장+상쇄 경로 {p} 차단",
                 )
 
     def test_shell_expansion_path_blocked(self):
@@ -1446,6 +1471,23 @@ class BashIntegrationTests(unittest.TestCase):
             ]
             self.assertEqual(blocked_te, [],
                              f"test-engineer mv 디렉토리 타깃 차단됨: {blocked_te}")
+
+    def test_quoted_redirect_dotdot_collapse_blocked(self):
+        # codex P2 (round10) — `echo x > "$PWD/../tests/x.py"` 는 추출되어 norm 에서 `$PWD/..`
+        # 가 상쇄(→ tests/x.py)되지만, 원본 셸확장 검사로 차단돼야 한다 (프로젝트 밖 write).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            paths = extract_bash_paths('echo x > "$PWD/../tests/x.py"')
+            self.assertIn("$PWD/../tests/x.py", paths)
+            blocked = [
+                p for p in paths
+                if check_write_allowed("test-engineer", p, cwd=cwd,
+                                       shell_context=True) is not None
+            ]
+            self.assertTrue(
+                any("$" in p for p in blocked),
+                f"$PWD/.. 상쇄 escape 가 차단되지 않음: {paths}",
+            )
 
     def test_quoted_sed_with_var_legit_edit_not_blocked(self):
         # codex P2 (round10) — engineer 의 `sed -i "s/$old/$new/" src/main.ts` 가 따옴표 안

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -523,6 +523,20 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                     f"산출물 루트 {p} 차단",
                 )
 
+    def test_shell_expansion_path_blocked(self):
+        # #694 codex P2 — Bash 의 $VAR/${}/$()/backtick 은 셸이 hook 후 확장하므로 위치 미확정.
+        # ALLOW 매칭 전 차단 (Edit/Write 리터럴엔 이 토큰 없음). tilde 와 동일 클래스.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("test-engineer", "$HOME/tests/test_x.py"),
+                ("engineer", "${HOME}/lib/x.rb"),
+                ("engineer", "$(pwd)/src/x.py"),
+                ("engineer", "`echo /etc`/src/x.py"),
+            ]:
+                reason = check_write_allowed(agent, p, cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} 셸 확장 경로 {p} 차단")
+
     def test_tilde_home_path_blocked(self):
         # #694 codex P2 — Bash 의 ~/... 는 셸이 hook 통과 후 home 으로 확장하므로 cwd 밖.
         # _normalize expanduser + cwd-밖 가드로 차단 (tests?/ 등 ALLOW 매칭 우회 방지).

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -423,10 +423,42 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
         # 회귀 가드 — engineer 가 docs / 루트 비소스 문서를 쓰면 안 된다 (기존 invariant 유지).
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
-            for p in ("README.md", "docs/storage-layout.md", "CHANGELOG.md"):
+            # 루트 비소스 문서 — ALLOW_MATRIX 미매칭 차단.
+            for p in ("README.md", "CHANGELOG.md"):
                 reason = check_write_allowed("engineer", p, cwd=cwd)
                 self.assertIsNotNone(reason, f"engineer 가 {p} 를 쓰면 안 됨")
                 self.assertIn("ALLOW_MATRIX", reason)
+            # docs/ — 전용영역 deny 로 차단 (#694 codex P2).
+            reason = check_write_allowed("engineer", "docs/storage-layout.md", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("docs", reason)
+
+    def test_code_agents_cannot_write_docs_subtree(self):
+        # #694 codex P2 — 언어중립 패턴이 docs/ 하위 동명 디렉토리(docs/internal·docs/lib·
+        # docs/spec·docs/tests)나 docs 안 테스트 파일명을 re.search 로 우회 허용하면 안 된다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            cases = [
+                ("engineer", "docs/internal/release-notes.md"),  # internal/ 우회
+                ("engineer", "docs/lib/guide.md"),               # lib/ 우회
+                ("engineer", "docs/app/overview.md"),            # app/ 우회
+                ("test-engineer", "docs/spec/api.md"),           # spec/ 우회
+                ("test-engineer", "docs/tests/plan.md"),         # tests/ 우회
+                ("test-engineer", "docs/test_examples.py"),      # test_*.py 파일명 우회
+                ("build-worker", "docs/internal/x.md"),          # 합집합 상속
+            ]
+            for agent, p in cases:
+                reason = check_write_allowed(agent, p, cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} 가 docs 하위 {p} 를 쓰면 안 됨")
+                self.assertIn("docs", reason)
+
+    def test_code_agents_cannot_write_design_variants(self):
+        # design-variants/ 는 designer 전용 — 코드 agent 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent in ("engineer", "test-engineer", "build-worker"):
+                reason = check_write_allowed(agent, "design-variants/v1/index.html", cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} 가 design-variants 를 쓰면 안 됨")
 
     # ── build-worker: 합집합으로 둘 다 허용 (youTubeGenerator 통합 시나리오) ──
     def test_build_worker_youtube_generator_scenario(self):
@@ -559,7 +591,8 @@ class RunDirProseCarveOutTests(unittest.TestCase):
             cwd = Path(td)
             reason = check_write_allowed("build-worker", "docs/impl/01-x.md", cwd=cwd)
             self.assertIsNotNone(reason)
-            self.assertIn("ALLOW_MATRIX", reason)
+            # docs/ 는 architect 전용 — 코드 agent 전용영역 deny 로 차단 (#694 codex P2).
+            self.assertIn("docs", reason)
 
     def test_tech_reviewer_allowed_paths(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -523,6 +523,34 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                     f"산출물 루트 {p} 차단",
                 )
 
+    def test_vendor_named_package_allowed(self):
+        # #694 codex P2 round10 — vendor/third_party 는 패키지명과 겹칠 수 있어 루트/패키지 루트
+        # 앵커. monorepo 의 `apps/vendor/src/` 같은 정당 패키지 소스는 허용돼야 한다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for p in ("apps/vendor/src/index.ts",
+                      "packages/third_party/src/x.ts"):
+                self.assertIsNone(
+                    check_write_allowed("engineer", p, cwd=cwd),
+                    f"vendor/third_party 이름의 정당 패키지 소스 {p} 허용",
+                )
+
+    def test_vendor_tree_root_and_package_blocked(self):
+        # 루트(^vendor/·^third_party/) 및 monorepo 패키지 루트(apps/*/vendor·packages/*/third_party)
+        # vendored 트리는 여전히 차단 — 동명 패키지 허용이 진짜 vendored 트리를 뚫으면 안 됨.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, p in [
+                ("engineer", "vendor/p/index.ts"),
+                ("test-engineer", "third_party/lib/spec/x_spec.rb"),
+                ("engineer", "apps/web/vendor/p/y.ts"),
+                ("build-worker", "packages/core/third_party/foo_test.go"),
+            ]:
+                self.assertIsNotNone(
+                    check_write_allowed(agent, p, cwd=cwd),
+                    f"{agent} 가 vendored 트리 {p} 를 쓰면 안 됨",
+                )
+
     def test_shell_expansion_path_blocked(self):
         # #694 codex P2 — Bash 출처(shell_context=True)의 $VAR/${}/$()/backtick 은 셸이 hook 후
         # 확장하므로 위치 미확정 → 차단. (literal Edit/Write 경로는 shell_context=False 라 허용.)
@@ -907,6 +935,35 @@ class BashHeuristicTests(unittest.TestCase):
         paths2 = extract_bash_paths("sed -i s/foo/bar/ src/main.ts")
         self.assertNotIn("s/foo/bar/", paths2)
         self.assertIn("src/main.ts", paths2)
+
+    def test_quoted_shell_expansion_token_extracted(self):
+        # codex P2 (round10) — 큰따옴표 안에 $/backtick 이 있는 토큰은 셸이 확장하므로 inner 를
+        # 살려 후보로 반환해야 한다. 따옴표째 버리면 `echo x > "$HOME/tests/x"` 가
+        # check_write_allowed 셸확장 가드에 도달 못 해 프로젝트 밖 write 우회가 된다.
+        paths = extract_bash_paths('echo x > "$HOME/tests/x.py"')
+        self.assertIn("$HOME/tests/x.py", paths)
+        # backtick 명령치환도 동일.
+        paths_bt = extract_bash_paths('echo x > "`pwd`/lib/y.rb"')
+        self.assertIn("`pwd`/lib/y.rb", paths_bt)
+
+    def test_quoted_literal_path_still_excluded(self):
+        # 확장 토큰 없는 따옴표(작은따옴표 전체 / $·backtick 없는 큰따옴표)는 제외 유지 —
+        # sed 스크립트 false positive 방지 원칙 보존.
+        self.assertNotIn(
+            "s/foo/bar/", extract_bash_paths("sed -i 's/foo/bar/' src/main.ts")
+        )
+        # $·backtick 없는 큰따옴표 literal 경로도 제외(false negative 우선 원칙).
+        self.assertNotIn(
+            "docs/x.md", extract_bash_paths('sed -i "s/a/b/" "docs/x.md"')
+        )
+
+    def test_quoted_sed_script_with_var_excluded(self):
+        # codex P2 (round10) — `sed -i "s/$old/$new/" src/main.ts` 의 큰따옴표 치환 스크립트는
+        # $ 가 있어 inner 가 살아나지만, 곧바로 sed 스크립트 제외 로직(^[sy]<delim>…)에 걸려
+        # 후보에서 빠진다. 실제 대상 src/main.ts 만 남아 정상 편집이 안 막혀야 한다.
+        paths = extract_bash_paths('sed -i "s/$old/$new/" src/main.ts')
+        self.assertNotIn("s/$old/$new/", paths)
+        self.assertIn("src/main.ts", paths)
 
 
 class BashMutationTests(unittest.TestCase):
@@ -1315,6 +1372,35 @@ class BashIntegrationTests(unittest.TestCase):
             blocked = [
                 p for p in extract_bash_paths("sed -i 's/foo/bar/' src/main.ts")
                 if check_write_allowed("engineer", p, cwd=cwd) is not None
+            ]
+            self.assertEqual(blocked, [], f"engineer 정상 편집이 차단됨: {blocked}")
+
+    def test_quoted_redirect_shell_expansion_blocked(self):
+        # codex P2 (round10) — `echo x > "$HOME/tests/x.py"` 가 따옴표째 버려져 검사 미도달로
+        # 프로젝트 밖 write 우회되던 결함 수정 검증. extract → shell_context 가드까지 도달해 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            paths = extract_bash_paths('echo x > "$HOME/tests/x.py"')
+            self.assertIn("$HOME/tests/x.py", paths)
+            blocked = [
+                p for p in paths
+                if check_write_allowed("test-engineer", p, cwd=cwd,
+                                       shell_context=True) is not None
+            ]
+            self.assertTrue(
+                any("$" in p for p in blocked),
+                f"quoted 셸확장 redirect 가 차단되지 않음: {paths}",
+            )
+
+    def test_quoted_sed_with_var_legit_edit_not_blocked(self):
+        # codex P2 (round10) — engineer 의 `sed -i "s/$old/$new/" src/main.ts` 가 따옴표 안
+        # 치환 스크립트 오인으로 차단되면 안 됨 (src/main.ts 만 후보, 정상 통과).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            blocked = [
+                p for p in extract_bash_paths('sed -i "s/$old/$new/" src/main.ts')
+                if check_write_allowed("engineer", p, cwd=cwd,
+                                       shell_context=True) is not None
             ]
             self.assertEqual(blocked, [], f"engineer 정상 편집이 차단됨: {blocked}")
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #694

## 배경 및 문제

`harness/agent_boundary.py` 의 `ALLOW_MATRIX` 가 sub-agent 의 write 경계를 **"역할"이 아니라 "JS/TS 모노레포 컨벤션"으로 정의**해서, 외부 활성 프로젝트가 비-JS(Python·Go·Ruby·JVM·C#·PHP·Elixir 등)이거나 src/ 밖 레이아웃(`remotion/` 등)을 쓰면 test-engineer / engineer / build-worker 가 정상 산출물을 디스크에 쓰지 못했다. dcness 가 표방하는 "언어 중립 하네스" 가 사실상 JS/TS 전용으로 좁혀져 있던 회귀.

즉시 영향: youTubeGenerator(Python `src/` + `tests/` + Remotion `remotion/`) 에서 test-engineer 가 `tests/core/domain/test_shorts.py` 를, engineer 가 `remotion/shorts-types.ts` 를 쓰지 못해 impl 이 막혔다.

## 원인 (해당 시)

- `ALLOW_MATRIX["test-engineer"]` 가 전부 JS/TS 패턴(`src/__tests__/`·`*.test.[jt]sx`·`apps/*/tests/` 등) — 다른 언어 테스트 컨벤션 전무.
- `ALLOW_MATRIX["engineer"]` 가 모노레포(`apps/`·`packages/`) + `src/` 단일 구조 가정 — 그 외 소스 레이아웃 부재.
- `ALLOW_MATRIX["build-worker"] = engineer ∪ test-engineer` → 합집합이 JS/TS 전용이라 한계 상속.
- 회귀 경위: 0.4.x 에선 build-worker 가 ALLOW_MATRIX 미등재 → "미정의 agent = 통과" fallback 으로 자유. #597(multi-session 업그레이드 동반)에서 build-worker 를 합집합으로 좁히며 JS/TS 전용 한계가 비-JS 를 통째로 차단.

## 작업내용

- **test-engineer** — 언어 중립 테스트 컨벤션으로 확장: 디렉토리(`tests?/`·`spec/`·`__tests__/`) + 파일명(`test_*.py`·`*_test.{go,rb,dart,exs}`·`*_spec.rb`·`*.test.{ts,..}`·`*Test(s).{java,kt,kts,scala,cs,php}`). 기존 JS/TS 전용 패턴은 광범위 패턴에 흡수.
- **engineer** — 언어 중립 소스 루트 레이아웃 추가: `lib/`·`app/`·`cmd/`·`internal/`·`pkg/` + `remotion/`(youTubeGenerator). 기존 모노레포 패턴 유지.
- **build-worker** — 합집합 정의 그대로라 자동 동기화.
- **경로 판정 안정화** — `./`·`..`·cwd 밖·tilde·셸확장·디렉토리 타깃·docs/ 전용영역·dependency/output tree 등 ALLOW 확장으로 열린 우회면을 정규화/deny 우선순위로 닫음.
- **Bash write target 추출 재정렬** — `extract_bash_paths()` 를 path-like 토큰 수집에서 실제 write 대상 추출로 변경. redirect/cp/mv/rm/tee/sed/perl/awk 기준으로 write operand 만 검사해 `cat README.md > src/generated.ts`, `cp README.md src/generated.ts`, `cat docs/prd.md | tee docs/tech-review/...` 같은 read operand 오차단을 제거하면서 quoted write target 은 계속 검사.
- **테스트** — 언어별 허용 + 역할 격리·docs 차단 invariant + youTubeGenerator 통합 시나리오 + 경로 정규화/셸확장/디렉토리 타깃 + Bash write target 회귀 테스트 추가.

## 결정 근거

- 검토 대안: (A) 확장자 화이트리스트, (B) deny 블랙리스트, (C) 프로젝트별 override.
- 채택: **언어 중립 기본값(allowlist) 확장** — zero-config 로 흔한 언어/레이아웃을 즉시 수용하면서 역할 격리(test-engineer=테스트만, engineer=소스, docs=architect) invariant 를 유지.
- Bash 경로 검사는 보안 파서가 아니라 실수 방지용 guard 이므로 모든 shell edge 를 닫는 방향이 아니라 **실제 write 대상만 검사**하는 쪽으로 책임을 줄였다. 이게 리뷰 churn 의 근본 원인(path-like 토큰 과수집/과소수집)을 줄인다.
- 무한한 비표준 레이아웃(임의 디렉토리)을 코어에 계속 나열하는 reactive cycle 회피 위해, 프로젝트별 override 메커니즘은 **#696 으로 분리**. `remotion/` 등 프로젝트 고유 디렉토리는 그때 코어에서 override 로 이관(코어 기본값 다이어트).

## 배포 경로 검증 (plug-in 영향 시)

- `harness/agent_boundary.py` = **plugin 본체(배포 경로 1축)** → 사용자가 plugin 버전업 받으면 자동 적용. 별도 cp 불필요.
- `agents/engineer.md`·`agents/test-engineer.md` 권한 경계 서술("Write 허용: src/** 와 *프로젝트가 허용한 구현 경로*", "테스트 작성 외 코드 수정 금지")은 언어 중립 확장과 이미 정합 → **변경 불필요**.
- `commands/init-dcness.md` deploy 스텝 — 신규 배포 파일/스크립트 없음 → **변경 불필요**.
- 사용자 SSOT 문서 영향 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public surface(skill/command/agent/gate) 변화 없음. 내부 권한 경계 매트릭스와 Bash write target 추출 로직 개선.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 — `python3.11 -m unittest tests.test_agent_boundary -v` 143 tests OK
- [x] 훅 통합 회귀 검증 — `python3.11 -m unittest tests.test_hooks -v` 180 tests OK
- [x] 전체 회귀 검증 — `python3.11 -m unittest discover -s tests -v` 1001 tests OK
- [x] commit 직전 hook 검증 — pre-commit pytest-gate 1001 tests OK + git-naming PASS
- [x] whitespace 검증 — `git diff --check` PASS

## 참고

- 후속: #696 (sub-agent ALLOW_MATRIX 프로젝트별 override 메커니즘)
