### PR TITLE
[issue-694] sed clustered in-place 플래그 추출 보강

### DIFF
--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -556,6 +556,17 @@ def _target_directory_flag(args: list[str]) -> Optional[str]:
     return None
 
 
+def _sed_short_options_include_in_place(arg: str) -> bool:
+    if not arg.startswith("-") or arg.startswith("--") or arg == "-":
+        return False
+    for opt in arg[1:]:
+        if opt == "i":
+            return True
+        if opt in ("e", "f"):
+            return False
+    return False
+
+
 def _sed_in_place_targets(args: list[str]) -> list[str]:
     in_place = False
     expression_supplied = False
@@ -575,7 +586,7 @@ def _sed_in_place_targets(args: list[str]) -> list[str]:
             else:
                 i += 1
             continue
-        if arg.startswith("-i") and arg != "-":
+        if _sed_short_options_include_in_place(arg):
             in_place = True
             i += 1
             continue

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -964,6 +964,18 @@ class BashHeuristicTests(unittest.TestCase):
         paths = extract_bash_paths("sed -i 's/x/y/' docs/foo.md")
         self.assertIn("docs/foo.md", paths)
 
+    def test_sed_clustered_in_place_extracts(self):
+        for flag in ("-ni", "-ri", "-nri", "-Ei"):
+            with self.subTest(flag=flag):
+                paths = extract_bash_paths(f"sed {flag} 's/x/y/' hooks/gate.sh")
+                self.assertIn("hooks/gate.sh", paths)
+
+    def test_sed_attached_expr_is_not_in_place(self):
+        self.assertEqual(
+            extract_bash_paths("sed -es/i/o/ input.txt > docs/out.txt"),
+            ["docs/out.txt"],
+        )
+
     def test_redirect_extracts(self):
         paths = extract_bash_paths("echo hi > hooks/evil.sh")
         self.assertIn("hooks/evil.sh", paths)


### PR DESCRIPTION
## 관련 이슈 번호

Part of #694

## 배경 및 문제

- #697에서 Bash write target 추출을 실제 mutation 대상 기준으로 재정렬했지만, `sed -ni` / `sed -ri`처럼 `-i`가 단축 플래그 클러스터 안에 들어간 경우 in-place target을 놓칠 수 있었다.
- 구 path-token 방식에서는 잡히던 케이스라 #697 후속 커버리지 회귀로 본다.

## 원인 (해당 시)

- `perl` 추출기는 단축 플래그 클러스터 전체에서 `i`를 확인하지만, `sed` 추출기는 `arg.startswith("-i")`만 확인했다.
- 그래서 `_BASH_WRITE_INDICATORS`는 `sed -ni ...`를 write 후보로 통과시키는데, 실제 path extractor는 빈 배열을 반환했다.

## 작업내용

- sed 단축 플래그 클러스터 내부의 `i`를 in-place로 인식하는 helper를 추가했다.
- `-eSCRIPT` / `-fSCRIPT`처럼 attached value가 올 수 있는 sed 옵션은 in-place로 오인하지 않도록 했다.
- `sed -ni`, `sed -ri`, `sed -nri`, `sed -Ei` 회귀 테스트를 추가했다.
- `sed -es/i/o/ input.txt > docs/out.txt`가 input을 write target으로 오인하지 않는 테스트를 추가했다.

## 결정 근거

- Bash parser를 더 키우지 않고, #697의 실제 write target 추출 원칙 안에서 sed 옵션 해석만 보강한다.
- `-e`/`-f` attached script/file 케이스를 같이 가드해 클러스터 검사로 생길 수 있는 false-positive를 좁힌다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/agent_boundary.py`는 dcness hook 런타임이 직접 사용하는 plugin body 경로다.
- init 복사 파일, public command, docs/plugin SSOT 변경 없음.
- hook 동작 변경은 pre-commit 전체 unittest로 검증했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public surface 추가 없음.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증

검증 명령:

- `python3.11 -m unittest tests.test_agent_boundary.BashHeuristicTests -v` — 14 tests OK
- `python3.11 -m unittest tests.test_agent_boundary -v` — 145 tests OK
- `git diff --check` — PASS
- git pre-commit hook — 1023 tests OK, git-naming PASS

## 참고

- #697 병합 후 발견한 좁은 후속 회귀 보강.
