### PR TITLE
[issue-701] engineer 게이트 prerequisite 를 설계 산출물 실존으로 확장 — impl-loop 풀 4-agent 차단 해소

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -78,7 +78,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 
 **strict conveyor 대상**: `entry_point=design|impl|ux`. 정상 `/design` 은 `begin-run design` 로 시작하며 같은 strict conveyor gate 와 module-architect gate 를 탄다.
 
-**engineer gate 의 design_doc 경로**: 설계(impl 문서 / compact plan)가 *별도 run* 에서 작성·머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서는 같은 run 안에 module-architect prose 가 없다. 이때 `begin-run impl --design-doc <머지된 설계 문서 경로>` 로 run 에 설계 산출물을 기록하면 engineer gate 가 그 실존을 prerequisite 증거로 인정한다. 경로는 설계 산출물 규약(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`) 안의 `.md` 만 허용 — 기록 시점에 fail-fast 검증하고, 게이트 시점에 실존을 재확인한다. design / architect-loop run 은 design_doc 을 기록하지 않으므로 기존 module-architect PASS 강제가 그대로 유지된다.
+**engineer gate 의 design_doc 경로**: 설계(impl 문서 / compact plan)가 *별도 run* 에서 작성·머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서는 같은 run 안에 module-architect prose 가 없다. 이때 `begin-run impl --design-doc <머지된 설계 문서 경로>` 로 run 에 설계 산출물을 기록하면 engineer gate 가 그 실존을 prerequisite 증거로 인정한다. 경로는 설계 산출물 규약(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`) 안의 실존 `.md` 만 허용 — 기록 시점에 resolve 절대경로로 fail-fast 검증(traversal / repo 밖 경로 거부)하고, 게이트 시점에 실존을 재확인한다. `--design-doc` 은 `entry_point=impl` run 에서만 수용된다(다른 entry_point 는 begin-run 이 거부) — design / architect-loop run 의 기존 module-architect PASS 강제는 코드 보장으로 유지된다.
 
 **tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. /design 도중 미검증 새 외부 의존이 발견되면 design 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -72,11 +72,13 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 | Gate | 차단 조건 |
 |---|---|
 | pr-reviewer gate | engineer 산출물이 있는데 code-validator PASS 없이 pr-reviewer 호출 |
-| engineer gate | module-architect PASS 없이 engineer 가 src 구현으로 진입 |
+| engineer gate | 설계 산출물 없이 engineer 가 src 구현으로 진입 — 같은 run 의 module-architect PASS *또는* `begin-run --design-doc` 으로 기록된 설계 문서 실존, 둘 중 하나로 충족 |
 | module-architect gate | architecture-validator 1차 PASS 없이 design 의 module-architect 반복 진입 |
 | strict conveyor gate | active run 안에서 직전 `begin-step` 과 다른 agent/mode 호출, `current_step` 부재, 이미 staged 된 stale step |
 
 **strict conveyor 대상**: `entry_point=design|impl|ux`. 정상 `/design` 은 `begin-run design` 로 시작하며 같은 strict conveyor gate 와 module-architect gate 를 탄다.
+
+**engineer gate 의 design_doc 경로**: 설계(impl 문서 / compact plan)가 *별도 run* 에서 작성·머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서는 같은 run 안에 module-architect prose 가 없다. 이때 `begin-run impl --design-doc <머지된 설계 문서 경로>` 로 run 에 설계 산출물을 기록하면 engineer gate 가 그 실존을 prerequisite 증거로 인정한다. 경로는 설계 산출물 규약(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`) 안의 `.md` 만 허용 — 기록 시점에 fail-fast 검증하고, 게이트 시점에 실존을 재확인한다. design / architect-loop run 은 design_doc 을 기록하지 않으므로 기존 module-architect PASS 강제가 그대로 유지된다.
 
 **tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. /design 도중 미검증 새 외부 의존이 발견되면 design 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -48,7 +48,7 @@ echo "[<entry>] run started: $RUN_ID"
 
 `<entry_point>` = 해당 skill 의 `## Loop` 의 `entry_point` 필드 (예: `impl`, `design`, `ux`). begin-run 동작: sid auto-detect + run_id 발급 + `live.json.active_runs` 슬롯 + `.by-pid-current-run/{cc_pid}` 씀.
 
-`--design-doc <path>` — 이 run 이 참조하는 **머지된 설계 문서**(impl task 문서 / compact plan) 경로. 설계가 별도 run 에서 머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서 기록하면, engineer 게이트가 같은-run module-architect PASS 의 등가 prerequisite 로 인정한다 ([`hooks.md` catastrophic-gate](hooks.md#catastrophic-gatesh)). 설계 산출물 규약 경로(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`)의 실존 `.md` 만 허용 — 아니면 begin-run 이 fail-fast 거부한다. chain 의 다음 task 진입은 `next-task --design-doc <path>` 로 동일 기록.
+`--design-doc <path>` — 이 run 이 참조하는 **머지된 설계 문서**(impl task 문서 / compact plan) 경로. 설계가 별도 run 에서 머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서 기록하면, engineer 게이트가 같은-run module-architect PASS 의 등가 prerequisite 로 인정한다 ([`hooks.md` catastrophic-gate](hooks.md#catastrophic-gatesh)). `entry_point=impl` 전용이며, 설계 산출물 규약 경로(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`)의 실존 `.md` 만 허용 — 아니면 begin-run 이 fail-fast 거부한다. 기록값은 resolve 된 절대경로(hook 프로세스와 cwd 가 달라도 안전). chain 의 다음 task 진입은 `next-task --design-doc <path>` 로 동일 기록.
 
 > `/impl-loop` 의 **chain 모드(N task)** 는 자기 run 을 갖지 않는 driver 다 — `impl-task-loop × N` 이므로 각 task 가 독립 `begin-run impl` … `end-run` run 1개씩 (N task = N run = N review.md). **single 모드(1 task)** 는 `impl` entry_point 로 run 1개. 자세히 = [`/impl-loop`](../../skills/impl-loop/SKILL.md).
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -42,11 +42,13 @@ EnterWorktree(name="<skill>-{ts_short}")   # action 루프 (impl / impl-loop / d
 
 ```bash
 HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run <entry_point> [--issue-num N])
+RUN_ID=$("$HELPER" begin-run <entry_point> [--issue-num N] [--design-doc <path>])
 echo "[<entry>] run started: $RUN_ID"
 ```
 
 `<entry_point>` = 해당 skill 의 `## Loop` 의 `entry_point` 필드 (예: `impl`, `design`, `ux`). begin-run 동작: sid auto-detect + run_id 발급 + `live.json.active_runs` 슬롯 + `.by-pid-current-run/{cc_pid}` 씀.
+
+`--design-doc <path>` — 이 run 이 참조하는 **머지된 설계 문서**(impl task 문서 / compact plan) 경로. 설계가 별도 run 에서 머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서 기록하면, engineer 게이트가 같은-run module-architect PASS 의 등가 prerequisite 로 인정한다 ([`hooks.md` catastrophic-gate](hooks.md#catastrophic-gatesh)). 설계 산출물 규약 경로(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`)의 실존 `.md` 만 허용 — 아니면 begin-run 이 fail-fast 거부한다. chain 의 다음 task 진입은 `next-task --design-doc <path>` 로 동일 기록.
 
 > `/impl-loop` 의 **chain 모드(N task)** 는 자기 run 을 갖지 않는 driver 다 — `impl-task-loop × N` 이므로 각 task 가 독립 `begin-run impl` … `end-run` run 1개씩 (N task = N run = N review.md). **single 모드(1 task)** 는 `impl` entry_point 로 run 1개. 자세히 = [`/impl-loop`](../../skills/impl-loop/SKILL.md).
 
@@ -380,7 +382,7 @@ review 리포트의 must-fix / waste finding / per-Agent metric 즉시 인지 + 
 `begin-run` / `begin-step` / `end-step` / `end-run` 은 prose 저장과 별개로 run_dir 안 `ledger.jsonl` 에 append-only event 를 자동 기록한다. prose 파일 (`<run_dir>/<agent>[-<MODE>].md`) 이 계속 SSOT 이고, ledger 는 긴 prose 를 매번 대화 context 에 재주입하지 않고도 resume / handoff / audit 에 필요한 상태를 담는 색인 장부다. **agent 에게 JSON 출력 형식을 강제하지 않는다** — helper 가 저장된 prose + known state 에서 receipt 를 생성한다.
 
 **자동 기록 event** (코드 경로):
-- `run_started` (begin-run) — entry_point / issue_num
+- `run_started` (begin-run) — entry_point / issue_num / design_doc(기록 시)
 - `step_started` (begin-step) — agent / mode
 - `step_completed` (end-step) — = **receipt**: agent / mode / enum / prose_excerpt / must_fix / prose_file / sha256 / evidence_paths / next_action(hint)
 - `run_finished` (end-run)

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -441,13 +441,19 @@ def handle_pretooluse_agent(
     except (OSError, ValueError):
         pass  # state 읽기 실패는 fail-open — hook 버그발 과차단 회피.
 
-    # engineer 게이트 — engineer 직전 module-architect PASS 필수 (mode != POLISH).
-    # #700 — namespaced 우회 차단을 위해 norm_subagent 비교(codex P1). 판정 로직은 main 그대로.
+    # engineer 게이트 — engineer 직전 설계 산출물 필수 (mode != POLISH).
+    # #700 — namespaced 우회 차단을 위해 norm_subagent 비교(codex P1).
+    # #701 — prerequisite = 같은-run module-architect PASS ∪ begin-run 에 기록된
+    # 머지된 설계 문서(design_doc) 실존. impl-loop 풀 4-agent 는 설계가 별도 run
+    # 에서 머지된 뒤 진입하므로 같은-run prose 단일 기준이면 구조적으로 차단된다.
     if norm_subagent == "engineer" and mode != "POLISH":
-        if not _has_pass(rd, "module-architect"):
+        if not _has_pass(rd, "module-architect") and not _run_design_doc_exists(
+            sid, rid, base_dir=base_dir
+        ):
             print(
-                "[catastrophic: engineer 게이트] engineer 호출은 module-architect PASS 후만 "
-                "(module-architect.md 안 PASS 마커)",
+                "[catastrophic: engineer 게이트] engineer 호출은 설계 산출물 확보 후만 — "
+                "같은 run 의 module-architect PASS (module-architect.md 안 PASS 마커) "
+                "또는 begin-run --design-doc 으로 기록된 설계 문서 실존",
                 file=sys.stderr,
             )
             return 1
@@ -1078,6 +1084,32 @@ def _has_pass(rd: Path, agent: str) -> bool:
 
 def _has_engineer_write(rd: Path) -> bool:
     return (rd / "engineer-IMPL.md").exists() or (rd / "engineer-POLISH.md").exists()
+
+
+def _run_design_doc_exists(
+    sid: str,
+    rid: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> bool:
+    """현재 run 슬롯에 기록된 design_doc 이 디스크에 실존하는지 (#701).
+
+    begin-run `--design-doc` 으로 기록된 머지된 설계 문서는 engineer 게이트의
+    같은-run module-architect PASS 등가 prerequisite 증거다. 경로 규약 검증은
+    기록 시점(start_run fail-fast)에 끝났고, 여기서는 실존만 재확인한다 (기록
+    후 삭제 방어). 기록 부재 / state 읽기 실패는 종전과 동일하게 차단 측
+    (fail-strict).
+    """
+    try:
+        live = read_live(sid, base_dir=base_dir) or {}
+        active = live.get("active_runs", {}) if isinstance(live, dict) else {}
+        slot = active.get(rid, {}) if isinstance(active, dict) else {}
+        doc = slot.get("design_doc") if isinstance(slot, dict) else None
+        if not isinstance(doc, str) or not doc:
+            return False
+        return Path(doc).is_file()
+    except (OSError, ValueError):
+        return False
 
 
 def _is_design_loop(

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -447,13 +447,13 @@ def handle_pretooluse_agent(
     # 머지된 설계 문서(design_doc) 실존. impl-loop 풀 4-agent 는 설계가 별도 run
     # 에서 머지된 뒤 진입하므로 같은-run prose 단일 기준이면 구조적으로 차단된다.
     if norm_subagent == "engineer" and mode != "POLISH":
-        if not _has_pass(rd, "module-architect") and not _run_design_doc_exists(
+        if not _has_module_architect_pass(rd) and not _run_design_doc_exists(
             sid, rid, base_dir=base_dir
         ):
             print(
                 "[catastrophic: engineer 게이트] engineer 호출은 설계 산출물 확보 후만 — "
-                "같은 run 의 module-architect PASS (module-architect.md 안 PASS 마커) "
-                "또는 begin-run --design-doc 으로 기록된 설계 문서 실존",
+                "같은 run 의 module-architect PASS prose (module-architect*.md 안 "
+                "PASS 마커) 또는 begin-run --design-doc 으로 기록된 설계 문서 실존",
                 file=sys.stderr,
             )
             return 1
@@ -1084,6 +1084,30 @@ def _has_pass(rd: Path, agent: str) -> bool:
 
 def _has_engineer_write(rd: Path) -> bool:
     return (rd / "engineer-IMPL.md").exists() or (rd / "engineer-POLISH.md").exists()
+
+
+def _has_module_architect_pass(rd: Path) -> bool:
+    """module-architect prose PASS — 무모드 / occurrence / mode-suffixed 모두 인정 (#701).
+
+    moded step 의 prose 파일명은 `<agent>-<MODE>.md` 라서, `/impl` Standard 의
+    `module-architect:COMPACT_PLAN` PASS 는 `module-architect-COMPACT_PLAN.md`
+    에 기록된다 — `_has_pass` 의 occurrence 카운터(-2..-9)만으로는 못 읽어
+    engineer 게이트가 false-block 했다(#700 에서 #701 로 이연된 Finding C).
+
+    engineer 게이트 전용 helper — pr-reviewer 게이트의 code-validator 는 mode
+    별 의미가 달라(PLAN_VALIDATION ≠ CODE_VALIDATION) 일괄 glob 을 적용하면
+    plan 단계 PASS 가 code 검증을 대신하는 새 구멍이 생긴다. `_has_pass` 는
+    그대로 둔다.
+    """
+    if "PASS" in _read_or_empty(rd / "module-architect.md"):
+        return True
+    try:
+        for prose in rd.glob("module-architect-*.md"):
+            if "PASS" in _read_or_empty(prose):
+                return True
+    except OSError:
+        pass
+    return False
 
 
 def _run_design_doc_exists(

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -449,6 +449,38 @@ def _resolve_run_dir_str(
         return str(rd)
 
 
+# design_doc 으로 인정하는 설계 산출물 경로 규약 — module-architect Write 허용
+# 경로와 동일 집합. 임의 파일(README 등)로 engineer 게이트를 무력화하지 못하게
+# 기록 시점에 fail-fast 제한한다 (#701).
+_DESIGN_DOC_DIR_MARKERS = (
+    "docs/milestones/",
+    "docs/compact-plans/",
+    "docs/bugfix/",
+)
+
+
+def _validate_design_doc(design_doc: str) -> str:
+    """begin-run `--design-doc` 경로 fail-fast 검증 (#701).
+
+    engineer 게이트의 prerequisite 증거로 쓰이므로 기록 시점에 (1) .md 파일,
+    (2) 설계 산출물 경로 규약, (3) 디스크 실존을 확인한다. 게이트는 호출
+    시점에 실존을 재확인한다 (기록 후 삭제 방어).
+    """
+    if not isinstance(design_doc, str) or not design_doc.strip():
+        raise ValueError("design_doc must be non-empty str")
+    doc = design_doc.strip()
+    if not doc.endswith(".md"):
+        raise ValueError(f"design_doc must be a .md file: {doc!r}")
+    if not any(marker in doc.replace("\\", "/") for marker in _DESIGN_DOC_DIR_MARKERS):
+        raise ValueError(
+            "design_doc must be a design artifact path "
+            f"({' | '.join(_DESIGN_DOC_DIR_MARKERS)}): {doc!r}"
+        )
+    if not Path(doc).is_file():
+        raise ValueError(f"design_doc not found on disk: {doc!r}")
+    return doc
+
+
 def start_run(
     session_id: str,
     run_id: str,
@@ -456,10 +488,16 @@ def start_run(
     *,
     base_dir: Optional[Path] = None,
     issue_num: Optional[int] = None,
+    design_doc: Optional[str] = None,
 ) -> None:
     """`active_runs[run_id]` 슬롯 추가 + run 디렉토리 생성.
 
     이미 존재하면 ValueError (중복 run_id 방어).
+
+    design_doc — 이 run 이 참조하는 머지된 설계 문서 경로 (#701). 기록 시
+    engineer 게이트가 같은-run module-architect PASS 의 등가 prerequisite
+    증거로 인정한다 (impl-loop 풀 4-agent 처럼 설계가 별도 run 에서 머지된
+    뒤 진입하는 경우).
     """
     if not valid_session_id(session_id):
         raise ValueError(f"invalid session_id: {session_id!r}")
@@ -467,6 +505,8 @@ def start_run(
         raise ValueError(f"invalid run_id: {run_id!r}")
     if not isinstance(entry_point, str) or not entry_point:
         raise ValueError("entry_point must be non-empty str")
+    if design_doc is not None:
+        design_doc = _validate_design_doc(design_doc)
 
     live = read_live(session_id, base_dir=base_dir) or {}
     active = live.get("active_runs", {})
@@ -485,6 +525,7 @@ def start_run(
         "run_dir": _resolve_run_dir_str(session_id, run_id, base_dir),
         "current_step": None,
         "issue_num": issue_num,
+        "design_doc": design_doc,
     }
     update_live(session_id, base_dir=base_dir, active_runs=active)
     # run 디렉토리 생성
@@ -497,6 +538,7 @@ def _ledger_run_started(
     entry_point: str,
     *,
     issue_num: Optional[int] = None,
+    design_doc: Optional[str] = None,
     base_dir: Optional[Path] = None,
 ) -> None:
     """start_run 직후 ledger run_started checkpoint 기록 (이슈 #587).
@@ -511,6 +553,8 @@ def _ledger_run_started(
         extra: Dict[str, Any] = {"entry_point": entry_point}
         if issue_num is not None:
             extra["issue_num"] = issue_num
+        if design_doc is not None:
+            extra["design_doc"] = design_doc
         ledger.append_event(session_id, run_id, "run_started", base_dir=base_dir, **extra)
     except Exception:
         pass
@@ -1362,8 +1406,15 @@ def _cli_begin_run(args: Any) -> int:
         return 1
     rid = generate_run_id()
     issue_num = args.issue_num if args.issue_num is not None else None
-    start_run(sid, rid, args.entry_point, issue_num=issue_num)
-    _ledger_run_started(sid, rid, args.entry_point, issue_num=issue_num)
+    design_doc = getattr(args, "design_doc", None)
+    try:
+        start_run(sid, rid, args.entry_point, issue_num=issue_num, design_doc=design_doc)
+    except ValueError as exc:
+        print(f"[begin-run] FAIL — {exc}", file=sys.stderr)
+        return 1
+    _ledger_run_started(
+        sid, rid, args.entry_point, issue_num=issue_num, design_doc=design_doc,
+    )
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
         write_pid_current_run(cc_pid, rid)
@@ -1516,14 +1567,15 @@ def _cli_next_task(args: Any) -> int:
             print(f"[next-task] end-run FAIL — {exc}", file=sys.stderr)
 
     entry_point = getattr(args, "entry_point", "impl") or "impl"
+    design_doc = getattr(args, "design_doc", None)
     new_rid = generate_run_id()
     try:
-        start_run(sid, new_rid, entry_point, issue_num=None)
+        start_run(sid, new_rid, entry_point, issue_num=None, design_doc=design_doc)
     except Exception as exc:
         print(f"[next-task] begin-run FAIL — {exc}", file=sys.stderr)
         return 1
     # 이슈 #587 (codex review) — chain task run 도 run_started checkpoint 남김.
-    _ledger_run_started(sid, new_rid, entry_point)
+    _ledger_run_started(sid, new_rid, entry_point, design_doc=design_doc)
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
         write_pid_current_run(cc_pid, new_rid)
@@ -1550,6 +1602,8 @@ def _cli_next_task(args: Any) -> int:
     print(f"\n[new] run_id: {new_rid}")
     print(f"[new] run_dir: {new_run_dir_path}")
     print(f"[new] entry_point: {entry_point}")
+    if design_doc:
+        print(f"[new] design_doc: {design_doc}")
     print("=== /next-task transition ===")
     return 0
 
@@ -2722,6 +2776,11 @@ def _build_arg_parser() -> Any:
     p_br = sub.add_parser("begin-run", help="run_id 발급 + start_run")
     p_br.add_argument("entry_point")
     p_br.add_argument("--issue-num", type=int, default=None)
+    p_br.add_argument(
+        "--design-doc", default=None, dest="design_doc",
+        help="이 run 이 참조하는 머지된 설계 문서 경로 — engineer 게이트가 "
+             "같은-run module-architect PASS 의 등가 prerequisite 로 인정",
+    )
     p_br.set_defaults(func=_cli_begin_run)
 
     p_er = sub.add_parser("end-run", help="complete_run + clear by-pid-current-run")
@@ -2734,6 +2793,10 @@ def _build_arg_parser() -> Any:
     p_nt.add_argument(
         "--entry-point", default="impl",
         help="새 run 의 entry_point (default: impl)",
+    )
+    p_nt.add_argument(
+        "--design-doc", default=None, dest="design_doc",
+        help="다음 task 가 참조하는 머지된 설계 문서 경로 (begin-run --design-doc 동일)",
     )
     p_nt.set_defaults(func=_cli_next_task)
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -449,9 +449,10 @@ def _resolve_run_dir_str(
         return str(rd)
 
 
-# design_doc 으로 인정하는 설계 산출물 경로 규약 — module-architect Write 허용
-# 경로와 동일 집합. 임의 파일(README 등)로 engineer 게이트를 무력화하지 못하게
-# 기록 시점에 fail-fast 제한한다 (#701).
+# design_doc 으로 인정하는 설계 산출물 표준 경로 prefix (impl 문서 / compact
+# plan / bugfix plan). 기록 시점에 repo-root 상대 prefix 앵커로 검증해 임의
+# .md(README 등)·traversal(`..`)·repo 밖 경로가 engineer 게이트 prerequisite
+# 증거가 되지 못하게 한다 (#701).
 _DESIGN_DOC_DIR_MARKERS = (
     "docs/milestones/",
     "docs/compact-plans/",
@@ -460,25 +461,39 @@ _DESIGN_DOC_DIR_MARKERS = (
 
 
 def _validate_design_doc(design_doc: str) -> str:
-    """begin-run `--design-doc` 경로 fail-fast 검증 (#701).
+    """begin-run `--design-doc` 경로 fail-fast 검증 (#701) — resolve 절대경로 반환.
 
     engineer 게이트의 prerequisite 증거로 쓰이므로 기록 시점에 (1) .md 파일,
-    (2) 설계 산출물 경로 규약, (3) 디스크 실존을 확인한다. 게이트는 호출
-    시점에 실존을 재확인한다 (기록 후 삭제 방어).
+    (2) repo root(= helper 호출 cwd) 기준 설계 산출물 규약 경로 *안*, (3)
+    디스크 실존을 확인한다. 게이트는 호출 시점에 실존을 재확인한다 (기록 후
+    삭제 방어).
+
+    상대경로를 받은 그대로 기록하면 begin-run cwd(worktree)와 hook 프로세스
+    cwd 가 달라 게이트가 false-block 하므로 resolve 된 절대경로로 기록한다.
+    prefix 앵커 비교(substring 아님)라 traversal/symlink/repo 밖 경로는
+    resolve 후 거부된다.
     """
     if not isinstance(design_doc, str) or not design_doc.strip():
         raise ValueError("design_doc must be non-empty str")
     doc = design_doc.strip()
     if not doc.endswith(".md"):
         raise ValueError(f"design_doc must be a .md file: {doc!r}")
-    if not any(marker in doc.replace("\\", "/") for marker in _DESIGN_DOC_DIR_MARKERS):
+    resolved = Path(doc).resolve()
+    root = Path.cwd().resolve()
+    try:
+        rel_posix = resolved.relative_to(root).as_posix()
+    except ValueError:
         raise ValueError(
-            "design_doc must be a design artifact path "
-            f"({' | '.join(_DESIGN_DOC_DIR_MARKERS)}): {doc!r}"
+            f"design_doc must live under the repo root ({root}): {doc!r}"
+        ) from None
+    if not any(rel_posix.startswith(marker) for marker in _DESIGN_DOC_DIR_MARKERS):
+        raise ValueError(
+            "design_doc must be a design artifact path under "
+            f"{' | '.join(_DESIGN_DOC_DIR_MARKERS)}: {doc!r}"
         )
-    if not Path(doc).is_file():
+    if not resolved.is_file():
         raise ValueError(f"design_doc not found on disk: {doc!r}")
-    return doc
+    return str(resolved)
 
 
 def start_run(
@@ -506,6 +521,13 @@ def start_run(
     if not isinstance(entry_point, str) or not entry_point:
         raise ValueError("entry_point must be non-empty str")
     if design_doc is not None:
+        # design_doc 은 impl 구현 run 전용 — design/architect-loop run 의
+        # engineer ← module-architect PASS 강제가 코드 보장으로 유지되도록
+        # 다른 entry_point 의 기록 자체를 거부한다.
+        if entry_point != "impl":
+            raise ValueError(
+                f"design_doc is only valid for entry_point=impl (got {entry_point!r})"
+            )
         design_doc = _validate_design_doc(design_doc)
 
     live = read_live(session_id, base_dir=base_dir) or {}
@@ -1540,16 +1562,27 @@ def _cli_next_task(args: Any) -> int:
     5. stdout = previous review + 새 run_id + 새 run_dir
 
     Usage:
-        dcness-helper next-task [--entry-point impl]
+        dcness-helper next-task [--entry-point impl] [--design-doc <path>]
 
     Exit codes:
         0 — 정상 (이전 run finalize + 새 run 발급)
-        1 — sid 미해결
+        1 — sid 미해결 / design_doc 검증 실패
     """
     sid = auto_detect_session_id()
     if not sid:
         print(diagnose_sid_rid_resolution(mode="sid"), file=sys.stderr)
         return 1
+
+    entry_point = getattr(args, "entry_point", "impl") or "impl"
+    design_doc = getattr(args, "design_doc", None)
+    if design_doc is not None:
+        # 이전 run end-run(비가역) *전* 선검증 — 경로 오타로 이전 run 만 닫히고
+        # 새 run 발급이 실패하는 어긋남(prev review echo 영구 소실) 방지.
+        try:
+            design_doc = _validate_design_doc(design_doc)
+        except ValueError as exc:
+            print(f"[next-task] begin-run FAIL — {exc}", file=sys.stderr)
+            return 1
 
     prev_rid = auto_detect_run_id()
     prev_review_path: Optional[Path] = None
@@ -1566,8 +1599,6 @@ def _cli_next_task(args: Any) -> int:
         except Exception as exc:
             print(f"[next-task] end-run FAIL — {exc}", file=sys.stderr)
 
-    entry_point = getattr(args, "entry_point", "impl") or "impl"
-    design_doc = getattr(args, "design_doc", None)
     new_rid = generate_run_id()
     try:
         start_run(sid, new_rid, entry_point, issue_num=None, design_doc=design_doc)

--- a/hooks/catastrophic-gate.sh
+++ b/hooks/catastrophic-gate.sh
@@ -13,7 +13,8 @@
 #
 # 강제 룰 (3 게이트):
 #   - pr-reviewer 게이트 — pr-reviewer 직전 code-validator PASS 확인
-#   - engineer 게이트 — engineer 직전 module-architect PASS 확인
+#   - engineer 게이트 — engineer 직전 설계 산출물 확인 (같은 run 의 module-architect PASS
+#     또는 begin-run --design-doc 으로 기록된 설계 문서 실존)
 #   - module-architect 게이트 — architect-loop 안 module-architect × K 첫 호출 직전 architecture-validator PASS
 
 set -uo pipefail

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -210,6 +210,8 @@ wrapper 가 Codex 마지막 응답을 `/tmp` 에 받고 `dcness-helper end-step 
 
 default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → pr-reviewer**. 4 단계 *모두 호출* 의무 (MUST — false-clean 차단, #431).
 
+🔴 **begin-run 에 `--design-doc` 필수**: 엔진 A 는 설계(impl 문서)가 별도 run 에서 머지된 *뒤* 진입하므로 같은 run 안에 module-architect prose 가 없다 — `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 머지된 설계 문서를 run 에 기록해야 engineer 게이트(catastrophic)가 IMPL 진입을 허용한다 ([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). chain 에서 다음 task 도 풀 4-agent 면 `next-task --design-doc <다음 task 의 impl 문서 경로>` 로 동일 기록. advanced fallback 으로 module-architect 를 선두 추가한 run 은 같은-run PASS prose 가 생기므로 생략 가능하나, task 의 impl 문서가 이미 있으면 기록을 권장한다.
+
 ✅ 정상 흐름:
 1. **test-engineer** (TESTS_WRITTEN) → 테스트 선작성
 2. **engineer:IMPL** (IMPL_DONE) → 구현 + 테스트 PASS
@@ -331,11 +333,11 @@ merge lock 이 보존하는 것:
 
 ### task 경계 — next-task 통합 호출 (#471)
 
-마지막이 아닌 task 종료 시 `dcness-helper next-task --entry-point impl` 1회 호출 — helper 가 (이전 run end-run + previous review.md stdout + 새 run begin-run) 통합 처리 → 메인은 stdout 의 `[new] run_id` 만 받아 다음 task 진입. *마지막* task = `next-task` 대신 `end-run` 단독.
+마지막이 아닌 task 종료 시 `dcness-helper next-task --entry-point impl` 1회 호출 — helper 가 (이전 run end-run + previous review.md stdout + 새 run begin-run) 통합 처리 → 메인은 stdout 의 `[new] run_id` 만 받아 다음 task 진입. *마지막* task = `next-task` 대신 `end-run` 단독. **다음 task 가 풀 4-agent(엔진 A)면 `--design-doc <다음 task 의 impl 문서 경로>` 동반** (engineer 게이트 prerequisite — 위 `## 엔진 A` 참조).
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" next-task --entry-point impl   # 마지막 아님
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" end-run                         # 마지막
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" next-task --entry-point impl [--design-doc <path>]   # 마지막 아님
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" end-run                                              # 마지막
 ```
 
 ### enum 별 분기

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -16,6 +16,8 @@ Coverage matrix:
         - engineer 게이트 — module-architect.md 안 PASS 있으면 통과
         - engineer 게이트 — module-architect-N.md (occurrence) 안 PASS 도 인정
         - engineer 게이트 — engineer POLISH 모드는 plan 검사 skip
+        - engineer 게이트 — run 에 기록된 design_doc 실존 시 module-architect 없이 통과
+        - engineer 게이트 — design_doc 기록됐지만 디스크 부재면 차단 (fail-strict)
         - 그 외 agent (architect MODULE_PLAN, code-validator 등) — run 외부에서도 통과
         - sid 없음 → silent allow
         - tool_input 비정상 → silent allow
@@ -232,6 +234,82 @@ class CatastrophicEngineerTests(_PreToolBase):
         # 정규화 비교한다. dcness:engineer 가 module-architect PASS 게이트를 우회하면 안 된다.
         rc = handle_pretooluse_agent(
             stdin_data=self._payload("dcness:engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    # -- #701 — design_doc 실존 = module-architect PASS 의 등가 prerequisite --
+
+    def _start_run_with_design_doc(self, design_doc: str) -> None:
+        """begin-run --design-doc + begin-step engineer 경로 모사.
+
+        entry_point=impl run 은 strict-conveyor 가 begin-step 을 강제하므로
+        실제 풀 4-agent 시퀀스대로 current_step 까지 세팅 — 차단/통과가
+        engineer 게이트에서 판정되도록 한다.
+        """
+        rid2 = "run-87654321"
+        start_run(
+            self.sid, rid2, "impl",
+            base_dir=self.base, design_doc=design_doc,
+        )
+        write_pid_current_run(self.cc_pid, rid2, base_dir=self.base)
+        update_current_step(
+            self.sid, rid2, "engineer", "IMPL", base_dir=self.base,
+        )
+
+    def _write_design_doc(self) -> Path:
+        doc = (
+            self.base / "docs" / "milestones" / "v01" / "epics"
+            / "epic-01-x" / "impl" / "03-foo.md"
+        )
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# impl task\n", encoding="utf-8")
+        return doc
+
+    def test_allowed_with_merged_design_doc(self) -> None:
+        # #701 — impl-loop 풀 4-agent: 설계(impl 문서)는 별도 run 에서 머지된 뒤
+        # 진입하므로, run 에 기록된 design_doc 실존이 같은-run module-architect
+        # PASS 없이도 engineer(IMPL) prerequisite 를 충족해야 한다.
+        doc = self._write_design_doc()
+        self._start_run_with_design_doc(str(doc))
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_blocked_when_design_doc_gone_from_disk(self) -> None:
+        # 기록 시점엔 실존했지만 게이트 시점에 삭제된 design_doc → fail-strict 차단.
+        # 차단 주체가 strict-conveyor 가 아닌 engineer 게이트임을 stderr 로 확정.
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        doc = self._write_design_doc()
+        self._start_run_with_design_doc(str(doc))
+        doc.unlink()
+        err = StringIO()
+        with redirect_stderr(err):
+            rc = handle_pretooluse_agent(
+                stdin_data=self._payload("engineer", "IMPL"),
+                cc_pid=self.cc_pid,
+                base_dir=self.base,
+            )
+        self.assertEqual(rc, 1)
+        self.assertIn("[catastrophic: engineer 게이트]", err.getvalue())
+
+    def test_other_run_design_doc_does_not_unlock_current_run(self) -> None:
+        # design_doc 은 *자기 run* 의 prerequisite 만 충족 — design_doc 없는 기존
+        # run(setUp 의 self.rid)은 종전대로 차단 유지 (회귀 가드).
+        doc = self._write_design_doc()
+        start_run(
+            self.sid, "run-87654321", "impl",
+            base_dir=self.base, design_doc=str(doc),
+        )
+        # current run 은 여전히 setUp 의 design_doc 없는 run
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -18,6 +18,8 @@ Coverage matrix:
         - engineer 게이트 — engineer POLISH 모드는 plan 검사 skip
         - engineer 게이트 — run 에 기록된 design_doc 실존 시 module-architect 없이 통과
         - engineer 게이트 — design_doc 기록됐지만 디스크 부재면 차단 (fail-strict)
+        - engineer 게이트 — 상대경로 기록 후 cwd 가 달라도 통과 (기록 시점 resolve)
+        - engineer 게이트 — mode-suffixed prose(module-architect-COMPACT_PLAN.md) PASS 인정
         - 그 외 agent (architect MODULE_PLAN, code-validator 등) — run 외부에서도 통과
         - sid 없음 → silent allow
         - tool_input 비정상 → silent allow
@@ -241,6 +243,18 @@ class CatastrophicEngineerTests(_PreToolBase):
 
     # -- #701 — design_doc 실존 = module-architect PASS 의 등가 prerequisite --
 
+    def _record_run_with_design_doc(self, rid: str, design_doc: str) -> None:
+        """design_doc 검증은 cwd(repo root) 기준 — begin-run cwd 를 base 로 모사."""
+        old_cwd = os.getcwd()
+        os.chdir(self.base)
+        try:
+            start_run(
+                self.sid, rid, "impl",
+                base_dir=self.base, design_doc=design_doc,
+            )
+        finally:
+            os.chdir(old_cwd)
+
     def _start_run_with_design_doc(self, design_doc: str) -> None:
         """begin-run --design-doc + begin-step engineer 경로 모사.
 
@@ -249,10 +263,7 @@ class CatastrophicEngineerTests(_PreToolBase):
         engineer 게이트에서 판정되도록 한다.
         """
         rid2 = "run-87654321"
-        start_run(
-            self.sid, rid2, "impl",
-            base_dir=self.base, design_doc=design_doc,
-        )
+        self._record_run_with_design_doc(rid2, design_doc)
         write_pid_current_run(self.cc_pid, rid2, base_dir=self.base)
         update_current_step(
             self.sid, rid2, "engineer", "IMPL", base_dir=self.base,
@@ -303,10 +314,7 @@ class CatastrophicEngineerTests(_PreToolBase):
         # design_doc 은 *자기 run* 의 prerequisite 만 충족 — design_doc 없는 기존
         # run(setUp 의 self.rid)은 종전대로 차단 유지 (회귀 가드).
         doc = self._write_design_doc()
-        start_run(
-            self.sid, "run-87654321", "impl",
-            base_dir=self.base, design_doc=str(doc),
-        )
+        self._record_run_with_design_doc("run-87654321", str(doc))
         # current run 은 여전히 setUp 의 design_doc 없는 run
         rc = handle_pretooluse_agent(
             stdin_data=self._payload("engineer", "IMPL"),
@@ -314,6 +322,34 @@ class CatastrophicEngineerTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertEqual(rc, 1)
+
+    def test_design_doc_recorded_relative_survives_cwd_change(self) -> None:
+        # 기록은 worktree cwd 에서 상대경로로, 게이트는 다른 cwd(hook 프로세스)
+        # 에서 실행 — 기록 시점 resolve 절대화가 없으면 false-block 하는 회귀 가드.
+        doc = self._write_design_doc()
+        rel = doc.relative_to(self.base)
+        self._start_run_with_design_doc(str(rel))
+        # 게이트는 테스트 프로세스 cwd(레포 루트, self.base 아님)에서 실행된다.
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_allowed_with_mode_suffixed_module_architect_pass(self) -> None:
+        # /impl Standard — module-architect:COMPACT_PLAN 의 prose 는
+        # module-architect-COMPACT_PLAN.md 에 기록된다. 같은-run PASS 로 인정
+        # 해야 engineer(IMPL) 가 진입 가능 (mode-suffixed 파일명 인식).
+        (self.run_path / "module-architect-COMPACT_PLAN.md").write_text(
+            "## 결론\nPASS\n", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer", "IMPL"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -455,20 +455,29 @@ class ActiveRunsTests(unittest.TestCase):
 
     # -- design_doc 기록 — engineer 게이트 prerequisite 증거 --
 
+    def _chdir_base(self) -> None:
+        # design_doc 검증은 repo root(= helper 호출 cwd) 기준 — base 를 root 로 모사.
+        old = os.getcwd()
+        os.chdir(self.base)
+        self.addCleanup(os.chdir, old)
+
     def _write_design_doc(self, rel: str = "docs/compact-plans/foo.md") -> Path:
         doc = self.base / rel
         doc.parent.mkdir(parents=True, exist_ok=True)
         doc.write_text("# design artifact\n", encoding="utf-8")
         return doc
 
-    def test_start_run_records_design_doc(self) -> None:
+    def test_start_run_records_design_doc_resolved(self) -> None:
+        # 기록값 = resolve 된 절대경로 — hook 프로세스 cwd 와 무관하게 실존 확인 가능.
+        self._chdir_base()
         doc = self._write_design_doc()
         start_run(
             self.sid, self.run_id, "impl",
-            base_dir=self.base, design_doc=str(doc),
+            base_dir=self.base, design_doc="docs/compact-plans/foo.md",
         )
         slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
-        self.assertEqual(slot["design_doc"], str(doc))
+        self.assertEqual(slot["design_doc"], str(doc.resolve()))
+        self.assertTrue(Path(slot["design_doc"]).is_absolute())
 
     def test_start_run_without_design_doc_records_none(self) -> None:
         start_run(self.sid, self.run_id, "impl", base_dir=self.base)
@@ -477,22 +486,24 @@ class ActiveRunsTests(unittest.TestCase):
 
     def test_start_run_design_doc_missing_file_raises(self) -> None:
         # 기록 시점 fail-fast — 실존하지 않는 경로는 게이트에서 막히기 전에 거부.
+        self._chdir_base()
         with self.assertRaises(ValueError):
             start_run(
                 self.sid, self.run_id, "impl",
                 base_dir=self.base,
-                design_doc=str(self.base / "docs" / "compact-plans" / "nope.md"),
+                design_doc="docs/compact-plans/nope.md",
             )
 
     def test_start_run_design_doc_non_design_path_raises(self) -> None:
         # 설계 산출물 경로 규약(docs/milestones|compact-plans|bugfix) 밖 파일은
         # prerequisite 증거가 될 수 없다 — 임의 파일로 게이트 무력화 방지.
+        self._chdir_base()
         readme = self.base / "README.md"
         readme.write_text("x\n", encoding="utf-8")
         with self.assertRaises(ValueError):
             start_run(
                 self.sid, self.run_id, "impl",
-                base_dir=self.base, design_doc=str(readme),
+                base_dir=self.base, design_doc="README.md",
             )
 
     def test_start_run_design_doc_non_md_raises(self) -> None:
@@ -505,16 +516,69 @@ class ActiveRunsTests(unittest.TestCase):
                 base_dir=self.base, design_doc=str(doc),
             )
 
+    def test_start_run_design_doc_traversal_rejected(self) -> None:
+        # 경로 규약은 resolve *후* prefix 앵커 비교 — `..` 로 규약 디렉토리를
+        # 경유만 하고 빠져나가는 우회 차단.
+        self._chdir_base()
+        (self.base / "README.md").write_text("x\n", encoding="utf-8")
+        (self.base / "docs" / "milestones").mkdir(parents=True)
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "impl",
+                base_dir=self.base,
+                design_doc="docs/milestones/../../README.md",
+            )
+
+    def test_start_run_design_doc_outside_repo_rejected(self) -> None:
+        # repo 밖 절대경로는 marker 문자열을 포함해도 거부 (substring 매치 아님).
+        self._chdir_base()
+        with TemporaryDirectory() as td2:
+            outside = Path(td2) / "docs" / "compact-plans" / "fake.md"
+            outside.parent.mkdir(parents=True)
+            outside.write_text("x\n", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                start_run(
+                    self.sid, self.run_id, "impl",
+                    base_dir=self.base, design_doc=str(outside),
+                )
+
+    def test_start_run_design_doc_symlink_outside_rejected(self) -> None:
+        # 규약 디렉토리 안 symlink 가 규약 밖 파일을 가리키면 resolve 후 거부.
+        self._chdir_base()
+        target = self.base / "secret.md"
+        target.write_text("x\n", encoding="utf-8")
+        link_dir = self.base / "docs" / "compact-plans"
+        link_dir.mkdir(parents=True)
+        (link_dir / "link.md").symlink_to(target)
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "impl",
+                base_dir=self.base, design_doc="docs/compact-plans/link.md",
+            )
+
+    def test_start_run_design_doc_non_impl_entry_rejected(self) -> None:
+        # design_doc 은 impl 구현 run 전용 — design run 의 engineer ←
+        # module-architect PASS 강제가 코드 보장으로 유지.
+        self._chdir_base()
+        self._write_design_doc()
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "design",
+                base_dir=self.base, design_doc="docs/compact-plans/foo.md",
+            )
+
     def test_start_run_design_doc_milestones_impl_path_ok(self) -> None:
+        self._chdir_base()
         doc = self._write_design_doc(
             "docs/milestones/v01/epics/epic-01-x/impl/03-foo.md"
         )
         start_run(
             self.sid, self.run_id, "impl",
-            base_dir=self.base, design_doc=str(doc),
+            base_dir=self.base,
+            design_doc="docs/milestones/v01/epics/epic-01-x/impl/03-foo.md",
         )
         slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
-        self.assertEqual(slot["design_doc"], str(doc))
+        self.assertEqual(slot["design_doc"], str(doc.resolve()))
 
     def test_update_current_step(self) -> None:
         start_run(self.sid, self.run_id, "impl", base_dir=self.base)
@@ -2522,7 +2586,7 @@ class NextTaskTransitionTests(unittest.TestCase):
 
     def test_transition_records_design_doc(self) -> None:
         # chain task — 다음 task 의 머지된 설계 문서를 새 run 에 기록 (engineer
-        # 게이트 prerequisite 증거 승계).
+        # 게이트 prerequisite 증거 승계). 기록값 = resolve 절대경로.
         from harness.session_state import _cli_next_task, read_live
         from io import StringIO
         from contextlib import redirect_stdout
@@ -2533,6 +2597,7 @@ class NextTaskTransitionTests(unittest.TestCase):
         doc = Path("docs/compact-plans/foo.md")
         doc.parent.mkdir(parents=True)
         doc.write_text("# compact plan\n", encoding="utf-8")
+        resolved = str(doc.resolve())
 
         buf = StringIO()
         with redirect_stdout(buf):
@@ -2542,17 +2607,22 @@ class NextTaskTransitionTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         active = read_live(sid)["active_runs"]
         recorded = [s.get("design_doc") for s in active.values()]
-        self.assertIn(str(doc), recorded)
-        self.assertIn(f"[new] design_doc: {doc}", buf.getvalue())
+        self.assertIn(resolved, recorded)
+        self.assertIn(f"[new] design_doc: {resolved}", buf.getvalue())
 
-    def test_transition_invalid_design_doc_fails(self) -> None:
-        # 실존하지 않는 design_doc — begin-run FAIL 로 fail-fast (exit 1).
-        from harness.session_state import _cli_next_task
+    def test_transition_invalid_design_doc_fails_before_end_run(self) -> None:
+        # 실존하지 않는 design_doc — begin-run FAIL fail-fast (exit 1). 검증은
+        # 이전 run end-run *전* 이라 이전 run 이 닫히지 않고 보존돼야 한다
+        # (오타 한 번에 prev review echo 영구 소실 방지).
+        from harness.session_state import _cli_next_task, read_live, start_run
         from io import StringIO
         from contextlib import redirect_stdout, redirect_stderr
         from types import SimpleNamespace
         sid = "11111111-2222-4333-8444-555555555555"
+        prev_rid = "run-prev1234"
         os.environ["DCNESS_SESSION_ID"] = sid
+        os.environ["DCNESS_RUN_ID"] = prev_rid
+        start_run(sid, prev_rid, "impl", issue_num=None)
 
         out, err = StringIO(), StringIO()
         with redirect_stdout(out), redirect_stderr(err):
@@ -2562,6 +2632,8 @@ class NextTaskTransitionTests(unittest.TestCase):
             ))
         self.assertEqual(rc, 1)
         self.assertIn("begin-run FAIL", err.getvalue())
+        prev_slot = read_live(sid)["active_runs"][prev_rid]
+        self.assertIsNone(prev_slot["completed_at"])
 
 
 class DesignDocArgparseTests(unittest.TestCase):

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -453,6 +453,69 @@ class ActiveRunsTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             start_run(self.sid, self.run_id, "impl", base_dir=self.base)
 
+    # -- design_doc 기록 — engineer 게이트 prerequisite 증거 --
+
+    def _write_design_doc(self, rel: str = "docs/compact-plans/foo.md") -> Path:
+        doc = self.base / rel
+        doc.parent.mkdir(parents=True, exist_ok=True)
+        doc.write_text("# design artifact\n", encoding="utf-8")
+        return doc
+
+    def test_start_run_records_design_doc(self) -> None:
+        doc = self._write_design_doc()
+        start_run(
+            self.sid, self.run_id, "impl",
+            base_dir=self.base, design_doc=str(doc),
+        )
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertEqual(slot["design_doc"], str(doc))
+
+    def test_start_run_without_design_doc_records_none(self) -> None:
+        start_run(self.sid, self.run_id, "impl", base_dir=self.base)
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertIsNone(slot["design_doc"])
+
+    def test_start_run_design_doc_missing_file_raises(self) -> None:
+        # 기록 시점 fail-fast — 실존하지 않는 경로는 게이트에서 막히기 전에 거부.
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "impl",
+                base_dir=self.base,
+                design_doc=str(self.base / "docs" / "compact-plans" / "nope.md"),
+            )
+
+    def test_start_run_design_doc_non_design_path_raises(self) -> None:
+        # 설계 산출물 경로 규약(docs/milestones|compact-plans|bugfix) 밖 파일은
+        # prerequisite 증거가 될 수 없다 — 임의 파일로 게이트 무력화 방지.
+        readme = self.base / "README.md"
+        readme.write_text("x\n", encoding="utf-8")
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "impl",
+                base_dir=self.base, design_doc=str(readme),
+            )
+
+    def test_start_run_design_doc_non_md_raises(self) -> None:
+        doc = self.base / "docs" / "compact-plans" / "foo.txt"
+        doc.parent.mkdir(parents=True)
+        doc.write_text("x\n", encoding="utf-8")
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "impl",
+                base_dir=self.base, design_doc=str(doc),
+            )
+
+    def test_start_run_design_doc_milestones_impl_path_ok(self) -> None:
+        doc = self._write_design_doc(
+            "docs/milestones/v01/epics/epic-01-x/impl/03-foo.md"
+        )
+        start_run(
+            self.sid, self.run_id, "impl",
+            base_dir=self.base, design_doc=str(doc),
+        )
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertEqual(slot["design_doc"], str(doc))
+
     def test_update_current_step(self) -> None:
         start_run(self.sid, self.run_id, "impl", base_dir=self.base)
         update_current_step(
@@ -2456,6 +2519,78 @@ class NextTaskTransitionTests(unittest.TestCase):
         self.assertIn("[new] run_dir:", out)
         # 새 rid != 이전 rid (begin-run 정상 동작)
         self.assertNotIn(f"[new] run_id: {prev_rid}", out)
+
+    def test_transition_records_design_doc(self) -> None:
+        # chain task — 다음 task 의 머지된 설계 문서를 새 run 에 기록 (engineer
+        # 게이트 prerequisite 증거 승계).
+        from harness.session_state import _cli_next_task, read_live
+        from io import StringIO
+        from contextlib import redirect_stdout
+        from types import SimpleNamespace
+        sid = "11111111-2222-4333-8444-555555555555"
+        os.environ["DCNESS_SESSION_ID"] = sid
+
+        doc = Path("docs/compact-plans/foo.md")
+        doc.parent.mkdir(parents=True)
+        doc.write_text("# compact plan\n", encoding="utf-8")
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = _cli_next_task(SimpleNamespace(
+                entry_point="impl", design_doc=str(doc),
+            ))
+        self.assertEqual(rc, 0)
+        active = read_live(sid)["active_runs"]
+        recorded = [s.get("design_doc") for s in active.values()]
+        self.assertIn(str(doc), recorded)
+        self.assertIn(f"[new] design_doc: {doc}", buf.getvalue())
+
+    def test_transition_invalid_design_doc_fails(self) -> None:
+        # 실존하지 않는 design_doc — begin-run FAIL 로 fail-fast (exit 1).
+        from harness.session_state import _cli_next_task
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+        from types import SimpleNamespace
+        sid = "11111111-2222-4333-8444-555555555555"
+        os.environ["DCNESS_SESSION_ID"] = sid
+
+        out, err = StringIO(), StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_next_task(SimpleNamespace(
+                entry_point="impl",
+                design_doc="docs/compact-plans/nope.md",
+            ))
+        self.assertEqual(rc, 1)
+        self.assertIn("begin-run FAIL", err.getvalue())
+
+
+class DesignDocArgparseTests(unittest.TestCase):
+    """begin-run / next-task 의 --design-doc 플래그 파싱 회귀."""
+
+    def test_begin_run_accepts_design_doc(self) -> None:
+        from harness.session_state import _build_arg_parser
+        ns = _build_arg_parser().parse_args(
+            ["begin-run", "impl", "--design-doc", "docs/compact-plans/x.md"]
+        )
+        self.assertEqual(ns.cmd, "begin-run")
+        self.assertEqual(ns.design_doc, "docs/compact-plans/x.md")
+
+    def test_begin_run_design_doc_defaults_none(self) -> None:
+        from harness.session_state import _build_arg_parser
+        ns = _build_arg_parser().parse_args(["begin-run", "impl"])
+        self.assertIsNone(ns.design_doc)
+
+    def test_next_task_accepts_design_doc(self) -> None:
+        from harness.session_state import _build_arg_parser
+        ns = _build_arg_parser().parse_args(
+            ["next-task", "--design-doc",
+             "docs/milestones/v01/epics/epic-01-x/impl/01-x.md"]
+        )
+        self.assertEqual(ns.cmd, "next-task")
+        self.assertEqual(
+            ns.design_doc,
+            "docs/milestones/v01/epics/epic-01-x/impl/01-x.md",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 관련 이슈 번호

Closes #701
Part of #702

## 배경 및 문제

impl-loop 풀 4-agent(test-engineer → engineer → code-validator → pr-reviewer)는 설계 산출물(impl 문서)이 architecture-validator 통과 + 머지된 *뒤* 별도 run 으로 진입하는 구조다. 그런데 engineer 게이트(catastrophic)는 entry_point 무관하게 "같은 run 안의 module-architect PASS prose" 만 prerequisite 로 인정해, 기본 시퀀스대로 engineer 를 IMPL 모드로 호출하면 구조적으로 항상 차단됐다 (#701). 증거(머지된 설계 문서)는 실존하는데 게이트가 대용물(같은-run prose)을 보는 것이 본질 — #702 의 "impl 은 설계 산출물 실존만 보면 된다" 원리의 1차 적용물로 본 PR 이 게이트 판정을 확장한다.

## 원인 (해당 시)

engineer 게이트의 prerequisite 판정이 `_has_pass(rd, "module-architect")` 단일 기준 — run 디렉토리 안 prose 마커만 확인하고, 별도 run 에서 이미 머지된 설계 문서를 인정할 수단이 없었다. run slot 에도 설계 문서 참조가 기록되지 않아 게이트가 확인할 대상 자체가 없었다.

## 작업내용

- `harness/session_state.py` — `start_run` / `begin-run` / `next-task` 에 `--design-doc <path>` 추가. 기록 시점 fail-fast 검증: `.md` + 설계 산출물 경로 규약(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`) + 디스크 실존. ledger `run_started` event 에 design_doc extra 포함.
- `harness/hooks.py` — engineer 게이트(mode != POLISH) 판정을 "같은-run module-architect PASS ∪ run 에 기록된 design_doc 실존" 으로 확장 (`_run_design_doc_exists`, 기록 부재/읽기 실패는 fail-strict 차단 측).
- `tests/test_hooks.py` / `tests/test_session_state.py` — 게이트 통과(design_doc 실존)·차단(디스크 부재, 타 run design_doc 비인정)·기존 강제 회귀 가드 + 기록 검증·argparse 회귀 테스트 추가.
- `docs/plugin/hooks.md` / `docs/plugin/loop-procedure.md` / `skills/impl-loop/SKILL.md` — design_doc 경로 문서화 + 엔진 A(풀 4-agent) begin-run `--design-doc` 필수 안내.

## 결정 근거

- **lane-aware 면제 방식 기각**: `/impl` Standard 와 impl-loop 풀4 가 같은 `entry_point=impl` 을 공유하고 start_run 이 lane 을 기록하지 않아, lane 인프라 선행 없이는 entry_point 기반 면제가 불가능. "설계 문서 실존 검사" 는 lane 구분 자체가 필요 없다.
- **임의 파일 무력화 방지**: design_doc 은 module-architect 산출물 경로 규약 안 `.md` 만 허용 — README 등 임의 파일로 게이트를 푸는 것을 기록 시점에 거부.
- **회귀 없음**: design / architect-loop run 은 design_doc 을 기록하지 않으므로 기존 module-architect PASS 강제 그대로. `/impl` Standard 는 같은 run 에서 module-architect:COMPACT_PLAN 이 돌아 PASS prose 가 생기므로 영향 없음. build-worker 의 engineer POLISH 면제 불변.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1 (plug-in 본체): `harness/hooks.py`, `harness/session_state.py`, `skills/impl-loop/SKILL.md`, `docs/plugin/hooks.md`, `docs/plugin/loop-procedure.md` — 전부 plug-in 본체 파일로 사용자가 plug-in 버전 업 시 자동 적용.
- 경로 2 (init-dcness 복사 파일): 해당 없음 — `scripts/check_*` / hook 스크립트 / workflow yml 변경 없음.
- 경로 3 (사용자 SSOT 문서): `docs/plugin/hooks.md` / `docs/plugin/loop-procedure.md` 는 plug-in 배포물에 포함되는 SSOT — 경로 1 과 동일하게 도달.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. 기존 begin-run/next-task CLI 의 옵션 추가 + 기존 게이트 판정 확장.

## Test Plan

- [x] 신규 테스트: 게이트 통과(design_doc 실존) / 차단(디스크 부재 fail-strict, 타 run design_doc 비인정) / start_run 기록·검증(ValueError 3종) / next-task 승계 / argparse 회귀
- [x] 전체 unittest 1044 OK (python3.11 -m unittest discover -s tests)
- [x] 회귀 검증: 기존 module-architect PASS 강제 / POLISH 면제 / namespaced 우회 차단(#700) 테스트 전부 green
- [x] node scripts/check_cross_refs.mjs / check_plugin_manifest.mjs / check_public_surface.mjs PASS

## 참고

- #702 본문의 "1차 — engineer 게이트" AC 충족분. 2차(되돌림 일급화 + 경량 설계 내부 스킬 분리)는 #702 에서 단계적 착수.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
