### PR TITLE
[issue-705] worktree 검증 명령 agent-boundary 오차단 수정 + 검증 미실행 PASS 금지 계약

### DIFF
--- a/agents/build-worker/build-worker-agent.md
+++ b/agents/build-worker/build-worker-agent.md
@@ -24,7 +24,7 @@
 - phase integrity: RED, GREEN, self-validate 증거가 각각 남는가.
 - 범위 준수: impl Scope 밖을 고쳐야 하는 순간 gap으로 보는가.
 - TDD 신뢰성: 테스트가 먼저 실패하고 구현 뒤 통과했는가.
-- 자체 검증: 구현 계획, 계약, lint 또는 프로젝트 표준 검증을 실제로 확인했는가.
+- 자체 검증: 구현 계획, 계약, lint 또는 프로젝트 표준 검증 명령을 실제로 실행해 종료코드로 판정했는가. 실행하지 못한 검증을 코드 읽기만으로 통과 처리하지 않았는가.
 - 신뢰 경계: 외부 HTTP, 파일/URL 입력, 보안, 도메인 invariant를 바꾸면 self-test가 놓친 실패 경로를 별도로 적발했는가.
 - handoff 품질: 메인이 PR과 커밋을 만들 수 있는 최소 정보를 남겼는가.
 - 도구 경제성: 같은 파일과 같은 명령을 반복하지 않고 읽은 내용과 편집 계획을 재사용했는가.
@@ -33,7 +33,7 @@
 
 1. build-test: 계획과 설계만 읽고 테스트를 작성한 뒤 RED를 확인한다.
 2. build-impl: 허용된 코드 경로만 수정하고 GREEN을 확인한다.
-3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다.
+3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다.
 4. 각 phase 결과를 phase prose 파일로 남긴다.
 5. PASS일 때만 다음 task를 위한 한 줄 요약을 남긴다.
 
@@ -52,6 +52,15 @@
 - 외부 데이터가 누락되거나 실패했을 때 도메인 모델을 날조하지 않는다.
 - 이 범위를 build-worker 한 호출로 신뢰하기 어렵다고 판단하면 구현을 억지로 끝내지 말고 `IMPLEMENTATION_ESCALATE` 또는 `SPEC_GAP_FOUND`로 메인에게 풀 4-agent 승격을 요구한다.
 
+## 검증 실행 불가 시 — 정적 분석 PASS 금지
+
+테스트/lint/build 게이트 명령이 환경 제약(도구 호출 차단, 의존성 부재, 권한 거부 등)으로 실행 자체가 안 될 수 있다. worktree 기반 실행에서는 `.venv`/`node_modules` 가 main repo 로 가는 심볼릭으로 연결되는 게 정상 패턴인데, 그 경로의 게이트 실행이 막히는 환경도 같은 경우다. 이때:
+
+- 실행하지 못한 검증을 코드 읽기(정적 분석)로 대체해 `PASS` 를 보고하지 않는다. 실행되지 않은 검증은 검증이 아니다.
+- `build-validate.md` 에 무엇을 실행하려 했고 어떻게 막혔는지(명령, 차단/오류 메시지)를 남긴다.
+- 마지막 단락 결론은 `VALIDATION_BLOCKED` 로 쓰고, 메인이 대신 실행할 검증 명령 목록을 함께 적는다. 메인이 같은 명령을 직접 실행해 종료코드로 판정을 복원한다.
+- 검증이 실행됐는데 실패한 것은 `VALIDATION_BLOCKED` 가 아니라 `TESTS_FAIL` 이다. 실행 불가와 실행 실패를 섞지 않는다.
+
 ## 도구 사용 가드
 
 - 같은 파일은 처음 읽은 내용을 기준으로 계획을 세우고, 의미 있는 외부 변경 가능성이 생긴 경우에만 다시 읽는다.
@@ -64,7 +73,7 @@
 - phase prose 3개 실존을 `ls`로 확인했다.
 - RED와 GREEN 결과가 보고된다.
 - 변경 파일이 impl Scope와 권한 경계 안에 있다.
-- 자체 검증 결과가 `PASS` 또는 finding으로 남는다.
+- 자체 검증 결과가 실제 실행 증거(명령 + 종료코드)와 함께 `PASS` 또는 finding으로 남는다. 실행 불가였다면 `VALIDATION_BLOCKED` 로 보고했다.
 - PR 본문 초안에 close keyword가 불확실하면 메인 검토 요청을 남긴다.
 
 ## 권한 경계
@@ -80,7 +89,7 @@
 
 ## 결론과 보고
 
-마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다.
+마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `VALIDATION_BLOCKED`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다. `VALIDATION_BLOCKED`에는 메인이 대신 실행할 검증 명령 목록을 함께 쓴다.
 
 ## 템플릿과 참고 문서
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -467,6 +467,24 @@ _SHELL_SEPARATORS = frozenset({"&&", "||", ";", "|", "&"})
 _CP_VALUE_FLAGS = frozenset({"-t", "--target-directory"})
 _SED_EXPR_FLAGS = frozenset({"-e", "--expression", "-f", "--file"})
 
+# ── write target 이 아닌 redirect 대상 (#705) ─────────────────────────
+# `cmd 2>&1` 의 `1` (fd 복제) 과 `cmd > /dev/null` 의 `/dev/null` (device sink) 은
+# 프로젝트 파일 write 가 아니다. 이들이 write target 으로 추출되면 ALLOW 미매칭(`1`) /
+# 경계 밖(`/dev/null`) 차단이 발화하는데, `2>&1`·`>/dev/null` 은 테스트/lint 게이트 호출의
+# 보편 스펠링이라 sub-agent (특히 worktree 기반 /impl-loop 의 build-worker) 의 read-only
+# 검증 실행이 통째로 막히고, 검증 미실행이 정적 분석 PASS 로 흡수되는 false-clean 으로
+# 이어졌다. device sink 는 *정확 일치* 만 — `/dev/shm/...` 등 하위 경로는 일반 경계 검사 유지.
+_DEVICE_SINKS = frozenset({"/dev/null", "/dev/stdout", "/dev/stderr", "/dev/tty"})
+
+
+def _is_fd_dup_target(op: str, target: str) -> bool:
+    """`>&` 의 대상이 fd 숫자(`2>&1`) 또는 `-`(fd 닫기, `2>&-`) 면 파일 아님.
+
+    bash 시맨틱 그대로 — `>&word` 는 word 가 숫자/`-` 면 fd 복제, 그 외면 파일 redirect
+    (csh 스타일 `>& out.log` 는 계속 write target). `&>word` 는 항상 파일이라 비대상.
+    """
+    return op == ">&" and (target.isdigit() or target == "-")
+
 
 def _shell_tokens_for_paths(command: str) -> list[str]:
     """Path 추출용 shell tokenization.
@@ -512,12 +530,16 @@ def _strip_redirections_for_paths(tokens: list[str]) -> tuple[list[str], list[st
         ):
             op = tokens[i + 1]
             if i + 2 < len(tokens) and op in _WRITE_REDIRECT_OPS:
-                paths.append(tokens[i + 2])
+                # fd 복제 (`2>&1`) / 닫기 (`2>&-`) 는 파일 write 아님 (#705).
+                if not _is_fd_dup_target(op, tokens[i + 2]):
+                    paths.append(tokens[i + 2])
             i += 3 if i + 2 < len(tokens) else 2
             continue
         if tok in (_WRITE_REDIRECT_OPS | _READ_REDIRECT_OPS):
             if i + 1 < len(tokens) and tok in _WRITE_REDIRECT_OPS:
-                paths.append(tokens[i + 1])
+                # fd 복제 (`>&2`) / 닫기 (`>&-`) 는 파일 write 아님 (#705).
+                if not _is_fd_dup_target(tok, tokens[i + 1]):
+                    paths.append(tokens[i + 1])
             i += 2 if i + 1 < len(tokens) else 1
             continue
         argv.append(tok)
@@ -734,6 +756,8 @@ def extract_bash_paths(command: str) -> list[str]:
     seen: set[str] = set()
     deduped: list[str] = []
     for path in paths:
+        if path in _DEVICE_SINKS:
+            continue  # `/dev/null` 등 무해 sink — 프로젝트 write 아님 (#705)
         if path not in seen:
             seen.add(path)
             deduped.append(path)

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -324,6 +324,9 @@ _CONCLUSION_ENUMS: tuple[tuple[str, str], ...] = (
     ("IMPLEMENTATION_ESCALATE", re.compile(r"\bIMPLEMENTATION_ESCALATE\b")),
     # test-engineer
     ("TESTS_WRITTEN", re.compile(r"\bTESTS_WRITTEN\b")),
+    # build-worker — 검증 명령 실행 불가 (환경 제약) 보고. 정적 분석 PASS 흡수 금지 —
+    # 메인이 게이트 대행 실행 (skills/impl-loop/impl-loop-routing.md).
+    ("VALIDATION_BLOCKED", re.compile(r"\bVALIDATION_BLOCKED\b")),
     # ux-architect
     ("UX_FLOW_DONE", re.compile(r"\bUX_FLOW_DONE\b")),
     ("UX_FLOW_ESCALATE", re.compile(r"\bUX_FLOW_ESCALATE\b")),
@@ -339,6 +342,7 @@ _STANDALONE_CONCLUSIONS: frozenset[str] = frozenset({
     "IMPL_DONE", "IMPL_PARTIAL",
     "POLISH_DONE", "IMPLEMENTATION_ESCALATE",
     "TESTS_WRITTEN", "TESTS_FAIL",
+    "VALIDATION_BLOCKED",
     "UX_FLOW_DONE", "UX_FLOW_ESCALATE",
 })
 _NEGATION_RE = re.compile(

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -248,8 +248,10 @@ default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → p
 > **advanced fallback — deep task 보강 필요 시 module-architect 선두** — build-worker 직전에 `begin-step module-architect` → `Agent(module-architect, prompt=<task 컨텍스트 + impl 파일 생성 위치>)` → `PASS` 시 impl 파일 생성 확인 후 `end-step module-architect` → 정상 build-worker 진입. 이것은 Lite direct 구현이 아니라 deep task 보강 경로다. `ESCALATE` 시 사용자 위임.
 >
 > **자동 폴백** — build-worker 가 진행 중 `SPEC_GAP_FOUND` 던지면 분량 메타 (small/medium/large) 기반 분기 (= [`impl-loop-routing.md`](impl-loop-routing.md#결론-다음-호출-매핑)). attempt 한도 초과 시 사용자 위임.
+>
+> **검증 대행 폴백** — build-worker 가 환경 제약으로 검증 명령을 실행하지 못해 `VALIDATION_BLOCKED` 를 보고하면, 메인이 worker 가 남긴 검증 명령을 같은 cwd(worktree)에서 직접 실행해 종료코드로 판정을 복원한다 (= [`impl-loop-routing.md`](impl-loop-routing.md#결론-다음-호출-매핑)). 검증 미실행 상태로 git/PR 진행 금지.
 
-❌ build-worker 안티패턴: phase 2 종료 전 GREEN 미확인 (false-clean) / build-worker 가 `Agent(pr-reviewer)` 또는 `git commit` 직접 호출 (권한 경계 위반 — 메인이 별 turn 처리) / phase prose 자체 Write 확인 skip (`build-{test,impl,validate}.md` 3개 실존 검증 의무, 부재 시 `blocked` 강등).
+❌ build-worker 안티패턴: phase 2 종료 전 GREEN 미확인 (false-clean) / 검증 실행 불가를 정적 분석 PASS 로 흡수 (실행 불가면 `VALIDATION_BLOCKED` — 메인이 게이트 대행) / build-worker 가 `Agent(pr-reviewer)` 또는 `git commit` 직접 호출 (권한 경계 위반 — 메인이 별 turn 처리) / phase prose 자체 Write 확인 skip (`build-{test,impl,validate}.md` 3개 실존 검증 의무, 부재 시 `blocked` 강등).
 
 ---
 

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -57,6 +57,9 @@ flowchart TB
   BW -->|TESTS_FAIL ≤3| EN2[engineer] -->|IMPL_DONE| CV2[code-validator]
   CV2 -->|PASS| MG
   CV2 -->|FAIL ≤3| EN2
+  BW -->|VALIDATION_BLOCKED| GV([메인 게이트 대행 실행])
+  GV -->|exit 0| MG
+  GV -->|게이트 FAIL ≤3| EN2
   BW -.->|IMPLEMENTATION_ESCALATE| U2((사용자))
   MA2 -.->|ESCALATE| U2
 
@@ -71,6 +74,7 @@ flowchart TB
 > 파랑 = 생산 agent · 초록 = 검증 agent · 회색 = 사용자 위임. 점선 = escalate. 엣지의 `≤N` = retry 한도 ([retry 한도](#retry-한도)).
 > build-worker 는 git/PR/pr-reviewer 직접 호출 금지 — 권한 = engineer + test-engineer 합집합, git/PR 은 메인 위임 ([`agent_boundary.py`](../../harness/agent_boundary.py)). deep task 보강 필요 시 module-architect 선두 (3-step).
 > **TESTS_FAIL 폴백 = 검증 복원 (MUST)**: build-worker 가 self-validate 미통과(TESTS_FAIL)면 engineer 가 마저 구현하되, build-worker phase 3 self-validate 가 건너뛴 검증을 **code-validator 가 대신 수행**한다. engineer `IMPL_DONE` → code-validator `PASS` 후에만 메인 git/PR. 검증 없이 degraded 산출이 PR 되는 경로 차단 (원본 `commands/impl-loop.md` "engineer 단발 4-agent 진입" 정합).
+> **VALIDATION_BLOCKED 폴백 = 메인 게이트 대행 (MUST)**: build-worker 가 환경 제약(도구 차단·의존성 부재 등)으로 검증 명령을 실행하지 못했다고 보고하면, 메인이 worker 가 남긴 검증 명령을 같은 cwd(worktree)에서 직접 실행해 종료코드로 판정을 복원한다. exit 0 → `PASS` 와 동일 진행(메인 git/PR → pr-reviewer) · 게이트 FAIL → engineer 재시도(TESTS_FAIL 경로 합류, ≤3) · 메인에서도 실행 불가 → 사용자 위임. 검증 미실행 상태로 git/PR 진행 금지 — 정적 분석만으로 PASS 를 흡수하는 false-clean 차단.
 
 ## 결론 → 다음 호출 매핑
 
@@ -80,7 +84,7 @@ flowchart TB
 | **engineer** | `IMPL_DONE` → code-validator · `IMPL_PARTIAL` → engineer(분할 — retry 아님, 상한 없음 [retry 한도](#retry-한도)) · `SPEC_GAP_FOUND` → module-architect(보강, ≤2) · `TESTS_FAIL` → engineer 재시도(≤3) · `POLISH_DONE` → pr-reviewer · `IMPLEMENTATION_ESCALATE` → 사용자 |
 | **code-validator** | `PASS` → pr-reviewer · `FAIL` → engineer 재시도(≤3) · `ESCALATE` → module-architect(보강) 또는 사용자. impl/bugfix/compact plan 경로로 scope 자동 분기 |
 | **pr-reviewer** | `PASS`(LGTM) → (CI PASS 후) 메인 즉시 regular merge · 변경 요청 → engineer POLISH → **메인 commit/push to PR branch** (엔진 B 는 PR 이 이미 생성됨 — POLISH 변경 반영 필수) → pr-reviewer 재리뷰(≤2) |
-| **build-worker** | `PASS` → 메인 git/PR → pr-reviewer · `SPEC_GAP_FOUND` → 분량 메타 분기(아래) · `TESTS_FAIL` → engineer(마저 구현) → **`IMPL_DONE` → code-validator → `PASS` 후 메인 git/PR** (self-validate 미통과분을 code-validator 가 복원 — 검증 없이 PR 금지) 또는 attempt 한도 초과 시 사용자 · `IMPLEMENTATION_ESCALATE` → 사용자 |
+| **build-worker** | `PASS` → 메인 git/PR → pr-reviewer · `SPEC_GAP_FOUND` → 분량 메타 분기(아래) · `TESTS_FAIL` → engineer(마저 구현) → **`IMPL_DONE` → code-validator → `PASS` 후 메인 git/PR** (self-validate 미통과분을 code-validator 가 복원 — 검증 없이 PR 금지) 또는 attempt 한도 초과 시 사용자 · `VALIDATION_BLOCKED` → **메인이 worker 가 남긴 검증 명령을 직접 실행(게이트 대행)** — exit 0 → 메인 git/PR → pr-reviewer · 게이트 FAIL → engineer 재시도(TESTS_FAIL 경로 합류, ≤3) · 메인도 실행 불가 → 사용자 · `IMPLEMENTATION_ESCALATE` → 사용자 |
 | **module-architect** | `PASS` → (impl 파일 생성·보강 후) build-worker 또는 test-engineer · `ESCALATE` → 사용자 |
 | **designer** | `PASS` → 사용자 PICK → test-engineer · `ESCALATE` → 사용자. 환경 = `docs/design.md` frontmatter `medium`. 재호출 한도 X |
 
@@ -125,7 +129,7 @@ chain (N task) 에서 *각 task run* 의 종료 결론에 따른 다음 task 진
 | `error` | 자동 재시도 (한도 `--retry-limit`, default 3). 한도 초과 시 정지 + 사용자 위임 |
 | `blocked` | 즉시 정지 + 사용자 위임 (재호출 또는 수동 처리) |
 
-- `clean` 판정 게이트 = code-validator(또는 build-worker self-validate) PASS + pr-reviewer 실행 + 메인 PR 생성·머지 완료 흔적 (셋 중 하나 부재 → false-clean → `blocked` 강등, #431).
+- `clean` 판정 게이트 = code-validator(또는 build-worker self-validate) PASS + pr-reviewer 실행 + 메인 PR 생성·머지 완료 흔적 (셋 중 하나 부재 → false-clean → `blocked` 강등, #431). build-worker `VALIDATION_BLOCKED` 는 메인 게이트 대행 exit 0 증거가 있을 때만 self-validate PASS 와 동치 — 대행 증거 없는 `VALIDATION_BLOCKED` 진행은 false-clean 으로 `blocked` 강등.
 - verify-only task 의 `clean` 판정 게이트 = `code-validator:VERIFY_ONLY` prose PASS + 검증 명령 exit 0 증거 + `git status --porcelain` 변경 0. 이 경우 pr-reviewer/PR 생성·머지 흔적은 요구하지 않는다.
 - 전체 완료 → 보고 (처리 N/N + 각 PR URL). 마지막 task = `next-task` 대신 `end-run` 단독.
 

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1538,5 +1538,156 @@ class BashIntegrationTests(unittest.TestCase):
             self.assertEqual(blocked, [], f"engineer 정상 편집이 차단됨: {blocked}")
 
 
+class FdRedirectAndDeviceSinkTests(unittest.TestCase):
+    """#705 — fd 복제 redirect / device sink 가 write path 로 오추출되던 false positive.
+
+    `cmd 2>&1` 의 `1`, `cmd > /dev/null` 의 `/dev/null` 은 프로젝트 파일 write 가 아니다.
+    이들이 write target 으로 추출되면 ALLOW 미매칭(`1`) / 경계 밖(`/dev/null`) 차단이 발화해
+    sub-agent 의 read-only 검증 명령(pytest/lint 게이트) 이 통째로 막힌다 — build-worker 가
+    검증을 한 번도 실행 못 하고 정적 분석만으로 PASS 를 보고하는 false-clean 의 근본원인.
+    """
+
+    # ── fd 복제 (N>&M) / fd 닫기 (N>&-) — 파일 아님 ──────────────────
+
+    def test_stderr_to_stdout_dup_not_extracted(self):
+        self.assertEqual(extract_bash_paths("pytest tests/ 2>&1"), [])
+        self.assertEqual(extract_bash_paths("pytest tests/ 2>&1 | tail -20"), [])
+
+    def test_stdout_to_stderr_dup_not_extracted(self):
+        self.assertEqual(extract_bash_paths("echo warn 1>&2"), [])
+        self.assertEqual(extract_bash_paths("echo warn >&2"), [])
+
+    def test_fd_close_not_extracted(self):
+        self.assertEqual(extract_bash_paths("cmd 2>&-"), [])
+        self.assertEqual(extract_bash_paths("cmd >&-"), [])
+
+    def test_plain_redirect_to_digit_named_file_still_extracted(self):
+        # `> 1` 은 fd 복제가 아니라 파일명 `1` write — 추출 유지 (경계 검사 대상).
+        self.assertEqual(extract_bash_paths("echo x > 1"), ["1"])
+
+    def test_csh_style_redirect_to_file_still_extracted(self):
+        # `>& out.log` (stdout+stderr 를 파일로) — 대상이 fd 숫자가 아니면 파일 write.
+        self.assertEqual(extract_bash_paths("cmd >& out.log"), ["out.log"])
+
+    def test_fd_numbered_file_redirect_still_extracted(self):
+        # `2> err.log` 는 stderr 를 *파일* 로 — write target 추출 유지.
+        self.assertEqual(extract_bash_paths("cmd 2> err.log"), ["err.log"])
+
+    # ── device sink — 어디에 써도 프로젝트 mutation 아님 ─────────────
+
+    def test_dev_null_redirect_not_extracted(self):
+        self.assertEqual(extract_bash_paths("pytest -q > /dev/null"), [])
+        self.assertEqual(extract_bash_paths("ruff check src/ 2>/dev/null"), [])
+        self.assertEqual(
+            extract_bash_paths("bash scripts/gate.sh >/dev/null 2>&1"), []
+        )
+
+    def test_dev_stream_sinks_not_extracted(self):
+        self.assertEqual(extract_bash_paths("cmd > /dev/stdout"), [])
+        self.assertEqual(extract_bash_paths("cmd > /dev/stderr"), [])
+        self.assertEqual(extract_bash_paths("cmd | tee /dev/null"), [])
+
+    def test_dev_lookalike_paths_still_extracted(self):
+        # device sink allowlist 는 정확한 경로만 — 하위/유사 경로는 일반 경계 검사 유지.
+        self.assertEqual(extract_bash_paths("echo x > /dev/shm/evil"), ["/dev/shm/evil"])
+        self.assertEqual(extract_bash_paths("echo x > dev/null"), ["dev/null"])
+
+    def test_real_outside_write_still_extracted(self):
+        # 회귀 가드 — repo 밖 실제 파일 write 는 계속 추출 (경계가 차단해야 함).
+        self.assertEqual(
+            extract_bash_paths("npm test 2>&1 | tee /tmp/test.log"), ["/tmp/test.log"]
+        )
+
+
+class WorktreeValidationBoundaryTests(unittest.TestCase):
+    """#705 통합 — worktree(.venv/node_modules 심볼릭) 의 read-only 검증 명령 비차단.
+
+    git worktree 에는 .venv/node_modules 가 없어(gitignore) main repo 로 가는 심볼릭으로
+    우회하는 게 정상 패턴이다. 그 경로로 게이트를 실행하는 Bash 가 agent-boundary 에
+    차단되지 않아야 하고(AC), 동시에 repo 밖 write / 의존 트리 write 차단은 유지돼야 한다.
+    """
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def _make_worktree(self, td: str) -> Path:
+        root = Path(td)
+        main = root / "mainrepo"
+        (main / ".venv" / "bin").mkdir(parents=True)
+        (main / "node_modules" / ".bin").mkdir(parents=True)
+        wt = root / "worktrees" / "wt1"
+        wt.mkdir(parents=True)
+        (wt / ".venv").symlink_to(main / ".venv")
+        (wt / "node_modules").symlink_to(main / "node_modules")
+        (wt / "tests").mkdir()
+        (wt / "scripts").mkdir()
+        return wt
+
+    def _blocked(self, agent: str, cmd: str, cwd: Path) -> list:
+        return [
+            p for p in extract_bash_paths(cmd)
+            if check_write_allowed(agent, p, cwd=cwd, shell_context=True) is not None
+        ]
+
+    def test_venv_symlink_pytest_not_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            wt = self._make_worktree(td)
+            for cmd in (
+                ".venv/bin/python -m pytest tests/ 2>&1",
+                ".venv/bin/python -m pytest tests/ -x -q 2>&1 | tail -20",
+                ".venv/bin/ruff check src/ 2>/dev/null",
+            ):
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(
+                        self._blocked("build-worker", cmd, wt), [],
+                        f"worktree 검증 명령이 차단됨: {cmd}",
+                    )
+
+    def test_node_modules_symlink_gate_not_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            wt = self._make_worktree(td)
+            for cmd in (
+                "node_modules/.bin/eslint src/ 2>&1",
+                "bash scripts/check_quality.sh >/dev/null 2>&1",
+                "npm test 2>&1",
+            ):
+                with self.subTest(cmd=cmd):
+                    self.assertEqual(
+                        self._blocked("build-worker", cmd, wt), [],
+                        f"worktree 검증 명령이 차단됨: {cmd}",
+                    )
+
+    def test_dependency_tree_write_still_blocked(self):
+        # 회귀 가드 — 심볼릭 *경유 실행* 허용이지 의존 트리 *write* 허용이 아니다.
+        with tempfile.TemporaryDirectory() as td:
+            wt = self._make_worktree(td)
+            self.assertIsNotNone(
+                check_write_allowed(
+                    "build-worker", ".venv/lib/site.py", cwd=wt, shell_context=True
+                )
+            )
+            self.assertIsNotNone(
+                check_write_allowed(
+                    "build-worker", "node_modules/pkg/index.js", cwd=wt,
+                    shell_context=True,
+                )
+            )
+
+    def test_outside_write_still_blocked(self):
+        # 회귀 가드 — repo 밖 실제 write 는 worktree 에서도 계속 차단.
+        with tempfile.TemporaryDirectory() as td:
+            wt = self._make_worktree(td)
+            blocked = self._blocked(
+                "build-worker", "echo pwned | tee /tmp/evil.sh", wt
+            )
+            self.assertEqual(blocked, ["/tmp/evil.sh"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -975,6 +975,14 @@ class ConclusionEnumExtractionTests(unittest.TestCase):
         prose = "재시도 한도 초과.\n\nIMPLEMENTATION_ESCALATE — 사용자 위임."
         self.assertEqual(_extract_conclusion_enum(prose), "IMPLEMENTATION_ESCALATE")
 
+    def test_extracts_validation_blocked(self):
+        # build-worker 결론 — 검증 명령 실행 불가 (환경 제약). PASS 로 오인 금지 (#705).
+        prose = (
+            "self-validate 시도.\n\n게이트 명령 실행이 환경 제약으로 막힘 — "
+            "VALIDATION_BLOCKED. 메인 대행 명령: python -m pytest tests/"
+        )
+        self.assertEqual(_extract_conclusion_enum(prose), "VALIDATION_BLOCKED")
+
     def test_extracts_tests_fail(self):
         # TESTS_FAIL 이 FAIL 보다 우선 매칭
         prose = "테스트 결과.\n\n3회 후에도 동일 FAIL — TESTS_FAIL 결론."


### PR DESCRIPTION
## 관련 이슈 번호
Closes #705

## 배경 및 문제
git worktree 기반 `/impl-loop` 에서 build-worker 가 테스트/lint 게이트를 실행하면 agent-boundary 가 Bash 를 차단해, 검증을 한 번도 실행하지 못한 채 정적 분석만으로 `PASS` 를 보고하는 false-clean 이 발생했다 (실측: PASS 보고된 변경에 path traversal 결함 + 항상 통과하는 가짜 테스트 잔존). 워크트리가 기본이라 common path 결함.

## 원인 (해당 시)
이슈는 `.venv`/`node_modules` 심볼릭을 원인으로 추정했으나, 실측 재현 결과 기계적 근본원인은 `extract_bash_paths` 의 redirect 오추출 2종이다:
1. **fd 복제 대상 오추출** — `cmd 2>&1` 의 `1` 을 write target 으로 추출 → `ALLOW_MATRIX 미매칭: 1` 차단. `2>&1` 은 검증 명령의 보편 스펠링이라 사실상 모든 게이트 호출이 차단됨.
2. **device sink 오추출** — `cmd > /dev/null` 의 `/dev/null` 추출 → "경계 밖 경로 차단 — 프로젝트 루트 밖 write 금지" 차단. 이 메시지가 "워크트리 밖 접근" 으로 보고된 것.

심볼릭 자체는 command position 이라 원래 검사 대상이 아님 — `.venv/bin/python -m pytest tests/ 2>&1` 차단도 위 1번 경로였다 (워크트리 시뮬레이션 테스트로 실증).

## 작업내용
- **commit 1** — `harness/agent_boundary.py`: fd 복제/닫기(`2>&1`/`1>&2`/`2>&-`) 대상과 device sink(`/dev/null`/`/dev/stdout`/`/dev/stderr`/`/dev/tty`, 정확 일치만)를 write target 추출에서 제외. `tests/test_agent_boundary.py`: 추출 단위 테스트 + worktree 심볼릭 통합 테스트 + 회귀 가드(`> 1` 파일 write·`2> err.log`·`tee /tmp/*` 차단·의존 트리 write 차단·repo 밖 write 차단 유지).
- **commit 2** — 검증 실행 불가 환경 계약(AC3): `agents/build-worker/build-worker-agent.md` 에 정적 분석 PASS 금지 + `VALIDATION_BLOCKED` 결론 추가, `skills/impl-loop/impl-loop-routing.md` 에 메인 게이트 대행 라우팅(exit 0 → git/PR 진행 · FAIL → engineer 합류 ≤3 · 메인도 불가 → 사용자 위임) + chain clean 판정 게이트에 대행 exit 0 증거 요건, `skills/impl-loop/SKILL.md` 폴백·안티패턴, `harness/run_review.py` 결론 enum 매트릭스 반영.

## 결정 근거
- fd/sink 제외는 *추출 단계* 에서 처리 — bash 시맨틱 그대로(`>&` + 숫자/`-` 만 fd 복제, csh `>& file` 은 파일 write 유지)라 기존 차단(repo 밖 write·`/tmp` tee·의존 트리 write·git push/gh mutation)은 회귀 없음 (AC4).
- `VALIDATION_BLOCKED` 는 신규 surface(skill/command/agent/gate)가 아니라 기존 라우팅 표의 결론 enum 1개 추가 — 형식 강제가 아닌 의미 가이드(agent 자율 원칙 유지), 라우팅은 권고 영역.
- `/tmp` 로그 write(`tee /tmp/x.log`)는 의도적으로 계속 차단 — read-only 검증에 불필요하고 repo 밖 write 경계 유지가 AC.

## Test Plan
- [x] `python3.11 -m unittest discover -s tests` — 1046 OK (신규 15개 포함)
- [x] 회귀 검증: 기존 boundary 테스트 159개 전체 GREEN, `git push`/`gh` mutation 차단·repo 밖 write 차단 테스트 유지
- [x] `node scripts/check_cross_refs.mjs` / `check_plugin_manifest.mjs` / `check_public_surface.mjs` PASS

## 참고
**배포 경로 검증**: 변경 파일 전부 plug-in 본체 경로 — `harness/agent_boundary.py`·`harness/run_review.py`(hook 이 PYTHONPATH 로 로드), `agents/build-worker/**`, `skills/impl-loop/**` → 경로 1 (plugin 버전 업데이트 시 외부 활성 프로젝트 자동 적용). init-dcness 복사 파일·사용자 SSOT 문서 변경 없음 → 경로 2/3 비해당. tests/ 는 repo 전용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)