### PR TITLE
[issue-709] engineer 게이트 effective mode = tool_input.mode ∪ current_step.mode

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -429,10 +429,14 @@ def handle_pretooluse_agent(
         slot = active.get(rid, {}) if isinstance(active, dict) else {}
         if isinstance(slot, dict):
             # #709 — begin-step 이 기록한 current_step.mode 를 effective mode fallback 으로
-            # 쓰기 위해 같은 slot read 에서 함께 추출(중복 read 회피).
-            cur_step = slot.get("current_step")
-            if isinstance(cur_step, dict):
-                step_mode = _mode_or_none(cur_step.get("mode"))
+            # 쓰기 위해 같은 slot read 에서 함께 추출(중복 read 회피). 단 fallback 의 신뢰
+            # 근거가 "strict-conveyor 가 begin-step↔Agent 정합을 보장" 이므로, strict
+            # entry_point 일 때만 step_mode 를 채운다 — 비-strict run 은 그 정합이 없어
+            # 다른 step 의 mode 가 면제로 새는 것을 원천 차단(게이트 약화 방향 방어).
+            if slot.get("entry_point", "") in _STRICT_CONVEYOR_ENTRY_POINTS:
+                cur_step = slot.get("current_step")
+                if isinstance(cur_step, dict):
+                    step_mode = _mode_or_none(cur_step.get("mode"))
             strict_msg = _strict_conveyor_gate_message(
                 sid=sid,
                 rid=rid,

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -422,11 +422,17 @@ def handle_pretooluse_agent(
     # issue #604 — active conveyor run 안에서는 begin-step 없이 Agent 직접 호출 금지.
     # PostToolUse staging 이후 같은 step 재호출, end-step 완료 후 stale current_step 도
     # PreToolUse 시점에서 차단해 `.steps.jsonl` 누락을 실행 전에 막는다.
+    step_mode = None
     try:
         live = read_live(sid, base_dir=base_dir) or {}
         active = live.get("active_runs", {}) if isinstance(live, dict) else {}
         slot = active.get(rid, {}) if isinstance(active, dict) else {}
         if isinstance(slot, dict):
+            # #709 — begin-step 이 기록한 current_step.mode 를 effective mode fallback 으로
+            # 쓰기 위해 같은 slot read 에서 함께 추출(중복 read 회피).
+            cur_step = slot.get("current_step")
+            if isinstance(cur_step, dict):
+                step_mode = _mode_or_none(cur_step.get("mode"))
             strict_msg = _strict_conveyor_gate_message(
                 sid=sid,
                 rid=rid,
@@ -441,12 +447,19 @@ def handle_pretooluse_agent(
     except (OSError, ValueError):
         pass  # state 읽기 실패는 fail-open — hook 버그발 과차단 회피.
 
-    # engineer 게이트 — engineer 직전 설계 산출물 필수 (mode != POLISH).
+    # engineer 게이트 — engineer 직전 설계 산출물 필수 (effective mode != POLISH).
     # #700 — namespaced 우회 차단을 위해 norm_subagent 비교(codex P1).
     # #701 — prerequisite = 같은-run module-architect PASS ∪ begin-run 에 기록된
     # 머지된 설계 문서(design_doc) 실존. impl-loop 풀 4-agent 는 설계가 별도 run
     # 에서 머지된 뒤 진입하므로 같은-run prose 단일 기준이면 구조적으로 차단된다.
-    if norm_subagent == "engineer" and mode != "POLISH":
+    # #709 — effective mode = tool_input.mode ∪ current_step.mode. Agent 도구 스키마에
+    # mode 파라미터가 없는 CC 빌드에선 tool_input.mode 가 안 실려, POLISH 면제가
+    # tool_input.mode 단독이면 죽는다(impl-loop engine B 의 pr-reviewer→engineer:POLISH 가
+    # design_doc·MA PASS 둘 다 없어 구조적 차단). begin-step 이 CLI 로 확실히 기록한
+    # current_step.mode 를 fallback 으로 봐 환경 무관하게 면제를 복원한다. strict-conveyor 가
+    # begin-step↔Agent(agent) 정합을 이미 보장하므로 current_step.mode=POLISH 는 신뢰 신호.
+    effective_mode = _mode_or_none(mode) or step_mode
+    if norm_subagent == "engineer" and effective_mode != "POLISH":
         if not _has_module_architect_pass(rd) and not _run_design_doc_exists(
             sid, rid, base_dir=base_dir
         ):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -221,14 +221,24 @@ class CatastrophicEngineerTests(_PreToolBase):
 
     # -- #709 — POLISH 면제의 effective mode 는 tool_input.mode ∪ current_step.mode --
 
+    def _strict_impl_run(self, rid: str = "run-87650001") -> Path:
+        # effective-mode fallback 은 strict entry_point(impl) 에서만 신뢰되므로
+        # current_step.mode 의존 테스트는 strict impl run 으로 세팅한다.
+        start_run(self.sid, rid, "impl", base_dir=self.base)
+        write_pid_current_run(self.cc_pid, rid, base_dir=self.base)
+        return run_dir(self.sid, rid, base_dir=self.base)
+
     def test_polish_via_current_step_when_toolinput_mode_absent(self) -> None:
         # impl-loop engine B 실전 — Agent 도구 스키마에 mode 파라미터가 없는 CC 빌드에선
         # tool_input.mode 가 안 실린다. begin-step 이 기록한 current_step.mode=POLISH 를
         # effective mode 로 봐야 POLISH 면제가 환경 무관하게 작동한다.
-        (self.run_path / "build-worker.md").write_text("PASS\n", encoding="utf-8")
-        self._begin_step("engineer", "POLISH")
+        rd = self._strict_impl_run()
+        (rd / "build-worker.md").write_text("PASS\n", encoding="utf-8")
+        update_current_step(
+            self.sid, "run-87650001", "engineer", "POLISH", base_dir=self.base,
+        )
         rc = handle_pretooluse_agent(
-            stdin_data=self._payload("engineer"),  # mode 키 부재 (실전 payload)
+            stdin_data=self._payload("engineer"),  # tool_input.mode 빈값 (실전 payload)
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
@@ -237,18 +247,39 @@ class CatastrophicEngineerTests(_PreToolBase):
     def test_impl_still_blocked_when_current_step_mode_impl_and_no_artifact(self) -> None:
         # 회귀 가드 — current_step.mode=IMPL 이고 설계 산출물 없으면 여전히 차단.
         # effective-mode fallback 이 IMPL 까지 면제로 새지 않는다.
-        self._begin_step("engineer", "IMPL")
+        self._strict_impl_run()
+        update_current_step(
+            self.sid, "run-87650001", "engineer", "IMPL", base_dir=self.base,
+        )
         rc = handle_pretooluse_agent(
-            stdin_data=self._payload("engineer"),  # mode 키 부재
+            stdin_data=self._payload("engineer"),  # tool_input.mode 빈값
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )
         self.assertEqual(rc, 1)
 
     def test_blocked_when_no_mode_anywhere_and_no_artifact(self) -> None:
-        # 회귀 가드 — tool_input.mode 도 current_step.mode 도 없고 설계 산출물도 없으면 차단.
+        # 회귀 가드 — tool_input.mode 도 current_step.mode(부재) 도 POLISH 가 아니고
+        # 설계 산출물도 없으면 차단. begin-step engineer(mode 없음) → current_step.mode=None.
+        self._strict_impl_run()
+        update_current_step(
+            self.sid, "run-87650001", "engineer", None, base_dir=self.base,
+        )
         rc = handle_pretooluse_agent(
             stdin_data=self._payload("engineer"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_polish_step_mode_ignored_in_nonstrict_run(self) -> None:
+        # 게이트 약화 방향 방어 — 비-strict entry_point 에서는 current_step.mode 정합이
+        # strict-conveyor 로 보장되지 않으므로 step_mode fallback 을 쓰지 않는다.
+        # setUp 의 run 은 entry_point="test"(비-strict). current_step.mode=POLISH 여도
+        # 산출물 없으면 차단(POLISH 누수 차단).
+        self._begin_step("engineer", "POLISH")
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer"),  # tool_input.mode 빈값
             cc_pid=self.cc_pid,
             base_dir=self.base,
         )

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -219,6 +219,41 @@ class CatastrophicEngineerTests(_PreToolBase):
         )
         self.assertEqual(rc, 0)
 
+    # -- #709 — POLISH 면제의 effective mode 는 tool_input.mode ∪ current_step.mode --
+
+    def test_polish_via_current_step_when_toolinput_mode_absent(self) -> None:
+        # impl-loop engine B 실전 — Agent 도구 스키마에 mode 파라미터가 없는 CC 빌드에선
+        # tool_input.mode 가 안 실린다. begin-step 이 기록한 current_step.mode=POLISH 를
+        # effective mode 로 봐야 POLISH 면제가 환경 무관하게 작동한다.
+        (self.run_path / "build-worker.md").write_text("PASS\n", encoding="utf-8")
+        self._begin_step("engineer", "POLISH")
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer"),  # mode 키 부재 (실전 payload)
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_impl_still_blocked_when_current_step_mode_impl_and_no_artifact(self) -> None:
+        # 회귀 가드 — current_step.mode=IMPL 이고 설계 산출물 없으면 여전히 차단.
+        # effective-mode fallback 이 IMPL 까지 면제로 새지 않는다.
+        self._begin_step("engineer", "IMPL")
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer"),  # mode 키 부재
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_blocked_when_no_mode_anywhere_and_no_artifact(self) -> None:
+        # 회귀 가드 — tool_input.mode 도 current_step.mode 도 없고 설계 산출물도 없으면 차단.
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("engineer"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
     def test_allowed_with_module_architect_occurrence(self) -> None:
         # module-architect-2.md (occurrence 카운터) 안 PASS 도 인정
         (self.run_path / "module-architect-2.md").write_text(


### PR DESCRIPTION
## 관련 이슈 번호

Closes #709

(이슈 #700→#701→#702 체인의 잔여 effective-mode 항목. #700 이 명시 이연한 "engineer 게이트 effective mode(POLISH) 판정"을 닫는다.)

## 배경 및 문제

#700/#701/#702 머지 후 연관 PR 통합 검증 중, impl-loop 엔진 B(build-worker) 경로의 `pr-reviewer 변경요청 → engineer:POLISH` 가 catastrophic engineer 게이트에 **구조적으로 차단**되는 구멍을 실측 시뮬레이션으로 발견했다.

## 원인

engineer 게이트의 POLISH 면제(`mode != "POLISH"`)가 `tool_input.mode` 단독에 의존한다. dcness 호출 규약(`loop-procedure.md:75`)은 `Agent(subagent_type, mode="<MODE>")` 로 mode 가 tool_input 에 실린다고 가정하나, **Claude Code Agent 도구 스키마에 `mode` 파라미터가 없는 빌드**에선 안 실린다. 그 환경에서 engine B 의 POLISH 는:
- `--design-doc` 미기록 (engine A 한정 규약)
- 같은 run 에 module-architect PASS 없음 (build-worker 2-step)

→ prerequisite(MA PASS ∪ design_doc)도 면제(POLISH)도 모두 불충족 → 차단.

Standard(같은 run MA COMPACT_PLAN PASS)·engine A(design_doc 기록)는 prerequisite 가 차서 면제와 무관하게 통과하므로, **engine B 만 노출**된다.

### 실측 시뮬레이션 (수정 전)

| 시나리오 | 결과 |
|---|---|
| mode='POLISH' tool_input 실림 (mode 실리는 빌드) | PASS |
| **mode 미실림 + current_step.mode='POLISH' (engine B 실전)** | **BLOCK ← 구멍** |
| Standard: MA COMPACT_PLAN PASS 존재, mode 미실림 | PASS |
| engine A: design_doc 기록됨, mode 미실림 | PASS |

## 작업내용

- `harness/hooks.py` — engineer 게이트 effective mode = `tool_input.mode ∪ current_step.mode`. strict-conveyor 블록의 같은 slot read 에서 `current_step.mode` 를 함께 추출(중복 read 회피)해 fallback 으로 사용.
- `tests/test_hooks.py` — 회귀 테스트 3종(engine B POLISH PASS 복원 / IMPL 차단 유지 / mode 부재 차단 유지).

## 결정 근거

- `begin-step` 이 CLI 로 확실히 기록하는 `current_step.mode` 를 fallback 으로 봐 **환경 의존성 제거**. strict-conveyor 가 begin-step↔Agent(agent) 정합을 이미 보장하므로 `current_step.mode=POLISH` 는 메인이 명시 선언한 신뢰 신호.
- POLISH 면제에 "산출물 존재 AND" 조건 신설은 기각 — 기존 무조건 면제 정책 유지(scope 확대·룰이 룰 부르는 안티패턴 회피).
- 회귀 불변: tool_input.mode=POLISH 면제 / Standard MA PASS / engine A design_doc / namespaced 우회 차단 전부 유지.

## 배포 경로 검증 (plug-in 영향 시)

- **경로 1 (plug-in 본체)**: `harness/hooks.py` — plug-in 본체 파일. 사용자 plug-in 버전 업 시 자동 적용. catastrophic 게이트라 사용자 환경 도달 즉시 효력.
- **경로 2 (init-dcness 복사)**: 해당 없음 (scripts/check_* / hook 스크립트 / workflow yml 변경 없음).
- **경로 3 (사용자 SSOT 문서)**: 해당 없음.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests` — 1070 OK (신규 3 포함)
- [x] `node scripts/check_cross_refs.mjs` / `check_public_surface.mjs` — PASS
- [x] 실측 시뮬레이션 4 시나리오 — engine B 차단 재현 → 수정 후 PASS, 나머지 회귀 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)
