### PR TITLE
[issue-705] 루트 직속 코드 파일 ALLOW 보강 — 엔트리포인트 Edit 차단 friction 해소

### DIFF
--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -104,6 +104,12 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'^internal/',     # Go 내부 패키지
         r'^pkg/',          # Go 공개 패키지
         r'^remotion/',     # Remotion 비디오 소스 (youTubeGenerator 등) — #696 override 이관 후보
+        # 루트 직속 단일 파일 엔트리포인트 — Flask/FastAPI `app.py`·`main.py`, Django
+        # `manage.py`, Go 루트 `main.go`, Node `server.js`/`index.js` 등 (#705 실측: 디렉토리
+        # 패턴만 있으면 worker 가 루트 엔트리 파일을 못 고쳐 "prose 제시 → 메인 대리 적용"
+        # 우회가 강제됨). *코드 확장자만* — `.sh`(게이트 스크립트)·`.md`(문서)·toml/json/yaml
+        # (매니페스트)·Makefile/Dockerfile 은 계속 미매칭 차단. 그 외 언어는 #696 override 영역.
+        r'^[^/]+\.(?:py|pyi|go|rs|rb|php|ex|exs|js|jsx|ts|tsx|mjs|cjs)$',
     ),
     "architect": (
         r'(^|/)docs/',
@@ -143,6 +149,7 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'(^|/)[^/]+\.test\.[jt]sx?$',                    # JS/TS *.test.*
         r'(^|/)[^/]+\.spec\.[jt]sx?$',                    # JS/TS *.spec.*
         r'(^|/)[^/]+Tests?\.(java|kt|kts|scala|cs|php)$', # JVM·C#·PHP *Test(s).*
+        r'(^|/)conftest\.py$',                            # pytest 픽스처 관례 파일 (#705)
     ),
     "ux-architect": (
         r'(^|/)docs/ux-flow\.md$',

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1689,5 +1689,86 @@ class WorktreeValidationBoundaryTests(unittest.TestCase):
             self.assertEqual(blocked, ["/tmp/evil.sh"])
 
 
+class RootCodeFileAllowTests(unittest.TestCase):
+    """#705 실측 보강 — repo 루트 직속 코드 파일(app.py 등) write 차단 friction.
+
+    엔트리포인트가 루트 단일 파일인 레이아웃(Flask/FastAPI `app.py`, Django `manage.py`,
+    Go `main.go`, Node `server.js`)에서 ALLOW_MATRIX 가 디렉토리 패턴만 갖고 있으면 code
+    agent 가 그 파일을 못 고쳐 "prose 제시 -> 메인 대리 적용" 우회가 강제된다. 루트 직속
+    *코드 확장자* 파일만 좁게 허용하고, 게이트 스크립트(.sh)/문서(.md)/매니페스트
+    (toml·json·yaml)/비루트 경로는 기존 차단을 유지한다.
+    """
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    def test_root_entry_code_files_allowed_for_code_agents(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, fp in (
+                ("engineer", "app.py"),
+                ("engineer", "main.py"),
+                ("engineer", "manage.py"),
+                ("engineer", "server.js"),
+                ("engineer", "main.go"),
+                ("build-worker", "app.py"),
+                ("build-worker", "main.go"),
+            ):
+                with self.subTest(agent=agent, fp=fp):
+                    self.assertIsNone(check_write_allowed(agent, fp, cwd=cwd))
+
+    def test_root_non_code_files_still_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent, fp in (
+                ("engineer", "README.md"),       # 문서 — 역할 격리 유지
+                ("engineer", "check.sh"),        # 게이트 스크립트 — agent 가 수정 금지
+                ("engineer", "pyproject.toml"),  # 매니페스트
+                ("engineer", "package.json"),
+                ("engineer", "Makefile"),
+                ("engineer", ".env"),
+                ("build-worker", "release.yaml"),
+            ):
+                with self.subTest(agent=agent, fp=fp):
+                    self.assertIsNotNone(check_write_allowed(agent, fp, cwd=cwd))
+
+    def test_non_root_code_paths_unchanged(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # 루트 전용 앵커 — 디렉토리 하위는 기존 패턴 영역 그대로.
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "scripts/run.py", cwd=cwd)
+            )
+            # docs/ 하위 코드 파일명은 전용영역 deny 가 계속 우선.
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "docs/app.py", cwd=cwd)
+            )
+
+    def test_conftest_allowed_for_test_engineer(self):
+        # pytest 관례 파일 — 같은 클래스 friction (디렉토리 패턴 밖 관례 파일).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("test-engineer", "conftest.py", cwd=cwd)
+            )
+            self.assertIsNone(
+                check_write_allowed("test-engineer", "tests/conftest.py", cwd=cwd)
+            )
+
+    def test_test_engineer_still_blocked_from_impl_source(self):
+        # 역할 격리 회귀 가드 — test-engineer 는 구현 엔트리 파일 write 금지 유지.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNotNone(
+                check_write_allowed("test-engineer", "app.py", cwd=cwd)
+            )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호
Part of #705

## 배경 및 문제
#705 머지 후 실측 보강 코멘트(v03 쇼츠 Story 1, 3 task)에서 새 데이터 포인트 확인: build-worker 가 `src/` 하위는 편집하는데 repo 루트 직속 파일(`app.py`)은 ALLOW_MATRIX 미매칭으로 Edit 자체가 차단 → worker 가 변경을 prose 로만 제시하고 메인이 대리 적용하는 구조적 우회 발생.

## 원인 (해당 시)
engineer/build-worker ALLOW_MATRIX 가 디렉토리 패턴(`src/`·`lib/`·`cmd/` 등)만 갖고 있어, 엔트리포인트가 루트 단일 파일인 보편 레이아웃(Flask/FastAPI `app.py`, Django `manage.py`, Go 루트 `main.go`, Node `server.js`)이 전부 미매칭.

## 작업내용
- engineer ALLOW 에 루트 직속 *코드 확장자* 파일 패턴 1개 추가 (`^[^/]+\.(py|pyi|go|rs|rb|php|ex|exs|js|jsx|ts|tsx|mjs|cjs)$`) — build-worker 는 engineer ∪ test-engineer 합집합으로 자동 상속.
- test-engineer 에 `conftest.py` (pytest 픽스처 관례 파일) 허용 — 같은 클래스 friction.
- 회귀 가드 테스트: README.md/check.sh/pyproject.toml/package.json/Makefile/.env 루트 비코드 파일 차단 유지, `scripts/`·`docs/` 하위 차단 유지, test-engineer 의 구현 소스(app.py) 차단 유지.

참고 — 같은 코멘트의 데이터 포인트 1(심볼릭 경유 check.sh Bash 차단)은 #707 수정으로 해소됨을 실측 확인 (보편 게이트 스펠링 전부 통과, `tee <루트로그>` 만 의도된 write 경계로 잔존).

## 결정 근거
- 코드 확장자만 허용 — `.sh`(게이트 스크립트)·`.md`(문서)·매니페스트(toml/json/yaml)·Makefile/Dockerfile 은 계속 차단해 역할 격리·게이트 보호 유지.
- 루트(`^`) 앵커 파일명 패턴이라 디렉토리 하위 우회 없음 (`docs/app.py` 는 전용영역 deny 우선, `scripts/run.py` 는 여전히 미매칭).
- 그 외 언어/비표준 레이아웃은 #696 프로젝트별 override 영역으로 유보.

## Test Plan
- [x] python3.11 -m unittest discover -s tests — 1076 OK (RootCodeFileAllowTests 5건 포함, RED→GREEN)
- [x] 회귀 검증: 기존 boundary 테스트 전체 GREEN
- [x] node scripts/check_cross_refs.mjs / check_public_surface.mjs PASS

## 참고
**배포 경로 검증**: `harness/agent_boundary.py` = plug-in 본체 (경로 1 — plugin 업데이트 시 외부 활성 프로젝트 자동 적용). init-dcness 복사 파일·사용자 SSOT 문서 변경 없음 → 경로 2/3 비해당. tests/ 는 repo 전용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)