### PR TITLE
[issue-726] github-project-lifecycle composite action GH_TOKEN 전달 + graceful degrade

### DIFF
--- a/.github/actions/github-project-lifecycle/action.yml
+++ b/.github/actions/github-project-lifecycle/action.yml
@@ -37,6 +37,10 @@ inputs:
     description: 'Set to true to create labels/fields or update Status'
     required: false
     default: 'false'
+  gh-token:
+    description: 'GitHub token with project scope (gh project read/write). 호출 워크플로에서 secrets.DCNESS_PROJECT_TOKEN || github.token 전달.'
+    required: false
+    default: ''
 runs:
   using: composite
   steps:
@@ -49,6 +53,8 @@ runs:
       shell: bash
       env:
         PR_BODY: ${{ inputs.pr-body }}
+        # composite action 은 부모 step 의 env 를 상속하지 않으므로 GH_TOKEN 을 input 으로 받아 명시 매핑.
+        GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         set -euo pipefail
         ARGS=(

--- a/.github/workflows/github-project-lifecycle.yml
+++ b/.github/workflows/github-project-lifecycle.yml
@@ -32,14 +32,13 @@ jobs:
 
       - name: Validate issue lifecycle via composite action
         uses: ./.github/actions/github-project-lifecycle
-        env:
-          GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
         with:
           mode: validate-issue
           repo: ${{ github.repository }}
           project-owner: ${{ vars.DCNESS_PROJECT_OWNER || github.repository_owner }}
           project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
           issue-number: ${{ github.event.issue.number }}
+          gh-token: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
 
   pr-merged:
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && vars.DCNESS_PROJECT_NUMBER != '' }}
@@ -50,8 +49,6 @@ jobs:
 
       - name: Correct Status=Done on merge via composite action
         uses: ./.github/actions/github-project-lifecycle
-        env:
-          GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
         with:
           mode: pr-merged
           repo: ${{ github.repository }}
@@ -59,3 +56,4 @@ jobs:
           project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
           pr-body: ${{ github.event.pull_request.body }}
           apply: "true"
+          gh-token: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -823,11 +823,25 @@ function main() {
   }
 }
 
+// 토큰/권한 부재로 추정되는 실패 패턴 — gh project 가 인증 실패를 "unknown owner type" 으로 표시하는 것 포함.
+// 이 부류는 CI 를 깨지 않고 graceful degrade (warn + exit 0): lifecycle 자동화는 best-effort 이고,
+// project scope 토큰이 없는 외부 활성 프로젝트의 PR CI 를 빨갛게 만들지 않기 위함.
+const TOKEN_DEGRADE_RE =
+  /unknown owner type|bad credentials|HTTP 40[13]|resource not accessible|requires .*scope|read:project|gh auth|not logged in|authentication/i;
+
 if (import.meta.url === `file://${process.argv[1]}`) {
   try {
     process.exitCode = main();
   } catch (error) {
     console.error(`[dcness-project] ${error.message}`);
-    process.exitCode = 1;
+    if (TOKEN_DEGRADE_RE.test(error.message)) {
+      console.error(
+        '[dcness-project] WARN: GitHub Project 토큰/권한 부재로 추정 — lifecycle 자동화를 건너뜁니다 (graceful degrade). ' +
+          'project scope 토큰(secrets.DCNESS_PROJECT_TOKEN)을 설정하면 활성화됩니다. CI 는 실패시키지 않습니다.',
+      );
+      process.exitCode = 0;
+    } else {
+      process.exitCode = 1;
+    }
   }
 }


### PR DESCRIPTION
## 관련 이슈 번호

Closes #726

## 배경 및 문제

- `github-project-lifecycle.yml` 이 토큰을 step-level `env: GH_TOKEN` 으로 걸었으나, 실제 실행되는 composite action(`action.yml`)의 run 스텝 env 에는 `PR_BODY` 만 있고 `GH_TOKEN` 이 없었다.
- **GitHub Actions 는 부모 step 의 env 를 composite action 내부 run 스텝에 자동 상속하지 않는다.** → `gh` 가 토큰 없이 실행 → 인증 실패 → `gh project view` 가 "unknown owner type" 으로 표시 → exit 1.
- 결과: 모든 PR 머지/issue 이벤트에서 lifecycle job 이 깨졌다. 토큰·secret 은 정상이었음(로컬 curl REST 200 + GraphQL viewer 200 확인, secret 재설정 후에도 CI 동일 실패로 전달 경로 문제 확정).

## 원인 (해당 시)

- composite action env 미상속 — 토큰이 `gh` 까지 도달하지 못함. 토큰/scope/secret 문제가 아니라 전달 경로 결함.

## 작업내용

- `action.yml`: `gh-token` input 추가 + run 스텝 env 에 `GH_TOKEN: ${{ inputs.gh-token }}` 명시 매핑.
- `github-project-lifecycle.yml`: step `env:` 제거하고 `with: gh-token: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}` 으로 전달 (validate-issue/pr-merged 양쪽 job).
- `github_project_lifecycle.mjs`: main catch 에서 토큰/권한 부재 추정 실패 패턴(`unknown owner type` / `bad credentials` / `HTTP 401·403` / scope 등)은 warn + exit 0 (graceful degrade), 그 외 로직 에러는 exit 1 유지.

## 결정 근거

- graceful degrade 를 토큰류 패턴으로 한정 — 모든 실패를 exit 0 으로 숨기면 진짜 버그가 묻히므로(안티패턴), 토큰/권한 실패만 degrade 하고 로직 에러는 exit 1 보존. 실측으로 두 경로 확인(토큰류 → 0, unknown command → 1).

## 배포 경로 검증 (plug-in 영향 시)

- composite action(`.github/actions/github-project-lifecycle`)은 외부 활성 프로젝트가 `uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main` 으로 직접 참조 → 본 PR 머지 시 외부 프로젝트도 `@main` 즉시 반영.
- `init-dcness` 가 사용자 repo 로 복사 배포하는 thin yml(워크플로) 도 `with: gh-token` 형식으로 갱신 필요 — 기존 활성 프로젝트는 thin yml 재배포 또는 `/init-dcness` 재실행으로 받음. (별도 follow-up: init-dcness deploy 스텝의 thin yml 템플릿 정합 확인)

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 워크플로/스크립트 수정. 신규 surface 없음.

## Test Plan

- [x] mjs 문법 체크(`node --check`) PASS
- [x] graceful degrade 실측: 잘못된 토큰 → validate-issue/pr-merged 가 `unknown owner type` 잡아 exit 0
- [x] 로직 에러 회귀: unknown command → exit 1 유지
- [x] cross-ref 게이트 로컬 PASS
- [ ] 머지 후 lifecycle job 이 실제 PASS(또는 토큰 정상 시 Status=Done 갱신) 확인

## 참고

- 토큰 자체는 처음부터 정상이었음. CI 실패의 진짜 원인은 composite action 의 env 미상속.