### PR TITLE
[issue-728] init-dcness thin yml 토큰 with:gh-token 전달 + read:org 안내

### DIFF
--- a/.github/workflows/github-project-lifecycle.yml
+++ b/.github/workflows/github-project-lifecycle.yml
@@ -5,8 +5,10 @@
 # 외부 활성화 프로젝트는 init-dcness Step 2.10.5 가 묻고 Y 답변 시 thin yml 을 사용자 repo 에 배포 — 그 yml 은
 # `uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main` 1줄로 동일 검증.
 #
-# Project v2 쓰기에는 project scope token 필요: secrets.DCNESS_PROJECT_TOKEN
-#   (없으면 github.token 폴백 → Projects v2 쓰기 불가, drift 검출만 동작).
+# Project v2 자동화에는 classic PAT 의 project + read:org scope 둘 다 필요: secrets.DCNESS_PROJECT_TOKEN
+#   (read:org 없으면 gh project owner 판별이 unknown owner type 으로 실패. 토큰 없거나 권한 부족이면
+#    github.token 폴백 → 스크립트가 warn+exit 0 으로 graceful degrade, CI 는 깨지지 않음).
+# 토큰은 with.gh-token 으로 composite action 에 전달 (composite 은 부모 step env 미상속).
 # Project 좌표: vars.DCNESS_PROJECT_NUMBER / vars.DCNESS_PROJECT_OWNER.
 
 name: github-project-lifecycle

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -591,7 +591,7 @@ GitHub Actions 에서 Project lifecycle drift 검출과 PR merge 후 `Done` 보�
   - issue open/edit/label 변경 시 Project IssueType 과 repo label drift 검출
   - PR closed+merged 시 Closes/Fixes/Resolves issue 의 Status=Done 보정
   - Part of #N 만 있는 PR 은 Done 후보로 보지 않음
-  - Project v2 쓰기에는 project scope token 필요: secrets.DCNESS_PROJECT_TOKEN
+  - Project v2 자동화에는 classic PAT 의 project + read:org scope 둘 다 필요: secrets.DCNESS_PROJECT_TOKEN (read:org 없으면 gh project owner 판별이 unknown owner type 으로 실패)
   - Project 번호/owner 는 vars.DCNESS_PROJECT_NUMBER / vars.DCNESS_PROJECT_OWNER 사용
 (Y/n)
 ```
@@ -615,21 +615,18 @@ GitHub Actions 에서 Project lifecycle drift 검출과 PR merge 후 `Done` 보�
       runs-on: ubuntu-latest
       steps:
         - uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main
-          env:
-            GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
           with:
             mode: validate-issue
             repo: ${{ github.repository }}
             project-owner: ${{ vars.DCNESS_PROJECT_OWNER || github.repository_owner }}
             project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
             issue-number: ${{ github.event.issue.number }}
+            gh-token: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
     pr-merged:
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true && vars.DCNESS_PROJECT_NUMBER != '' }}
       runs-on: ubuntu-latest
       steps:
         - uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main
-          env:
-            GH_TOKEN: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
           with:
             mode: pr-merged
             repo: ${{ github.repository }}
@@ -637,6 +634,7 @@ GitHub Actions 에서 Project lifecycle drift 검출과 PR merge 후 `Done` 보�
             project-number: ${{ vars.DCNESS_PROJECT_NUMBER }}
             pr-body: ${{ github.event.pull_request.body }}
             apply: "true"
+            gh-token: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}
   ```
 
 - **n**: skip. 메인은 PR merge 후 `scripts/github_project_lifecycle.mjs pr-merged` 를 수동 실행해 drift 를 확인한다.


### PR DESCRIPTION
## 관련 이슈 번호

Closes #728

## 배경 및 문제

- #726(PR #727)은 dcness self repo 의 `github-project-lifecycle.yml` 만 `with: gh-token` 으로 고쳤다.
- `init-dcness` 가 외부 활성 프로젝트로 배포하는 thin yml 템플릿(`commands/init-dcness.md` always-overwrite yml)은 여전히 `env: GH_TOKEN` 이라, composite action env 미상속 버그가 **외부 프로젝트에 그대로 배포**됐다 (CLAUDE.md "배포 경로 포함" 위반).
- 토큰 scope 안내에 `read:org` 누락 — project scope 만 부여하면 `gh project` owner 판별(`organization(login:).id` → read:org 요구)이 INSUFFICIENT_SCOPES 로 실패해 unknown owner type.

## 원인 (해당 시)

- self 만 고치고 배포 템플릿 미반영 — 외부 프로젝트는 수정이 안 닿음.

## 작업내용

- `commands/init-dcness.md`: thin yml 양쪽 job(issue-drift/pr-merged) `env: GH_TOKEN` 제거 → `with: gh-token: ${{ secrets.DCNESS_PROJECT_TOKEN || github.token }}`.
- `commands/init-dcness.md`: 토큰 안내를 "project + read:org scope 둘 다 필요"로 명시.
- `.github/workflows/github-project-lifecycle.yml`: self yml 헤더 주석도 read:org + with:gh-token + graceful degrade 로 정합.

## 결정 근거

- self repo 워크플로(#727)와 배포 템플릿의 형식을 일치시켜, 외부 활성 프로젝트가 같은 토큰 전달 함정에 빠지지 않게 함.

## 배포 경로 검증 (plug-in 영향 시)

- `commands/init-dcness.md` 의 thin yml = init-dcness 가 사용자 repo `.github/workflows/` 로 복사·배포하는 경로(2). 본 수정으로 신규 활성 프로젝트는 올바른 형식을 받음.
- **기존 활성 프로젝트**: thin yml 은 always-overwrite 이므로 `/init-dcness` 재실행 시 갱신됨 (PR 본문/커밋에 고지).
- composite action 본체(`.github/actions/**`)와 graceful degrade(`scripts/github_project_lifecycle.mjs`)는 `@main` 참조 + #727 머지로 이미 외부 반영됨.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 배포 템플릿/문서 수정.

## Test Plan

- [x] env:GH_TOKEN 잔재 0 (init-dcness + self yml)
- [x] with:gh-token 양쪽 job 반영, read:org 안내 반영
- [x] cross-ref 게이트 로컬 PASS
- [x] pytest-gate PASS (commit hook)

## 참고

- self repo 의 실제 동작 검증은 #727 에서 완료 (Status=Done 실전이 확인). 본 PR 은 그 수정을 외부 배포 경로로 전파.