### PR TITLE
[issue-730] fix step reentry run resolution

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -208,7 +208,7 @@ def _strict_conveyor_gate_message(
     entry_point = slot.get("entry_point", "")
     if entry_point not in _STRICT_CONVEYOR_ENTRY_POINTS:
         return None
-    if slot.get("completed_at") or slot.get("finalized_at"):
+    if slot.get("completed_at"):
         return None
 
     requested = _agent_mode_label(subagent, mode)
@@ -1231,7 +1231,8 @@ def handle_stop(
 
     Stop hook 으로 *코드 강제 승격*:
     1. stop_hook_active=true → 무한 루프 방지, skip
-    2. active_runs[rid] 슬롯 부재 / finalized_at 있음 → skip (이미 종료)
+    2. active_runs[rid] 슬롯 부재 → skip. finalized-only 상태는 run_finished 가
+       없으면 end-run 후보로 유지하고, run_finished 가 있으면 이미 종료로 skip
     3. `.steps.jsonl` 마지막 row 의 (agent, mode) 가 live.json.current_step.
        (agent, mode) 와 일치 → end-step 완료 상태 = 종료 후보 / 불일치 →
        begin-step 후 end-step 미호출 진행 중 → skip (false positive 회피)

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1181,11 +1181,21 @@ def diagnose_sid_rid_resolution(
     return "\n".join(lines)
 
 
-def _is_open_active_run_slot(slot: Any) -> bool:
-    """active_runs 슬롯이 helper fallback 후보인지 판정."""
+def _is_open_active_run_slot(
+    slot: Any,
+    *,
+    include_finalized_uncompleted: bool = False,
+) -> bool:
+    """active_runs 슬롯이 helper fallback 후보인지 판정.
+
+    `finalized_at` 은 finalize-run/review snapshot 완료 신호이고, run 종료 신호는
+    `completed_at` 이다. 전역 best-guess scan 에서는 오래된 finalize-only run 을
+    피하려고 finalized slot 을 제외하지만, sid 가 이미 특정된 scan 은 같은 run 의
+    fix round 재진입을 복구해야 하므로 completed 전까지 후보로 유지한다 (#730).
+    """
     if not isinstance(slot, dict):
         return False
-    if slot.get("finalized_at"):
+    if slot.get("finalized_at") and not include_finalized_uncompleted:
         return False
     return slot.get("completed_at") is None
 
@@ -1194,6 +1204,7 @@ def _scan_live_file_for_active_run(
     live_file: Path,
     *,
     session_id: Optional[str] = None,
+    include_finalized_uncompleted: bool = False,
 ) -> Optional[tuple[str, str, str]]:
     """live.json 하나에서 최신 open active_run 후보 반환.
 
@@ -1232,7 +1243,10 @@ def _scan_live_file_for_active_run(
     for rid, slot in active_runs.items():
         if not isinstance(rid, str) or not RUN_ID_RE.match(rid):
             continue
-        if not _is_open_active_run_slot(slot):
+        if not _is_open_active_run_slot(
+            slot,
+            include_finalized_uncompleted=include_finalized_uncompleted,
+        ):
             continue
         started = slot.get("started_at") or slot.get("last_confirmed_at") or ""
         if not isinstance(started, str):
@@ -1248,18 +1262,18 @@ def _scan_recent_active_run_slot(
     max_sessions: int = 5,
     session_id: Optional[str] = None,
 ) -> Optional[tuple[str, str]]:
-    """.sessions/ 디렉토리 scan 후 가장 최근 미finalized active_run slot 의 (sid, rid).
+    """.sessions/ 디렉토리 scan 후 가장 최근 fallback 후보 active_run 의 (sid, rid).
 
     issue #469 결함 B 의 best-effort 폴백 — PPID chain 미해결 시 사용.
     다음 우선순위:
-    1. `session_id` 가 주어지면 그 세션 live.json 을 직접 검사 (#684)
+    1. `session_id` 가 주어지면 그 세션 live.json 을 직접 검사 (#684/#730)
     2. live.json mtime 최신 `max_sessions` 개만 검사 (비용 가드)
-    3. 각 live.json 의 `active_runs` 중 `finalized_at`/`completed_at` 부재 +
-       `started_at` 가장 최근 slot 있는 (sid, rid) 반환
+    3. 전역 scan 은 `finalized_at`/`completed_at` 부재 + `started_at` 최신 slot 반환
+    4. sid-scoped scan 은 `completed_at` 전이면 `finalized_at` 이후 fix round 도 반환
 
     Returns:
         (session_id, run_id) tuple — best-guess.
-        None — 매치 부재 (clean session 또는 모든 run finalized).
+        None — 매치 부재 (clean session 또는 fallback 후보 없음).
 
     주의: multi-session 환경에서 잘못된 매핑 위험 있음. 본 폴백은 PPID chain
     실패 케이스의 무대응 (= helper 동작 X) 대신 best-guess 제공. 정확 매핑 필요시
@@ -1277,6 +1291,7 @@ def _scan_recent_active_run_slot(
             slot = _scan_live_file_for_active_run(
                 sessions_dir / session_id / "live.json",
                 session_id=session_id,
+                include_finalized_uncompleted=True,
             )
             if slot and (best is None or slot[0] > best[0]):
                 best = slot

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1062,7 +1062,7 @@ def auto_detect_session_id(*, base_dir: Optional[Path] = None) -> str:
     sid = current_session_id(base_dir=base_dir)
     if sid:
         return sid
-    # (d) active_runs scan 폴백 — 가장 최근 미finalized run 의 session_id
+    # (d) active_runs scan 폴백 — 가장 최근 미완료 run 의 session_id
     slot_info = _scan_recent_active_run_slot(base_dir=base_dir)
     if slot_info:
         return slot_info[0]  # (sid, rid)
@@ -1097,7 +1097,7 @@ def auto_detect_run_id(*, base_dir: Optional[Path] = None) -> str:
         slot_info = _scan_recent_active_run_slot(base_dir=base_dir, session_id=sid)
         if slot_info:
             return slot_info[1]
-    # (d) active_runs scan 폴백 — 가장 최근 미finalized run 의 run_id
+    # (d) active_runs scan 폴백 — 가장 최근 미완료 run 의 run_id
     slot_info = _scan_recent_active_run_slot(base_dir=base_dir)
     if slot_info:
         return slot_info[1]
@@ -1167,7 +1167,7 @@ def diagnose_sid_rid_resolution(
         session_id=sid_hint or None,
     )
     if slot is None:
-        lines.append("  (c) active_runs scan: 매치 없음 (모든 run finalized 또는 sessions dir 비어있음)")
+        lines.append("  (c) active_runs scan: 매치 없음 (모든 run completed 또는 sessions dir 비어있음)")
     else:
         lines.append(f"  (c) active_runs scan best-guess: sid={slot[0]} rid={slot[1]}")
 
@@ -1181,21 +1181,14 @@ def diagnose_sid_rid_resolution(
     return "\n".join(lines)
 
 
-def _is_open_active_run_slot(
-    slot: Any,
-    *,
-    include_finalized_uncompleted: bool = False,
-) -> bool:
+def _is_open_active_run_slot(slot: Any) -> bool:
     """active_runs 슬롯이 helper fallback 후보인지 판정.
 
     `finalized_at` 은 finalize-run/review snapshot 완료 신호이고, run 종료 신호는
-    `completed_at` 이다. 전역 best-guess scan 에서는 오래된 finalize-only run 을
-    피하려고 finalized slot 을 제외하지만, sid 가 이미 특정된 scan 은 같은 run 의
-    fix round 재진입을 복구해야 하므로 completed 전까지 후보로 유지한다 (#730).
+    `completed_at` 이다. 같은 run 의 fix round 재진입과 PPID mapping 단절 복구를
+    위해 `completed_at` 전까지는 전역/sid-scoped scan 모두 후보로 유지한다 (#730).
     """
     if not isinstance(slot, dict):
-        return False
-    if slot.get("finalized_at") and not include_finalized_uncompleted:
         return False
     return slot.get("completed_at") is None
 
@@ -1204,7 +1197,6 @@ def _scan_live_file_for_active_run(
     live_file: Path,
     *,
     session_id: Optional[str] = None,
-    include_finalized_uncompleted: bool = False,
 ) -> Optional[tuple[str, str, str]]:
     """live.json 하나에서 최신 open active_run 후보 반환.
 
@@ -1243,10 +1235,7 @@ def _scan_live_file_for_active_run(
     for rid, slot in active_runs.items():
         if not isinstance(rid, str) or not RUN_ID_RE.match(rid):
             continue
-        if not _is_open_active_run_slot(
-            slot,
-            include_finalized_uncompleted=include_finalized_uncompleted,
-        ):
+        if not _is_open_active_run_slot(slot):
             continue
         started = slot.get("started_at") or slot.get("last_confirmed_at") or ""
         if not isinstance(started, str):
@@ -1262,18 +1251,18 @@ def _scan_recent_active_run_slot(
     max_sessions: int = 5,
     session_id: Optional[str] = None,
 ) -> Optional[tuple[str, str]]:
-    """.sessions/ 디렉토리 scan 후 가장 최근 fallback 후보 active_run 의 (sid, rid).
+    """.sessions/ 디렉토리 scan 후 가장 최근 미완료 active_run slot 의 (sid, rid).
 
     issue #469 결함 B 의 best-effort 폴백 — PPID chain 미해결 시 사용.
     다음 우선순위:
     1. `session_id` 가 주어지면 그 세션 live.json 을 직접 검사 (#684/#730)
     2. live.json mtime 최신 `max_sessions` 개만 검사 (비용 가드)
-    3. 전역 scan 은 `finalized_at`/`completed_at` 부재 + `started_at` 최신 slot 반환
-    4. sid-scoped scan 은 `completed_at` 전이면 `finalized_at` 이후 fix round 도 반환
+    3. 각 live.json 의 `active_runs` 중 `completed_at` 부재 + `started_at` 최신 slot 반환
+    4. `finalized_at` 은 review snapshot 신호일 뿐 종료 신호가 아니므로 제외 조건이 아니다
 
     Returns:
         (session_id, run_id) tuple — best-guess.
-        None — 매치 부재 (clean session 또는 fallback 후보 없음).
+        None — 매치 부재 (clean session 또는 모든 run completed).
 
     주의: multi-session 환경에서 잘못된 매핑 위험 있음. 본 폴백은 PPID chain
     실패 케이스의 무대응 (= helper 동작 X) 대신 best-guess 제공. 정확 매핑 필요시
@@ -1291,7 +1280,6 @@ def _scan_recent_active_run_slot(
             slot = _scan_live_file_for_active_run(
                 sessions_dir / session_id / "live.json",
                 session_id=session_id,
-                include_finalized_uncompleted=True,
             )
             if slot and (best is None or slot[0] > best[0]):
                 best = slot
@@ -1317,7 +1305,7 @@ def _scan_recent_active_run_slot(
     candidates.sort(key=lambda x: x[0], reverse=True)
     candidates = candidates[:max_sessions]
 
-    # 각 live.json 의 미finalized active_run 중 started_at 최신 후보 수집
+    # 각 live.json 의 미완료 active_run 중 started_at 최신 후보 수집
     best: Optional[tuple[str, str, str]] = None  # (started_at, sid, rid)
     for _, live_file in candidates:
         slot = _scan_live_file_for_active_run(live_file)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -947,7 +947,23 @@ class StrictConveyorGateTests(_PreToolBase):
         )
         self.assertEqual(rc, 0)
 
-    def test_skips_strict_gate_after_finalized_run(self) -> None:
+    def test_enforces_strict_gate_after_finalized_uncompleted_run(self) -> None:
+        live = read_live(self.sid, base_dir=self.base) or {}
+        active = live.get("active_runs", {}) or {}
+        slot = dict(active[self.rid])
+        slot["finalized_at"] = "2026-06-04T12:00:00+00:00"
+        active[self.rid] = slot
+        update_live(self.sid, base_dir=self.base, active_runs=active)
+
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("module-architect"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 1)
+
+    def test_allows_matching_begin_step_after_finalized_uncompleted_run(self) -> None:
+        self._begin_step("module-architect")
         live = read_live(self.sid, base_dir=self.base) or {}
         active = live.get("active_runs", {}) or {}
         slot = dict(active[self.rid])

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1066,6 +1066,69 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn(self.rid, out.getvalue())
 
+    def test_step_reentry_after_finalize_resolves_same_run_without_pointer(self) -> None:
+        """issue #730 — pr-reviewer FAIL 후 fix round begin-step 재진입 회귀."""
+        from harness.session_state import (
+            _cli_begin_step,
+            _cli_end_step,
+            _cli_finalize_run,
+            clear_pid_current_run,
+            read_live,
+        )
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+
+        clear_pid_current_run(self.cc_pid)
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_begin_step(SimpleNamespace(agent="build-worker", mode=None))
+        self.assertEqual(rc, 0, out.getvalue())
+
+        build_prose = self.base / "build_prose.md"
+        build_prose.write_text("구현 라운드 완료\n\nPASS\n", encoding="utf-8")
+        with redirect_stdout(StringIO()):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="build-worker",
+                mode=None,
+                prose_file=str(build_prose),
+            ))
+        self.assertEqual(rc, 0)
+
+        with redirect_stdout(StringIO()):
+            rc = _cli_begin_step(SimpleNamespace(agent="pr-reviewer", mode=None))
+        self.assertEqual(rc, 0)
+
+        review_prose = self.base / "review_prose.md"
+        review_prose.write_text("MUST FIX: 보강 필요\n\nFAIL\n", encoding="utf-8")
+        with redirect_stdout(StringIO()):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="pr-reviewer",
+                mode=None,
+                prose_file=str(review_prose),
+            ))
+        self.assertEqual(rc, 0)
+
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            rc = _cli_finalize_run(SimpleNamespace(
+                expected_steps=2,
+                auto_review=False,
+            ))
+        self.assertEqual(rc, 0)
+        slot = read_live(self.sid)["active_runs"][self.rid]
+        self.assertIsNotNone(slot.get("finalized_at"))
+        self.assertIsNone(slot.get("completed_at"))
+
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_begin_step(SimpleNamespace(agent="build-worker", mode=None))
+        self.assertEqual(rc, 0, err.getvalue())
+        self.assertIn("ok", out.getvalue())
+        slot = read_live(self.sid)["active_runs"][self.rid]
+        self.assertEqual(slot["current_step"]["agent"], "build-worker")
+
     def test_end_step_drift_warn_on_agent_mismatch(self) -> None:
         # DCN-30-25: end-step 호출 시 current_step 의 agent 와 args.agent 불일치
         # → stderr DRIFT WARN. 자동 보정 X (동작은 정상 진행).
@@ -2292,6 +2355,7 @@ class AutoDetectFallbackTests(unittest.TestCase):
       - #469: impl-loop/helper 직접 호출의 PPID mismatch fallback
       - #483: sid/rid 미해결 진단 출력
       - #684: by-pid sid 는 있으나 current-run pointer 유실 + 전역 scan miss
+      - #730: finalize-run 후 같은 run fix round begin-step 재진입 scan miss
     """
 
     SID_A = "11111111-2222-4333-8444-555555555555"
@@ -2397,6 +2461,26 @@ class AutoDetectFallbackTests(unittest.TestCase):
         )
         result = _scan_recent_active_run_slot(base_dir=self.base)
         self.assertEqual(result, (self.SID_B, self.RID_B))
+
+    def test_session_scoped_scan_includes_finalized_uncompleted_run(self) -> None:
+        """issue #730 — finalized_at 은 review snapshot 이지 run close 가 아니다."""
+        from harness.session_state import _scan_recent_active_run_slot
+
+        self._write_live(
+            self.SID_A,
+            root=".sessions",
+            runs={self.RID_A: {
+                "run_id": self.RID_A,
+                "started_at": "2026-06-11T01:00:00+00:00",
+                "completed_at": None,
+                "finalized_at": "2026-06-11T01:30:00+00:00",
+            }},
+        )
+        result = _scan_recent_active_run_slot(
+            base_dir=self.base,
+            session_id=self.SID_A,
+        )
+        self.assertEqual(result, (self.SID_A, self.RID_A))
 
     def test_scan_skips_completed_runs_without_finalized_at(self) -> None:
         """completed_at tombstone 만 있는 end-run 완료 슬롯도 fallback 후보에서 제외."""

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1129,6 +1129,70 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         slot = read_live(self.sid)["active_runs"][self.rid]
         self.assertEqual(slot["current_step"]["agent"], "build-worker")
 
+    def test_step_reentry_after_finalize_resolves_when_pid_mapping_missing(self) -> None:
+        """#625 + #730 — PPID mapping 단절 후 finalized 미완료 run 전역 fallback."""
+        from harness.session_state import (
+            _cli_begin_step,
+            _cli_end_step,
+            _cli_finalize_run,
+            clear_pid_current_run,
+            pid_session_path,
+            read_live,
+        )
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+
+        clear_pid_current_run(self.cc_pid)
+        pid_session_path(self.cc_pid).unlink()
+
+        with redirect_stdout(StringIO()):
+            rc = _cli_begin_step(SimpleNamespace(agent="build-worker", mode=None))
+        self.assertEqual(rc, 0)
+
+        build_prose = self.base / "build_prose_global.md"
+        build_prose.write_text("구현 라운드 완료\n\nPASS\n", encoding="utf-8")
+        with redirect_stdout(StringIO()):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="build-worker",
+                mode=None,
+                prose_file=str(build_prose),
+            ))
+        self.assertEqual(rc, 0)
+
+        with redirect_stdout(StringIO()):
+            rc = _cli_begin_step(SimpleNamespace(agent="pr-reviewer", mode=None))
+        self.assertEqual(rc, 0)
+
+        review_prose = self.base / "review_prose_global.md"
+        review_prose.write_text("MUST FIX: 보강 필요\n\nFAIL\n", encoding="utf-8")
+        with redirect_stdout(StringIO()):
+            rc = _cli_end_step(SimpleNamespace(
+                agent="pr-reviewer",
+                mode=None,
+                prose_file=str(review_prose),
+            ))
+        self.assertEqual(rc, 0)
+
+        with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+            rc = _cli_finalize_run(SimpleNamespace(
+                expected_steps=2,
+                auto_review=False,
+            ))
+        self.assertEqual(rc, 0)
+        slot = read_live(self.sid)["active_runs"][self.rid]
+        self.assertIsNotNone(slot.get("finalized_at"))
+        self.assertIsNone(slot.get("completed_at"))
+
+        out = StringIO()
+        err = StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_begin_step(SimpleNamespace(agent="build-worker", mode=None))
+        self.assertEqual(rc, 0, err.getvalue())
+        self.assertIn("ok", out.getvalue())
+        slot = read_live(self.sid)["active_runs"][self.rid]
+        self.assertEqual(slot["current_step"]["agent"], "build-worker")
+
     def test_end_step_drift_warn_on_agent_mismatch(self) -> None:
         # DCN-30-25: end-step 호출 시 current_step 의 agent 와 args.agent 불일치
         # → stderr DRIFT WARN. 자동 보정 X (동작은 정상 진행).
@@ -2426,9 +2490,9 @@ class AutoDetectFallbackTests(unittest.TestCase):
         # env 무시 + PPID chain (실 환경 X) + pointer 부재 → active_runs scan 박힘
         self.assertEqual(sid, self.SID_B)
 
-    def test_scan_picks_recent_unfinalized_run(self) -> None:
+    def test_scan_picks_recent_uncompleted_run(self) -> None:
         from harness.session_state import _scan_recent_active_run_slot
-        # session A 의 run A = 미finalized (오래된), session B 의 run B = 미finalized (최신)
+        # session A 의 run A = 미완료 (오래된), session B 의 run B = 미완료 (최신)
         self._write_live(
             self.SID_A,
             runs={self.RID_A: {"run_id": self.RID_A, "started_at": "2026-05-22T00:00:00+00:00"}},
@@ -2440,27 +2504,20 @@ class AutoDetectFallbackTests(unittest.TestCase):
         result = _scan_recent_active_run_slot(base_dir=self.base)
         self.assertEqual(result, (self.SID_B, self.RID_B))
 
-    def test_scan_skips_finalized_runs(self) -> None:
+    def test_global_scan_includes_finalized_uncompleted_run(self) -> None:
         from harness.session_state import _scan_recent_active_run_slot
-        # session A: finalized run (skip 대상)
-        # session B: 미finalized run (선택 대상)
+
         self._write_live(
             self.SID_A,
             runs={self.RID_A: {
                 "run_id": self.RID_A,
-                "started_at": "2026-05-22T02:00:00+00:00",  # 더 최신이지만
-                "finalized_at": "2026-05-22T02:30:00+00:00",  # finalized = skip
-            }},
-        )
-        self._write_live(
-            self.SID_B,
-            runs={self.RID_B: {
-                "run_id": self.RID_B,
-                "started_at": "2026-05-22T01:00:00+00:00",
+                "started_at": "2026-06-11T01:00:00+00:00",
+                "completed_at": None,
+                "finalized_at": "2026-06-11T01:30:00+00:00",
             }},
         )
         result = _scan_recent_active_run_slot(base_dir=self.base)
-        self.assertEqual(result, (self.SID_B, self.RID_B))
+        self.assertEqual(result, (self.SID_A, self.RID_A))
 
     def test_session_scoped_scan_includes_finalized_uncompleted_run(self) -> None:
         """issue #730 — finalized_at 은 review snapshot 이지 run close 가 아니다."""
@@ -2511,14 +2568,15 @@ class AutoDetectFallbackTests(unittest.TestCase):
         result = _scan_recent_active_run_slot(base_dir=self.base)
         self.assertIsNone(result)
 
-    def test_scan_all_finalized_returns_none(self) -> None:
+    def test_scan_all_completed_returns_none(self) -> None:
         from harness.session_state import _scan_recent_active_run_slot
-        # 모든 run finalized → None
+        # 모든 run completed → None
         self._write_live(
             self.SID_A,
             runs={self.RID_A: {
                 "run_id": self.RID_A,
                 "started_at": "2026-05-22T00:00:00+00:00",
+                "completed_at": "2026-05-22T00:31:00+00:00",
                 "finalized_at": "2026-05-22T00:30:00+00:00",
             }},
         )
@@ -2558,8 +2616,8 @@ class AutoDetectFallbackTests(unittest.TestCase):
         )
         os.utime(target_live, (1000, 1000))
 
-        # 전역 scan 의 live.json mtime 최신 5개가 모두 finalized 면 기존 fallback 은
-        # target sid 의 active_runs 를 보지 못하고 None 으로 떨어졌다.
+        # 전역 scan 의 최신 후보가 다른 session 의 finalized-only noise 여도,
+        # by-pid 로 sid 가 특정되면 target sid active_runs 를 직접 봐야 한다.
         for idx in range(6):
             sid = f"noise-sid-{idx}"
             rid = f"run-abc0000{idx}"


### PR DESCRIPTION
## 관련 이슈 번호

Closes #730

## 배경 및 문제

`/impl-loop` single task에서 `build-worker` 1회차와 `pr-reviewer` FAIL 기록까지 정상 진행한 뒤, 같은 run의 fix 라운드에서 `begin-step build-worker`를 2회차로 재진입하면 sid/rid 자동 resolve가 `active_runs scan: 매치 없음`으로 실패했다. 이 회귀는 #469/#483/#625/#684 계보 이후 5번째 재현이며, 이번 트리거는 장시간 run만이 아니라 같은 run 안의 step 재진입이었다.

## 원인 (해당 시)

`finalize-run`은 `active_runs[rid].finalized_at`을 기록하지만 `end-run` 전까지 `completed_at`은 `None`이다. 기존 fallback 후보 판정은 #469 당시의 `finalized_at` skip 의미를 유지해, 아직 완료되지 않은 run도 종료된 것처럼 제외했다. #684는 sid-scoped pointer 유실 축을 막았지만, #625처럼 PPID/session mapping까지 끊긴 상태에서는 전역 scan도 같은 잘못된 `finalized_at` 종료 해석을 유지하고 있었다. 따라서 최종 불변식은 `completed_at`만 active_run fallback tombstone 이고, `finalized_at`은 review snapshot 신호일 뿐 run closure가 아니다.

## 작업내용

- `harness/session_state.py`: active_runs fallback 후보 판정을 `completed_at is None`으로 단일화했다. 전역 scan과 sid-scoped scan 모두 finalized/uncompleted run을 후보로 유지하고, completed run만 제외한다.
- `harness/hooks.py`: strict conveyor gate도 `finalized_at`을 active run 종료로 보지 않도록 맞췄다. finalize 이후 fix round에서도 begin-step/current_step 순서 검사가 유지된다.
- `tests/test_session_state.py`: #730 same-run reentry, #625 + #730 hybrid(PPID current-run/sid mapping 동시 유실), finalized/uncompleted global/sid-scoped scan 포함, completed tombstone 제외를 회귀 테스트로 고정했다.
- `tests/test_hooks.py`: finalized/uncompleted run에서 strict gate가 계속 begin-step을 강제하고, matching begin-step은 통과하는 계약을 추가했다.

## 결정 근거

#469/#483/#625/#684/#730을 다시 연결해 보면 문제 축은 매번 달랐지만 공통 원인은 run lifecycle 신호 해석 불일치였다. `finalized_at`은 review/finalize snapshot 완료이고, run이 helper fallback/ordering에서 닫히는 시점은 `completed_at` 또는 stop-hook의 별도 `run_finished` ledger 판정이다. 전역 scan에는 기존 best-effort multi-session risk가 남지만, completed tombstone 제외와 env override 안내가 유지되므로 이번 패치가 새 blocker를 만들지는 않는다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/session_state.py`와 `harness/hooks.py`는 dcNess helper/runtime hook 코드로 플러그인 업데이트 시 배포된다.
- `/init-dcness`가 사용자 프로젝트로 복사하는 파일 추가/변경은 없다.
- public command/agent/skill surface 추가는 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public surface 변화 없음.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_hooks tests.test_session_state tests.test_codex_validator_wrapper -v` (376 tests)
- [x] `python3.11 -m unittest discover -s tests -v` (1103 tests)
- [x] `git diff --check`
- [x] stale finalized-skip 표현 검색: `rg -n "unfinalized|미finalized|finalized_at 있음 → skip|finalized = skip|scan_skips_finalized|all_finalized|include_finalized_uncompleted|모든 run finalized" harness tests scripts agents README.md CLAUDE.md PROGRESS.md` (no matches)
- [x] pre-commit hook during commit: PASS (`scripts/check_python_tests.sh`, 1103 tests)
- [x] independent read-only code review after final patch: PASS

## 참고

- Root invariant: `completed_at` is the only active-run fallback tombstone.
- `finalized_at` remains meaningful for finalize idempotency and stop-hook `run_finished` recovery, but it no longer closes an uncompleted run for helper fallback or strict Agent ordering.