### PR TITLE
[issue-722] acceptance marker로 Stop hook 종료 판정 보강

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -178,6 +178,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 - 마지막 step 이 완료됐고 run 이 미finalized 상태면 `end-run` 을 자동 수행
 - 마지막 step 결론이 다음 step 으로 이어져야 하는 enum 이고 종료 agent 가 아니면 continuation signal 을 내보내 메인 turn 재발화
+- `begin-run impl --acceptance-required` 로 기록된 마감 task run 에서는 `pr-reviewer` 를 종료 agent 로 취급하지 않는다. `pr-reviewer` 결론이 `PASS`/`LGTM` 이면 Stop hook 이 `product-acceptance` 진입용 continuation signal 을 내보내며, marker 가 없는 중간 task / `--no-acceptance` run / verify-only run 은 기존 종료 동작을 유지한다.
 - 같은 step 에서 반복 block 횟수가 한도를 넘으면 사용자/메인의 종료 의도를 존중하고 skip
 
 **차단**: tool 차단은 아니다. 필요 시 stdout JSON 으로 메인 turn 을 재발화한다.

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -42,13 +42,15 @@ EnterWorktree(name="<skill>-{ts_short}")   # action 루프 (impl / impl-loop / d
 
 ```bash
 HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)/scripts/dcness-helper"
-RUN_ID=$("$HELPER" begin-run <entry_point> [--issue-num N] [--design-doc <path>])
+RUN_ID=$("$HELPER" begin-run <entry_point> [--issue-num N] [--design-doc <path>] [--acceptance-required])
 echo "[<entry>] run started: $RUN_ID"
 ```
 
 `<entry_point>` = 해당 skill 의 `## Loop` 의 `entry_point` 필드 (예: `impl`, `design`, `ux`). begin-run 동작: sid auto-detect + run_id 발급 + `live.json.active_runs` 슬롯 + `.by-pid-current-run/{cc_pid}` 씀.
 
 `--design-doc <path>` — 이 run 이 참조하는 **머지된 설계 문서**(impl task 문서 / compact plan) 경로. 설계가 별도 run 에서 머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서 기록하면, engineer 게이트가 같은-run module-architect PASS 의 등가 사전 조건으로 인정한다 ([`hooks.md` 순서 차단 훅](hooks.md#catastrophic-gatesh)). `entry_point=impl` 전용이며, 설계 산출물 규약 경로(`docs/milestones/**` / `docs/compact-plans/**` / `docs/bugfix/**`)의 실존 `.md` 만 허용 — 아니면 begin-run 이 fail-fast 거부한다. 기록값은 resolve 된 절대경로(hook 프로세스와 cwd 가 달라도 안전). chain 의 다음 task 진입은 `next-task --design-doc <path>` 로 동일 기록.
+
+`--acceptance-required` — story/epic 마감 task 처럼 `pr-reviewer` 뒤 inline `product-acceptance` 를 거쳐야 run 이 정상 종료되는 경우에만 기록한다. Stop hook 은 이 marker 가 있는 `entry_point=impl` run 에서 `pr-reviewer` 를 종료 agent 로 취급하지 않고 product-acceptance 진입 turn 을 재발화한다. 중간 task / `--no-acceptance` run / verify-only run 은 이 플래그를 주지 않는다. chain 의 다음 task 진입은 `next-task --acceptance-required` 로 동일 기록한다.
 
 > `/impl-loop` 의 **chain 모드(N task)** 는 자기 run 을 갖지 않는 driver 다 — `impl-task-loop × N` 이므로 각 task 가 독립 `begin-run impl` … `end-run` run 1개씩 (N task = N run = N review.md). **single 모드(1 task)** 는 `impl` entry_point 로 run 1개. 자세히 = [`/impl-loop`](../../skills/impl-loop/SKILL.md).
 

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -1390,7 +1390,9 @@ def _maybe_emit_continuation_signal(
     """issue #469 결함 A — 중간 step PASS 후 메인 turn 발화 강제 신호 박기.
 
     조건:
-    1. 마지막 step agent 가 종료 agent (pr-reviewer) 아님
+    1. 마지막 step agent 가 종료 agent (pr-reviewer) 아님. 단
+       acceptance_required run 의 pr-reviewer 는 product-acceptance 전 단계라 종료 agent
+       로 취급하지 않음 (#722).
     2. 마지막 step prose 파일 존재 + 결론 enum 이 다음 step 진입 가능 enum
     3. stop_block_count[step_key] < _STOP_BLOCK_COUNT_MAX (무한 루프 가드)
 
@@ -1398,7 +1400,12 @@ def _maybe_emit_continuation_signal(
         True  — decision:block JSON stdout 씀 + 호출자는 return 0 해야 함
         False — 조건 미충족, 호출자는 기존 분기 (end-run 자동 호출) 진행
     """
-    if not last_agent or last_agent in _TERMINAL_AGENTS:
+    if not last_agent:
+        return False
+    acceptance_after_pr = (
+        last_agent == "pr-reviewer" and slot.get("acceptance_required") is True
+    )
+    if last_agent in _TERMINAL_AGENTS and not acceptance_after_pr:
         return False
     rdir = slot.get("run_dir")
     if not isinstance(rdir, str) or not rdir:
@@ -1419,7 +1426,7 @@ def _maybe_emit_continuation_signal(
     except OSError:
         return False
     enum = _extract_conclusion_enum(prose)
-    if enum not in _CONTINUE_ENUMS:
+    if enum not in _CONTINUE_ENUMS and not (acceptance_after_pr and enum == "LGTM"):
         return False
 
     # 무한 루프 가드 — 같은 step 에서 block 쓴 횟수 상한 검사.
@@ -1443,13 +1450,19 @@ def _maybe_emit_continuation_signal(
     except Exception:
         pass  # persist 실패해도 block 자체는 씀 (다음 호출 시 cur_count 만 미증가)
 
-    next_hint = (
-        "worker 가 남긴 검증 명령을 메인이 직접 실행(게이트 대행) 후 exit 0 이면 "
-        "git/PR, FAIL 이면 engineer 재시도 분기. "
-        if enum == "VALIDATION_BLOCKED"
-        else "정의된 다음 agent 호출 또는 PR/review/merge 영역 "
-        "(예: begin-step pr-reviewer + Agent pr-reviewer + end-step + PR 머지). "
-    )
+    if acceptance_after_pr:
+        next_hint = (
+            "이 run 은 story/epic 마감 acceptance 대상이므로 "
+            "begin-step product-acceptance 후 inline 검수를 진행해야 함. "
+        )
+    else:
+        next_hint = (
+            "worker 가 남긴 검증 명령을 메인이 직접 실행(게이트 대행) 후 exit 0 이면 "
+            "git/PR, FAIL 이면 engineer 재시도 분기. "
+            if enum == "VALIDATION_BLOCKED"
+            else "정의된 다음 agent 호출 또는 PR/review/merge 영역 "
+            "(예: begin-step pr-reviewer + Agent pr-reviewer + end-step + PR 머지). "
+        )
     reason = (
         f"[dcness Stop hook · issue #469 결함 A] sub-step "
         f"'{last_agent}{mode_suffix}' 결론 '{enum}' — 다음 sub-step 진입 turn "

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -512,6 +512,7 @@ def start_run(
     issue_num: Optional[int] = None,
     design_doc: Optional[str] = None,
     lane: Optional[str] = None,
+    acceptance_required: bool = False,
 ) -> None:
     """`active_runs[run_id]` 슬롯 추가 + run 디렉토리 생성.
 
@@ -528,6 +529,10 @@ def start_run(
     수용하고 (2) design_doc 과 동일하게 entry_point=impl run 에서만 기록을
     허용한다 — design/architect-loop run 의 module-architect PASS 강제는 코드
     보장으로 유지된다.
+
+    acceptance_required — story/epic 마감 task 로, pr-reviewer PASS 뒤 inline
+    product-acceptance 를 거쳐야 정상 종료되는 run 이라는 신호 (#722).
+    Stop hook 이 이 marker 를 읽어 pr-reviewer 를 종료 agent 로 취급하지 않는다.
     """
     if not valid_session_id(session_id):
         raise ValueError(f"invalid session_id: {session_id!r}")
@@ -544,6 +549,11 @@ def start_run(
             raise ValueError(
                 f"lane must be one of {_VALID_LANES} (got {lane!r})"
             )
+    if acceptance_required and entry_point != "impl":
+        raise ValueError(
+            "acceptance_required is only valid for entry_point=impl "
+            f"(got {entry_point!r})"
+        )
     if design_doc is not None:
         # design_doc 은 impl 구현 run 전용 — design/architect-loop run 의
         # engineer ← module-architect PASS 강제가 코드 보장으로 유지되도록
@@ -573,6 +583,7 @@ def start_run(
         "issue_num": issue_num,
         "design_doc": design_doc,
         "lane": lane,
+        "acceptance_required": bool(acceptance_required),
     }
     update_live(session_id, base_dir=base_dir, active_runs=active)
     # run 디렉토리 생성
@@ -587,6 +598,7 @@ def _ledger_run_started(
     issue_num: Optional[int] = None,
     design_doc: Optional[str] = None,
     lane: Optional[str] = None,
+    acceptance_required: bool = False,
     base_dir: Optional[Path] = None,
 ) -> None:
     """start_run 직후 ledger run_started checkpoint 기록 (이슈 #587).
@@ -605,6 +617,8 @@ def _ledger_run_started(
             extra["design_doc"] = design_doc
         if lane is not None:
             extra["lane"] = lane
+        if acceptance_required:
+            extra["acceptance_required"] = True
         ledger.append_event(session_id, run_id, "run_started", base_dir=base_dir, **extra)
     except Exception:
         pass
@@ -1461,10 +1475,12 @@ def _cli_begin_run(args: Any) -> int:
     issue_num = args.issue_num if args.issue_num is not None else None
     design_doc = getattr(args, "design_doc", None)
     lane = getattr(args, "lane", None)
+    acceptance_required = bool(getattr(args, "acceptance_required", False))
     try:
         start_run(
             sid, rid, args.entry_point,
             issue_num=issue_num, design_doc=design_doc, lane=lane,
+            acceptance_required=acceptance_required,
         )
     except ValueError as exc:
         print(f"[begin-run] FAIL — {exc}", file=sys.stderr)
@@ -1472,6 +1488,7 @@ def _cli_begin_run(args: Any) -> int:
     _ledger_run_started(
         sid, rid, args.entry_point,
         issue_num=issue_num, design_doc=design_doc, lane=lane,
+        acceptance_required=acceptance_required,
     )
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
@@ -1611,6 +1628,14 @@ def _cli_next_task(args: Any) -> int:
 
     entry_point = getattr(args, "entry_point", "impl") or "impl"
     design_doc = getattr(args, "design_doc", None)
+    acceptance_required = bool(getattr(args, "acceptance_required", False))
+    if acceptance_required and entry_point != "impl":
+        print(
+            "[next-task] begin-run FAIL — acceptance_required is only valid "
+            f"for entry_point=impl (got {entry_point!r})",
+            file=sys.stderr,
+        )
+        return 1
     if design_doc is not None:
         # 이전 run end-run(비가역) *전* 선검증 — 경로 오타로 이전 run 만 닫히고
         # 새 run 발급이 실패하는 어긋남(prev review echo 영구 소실) 방지.
@@ -1637,12 +1662,18 @@ def _cli_next_task(args: Any) -> int:
 
     new_rid = generate_run_id()
     try:
-        start_run(sid, new_rid, entry_point, issue_num=None, design_doc=design_doc)
+        start_run(
+            sid, new_rid, entry_point, issue_num=None, design_doc=design_doc,
+            acceptance_required=acceptance_required,
+        )
     except Exception as exc:
         print(f"[next-task] begin-run FAIL — {exc}", file=sys.stderr)
         return 1
     # 이슈 #587 (codex review) — chain task run 도 run_started checkpoint 남김.
-    _ledger_run_started(sid, new_rid, entry_point, design_doc=design_doc)
+    _ledger_run_started(
+        sid, new_rid, entry_point, design_doc=design_doc,
+        acceptance_required=acceptance_required,
+    )
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
         write_pid_current_run(cc_pid, new_rid)
@@ -1671,6 +1702,8 @@ def _cli_next_task(args: Any) -> int:
     print(f"[new] entry_point: {entry_point}")
     if design_doc:
         print(f"[new] design_doc: {design_doc}")
+    if acceptance_required:
+        print("[new] acceptance_required: true")
     print("=== /next-task transition ===")
     return 0
 
@@ -2854,6 +2887,11 @@ def _build_arg_parser() -> Any:
              "설계도 없는 Lite 구현 경로로 engineer 게이트 설계 산출물 사전 조건 "
              "면제 신호. entry_point=impl 에서만 수용",
     )
+    p_br.add_argument(
+        "--acceptance-required", action="store_true",
+        help="story/epic 마감 task run marker (#722) — pr-reviewer PASS 뒤 "
+             "product-acceptance 전 Stop hook auto end-run 방지. entry_point=impl 전용",
+    )
     p_br.set_defaults(func=_cli_begin_run)
 
     p_er = sub.add_parser("end-run", help="complete_run + clear by-pid-current-run")
@@ -2870,6 +2908,10 @@ def _build_arg_parser() -> Any:
     p_nt.add_argument(
         "--design-doc", default=None, dest="design_doc",
         help="다음 task 가 참조하는 머지된 설계 문서 경로 (begin-run --design-doc 동일)",
+    )
+    p_nt.add_argument(
+        "--acceptance-required", action="store_true",
+        help="다음 task 가 story/epic 마감 acceptance 대상임을 기록 (#722)",
     )
     p_nt.set_defaults(func=_cli_next_task)
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -212,7 +212,7 @@ wrapper 가 Codex 마지막 응답을 `/tmp` 에 받고 `dcness-helper end-step 
 
 default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → pr-reviewer**. 4 단계 *모두 호출* 의무 (MUST — false-clean 차단, #431).
 
-🔴 **begin-run 에 `--design-doc` 필수**: 엔진 A 는 설계(impl 문서)가 별도 run 에서 머지된 *뒤* 진입하므로 같은 run 안에 module-architect prose 가 없다 — `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 머지된 설계 문서를 run 에 기록해야 engineer 게이트(순서 차단 훅)가 IMPL 진입을 허용한다 ([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). chain 에서 다음 task 도 풀 4-agent 면 `next-task --design-doc <다음 task 의 impl 문서 경로>` 로 동일 기록. advanced fallback 으로 module-architect 를 선두 추가한 run 은 같은-run PASS prose 가 생기므로 생략 가능하나, task 의 impl 문서가 이미 있으면 기록을 권장한다.
+🔴 **begin-run 에 `--design-doc` 필수**: 엔진 A 는 설계(impl 문서)가 별도 run 에서 머지된 *뒤* 진입하므로 같은 run 안에 module-architect prose 가 없다 — `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 머지된 설계 문서를 run 에 기록해야 engineer 게이트(순서 차단 훅)가 IMPL 진입을 허용한다 ([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). story/epic 마감 task 이고 acceptance 기본 ON 이면 같은 begin-run 에 `--acceptance-required` 도 붙인다. 이 marker 는 Stop hook 이 pr-reviewer 직후 run 을 자동 종료하지 않고 product-acceptance 진입 turn 을 재발화하게 하는 신호다. chain 에서 다음 task 도 풀 4-agent 면 `next-task --design-doc <다음 task 의 impl 문서 경로>` 로 동일 기록하고, 다음 task 가 마감 acceptance 대상이면 `--acceptance-required` 도 함께 기록한다. advanced fallback 으로 module-architect 를 선두 추가한 run 은 같은-run PASS prose 가 생기므로 생략 가능하나, task 의 impl 문서가 이미 있으면 기록을 권장한다.
 
 ✅ 정상 흐름:
 1. **test-engineer** (TESTS_WRITTEN) → 테스트 선작성
@@ -232,7 +232,7 @@ default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → p
 
 시퀀스 = **build-worker (2-step: test+impl+self-validate 통합) → pr-reviewer**. deep task 보강 필요 시 module-architect 선두 (3-step).
 
-1. **begin-run + (reset) + build-worker step** — `begin-run impl --design-doc <task 의 impl 문서 경로>` → **(chain 의 첫 task 또는 single 모드면 `dcness-helper prev-tasks-reset` — `begin-step` *전*, prev-tasks 초기화)** → `begin-step build-worker` → `dcness-helper run-dir` 로 `<run_dir>` 확인 → `Agent(build-worker, prompt=<impl 경로 + task slug + RUN_ID + run_dir + (begin-step stdout 의 [PREVIOUS_TASKS] 섹션 있으면 그대로 포함, #525)>)` → 반환 prose 결론 분기 (= [`impl-loop-routing.md`](impl-loop-routing.md#결론-다음-호출-매핑)). 이후 `end-step build-worker`. worker 안 phase 별 prose (`build-test.md` / `build-impl.md` / `build-validate.md`) 는 worker 자체 Write — [`loop-procedure.md` build-worker phase prose](../../docs/plugin/loop-procedure.md#build-worker-phase-prose-impl-loop-hybrid-a-한정). `<run_dir>` 는 harness-state run_dir 그대로이며 `phases/<RUN_ID>/` 별도 경로가 아니다.
+1. **begin-run + (reset) + build-worker step** — `begin-run impl --design-doc <task 의 impl 문서 경로>` (마감 acceptance 대상이면 `--acceptance-required` 추가) → **(chain 의 첫 task 또는 single 모드면 `dcness-helper prev-tasks-reset` — `begin-step` *전*, prev-tasks 초기화)** → `begin-step build-worker` → `dcness-helper run-dir` 로 `<run_dir>` 확인 → `Agent(build-worker, prompt=<impl 경로 + task slug + RUN_ID + run_dir + (begin-step stdout 의 [PREVIOUS_TASKS] 섹션 있으면 그대로 포함, #525)>)` → 반환 prose 결론 분기 (= [`impl-loop-routing.md`](impl-loop-routing.md#결론-다음-호출-매핑)). 이후 `end-step build-worker`. worker 안 phase 별 prose (`build-test.md` / `build-impl.md` / `build-validate.md`) 는 worker 자체 Write — [`loop-procedure.md` build-worker phase prose](../../docs/plugin/loop-procedure.md#build-worker-phase-prose-impl-loop-hybrid-a-한정). `<run_dir>` 는 harness-state run_dir 그대로이며 `phases/<RUN_ID>/` 별도 경로가 아니다.
    `--design-doc` 은 build-worker 자체를 위한 값이 아니라, worker self-validate 실패나 마감 acceptance FAIL 뒤 `engineer:IMPL` 로 재진입할 때 engineer gate 의 설계 산출물 사전 조건을 만족시키는 기록이다. deep task 구현은 항상 impl 문서가 입력이므로 엔진 B 에서도 기록한다.
 2. **git/PR 생성 (메인)** — worker prose 의 commit message + PR 본문 초안을 임시 파일로 박고 `scripts/pr-create.sh` 통합 호출:
    ```bash
@@ -270,6 +270,8 @@ story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후
 - **epic 마감 task** (`Closes #story` + `Closes #epic`) → `STORY_ACCEPTANCE` → `EPIC_ACCEPTANCE` 순 2회 (마지막 story 의 AC 와 epic 전체 PRD Must·cross-story 를 각각 닫는다)
 - 중간 task (`Part of`) / 공통 task / verify-only task → 비대상
 - **통합 브랜치 모드 (sub-PR base ≠ main)** — sub-PR 의 `Closes` 는 머지해도 발동하지 않으므로 **sub-PR 단계에서는 acceptance 를 발동하지 않는다**. 검수는 *마지막 main 머지 PR* (`Closes #story×N + #epic` 일괄) 의 머지 전에 story×N → epic 순으로 일괄 수행한다 — 발동 기준은 "task_index" 가 아니라 "이 PR 머지로 issue close 가 실제 발동하는가"다.
+
+**run marker**: 위 판정 결과가 acceptance 대상이고 `--no-acceptance` 가 아니면 run 시작 시 `begin-run impl --acceptance-required` 를 기록한다. chain 에서 다음 task 가 대상이면 `next-task --acceptance-required` 로 새 run 에 승계한다. 이 marker 는 Stop hook 이 `pr-reviewer` 를 종료 agent 로 보지 않게 하는 신호다. marker 없는 run 은 `pr-reviewer` 직후 기존처럼 auto end-run 후보가 된다.
 
 **시점 — pr-reviewer PASS 후 · `pr-finalize.sh`(머지) *전*, 단 story 구현 증거가 모두 모인 뒤**. `Closes #story` auto-close 는 머지 시 발동하므로, 머지 전에 검수해야 (1) story/epic issue close = 검수 통과와 동기화되고 (2) gap 수정이 *열려 있는 같은 PR* 에 commit 추가로 들어간다 (gap fix PR 난립 X). 엔진별 삽입점: 엔진 A 는 `pr-create.sh` 로 PR 생성까지 마친 뒤 pr-finalize 전, 엔진 B 는 pr-reviewer PASS 후 pr-finalize 전 — 두 경우 모두 open PR 번호가 검수 증거에 들어간다. **병렬 peer 세션의 마감 task 는 같은 story 의 prior sibling task 가 *모두 완료(머지)* 됐음을 `wave-status` 로 먼저 확인한 후** acceptance 를 수행하고, 그 다음 `pr-finalize.sh`(merge lock + order gate) 를 호출한다 — sibling 미완료 상태의 검수는 불완전 증거 검수라 금지. sibling 이 아직 진행 중이면 완료를 기다렸다가 검수한다 (직렬 chain 은 순서상 자동 충족).
 
@@ -379,11 +381,11 @@ merge lock 이 보존하는 것:
 
 ### task 경계 — next-task 통합 호출 (#471)
 
-마지막이 아닌 task 종료 시 `dcness-helper next-task --entry-point impl --design-doc <다음 task 의 impl 문서 경로>` 1회 호출 — helper 가 (이전 run end-run + previous review.md stdout + 새 run begin-run) 통합 처리 → 메인은 stdout 의 `[new] run_id` 만 받아 다음 task 진입. *마지막* task = `next-task` 대신 `end-run` 단독. `--design-doc` 은 풀 4-agent(엔진 A)의 최초 engineer 진입뿐 아니라 build-worker(엔진 B)의 fallback/acceptance gap 수정 `engineer:IMPL` 재진입에도 쓰이는 사전 조건 기록이다.
+마지막이 아닌 task 종료 시 `dcness-helper next-task --entry-point impl --design-doc <다음 task 의 impl 문서 경로>` 1회 호출 — helper 가 (이전 run end-run + previous review.md stdout + 새 run begin-run) 통합 처리 → 메인은 stdout 의 `[new] run_id` 만 받아 다음 task 진입. *마지막* task = `next-task` 대신 `end-run` 단독. `--design-doc` 은 풀 4-agent(엔진 A)의 최초 engineer 진입뿐 아니라 build-worker(엔진 B)의 fallback/acceptance gap 수정 `engineer:IMPL` 재진입에도 쓰이는 사전 조건 기록이다. 다음 task 가 story/epic 마감 acceptance 대상이면 같은 호출에 `--acceptance-required` 를 추가한다.
 
 ```bash
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" next-task --entry-point impl --design-doc <path>   # 마지막 아님
-bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" end-run                                              # 마지막
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" next-task --entry-point impl --design-doc <path> [--acceptance-required]   # 마지막 아님
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/dcness-helper" end-run                                                                       # 마지막
 ```
 
 ### enum 별 분기

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -126,6 +126,8 @@ flowchart TB
 
 story/epic 마감 task (PR 트레일러 `Closes #story` / `Closes #epic` 대상) 의 pr-reviewer `PASS` 후 · pr-finalize(머지) *전* 에 product-acceptance 검수를 끼운다 (절차·경계 판정·시점 전제조건 = [`SKILL.md` 마감 acceptance](SKILL.md#마감-acceptance) — 병렬 peer 는 같은 story sibling 완료 확인 후, 통합 브랜치 모드는 sub-PR 이 아니라 마지막 main 머지 PR 전). 기본 ON, `--no-acceptance` 명시 run 만 비대상. epic 마감 task 는 `STORY_ACCEPTANCE` → `EPIC_ACCEPTANCE` 직렬 2회 — 앞이 PASS 못 닫으면 뒤로 진행하지 않는다.
 
+마감 acceptance 대상 run 은 `begin-run impl --acceptance-required` 또는 `next-task --acceptance-required` marker 를 기록한다. 이 marker 가 있어야 Stop hook 이 pr-reviewer 를 종료 agent 로 보지 않고 product-acceptance 분기 turn 을 재발화한다. 비대상 run / `--no-acceptance` / verify-only 는 marker 를 기록하지 않아 기존 종료 동작을 유지한다.
+
 standalone `/acceptance` 의 분기 규칙([`acceptance-routing.md`](../acceptance/acceptance-routing.md) — 자동 수정 X, 보고만)과 **별개** — 같은 agent 지만 inline 검수의 결론→다음은 본 문서가 소유한다 (위 "분기 규칙은 skill 이 소유" 원칙). inline 검수에서 gap 수정 루프가 도는 이유: 마감 PR 이 아직 열려 있어 gap 수정이 같은 PR 의 commit 으로 수렴 가능한 시점이기 때문이다.
 
 **`FAIL` → gap 분류 분기** (gap taxonomy = [`acceptance-routing.md`](../acceptance/acceptance-routing.md) 기준):

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -2717,6 +2717,53 @@ class StopHookContinuationSignalTests(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(stdout, "")
 
+    def test_pr_reviewer_blocks_when_acceptance_required(self):
+        # #722 — 마감 acceptance 대상 run 에서는 pr-reviewer 가 종료 agent 가 아니다.
+        self._write_prose("pr-reviewer", "LGTM — product acceptance 전 merge 금지")
+        slot = self._slot()
+        slot["acceptance_required"] = True
+        result, stdout = self._invoke(slot=slot, last_agent="pr-reviewer")
+        self.assertTrue(result)
+        payload = json.loads(stdout)
+        self.assertEqual(payload["decision"], "block")
+        self.assertIn("product-acceptance", payload["reason"])
+        self.assertIn("LGTM", payload["reason"])
+
+    def test_stop_hook_does_not_auto_end_run_before_required_acceptance(self):
+        # #722 — pr-reviewer 직후 메인 turn 이 멈춰도 acceptance 전 auto end-run 금지.
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        from harness import ledger
+        from harness.session_state import read_live, run_dir, start_run, update_live
+
+        sid = "sid-acceptance-required"
+        rid = "run-7220abcd"
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            update_live(sid, base_dir=base)
+            start_run(sid, rid, "impl", base_dir=base, acceptance_required=True)
+            prose_path = run_dir(sid, rid, base_dir=base) / "pr-reviewer.md"
+            prose = "LGTM — product acceptance 전 merge 금지\n"
+            prose_path.write_text(prose, encoding="utf-8")
+            ledger.append_step_completed(
+                sid, rid, "pr-reviewer", None, "PROSE_LOGGED", prose, prose_path, base_dir=base)
+
+            live = read_live(sid, base_dir=base)
+            slot = dict(live["active_runs"][rid])
+            active = dict(live["active_runs"])
+            active[rid] = slot
+            update_live(sid, base_dir=base, active_runs=active)
+
+            env = {"DCNESS_SESSION_ID": sid, "DCNESS_RUN_ID": rid}
+            with patch.dict(os.environ, env, clear=False), patch(
+                "harness.session_state._cli_end_run", return_value=0
+            ) as end_run:
+                rc = handle_stop(stdin_data={}, base_dir=base)
+
+        self.assertEqual(rc, 0)
+        end_run.assert_not_called()
+
     def test_fail_enum_skips(self):
         # FAIL → 메인 사용자 위임 영역 — block 안 박음
         self._write_prose("code-validator", "전반적 FAIL — 4 항목 위반")

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -442,6 +442,7 @@ class ActiveRunsTests(unittest.TestCase):
         self.assertIn("started_at", slot)
         self.assertIn("last_confirmed_at", slot)
         self.assertIn("run_dir", slot)
+        self.assertFalse(slot["acceptance_required"])
 
     def test_start_run_creates_dir(self) -> None:
         start_run(self.sid, self.run_id, "impl", base_dir=self.base)
@@ -608,6 +609,24 @@ class ActiveRunsTests(unittest.TestCase):
         # 의 lane 기록 자체를 거부한다 (lite 면제가 설계 루프로 새는 것 차단).
         with self.assertRaises(ValueError):
             start_run(self.sid, self.run_id, "design", base_dir=self.base, lane="lite")
+
+    # -- #722 — 마감 acceptance 대상 run marker --
+
+    def test_start_run_records_acceptance_required(self) -> None:
+        start_run(
+            self.sid, self.run_id, "impl",
+            base_dir=self.base, acceptance_required=True,
+        )
+        slot = read_live(self.sid, base_dir=self.base)["active_runs"][self.run_id]
+        self.assertTrue(slot["acceptance_required"])
+
+    def test_start_run_acceptance_required_non_impl_entry_rejected(self) -> None:
+        # inline product-acceptance 는 impl-loop/impl run 의 마감 PR 전 게이트다.
+        with self.assertRaises(ValueError):
+            start_run(
+                self.sid, self.run_id, "design",
+                base_dir=self.base, acceptance_required=True,
+            )
 
     def test_update_current_step(self) -> None:
         start_run(self.sid, self.run_id, "impl", base_dir=self.base)
@@ -2781,6 +2800,25 @@ class NextTaskTransitionTests(unittest.TestCase):
         self.assertIn(resolved, recorded)
         self.assertIn(f"[new] design_doc: {resolved}", buf.getvalue())
 
+    def test_transition_records_acceptance_required(self) -> None:
+        # chain task — 다음 task 가 story/epic 마감이면 새 run 에 acceptance marker 를 기록.
+        from harness.session_state import _cli_next_task, read_live
+        from io import StringIO
+        from contextlib import redirect_stdout
+        from types import SimpleNamespace
+        sid = "11111111-2222-4333-8444-555555555555"
+        os.environ["DCNESS_SESSION_ID"] = sid
+
+        buf = StringIO()
+        with redirect_stdout(buf):
+            rc = _cli_next_task(SimpleNamespace(
+                entry_point="impl", acceptance_required=True,
+            ))
+        self.assertEqual(rc, 0)
+        active = read_live(sid)["active_runs"]
+        self.assertIn(True, [s.get("acceptance_required") for s in active.values()])
+        self.assertIn("[new] acceptance_required: true", buf.getvalue())
+
     def test_transition_invalid_design_doc_fails_before_end_run(self) -> None:
         # 실존하지 않는 design_doc — begin-run FAIL fail-fast (exit 1). 검증은
         # 이전 run end-run *전* 이라 이전 run 이 닫히지 않고 보존돼야 한다
@@ -2806,6 +2844,29 @@ class NextTaskTransitionTests(unittest.TestCase):
         prev_slot = read_live(sid)["active_runs"][prev_rid]
         self.assertIsNone(prev_slot["completed_at"])
 
+    def test_transition_invalid_acceptance_marker_fails_before_end_run(self) -> None:
+        # acceptance_required 는 impl run 전용 — 잘못된 entry_point 면 이전 run 닫기 전 실패.
+        from harness.session_state import _cli_next_task, read_live, start_run
+        from io import StringIO
+        from contextlib import redirect_stdout, redirect_stderr
+        from types import SimpleNamespace
+        sid = "11111111-2222-4333-8444-555555555555"
+        prev_rid = "run-prev1234"
+        os.environ["DCNESS_SESSION_ID"] = sid
+        os.environ["DCNESS_RUN_ID"] = prev_rid
+        start_run(sid, prev_rid, "impl", issue_num=None)
+
+        out, err = StringIO(), StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            rc = _cli_next_task(SimpleNamespace(
+                entry_point="design",
+                acceptance_required=True,
+            ))
+        self.assertEqual(rc, 1)
+        self.assertIn("acceptance_required is only valid", err.getvalue())
+        prev_slot = read_live(sid)["active_runs"][prev_rid]
+        self.assertIsNone(prev_slot["completed_at"])
+
 
 class DesignDocArgparseTests(unittest.TestCase):
     """begin-run / next-task 의 --design-doc 플래그 파싱 회귀."""
@@ -2823,6 +2884,19 @@ class DesignDocArgparseTests(unittest.TestCase):
         ns = _build_arg_parser().parse_args(["begin-run", "impl"])
         self.assertIsNone(ns.design_doc)
 
+    def test_begin_run_accepts_acceptance_required(self) -> None:
+        from harness.session_state import _build_arg_parser
+        ns = _build_arg_parser().parse_args(
+            ["begin-run", "impl", "--acceptance-required"]
+        )
+        self.assertEqual(ns.cmd, "begin-run")
+        self.assertTrue(ns.acceptance_required)
+
+    def test_begin_run_acceptance_required_defaults_false(self) -> None:
+        from harness.session_state import _build_arg_parser
+        ns = _build_arg_parser().parse_args(["begin-run", "impl"])
+        self.assertFalse(ns.acceptance_required)
+
     def test_next_task_accepts_design_doc(self) -> None:
         from harness.session_state import _build_arg_parser
         ns = _build_arg_parser().parse_args(
@@ -2834,6 +2908,12 @@ class DesignDocArgparseTests(unittest.TestCase):
             ns.design_doc,
             "docs/milestones/v01/epics/epic-01-x/impl/01-x.md",
         )
+
+    def test_next_task_accepts_acceptance_required(self) -> None:
+        from harness.session_state import _build_arg_parser
+        ns = _build_arg_parser().parse_args(["next-task", "--acceptance-required"])
+        self.assertEqual(ns.cmd, "next-task")
+        self.assertTrue(ns.acceptance_required)
 
     # -- #714 — begin-run --lane 플래그 파싱 --
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #722

## 배경 및 문제

impl-loop story/epic 마감 task 는 pr-reviewer 이후 product-acceptance 를 거친 뒤 pr-finalize 로 머지되어야 한다. 기존 Stop hook continuation 판정은 pr-reviewer 를 항상 종료 agent 로 취급해서, pr-reviewer PASS/LGTM 직후 메인 turn 이 멈추면 acceptance 전에 auto end-run 으로 run 이 닫힐 수 있었다.

## 원인 (해당 시)

Stop hook 의 `_maybe_emit_continuation_signal` 이 종료 agent 집합(`pr-reviewer`)만 보고 판단했고, 해당 run 이 마감 acceptance 대상인지 알 수 있는 run-level marker 가 없었다.

## 작업내용

- `begin-run impl --acceptance-required` / `next-task --acceptance-required` marker 를 추가해 story/epic 마감 acceptance 대상 run 을 live slot 및 ledger run_started 이벤트에 기록한다.
- Stop hook 이 `acceptance_required` run 의 `pr-reviewer` PASS/LGTM 을 terminal 로 취급하지 않고 `product-acceptance` 진입용 continuation block 을 내보내도록 보강했다.
- 비대상 run, `--no-acceptance` run, verify-only run 은 marker 를 기록하지 않아 기존 pr-reviewer 종료 동작을 유지한다.
- impl-loop SKILL/라우팅 문서와 hooks/loop-procedure 문서를 새 marker 경로와 정합시켰다.
- Stop hook/session_state 단위 테스트를 추가했다.

## 결정 근거

기존 `--design-doc` / `--lane lite` 와 같은 run slot marker 방식으로 좁게 구현했다. acceptance 대상 여부만 Stop hook 에 전달하고, acceptance 경계 판정 자체는 기존 impl-loop PR 트레일러 판정을 유지한다. catastrophic block 범위도 pr-reviewer 직후 product-acceptance 누락 방지에 한정했다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체 코드 경로: `harness/hooks.py`, `harness/session_state.py` 변경으로 Stop hook/helper 동작이 plug-in 업데이트 시 적용된다.
- plug-in 사용자-facing 절차 문서: `skills/impl-loop/SKILL.md`, `skills/impl-loop/impl-loop-routing.md`, `docs/plugin/hooks.md`, `docs/plugin/loop-procedure.md` 갱신으로 `/impl-loop` 마감 acceptance 절차와 helper 옵션이 정합한다.
- `/init-dcness` 복사 파일 변경 없음: 새 동작은 plug-in 본체 hook/helper 경로에서 소비되며 사용자 프로젝트로 별도 복사되는 파일 추가가 아니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public skill/command/agent 추가 없음. 기존 helper 옵션으로 run marker 를 기록한다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `bash scripts/check_python_tests.sh`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/check_cross_refs.mjs`

## 참고

- local pr-reviewer 관점 검토: MUST FIX 없음, PASS.
