### PR TITLE
[issue-723] codex validator mktemp BSD 호환 회귀 가드

### DIFF
--- a/scripts/dcness-codex-validator
+++ b/scripts/dcness-codex-validator
@@ -179,6 +179,10 @@ if git -C "$PROJECT_ROOT" diff --quiet --no-ext-diff 2>/dev/null \
   BASELINE_CLEAN=1
 fi
 
+# BSD(macOS) mktemp 는 템플릿 끝에 붙은 X 만 랜덤화한다. X 뒤에 확장자(예: .md)를
+# 두면 mktemp 가 리터럴 파일을 만들어, 같은 템플릿의 다음 호출이 'File exists' 로
+# 깨지고 잔재가 다음 실행을 오염시킨다. 그래서 템플릿은 반드시 trailing XXXXXX 로
+# 끝나야 한다 (GNU mktemp 는 embedded X 도 처리하므로 Linux CI 에선 안 드러남).
 TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-${AGENT}.XXXXXX")"
 TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-prompt-${AGENT}.XXXXXX")"
 trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import tempfile
 import textwrap
@@ -259,6 +260,8 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             attempts_file = tmp / "attempts.txt"
             prose_capture = tmp / "timeout-prose.md"
             helper_args = tmp / "helper-args.txt"
+            wrapper_tmpdir = tmp / "wrapper-tmp"
+            wrapper_tmpdir.mkdir()
 
             bin_dir = tmp / "bin"
             bin_dir.mkdir()
@@ -316,6 +319,7 @@ class CodexValidatorWrapperTests(unittest.TestCase):
                     "HELPER_ARGS": str(helper_args),
                     "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
                     "PROSE_CAPTURE": str(prose_capture),
+                    "TMPDIR": str(wrapper_tmpdir),
                 }
             )
 
@@ -348,6 +352,145 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             prose = prose_capture.read_text(encoding="utf-8")
             self.assertIn("did not finish within 1s", prose)
             self.assertTrue(prose.rstrip().endswith("ESCALATE"))
+            # issue #723 — the timeout/retry path must clean up its temp files so
+            # no residue pollutes the next run (the EXIT trap fires on exit 124).
+            residue = sorted(p.name for p in wrapper_tmpdir.iterdir())
+            self.assertEqual(
+                residue, [], f"wrapper left temp residue after timeout: {residue}"
+            )
+
+
+    def test_mktemp_templates_use_trailing_random_field(self) -> None:
+        """issue #723 — BSD(macOS) mktemp only randomizes a trailing run of X's;
+        a suffix after the X-field (e.g. '.md') makes literal, colliding temp
+        files. GNU mktemp on Linux CI tolerates embedded X's, so only this static
+        check catches reintroduction across platforms."""
+        text = WRAPPER.read_text(encoding="utf-8")
+        templates = re.findall(r'mktemp\s+(?:-\S+\s+)?"([^"]+)"', text)
+        self.assertTrue(
+            templates, "expected at least one mktemp template in the wrapper"
+        )
+        for tpl in templates:
+            self.assertRegex(
+                tpl,
+                r"X{6,}$",
+                f"mktemp template must end with the trailing random field: {tpl!r}",
+            )
+
+    def test_tempfiles_unique_and_cleaned_in_isolated_tmpdir(self) -> None:
+        """issue #723 — temp file creation must succeed uniquely and leave no
+        residue regardless of prior TMPDIR state (deterministic across runs)."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            wrapper_tmpdir = tmp / "wrapper-tmp"
+            wrapper_tmpdir.mkdir()
+            # Residue a prior SIGKILLed run could leave under the broken
+            # embedded-suffix template; the wrapper must not collide with it.
+            seed = wrapper_tmpdir / "dcness-codex-pr-reviewer.XXXXXX"
+            seed.write_text("stale", encoding="utf-8")
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Review this implementation.\n", encoding="utf-8")
+            prose_capture = tmp / "prose.md"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "exec" ] && [ "${2:-}" = "--help" ]; then
+                      echo "Usage: codex exec"
+                      exit 0
+                    fi
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    printf 'Codex prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --prose-file)
+                          cp "$2" "$PROSE_CAPTURE"
+                          exit 0
+                          ;;
+                      esac
+                      shift
+                    done
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_RUN_ID": "run-13572468",
+                    "DCNESS_SESSION_ID": "sid-iso",
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    "PROSE_CAPTURE": str(prose_capture),
+                    "TMPDIR": str(wrapper_tmpdir),
+                }
+            )
+
+            # Two consecutive runs: the broken embedded-suffix template would make
+            # the second mktemp fail with 'File exists'; trailing X's stay unique.
+            for _ in range(2):
+                result = subprocess.run(
+                    [
+                        str(WRAPPER),
+                        "pr-reviewer",
+                        "--prompt-file",
+                        str(prompt_file),
+                        "--project-root",
+                        str(project),
+                        "--helper",
+                        str(helper),
+                    ],
+                    capture_output=True,
+                    env=env,
+                    text=True,
+                    timeout=30,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+            self.assertEqual(
+                prose_capture.read_text(encoding="utf-8"), "Codex prose\n\nPASS\n"
+            )
+            # Only the pre-seeded residue remains; the wrapper cleaned its own files.
+            leftovers = sorted(p.name for p in wrapper_tmpdir.iterdir())
+            self.assertEqual(
+                leftovers,
+                ["dcness-codex-pr-reviewer.XXXXXX"],
+                f"wrapper left unexpected temp residue: {leftovers}",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #723

## 배경 및 문제

`dcness-codex-validator` 의 임시 파일 mktemp 템플릿이 과거 `.XXXXXX.md`(랜덤 X 필드 뒤에 `.md` suffix) 형태였다. BSD(macOS) mktemp 는 템플릿 **끝(trailing)** 의 X 만 랜덤화하므로, embedded `XXXXXX` 는 리터럴 파일 `dcness-codex-<agent>.XXXXXX.md` 로 생성된다. 첫 호출은 성공하지만 같은 템플릿의 다음 호출이 `mkstemp failed ... File exists` 로 깨지고, 그 잔재가 다음 pytest(pre-commit 게이트) 실행을 간헐 실패시키는 flake 였다. GNU(Linux CI) mktemp 는 embedded X 도 랜덤화해 CI 에서는 재현되지 않는 macOS 로컬 한정 버그.

## 원인 (해당 시)

BSD mktemp 의 trailing-X-only 랜덤화 규칙. 함수적 수정(trailing `.XXXXXX`)은 직전 커밋(`85c7656`)에 **부수적으로** 이미 반영돼 있었으나, ① 회귀 방지 테스트 부재, ② CI 의 GNU mktemp 는 이 결함 클래스를 못 잡음, ③ 의도가 코드에 문서화되지 않아 `.md` 같은 suffix 재유입 위험이 남아 있었다.

## 작업내용

- `scripts/dcness-codex-validator`: mktemp 라인 위에 **trailing XXXXXX 제약** 주석 추가 (동작 불변, 내부 ID 없는 순수 코드 문서).
- `tests/test_codex_validator_wrapper.py` 회귀 가드 3종:
  - **정적 가드** (`test_mktemp_templates_use_trailing_random_field`): wrapper 의 모든 mktemp 템플릿이 항상 trailing X-field(`X{6,}$`)로 끝나는지 검사 → `.md` 등 suffix 재유입을 **크로스플랫폼**으로 차단(CI GNU mktemp 가 못 잡는 갭 보완).
  - **격리 행위** (`test_tempfiles_unique_and_cleaned_in_isolated_tmpdir`): 독립 TMPDIR + 리터럴 잔재 pre-seed + 연속 2회 호출 성공 + 실행 후 자기 임시파일 잔재 0(cleanup) 검증.
  - **timeout 테스트 hermetic 화**: 기존 `test_timeout_retries_once_and_logs_escalate_prose` 에 독립 TMPDIR + timeout/retry 경로 후 잔재 0 검증 추가.

## 결정 근거

`mktemp -d` 리팩터(파일명·랜덤화 분리)도 검토했으나, trap·temp 핸들링(되돌리기 어려운 경계)을 건드려 위험이 크다. 현재 trailing `.XXXXXX` 형태는 이미 정확하므로 그대로 두고, **정적 가드 테스트**로 동일한 크로스플랫폼 재유입 차단을 더 낮은 위험으로 달성. (정적 가드가 OLD `.XXXXXX.md` 를 실제 차단함을 `guard_pass=False` 로 증명.)

## 배포 경로 검증 (plug-in 영향 시)

- **경로 1 (plug-in 본체)**: `scripts/dcness-codex-validator` 는 `$PLUGIN_ROOT/scripts/...` 에서 직접 실행되는 plug-in 본체 파일 — 사용자가 plug-in 업데이트 시 자동 적용. init-dcness deploy 스텝/복사 변경 불필요.
- `tests/**` 는 dcness self 전용(외부 미배포).

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 surface 변화 없음. 기존 wrapper 동작 보존 + 테스트 가드만 추가.

## Test Plan

- [x] `python3.11 -m unittest tests.test_codex_validator_wrapper -v` → 5 ok
- [x] 정적 가드가 OLD `.XXXXXX.md` 차단 증명 (guard_pass=False / NEW=True / 주석 false-positive 0)
- [x] `bash -n scripts/dcness-codex-validator` OK
- [x] 전체 회귀 `python3.11 -m unittest discover -s tests` → 1108 tests OK
- [x] pre-commit pytest 게이트 PASS

## 참고

- BSD mktemp 실측 재현: OLD `.XXXXXX.md` → 2번째 호출 `File exists` 실패 + 리터럴 잔재. NEW trailing `.XXXXXX` → 양 호출 랜덤 성공.
