### PR TITLE
[docs] release 0.6.6 — patch roundup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — Claude Code 가 테스트/리뷰/파일 경계를 건너뛰기 전에 막는 PR workflow guard. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.6.5"
+    "version": "0.6.6"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Claude Code PR workflow guard that stops skipped tests, skipped reviews, and out-of-bound agent writes before PRs.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,34 @@
 
 ---
 
+## v0.6.6 (2026-06-11)
+
+**커밋 범위**: `v0.6.5..v0.6.6` (머지 PR 7개)
+**핵심 변경**: v0.6.5 직후 누적된 버그픽스·문서 정합 패치 롤업. GitHub Project lifecycle CI 의 gh 토큰 전달 결함 수정, conveyor 종료·step 재진입 게이트 보강, codex validator mktemp macOS flake 회귀 가드, plugin 용어 SSOT 문서 추가. 기능 변경 없는 trivial patch.
+
+### 무엇이 바뀌나
+
+1. **GitHub Project lifecycle CI 토큰 전달 수정** ([#727](https://github.com/alruminum/dcNess/pull/727) [#726](https://github.com/alruminum/dcNess/issues/726), [#729](https://github.com/alruminum/dcNess/pull/729) [#728](https://github.com/alruminum/dcNess/issues/728)) — github-project-lifecycle composite action 이 `with: gh-token` 으로 토큰을 전달(env 미상속 결함 해소) + owner type 판별 실패 시 graceful degrade. init-dcness 가 배포하는 thin yml 도 동일 토큰 전달 + `read:org` 스코프 안내 추가.
+
+2. **conveyor 종료·step 재진입 게이트 보강** ([#732](https://github.com/alruminum/dcNess/pull/732) [#730](https://github.com/alruminum/dcNess/issues/730), [#733](https://github.com/alruminum/dcNess/pull/733) [#731](https://github.com/alruminum/dcNess/issues/731), [#734](https://github.com/alruminum/dcNess/pull/734) [#722](https://github.com/alruminum/dcNess/issues/722)) — finalized fallback recurrence gap 차단 + step reentry run resolution 수정 + build-worker phase prose write 허용 + acceptance marker 로 Stop hook 종료 판정 보강.
+
+3. **codex validator mktemp macOS 호환 회귀 가드** ([#735](https://github.com/alruminum/dcNess/pull/735) [#723](https://github.com/alruminum/dcNess/issues/723)) — BSD mktemp 의 trailing-X 제약 문서화 + 회귀 가드 테스트(정적+행위) 추가로 `.XXXXXX.md` 형 suffix 재유입 차단(macOS 로컬 pytest flake 해소).
+
+4. **plugin 용어 SSOT 문서** ([#725](https://github.com/alruminum/dcNess/pull/725) [#721](https://github.com/alruminum/dcNess/issues/721)) — `docs/plugin/terms.md` 추가(용어·공개 진입점·분기 표현 기준).
+
+### 사용자 영향
+
+- **`claude plugin update dcness@dcness` 로 자동 반영** — plug-in 본체 경로(`harness/**`, `skills/**`, `scripts/**`, `docs/plugin/**`) + init-dcness 가 배포하는 yml.
+- GitHub Project lifecycle CI 를 쓰는 활성 프로젝트는 토큰 전달 수정으로 머지→Done 자동전이가 안정화된다(기존 활성 프로젝트는 init-dcness yml 재배포 필요 — [#728](https://github.com/alruminum/dcNess/issues/728)).
+
+### 업데이트
+
+```sh
+claude plugin update dcness@dcness
+```
+
+---
+
 ## v0.6.5 (2026-06-11)
 
 **커밋 범위**: `v0.6.1..v0.6.5` (머지 PR 12개)


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 릴리즈 버전 bump (0.6.5 → 0.6.6) — 이슈 없음. v0.6.5 이후 머지된 #721/#722/#723/#726/#728/#730/#731 변경의 배포 롤업.

## 배경 및 문제

v0.6.5 릴리즈 이후 main 에 버그픽스·문서 정합 패치 7개 PR 이 쌓였으나 미배포 상태. 사용자(외부 활성 프로젝트)는 plug-in 버전이 올라가야 `claude plugin update` 로 받는다.

## 원인 (해당 시)

-

## 작업내용

- `.claude-plugin/plugin.json` `version` 0.6.5 → 0.6.6
- `.claude-plugin/marketplace.json` `metadata.version` 0.6.5 → 0.6.6
- `docs/internal/release-notes.md` v0.6.6 항목 추가 (커밋 범위 `v0.6.5..v0.6.6`, 머지 PR 7개 요약)

포함 변경:
- GitHub Project lifecycle CI 토큰 전달 수정 (#726/#728)
- conveyor 종료·step 재진입 게이트 보강 (#730/#731/#722)
- codex validator mktemp macOS flake 회귀 가드 (#723)
- plugin 용어 SSOT 문서 (#721)

## 결정 근거

기능 변경 없는 버그픽스·문서 롤업이므로 trivial patch bump (0.6.5 → 0.6.6). 절차: `docs/internal/plugin-release.md`.

## 배포 경로 검증 (plug-in 영향 시)

버전 파일 2개 동시 bump (plugin.json + marketplace.json) — `docs/internal/plugin-release.md` §1 준수. `source: "./"` 유지(§2). 포함 변경은 전부 plug-in 본체 경로 + init-dcness 배포 yml 로, 머지 후 태그(v0.6.6) → `claude plugin update` 로 사용자 도달.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 버전 bump 만.

## Test Plan

- [x] `node scripts/check_plugin_manifest.mjs` → PASS (dcness@0.6.6)
- [x] `node scripts/check_cross_refs.mjs` → PASS
- [x] 버전 정합 (plugin.json == marketplace.json == 0.6.6)

## 참고

- 머지 후 `git tag v0.6.6 && git push origin v0.6.6` 로 release 태그 박음.
