### PR TITLE
[feature] PR 트레일러 자동 생성 + pr-finalize 통합 브랜치 인지

### DIFF
--- a/docs/plugin/git-spec.md
+++ b/docs/plugin/git-spec.md
@@ -125,7 +125,8 @@ Part of #N
 - `gh pr checks --watch` (CI 결과 대기)
 - auto-merge 완료 대기 (GitHub 백그라운드 lag)
 - peer claim 이 있으면 completed 기록 (`merge-lock complete`)
-- `git fetch origin main` (origin/main ref 동기화 — worktree 호환)
+- `git fetch origin main` (origin/main ref 동기화 — worktree 호환. 통합 브랜치 sub-PR 이면 origin/<base> 도 fetch)
+- **통합 브랜치 sub-PR (base ≠ default branch) 자동 인지** — CI 체크 0개 정상 처리 + 머지 후 PR body close 선언 기반 issue close 보정 ([통합 브랜치 케이스](#통합-브랜치-케이스-base-main-sub-pr-의-auto-close-한계-must))
 - (예정) Test Plan 종합 — 하위 commit 들의 `## Test Plan` 자동 수집·중복 제거·PR body 갱신
 
 argument 없이 호출 시 current branch 의 open PR 자동 검출. 명시 시 `pr-finalize.sh <PR_NUMBER>`.
@@ -200,6 +201,7 @@ stories.md 상단에 `**Base Branch:** feature/<slug>` 마커 박힌 epic (= 통
 흐름:
 
 1. **각 sub-PR (base = `feature/<slug>`)** — PR body 에 평소대로 `Part of #<story>` / `Closes #<story>` 박되 머지 시 *발동 안 됨* 전제. `Document-Exception-PR-Close: 통합 브랜치 sub-PR — main 머지 시 일괄 close` 박아 `check_pr_body.mjs` 게이트 우회 가능 (자유 선택).
+   - **close 보정 자동화**: sub-PR 머지를 [`scripts/pr-finalize.sh`](../../scripts/pr-finalize.sh) 로 하면 base ≠ default branch 를 감지해 (a) CI 체크 0개를 정상으로 처리하고 (b) PR body 의 `Closes`/`Fixes`/`Resolves` 선언이 가리키는 OPEN issue 를 PR 링크 코멘트와 함께 close 보정한다. 수동 CLOSE 불필요. 이미 close 된 issue 에 대한 마지막 →main 일괄 `Closes` 는 무해 (GitHub 이 무시).
 2. **마지막 통합 → main 머지 PR (base = main)** — PR body 에 **모든 story + epic 을 일괄 close**:
    ```
    Closes #<story1>
@@ -227,6 +229,8 @@ stories.md 상단에 `**Base Branch:** feature/<slug>` 마커 박힌 epic (= 통
    - i < total → `Part of #${STORY_ISSUE}`
    - **공통 task** (`story: 공통`) → `Part of #${EPIC_ISSUE}` (task-index trailer omit). 공통 여부의 진본 신호 = `story: 공통` (task_index 형식 아님).
    - **malformed/누락 가드 (MUST)**: 공통 형식(`—`)은 `story: 공통` 일 때만 유효하다. `story` 가 숫자(공통 아님)인데 `task_index` 가 `i/total` 형식이 아니면 — `—` 포함 무엇이든 (누락/malformed/legacy/version-skew) — **PR 생성 전 정지**. 숫자 story 의 `—` 를 공통으로 오분류해 `Part of #epic` 내보내면 story 이슈가 silent open 으로 남아 story-close 의미가 깨진다. `check_pr_body.mjs` 는 task-index 부재를 fallback(트레일러 1건)으로만 통과시켜 이 오분류를 못 잡으므로, 메인이 PR body 작성 전 본 가드를 직접 적용한다.
+
+**한 명령 구현 = [`scripts/pr-trailer.sh`](../../scripts/pr-trailer.sh)** — `"$PLUGIN_ROOT/scripts/pr-trailer.sh" <impl파일>` 이 위 1~4 판정을 수행해 트레일러 블록을 stdout 으로 출력한다 (`--base` 모드 = stories.md `**Base Branch:**` 마커 기반 PR base 출력). malformed 가드 hit 시 exit 1 로 PR 생성을 정지시킨다. 아래 bash recipe 는 스크립트의 동작 정의이자 수동 폴백이다.
 
 bash recipe (PR body 작성 직전 — 분기 키는 `STORY_NUM`, task_index 형식만으로 공통 판정 금지. 위 분기표를 그대로 PR_BODY 로 구성):
 
@@ -301,6 +305,8 @@ $cur"
 ### API 직접 close 절대금지
 
 `mcp__github__update_issue state:closed` 호출 금지 (epic / story 모두). 반드시 PR body `Closes #N` — [기본 룰](#기본-룰) 참조 (regular merge auto-close 인식 한계).
+
+> **예외 (유일)**: 통합 브랜치 sub-PR 머지 시 `pr-finalize.sh` 의 close 보정. base ≠ default branch 라 GitHub auto-close 가 구조적으로 발동 불가한 케이스에서, *PR body 의 close 선언을 근거로* 스크립트가 기계 보정하는 것이다 — 선언 없는 issue 를 임의로 닫는 직접 close 가 아니므로 본 금지의 취지(close 근거를 PR body 선언으로 일원화)를 유지한다.
 
 ---
 

--- a/scripts/pr-finalize.sh
+++ b/scripts/pr-finalize.sh
@@ -6,6 +6,13 @@
 #   2. gh pr checks --watch (CI 결과 대기)
 #   3. auto-merge 완료 대기 (GitHub 백그라운드 lag)
 #   4. git fetch origin main (origin/main remote-tracking 만 갱신, refspec 없이)
+#   5. (통합 브랜치 sub-PR 만) PR body 의 close 선언 기반 issue close 보정
+#
+# 통합 브랜치 sub-PR (base ≠ default branch) 인지:
+#   - CI 체크 0개를 정상으로 처리 — 검증 워크플로는 default branch 대상 PR 만 발동.
+#   - GitHub auto-close 는 default branch 머지만 인식 → PR body 의 Closes/Fixes/Resolves
+#     선언을 근거로 머지 후 gh issue close 보정 (git-spec "통합 브랜치 케이스" 절).
+#     임의 직접 close 가 아니라 PR body 선언의 기계 보정이다.
 #
 # 사용:
 #   pr-finalize.sh                # current branch 의 open PR 자동 검출
@@ -77,6 +84,21 @@ if [ -z "$BRANCH" ]; then
   BRANCH=$(git rev-parse --abbrev-ref HEAD)
 fi
 
+# 통합 브랜치 sub-PR 판정 — base ≠ default branch
+DEFAULT_REF=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null || true)
+if [ -z "$DEFAULT_REF" ]; then
+  DEFAULT_REF=main
+fi
+BASE_REF=$(gh pr view "$PR" --json baseRefName -q .baseRefName 2>/dev/null || true)
+if [ -z "$BASE_REF" ]; then
+  BASE_REF="$DEFAULT_REF"
+fi
+INTEGRATION=false
+if [ "$BASE_REF" != "$DEFAULT_REF" ]; then
+  INTEGRATION=true
+  echo "[pr-finalize] base=$BASE_REF ≠ default=$DEFAULT_REF — 통합 브랜치 sub-PR 모드" >&2
+fi
+
 # working tree dirty check
 if [ -n "$(git status --porcelain)" ]; then
   echo "[pr-finalize] WARN: working tree dirty — fetch sync 영향은 없지만 다음 작업 시 충돌 위험" >&2
@@ -131,10 +153,23 @@ MERGE_ERR=$(gh pr merge "$PR" --auto --merge 2>&1 >/dev/null) || {
 }
 
 # Step 2: CI 결과 대기
+# 통합 브랜치 sub-PR 은 CI 체크 0개가 정상 (검증 워크플로는 default branch 대상 PR 만
+# 발동) — watch 가 "no checks reported" 로 실패하면 check-run 수를 재확인해 0개면 통과.
 echo "[pr-finalize] CI 결과 대기 (gh pr checks --watch)" >&2
 if ! gh pr checks "$PR" --watch >&2; then
-  echo "[pr-finalize] ERROR: CI FAIL — 머지 안 됨. sync skip" >&2
-  exit 1
+  CHECKS_OK=false
+  if [ "$INTEGRATION" = "true" ]; then
+    HEAD_OID=$(gh pr view "$PR" --json headRefOid -q .headRefOid 2>/dev/null || true)
+    CHECK_COUNT=$(gh api "repos/{owner}/{repo}/commits/${HEAD_OID}/check-runs" -q '.total_count' 2>/dev/null || true)
+    if [ "$CHECK_COUNT" = "0" ]; then
+      echo "[pr-finalize] 통합 브랜치 sub-PR 에 CI 체크 없음 — 정상, 계속 진행" >&2
+      CHECKS_OK=true
+    fi
+  fi
+  if [ "$CHECKS_OK" != "true" ]; then
+    echo "[pr-finalize] ERROR: CI FAIL — 머지 안 됨. sync skip" >&2
+    exit 1
+  fi
 fi
 
 # Step 3: auto-merge 완료 대기 (GitHub 백그라운드)
@@ -167,16 +202,42 @@ if [ -n "$MERGE_LOCK_TOKEN" ]; then
   MERGE_CLAIM_KEY=""
 fi
 
+# Step 5: 통합 브랜치 sub-PR issue close 보정
+# GitHub auto-close 는 base = default branch 인 PR 머지만 인식 — base ≠ default 인
+# sub-PR 의 PR body close 선언(Closes/Fixes/Resolves #N)은 머지돼도 발동하지 않는다.
+# 선언이 있는 OPEN issue 를 PR 링크 코멘트와 함께 close 보정한다 (선언 없는 issue 는
+# 건드리지 않음). epic→main 일괄 머지 PR 의 중복 Closes 는 이미 closed issue 에 무해.
+if [ "$INTEGRATION" = "true" ]; then
+  CLOSE_NUMS=$(gh pr view "$PR" --json body -q .body 2>/dev/null \
+    | grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+    | grep -oE '[0-9]+' | sort -un || true)
+  for N in $CLOSE_NUMS; do
+    ISSUE_STATE=$(gh issue view "$N" --json state -q .state 2>/dev/null || true)
+    if [ "$ISSUE_STATE" = "OPEN" ]; then
+      if gh issue close "$N" --comment "[pr-finalize] PR #${PR} 가 통합 브랜치 '${BASE_REF}' 에 머지됨 — base 가 default branch 가 아니어서 GitHub auto-close 미발동. PR body 의 close 선언을 근거로 보정 close. $PR_URL" >&2; then
+        echo "[pr-finalize] issue #$N close 보정 (통합 브랜치 — auto-close 미발동)" >&2
+      else
+        echo "[pr-finalize] WARN: issue #$N close 실패 — 수동 확인 필요: gh issue view $N" >&2
+      fi
+    fi
+  done
+fi
+
 if [ "${SKIP_SYNC:-}" = "true" ]; then
-  echo "[pr-finalize] origin/main 동기화 skip (working tree dirty)" >&2
+  echo "[pr-finalize] origin/$DEFAULT_REF 동기화 skip (working tree dirty)" >&2
   echo "[pr-finalize] PR #$PR merged · $PR_URL"
   exit 0
 fi
 
-echo "[pr-finalize] origin/main ref 동기화" >&2
-if ! git fetch origin main --quiet; then
-  echo "[pr-finalize] ERROR: git fetch origin main 실패 (네트워크 / 권한)" >&2
+echo "[pr-finalize] origin/$DEFAULT_REF ref 동기화" >&2
+if ! git fetch origin "$DEFAULT_REF" --quiet; then
+  echo "[pr-finalize] ERROR: git fetch origin $DEFAULT_REF 실패 (네트워크 / 권한)" >&2
   exit 1
+fi
+if [ "$INTEGRATION" = "true" ]; then
+  if ! git fetch origin "$BASE_REF" --quiet; then
+    echo "[pr-finalize] WARN: git fetch origin $BASE_REF 실패 — 다음 sub-PR branch 생성 전 수동 fetch 권장" >&2
+  fi
 fi
 
 echo "[pr-finalize] PR #$PR merged · $PR_URL"

--- a/scripts/pr-trailer.sh
+++ b/scripts/pr-trailer.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# dcness pr-trailer — impl task 파일 frontmatter 기반 PR body 트레일러 자동 생성
+#
+# 룰 SSOT = docs/plugin/git-spec.md 의 "PR 트레일러 (Part of / Closes)" 절.
+# 본 스크립트는 그 적용 절차(수동 bash recipe)의 한 명령 구현이다 — 메인이 PR body
+# 작성 직전 frontmatter 를 손으로 읽고 분기하던 수작업을 대체한다.
+#
+# 사용:
+#   scripts/pr-trailer.sh <impl-task-file>          # 트레일러 블록을 stdout 출력
+#   scripts/pr-trailer.sh --base <impl-task-file>   # PR base 브랜치만 stdout 출력
+#
+# stdout / stderr 분리:
+#   - stdout = 트레일러 블록(또는 --base 시 base 브랜치명)만 — PR body 에 그대로 붙임.
+#   - stderr = 판정 근거 / WARN / ERROR.
+#
+# 분기 (git-spec 기본 룰):
+#   - story: 공통           → Part of #<epic>            (task-index omit)
+#   - task_index i < total  → Part of #<story> + task-index
+#   - task_index i == total → Closes #<story> (+ epic 마지막 story 면 Closes #<epic>) + task-index
+#   - malformed (숫자 story 인데 i/total 형식 아님) → exit 1 (PR 생성 정지 — git-spec MUST 가드)
+#
+# 통합 브랜치: stories.md 상단 `**Base Branch:** feature/<slug>` 마커가 있으면
+# base = 그 값. base ≠ main 이면 Closes 는 머지 시 미발동(GitHub 은 default branch
+# 머지만 auto-close) — pr-finalize.sh 가 머지 후 close 보정한다.
+
+set -e
+
+MODE=trailer
+if [ "$1" = "--base" ]; then
+  MODE=base
+  shift
+fi
+
+TASK_FILE="$1"
+if [ -z "$TASK_FILE" ]; then
+  echo "[pr-trailer] ERROR: impl task 파일 경로 인자 필요 — 사용법: pr-trailer.sh [--base] <impl-task-file>" >&2
+  exit 2
+fi
+if [ ! -f "$TASK_FILE" ]; then
+  echo "[pr-trailer] ERROR: impl task 파일 부재: $TASK_FILE" >&2
+  exit 2
+fi
+
+# stories.md 위치 — epic 단위 (impl/ 의 상위 디렉토리), root docs/stories.md = legacy 폴백
+STORIES="$(dirname "$(dirname "$TASK_FILE")")/stories.md"
+if [ ! -f "$STORIES" ]; then
+  STORIES="docs/stories.md"
+fi
+if [ ! -f "$STORIES" ]; then
+  echo "[pr-trailer] ERROR: stories.md 미발견 — $(dirname "$(dirname "$TASK_FILE")")/stories.md 또는 docs/stories.md 필요" >&2
+  exit 1
+fi
+
+STORY_NUM=$(awk '/^story:/ {gsub(/[",]/,""); print $2; exit}' "$TASK_FILE")
+TASK_INDEX=$(awk '/^task_index:/ {gsub(/[",]/,""); print $2; exit}' "$TASK_FILE")
+
+# Base Branch 마커 (통합 브랜치 모드) — 매치 없으면 main (git-spec Git 절차 base 분기 룰)
+BASE=$(grep -m1 -E '^\*\*Base Branch:\*\*' "$STORIES" 2>/dev/null | sed -E 's/^\*\*Base Branch:\*\*[[:space:]]*//' | awk '{print $1}' || true)
+if [ -z "$BASE" ]; then
+  BASE=main
+fi
+
+if [ "$MODE" = "base" ]; then
+  echo "$BASE"
+  exit 0
+fi
+
+EPIC_ISSUE=$(grep -m1 -E '^\*\*GitHub Epic Issue:\*\*' "$STORIES" 2>/dev/null | grep -oE '#[0-9]+' | head -1 | tr -d '#' || true)
+
+# story 이슈 번호 — `### Story <N>` 섹션 안의 첫 `**GitHub Issue:**` 마커
+STORY_ISSUE=""
+if [ "$STORY_NUM" != "공통" ] && [ -n "$STORY_NUM" ]; then
+  STORY_ISSUE=$(awk -v n="$STORY_NUM" '
+    $0 ~ ("^### Story " n "([^0-9]|$)") {insec=1; next}
+    insec && /^### Story / {insec=0}
+    insec && /^\*\*GitHub Issue:\*\*/ {
+      if (match($0, /#[0-9]+/)) { print substr($0, RSTART+1, RLENGTH-1); exit }
+    }
+  ' "$STORIES")
+fi
+
+if [ "$STORY_NUM" = "공통" ]; then
+  # 공통 task — Part of #<epic>, task-index omit (git-spec 기본 룰)
+  if [ -z "$EPIC_ISSUE" ]; then
+    echo "[pr-trailer] ERROR: 공통 task 인데 $STORIES 에 '**GitHub Epic Issue:** #N' 마커 미해결 — 빈 'Part of #' 방지 위해 정지" >&2
+    exit 1
+  fi
+  TRAILER="Part of #${EPIC_ISSUE}"
+  echo "[pr-trailer] 공통 task → Part of #${EPIC_ISSUE} (task-index omit)" >&2
+elif printf '%s' "$TASK_INDEX" | grep -qE '^[0-9]+/[0-9]+$'; then
+  if [ -z "$STORY_ISSUE" ]; then
+    echo "[pr-trailer] ERROR: story $STORY_NUM 의 '**GitHub Issue:** #N' 마커를 $STORIES 에서 못 찾음 — 이슈 미등록이면 등록 후 재시도" >&2
+    exit 1
+  fi
+  I="${TASK_INDEX%/*}"
+  TOTAL="${TASK_INDEX#*/}"
+  if [ "$I" = "$TOTAL" ]; then
+    TRAILER="Closes #${STORY_ISSUE}"
+    echo "[pr-trailer] story $STORY_NUM 마지막 task (${TASK_INDEX}) → Closes #${STORY_ISSUE}" >&2
+    # epic 마지막 story 판정 — epic 라벨은 stories.md 디렉토리명(epic-NN-<slug>) 우선,
+    # 없으면 epic 이슈의 라벨에서 조회. OPEN story 가 본 story 뿐이면 epic 도 동봉.
+    EPIC_LABEL=$(basename "$(dirname "$STORIES")" | grep -E '^epic-[0-9]+-' || true)
+    if [ -z "$EPIC_LABEL" ] && [ -n "$EPIC_ISSUE" ]; then
+      EPIC_LABEL=$(gh issue view "$EPIC_ISSUE" --json labels -q '.labels[].name' 2>/dev/null | grep -E '^epic-[0-9]+-' | head -1 || true)
+    fi
+    if [ -n "$EPIC_LABEL" ] && [ -n "$EPIC_ISSUE" ]; then
+      OPEN=$(gh issue list --label "$EPIC_LABEL" --milestone Story --state open --json number --jq 'length' 2>/dev/null || true)
+      if [ "$OPEN" = "1" ]; then
+        TRAILER="${TRAILER}
+Closes #${EPIC_ISSUE}"
+        echo "[pr-trailer] epic 마지막 story — Closes #${EPIC_ISSUE} 동봉" >&2
+      elif [ -z "$OPEN" ]; then
+        echo "[pr-trailer] WARN: epic 마지막 story 판정 불가 (gh issue list 실패) — Closes #${EPIC_ISSUE} 미동봉. 수동 확인: gh issue list --label $EPIC_LABEL --milestone Story --state open" >&2
+      fi
+    elif [ -n "$EPIC_ISSUE" ]; then
+      echo "[pr-trailer] WARN: epic 라벨(epic-NN-<slug>) 미해결 — epic 마지막 story 판정 skip" >&2
+    fi
+  else
+    TRAILER="Part of #${STORY_ISSUE}"
+    echo "[pr-trailer] story $STORY_NUM 중간 task (${TASK_INDEX}) → Part of #${STORY_ISSUE}" >&2
+  fi
+  TRAILER="${TRAILER}
+task-index: ${TASK_INDEX}"
+else
+  echo "[pr-trailer] ERROR: story=$STORY_NUM 인데 task_index='$TASK_INDEX' 가 i/total 도 공통(—)도 아님 — malformed/누락 가드, PR 생성 정지 (git-spec PR 트레일러 MUST)" >&2
+  exit 1
+fi
+
+if [ "$BASE" != "main" ]; then
+  echo "[pr-trailer] base=$BASE (통합 브랜치) — GitHub auto-close 는 default branch 머지만 인식하므로 Closes 는 머지 시 미발동. pr-finalize.sh 가 머지 후 close 보정." >&2
+fi
+
+echo "$TRAILER"

--- a/tests/test_pr_finalize_integration.py
+++ b/tests/test_pr_finalize_integration.py
@@ -1,0 +1,70 @@
+"""pr-finalize 통합 브랜치 sub-PR 처리 테스트.
+
+base ≠ default branch 인 sub-PR 에서 (1) CI 체크 0개를 정상으로 처리하고
+(2) 머지 후 PR body 의 close 선언 기반 issue close 보정이 와이어링됐는지 확인한다.
+(기존 test_pr_finalize_peer_lock.py 와 같은 content-assertion 패턴.)
+"""
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "pr-finalize.sh"
+
+
+class PrFinalizeIntegrationBranchTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.script = SCRIPT_PATH.read_text(encoding="utf-8")
+
+    def test_script_syntax_valid(self) -> None:
+        result = subprocess.run(
+            ["bash", "-n", str(SCRIPT_PATH)], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_detects_integration_base_via_default_branch_ref(self) -> None:
+        self.assertIn("defaultBranchRef", self.script)
+        self.assertIn("baseRefName", self.script)
+        self.assertIn("INTEGRATION=true", self.script)
+
+    def test_zero_checks_pass_only_in_integration_mode(self) -> None:
+        # check-run 0개 재확인은 통합 브랜치 모드 분기 안에서만 일어난다.
+        self.assertIn("check-runs", self.script)
+        self.assertIn('CHECK_COUNT" = "0"', self.script)
+        idx_integration_guard = self.script.index('[ "$INTEGRATION" = "true" ]')
+        idx_check_runs = self.script.index("check-runs")
+        self.assertLess(idx_integration_guard, idx_check_runs)
+
+    def test_close_compensation_uses_pr_body_declarations(self) -> None:
+        # close 보정은 PR body 의 Closes/Fixes/Resolves 선언만 근거로 한다 —
+        # Part of 는 매치되지 않아야 한다 (선언 없는 issue 임의 close 금지).
+        self.assertIn("gh issue close", self.script)
+        self.assertIn("close[sd]?", self.script)
+        self.assertIn("resolve[sd]?", self.script)
+        self.assertNotIn("Part of", self.script.split("gh issue close")[0].split("CLOSE_NUMS=")[-1])
+
+    def test_close_keyword_extraction_ignores_part_of(self) -> None:
+        body = "Closes #219\ntask-index: 3/3\nPart of #220\nFixes #11\n"
+        pipeline = (
+            "grep -ioE '(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+'"
+            " | grep -oE '[0-9]+' | sort -un"
+        )
+        result = subprocess.run(
+            ["bash", "-c", f"printf '%s' \"$1\" | {pipeline}", "_", body],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.stdout.split(), ["11", "219"])
+
+    def test_close_only_when_issue_open(self) -> None:
+        self.assertIn('ISSUE_STATE" = "OPEN"', self.script)
+
+    def test_fetches_integration_base_after_merge(self) -> None:
+        self.assertIn('git fetch origin "$BASE_REF"', self.script)
+        self.assertIn('git fetch origin "$DEFAULT_REF"', self.script)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_trailer.py
+++ b/tests/test_pr_trailer.py
@@ -1,0 +1,159 @@
+"""pr-trailer.sh 행동 테스트 — impl frontmatter 기반 PR 트레일러 자동 생성.
+
+git-spec "PR 트레일러 (Part of / Closes)" 적용 절차의 한 명령 구현이 분기표대로
+동작하는지 fixture 저장소 + 가짜 gh 스텁으로 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "pr-trailer.sh"
+
+STORIES_BODY = """# Story Backlog
+
+## Epic — demo epic
+
+**GitHub Epic Issue:** [#10](https://github.com/x/y/issues/10)
+
+### Story 1 — first story
+
+**GitHub Issue:** [#11](https://github.com/x/y/issues/11)
+
+### Story 2 — second story
+
+**GitHub Issue:** [#12](https://github.com/x/y/issues/12)
+"""
+
+
+def _write_fake_gh(bin_dir: Path, open_story_count: str) -> None:
+    """gh 스텁 — `gh issue list ... --jq length` 호출에 open story 수를 돌려준다."""
+    gh = bin_dir / "gh"
+    gh.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = "issue" ] && [ "$2" = "list" ]; then\n'
+        f"  echo {open_story_count}\n"
+        "  exit 0\n"
+        "fi\n"
+        'if [ "$1" = "issue" ] && [ "$2" = "view" ]; then\n'
+        "  echo epic-07-demo\n"
+        "  exit 0\n"
+        "fi\n"
+        "exit 1\n",
+        encoding="utf-8",
+    )
+    gh.chmod(gh.stat().st_mode | stat.S_IEXEC)
+
+
+class PrTrailerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.root = Path(self._td.name)
+        self.epic_dir = self.root / "docs/milestones/v01/epics/epic-07-demo"
+        (self.epic_dir / "impl").mkdir(parents=True)
+        (self.epic_dir / "stories.md").write_text(STORIES_BODY, encoding="utf-8")
+        self.bin_dir = self.root / "bin"
+        self.bin_dir.mkdir()
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _task(self, name: str, story: str, task_index: str) -> Path:
+        p = self.epic_dir / "impl" / name
+        p.write_text(
+            f"---\nstory: {story}\ntask_index: {task_index}\ndepends_on: []\n---\n# task\n",
+            encoding="utf-8",
+        )
+        return p
+
+    def _run(self, *args: str, open_story_count: str = "2") -> subprocess.CompletedProcess:
+        _write_fake_gh(self.bin_dir, open_story_count)
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin_dir}:{env['PATH']}"
+        return subprocess.run(
+            ["bash", str(SCRIPT), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=self.root,
+        )
+
+    def test_middle_task_part_of_story(self) -> None:
+        task = self._task("01-first.md", "1", "1/2")
+        result = self._run(str(task))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "Part of #11\ntask-index: 1/2")
+
+    def test_last_task_closes_story_only_when_epic_has_open_stories(self) -> None:
+        task = self._task("02-last.md", "1", "2/2")
+        result = self._run(str(task), open_story_count="2")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "Closes #11\ntask-index: 2/2")
+
+    def test_last_task_of_last_story_closes_epic_too(self) -> None:
+        task = self._task("02-last.md", "2", "2/2")
+        result = self._run(str(task), open_story_count="1")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.strip(), "Closes #12\nCloses #10\ntask-index: 2/2"
+        )
+
+    def test_common_task_part_of_epic_without_task_index(self) -> None:
+        task = self._task("00-common.md", "공통", "—")
+        result = self._run(str(task))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "Part of #10")
+        self.assertNotIn("task-index", result.stdout)
+
+    def test_malformed_task_index_blocks(self) -> None:
+        task = self._task("03-bad.md", "1", "—")
+        result = self._run(str(task))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("malformed", result.stderr)
+
+    def test_missing_story_issue_marker_blocks(self) -> None:
+        (self.epic_dir / "stories.md").write_text(
+            "# Story Backlog\n\n**GitHub Epic Issue:** [#10](u)\n\n### Story 1 — x\n\n본문만\n",
+            encoding="utf-8",
+        )
+        task = self._task("01-first.md", "1", "1/2")
+        result = self._run(str(task))
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("GitHub Issue", result.stderr)
+
+    def test_base_mode_reads_integration_branch_marker(self) -> None:
+        (self.epic_dir / "stories.md").write_text(
+            "**Base Branch:** feature/shorts-template\n\n" + STORIES_BODY,
+            encoding="utf-8",
+        )
+        task = self._task("01-first.md", "1", "1/2")
+        result = self._run("--base", str(task))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "feature/shorts-template")
+
+    def test_base_mode_defaults_to_main(self) -> None:
+        task = self._task("01-first.md", "1", "1/2")
+        result = self._run("--base", str(task))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "main")
+
+    def test_integration_base_warns_autoclose_not_firing(self) -> None:
+        (self.epic_dir / "stories.md").write_text(
+            "**Base Branch:** feature/shorts-template\n\n" + STORIES_BODY,
+            encoding="utf-8",
+        )
+        task = self._task("01-first.md", "1", "1/2")
+        result = self._run(str(task))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "Part of #11\ntask-index: 1/2")
+        self.assertIn("통합 브랜치", result.stderr)
+        self.assertIn("pr-finalize", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 하네스 분석 후속 자동화 2건 — 별도 이슈 없는 도구 추가

## 배경 및 문제

하네스 분석(2026-06-12)에서 확인된 메인 수작업 마찰 중 코드로 닫을 수 있는 2건:

1. **PR 트레일러 수작업**: PR body 의 Part of/Closes + task-index 를 메인이 매번 impl 파일 frontmatter 를 열어 읽고 git-spec 의 30줄 bash recipe 를 손으로 따라 작성 — 오기재 실수 1순위.
2. **통합 브랜치 sub-PR 수작업**: base ≠ main 인 sub-PR 은 (a) CI 체크가 없어 pr-finalize 의 checks --watch 가 실패하고, (b) GitHub auto-close 가 default branch 머지만 인식해 Closes 선언이 미발동 — 매번 "머지해 주세요 / 수동 CLOSE 필요합니다" 안내가 나가고 이슈가 silent open 으로 남음 (외부 활성 프로젝트 실사용에서 반복 발생).

## 원인 (해당 시)

-

## 작업내용

- commit 1 `[feature] pr-trailer 스크립트`: `scripts/pr-trailer.sh` 신규 — impl frontmatter(story/task_index) + stories.md 마커(epic/story 이슈, Base Branch)로 트레일러 블록 자동 생성. 공통 task / epic 마지막 story 판정 / malformed 정지 가드 포함. `--base` 모드로 PR base 도 출력. 행동 테스트 9개.
- commit 2 `[feature] pr-finalize 통합 브랜치 인지`: base ≠ default branch 자동 감지 → CI 체크 0개 정상 처리(check-run 수 재확인) + 머지 후 PR body 의 Closes/Fixes/Resolves 선언 기반 OPEN issue close 보정(PR 링크 코멘트 동반) + origin/<base> fetch. 테스트 7개.
- commit 3 `[docs] git-spec 반영`: 적용 절차에 스크립트 명시, 통합 브랜치 케이스에 close 보정 명문화, API 직접 close 절대금지 절에 유일 예외 추가.

## 결정 근거

- close 보정을 "PR body 선언 근거"로 한정 — `Part of` 는 비대상, 선언 없는 issue 를 임의로 닫지 않음. git-spec 절대금지(close 근거의 PR body 일원화) 취지 유지가 목적이고, base ≠ default 라 auto-close 가 구조적으로 발동 불가한 케이스의 기계 보정만 허용.
- 트레일러 생성을 pr-create.sh 통합이 아니라 독립 스크립트로 — Lite 경로 등 pr-create 를 안 쓰는 흐름에서도 사용 가능, 기존 스크립트 무변경.
- CI 부재 통과는 통합 브랜치 모드에서만 + check-run 수 0 재확인 후 — default branch PR 의 CI FAIL 처리(기존 동작)는 그대로.

## 배포 경로 검증 (plug-in 영향 시)

- `scripts/pr-trailer.sh` 신규 / `scripts/pr-finalize.sh` 수정 — 경로 1 (plug-in 본체, $PLUGIN_ROOT/scripts/ 로 호출). init-dcness 복사 파일 아님(경로 2 해당 없음).
- `docs/plugin/git-spec.md` — 경로 1 (plug-in 동봉 SSOT). 외부 활성 프로젝트는 plug-in 업데이트로 자동 수신.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public skill/command/agent/gate 아님 (메인이 호출하는 보조 스크립트).

## Test Plan

- [x] tests/test_pr_trailer.py 9건 + tests/test_pr_finalize_integration.py 7건 + 기존 test_pr_finalize_peer_lock 회귀 — 전부 PASS
- [x] bash -n 문법 검증 2종
- [x] node scripts/check_cross_refs.mjs PASS
- [x] pytest 게이트 (pre-commit 자동) PASS

## 참고

- 분석 리포트 개선 제안 ②번 + 사용자 보고 통합 브랜치 수작업 사례 기반

🤖 Generated with [Claude Code](https://claude.com/claude-code)