### PR TITLE
[feature] 상태 위생 청소 — run 디렉토리 7d TTL + SessionStart 와이어링

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -57,6 +57,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 **역할**:
 
 - sid 추출, `.by-pid/<cc_pid>` 작성, `live.json` 초기화
+- 상태 위생 청소 (세션당 1회, fail-open): stale by-pid 파일(24h) + 본 세션의 만료 run 슬롯(24h) + 전 세션의 run 디렉토리(prose/ledger, 7d — `/run-review` 원자료라 슬롯보다 길게 보관). TTL 상수 SSOT = `harness/session_state.py`
 - `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
 - 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
 - 설치된 plug-in 버전과 `main` 의 최신 버전을 비교(하루 1회 캐시)해 더 높은 버전이 있을 때만 `claude plugin update` 알림을 함께 inject — 외부 활성 프로젝트가 옛 plug-in 버전 운영 룰에 묶이는 drift 회피

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -33,6 +33,9 @@ from typing import Any, Dict, Optional
 from harness.agent_names import normalize_agent_type
 from harness.session_state import (
     _read_steps_jsonl,
+    cleanup_stale_pid_files,
+    cleanup_stale_run_dirs,
+    cleanup_stale_runs,
     read_live,
     read_pid_current_run,
     run_dir,
@@ -343,6 +346,8 @@ def handle_session_start(
     2. regex 검증
     3. `.by-pid/{cc_pid}` ← sid 작성
     4. `.sessions/{sid}/live.json` 초기화 (없으면)
+    5. 상태 위생 청소 — stale by-pid 파일(24h) + 본 세션 run 슬롯(24h)
+       + 전 세션 run 디렉토리(7d). 실패해도 세션 시작을 막지 않는다.
 
     실패 시 silent (exit 0).
     """
@@ -369,6 +374,21 @@ def handle_session_start(
             update_live(sid, base_dir=base_dir)
     except (OSError, ValueError):
         return 0
+
+    # 상태 위생 청소 — 세션 시작마다 1회. TTL 상수는 session_state 가 SSOT.
+    # 청소 실패가 세션 시작을 막으면 안 되므로 fail-open.
+    try:
+        removed_pids = cleanup_stale_pid_files(base_dir=base_dir)
+        removed_slots = cleanup_stale_runs(sid, base_dir=base_dir)
+        removed_dirs = cleanup_stale_run_dirs(base_dir=base_dir)
+        if removed_pids or removed_slots or removed_dirs:
+            print(
+                f"[session-start] 상태 청소 — by-pid {removed_pids}건, "
+                f"run 슬롯 {removed_slots}건, run 디렉토리 {removed_dirs}건 제거",
+                file=sys.stderr,
+            )
+    except Exception:
+        pass
     return 0
 
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -32,6 +32,7 @@ import os
 import re
 import secrets
 import select
+import shutil
 import subprocess
 import sys
 import uuid
@@ -43,6 +44,7 @@ __all__ = [
     "SESSION_ID_RE",
     "DEFAULT_RUN_TTL_SEC",
     "DEFAULT_PID_TTL_SEC",
+    "DEFAULT_RUN_DIR_TTL_SEC",
     "LIVE_JSON_VERSION",
     "STDIN_TIMEOUT_SEC",
     "valid_cc_pid",
@@ -76,6 +78,7 @@ __all__ = [
     "clear_pending_agent",
     "complete_run",
     "cleanup_stale_runs",
+    "cleanup_stale_run_dirs",
     "is_project_active",
     "enable_project",
     "disable_project",
@@ -89,6 +92,7 @@ RUN_ID_RE = re.compile(r"^run-[a-z0-9]{8}$")
 
 DEFAULT_RUN_TTL_SEC = 24 * 60 * 60        # 24h — completed slot 보관 후 cleanup
 DEFAULT_PID_TTL_SEC = 24 * 60 * 60        # 24h — by-pid 파일 stale 기준 (PID 재사용 보호)
+DEFAULT_RUN_DIR_TTL_SEC = 7 * 24 * 60 * 60  # 7d — run 디렉토리(prose/ledger) 보관. /run-review 원자료라 슬롯(24h)보다 길게
 STALE_STEP_TTL_SEC = 30 * 60              # 30min — current_step heartbeat stale 기준 (DCN-30-30)
 LIVE_JSON_VERSION = 1                      # 스키마 진화 추적
 STDIN_TIMEOUT_SEC = 2.0                    # 훅 stdin 읽기 hang 방지
@@ -900,6 +904,59 @@ def cleanup_stale_runs(
 
     if removed:
         update_live(session_id, base_dir=base_dir, active_runs=survivors)
+    return removed
+
+
+def cleanup_stale_run_dirs(
+    *,
+    ttl_sec: int = DEFAULT_RUN_DIR_TTL_SEC,
+    base_dir: Optional[Path] = None,
+) -> int:
+    """오래된 run 디렉토리(prose/ledger) 삭제 — 모든 세션 공통.
+
+    `.sessions/*/runs/<rid>/` 중 디렉토리·직계 파일의 최신 mtime 이 ttl_sec
+    (기본 7일)을 초과한 run 디렉토리를 통째로 제거한다.
+
+    run 슬롯(24h)·by-pid(24h)와 달리 prose 는 `/run-review` 사후 분석의
+    원자료라 더 길게 보관한다. heartbeat TTL(24h)의 7배 여유 + 최신 mtime
+    기준이라 7일 안에 쓰기가 한 번이라도 있던 run 은 보존된다 — 살아있는
+    run 을 지울 일은 없다.
+
+    Returns: 삭제된 run 디렉토리 수. 개별 실패는 건너뛴다 (best-effort).
+    """
+    base = _resolve_base(base_dir)
+    sessions = base / ".sessions"
+    if not sessions.exists():
+        return 0
+    now = datetime.now(timezone.utc).timestamp()
+    removed = 0
+    try:
+        session_dirs = list(sessions.iterdir())
+    except OSError:
+        return 0
+    for sdir in session_dirs:
+        runs = sdir / "runs"
+        if not runs.is_dir():
+            continue
+        try:
+            run_dirs = list(runs.iterdir())
+        except OSError:
+            continue
+        for rdir in run_dirs:
+            if not rdir.is_dir():
+                continue
+            try:
+                newest = rdir.stat().st_mtime
+                for child in rdir.iterdir():
+                    newest = max(newest, child.stat().st_mtime)
+            except OSError:
+                continue
+            if now - newest > ttl_sec:
+                try:
+                    shutil.rmtree(rdir)
+                    removed += 1
+                except OSError:
+                    pass
     return removed
 
 

--- a/tests/test_state_cleanup.py
+++ b/tests/test_state_cleanup.py
@@ -1,0 +1,149 @@
+"""상태 위생 청소 테스트 — run 디렉토리 7d TTL + SessionStart 와이어링.
+
+cleanup_stale_pid_files / cleanup_stale_runs 는 정의만 있고 호출처가 없었고,
+run 디렉토리(prose/ledger)는 삭제 로직 자체가 없어 무한 누적이었다.
+본 테스트는 (1) 신규 cleanup_stale_run_dirs 의 mtime 기준 판정과
+(2) handle_session_start 가 청소 3종을 fail-open 으로 수행하는지 검증한다.
+"""
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from harness.hooks import handle_session_start
+from harness.session_state import (
+    DEFAULT_RUN_DIR_TTL_SEC,
+    cleanup_stale_run_dirs,
+    read_live,
+    start_run,
+    update_live,
+)
+
+SID = "11111111-2222-4333-8444-555555555555"
+
+
+def _set_old_mtime(path: Path, age_sec: float) -> None:
+    old = time.time() - age_sec
+    os.utime(path, (old, old))
+
+
+class CleanupStaleRunDirsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.base = Path(self._td.name) / ".claude" / "harness-state"
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _make_run_dir(self, sid: str, rid: str) -> Path:
+        rdir = self.base / ".sessions" / sid / "runs" / rid
+        rdir.mkdir(parents=True)
+        (rdir / "engineer.md").write_text("prose\n", encoding="utf-8")
+        return rdir
+
+    def _age_run_dir(self, rdir: Path, age_sec: float) -> None:
+        for child in rdir.iterdir():
+            _set_old_mtime(child, age_sec)
+        _set_old_mtime(rdir, age_sec)
+
+    def test_removes_only_expired_run_dirs(self) -> None:
+        old = self._make_run_dir(SID, "run-aaaaaaaa")
+        recent = self._make_run_dir(SID, "run-bbbbbbbb")
+        self._age_run_dir(old, DEFAULT_RUN_DIR_TTL_SEC + 3600)
+
+        removed = cleanup_stale_run_dirs(base_dir=self.base)
+
+        self.assertEqual(removed, 1)
+        self.assertFalse(old.exists())
+        self.assertTrue(recent.exists())
+
+    def test_recent_child_write_preserves_old_dir(self) -> None:
+        # 디렉토리 mtime 은 오래됐어도 직계 파일에 7일 내 쓰기가 있으면 보존.
+        rdir = self._make_run_dir(SID, "run-cccccccc")
+        self._age_run_dir(rdir, DEFAULT_RUN_DIR_TTL_SEC + 3600)
+        (rdir / "pr-reviewer.md").write_text("late prose\n", encoding="utf-8")
+
+        removed = cleanup_stale_run_dirs(base_dir=self.base)
+
+        self.assertEqual(removed, 0)
+        self.assertTrue(rdir.exists())
+
+    def test_spans_all_sessions(self) -> None:
+        other_sid = "99999999-8888-4777-8666-555555555555"
+        old_a = self._make_run_dir(SID, "run-dddddddd")
+        old_b = self._make_run_dir(other_sid, "run-eeeeeeee")
+        self._age_run_dir(old_a, DEFAULT_RUN_DIR_TTL_SEC + 3600)
+        self._age_run_dir(old_b, DEFAULT_RUN_DIR_TTL_SEC + 3600)
+
+        removed = cleanup_stale_run_dirs(base_dir=self.base)
+
+        self.assertEqual(removed, 2)
+
+    def test_missing_sessions_dir_returns_zero(self) -> None:
+        self.assertEqual(cleanup_stale_run_dirs(base_dir=self.base), 0)
+
+
+class SessionStartCleanupWiringTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._td = tempfile.TemporaryDirectory()
+        self.base = Path(self._td.name) / ".claude" / "harness-state"
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def _start(self) -> int:
+        return handle_session_start(
+            {"session_id": SID}, cc_pid=12345, base_dir=self.base
+        )
+
+    def test_session_start_removes_stale_pid_and_run_dir(self) -> None:
+        stale_pid = self.base / ".by-pid" / "777"
+        stale_pid.parent.mkdir(parents=True)
+        stale_pid.write_text(SID, encoding="utf-8")
+        _set_old_mtime(stale_pid, 25 * 3600)
+
+        stale_run = self.base / ".sessions" / SID / "runs" / "run-ffffffff"
+        stale_run.mkdir(parents=True)
+        (stale_run / "engineer.md").write_text("old\n", encoding="utf-8")
+        for p in (stale_run / "engineer.md", stale_run):
+            _set_old_mtime(p, DEFAULT_RUN_DIR_TTL_SEC + 3600)
+
+        rc = self._start()
+
+        self.assertEqual(rc, 0)
+        self.assertFalse(stale_pid.exists())
+        self.assertFalse(stale_run.exists())
+        # 본 세션의 by-pid 파일(방금 작성)은 살아 있어야 한다.
+        self.assertTrue((self.base / ".by-pid" / "12345").exists())
+
+    def test_session_start_removes_expired_tombstone_slot(self) -> None:
+        update_live(SID, base_dir=self.base)
+        start_run(SID, "run-abcd1234", entry_point="impl", base_dir=self.base)
+        live = read_live(SID, base_dir=self.base)
+        slot = live["active_runs"]["run-abcd1234"]
+        slot["completed_at"] = "2020-01-01T00:00:00+00:00"
+        slot["last_confirmed_at"] = "2020-01-01T00:00:00+00:00"
+        update_live(SID, base_dir=self.base, active_runs=live["active_runs"])
+
+        rc = self._start()
+
+        self.assertEqual(rc, 0)
+        live_after = read_live(SID, base_dir=self.base)
+        self.assertNotIn("run-abcd1234", live_after.get("active_runs", {}))
+
+    def test_cleanup_failure_does_not_block_session_start(self) -> None:
+        with mock.patch(
+            "harness.hooks.cleanup_stale_run_dirs",
+            side_effect=RuntimeError("simulated cleanup bug"),
+        ):
+            rc = self._start()
+        self.assertEqual(rc, 0)
+        self.assertTrue((self.base / ".by-pid" / "12345").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 하네스 분석 후속 — 별도 이슈 없는 내부 위생 작업

## 배경 및 문제

하네스 분석(2026-06-12)에서 확인: `cleanup_stale_pid_files()`(24h TTL)와 `cleanup_stale_runs()`(24h TTL)가 **정의·export 만 있고 production 호출처가 0곳**이라 TTL 이 실제로 작동한 적이 없고, run 디렉토리(에이전트 prose/ledger)는 **삭제 로직 자체가 없어**(`rmtree` 0건) 무한 누적이었다. 헤비 사용 외부 프로젝트에서 stale by-pid 파일의 PID 재사용 오참조 위험 + 세션 스캔 잡음 + 디스크 누적.

## 원인 (해당 시)

cleanup 함수 구현 시점에 호출 지점(어느 hook 이 언제 부를지)이 정의되지 않은 채 머지됨 — 함수만 남고 와이어링 누락.

## 작업내용

- `cleanup_stale_run_dirs()` 신규: `.sessions/*/runs/<rid>/` 중 디렉토리·직계 파일의 최신 mtime 이 **7일**(`DEFAULT_RUN_DIR_TTL_SEC`) 초과면 제거. prose 는 /run-review 사후 분석 원자료라 슬롯(24h)보다 길게 보관 (보관 정책 = 사용자 B안 승인)
- `handle_session_start` 에 청소 3종 연결: stale by-pid(24h) + 본 세션 만료 run 슬롯(24h) + 전 세션 run 디렉토리(7d). 세션당 1회, **fail-open** — 청소 실패가 세션 시작을 막지 않음
- docs/plugin/hooks.md session-start 역할에 청소 단계 명문화
- tests/test_state_cleanup.py 7건

## 결정 근거

- 호출 시점 = SessionStart: 세션당 1회라 비용 무시 가능, hook 시스템의 기존 fail-open 원칙과 정합. 별도 cron/CLI 진입점을 만들지 않음 (신규 surface 없음)
- 살아있는 run 보호: 최신 mtime 기준 + heartbeat TTL(24h)의 7배 여유 — 7일 내 쓰기가 한 번이라도 있으면 보존
- 모델에게 거는 룰이 아니라 하네스 내부 위생 코드 — 강제 원칙(순서/접근 2종) 무변경

## 배포 경로 검증 (plug-in 영향 시)

- `harness/session_state.py`, `harness/hooks.py`, `docs/plugin/hooks.md` — 경로 1 (plug-in 본체, 업데이트 시 자동 적용). init-dcness 복사 파일(경로 2)·사용자 SSOT(경로 3) 해당 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public 진입점·gate 추가 없음 (기존 SessionStart hook 내부 단계).

## Test Plan

- [x] python3.11 -m unittest discover -s tests — 1,183 tests OK (전체 회귀 없음)
- [x] tests/test_state_cleanup.py: 만료/비만료 경계, 최신 child 쓰기 보존, 전 세션 스캔, tombstone 슬롯 제거, fail-open
- [x] node scripts/check_cross_refs.mjs PASS

## 참고

- 분석 리포트 개선 제안 ⑥ — 보관 정책 B안(prose 7일 / 나머지 24h) 사용자 승인 (2026-06-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)