### PR TITLE
[feature] release 브랜치 동기화에서 evals/ 제외

### DIFF
--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -12,6 +12,7 @@ EXCLUDE_PATHS=(
     "docs/internal"
     "docs/archive"
     "tests"
+    "evals"
     "PROGRESS.md"
     "CLAUDE.md"
     "scripts/sync_release.sh"


### PR DESCRIPTION
## 관련 이슈 번호

-

## 배경 및 문제

v0.7.0 릴리즈 후 확인 결과, `sync_release.sh` 가 `docs/internal`·`docs/archive`·`tests` 만 제외하고 `evals/`(행동 eval 하네스)는 release 브랜치에 그대로 포함시켜 외부 배포물에 실렸다. `evals/README.md` 는 "dcness 자체 QA 도구 — 외부 활성 프로젝트 배포 대상 아님" 이라 명시하므로 어긋난다.

## 원인 (해당 시)

`evals/` 가 #750 에서 신규 추가됐는데 `sync_release.sh` 의 `EXCLUDE_PATHS` 에 등록되지 않았다.

## 작업내용

- `scripts/sync_release.sh` `EXCLUDE_PATHS` 에 `evals` 추가 (`tests` 와 동일 성격의 dcness self QA 도구).

## 결정 근거

기능 무해(자동 실행 안 됨)하지만 (1) 배포물 청결성 — youTubeGenerator fixture 등 self QA 자산이 사용자 환경에 실릴 이유 없음, (2) `evals/README.md` 의 배포 비대상 선언과의 정합. 다음 main push 시 `release-sync` 워크플로가 `sync_release.sh --yes` 를 자동 실행해 release 브랜치에서 `evals/` 를 제거한다.

## 배포 경로 검증 (plug-in 영향 시)

- `scripts/sync_release.sh` 는 dcness self 전용 빌드 스크립트(자체적으로 release 브랜치에서 제외됨) — 외부 활성 프로젝트로 배포되지 않는다.
- 효과: 다음 릴리즈 동기화부터 release 브랜치(= 사용자 배포물)에서 `evals/` 가 빠진다. plug-in 본체(`agents/**`/`skills/**`) 영향 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. 빌드 제외 목록 1줄 추가.

## Test Plan

- [x] `bash -n scripts/sync_release.sh`
- [x] `python3.11 -m unittest discover -s tests` (1188 tests OK)
- [x] git pre-commit hook (pytest-gate + git-naming) PASS

Document-Exception-PR-Close: infra-only follow-up — issue 없음, v0.7.0 후속 배포물 정리(release 빌드 제외 목록). close 대상 이슈 없음.
