### PR TITLE
[docs] release 0.7.1 — 검증 보고 가이드 + evals 배포 제외

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — Claude Code 가 테스트/리뷰/파일 경계를 건너뛰기 전에 막는 PR workflow guard. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Claude Code PR workflow guard that stops skipped tests, skipped reviews, and out-of-bound agent writes before PRs.",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -4,6 +4,31 @@
 
 ---
 
+## v0.7.1 (2026-06-14)
+
+**커밋 범위**: `v0.7.0..v0.7.1` (머지 PR 2개)
+**핵심 변경**: 검증/리뷰 계열 agent 의 보고 가이드 보강 + 배포물 정리. 기능 추가 없는 patch.
+
+### 무엇이 바뀌나
+
+1. **검증 보고 가이드 보강** ([#759](https://github.com/alruminum/dcNess/pull/759) [#758](https://github.com/alruminum/dcNess/issues/758)) — `agents/_shared/validation-reporting-guidance.md` 추가. code-validator / architecture-validator / pr-reviewer(Claude) + Codex read-only validator skill 3종이 FAIL/ESCALATE 판단 근거와 재검증 delta 를 run-local prose 로 남기도록 가이드. 새 handoff 산출물·JSON·marker 없이 기존 자유서술 흐름 유지.
+
+2. **배포물에서 `evals/` 제외** ([#760](https://github.com/alruminum/dcNess/pull/760)) — `sync_release.sh` 제외 목록에 `evals` 추가. 행동 eval 하네스는 dcness 자체 QA 도구라 release 브랜치(사용자 배포물)에서 빠진다. plug-in 본체 영향 없음.
+
+### 사용자 영향
+
+- **`claude plugin update dcness@dcness` 로 자동 반영** — validator/reviewer 보고 가이드(`agents/**`).
+- **Codex opt-in 프로젝트**는 `codex/skills/dcness-{code-validator,architecture-validator,pr-reviewer}` 갱신을 받으려면 plugin update 후 `/init-dcness` 재실행 필요.
+- 배포물에서 `evals/` 가 빠져 설치물이 가벼워진다(기능 영향 없음).
+
+### 업데이트
+
+```sh
+claude plugin update dcness@dcness
+```
+
+---
+
 ## v0.7.0 (2026-06-13)
 
 **커밋 범위**: `v0.6.6..v0.7.0` (머지 PR 13개)


### PR DESCRIPTION
## 관련 이슈 번호

Part of #758

## 배경 및 문제

v0.7.0 이후 머지된 2개 PR(검증 보고 가이드 보강 #759, evals 배포 제외 #760)을 외부 배포하기 위한 patch 릴리즈.

## 작업내용

- `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` version 0.7.0 → 0.7.1
- `docs/internal/release-notes.md` v0.7.1 항목 추가 (머지 PR 2개 요약 + 사용자 영향)

## 결정 근거

기존 validator/reviewer agent 가이드 보강 + 빌드 정리라 새 user-facing surface 없음 → patch 올림(0.7.1). 두 버전 파일 동시 갱신으로 plugin-manifest 게이트 정합.

## 배포 경로 검증 (plug-in 영향 시)

- 버전 갱신으로 `claude plugin update dcness@dcness` 가 #759 의 `agents/**` 가이드를 사용자에게 전달.
- Codex opt-in 프로젝트는 `codex/skills/**` 갱신 위해 update 후 `/init-dcness` 재실행 필요(릴리즈 노트 명시).
- #760 효과로 release 브랜치에서 `evals/` 가 빠진 상태가 본 릴리즈에 반영된다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 버전 릴리즈. 새 public surface 없음.

## Test Plan

- [x] `node scripts/check_plugin_manifest.mjs` (dcness@0.7.1 PASS)
- [x] `node scripts/check_cross_refs.mjs` PASS