### PR TITLE
[feature] dcness-helper status 진단표 확장 (설치 상태 한눈 검증)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ claude plugin install dcness@dcness
 /init-dcness        # 현 프로젝트를 활성 whitelist 에 등록 (+ Read 권한 / git hook 자동 셋업)
 ```
 
-**활성화 성공 기준** — 아래처럼 `active: YES` 가 출력되면 정상이다.
+**활성화 성공 기준** — `/init-dcness` 가 출력하는 진단표에서 `whitelist 활성` 이 PASS 이고 FAIL 항목이 0 이면 정상이다 (INFO·선택 WARN 은 정상).
 
 ```
-[dcness] active: YES
+[dcness] === 외부 활성 프로젝트 진단 ===
+  [PASS] whitelist 활성: 활성
+  ...
+[dcness] 요약: N PASS / 0 WARN / 0 FAIL
 ```
 
 > plugin 갱신: `claude plugin update dcness@dcness`

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -47,13 +47,21 @@ HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
 
 ## 절차
 
-### Step 1 - 현재 상태 확인
+### Step 1 - 상태 진단
 
 ```bash
 "$HELPER" status
 ```
 
-이미 활성(`active: YES`)이면 Step 2 는 skip 하고 나머지 bootstrap 갱신 여부만 확인한다.
+`status` 는 현재 설치 상태를 PASS / WARN / FAIL / INFO / NA 진단표로 출력한다. 각 FAIL 항목은 해결 명령을 함께 보여주므로, 별도 doctor 명령 없이 셋업과 점검을 겸한다. self repo(dcNess 본체)에서는 외부 활성 항목이 `NA` 로 표기되어 self 작업 규칙과 섞이지 않는다.
+
+진단표 기준 분기:
+
+- `whitelist 활성` 이 PASS 면 Step 2 skip. FAIL 이면 Step 2.
+- `Read 권한` FAIL → Step 3.
+- `git hook shim 3종` FAIL → Step 4.
+- `선택형 CI workflow` (INFO) → 필요 시 Step 5 / Step 8.
+- 전부 PASS 면 나머지 bootstrap 갱신 여부만 확인하고 마친다.
 
 ### Step 2 - 활성화
 
@@ -389,6 +397,9 @@ support:
 
 비활성화:
 - "$HELPER" disable
+
+마지막 점검 (권장):
+- "$HELPER" status 를 재실행해 진단표가 전부 PASS 인지 확인한다.
 
 Claude Code 세션 재시작 권장:
 - SessionStart 훅은 현재 세션에는 소급 적용되지 않는다.

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -61,7 +61,7 @@ HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
 - `Read 권한` FAIL → Step 3.
 - `git hook shim 3종` FAIL → Step 4.
 - `선택형 CI workflow` (INFO) → 필요 시 Step 5 / Step 8.
-- 전부 PASS 면 나머지 bootstrap 갱신 여부만 확인하고 마친다.
+- FAIL 이 0 이면 (INFO·NA 행과 선택 WARN 은 정상) 나머지 bootstrap 갱신 여부만 확인하고 마친다.
 
 ### Step 2 - 활성화
 
@@ -399,7 +399,7 @@ support:
 - "$HELPER" disable
 
 마지막 점검 (권장):
-- "$HELPER" status 를 재실행해 진단표가 전부 PASS 인지 확인한다.
+- "$HELPER" status 를 재실행해 FAIL 항목이 0 인지 확인한다 (INFO·NA 행과 선택 WARN 은 정상).
 
 Claude Code 세션 재시작 권장:
 - SessionStart 훅은 현재 세션에는 소급 적용되지 않는다.

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -26,6 +26,8 @@
 | Project coordinates | repo variables `DCNESS_PROJECT_NUMBER`, `DCNESS_PROJECT_OWNER` | `gh variable set` | Project bootstrap 선택 | 값 갱신 | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
 
+> 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다 (#520).
+
 ## Already Automatic
 
 `/init-dcness` 가 whitelist 를 활성화하면 새 Claude Code 세션부터 [`hooks/hooks.json`](../../hooks/hooks.json) 의 CC hooks 가 자동 등록된다. 사용자가 따로 설치할 파일은 없다.

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -26,7 +26,7 @@
 | Project coordinates | repo variables `DCNESS_PROJECT_NUMBER`, `DCNESS_PROJECT_OWNER` | `gh variable set` | Project bootstrap 선택 | 값 갱신 | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
 
-> 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다 (#520).
+> 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다.
 
 ## Already Automatic
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -2946,9 +2946,40 @@ def _check_read_permission(settings_path: Path) -> bool:
     return isinstance(allow, list) and _READ_PERM in allow
 
 
-def _check_git_hooks(project_root: Path) -> Dict[str, str]:
-    """각 git hook 의 상태: 'ok' (thin shim) / 'missing' / 'foreign' (dcness shim 아님)."""
-    hooks_dir = project_root / ".git" / "hooks"
+def _resolve_git_hooks_dir(project_root: Path) -> Path:
+    """git 이 실제로 실행하는 hooks 디렉토리.
+
+    `core.hooksPath` (Husky 등) 가 설정되면 git 은 `.git/hooks` 를 무시한다. 진단이
+    "git 이 정말 이 hook 을 실행하는가" 를 보려면 git 이 보는 경로를 따라야 한다.
+    git 호출 실패 시 `.git/hooks` 폴백.
+    """
+    try:
+        proc = subprocess.run(
+            [
+                "git", "-C", str(project_root),
+                "rev-parse", "--path-format=absolute", "--git-path", "hooks",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+            text=True,
+        )
+        if proc.returncode == 0:
+            out = proc.stdout.strip()
+            if out:
+                return Path(out)
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return project_root / ".git" / "hooks"
+
+
+def _check_git_hooks(hooks_dir: Path) -> Dict[str, str]:
+    """각 git hook 의 상태.
+
+    git 이 그 hook 을 실제로 실행할 조건까지 본다:
+    'ok' (thin shim + 실행권한) / 'missing' / 'foreign' (dcness shim 아님)
+    / 'not-exec' (dcness shim 이지만 실행권한 없어 git 이 무시 — POSIX).
+    """
     result: Dict[str, str] = {}
     for name in _GIT_HOOK_SHIMS:
         p = hooks_dir / name
@@ -2960,7 +2991,13 @@ def _check_git_hooks(project_root: Path) -> Dict[str, str]:
         except OSError:
             result[name] = "foreign"
             continue
-        result[name] = "ok" if any(m in content for m in _SHIM_MARKERS) else "foreign"
+        if not any(m in content for m in _SHIM_MARKERS):
+            result[name] = "foreign"
+            continue
+        if not os.access(p, os.X_OK):
+            result[name] = "not-exec"
+            continue
+        result[name] = "ok"
     return result
 
 
@@ -3043,16 +3080,20 @@ def collect_status_diagnostics(
             f"{_READ_PERM} {'존재' if has_perm else '없음'}",
             None if has_perm else f"init-dcness Step 3 으로 {_READ_PERM} 추가",
         )
-        # git hook shim 3종
-        hooks = _check_git_hooks(project_root)
+        # git hook shim 3종 (git 이 실제 실행하는 경로 + 실행권한까지 검사)
+        hooks_dir = _resolve_git_hooks_dir(project_root)
+        hooks = _check_git_hooks(hooks_dir)
         all_ok = all(v == "ok" for v in hooks.values())
+        custom_path = hooks_dir != (project_root / ".git" / "hooks")
         hook_detail = ", ".join(f"{k}={v}" for k, v in hooks.items())
+        if custom_path:
+            hook_detail += f" (core.hooksPath={hooks_dir})"
         add(
             "git_hooks",
             "git hook shim 3종",
             "PASS" if all_ok else "FAIL",
             hook_detail,
-            None if all_ok else "init-dcness Step 4 로 thin shim 재설치",
+            None if all_ok else "init-dcness Step 4 로 thin shim 재설치 (chmod +x 포함)",
         )
         # 선택형 CI workflow (선택 — INFO)
         ci = _check_ci_workflows(project_root)

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -2908,10 +2908,16 @@ def _is_self_repo(project_root: Path) -> bool:
 
 
 def _plugin_root() -> Path:
-    """설치된 plugin root. CLAUDE_PLUGIN_ROOT env 우선, 없으면 본 파일 기준."""
+    """설치된 plugin root.
+
+    CLAUDE_PLUGIN_ROOT env 우선 — 단 그 경로가 실제 plugin manifest 를 들고 있을
+    때만 신뢰한다. env 가 비었거나 잘못된 경로면 본 파일 기준(harness 의 부모)으로 폴백.
+    """
     env = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if env:
-        return Path(env)
+        cand = Path(env)
+        if (cand / ".claude-plugin" / "plugin.json").exists():
+            return cand
     return Path(__file__).resolve().parent.parent
 
 
@@ -3084,16 +3090,26 @@ def collect_status_diagnostics(
         hooks_dir = _resolve_git_hooks_dir(project_root)
         hooks = _check_git_hooks(hooks_dir)
         all_ok = all(v == "ok" for v in hooks.values())
-        custom_path = hooks_dir != (project_root / ".git" / "hooks")
+        custom_path = hooks_dir.resolve() != (project_root / ".git" / "hooks").resolve()
         hook_detail = ", ".join(f"{k}={v}" for k, v in hooks.items())
         if custom_path:
             hook_detail += f" (core.hooksPath={hooks_dir})"
+        if all_ok:
+            hook_fix = None
+        elif custom_path:
+            # init-dcness Step 4 는 .git/hooks 로 복사 → core.hooksPath 환경에선 무효.
+            hook_fix = (
+                f"core.hooksPath={hooks_dir} 설정됨 — Step 4(.git/hooks 복사)로는 해결 안 됨. "
+                f"shim 을 {hooks_dir} 로 설치(chmod +x)하거나 core.hooksPath 를 해제하세요."
+            )
+        else:
+            hook_fix = "init-dcness Step 4 로 thin shim 재설치 (chmod +x 포함)"
         add(
             "git_hooks",
             "git hook shim 3종",
             "PASS" if all_ok else "FAIL",
             hook_detail,
-            None if all_ok else "init-dcness Step 4 로 thin shim 재설치 (chmod +x 포함)",
+            hook_fix,
         )
         # 선택형 CI workflow (선택 — INFO)
         ci = _check_ci_workflows(project_root)

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -2872,21 +2872,267 @@ def _cli_is_active(args: Any) -> int:
     return 0 if is_project_active() else 1
 
 
-def _cli_status(args: Any) -> int:
-    """whitelist + 현재 cwd 활성 상태 출력."""
-    active = is_project_active()
-    cwd_root = _resolve_project_root().resolve()
-    print(f"[dcness] cwd project root: {cwd_root}")
-    print(f"[dcness] active: {'YES' if active else 'NO'}")
-    print(f"[dcness] whitelist file: {whitelist_path()}")
-    projects = list_active_projects()
-    if projects:
-        print(f"[dcness] {len(projects)} active project(s):")
-        for p in projects:
-            mark = "*" if p == str(cwd_root) else " "
-            print(f"  {mark} {p}")
+# ── status 진단표 (#520) ────────────────────────────────────────────
+#
+# `dcness-helper status` 를 PASS/WARN/FAIL/INFO/NA 진단표로 확장한다. 별도 doctor
+# 진입점을 추가하지 않고 (사용자가 외울 표면 최소화), init-dcness 가 셋업과 상태 점검을
+# 겸하게 한다. 진단 수집은 deterministic 코드 (추측 누락 차단), 출력 종합/권유는
+# init-dcness skill prose 가 담당. routing doctor 의 PASS/FAIL 관용구를 따른다.
+#
+# 배포 항목을 새로 추가할 때 (init-dcness 의 git hook / CI workflow / Read 권한 등)
+# 아래 검사 항목도 함께 갱신해야 한다 (docs/plugin/init-dcness.md 의무 명시).
+
+_READ_PERM = "Read(~/.claude/plugins/cache/dcness/**)"
+_GIT_HOOK_SHIMS = ("commit-msg", "post-checkout", "pre-push")
+# thin-shim 식별: 세 hook 모두 plugin cache 경로를 동적 resolve 한다.
+_SHIM_MARKERS = ("plugins/cache/dcness", "CLAUDE_PLUGIN_ROOT")
+_CI_WORKFLOWS = (
+    "git-naming-validation.yml",
+    "pr-body-validation.yml",
+    "github-project-lifecycle.yml",
+)
+
+
+def _is_self_repo(project_root: Path) -> bool:
+    """dcNess plugin 본체 repo 판정 — `.claude-plugin/plugin.json` name == dcness.
+
+    외부 활성 프로젝트엔 이 파일이 없다. self repo 는 init-dcness 미적용이라
+    외부 활성 규칙(whitelist/Read권한/hook/CI)을 검사 대상에서 제외한다 (#520 AC 5).
+    """
+    pj = project_root / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(pj.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(data, dict) and data.get("name") == "dcness"
+
+
+def _plugin_root() -> Path:
+    """설치된 plugin root. CLAUDE_PLUGIN_ROOT env 우선, 없으면 본 파일 기준."""
+    env = os.environ.get("CLAUDE_PLUGIN_ROOT")
+    if env:
+        return Path(env)
+    return Path(__file__).resolve().parent.parent
+
+
+def _installed_plugin_version(plugin_root: Path) -> Optional[str]:
+    """설치된 plugin 의 manifest version. 읽기 실패 시 None."""
+    pj = plugin_root / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(pj.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    v = data.get("version")
+    return v if isinstance(v, str) else None
+
+
+def _settings_path() -> Path:
+    """CC 사용자 settings.json 경로."""
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _check_read_permission(settings_path: Path) -> bool:
+    """SessionStart 가 plugin SSOT 문서를 inject 하려면 필요한 Read allow 존재 여부."""
+    try:
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    perms = data.get("permissions")
+    allow = perms.get("allow") if isinstance(perms, dict) else None
+    return isinstance(allow, list) and _READ_PERM in allow
+
+
+def _check_git_hooks(project_root: Path) -> Dict[str, str]:
+    """각 git hook 의 상태: 'ok' (thin shim) / 'missing' / 'foreign' (dcness shim 아님)."""
+    hooks_dir = project_root / ".git" / "hooks"
+    result: Dict[str, str] = {}
+    for name in _GIT_HOOK_SHIMS:
+        p = hooks_dir / name
+        if not p.exists():
+            result[name] = "missing"
+            continue
+        try:
+            content = p.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            result[name] = "foreign"
+            continue
+        result[name] = "ok" if any(m in content for m in _SHIM_MARKERS) else "foreign"
+    return result
+
+
+def _check_ci_workflows(project_root: Path) -> Dict[str, bool]:
+    """선택형 CI workflow yml 존재 여부 (선택이라 부재해도 FAIL 아님)."""
+    wf_dir = project_root / ".github" / "workflows"
+    return {name: (wf_dir / name).exists() for name in _CI_WORKFLOWS}
+
+
+def _check_gh_auth() -> bool:
+    """gh CLI 인증 여부 (read-only). gh 미설치/미인증 시 False."""
+    try:
+        proc = subprocess.run(
+            ["gh", "auth", "status"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
+
+
+def collect_status_diagnostics(
+    cwd: Optional[Path] = None,
+    *,
+    settings_path: Optional[Path] = None,
+    plugin_root: Optional[Path] = None,
+    check_gh: bool = True,
+    check_routing: bool = True,
+) -> Dict[str, Any]:
+    """현재 프로젝트 설치 상태를 검사해 진단 결과를 모은다 (read-only, deterministic).
+
+    반환: {project_root, self_repo, checks: [{key,label,status,detail,fix}], summary}.
+    status ∈ {PASS, FAIL, WARN, INFO, NA}. 외부 의존(gh / routing)은 toggle 로 분리해
+    단위 테스트에서 부수효과를 끈다.
+    """
+    project_root = _resolve_project_root(cwd).resolve()
+    self_repo = _is_self_repo(project_root)
+    settings_path = settings_path or _settings_path()
+    plugin_root = plugin_root or _plugin_root()
+
+    checks: list = []
+
+    def add(key: str, label: str, status: str, detail: str, fix: Optional[str] = None) -> None:
+        checks.append(
+            {"key": key, "label": label, "status": status, "detail": detail, "fix": fix}
+        )
+
+    # 정보 항목 (self / 외부 공통)
+    add("project_root", "cwd project root", "INFO", str(project_root))
+    version = _installed_plugin_version(plugin_root)
+    add("plugin_version", "installed plugin version", "INFO", version or "unknown")
+
+    if self_repo:
+        na_detail = "self repo — init-dcness 미적용 (CLAUDE.md + git-spec 만 적용)"
+        for key, label in (
+            ("whitelist", "whitelist 활성"),
+            ("read_perm", "Read 권한 (~/.claude/settings.json)"),
+            ("git_hooks", "git hook shim 3종"),
+            ("ci_workflows", "선택형 CI workflow"),
+        ):
+            add(key, label, "NA", na_detail)
     else:
-        print("[dcness] no active projects (whitelist empty)")
+        # whitelist 활성
+        active = is_project_active(cwd)
+        add(
+            "whitelist",
+            "whitelist 활성",
+            "PASS" if active else "FAIL",
+            "활성" if active else "비활성 (이 프로젝트가 whitelist 에 없음)",
+            None if active else 'dcness-helper enable',
+        )
+        # Read 권한
+        has_perm = _check_read_permission(settings_path)
+        add(
+            "read_perm",
+            "Read 권한 (~/.claude/settings.json)",
+            "PASS" if has_perm else "FAIL",
+            f"{_READ_PERM} {'존재' if has_perm else '없음'}",
+            None if has_perm else f"init-dcness Step 3 으로 {_READ_PERM} 추가",
+        )
+        # git hook shim 3종
+        hooks = _check_git_hooks(project_root)
+        all_ok = all(v == "ok" for v in hooks.values())
+        hook_detail = ", ".join(f"{k}={v}" for k, v in hooks.items())
+        add(
+            "git_hooks",
+            "git hook shim 3종",
+            "PASS" if all_ok else "FAIL",
+            hook_detail,
+            None if all_ok else "init-dcness Step 4 로 thin shim 재설치",
+        )
+        # 선택형 CI workflow (선택 — INFO)
+        ci = _check_ci_workflows(project_root)
+        installed = [k for k, present in ci.items() if present]
+        add(
+            "ci_workflows",
+            "선택형 CI workflow",
+            "INFO",
+            f"설치됨: {', '.join(installed)}" if installed else "없음 (선택 사항)",
+        )
+
+    # Codex validation routing (self / 외부 공통 — INFO)
+    if check_routing:
+        try:
+            from harness import agent_routing
+
+            routing_detail = agent_routing.format_status().strip().replace("\n", " | ")
+        except Exception:
+            routing_detail = "조회 실패"
+        add("routing", "Codex validation routing", "INFO", routing_detail)
+
+    # gh CLI 인증 (self / 외부 공통 — WARN)
+    if check_gh:
+        gh_ok = _check_gh_auth()
+        add(
+            "gh_auth",
+            "GitHub CLI 인증",
+            "PASS" if gh_ok else "WARN",
+            "인증됨" if gh_ok else "미인증/미설치 — PR·issue 자동화 제한",
+            None if gh_ok else "gh auth login",
+        )
+
+    summary = {"PASS": 0, "WARN": 0, "FAIL": 0}
+    for c in checks:
+        if c["status"] in summary:
+            summary[c["status"]] += 1
+
+    return {
+        "project_root": str(project_root),
+        "self_repo": self_repo,
+        "checks": checks,
+        "summary": summary,
+    }
+
+
+def format_status_report(diag: Dict[str, Any]) -> str:
+    """진단 결과를 사람이 읽는 PASS/WARN/FAIL prose 로 포맷한다."""
+    lines: list = []
+    if diag["self_repo"]:
+        lines.append("[dcness] === self repo (dcNess plugin 본체) 진단 ===")
+        lines.append(
+            "[dcness] init-dcness 미적용 — CLAUDE.md + docs/plugin/git-spec.md 만 적용"
+        )
+        lines.append("[dcness] 외부 활성 항목은 self repo 에 해당 없음 (N/A)")
+    else:
+        lines.append("[dcness] === 외부 활성 프로젝트 진단 ===")
+
+    for c in diag["checks"]:
+        line = f"  [{c['status']}] {c['label']}: {c['detail']}"
+        lines.append(line)
+        if c["status"] in ("FAIL", "WARN") and c["fix"]:
+            lines.append(f"        → 해결: {c['fix']}")
+
+    s = diag["summary"]
+    lines.append(
+        f"[dcness] 요약: {s['PASS']} PASS / {s['WARN']} WARN / {s['FAIL']} FAIL"
+    )
+    if s["FAIL"]:
+        lines.append("[dcness] FAIL 항목을 위 해결 명령으로 처리한 뒤 status 를 재실행하세요.")
+    elif s["WARN"]:
+        lines.append("[dcness] WARN 항목은 선택 — 필요 시 해결 명령을 실행하세요.")
+    elif not diag["self_repo"]:
+        lines.append("[dcness] 모든 필수 항목 PASS — 활성화 정상.")
+    return "\n".join(lines)
+
+
+def _cli_status(args: Any) -> int:
+    """whitelist + 현재 cwd 활성 상태를 진단표로 출력 (#520)."""
+    diag = collect_status_diagnostics()
+    print(format_status_report(diag))
     return 0
 
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -2910,13 +2910,15 @@ def _is_self_repo(project_root: Path) -> bool:
 def _plugin_root() -> Path:
     """설치된 plugin root.
 
-    CLAUDE_PLUGIN_ROOT env 우선 — 단 그 경로가 실제 plugin manifest 를 들고 있을
-    때만 신뢰한다. env 가 비었거나 잘못된 경로면 본 파일 기준(harness 의 부모)으로 폴백.
+    CLAUDE_PLUGIN_ROOT env 우선 — 단 그 경로의 manifest 가 *dcness* 일 때만 신뢰한다.
+    다른 plugin/agent runtime 이 env 를 set 한 경우 그 plugin 의 version 을 dcNess
+    version 으로 오보하지 않도록, env 가 비었거나 dcness 가 아니면 본 파일 기준
+    (harness 의 부모) 으로 폴백.
     """
     env = os.environ.get("CLAUDE_PLUGIN_ROOT")
     if env:
         cand = Path(env)
-        if (cand / ".claude-plugin" / "plugin.json").exists():
+        if _is_self_repo(cand):
             return cand
     return Path(__file__).resolve().parent.parent
 

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -31,6 +31,7 @@ from harness.session_state import (
     _check_read_permission,
     _installed_plugin_version,
     _is_self_repo,
+    _plugin_root,
     _resolve_git_hooks_dir,
     collect_status_diagnostics,
     format_status_report,
@@ -76,6 +77,24 @@ class InstalledVersionTests(unittest.TestCase):
     def test_missing_returns_none(self) -> None:
         with TemporaryDirectory() as td:
             self.assertIsNone(_installed_plugin_version(Path(td)))
+
+
+class PluginRootTests(unittest.TestCase):
+    def tearDown(self) -> None:
+        os.environ.pop("CLAUDE_PLUGIN_ROOT", None)
+
+    def test_invalid_env_falls_back(self) -> None:
+        with TemporaryDirectory() as td:
+            os.environ["CLAUDE_PLUGIN_ROOT"] = td  # no .claude-plugin/plugin.json
+            # 잘못된 env 는 무시하고 본 파일 기준 폴백 → td 가 아니어야 한다
+            self.assertNotEqual(_plugin_root().resolve(), Path(td).resolve())
+
+    def test_valid_env_used(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", '{"name":"dcness"}')
+            os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+            self.assertEqual(_plugin_root().resolve(), root.resolve())
 
 
 class ReadPermissionTests(unittest.TestCase):

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -23,12 +23,15 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+import subprocess
+
 from harness.session_state import (
     _check_ci_workflows,
     _check_git_hooks,
     _check_read_permission,
     _installed_plugin_version,
     _is_self_repo,
+    _resolve_git_hooks_dir,
     collect_status_diagnostics,
     format_status_report,
 )
@@ -96,34 +99,76 @@ class ReadPermissionTests(unittest.TestCase):
 
 
 class GitHooksTests(unittest.TestCase):
-    def _hooks_dir(self, root: Path) -> Path:
-        d = root / ".git" / "hooks"
-        d.mkdir(parents=True, exist_ok=True)
-        return d
+    def _shim(self, hd: Path, name: str, *, executable: bool = True) -> None:
+        p = hd / name
+        _write(p, "#!/bin/sh\n# uses ~/.claude/plugins/cache/dcness/dcness\n")
+        p.chmod(0o755 if executable else 0o644)
 
     def test_thin_shim_ok(self) -> None:
         with TemporaryDirectory() as td:
-            root = Path(td)
-            hd = self._hooks_dir(root)
+            hd = Path(td)
             for name in ("commit-msg", "post-checkout", "pre-push"):
-                _write(hd / name, "#!/bin/sh\n# uses ~/.claude/plugins/cache/dcness/dcness\n")
-            result = _check_git_hooks(root)
+                self._shim(hd, name)
+            result = _check_git_hooks(hd)
             self.assertEqual(set(result.values()), {"ok"})
 
     def test_missing_hook(self) -> None:
         with TemporaryDirectory() as td:
-            root = Path(td)
-            self._hooks_dir(root)
-            result = _check_git_hooks(root)
+            result = _check_git_hooks(Path(td))
             self.assertEqual(result["commit-msg"], "missing")
 
     def test_foreign_hook(self) -> None:
         with TemporaryDirectory() as td:
-            root = Path(td)
-            hd = self._hooks_dir(root)
-            _write(hd / "commit-msg", "#!/bin/sh\necho hello\n")
-            result = _check_git_hooks(root)
+            hd = Path(td)
+            p = hd / "commit-msg"
+            _write(p, "#!/bin/sh\necho hello\n")
+            p.chmod(0o755)
+            result = _check_git_hooks(hd)
             self.assertEqual(result["commit-msg"], "foreign")
+
+    def test_shim_without_exec_bit_flagged(self) -> None:
+        # dcNess shim 이지만 실행권한 없음 → git 이 무시하므로 'ok' 아님 (codex P2)
+        with TemporaryDirectory() as td:
+            hd = Path(td)
+            self._shim(hd, "commit-msg", executable=False)
+            result = _check_git_hooks(hd)
+            self.assertEqual(result["commit-msg"], "not-exec")
+
+
+class ResolveGitHooksDirTests(unittest.TestCase):
+    def _git(self, root: Path, *args: str) -> None:
+        subprocess.run(
+            ["git", "-C", str(root), *args],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=True,
+        )
+
+    def test_default_hooks_dir(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._git(root, "init")
+            self.assertEqual(
+                _resolve_git_hooks_dir(root).resolve(),
+                (root / ".git" / "hooks").resolve(),
+            )
+
+    def test_custom_hooks_path_honored(self) -> None:
+        # core.hooksPath 설정 시 .git/hooks 가 아닌 그 경로를 따라야 한다 (codex P2)
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._git(root, "init")
+            self._git(root, "config", "core.hooksPath", "myhooks")
+            resolved = _resolve_git_hooks_dir(root).resolve()
+            self.assertEqual(resolved, (root / "myhooks").resolve())
+
+    def test_non_git_dir_fallback(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)  # not a git repo
+            self.assertEqual(
+                _resolve_git_hooks_dir(root),
+                root / ".git" / "hooks",
+            )
 
 
 class CiWorkflowTests(unittest.TestCase):

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -1,0 +1,212 @@
+"""test_status_diagnostics — `dcness-helper status` 진단표 (#520).
+
+Coverage matrix:
+    _is_self_repo            : name==dcness / 다른 name / 파일 없음 / 깨진 json
+    _installed_plugin_version: 정상 / 파일 없음
+    _check_read_permission   : PERM 존재 / 부재 / 파일 없음
+    _check_git_hooks         : thin-shim ok / missing / foreign
+    _check_ci_workflows      : 존재 / 부재
+    collect_status_diagnostics:
+        self repo  → 외부 활성 항목 전부 NA
+        외부 repo  → whitelist 미등록 시 FAIL + fix 명령
+    format_status_report     : badge 출력 / self 헤더 분리 / 요약 카운트
+
+대 원칙 정합:
+    - 진단 수집은 deterministic 코드 (추측 누락 차단). 출력 종합/권유는 init-dcness skill.
+    - self repo 와 외부 활성 규칙을 섞지 않는다 (#520 AC 5).
+"""
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.session_state import (
+    _check_ci_workflows,
+    _check_git_hooks,
+    _check_read_permission,
+    _installed_plugin_version,
+    _is_self_repo,
+    collect_status_diagnostics,
+    format_status_report,
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+class IsSelfRepoTests(unittest.TestCase):
+    def test_name_dcness_is_self(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", '{"name":"dcness","version":"0.7.1"}')
+            self.assertTrue(_is_self_repo(root))
+
+    def test_other_name_not_self(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", '{"name":"other"}')
+            self.assertFalse(_is_self_repo(root))
+
+    def test_missing_file_not_self(self) -> None:
+        with TemporaryDirectory() as td:
+            self.assertFalse(_is_self_repo(Path(td)))
+
+    def test_broken_json_not_self(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", "{not json")
+            self.assertFalse(_is_self_repo(root))
+
+
+class InstalledVersionTests(unittest.TestCase):
+    def test_reads_version(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", '{"name":"dcness","version":"9.9.9"}')
+            self.assertEqual(_installed_plugin_version(root), "9.9.9")
+
+    def test_missing_returns_none(self) -> None:
+        with TemporaryDirectory() as td:
+            self.assertIsNone(_installed_plugin_version(Path(td)))
+
+
+class ReadPermissionTests(unittest.TestCase):
+    PERM = "Read(~/.claude/plugins/cache/dcness/**)"
+
+    def test_perm_present(self) -> None:
+        with TemporaryDirectory() as td:
+            sp = Path(td) / "settings.json"
+            _write(sp, json.dumps({"permissions": {"allow": [self.PERM]}}))
+            self.assertTrue(_check_read_permission(sp))
+
+    def test_perm_absent(self) -> None:
+        with TemporaryDirectory() as td:
+            sp = Path(td) / "settings.json"
+            _write(sp, json.dumps({"permissions": {"allow": ["Read(/other/**)"]}}))
+            self.assertFalse(_check_read_permission(sp))
+
+    def test_missing_file(self) -> None:
+        with TemporaryDirectory() as td:
+            self.assertFalse(_check_read_permission(Path(td) / "settings.json"))
+
+
+class GitHooksTests(unittest.TestCase):
+    def _hooks_dir(self, root: Path) -> Path:
+        d = root / ".git" / "hooks"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
+    def test_thin_shim_ok(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            hd = self._hooks_dir(root)
+            for name in ("commit-msg", "post-checkout", "pre-push"):
+                _write(hd / name, "#!/bin/sh\n# uses ~/.claude/plugins/cache/dcness/dcness\n")
+            result = _check_git_hooks(root)
+            self.assertEqual(set(result.values()), {"ok"})
+
+    def test_missing_hook(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            self._hooks_dir(root)
+            result = _check_git_hooks(root)
+            self.assertEqual(result["commit-msg"], "missing")
+
+    def test_foreign_hook(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            hd = self._hooks_dir(root)
+            _write(hd / "commit-msg", "#!/bin/sh\necho hello\n")
+            result = _check_git_hooks(root)
+            self.assertEqual(result["commit-msg"], "foreign")
+
+
+class CiWorkflowTests(unittest.TestCase):
+    def test_present_and_absent(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            wf = root / ".github" / "workflows"
+            wf.mkdir(parents=True, exist_ok=True)
+            _write(wf / "git-naming-validation.yml", "name: x\n")
+            result = _check_ci_workflows(root)
+            self.assertTrue(result["git-naming-validation.yml"])
+            self.assertFalse(result["pr-body-validation.yml"])
+
+
+class CollectSelfRepoTests(unittest.TestCase):
+    def test_self_repo_external_items_na(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", '{"name":"dcness","version":"0.7.1"}')
+            diag = collect_status_diagnostics(
+                cwd=root, check_gh=False, check_routing=False
+            )
+            self.assertTrue(diag["self_repo"])
+            by_key = {c["key"]: c for c in diag["checks"]}
+            for key in ("whitelist", "read_perm", "git_hooks", "ci_workflows"):
+                self.assertEqual(by_key[key]["status"], "NA", key)
+
+
+class CollectExternalRepoTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._wl = TemporaryDirectory()
+        os.environ["DCNESS_WHITELIST_PATH"] = str(Path(self._wl.name) / "projects.json")
+
+    def tearDown(self) -> None:
+        os.environ.pop("DCNESS_WHITELIST_PATH", None)
+        self._wl.cleanup()
+
+    def test_external_unregistered_whitelist_fail(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)  # no .claude-plugin → external
+            diag = collect_status_diagnostics(
+                cwd=root, check_gh=False, check_routing=False
+            )
+            self.assertFalse(diag["self_repo"])
+            by_key = {c["key"]: c for c in diag["checks"]}
+            self.assertEqual(by_key["whitelist"]["status"], "FAIL")
+            self.assertIn("enable", (by_key["whitelist"]["fix"] or ""))
+
+
+class FormatReportTests(unittest.TestCase):
+    def test_self_header_and_summary(self) -> None:
+        diag = {
+            "project_root": "/x",
+            "self_repo": True,
+            "checks": [
+                {"key": "a", "label": "A", "status": "INFO", "detail": "d", "fix": None},
+                {"key": "b", "label": "B", "status": "NA", "detail": "self", "fix": None},
+            ],
+            "summary": {"PASS": 0, "WARN": 0, "FAIL": 0},
+        }
+        out = format_status_report(diag)
+        self.assertIn("self repo", out.lower())
+        self.assertIn("[NA]", out)
+
+    def test_external_badges_and_counts(self) -> None:
+        diag = {
+            "project_root": "/x",
+            "self_repo": False,
+            "checks": [
+                {"key": "w", "label": "whitelist", "status": "FAIL", "detail": "no", "fix": "dcness-helper enable"},
+                {"key": "g", "label": "gh", "status": "WARN", "detail": "no auth", "fix": "gh auth login"},
+                {"key": "p", "label": "perm", "status": "PASS", "detail": "ok", "fix": None},
+            ],
+            "summary": {"PASS": 1, "WARN": 1, "FAIL": 1},
+        }
+        out = format_status_report(diag)
+        self.assertIn("[FAIL]", out)
+        self.assertIn("[WARN]", out)
+        self.assertIn("[PASS]", out)
+        self.assertIn("dcness-helper enable", out)  # fix 명령 노출
+        self.assertIn("1 PASS", out)
+        self.assertIn("1 FAIL", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -89,6 +89,14 @@ class PluginRootTests(unittest.TestCase):
             # 잘못된 env 는 무시하고 본 파일 기준 폴백 → td 가 아니어야 한다
             self.assertNotEqual(_plugin_root().resolve(), Path(td).resolve())
 
+    def test_other_plugin_env_falls_back(self) -> None:
+        # 다른 plugin 이 CLAUDE_PLUGIN_ROOT 를 set 한 경우 그 version 을 오보하지 않음
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _write(root / ".claude-plugin" / "plugin.json", '{"name":"some-other-plugin"}')
+            os.environ["CLAUDE_PLUGIN_ROOT"] = str(root)
+            self.assertNotEqual(_plugin_root().resolve(), root.resolve())
+
     def test_valid_env_used(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #520

## 배경 및 문제

dcNess 는 plugin 설치만으로 동작하지 않고 `/init-dcness` 로 whitelist / Read 권한 / git hook / 선택 CI 를 맞춰야 한다. 외부 사용자가 "정상 설치됐는지" 를 한 명령으로 확인할 길이 없었다. 초기 이슈 제안은 별도 `dcness-helper doctor` 모드였으나, 이는 `CLAUDE.md` 안티패턴 5(신규 공개 진입점 무근거 추가)와 충돌한다.

## 원인 (해당 시)

-

## 작업내용

- `harness/session_state.py`: `collect_status_diagnostics`(read-only deterministic 수집) + `format_status_report` 추가. 기존 `_cli_status` 를 진단표 출력으로 교체.
- 검사 항목: whitelist 활성 / Read 권한 / git hook shim 3종 / 선택 CI workflow / installed plugin version / Codex validation routing / gh CLI 인증. FAIL·WARN 마다 해결 명령 동반.
- self repo(`.claude-plugin/plugin.json` name==dcness) 는 외부 활성 항목을 `NA` 로 분리 — self 작업 규칙과 외부 활성 규칙이 섞이지 않음.
- `commands/init-dcness.md`: Step 1 을 "상태 진단" 으로 격상(진단표 기준 분기) + `active: YES` 옛 참조 제거 + 완료 안내에 status 재실행 권유.
- `docs/plugin/init-dcness.md`: bootstrap inventory 에 배포 항목↔진단 항목 동기화 의무 명시.
- `tests/test_status_diagnostics.py`: 17 케이스.

## 결정 근거

- **별도 doctor 진입점 안 만듦** — 사용자가 외울 표면 최소화(안티패턴 5). 기존 `status` 확장이 init-dcness 의 멱등 셋업 골격과 자연스럽게 결합.
- **진단 수집 = 코드 / 출력·권유 = skill** — deterministic 수집으로 추측 누락 차단(제1룰), 형식·안내는 skill 자율(dcness 강제원칙: harness 는 순서·영역만 강제).
- gh·routing 은 외부 의존이라 `check_gh` / `check_routing` toggle 로 단위 테스트에서 부수효과 차단.

## 배포 경로 검증 (plug-in 영향 시)

- **경로 1 (plugin 본체 자동 갱신)**: 변경 전부 — `harness/session_state.py`, `commands/init-dcness.md`, `docs/plugin/init-dcness.md`. 사용자가 plugin update 받으면 자동 적용.
- **경로 2 (init-dcness 복사·배포)**: 신규 복사 파일 0개. status 로직은 plugin 에서 실행되며 사용자 repo 로 복사되지 않음.
- **경로 3 (사용자 SSOT 문서)**: `docs/plugin/init-dcness.md` 는 plugin 본체 docs 로 경로 1 에 포함.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public 발화 없음. 기존 `dcness-helper status` 서브커맨드를 확장만 함(별도 doctor 진입점 의도적 회피).

## Test Plan

- [x] 관련 테스트 추가: `tests/test_status_diagnostics.py` 17 케이스 (self/외부 분기, 항목별 PASS/FAIL/foreign/missing, format badge·요약)
- [x] 전체 unittest 1258 통과
- [x] cross-ref / plugin-manifest 게이트 PASS
- [x] self repo 실측 출력 확인 (NA 분리 정상)

## 참고

-
