### PR TITLE
[issue-770] MUST_FIX_GHOST 오탐 수정 — 게이트 모순만 검출

### DIFF
--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -128,7 +128,7 @@ python3 "$DCN"/harness/benchmark_aggregate.py <sessions-root> --json
 | pr-reviewer FAIL 비율 | 42.6% | PASS 35 / FAIL 29 / LGTM 4 — 리뷰 게이트가 실제로 반려 |
 | escalate 결론 | 2 | 주로 architecture-validator |
 | blocked 이벤트 | 1 | |
-| waste top | MUST_FIX_GHOST 41 / TOOL_REPEAT_HIGH 39 / MUST_FIX_LEAK 11 | `/run-review` 가 잡는 낭비 패턴 |
+| waste top | TOOL_REPEAT_HIGH 39 / MUST_FIX_LEAK 11 / MISSING_CONCLUSION_ENUM 2 | `/run-review` 가 잡는 낭비 패턴 |
 
 해석: pr-reviewer 의 ~42% FAIL 은 "리뷰가 형식적으로 통과만 시키지 않고 실제로
 반려한다"는 뜻이다 — 가드가 동작한다는 신호. waste top 은 어디를 개선하면 비용이

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -111,8 +111,22 @@ WINDOW_TS_PADDING = timedelta(seconds=60)
 
 # issue #770 — MUST_FIX_GHOST 는 *게이트* agent 가 advance 결론을 내면서 미해결
 # MUST FIX 를 남긴 모순만 검출한다 (producer 의 must_fix·reviewer FAIL 은 정상 흐름).
-MUST_FIX_GATE_AGENTS = {"pr-reviewer", "code-validator", "architecture-validator"}
+# product-acceptance 도 PASS/FAIL 게이트 (acceptance gate) 라 포함.
+MUST_FIX_GATE_AGENTS = {
+    "pr-reviewer", "code-validator", "architecture-validator", "product-acceptance",
+}
 MUST_FIX_GHOST_PASS_ENUMS = {"PASS", "LGTM"}
+# stored enum 이 실제 verdict 면 그것을 우선 (legacy .steps.jsonl row). PROSE_LOGGED /
+# AMBIGUOUS 같은 sentinel 일 때만 prose 파싱 결론을 쓴다 — prose 오파싱(예 "LGTM 후보 X")
+# 이 stored verdict(CHANGES_REQUESTED 등)를 덮어써 거짓 GHOST 를 내는 회귀 차단 (#770).
+_VERDICT_SENTINELS = {"PROSE_LOGGED", "AMBIGUOUS", ""}
+
+
+def _resolved_verdict(step) -> str:
+    """step 의 verdict — stored enum 우선, sentinel 이면 prose 결론."""
+    if step.enum and step.enum not in _VERDICT_SENTINELS:
+        return step.enum
+    return step.conclusion_enum or ""
 
 # DCN-CHG-20260430-38: engineer self-verify echo anchor 옵션 (DCN-30-34 강제 → DCN-30-38 자율화).
 # prose 끝에 *어느 한 anchor* 라도 있으면 통과. 형식 자율 + substance 의무.
@@ -621,7 +635,7 @@ def detect_wastes(
             continue
         if s.agent not in MUST_FIX_GATE_AGENTS:
             continue
-        verdict = s.conclusion_enum or s.enum
+        verdict = _resolved_verdict(s)
         if verdict not in MUST_FIX_GHOST_PASS_ENUMS:
             continue
         findings.append(WasteFinding(

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -413,14 +413,15 @@ def _prose_final_verdict_is_fail(prose: str) -> bool:
     하나라도 있으면 실패로 본다 (incidental pass 단어보다 fail 이 이김, issue #771).
     """
     for line in reversed([l for l in prose.splitlines() if l.strip()]):
-        toks = {m.group(1) for m in _ANY_VERDICT_RE.finditer(line)}
-        if not toks:
+        matches = list(_ANY_VERDICT_RE.finditer(line))
+        if not matches:
             continue  # verdict 없는 줄 — 위로
-        if toks & _FAIL_CLASS_VERDICTS:
-            return True  # fail 토큰 존재 → fail 우선
-        # pass 토큰만 있는 줄: 부정 아니면 pass 결론(=fail 아님), 부정이면 불명 → 위로
-        if not _NEGATION_RE.search(line):
-            return False
+        # 위치상 *마지막*(rightmost) 토큰이 결론. 혼합줄 "PASS / FAIL 중 FAIL" → FAIL,
+        # "PASS / FAIL 중 PASS" → PASS (round4↔round5 진동 종결, issue #771).
+        last = matches[-1].group(1)
+        if last in _PASS_CLASS_VERDICTS and _NEGATION_RE.search(line):
+            continue  # 마지막 토큰이 부정된 pass — 결론 불명, 위로
+        return last in _FAIL_CLASS_VERDICTS
     return False
 
 

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -406,19 +406,21 @@ _ANY_VERDICT_RE = re.compile(
 
 
 def _prose_final_verdict_is_fail(prose: str) -> bool:
-    """prose 를 아래에서 위로 스캔해 *위치상 마지막* verdict 가 fail-class 인지.
+    """prose 를 아래에서 위로 스캔해 *결론줄* 이 fail-class 결론인지.
 
-    마지막 결론줄이 진짜 결론 (dcness agent 규약 = 마지막 단락에 결론). pass 단어가
-    부정문이면 건너뛴다.
+    dcness agent 규약 = 마지막 단락에 결론. verdict 토큰을 가진 첫 줄(아래에서)이 결론줄.
+    혼합줄("PASS / FAIL 중 FAIL", "PASS 아님 — FAIL")은 **fail 우선** — fail-class 토큰이
+    하나라도 있으면 실패로 본다 (incidental pass 단어보다 fail 이 이김, issue #771).
     """
     for line in reversed([l for l in prose.splitlines() if l.strip()]):
-        m = _ANY_VERDICT_RE.search(line)
-        if not m:
-            continue
-        tok = m.group(1)
-        if tok in _PASS_CLASS_VERDICTS and _NEGATION_RE.search(line):
-            continue  # 부정된 pass — 결론 아님
-        return tok in _FAIL_CLASS_VERDICTS
+        toks = {m.group(1) for m in _ANY_VERDICT_RE.finditer(line)}
+        if not toks:
+            continue  # verdict 없는 줄 — 위로
+        if toks & _FAIL_CLASS_VERDICTS:
+            return True  # fail 토큰 존재 → fail 우선
+        # pass 토큰만 있는 줄: 부정 아니면 pass 결론(=fail 아님), 부정이면 불명 → 위로
+        if not _NEGATION_RE.search(line):
+            return False
     return False
 
 

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -109,6 +109,11 @@ from harness.agent_names import LEGACY_AGENT_ALIASES  # noqa: E402,F401
 # 첫 step metric 매번 누락. ±60s 여유로 jajang 실측 8s off-by-N 흡수.
 WINDOW_TS_PADDING = timedelta(seconds=60)
 
+# issue #770 — MUST_FIX_GHOST 는 *게이트* agent 가 advance 결론을 내면서 미해결
+# MUST FIX 를 남긴 모순만 검출한다 (producer 의 must_fix·reviewer FAIL 은 정상 흐름).
+MUST_FIX_GATE_AGENTS = {"pr-reviewer", "code-validator", "architecture-validator"}
+MUST_FIX_GHOST_PASS_ENUMS = {"PASS", "LGTM"}
+
 # DCN-CHG-20260430-38: engineer self-verify echo anchor 옵션 (DCN-30-34 강제 → DCN-30-38 자율화).
 # prose 끝에 *어느 한 anchor* 라도 있으면 통과. 형식 자율 + substance 의무.
 # heading 라인에 검증 / verification / self-verify 단어가 *포함* 되면 매칭 (issue #249 — `## 수용 기준 검증` 같은 변형 허용).
@@ -603,17 +608,30 @@ def detect_wastes(
                 fix=f"agents/{s.agent}.md 디렉토리명 정확 인지 룰 보강 또는 사용자 환경 검증",
             ))
 
-    # MUST_FIX_GHOST — must_fix=true 이후 다음 step 진행
+    # MUST_FIX_GHOST — 게이트(리뷰어/검증자)가 PASS/LGTM 결론을 내면서 prose 에 미해결
+    # MUST FIX 를 남긴 모순 (= 통과시키면 안 되는데 통과). issue #770: 옛 룰은
+    # `must_fix and 다음 step 존재` 만으로 위반 판정 → conveyor 의 정상 흐름
+    # (reviewer FAIL → engineer fix → 재리뷰) + producer 의 고친-항목 재진술
+    # (engineer POLISH 가 "## MUST FIX 1 …" 헤더로 처방 내역 기재) 을 전수 오탐.
+    # 실측 41/41 false positive. 진짜 신호는 *게이트가 advance(PASS/LGTM)하면서
+    # blocker 를 남긴* 경우뿐 — producer(engineer/build-worker/test-engineer)의 must_fix
+    # 와 reviewer 의 FAIL 은 정상. 마지막 step 미해결은 MUST_FIX_LEAK 담당이라 제외.
     for i, s in enumerate(steps):
-        if s.must_fix and i + 1 < len(steps):
-            findings.append(WasteFinding(
-                pattern="MUST_FIX_GHOST",
-                severity="HIGH",
-                step_idx=i,
-                agent=s.agent,
-                detail=f"step {i} ({s.agent}) MUST_FIX 발견됐는데 step {i+1} 진행 — 멈춤 위반",
-                fix="commands/{skill}.md caveat 멈춤 룰 강화",
-            ))
+        if not (s.must_fix and i + 1 < len(steps)):
+            continue
+        if s.agent not in MUST_FIX_GATE_AGENTS:
+            continue
+        verdict = s.conclusion_enum or s.enum
+        if verdict not in MUST_FIX_GHOST_PASS_ENUMS:
+            continue
+        findings.append(WasteFinding(
+            pattern="MUST_FIX_GHOST",
+            severity="HIGH",
+            step_idx=i,
+            agent=s.agent,
+            detail=f"step {i} ({s.agent}) {verdict} 결론인데 prose 에 미해결 MUST FIX — 게이트 통과 모순",
+            fix=f"agents/{s.agent}.md 결론 일관성 — MUST FIX 가 있으면 PASS/LGTM 이 아니라 FAIL",
+        ))
 
     # issue #383 B3 — MUST_FIX_LEAK. 마지막 step 의 must_fix=True (= caveat 신호)
     # 는 MUST_FIX_GHOST 룰이 *다음 step 없음* 으로 skip → wastes 비어있는

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -390,6 +390,38 @@ _NEGATION_RE = re.compile(
 )
 
 
+# issue #771 — GHOST 가드용. _extract_conclusion_enum 은 라벨 우선순위(PASS/LGTM 먼저)
+# 로 끝 15줄을 스캔해 "tests PASS" 같은 incidental pass 단어를 결론으로 잡을 수 있다.
+# GHOST 는 게이트가 *진짜* 통과했을 때만 모순이므로, prose 의 *위치상 마지막* 결론이
+# fail-class 면(= 실제 실패) pass 단어가 섞였어도 GHOST 에서 제외한다 (fail wins).
+_FAIL_CLASS_VERDICTS = frozenset({
+    "FAIL", "CHANGES_REQUESTED", "TESTS_FAIL", "ESCALATE",
+    "IMPLEMENTATION_ESCALATE", "UX_FLOW_ESCALATE", "VALIDATION_BLOCKED",
+})
+_PASS_CLASS_VERDICTS = frozenset({"PASS", "LGTM"})
+_ANY_VERDICT_RE = re.compile(
+    r"\b(LGTM|PASS|CHANGES_REQUESTED|TESTS_FAIL|IMPLEMENTATION_ESCALATE|"
+    r"UX_FLOW_ESCALATE|VALIDATION_BLOCKED|FAIL|ESCALATE)\b"
+)
+
+
+def _prose_final_verdict_is_fail(prose: str) -> bool:
+    """prose 를 아래에서 위로 스캔해 *위치상 마지막* verdict 가 fail-class 인지.
+
+    마지막 결론줄이 진짜 결론 (dcness agent 규약 = 마지막 단락에 결론). pass 단어가
+    부정문이면 건너뛴다.
+    """
+    for line in reversed([l for l in prose.splitlines() if l.strip()]):
+        m = _ANY_VERDICT_RE.search(line)
+        if not m:
+            continue
+        tok = m.group(1)
+        if tok in _PASS_CLASS_VERDICTS and _NEGATION_RE.search(line):
+            continue  # 부정된 pass — 결론 아님
+        return tok in _FAIL_CLASS_VERDICTS
+    return False
+
+
 def _extract_conclusion_enum(prose: str) -> str:
     """prose 본문 끝 ~15줄에서 positive 결론 enum 추출.
 
@@ -654,6 +686,13 @@ def detect_wastes(
         verdict = _resolved_verdict(s)
         if verdict not in MUST_FIX_GHOST_PASS_ENUMS:
             continue
+        # issue #771 — prose 의 위치상 마지막 결론이 fail-class 면, conclusion_enum 이
+        # LGTM/PASS-first 스캔으로 incidental pass 단어("tests PASS")를 잘못 집은 것.
+        # 실제로는 실패(정상 fail→fix 루프)이므로 GHOST 아님 (fail wins over pass words).
+        if not (s.enum and s.enum not in _VERDICT_SENTINELS):
+            # stored enum 이 sentinel(=prose 의존)일 때만 prose 최종결론으로 교차검증.
+            if _prose_final_verdict_is_fail(s.prose_full or s.prose_excerpt):
+                continue
         findings.append(WasteFinding(
             pattern="MUST_FIX_GHOST",
             severity="HIGH",

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -109,11 +109,18 @@ from harness.agent_names import LEGACY_AGENT_ALIASES  # noqa: E402,F401
 # 첫 step metric 매번 누락. ±60s 여유로 jajang 실측 8s off-by-N 흡수.
 WINDOW_TS_PADDING = timedelta(seconds=60)
 
-# issue #770 — MUST_FIX_GHOST 는 *게이트* agent 가 advance 결론을 내면서 미해결
+# issue #770/#771 — MUST_FIX_GHOST 는 *게이트* agent 가 advance 결론을 내면서 미해결
 # MUST FIX 를 남긴 모순만 검출한다 (producer 의 must_fix·reviewer FAIL 은 정상 흐름).
-# product-acceptance 도 PASS/FAIL 게이트 (acceptance gate) 라 포함.
+# 게이트 = PASS/FAIL/(LGTM) 결론으로 진행을 막는 read-only 검증/리뷰/검수 agent.
+#   - conveyor 검증 게이트: code-validator / pr-reviewer / architecture-validator
+#     / product-acceptance  (= ledger._VALIDATOR_AGENTS)
+#   - tech-reviewer: /tech-review preflight 게이트 — PASS/FAIL/ESCALATE 결론
+#     (conveyor validator set 엔 없지만 게이트 성격 동일, agents/tech-reviewer 결론 규약).
+# drift 가드: tests 가 ledger._VALIDATOR_AGENTS ⊆ 본 집합을 강제 (검증 게이트 추가 시
+# 본 집합도 같이 커지도록).
 MUST_FIX_GATE_AGENTS = {
-    "pr-reviewer", "code-validator", "architecture-validator", "product-acceptance",
+    "pr-reviewer", "code-validator", "architecture-validator",
+    "product-acceptance", "tech-reviewer",
 }
 MUST_FIX_GHOST_PASS_ENUMS = {"PASS", "LGTM"}
 # stored enum 이 실제 verdict 면 그것을 우선 (legacy .steps.jsonl row). PROSE_LOGGED /

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -112,16 +112,25 @@ WINDOW_TS_PADDING = timedelta(seconds=60)
 # issue #770/#771 — MUST_FIX_GHOST 는 *게이트* agent 가 advance 결론을 내면서 미해결
 # MUST FIX 를 남긴 모순만 검출한다 (producer 의 must_fix·reviewer FAIL 은 정상 흐름).
 # 게이트 = PASS/FAIL/(LGTM) 결론으로 진행을 막는 read-only 검증/리뷰/검수 agent.
-#   - conveyor 검증 게이트: code-validator / pr-reviewer / architecture-validator
-#     / product-acceptance  (= ledger._VALIDATOR_AGENTS)
-#   - tech-reviewer: /tech-review preflight 게이트 — PASS/FAIL/ESCALATE 결론
-#     (conveyor validator set 엔 없지만 게이트 성격 동일, agents/tech-reviewer 결론 규약).
-# drift 가드: tests 가 ledger._VALIDATOR_AGENTS ⊆ 본 집합을 강제 (검증 게이트 추가 시
-# 본 집합도 같이 커지도록).
-MUST_FIX_GATE_AGENTS = {
-    "pr-reviewer", "code-validator", "architecture-validator",
-    "product-acceptance", "tech-reviewer",
-}
+# hardcode 대신 권한 metadata 에서 *파생* — agent_boundary.ALLOW_MATRIX 의 *빈 허용*
+# (Write 권한 0 = read-only) agent 가 곧 게이트다 (code/architecture-validator,
+# pr-reviewer, product-acceptance, plan-reviewer 자동 포함). tech-reviewer 는 자기
+# 보고서를 쓰므로 빈 허용은 아니지만 PASS/FAIL/ESCALATE 게이트라 명시 추가.
+# 이렇게 단일 SSOT 에서 파생하면 게이트가 늘어도 본 집합이 자동으로 따라간다 (#771
+# whack-a-mole 종료 — 게이트 하나씩 누락되던 hardcode 회귀 차단).
+def _derive_gate_agents() -> set[str]:
+    try:
+        from harness.agent_boundary import ALLOW_MATRIX
+        read_only = {a for a, paths in ALLOW_MATRIX.items() if not paths}
+    except Exception:
+        read_only = {
+            "code-validator", "architecture-validator", "pr-reviewer",
+            "product-acceptance", "plan-reviewer",
+        }
+    return read_only | {"tech-reviewer"}
+
+
+MUST_FIX_GATE_AGENTS = _derive_gate_agents()
 MUST_FIX_GHOST_PASS_ENUMS = {"PASS", "LGTM"}
 # stored enum 이 실제 verdict 면 그것을 우선 (legacy .steps.jsonl row). PROSE_LOGGED /
 # AMBIGUOUS 같은 sentinel 일 때만 prose 파싱 결론을 쓴다 — prose 오파싱(예 "LGTM 후보 X")

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -333,15 +333,44 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)  # run_dir 미전달
         self.assertIn("INFRA_READ", {w.pattern for w in wastes})
 
-    def test_must_fix_ghost(self):
+    def test_must_fix_ghost_gate_pass_with_must_fix(self):
+        # #770 — 게이트(reviewer)가 PASS/LGTM 결론인데 must_fix 남김 = 진짜 모순 → GHOST.
         steps = [
-            StepRecord(idx=0, ts="t1", agent="validator", mode="CODE_VALIDATION",
-                       enum="FAIL", must_fix=True, prose_excerpt="a\nb\nc\nd\ne"),
-            StepRecord(idx=1, ts="t2", agent="engineer", mode="IMPL",
-                       enum="IMPL_DONE", must_fix=False, prose_excerpt="a\nb\nc\nd\ne"),
+            StepRecord(idx=0, ts="t1", agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="LGTM",
+                       prose_excerpt="a"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="b"),
         ]
         wastes = detect_wastes(steps)
         self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
+    def test_must_fix_ghost_not_fired_on_normal_fix_loop(self):
+        # #770 — reviewer FAIL + must_fix → 다음 step(fix)은 정상 conveyor, GHOST 아님.
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="FAIL",
+                       prose_excerpt="MUST FIX: x"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="fixed"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
+    def test_must_fix_ghost_not_fired_on_producer_restatement(self):
+        # #770 — engineer POLISH_DONE 가 고친 MUST FIX 항목 재진술 = producer, GHOST 아님.
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="## MUST FIX 1 (전면 예외 래핑)"),
+            StepRecord(idx=1, ts="t2", agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="PASS",
+                       prose_excerpt="ok"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
     def test_spec_gap_loop(self):
         steps = [

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -372,6 +372,33 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
+    def test_must_fix_ghost_stored_verdict_beats_misparsed_prose(self):
+        # #770/#771 — legacy stored enum(CHANGES_REQUESTED)이 prose 오파싱(LGTM)을 이김
+        # → 거부된 리뷰가 PASS-class 로 오인돼 거짓 GHOST 나는 회귀 차단.
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="pr-reviewer", mode=None,
+                       enum="CHANGES_REQUESTED", must_fix=True, conclusion_enum="LGTM",
+                       prose_excerpt="MUST FIX: x\nLGTM 후보 X"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="fixed"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
+    def test_must_fix_ghost_fires_on_product_acceptance_gate(self):
+        # #771 — product-acceptance 도 게이트 — PASS + must_fix 모순이면 GHOST.
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="product-acceptance", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="PASS",
+                       prose_excerpt="MUST FIX: 누락 AC"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="x"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
     def test_spec_gap_loop(self):
         steps = [
             StepRecord(idx=i, ts=f"t{i}", agent="architect", mode="SPEC_GAP",

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -399,6 +399,28 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
+    def test_must_fix_ghost_fires_on_tech_reviewer_gate(self):
+        # #771 — tech-reviewer 도 PASS/FAIL 게이트 (agents/tech-reviewer 결론 규약).
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="tech-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="PASS",
+                       prose_excerpt="MUST FIX: 외부 API 미검증"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="IMPL",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="IMPL_DONE",
+                       prose_excerpt="x"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
+    def test_ghost_gate_set_covers_ledger_validators(self):
+        # #771 drift 가드 — conveyor 검증 게이트가 늘면 GHOST 게이트도 같이 커져야 함.
+        from harness.run_review import MUST_FIX_GATE_AGENTS
+        from harness import ledger
+        self.assertTrue(
+            ledger._VALIDATOR_AGENTS <= MUST_FIX_GATE_AGENTS,
+            "ledger._VALIDATOR_AGENTS 의 모든 게이트가 MUST_FIX_GATE_AGENTS 에 있어야 함",
+        )
+
     def test_spec_gap_loop(self):
         steps = [
             StepRecord(idx=i, ts=f"t{i}", agent="architect", mode="SPEC_GAP",

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -372,6 +372,21 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
+    def test_must_fix_ghost_prose_final_fail_beats_incidental_pass(self):
+        # #771 — PROSE_LOGGED 게이트의 prose 가 "tests PASS … FAIL" 로 끝나면 실제 실패.
+        # conclusion_enum 이 PASS 로 오파싱돼도 위치상 마지막 결론(FAIL)이 이겨 GHOST 아님.
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="PASS",
+                       prose_excerpt="",
+                       prose_full="검토함.\ntests PASS 증거 참고.\n\nMUST FIX: x\n\nFAIL"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="fixed"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
     def test_must_fix_ghost_stored_verdict_beats_misparsed_prose(self):
         # #770/#771 — legacy stored enum(CHANGES_REQUESTED)이 prose 오파싱(LGTM)을 이김
         # → 거부된 리뷰가 PASS-class 로 오인돼 거짓 GHOST 나는 회귀 차단.

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -401,6 +401,21 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
+    def test_must_fix_ghost_mixed_line_trailing_pass_still_fires(self):
+        # #771 — 혼합줄이 PASS 로 *끝나면* 진짜 PASS 결론 → must_fix 와 모순이라 GHOST 유지
+        # (round5: fail 토큰 존재만으로 over-suppress 하지 않음 — 위치상 마지막 토큰이 결론).
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="PASS",
+                       prose_excerpt="",
+                       prose_full="검토.\nMUST FIX: x\n\nPASS / FAIL 중 PASS"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="y"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
     def test_must_fix_ghost_stored_verdict_beats_misparsed_prose(self):
         # #770/#771 — legacy stored enum(CHANGES_REQUESTED)이 prose 오파싱(LGTM)을 이김
         # → 거부된 리뷰가 PASS-class 로 오인돼 거짓 GHOST 나는 회귀 차단.

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -387,6 +387,20 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
+    def test_must_fix_ghost_mixed_conclusion_line_fail_wins(self):
+        # #771 — 혼합 결론줄 "PASS / FAIL 중 FAIL" 도 fail 우선 → GHOST 아님.
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="pr-reviewer", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="PASS",
+                       prose_excerpt="",
+                       prose_full="tests PASS 참고.\nMUST FIX: x\n\nPASS / FAIL 중 FAIL"),
+            StepRecord(idx=1, ts="t2", agent="engineer", mode="POLISH",
+                       enum="PROSE_LOGGED", must_fix=False, conclusion_enum="POLISH_DONE",
+                       prose_excerpt="fixed"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
     def test_must_fix_ghost_stored_verdict_beats_misparsed_prose(self):
         # #770/#771 — legacy stored enum(CHANGES_REQUESTED)이 prose 오파싱(LGTM)을 이김
         # → 거부된 리뷰가 PASS-class 로 오인돼 거짓 GHOST 나는 회귀 차단.

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -412,14 +412,19 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertTrue(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
-    def test_ghost_gate_set_covers_ledger_validators(self):
-        # #771 drift 가드 — conveyor 검증 게이트가 늘면 GHOST 게이트도 같이 커져야 함.
+    def test_ghost_gate_set_derived_from_allow_matrix(self):
+        # #771 — 게이트셋은 ALLOW_MATRIX 빈 허용(read-only)에서 파생 — hardcode 누락
+        # whack-a-mole 차단. read-only 게이트 전부 + tech-reviewer 포함.
         from harness.run_review import MUST_FIX_GATE_AGENTS
+        from harness.agent_boundary import ALLOW_MATRIX
         from harness import ledger
-        self.assertTrue(
-            ledger._VALIDATOR_AGENTS <= MUST_FIX_GATE_AGENTS,
-            "ledger._VALIDATOR_AGENTS 의 모든 게이트가 MUST_FIX_GATE_AGENTS 에 있어야 함",
-        )
+        read_only = {a for a, paths in ALLOW_MATRIX.items() if not paths}
+        self.assertTrue(read_only <= MUST_FIX_GATE_AGENTS,
+                        "ALLOW_MATRIX 의 모든 read-only 게이트 포함 필수")
+        self.assertTrue(ledger._VALIDATOR_AGENTS <= MUST_FIX_GATE_AGENTS)
+        # 폐기됐지만 legacy 트레이스용 plan-reviewer 자동 포함 + tech-reviewer 명시
+        self.assertIn("plan-reviewer", MUST_FIX_GATE_AGENTS)
+        self.assertIn("tech-reviewer", MUST_FIX_GATE_AGENTS)
 
     def test_spec_gap_loop(self):
         steps = [


### PR DESCRIPTION
## 배경·문제

fleet 집계기([#766](https://github.com/alruminum/dcNess/issues/766))로 외부 활성 프로젝트 44 run 을 돌리니 `MUST_FIX_GHOST` 가 **41건 전부 false positive** 로 나왔다. HIGH severity waste 인데 실제 위반이 0건이라 `/run-review` 와 fleet 벤치마크를 오도한다.

## 근본원인

옛 룰: `must_fix=True and 다음 step 존재` → "멈춤 위반". 그러나 conveyor 에서 **reviewer FAIL → engineer fix → 재리뷰는 설계된 정상 흐름**이고, engineer POLISH 가 고친 MUST FIX 항목을 prose 에 재진술(`## MUST FIX 1 …`)하는 것도 정상이다. 실측 전이 분포(41건):
- `pr-reviewer:FAIL → engineer/pr-reviewer` 28 (정상 fix 루프)
- `engineer:POLISH_DONE` 10 (고친 항목 재진술)
- producer(test-engineer/build-worker) 3
- **`리뷰어 PASS/LGTM + must_fix`(진짜 게이트 모순) = 0**

## 작업내용

- `harness/run_review.py` — MUST_FIX_GHOST 를 **게이트 agent(pr-reviewer/code-validator/architecture-validator)가 PASS/LGTM 결론 + must_fix=True** 로 좁힘. producer 의 must_fix·reviewer FAIL·정상 fix 루프 제외. 끝까지 미해결은 기존 `MUST_FIX_LEAK`(마지막 step) 담당 유지. 상수 `MUST_FIX_GATE_AGENTS` / `MUST_FIX_GHOST_PASS_ENUMS` 추가.
- `tests/test_run_review.py` — 틀린 동작을 박아둔 옛 `test_must_fix_ghost`(validator FAIL→engineer 를 위반이라 단정) 교체. 3 테스트: 게이트 PASS+must_fix→검출 / 정상 fix 루프→미검출 / producer 재진술→미검출.
- `docs/plugin/benchmark.md` — fleet 스냅샷 waste top 갱신 (MUST_FIX_GHOST 제거 → TOOL_REPEAT_HIGH 39 / MUST_FIX_LEAK 11 / MISSING_CONCLUSION_ENUM 2).

## 결정근거

remove 가 아니라 narrow — "게이트가 통과시키며 blocker 남김"은 논리적으로 진짜 결함 신호라 보존. 실측 0건이라 현재 노이즈 없이 의미만 남음. (측정으로 remove vs narrow 판정)

## Test Plan

- `python3.11 -m unittest tests.test_run_review` → 80 PASS
- `python3.11 -m unittest discover -s tests` → 1286 PASS
- pre-commit pytest-gate / cross-ref PASS
- 실데이터: youtube 44 run 재집계 → MUST_FIX_GHOST 0 확인

## 배포 경로 검증

- `harness/run_review.py` = plug-in 본체(경로 1, `plugin update` 자동). `/run-review` skill 출력 정확도 직접 개선.
- `docs/plugin/benchmark.md` = 본체 문서(경로 1).

Closes #770
