### PR TITLE
[issue-772] Codex validator skill frontmatter 추가

### DIFF
--- a/codex/skills/dcness-architecture-validator/SKILL.md
+++ b/codex/skills/dcness-architecture-validator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dcness-architecture-validator
+description: Use when dcNess routes architecture-validator cross-review work to Codex before implementation or architecture PR merge to validate design contracts read-only.
+---
+
 # dcness-architecture-validator
 
 ## 언제 쓰나

--- a/codex/skills/dcness-code-validator/SKILL.md
+++ b/codex/skills/dcness-code-validator/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dcness-code-validator
+description: Use when dcNess routes code-validator cross-review work to Codex after implementation to verify that code, tests, and contracts satisfy the provided plan, changed files, and test evidence.
+---
+
 # dcness-code-validator
 
 ## 언제 쓰나

--- a/codex/skills/dcness-pr-reviewer/SKILL.md
+++ b/codex/skills/dcness-pr-reviewer/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: dcness-pr-reviewer
+description: Use when dcNess routes pr-reviewer cross-review work to Codex before merge to review PR diffs for merge risk, maintainability, integration safety, security-sensitive patterns, and credible test evidence.
+---
+
 # dcness-pr-reviewer
 
 ## 언제 쓰나

--- a/tests/test_validator_handoff_guidance.py
+++ b/tests/test_validator_handoff_guidance.py
@@ -43,6 +43,16 @@ class ValidatorHandoffGuidanceTests(unittest.TestCase):
             ).read_text(encoding="utf-8"),
         }
 
+    def test_codex_read_only_validation_skills_have_native_frontmatter(self) -> None:
+        for name, text in self.codex_skills.items():
+            with self.subTest(skill=name):
+                self.assertTrue(text.startswith("---\n"))
+                end = text.find("\n---\n", 4)
+                self.assertNotEqual(end, -1)
+                frontmatter = text[4:end]
+                self.assertIn(f"name: {name}", frontmatter)
+                self.assertIn("description: ", frontmatter)
+
     def test_shared_guidance_defines_fail_escalate_note_and_delta_first(self) -> None:
         for needle in (
             "# 검증 보고 가이드",


### PR DESCRIPTION
## 관련 이슈 번호

Closes #772

## 배경 및 문제

Codex companion review 실행 시 `$CODEX_HOME/skills/dcness-*` native skill 로더가 `SKILL.md` YAML frontmatter 부재 때문에 반복 stderr 에러를 냈습니다.

## 원인 (해당 시)

`codex/skills/dcness-{architecture-validator,code-validator,pr-reviewer}/SKILL.md` 3개가 모두 `--- name/description ---` frontmatter 없이 H1으로 시작했습니다. `/init-dcness` 는 이 파일들을 `$CODEX_HOME/skills` 로 always-overwrite 하므로 fresh deploy 시 native skill registry 로드가 실패할 수 있었습니다.

## 작업내용

- Codex validator skill 3종에 native loader용 `name` / `description` frontmatter 추가
- `tests/test_validator_handoff_guidance.py` 에 3종 frontmatter 존재와 skill 디렉터리명 일치 회귀 테스트 추가

## 결정 근거

기존 wrapper는 `SKILL.md` 본문을 직접 prompt에 주입하므로 기능 자체보다 native registry 로드 노이즈가 문제였습니다. 따라서 배포 소스인 `codex/skills/**/SKILL.md` 에 최소 frontmatter만 추가하고, 같은 문제가 재발하지 않도록 테스트로 고정했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- 영향 경로: `codex/skills/dcness-*` → `commands/init-dcness.md` Step 2.10에서 `$CODEX_HOME/skills/dcness-*` 로 always-overwrite 복사
- 신규/기존 사용자는 plugin update 후 `/init-dcness` 재실행 시 수정된 skill을 받습니다.
- `commands/init-dcness.md` 배포 루프는 이미 세 디렉터리를 복사하고 있어 스크립트 변경은 필요 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 Codex validator skill metadata 보정이며 새 public surface 추가 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_validator_handoff_guidance -v`
- [x] `python3.11 -m unittest tests.test_codex_validator_wrapper -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] pre-commit hook 실행 통과
- [x] 임시 `CODEX_HOME` 에 수정본 복사 후 `codex debug prompt-input "skill load smoke"` 실행 시 stderr 로드 에러 없음

## 참고

- 이슈 발견 경위: #770 작업 중 Codex companion review stderr 반복 에러
