### PR TITLE
[issue-696] sub-agent ALLOW_MATRIX 프로젝트별 override 메커니즘 (.dcness/boundary.json)

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -130,6 +130,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 - **INFRA 경로** (`DCNESS_INFRA_PATTERNS` — `hooks/`, `harness/*.py` 등) 는 `add` 로 열 수 없다. INFRA 검사가 ALLOW(코어+add) 검사보다 *먼저* 발화하기 때문.
 - **`.dcness/boundary.json` 자신**(과 `.dcness/` 디렉토리 전체) 은 sub-agent write 차단 영역 (자기 경계 셀프 확장/축소 금지). INFRA 로 보호되며 `remove` 로도 풀 수 없고, 디렉토리 타깃 write 우회도 닫힌다.
 - **판정/검증 전용 agent**(`code-validator` / `pr-reviewer` / `architecture-validator` / `product-acceptance` / `plan-reviewer` — 코어 ALLOW 가 빈 `()`) 는 `add` 로도 write 를 열 수 없다. "검증자는 자기가 검증하는 것을 못 고친다" 는 역할 격리는 catastrophic gate 신뢰의 근간이라 되돌릴 수 없는 경계 — `add` 로 mutation agent 로 승격시킬 수 없다.
+- **guard self-disable 마커** (`.no-dcness-guard` = file-guard 임시 우회 / `.claude-plugin/` = `is_infra_project` self-repo 신호) 도 INFRA 로 보호된다. broad `add`(예 `.*`)로도 sub-agent 가 file guard 자체를 끄는 통제 파일을 쓸 수 없다.
 - 그 외 기본값(예: engineer 의 `tests/` 제외 = self-grading 방어)은 **강제 가드가 아니라 권고** 다. 프로젝트가 `add` 로 풀 수 있고, 그 경우 self-grading drift(구현자가 자기 코드를 통과시키도록 테스트를 편향) 위험은 프로젝트가 감수한다.
 
 GitHub issue 외부 상태 변경은 경로에 따라 다르게 처리한다 — 같은 "issue 변경"이라도 차단 여부가 갈린다.

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -100,10 +100,35 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 | `DCNESS_INFRA_PATTERNS` | sub-agent 의 `.claude/`, `hooks/`, `harness/*.py`, `docs/plugin/*.md`, `scripts/*.mjs` 등 infra path 접근 차단 |
 | `RUN_DIR_PROSE_ALLOW` | build-worker 가 자기 run dir 의 `build-{test,impl,validate,polish}.md` prose 를 쓰는 좁은 예외 |
 | `ALLOW_MATRIX` | agent 별 Write 허용 path 제한 |
+| `.dcness/boundary.json` | **프로젝트별 override** — agent 별 `add`(허용 확장) / `remove`(코어 기본 제거)로 코어 `ALLOW_MATRIX` 를 양방향 커스텀 (아래 참조) |
 | `READ_DENY_MATRIX` | agent 별 Read 금지 path 제한 |
 | 외부 변경 차단 목록 | sub-agent 의 `git push`, Bash `gh pr create/merge/review`, Bash `gh issue create/edit/close/comment`, 상태 변경 `gh api`, GitHub MCP PR/repo 외부 상태 변경 차단 |
 
 메인 Claude turn 은 file boundary 를 통과한다.
+
+#### 프로젝트별 write 경계 override — `.dcness/boundary.json`
+
+코어 `ALLOW_MATRIX` 는 흔한 언어·레이아웃의 합리적 기본값만 잡는다. 프로젝트 사정은 무한하므로(비표준 소스 디렉토리, 또는 코어 기본 제외를 의도적으로 완화하고 싶은 경우 — 예: engineer 의 `tests/` 제외를 "구현·테스트 한 호흡" 워크플로에서 열기), 프로젝트가 **루트의 `.dcness/boundary.json`** 으로 자기 사정을 직접 선언한다. 코어는 건드리지 않고, 예외는 프로젝트가 SSOT 로 가진다.
+
+```json
+{
+  "engineer":      { "add": ["(^|/)remotion/", "(^|/)tests?/"], "remove": ["^app/"] },
+  "test-engineer": { "add": ["(^|/)custom-e2e/"] }
+}
+```
+
+- **형식**: agent 별 `add` / `remove` 정규식(코어 `ALLOW_MATRIX` 와 동일한 `re.search` 패턴) 배열.
+- **`add`**: 코어 `ALLOW_MATRIX` 에 없는 경로를 그 agent 에 허용 (비표준 레이아웃 / 의도적 기본 제외 완화).
+- **`remove`**: 코어 기본 허용 경로를 이 프로젝트에서 제거 (ALLOW 보다 우선하는 DENY 오버레이).
+- **탐색**: `harness/agent_boundary.py` 가 cwd 조상에서 이 파일을 찾는다. worktree·하위 디렉토리에서도 프로젝트 루트 설정이 적용된다.
+- **안전 degrade**: 파일 부재·깨진 JSON·형식 위반·컴파일 불가 정규식은 조용히 무시하고 코어 기본값을 유지한다 (잘못된 설정이 경계를 깨뜨리지 않는다).
+- **배포**: 읽는 로직은 plugin 본체(`harness/`)라 plugin 버전업으로 자동 적용 (cp 0). 설정 파일은 프로젝트가 직접 작성한다.
+
+**override 가 뚫지 못하는 가드 (되돌릴 수 없는 경계만)**:
+
+- **INFRA 경로** (`DCNESS_INFRA_PATTERNS` — `hooks/`, `harness/*.py` 등) 는 `add` 로 열 수 없다. INFRA 검사가 ALLOW(코어+add) 검사보다 *먼저* 발화하기 때문.
+- **`.dcness/boundary.json` 자신** 은 sub-agent write 차단 영역 (자기 경계 셀프 확장/축소 금지). INFRA 로 보호되며 `remove` 로도 풀 수 없다.
+- 그 외 기본값(예: engineer 의 `tests/` 제외 = self-grading 방어)은 **강제 가드가 아니라 권고** 다. 프로젝트가 `add` 로 풀 수 있고, 그 경우 self-grading drift(구현자가 자기 코드를 통과시키도록 테스트를 편향) 위험은 프로젝트가 감수한다.
 
 GitHub issue 외부 상태 변경은 경로에 따라 다르게 처리한다 — 같은 "issue 변경"이라도 차단 여부가 갈린다.
 

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -120,7 +120,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 - **형식**: agent 별 `add` / `remove` 정규식(코어 `ALLOW_MATRIX` 와 동일한 `re.search` 패턴) 배열.
 - **`add`**: 코어 `ALLOW_MATRIX` 에 없는 경로를 그 agent 에 허용 (비표준 레이아웃 / 의도적 기본 제외 완화).
 - **`remove`**: 코어 기본 허용 경로를 이 프로젝트에서 제거 (ALLOW 보다 우선하는 DENY 오버레이).
-- **탐색**: `harness/agent_boundary.py` 가 cwd 조상에서 이 파일을 찾는다. worktree·하위 디렉토리에서도 프로젝트 루트 설정이 적용된다.
+- **탐색**: `harness/agent_boundary.py` 가 cwd 에서 **프로젝트 루트(git common-dir 기준)까지만** 조상을 거슬러 이 파일을 찾는다. worktree·하위 디렉토리에서도 프로젝트 루트 설정이 적용되지만, 그 *위* 상위 워크스페이스·home 디렉토리의 `.dcness/boundary.json` 은 무시된다 (무관한 상위 설정이 경계를 약화하지 못하도록).
 - **build-worker 전파**: 코어 `ALLOW_MATRIX["build-worker"]` 가 `engineer ∪ test-engineer` 합집합이듯, `engineer` / `test-engineer` 의 `add`·`remove` 는 `build-worker`(`/impl-loop` 의 실제 mutation agent)에도 합쳐 전파된다. 즉 `"engineer": {"remove": ["^app/"]}` 만 선언해도 build-worker 의 `app/` write 가 함께 막힌다 (별도 `build-worker` 키 불필요).
 - **안전 degrade**: 파일 부재·깨진 JSON·형식 위반·컴파일 불가 정규식은 조용히 무시하고 코어 기본값을 유지한다 (잘못된 설정이 경계를 깨뜨리지 않는다).
 - **배포**: 읽는 로직은 plugin 본체(`harness/`)라 plugin 버전업으로 자동 적용 (cp 0). 설정 파일은 프로젝트가 직접 작성한다.

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -128,7 +128,8 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 **override 가 뚫지 못하는 가드 (되돌릴 수 없는 경계만)**:
 
 - **INFRA 경로** (`DCNESS_INFRA_PATTERNS` — `hooks/`, `harness/*.py` 등) 는 `add` 로 열 수 없다. INFRA 검사가 ALLOW(코어+add) 검사보다 *먼저* 발화하기 때문.
-- **`.dcness/boundary.json` 자신** 은 sub-agent write 차단 영역 (자기 경계 셀프 확장/축소 금지). INFRA 로 보호되며 `remove` 로도 풀 수 없다.
+- **`.dcness/boundary.json` 자신**(과 `.dcness/` 디렉토리 전체) 은 sub-agent write 차단 영역 (자기 경계 셀프 확장/축소 금지). INFRA 로 보호되며 `remove` 로도 풀 수 없고, 디렉토리 타깃 write 우회도 닫힌다.
+- **판정/검증 전용 agent**(`code-validator` / `pr-reviewer` / `architecture-validator` / `product-acceptance` / `plan-reviewer` — 코어 ALLOW 가 빈 `()`) 는 `add` 로도 write 를 열 수 없다. "검증자는 자기가 검증하는 것을 못 고친다" 는 역할 격리는 catastrophic gate 신뢰의 근간이라 되돌릴 수 없는 경계 — `add` 로 mutation agent 로 승격시킬 수 없다.
 - 그 외 기본값(예: engineer 의 `tests/` 제외 = self-grading 방어)은 **강제 가드가 아니라 권고** 다. 프로젝트가 `add` 로 풀 수 있고, 그 경우 self-grading drift(구현자가 자기 코드를 통과시키도록 테스트를 편향) 위험은 프로젝트가 감수한다.
 
 GitHub issue 외부 상태 변경은 경로에 따라 다르게 처리한다 — 같은 "issue 변경"이라도 차단 여부가 갈린다.

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -120,7 +120,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 - **형식**: agent 별 `add` / `remove` 정규식(코어 `ALLOW_MATRIX` 와 동일한 `re.search` 패턴) 배열.
 - **`add`**: 코어 `ALLOW_MATRIX` 에 없는 경로를 그 agent 에 허용 (비표준 레이아웃 / 의도적 기본 제외 완화).
 - **`remove`**: 코어 기본 허용 경로를 이 프로젝트에서 제거 (ALLOW 보다 우선하는 DENY 오버레이).
-- **탐색**: `harness/agent_boundary.py` 가 cwd 에서 **프로젝트 루트(git common-dir 기준)까지만** 조상을 거슬러 이 파일을 찾는다. worktree·하위 디렉토리에서도 프로젝트 루트 설정이 적용되지만, 그 *위* 상위 워크스페이스·home 디렉토리의 `.dcness/boundary.json` 은 무시된다 (무관한 상위 설정이 경계를 약화하지 못하도록).
+- **탐색**: `harness/agent_boundary.py` 가 cwd 에서 **working tree top-level(`git rev-parse --show-toplevel`)까지만** 조상을 거슬러 이 파일을 찾는다. nested·linked worktree 와 하위 디렉토리에서도 worktree 루트 설정이 적용되지만, 그 *위* 상위 워크스페이스·home 디렉토리의 `.dcness/boundary.json` 은 무시된다 (무관한 상위 설정이 경계를 약화하지 못하도록).
 - **build-worker 전파**: 코어 `ALLOW_MATRIX["build-worker"]` 가 `engineer ∪ test-engineer` 합집합이듯, `engineer` / `test-engineer` 의 `add`·`remove` 는 `build-worker`(`/impl-loop` 의 실제 mutation agent)에도 합쳐 전파된다. 즉 `"engineer": {"remove": ["^app/"]}` 만 선언해도 build-worker 의 `app/` write 가 함께 막힌다 (별도 `build-worker` 키 불필요).
 - **안전 degrade**: 파일 부재·깨진 JSON·형식 위반·컴파일 불가 정규식은 조용히 무시하고 코어 기본값을 유지한다 (잘못된 설정이 경계를 깨뜨리지 않는다).
 - **배포**: 읽는 로직은 plugin 본체(`harness/`)라 plugin 버전업으로 자동 적용 (cp 0). 설정 파일은 프로젝트가 직접 작성한다.

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -121,6 +121,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 - **`add`**: 코어 `ALLOW_MATRIX` 에 없는 경로를 그 agent 에 허용 (비표준 레이아웃 / 의도적 기본 제외 완화).
 - **`remove`**: 코어 기본 허용 경로를 이 프로젝트에서 제거 (ALLOW 보다 우선하는 DENY 오버레이).
 - **탐색**: `harness/agent_boundary.py` 가 cwd 조상에서 이 파일을 찾는다. worktree·하위 디렉토리에서도 프로젝트 루트 설정이 적용된다.
+- **build-worker 전파**: 코어 `ALLOW_MATRIX["build-worker"]` 가 `engineer ∪ test-engineer` 합집합이듯, `engineer` / `test-engineer` 의 `add`·`remove` 는 `build-worker`(`/impl-loop` 의 실제 mutation agent)에도 합쳐 전파된다. 즉 `"engineer": {"remove": ["^app/"]}` 만 선언해도 build-worker 의 `app/` write 가 함께 막힌다 (별도 `build-worker` 키 불필요).
 - **안전 degrade**: 파일 부재·깨진 JSON·형식 위반·컴파일 불가 정규식은 조용히 무시하고 코어 기본값을 유지한다 (잘못된 설정이 경계를 깨뜨리지 않는다).
 - **배포**: 읽는 로직은 plugin 본체(`harness/`)라 plugin 버전업으로 자동 적용 (cp 0). 설정 파일은 프로젝트가 직접 작성한다.
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -61,11 +61,16 @@ DCNESS_INFRA_PATTERNS: tuple[str, ...] = (
     r'(^|/)docs/internal/governance\.md$',
     r'(^|/)scripts/(check_document_sync|check_task_id|setup_branch_protection)\.mjs$',
     r'^CLAUDE\.md$',
-    # 프로젝트별 boundary override 설정 파일 자신 (#696) — 위조 방지. sub-agent 가
-    # 자기 write 경계를 셀프 확장/축소하지 못하도록 INFRA 로 보호한다. INFRA 검사는
+    # 프로젝트별 boundary override 설정 디렉토리 `.dcness/` 전체 (#696) — 위조 방지.
+    # sub-agent 가 자기 write 경계를 셀프 확장/축소하지 못하도록 INFRA 로 보호한다.
+    # 파일 단위(`boundary\.json$`)만 막으면, 프로젝트가 add 로 `.dcness/` 를 연 뒤
+    # 디렉토리 타깃 Bash write(`cp x .dcness/`)로 boundary.json 을 *교체* 해 보호를 우회할
+    # 수 있다 (codex P2). 디렉토리 자체(`.dcness`)·하위(`.dcness/...`) 를 모두 매칭해
+    # 디렉토리 타깃 우회를 닫는다. `.dcness` 는 dcness 제어 영역이라 sub-agent write 가
+    # 정당하지 않다 (메인 Claude 는 INFRA 통과로 boundary.json 작성). INFRA 검사는
     # ALLOW(코어+add) 검사보다 *먼저* 발화하므로 add 로 못 열고, remove 는 ALLOW 에서만
     # 빼는 DENY 오버레이라 INFRA 보호를 못 푼다 (가드 = 검사 순서로 자동 보장).
-    r'(^|/)\.dcness/boundary\.json$',
+    r'(^|/)\.dcness(/|$)',
 )
 
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -41,6 +41,7 @@ __all__ = [
     "READ_DENY_MATRIX",
     "is_infra_project",
     "is_opt_out",
+    "load_project_boundary_overrides",
     "check_write_allowed",
     "check_read_allowed",
     "extract_bash_paths",
@@ -60,6 +61,11 @@ DCNESS_INFRA_PATTERNS: tuple[str, ...] = (
     r'(^|/)docs/internal/governance\.md$',
     r'(^|/)scripts/(check_document_sync|check_task_id|setup_branch_protection)\.mjs$',
     r'^CLAUDE\.md$',
+    # 프로젝트별 boundary override 설정 파일 자신 (#696) — 위조 방지. sub-agent 가
+    # 자기 write 경계를 셀프 확장/축소하지 못하도록 INFRA 로 보호한다. INFRA 검사는
+    # ALLOW(코어+add) 검사보다 *먼저* 발화하므로 add 로 못 열고, remove 는 ALLOW 에서만
+    # 빼는 DENY 오버레이라 INFRA 보호를 못 푼다 (가드 = 검사 순서로 자동 보장).
+    r'(^|/)\.dcness/boundary\.json$',
 )
 
 
@@ -296,6 +302,73 @@ def is_opt_out(cwd: Optional[Path] = None) -> bool:
     return (cwd / ".no-dcness-guard").exists()
 
 
+# ── 프로젝트별 boundary override (#696) ────────────────────────────────
+def load_project_boundary_overrides(
+    cwd: Optional[Path] = None,
+) -> dict[str, dict[str, tuple[str, ...]]]:
+    """cwd 조상에서 `.dcness/boundary.json` 을 찾아 agent별 add/remove 패턴을 반환한다.
+
+    #696 — 외부 활성 프로젝트가 자기 레이아웃·정책을 직접 선언해 sub-agent write 경계를
+    양방향으로 커스텀하는 메커니즘. 코어 ALLOW_MATRIX 는 합리적 기본값만 잡고, 무한한
+    프로젝트별 예외는 프로젝트가 SSOT (reactive cycle 을 코어 밖으로 이관).
+
+    형식: `{"<agent>": {"add": [regex...], "remove": [regex...]}}`.
+    - add  — 코어 ALLOW 에 없는 경로 허용 (비표준 레이아웃 / 의도적 기본 제외 완화).
+    - remove — 코어 기본 허용 경로를 이 프로젝트에서 제거 (DENY 오버레이).
+
+    되돌릴 수 없는 경계(INFRA / boundary.json 자기보호)는 호출부(check_write_allowed)가
+    ALLOW 검사보다 *먼저* 강제하므로 여기서 거르지 않는다 — add 로 INFRA 를 못 열고,
+    remove 는 ALLOW 에서만 빼므로 INFRA 보호를 못 푼다 (가드 = 검사 순서로 자동 보장).
+
+    안전 degrade: 파일 부재·파싱 실패·형식 위반·컴파일 불가 정규식은 조용히 무시하고
+    해당 부분만 제외한다 (잘못된 설정이 코어 기본값을 깨뜨리지 않는다).
+    """
+    if cwd is None:
+        cwd = Path.cwd()
+    try:
+        cur = cwd.resolve()
+    except (OSError, RuntimeError):
+        return {}
+    cfg_path: Optional[Path] = None
+    for d in (cur, *cur.parents):
+        candidate = d / ".dcness" / "boundary.json"
+        if candidate.is_file():
+            cfg_path = candidate
+            break
+    if cfg_path is None:
+        return {}
+    try:
+        data = json.loads(cfg_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+
+    result: dict[str, dict[str, tuple[str, ...]]] = {}
+    for agent, spec in data.items():
+        if not isinstance(agent, str) or not isinstance(spec, dict):
+            continue
+        entry: dict[str, tuple[str, ...]] = {}
+        for key in ("add", "remove"):
+            raw = spec.get(key, [])
+            if not isinstance(raw, list):
+                continue
+            valid: list[str] = []
+            for pat in raw:
+                if not isinstance(pat, str):
+                    continue
+                try:
+                    re.compile(pat)
+                except re.error:
+                    continue
+                valid.append(pat)
+            if valid:
+                entry[key] = tuple(valid)
+        if entry:
+            result[agent] = entry
+    return result
+
+
 # ── path 정규화 ───────────────────────────────────────────────────────
 
 
@@ -444,15 +517,31 @@ def check_write_allowed(
                 f"docs/ 는 architect, design-variants/ 는 designer 전용 (코드 agent write 금지)."
             )
 
-    # 3. ALLOW_MATRIX 미매칭 → 차단.
+    # 3. 프로젝트별 boundary override (#696) — 코어 ALLOW 검사 직전에 적용.
+    #    INFRA(1)·코드 agent 전용 deny(2) 를 모두 통과한 뒤이므로, override 는 되돌릴 수
+    #    없는 경계를 건드리지 못한다 (가드 = 검사 순서). remove 는 ALLOW 보다 우선하는
+    #    DENY 오버레이, add 는 코어 ALLOW 확장.
+    ov = load_project_boundary_overrides(cwd).get(agent)
+
+    # 3a. remove 오버레이 — 코어 기본 허용 경로를 이 프로젝트에서 제거.
+    if ov and ov.get("remove"):
+        matched = _matches_any(norm, ov["remove"])
+        if matched:
+            return (
+                f"{agent} 프로젝트 boundary remove: `{norm}` matched `{matched}` "
+                f"(.dcness/boundary.json — 코어 기본값에서 제거)"
+            )
+
+    # 3b. ALLOW_MATRIX (코어 + 프로젝트 add) 미매칭 → 차단.
     allowed = ALLOW_MATRIX.get(agent)
     if allowed is None:
         # 미정의 agent — false positive 회피로 통과.
         return None
-    if not _matches_any(norm, allowed):
+    effective = allowed + (ov.get("add", ()) if ov else ())
+    if not _matches_any(norm, effective):
         return (
             f"{agent} ALLOW_MATRIX 미매칭: `{norm}` "
-            f"(ALLOW_MATRIX — 허용 = {list(allowed)})"
+            f"(ALLOW_MATRIX — 허용 = {list(effective)})"
         )
     return None
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -72,6 +72,16 @@ DCNESS_INFRA_PATTERNS: tuple[str, ...] = (
     # ALLOW(코어+add) 검사보다 *먼저* 발화하므로 add 로 못 열고, remove 는 ALLOW 에서만
     # 빼는 DENY 오버레이라 INFRA 보호를 못 푼다 (가드 = 검사 순서로 자동 보장).
     r'(^|/)\.dcness(/|$)',
+    # guard self-disable 마커 (#696 codex P1) — boundary override 의 broad add(예 `.*`)로
+    # sub-agent 가 file guard 자체를 끄는 통제 파일을 쓰지 못하도록 INFRA 로 보호한다.
+    #   - `.no-dcness-guard` — is_opt_out() 마커. 쓰면 다음 검사부터 file guard 전면 우회.
+    #   - `.claude-plugin/` — plugin.json name=dcness 가 _is_dcness_self_repo() 신호라,
+    #     쓰면 is_infra_project() True 로 모든 sub-agent 경계가 무력화된다. `(^|/)\.claude/`
+    #     는 `.claude-plugin/`(≠`.claude/`)에 미매칭이라 별도 보호 필요. 디렉토리 타깃 우회
+    #     방지로 디렉토리 자체·하위를 모두 매칭. (`~/.claude/.dcness-infra` 는 home 이라
+    #     cwd-밖 가드가 이미 차단 — sub-agent 가 경계 밖 write 불가.)
+    r'(^|/)\.no-dcness-guard(/|$)',
+    r'(^|/)\.claude-plugin(/|$)',
 )
 
 

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -335,8 +335,24 @@ def load_project_boundary_overrides(
         cur = cwd.resolve()
     except (OSError, RuntimeError):
         return {}
-    cfg_path: Optional[Path] = None
+    # 탐색 범위를 active project root 까지로 제한 (#696 codex P2). 무한정 상위로 올라가면
+    # 현재 프로젝트 밖(상위 워크스페이스 / home)의 boundary.json 이 무관한 하위 프로젝트의
+    # sub-agent write 경계를 silently 확장/축소해 file guard 를 약화한다. project root 는
+    # git common-dir 기준(worktree·하위 디렉토리에서도 main repo 루트로 해소)이라, 그 위
+    # 조상은 검사하지 않는다. root 가 cwd 조상이 아니면(폴백·예외) cwd 자신만 검사한다.
+    try:
+        root = _resolve_project_root(cwd).resolve()
+    except (OSError, RuntimeError, ValueError):
+        root = cur
+    search_dirs: list[Path] = []
     for d in (cur, *cur.parents):
+        search_dirs.append(d)
+        if d == root:
+            break
+    else:
+        search_dirs = [cur]
+    cfg_path: Optional[Path] = None
+    for d in search_dirs:
         candidate = d / ".dcness" / "boundary.json"
         if candidate.is_file():
             cfg_path = candidate

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -29,6 +29,7 @@ import json
 import os
 import re
 import shlex
+import subprocess
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -314,6 +315,42 @@ def is_opt_out(cwd: Optional[Path] = None) -> bool:
 
 
 # ── 프로젝트별 boundary override (#696) ────────────────────────────────
+_BOUNDARY_ROOT_CACHE: dict[str, Optional[str]] = {}
+
+
+def _git_worktree_toplevel(cwd: Path) -> Optional[Path]:
+    """현재 working tree 의 top-level (`git rev-parse --show-toplevel`) — boundary 탐색 상한.
+
+    `_resolve_project_root` 는 state 공유 목적으로 git common-dir parent(= main repo
+    루트)를 돌려주는데, linked worktree(메인 체크아웃 밖에 둔 worktree)에선 그 루트가
+    worktree cwd 의 조상이 아니라 boundary.json 탐색 경계로 부적합하다 (#696 codex P2).
+    boundary.json 은 worktree-local 체크아웃 파일이므로, 현재 working tree top-level 까지
+    탐색해야 nested·linked worktree 양쪽에서 정확하고, 그 *위* 상위 워크스페이스·home 은
+    무시된다. git 아님·실패 시 None (호출부가 cwd 폴백).
+    """
+    key = str(cwd)
+    if key in _BOUNDARY_ROOT_CACHE:
+        cached = _BOUNDARY_ROOT_CACHE[key]
+        return Path(cached) if cached else None
+    top: Optional[Path] = None
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+            cwd=str(cwd),
+            timeout=2,
+        )
+        out = result.stdout.strip()
+        if out:
+            top = Path(out).resolve()
+    except (subprocess.SubprocessError, OSError, ValueError):
+        top = None
+    _BOUNDARY_ROOT_CACHE[key] = str(top) if top else None
+    return top
+
+
 def load_project_boundary_overrides(
     cwd: Optional[Path] = None,
 ) -> dict[str, dict[str, tuple[str, ...]]]:
@@ -340,14 +377,14 @@ def load_project_boundary_overrides(
         cur = cwd.resolve()
     except (OSError, RuntimeError):
         return {}
-    # 탐색 범위를 active project root 까지로 제한 (#696 codex P2). 무한정 상위로 올라가면
-    # 현재 프로젝트 밖(상위 워크스페이스 / home)의 boundary.json 이 무관한 하위 프로젝트의
-    # sub-agent write 경계를 silently 확장/축소해 file guard 를 약화한다. project root 는
-    # git common-dir 기준(worktree·하위 디렉토리에서도 main repo 루트로 해소)이라, 그 위
-    # 조상은 검사하지 않는다. root 가 cwd 조상이 아니면(폴백·예외) cwd 자신만 검사한다.
-    try:
-        root = _resolve_project_root(cwd).resolve()
-    except (OSError, RuntimeError, ValueError):
+    # 탐색 범위를 현재 working tree top-level 까지로 제한 (#696 codex P2). 무한정 상위로
+    # 올라가면 현재 프로젝트 밖(상위 워크스페이스 / home)의 boundary.json 이 무관한 하위
+    # 프로젝트의 sub-agent write 경계를 silently 확장/축소해 file guard 를 약화한다.
+    # top-level 은 nested·linked worktree 양쪽에서 worktree-local 루트로 해소되므로, 하위
+    # 디렉토리에서도 worktree 루트 boundary.json 을 찾되 그 위는 무시한다. top-level 이
+    # cwd 조상이 아니면(git 아님·폴백·예외) cwd 자신만 검사한다.
+    root = _git_worktree_toplevel(cur)
+    if root is None:
         root = cur
     search_dirs: list[Path] = []
     for d in (cur, *cur.parents):

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -192,6 +192,12 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
 # 경계가 무력화되던 결함(#597) 수정. (run_dir prose self-write 는 RUN_DIR_PROSE_ALLOW carve-out.)
 ALLOW_MATRIX["build-worker"] = ALLOW_MATRIX["engineer"] + ALLOW_MATRIX["test-engineer"]
 
+# build-worker 의 합집합 구성 역할 — 프로젝트 override(#696) 전파 대상. 코어 ALLOW 가
+# engineer ∪ test-engineer 인 것과 동일 원리로, `.dcness/boundary.json` 의 engineer /
+# test-engineer add·remove 도 build-worker 에 합쳐 전파해야 한다 (안 그러면 /impl-loop 의
+# 실제 mutation agent 인 build-worker 가 engineer.remove 를 우회하고 engineer.add 를 무효화).
+_BUILD_WORKER_UNION_ROLES: tuple[str, ...] = ("engineer", "test-engineer", "build-worker")
+
 
 # ── 코드 agent 전용영역 deny (#694 codex P2) ───────────────────────
 # engineer / test-engineer / build-worker 의 언어 중립 ALLOW 패턴(lib/·internal/·cmd/·
@@ -369,6 +375,28 @@ def load_project_boundary_overrides(
     return result
 
 
+def _effective_overrides(
+    overrides: dict[str, dict[str, tuple[str, ...]]], agent: str
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """agent 에 적용할 (add, remove) 패턴을 반환한다.
+
+    build-worker 는 코어 ALLOW 가 engineer ∪ test-engineer 합집합이므로(#597), 프로젝트
+    override 도 구성 역할(engineer / test-engineer)의 add·remove 를 합쳐 전파한다 (codex
+    P1 #696). 안 그러면 /impl-loop 의 실제 mutation agent 인 build-worker 가 engineer.remove
+    를 우회하고 engineer.add 를 무효화한다. 그 외 agent 는 자기 키만 본다.
+    """
+    roles = _BUILD_WORKER_UNION_ROLES if agent == "build-worker" else (agent,)
+    add: list[str] = []
+    remove: list[str] = []
+    for role in roles:
+        ov = overrides.get(role)
+        if not ov:
+            continue
+        add.extend(ov.get("add", ()))
+        remove.extend(ov.get("remove", ()))
+    return tuple(add), tuple(remove)
+
+
 # ── path 정규화 ───────────────────────────────────────────────────────
 
 
@@ -521,11 +549,13 @@ def check_write_allowed(
     #    INFRA(1)·코드 agent 전용 deny(2) 를 모두 통과한 뒤이므로, override 는 되돌릴 수
     #    없는 경계를 건드리지 못한다 (가드 = 검사 순서). remove 는 ALLOW 보다 우선하는
     #    DENY 오버레이, add 는 코어 ALLOW 확장.
-    ov = load_project_boundary_overrides(cwd).get(agent)
+    add_patterns, remove_patterns = _effective_overrides(
+        load_project_boundary_overrides(cwd), agent
+    )
 
     # 3a. remove 오버레이 — 코어 기본 허용 경로를 이 프로젝트에서 제거.
-    if ov and ov.get("remove"):
-        matched = _matches_any(norm, ov["remove"])
+    if remove_patterns:
+        matched = _matches_any(norm, remove_patterns)
         if matched:
             return (
                 f"{agent} 프로젝트 boundary remove: `{norm}` matched `{matched}` "
@@ -537,7 +567,7 @@ def check_write_allowed(
     if allowed is None:
         # 미정의 agent — false positive 회피로 통과.
         return None
-    effective = allowed + (ov.get("add", ()) if ov else ())
+    effective = allowed + add_patterns
     if not _matches_any(norm, effective):
         return (
             f"{agent} ALLOW_MATRIX 미매칭: `{norm}` "

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -625,6 +625,17 @@ def check_write_allowed(
     if allowed is None:
         # 미정의 agent — false positive 회피로 통과.
         return None
+    # write-zero agent (판정/검증 전용 — code-validator / pr-reviewer /
+    # architecture-validator / product-acceptance / plan-reviewer 의 빈 ALLOW) 는
+    # 프로젝트 add 로도 write 를 열 수 없다 (#696 codex P2). "검증자는 자기가 검증하는
+    # 것을 못 고친다" 는 역할 격리는 catastrophic gate 신뢰의 근간이라 되돌릴 수 없는
+    # 경계다 — add 로 mutation agent 로 승격시키면 gate forge 위험. 이슈가 "프로젝트
+    # 감수" 로 연 것은 mutation agent 내부 경계(engineer 의 tests/)이지 검증자 승격이 아니다.
+    if allowed == ():
+        return (
+            f"{agent} 는 write-zero(판정/검증 전용) — 프로젝트 boundary add 로도 "
+            f"write 를 열 수 없다 (`{norm}`): 검증자 역할 격리는 되돌릴 수 없는 경계."
+        )
     effective = allowed + add_patterns
     if not _matches_any(norm, effective):
         return (

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -2010,6 +2010,19 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
             self.assertIsNotNone(reason)
             self.assertIn("인프라", reason)
 
+    def test_add_dcness_dir_target_write_still_blocked(self):
+        # #696 codex P2 — add 로 .dcness/ 를 열어도 디렉토리 타깃 write(cp x .dcness/)로
+        # boundary.json 을 교체하는 우회를 차단. .dcness 디렉토리 자체·하위 모두 INFRA.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(cwd, {"engineer": {"add": [r"(^|/)\.dcness/"]}})
+            for target in (".dcness/", ".dcness", ".dcness/other.json"):
+                reason = check_write_allowed(
+                    "engineer", target, cwd=cwd, shell_context=True
+                )
+                self.assertIsNotNone(reason, f"{target} 우회 가능하면 안 됨")
+                self.assertIn("인프라", reason)
+
     def test_remove_cannot_unprotect_boundary_file(self):
         # remove 로 boundary.json INFRA 보호를 풀 수 없다.
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1892,5 +1892,181 @@ class RootCodeFileAllowTests(unittest.TestCase):
             )
 
 
+class ProjectBoundaryOverrideTests(unittest.TestCase):
+    """#696 — 프로젝트별 ALLOW_MATRIX override (`.dcness/boundary.json`).
+
+    외부 활성 프로젝트가 자기 사정을 직접 선언해 sub-agent write 경계를 양방향으로
+    커스텀한다 (add = 허용 확장, remove = 코어 기본값 제거). 코어는 합리적 기본값만,
+    예외는 프로젝트가 SSOT. 외부 프로젝트 시뮬레이션(DCNESS_INFRA="" + tempdir).
+    """
+
+    def setUp(self):
+        self._patcher = patch.dict(
+            os.environ, {"DCNESS_INFRA": "", "CLAUDE_PLUGIN_ROOT": ""}, clear=False
+        )
+        self._patcher.start()
+
+    def tearDown(self):
+        self._patcher.stop()
+
+    @staticmethod
+    def _write_boundary(root: Path, mapping: dict) -> None:
+        cfg_dir = root / ".dcness"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "boundary.json").write_text(
+            json.dumps(mapping), encoding="utf-8"
+        )
+
+    # ── add: 허용 확장 ──
+    def test_add_extends_allow_for_nonstandard_layout(self):
+        # 코어에 없는 비표준 소스 레이아웃을 add 로 허용.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # add 전 — 차단 확인.
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "custom-pkg/widget.go", cwd=cwd)
+            )
+            self._write_boundary(cwd, {"engineer": {"add": [r"(^|/)custom-pkg/"]}})
+            self.assertIsNone(
+                check_write_allowed("engineer", "custom-pkg/widget.go", cwd=cwd)
+            )
+
+    def test_add_opens_default_excluded_tests_for_engineer(self):
+        # engineer 의 tests/ 기본 제외(self-grading 방어)를 프로젝트가 add 로 완화.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "tests/test_widget.py", cwd=cwd)
+            )
+            self._write_boundary(cwd, {"engineer": {"add": [r"(^|/)tests?/"]}})
+            self.assertIsNone(
+                check_write_allowed("engineer", "tests/test_widget.py", cwd=cwd)
+            )
+
+    # ── remove: 코어 기본값 제거 ──
+    def test_remove_blocks_core_default(self):
+        # 코어 기본 허용 경로(^app/)를 프로젝트가 remove 로 제거.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("engineer", "app/models.rb", cwd=cwd)
+            )
+            self._write_boundary(cwd, {"engineer": {"remove": [r"^app/"]}})
+            reason = check_write_allowed("engineer", "app/models.rb", cwd=cwd)
+            self.assertIsNotNone(reason)
+
+    def test_remove_overrides_add_on_conflict(self):
+        # 같은 경로에 add+remove 동시 → remove 우선(보수적 차단).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(
+                cwd,
+                {"engineer": {"add": [r"(^|/)zone/"], "remove": [r"(^|/)zone/"]}},
+            )
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "zone/x.go", cwd=cwd)
+            )
+
+    # ── 가드: 되돌릴 수 없는 경계는 override 가 못 뚫는다 ──
+    def test_add_cannot_open_infra_path(self):
+        # add 로 INFRA 경로(hooks/)를 열려 해도 INFRA 검사가 먼저라 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(cwd, {"engineer": {"add": [r"(^|/)hooks/"]}})
+            reason = check_write_allowed("engineer", "hooks/evil.py", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_boundary_file_itself_blocked_for_subagent(self):
+        # 위조 방지 — 설정 파일 자신은 어떤 sub-agent 도 write 못 함 (self 확장/축소 금지).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for agent in ("engineer", "test-engineer", "build-worker", "architect"):
+                reason = check_write_allowed(
+                    agent, ".dcness/boundary.json", cwd=cwd
+                )
+                self.assertIsNotNone(reason, f"{agent} 가 boundary.json 쓰면 안 됨")
+                self.assertIn("인프라", reason)
+
+    def test_add_cannot_open_boundary_file(self):
+        # add 로 .dcness/ 를 열려 해도 boundary.json 은 INFRA 라 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(cwd, {"engineer": {"add": [r"(^|/)\.dcness/"]}})
+            reason = check_write_allowed(
+                "engineer", ".dcness/boundary.json", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    def test_remove_cannot_unprotect_boundary_file(self):
+        # remove 로 boundary.json INFRA 보호를 풀 수 없다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(
+                cwd, {"engineer": {"remove": [r"(^|/)\.dcness/boundary\.json$"]}}
+            )
+            reason = check_write_allowed(
+                "engineer", ".dcness/boundary.json", cwd=cwd
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("인프라", reason)
+
+    # ── 회귀/안전 ──
+    def test_no_boundary_file_core_defaults_intact(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            # 코어 기본값 그대로 — src 허용, random 차단.
+            self.assertIsNone(check_write_allowed("engineer", "src/x.ts", cwd=cwd))
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "README.md", cwd=cwd)
+            )
+
+    def test_malformed_boundary_ignored(self):
+        # 깨진 JSON → 무시하고 코어 기본값 유지 (안전 degrade).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            cfg_dir = cwd / ".dcness"
+            cfg_dir.mkdir()
+            (cfg_dir / "boundary.json").write_text("{not json", encoding="utf-8")
+            self.assertIsNone(check_write_allowed("engineer", "src/x.ts", cwd=cwd))
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "custom-pkg/x.go", cwd=cwd)
+            )
+
+    def test_invalid_regex_pattern_skipped(self):
+        # 컴파일 불가 정규식은 그 패턴만 skip — 나머지 add 는 유효.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(
+                cwd, {"engineer": {"add": [r"(unclosed", r"(^|/)okdir/"]}}
+            )
+            self.assertIsNone(
+                check_write_allowed("engineer", "okdir/x.go", cwd=cwd)
+            )
+
+    def test_boundary_found_in_ancestor(self):
+        # cwd 가 하위 디렉토리여도 조상의 boundary.json 적용.
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write_boundary(root, {"engineer": {"add": [r"(^|/)custom-pkg/"]}})
+            sub = root / "services" / "api"
+            sub.mkdir(parents=True)
+            self.assertIsNone(
+                check_write_allowed("engineer", "custom-pkg/x.go", cwd=sub)
+            )
+
+    def test_override_ignored_in_infra_project(self):
+        # dcness self / infra project 는 어차피 통과 — override 무관, 메인 SSOT 편집 보존.
+        with patch.dict(os.environ, {"DCNESS_INFRA": "1"}, clear=False):
+            with tempfile.TemporaryDirectory() as td:
+                cwd = Path(td)
+                self._write_boundary(cwd, {"engineer": {"remove": [r"(^|/)src/"]}})
+                # remove 했어도 infra project 는 통과.
+                self.assertIsNone(
+                    check_write_allowed("engineer", "src/x.ts", cwd=cwd)
+                )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1917,6 +1917,17 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
             json.dumps(mapping), encoding="utf-8"
         )
 
+    @staticmethod
+    def _git_init(root: Path) -> None:
+        # 외부 활성 프로젝트는 git repo — project-root 경계(#696 P2)가 git common-dir
+        # 기준으로 동작하므로, 조상 탐색 테스트는 실제 repo 로 시뮬레이션한다.
+        import subprocess
+
+        subprocess.run(
+            ["git", "init", "-q"], cwd=str(root), check=True,
+            capture_output=True,
+        )
+
     # ── add: 허용 확장 ──
     def test_add_extends_allow_for_nonstandard_layout(self):
         # 코어에 없는 비표준 소스 레이아웃을 add 로 허용.
@@ -2046,14 +2057,31 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
             )
 
     def test_boundary_found_in_ancestor(self):
-        # cwd 가 하위 디렉토리여도 조상의 boundary.json 적용.
+        # cwd 가 하위 디렉토리여도 *프로젝트 루트* 의 boundary.json 적용.
         with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
+            root = Path(td).resolve()
+            self._git_init(root)
             self._write_boundary(root, {"engineer": {"add": [r"(^|/)custom-pkg/"]}})
             sub = root / "services" / "api"
             sub.mkdir(parents=True)
             self.assertIsNone(
                 check_write_allowed("engineer", "custom-pkg/x.go", cwd=sub)
+            )
+
+    def test_boundary_outside_project_root_ignored(self):
+        # #696 codex P2 — 프로젝트 루트 밖(상위 워크스페이스)의 boundary.json 은 무시.
+        # 상위 디렉토리의 override 가 무관한 하위 프로젝트의 경계를 약화하면 안 된다.
+        with tempfile.TemporaryDirectory() as td:
+            outer = Path(td).resolve()
+            # 상위 워크스페이스에 boundary (engineer 에 custom-pkg 허용).
+            self._write_boundary(outer, {"engineer": {"add": [r"(^|/)custom-pkg/"]}})
+            # 하위에 독립 프로젝트(git repo) — 자기 boundary 없음.
+            proj = outer / "child-project"
+            proj.mkdir()
+            self._git_init(proj)
+            # 상위 boundary 가 새지 않아 여전히 차단되어야 한다.
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "custom-pkg/x.go", cwd=proj)
             )
 
     # ── build-worker 합집합 전파 (codex P1) ──

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -2192,6 +2192,22 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
                 self.assertIsNotNone(reason, f"{agent} 가 add 로 write 열리면 안 됨")
                 self.assertIn("write-zero", reason)
 
+    def test_add_cannot_write_guard_disable_markers(self):
+        # #696 codex P1 — broad add(.*)로도 file guard self-disable 마커는 못 쓴다.
+        # .no-dcness-guard(is_opt_out) / .claude-plugin/plugin.json(is_infra_project).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(cwd, {"engineer": {"add": [r".*"]}})
+            for target in (
+                ".no-dcness-guard", ".no-dcness-guard/",
+                ".claude-plugin/plugin.json", ".claude-plugin/", ".claude-plugin",
+            ):
+                reason = check_write_allowed(
+                    "engineer", target, cwd=cwd, shell_context=True
+                )
+                self.assertIsNotNone(reason, f"{target} self-disable 가능하면 안 됨")
+                self.assertIn("인프라", reason)
+
     def test_override_ignored_in_infra_project(self):
         # dcness self / infra project 는 어차피 통과 — override 무관, 메인 SSOT 편집 보존.
         with patch.dict(os.environ, {"DCNESS_INFRA": "1"}, clear=False):

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -261,14 +261,15 @@ class WriteAllowedAllowMatrixTests(unittest.TestCase):
             cwd = Path(td)
             reason = check_write_allowed("code-validator", "src/foo.ts", cwd=cwd)
             self.assertIsNotNone(reason)
-            self.assertIn("ALLOW_MATRIX", reason)
+            # write-zero agent (빈 ALLOW) — #696 이후 전용 차단 reason.
+            self.assertIn("write-zero", reason)
 
     def test_architecture_validator_readonly(self):
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
             reason = check_write_allowed("architecture-validator", "docs/architecture.md", cwd=cwd)
             self.assertIsNotNone(reason)
-            self.assertIn("ALLOW_MATRIX", reason)
+            self.assertIn("write-zero", reason)
 
     def test_module_architect_docs_allowed(self):
         with tempfile.TemporaryDirectory() as td:
@@ -2173,6 +2174,23 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
             self.assertIsNotNone(
                 check_write_allowed("engineer", "bw-only/x.go", cwd=cwd)
             )
+
+    def test_add_cannot_grant_write_to_readonly_agent(self):
+        # #696 codex P2 — 판정/검증 전용 agent(빈 ALLOW)는 add 로도 write 못 연다.
+        # 검증자 역할 격리는 catastrophic gate 신뢰의 근간 (되돌릴 수 없는 경계).
+        readonly = (
+            "code-validator", "pr-reviewer", "architecture-validator",
+            "product-acceptance", "plan-reviewer",
+        )
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(
+                cwd, {a: {"add": [r"(^|/)src/"]} for a in readonly}
+            )
+            for agent in readonly:
+                reason = check_write_allowed(agent, "src/x.ts", cwd=cwd)
+                self.assertIsNotNone(reason, f"{agent} 가 add 로 write 열리면 안 됨")
+                self.assertIn("write-zero", reason)
 
     def test_override_ignored_in_infra_project(self):
         # dcness self / infra project 는 어차피 통과 — override 무관, 메인 SSOT 편집 보존.

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -2056,6 +2056,60 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
                 check_write_allowed("engineer", "custom-pkg/x.go", cwd=sub)
             )
 
+    # ── build-worker 합집합 전파 (codex P1) ──
+    def test_build_worker_inherits_engineer_add(self):
+        # build-worker = engineer ∪ test-engineer — engineer.add 가 build-worker 에 전파.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNotNone(
+                check_write_allowed("build-worker", "custom-pkg/x.go", cwd=cwd)
+            )
+            self._write_boundary(cwd, {"engineer": {"add": [r"(^|/)custom-pkg/"]}})
+            self.assertIsNone(
+                check_write_allowed("build-worker", "custom-pkg/x.go", cwd=cwd)
+            )
+
+    def test_build_worker_inherits_engineer_remove(self):
+        # engineer.remove 가 build-worker 에 전파 — remove 우회 방지.
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNone(
+                check_write_allowed("build-worker", "app/models.rb", cwd=cwd)
+            )
+            self._write_boundary(cwd, {"engineer": {"remove": [r"^app/"]}})
+            self.assertIsNotNone(
+                check_write_allowed("build-worker", "app/models.rb", cwd=cwd)
+            )
+
+    def test_build_worker_inherits_test_engineer_add(self):
+        # test-engineer.add 도 build-worker 에 전파 (합집합 구성 역할).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self.assertIsNotNone(
+                check_write_allowed("build-worker", "custom-e2e/run.yml", cwd=cwd)
+            )
+            self._write_boundary(
+                cwd, {"test-engineer": {"add": [r"(^|/)custom-e2e/.*"]}}
+            )
+            self.assertIsNone(
+                check_write_allowed("build-worker", "custom-e2e/run.go", cwd=cwd)
+            )
+
+    def test_build_worker_own_key_still_applies(self):
+        # build-worker 자체 키 override 도 유효 (union 에 build-worker 포함).
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            self._write_boundary(
+                cwd, {"build-worker": {"add": [r"(^|/)bw-only/"]}}
+            )
+            self.assertIsNone(
+                check_write_allowed("build-worker", "bw-only/x.go", cwd=cwd)
+            )
+            # engineer 단독은 build-worker 키 add 를 받지 않는다 (역방향 전파 없음).
+            self.assertIsNotNone(
+                check_write_allowed("engineer", "bw-only/x.go", cwd=cwd)
+            )
+
     def test_override_ignored_in_infra_project(self):
         # dcness self / infra project 는 어차피 통과 — override 무관, 메인 SSOT 편집 보존.
         with patch.dict(os.environ, {"DCNESS_INFRA": "1"}, clear=False):

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -2081,6 +2081,29 @@ class ProjectBoundaryOverrideTests(unittest.TestCase):
                 check_write_allowed("engineer", "custom-pkg/x.go", cwd=sub)
             )
 
+    def test_boundary_in_linked_worktree_from_subdir(self):
+        # #696 codex P2 — 메인 체크아웃 밖에 둔 linked worktree 의 하위 디렉토리에서도
+        # worktree 루트 boundary.json 이 적용된다 (top-level 기준 탐색).
+        import subprocess
+
+        env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@t",
+                   GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@t")
+        with tempfile.TemporaryDirectory() as ta, tempfile.TemporaryDirectory() as tb:
+            main = Path(ta).resolve()
+            subprocess.run(["git", "init", "-q"], cwd=str(main), check=True,
+                           capture_output=True)
+            subprocess.run(["git", "commit", "--allow-empty", "-q", "-m", "init"],
+                           cwd=str(main), check=True, capture_output=True, env=env)
+            wt = Path(tb).resolve() / "linked-wt"  # 메인 밖 경로
+            subprocess.run(["git", "worktree", "add", "-q", str(wt)],
+                           cwd=str(main), check=True, capture_output=True, env=env)
+            self._write_boundary(wt, {"engineer": {"add": [r"(^|/)custom-pkg/"]}})
+            sub = wt / "services" / "api"
+            sub.mkdir(parents=True)
+            self.assertIsNone(
+                check_write_allowed("engineer", "custom-pkg/x.go", cwd=sub)
+            )
+
     def test_boundary_outside_project_root_ignored(self):
         # #696 codex P2 — 프로젝트 루트 밖(상위 워크스페이스)의 boundary.json 은 무시.
         # 상위 디렉토리의 override 가 무관한 하위 프로젝트의 경계를 약화하면 안 된다.


### PR DESCRIPTION
## 관련 이슈 번호

Closes #696

## 배경 및 문제

#694 에서 ALLOW_MATRIX 언어 중립성 회귀를 수정하며 코어 기본값 확장만 처리하고
프로젝트별 override 는 #696 으로 분리했다. 코어 ALLOW_MATRIX 는 흔한 언어·레이아웃의
합리적 기본값만 잡을 수 있고, 무한한 프로젝트별 사정(비표준 소스/테스트 디렉토리, 또는
코어 기본 제외를 의도적으로 완화하고 싶은 경우 — 예: engineer 의 `tests/` 제외를
"구현·테스트 한 호흡" 워크플로에서 열기)을 코어가 다 알 수 없다. 코어에 계속 추가하면
reactive cycle(룰이 룰을 부름 — CLAUDE.md 안티패턴 1).

## 원인 (해당 시)

-

## 작업내용

프로젝트가 루트의 `.dcness/boundary.json` 으로 자기 사정을 직접 선언해 sub-agent write
경계를 양방향 커스텀하는 메커니즘 도입. reactive cycle 을 코어 밖(프로젝트)으로 이관.

- `harness/agent_boundary.py`
  - `load_project_boundary_overrides(cwd)`: cwd 조상에서 `.dcness/boundary.json` 탐색
    (`_is_dcness_self_repo` 조상 패턴 재사용) + 형식/정규식 컴파일 검증. 깨진 설정은
    조용히 무시하고 코어 기본값 유지 (안전 degrade).
  - `check_write_allowed`: INFRA·코드 agent 전용 deny 통과 후 `remove` 오버레이(코어
    기본 제거, ALLOW 보다 우선) + `add` 확장(코어 ALLOW 에 패턴 추가) 적용.
  - `DCNESS_INFRA_PATTERNS` 에 `.dcness/boundary.json` 추가 — 위조 방지(self 확장/축소 금지).
- `docs/plugin/hooks.md`: 사용자용 SSOT 에 형식·`add`/`remove` 의미·가드·배포 경로 명시.
- 테스트 13건 (`tests/test_agent_boundary.py` — `ProjectBoundaryOverrideTests`).

## 결정 근거

- **패턴 형식 = 정규식**: 코어 ALLOW_MATRIX 와 동일한 `re.search` 패턴으로 일관성 유지.
- **`remove` = DENY 오버레이 (ALLOW 보다 우선)**: "코어 기본값 제거" 의미를 정규식 매칭으로
  구현. ALLOW 튜플에서 문자열 정확 일치로 빼는 방식(사용자가 코어 정규식을 알아야 함)보다
  견고하고 `add` 와 대칭.
- **가드는 검사 순서로 자동 보장**: INFRA 검사가 ALLOW(코어+add) 검사보다 먼저라
  `add` 로 `hooks/` 등 INFRA 를 못 연다. `.dcness/boundary.json` 자신을 INFRA 로 보호해
  `remove` 로도 self 경계를 못 푼다 — 별도 가드 코드 없이 기존 순서로 강제됨.

## 배포 경로 검증 (plug-in 영향 시)

- **경로 1 (plugin 본체)**: 읽는 로직은 `harness/agent_boundary.py` 라 plugin 버전업으로
  자동 적용 (cp 0 — #198 "사용자 repo 로직 cp 0" 정책 정합). init-dcness 복사 대상 아님.
- **경로 3 (사용자 SSOT 문서)**: `docs/plugin/hooks.md` 에 `.dcness/boundary.json` 형식·
  가드·배포를 명시해 외부 활성 프로젝트가 기능 존재·사용법을 인지하도록 함. 설정 파일은
  프로젝트가 직접 작성 (배포물 아님).

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

설정 파일 1개의 신규 surface. (1) 기존 risk router lane 으로 흡수 안 됨 — write 경계는
lane 이 아니라 path 매트릭스. (2) 기존 validator/reviewer 무관 — sub-agent write-time
강제. (3) 프로젝트 사정은 무한 → 코어가 다 알 수 없고 deny 블랙리스트는 경계를 과하게
엶. "프로젝트가 자기 레이아웃·정책 SSOT" 가 올바른 위치라 정당 (CLAUDE.md 안티패턴 5
justification). 최소 형태(agent별 add/remove)만 유지.

## Test Plan

- [x] 관련 테스트 추가 — `ProjectBoundaryOverrideTests` 13건 (add/remove/가드/안전
  degrade/조상 탐색/infra 무관/conflict)
- [x] 회귀 검증 — `tests.test_agent_boundary` 185건 PASS, 전체 `discover` 1307건 PASS
- [x] cross-ref 게이트 PASS (`node scripts/check_cross_refs.mjs`)

## 참고

- **follow-up 분리**: 코어 기본값의 프로젝트 고유 디렉토리(`^remotion/`) 를 코어에서 빼고
  override(add)로 이관(#696 "완료 후" 항목)은 별도 PR — 지금 빼면 youTubeGenerator 가
  `boundary.json` 작성 전 회귀하므로 배포+설정 작성과 함께 진행해야 안전.
