### PR TITLE
[issue-781] GitHub Actions zizmor hardening

### DIFF
--- a/.github/actions/git-naming/action.yml
+++ b/.github/actions/git-naming/action.yml
@@ -13,16 +13,20 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
 
     - name: Validate branch name
       if: inputs.branch != ''
       shell: bash
-      run: node "${{ github.action_path }}/../../../scripts/check_git_naming.mjs" --branch "${{ inputs.branch }}"
+      env:
+        INPUT_BRANCH: ${{ inputs.branch }}
+      run: node "${{ github.action_path }}/../../../scripts/check_git_naming.mjs" --branch "$INPUT_BRANCH"
 
     - name: Validate title
       if: inputs.title != ''
       shell: bash
-      run: node "${{ github.action_path }}/../../../scripts/check_git_naming.mjs" --title "${{ inputs.title }}"
+      env:
+        INPUT_TITLE: ${{ inputs.title }}
+      run: node "${{ github.action_path }}/../../../scripts/check_git_naming.mjs" --title "$INPUT_TITLE"

--- a/.github/actions/github-project-lifecycle/action.yml
+++ b/.github/actions/github-project-lifecycle/action.yml
@@ -45,40 +45,49 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
 
     - name: Run Project lifecycle guard
       shell: bash
       env:
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_REPO: ${{ inputs.repo }}
+        INPUT_PROJECT_OWNER: ${{ inputs.project-owner }}
+        INPUT_PROJECT_NUMBER: ${{ inputs.project-number }}
+        INPUT_ISSUE_NUMBER: ${{ inputs.issue-number }}
+        INPUT_EXPECTED_STATUS: ${{ inputs.expected-status }}
+        INPUT_EXPECTED_ISSUE_TYPE: ${{ inputs.expected-issue-type }}
+        INPUT_EXPECTED_PRIORITY: ${{ inputs.expected-priority }}
+        INPUT_APPLY: ${{ inputs.apply }}
         PR_BODY: ${{ inputs.pr-body }}
         # composite action 은 부모 step 의 env 를 상속하지 않으므로 GH_TOKEN 을 input 으로 받아 명시 매핑.
         GH_TOKEN: ${{ inputs.gh-token }}
       run: |
         set -euo pipefail
         ARGS=(
-          "${{ inputs.mode }}"
-          --repo "${{ inputs.repo }}"
-          --owner "${{ inputs.project-owner }}"
-          --project "${{ inputs.project-number }}"
+          "$INPUT_MODE"
+          --repo "$INPUT_REPO"
+          --owner "$INPUT_PROJECT_OWNER"
+          --project "$INPUT_PROJECT_NUMBER"
         )
-        if [ -n "${{ inputs.issue-number }}" ]; then
-          ARGS+=(--issue "${{ inputs.issue-number }}")
+        if [ -n "$INPUT_ISSUE_NUMBER" ]; then
+          ARGS+=(--issue "$INPUT_ISSUE_NUMBER")
         fi
-        if [ -n "${{ inputs.expected-status }}" ]; then
-          ARGS+=(--expected-status "${{ inputs.expected-status }}")
+        if [ -n "$INPUT_EXPECTED_STATUS" ]; then
+          ARGS+=(--expected-status "$INPUT_EXPECTED_STATUS")
         fi
-        if [ -n "${{ inputs.expected-issue-type }}" ]; then
-          ARGS+=(--expected-issue-type "${{ inputs.expected-issue-type }}")
+        if [ -n "$INPUT_EXPECTED_ISSUE_TYPE" ]; then
+          ARGS+=(--expected-issue-type "$INPUT_EXPECTED_ISSUE_TYPE")
         fi
-        if [ -n "${{ inputs.expected-priority }}" ]; then
-          ARGS+=(--expected-priority "${{ inputs.expected-priority }}")
+        if [ -n "$INPUT_EXPECTED_PRIORITY" ]; then
+          ARGS+=(--expected-priority "$INPUT_EXPECTED_PRIORITY")
         fi
-        if [ "${{ inputs.mode }}" = "pr-merged" ]; then
+        if [ "$INPUT_MODE" = "pr-merged" ]; then
           ARGS+=(--body-env PR_BODY)
         fi
-        if [ "${{ inputs.apply }}" = "true" ]; then
+        if [ "$INPUT_APPLY" = "true" ]; then
           ARGS+=(--apply)
         fi
         node "${{ github.action_path }}/../../../scripts/github_project_lifecycle.mjs" "${ARGS[@]}"

--- a/.github/actions/pr-body/action.yml
+++ b/.github/actions/pr-body/action.yml
@@ -8,7 +8,7 @@ runs:
   using: composite
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
 

--- a/.github/workflows/cross-ref-validation.yml
+++ b/.github/workflows/cross-ref-validation.yml
@@ -37,10 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 

--- a/.github/workflows/git-naming-validation.yml
+++ b/.github/workflows/git-naming-validation.yml
@@ -23,7 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Validate branch + PR title via composite action
         uses: ./.github/actions/git-naming

--- a/.github/workflows/github-project-lifecycle.yml
+++ b/.github/workflows/github-project-lifecycle.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Validate issue lifecycle via composite action
         uses: ./.github/actions/github-project-lifecycle
@@ -47,7 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Correct Status=Done on merge via composite action
         uses: ./.github/actions/github-project-lifecycle

--- a/.github/workflows/plugin-manifest.yml
+++ b/.github/workflows/plugin-manifest.yml
@@ -38,10 +38,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 

--- a/.github/workflows/pr-body-validation.yml
+++ b/.github/workflows/pr-body-validation.yml
@@ -22,7 +22,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Validate PR body via composite action
         uses: ./.github/actions/pr-body

--- a/.github/workflows/public-surface-validation.yml
+++ b/.github/workflows/public-surface-validation.yml
@@ -31,10 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -55,15 +55,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.11'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: '20'
 

--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -14,12 +14,15 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: configure git
         run: |
           git config user.name "release-sync-bot"
           git config user.email "release-sync@dcness.local"
       - name: run sync
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: bash scripts/sync_release.sh --yes

--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -24,6 +24,19 @@ EXCLUDE_PATHS=(
 
 ORIG_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
 
+git_with_token() {
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        local auth_header
+        auth_header=$(printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\n')
+        GIT_CONFIG_COUNT=1 \
+        GIT_CONFIG_KEY_0=http.https://github.com/.extraheader \
+        GIT_CONFIG_VALUE_0="AUTHORIZATION: basic ${auth_header}" \
+            git "$@"
+    else
+        git "$@"
+    fi
+}
+
 restore_branch() {
     local current
     current=$(git symbolic-ref --short HEAD 2>/dev/null || echo "")
@@ -51,7 +64,7 @@ confirm() {
 }
 
 # 위험 경고: release 위 직접 commit 체크
-git fetch origin --quiet
+git_with_token fetch origin --quiet
 if git show-ref --verify --quiet refs/remotes/origin/release; then
     DIVERGED=$(git log origin/release ^origin/main --oneline 2>/dev/null | wc -l | tr -d ' ')
     if [ "$DIVERGED" -gt 0 ]; then
@@ -104,5 +117,5 @@ if ! confirm "release 브랜치를 origin 에 force-with-lease push"; then
     exit 0
 fi
 
-git push --force-with-lease origin release
+git_with_token push --force-with-lease origin release
 echo "✓ release 브랜치 sync 완료 — main@${SHORT_SHA}"


### PR DESCRIPTION
## 관련 이슈 번호

Closes #781

## 배경 및 문제

GitHub Actions 공급망 감사에서 composite action input template injection, unpinned third-party action, checkout credential persistence findings가 확인됐습니다. dcNess는 외부 활성 프로젝트에서도 CI guard를 제공하므로, self workflow와 배포되는 composite action 모두 `zizmor` 기준을 통과해야 합니다.

## 원인 (해당 시)

- 일부 composite action input이 shell `run` 블록 안에서 `${{ inputs.* }}` 형태로 직접 확장됐습니다.
- workflow/composite action의 `actions/*` reference가 tag로만 고정돼 있었습니다.
- read-only workflow checkout이 기본 credential persistence를 사용했습니다.

## 작업내용

- `git-naming`, `pr-body`, `github-project-lifecycle` composite action의 public input surface는 유지하고, shell 실행부는 env 변수와 quoted shell variable 경유로 변경했습니다.
- `actions/checkout`, `actions/setup-node`, `actions/setup-python` reference를 현재 tag commit SHA로 pinning했습니다.
- read-only verification workflow checkout에 `persist-credentials: false`를 적용했습니다.
- `release-sync`는 checkout credential persistence를 끄고, fetch/push 시점에만 `GITHUB_TOKEN` extraheader를 임시 주입하도록 바꿨습니다.

## 결정 근거

- public input 이름과 workflow/check 이름을 바꾸지 않아 기존 required-check 및 활성 프로젝트 thin workflow 호환성을 유지했습니다.
- `release-sync`는 push가 필요한 workflow라 read-only workflow와 달리 token이 필요하지만, checkout에 credential을 남기지 않고 git fetch/push 호출에만 제한했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `.github/actions/**`: dcNess composite action 본체입니다. 활성 프로젝트의 thin workflow가 `alruminum/dcNess/.github/actions/*@main`을 호출하므로 main merge 후 plugin repository 경유로 적용됩니다.
- `.github/workflows/**`, `scripts/sync_release.sh`: dcNess self CI/release 운영 경로입니다. `/init-dcness`가 복사하는 thin workflow snippet의 public interface는 변경하지 않았습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] `uvx zizmor --no-online-audits .`
- [x] `bash -n scripts/sync_release.sh`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_git_naming.mjs --branch fix/issue781_zizmor_actions_hardening`
- [x] `node scripts/check_git_naming.mjs --title "[issue-781] GitHub Actions zizmor findings hardening"`
- [x] `node scripts/check_pr_body.mjs --body "Part of #781"`
- [x] `git diff --check`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] pre-commit hook during `git commit` — PASS
- [x] 별도 code-validator subagent review — PASS

## 참고

- `bash scripts/check.sh`는 이 저장소에 존재하지 않아 실행 불가했습니다. 실제 commit gate는 `scripts/hooks/pre-commit`이며 커밋 중 정상 실행됐습니다.