### PR TITLE
[feature] guard 효능 eval 확장

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@
 - **public-surface**: `scripts/check_public_surface.mjs` (CI `public-surface-validation.yml`) — 공개 workflow/command/agent 진입점 계약 검증
 - **cross-ref**: `scripts/check_cross_refs.mjs` (CI `cross-ref-validation.yml`) — markdown link 파일/anchor 실존 + 옛 명칭 deny-list (외부 배포 영역 한정) 회귀 차단
 - **static-quality**: `pyproject.toml` + `requirements-quality.txt` + `scripts/check_static_quality.sh` (CI `static-quality.yml`) — Python 3.11 기준 ruff lint/complexity, mypy, Bandit baseline 회귀 차단
+- **결정적 guard-efficacy eval (권고 — CI 차단 아님)**: `python3 evals/guard_efficacy.py` — guard/hook 변경 PR 머지 전 1회. LLM 없이 file boundary / Bash·MCP mutation / order gate / TDD allow·block fixture 를 범주별 count 로 재현.
 - **행동 eval (권고 — CI 차단 아님)**: `bash evals/run.sh` — `agents/**`/`skills/**` 지침 변경 PR 머지 전 + 플러그인 릴리즈 전 1회. agent 가 기준대로 실제 판정하는지 사고 기반 fixture 로 확인. 상세 [`evals/README.md`](evals/README.md)
 
 > ⚠️ **금지**: `--no-verify` 등 hook 우회. main 직접 push.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ scope 가 아니다). Codex 분기는 read-only validator 3종 opt-in 에만 한
 다른 skill-workflow 하네스(Superpowers, OMC 등)와의 정성 비교: 그쪽은 onboarding 과
 다양한 supported harness 노출이 강점이다. dcNess 는 onboarding 표면은 작은 대신,
 **작업 순서·파일 경계의 governance 와 run 단위 replayability** 가 강하다. 실측 수치와
-재현 명령은 [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) 참조 (표본 크기와
-한계를 함께 명시한다).
+재현 명령은 [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) 참조. turn/fleet
+측정, 결정적 guard-efficacy fixture, LLM 행동 eval 의 범위와 한계를 구분해 명시한다.
 
 ## 설치 & 활성화
 
@@ -226,7 +226,7 @@ bash scripts/dcness-codex-validator --help # Codex validator wrapper smoke
 | [`CLAUDE.md`](CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일) | 정체성 SSOT (강제 영역 2 + 안티패턴 4) |
 | [`docs/plugin/terms.md`](docs/plugin/terms.md) | 사용자-facing 용어 사전 — 용어·공개 진입점·분기 표현 수정/리뷰 시 lazy read |
 | [`docs/plugin/positioning.md`](docs/plugin/positioning.md) | 공개 workflow 진입점 계약 — 기본/support/고급/유틸리티/내부 agent 분류 |
-| [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현 가이드(measure_main_turns / run-review) + turn 절감 실측 샘플 + 한계 |
+| [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현 가이드(measure_main_turns / run-review / guard-efficacy) + turn 절감 실측 샘플 + 한계 |
 | 각 skill 의 `<skill>-routing.md` ([`impl`](skills/impl/impl-routing.md) / [`design`](skills/design/design-routing.md) / [`impl-loop`](skills/impl-loop/impl-loop-routing.md) 등) | 분기 규칙 진본 (mermaid + enum 표 + retry + escalate) |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md#진입-모델) | loop 실행 절차 — Step 0~8 mechanics (각 loop spec = 해당 skill `## Loop`) |
 | [`docs/plugin/hooks.md`](docs/plugin/hooks.md#catastrophic-gatesh) | 순서 차단 훅 + 8 hook SSOT |

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -15,6 +15,21 @@ dcNess 는 측정 인프라를 plug-in 본체에 같이 배포한다.
 | [`harness/run_review.py`](../../harness/run_review.py) | run 1개의 step별 비용·토큰 + 낭비(waste) finding | `/run-review` skill |
 | [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py) | 여러 run 가로질러 fleet 집계 (FAIL 비율 / escalate / blocked / waste top-N) | 직접 실행 |
 
+guard 효능 재현은 별도다. dcNess 소스 checkout 에서만 제공되는
+`evals/guard_efficacy.py` 는 LLM 없이 hook/function 진입점을 직접 호출해 file boundary,
+Bash/MCP mutation, order gate, TDD guard 의 allow/block fixture 를 검증하고 범주별
+pass/fail count 를 출력한다.
+
+```sh
+python3 evals/guard_efficacy.py
+python3 evals/guard_efficacy.py --json
+```
+
+이 결정적 suite 의 PASS 는 "fixture 로 박은 guard 계약이 재현된다"는 뜻이다. 보안 증명이나
+악의적 agent 완전 차단 주장이 아니다. `known-bypass-boundary` 범주는 문서화된 한계
+(예: Bash 경유 구현 파일은 TDD 존재 검사를 받지 않음, command substitution 은 외부 변경
+denylist 의 best-effort 범위 밖)를 숨기지 않고 측정 표면에 올려둔다.
+
 > **스크립트 위치** — `scripts/` · `harness/` 는 plug-in 본체로 배포된다. 외부 활성
 > 프로젝트는 이 파일들이 repo 안이 아니라 **plug-in 캐시**에 있으므로, 아래 명령은
 > 먼저 그 루트를 변수로 잡고 prefix 한다. `/run-review` 는 skill 이 경로 해석을
@@ -31,6 +46,10 @@ dcNess 는 측정 인프라를 plug-in 본체에 같이 배포한다.
 
 핵심 가설은 단순하다. dcNess 의 무거운 절차(검증·구현·리뷰 시퀀스)를 sub-agent 가
 흡수하면 **메인 Claude 의 turn 누적이 줄어든다**. 그게 사실인지 숫자로 본다.
+
+LLM 행동 eval 은 또 다른 범위다. [`evals/run.sh`](../../evals/run.sh) 는 실제 agent 를
+호출해 지침이 story slicing 같은 판단을 계속 하게 만드는지 보는 회귀 도구이며, guard
+hook/function 의 결정적 allow/block 성능을 대신하지 않는다.
 
 ## 재현 1 — 메인 turn 측정
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,21 +1,44 @@
-# 행동 eval 하네스
+# eval 하네스
 
-agent 지침 변경이 기존 보호를 깨먹는지, 실제 agent 실행으로 확인하는 dcness 자체 QA 도구다. 문서 계약 테스트(`tests/` — 문구가 살아있는가)와 달리, 여기서는 "agent 가 그 기준대로 실제 판정하는가"를 확인한다. plug-in 배포물이 아니다.
+dcness 자체 QA 도구다. plug-in 배포물이 아니다.
+
+eval 은 두 종류로 나눈다.
+
+- **결정적 guard-efficacy** — hook/function 진입점을 LLM 없이 호출해 file boundary,
+  Bash/MCP mutation, order gate, TDD guard 의 allow/block 동작을 fixture 로 확인한다.
+- **LLM 행동 eval** — agent 지침 변경이 기존 보호를 깨먹는지, 실제 agent 실행으로
+  "agent 가 그 기준대로 실제 판정하는가"를 확인한다.
+
+문서 계약 테스트(`tests/` — 문구가 살아있는가), 결정적 guard-efficacy, LLM 행동 eval 은
+서로 다른 범위다. guard 성능 주장은 결정적 suite 로 재현하고, agent 지침 회귀는 LLM
+행동 eval 로 본다.
 
 ## 언제 돌리나
 
+- guard/hook 동작, 순서 차단, 외부 상태 변경 차단, TDD guard 를 수정하는 PR 의 머지 전
+  `python3 evals/guard_efficacy.py` 1회
 - `agents/**` 또는 `skills/**` 지침을 변경하는 PR 의 머지 전 1회
 - 플러그인 릴리즈 직전 1회
 
-권고이며 CI 차단 게이트가 아니다 — LLM 판정은 매 실행 조금씩 다르고 비용이 든다. 그래서 측정 + 사용자 개입 영역에 둔다.
+권고이며 CI 차단 게이트가 아니다. 결정적 suite 는 비용 없이 재현 가능하지만 adversarial
+fixture 범위만 보며, LLM 행동 eval 은 매 실행 조금씩 다르고 비용이 든다. 그래서 둘 다
+측정 + 사용자 개입 영역에 둔다.
 
 ## 어떻게 돌리나
 
 ```sh
+python3 evals/guard_efficacy.py        # 결정적 guard-efficacy suite (LLM 호출 없음)
+python3 evals/guard_efficacy.py --json # 범주별 pass/fail JSON
+
 bash evals/run.sh                    # 전 케이스 1회씩
 EVAL_RUNS=3 bash evals/run.sh        # 케이스당 3회 반복 (릴리즈 전 권장)
 EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonnet)
 ```
+
+`guard_efficacy.py` 는 범주별 pass/fail count 를 출력한다. `known-bypass-boundary`
+범주는 "보호됨" 이 아니라 문서화된 한계가 실제로 한계로 남아 있음을 드러내는 항목이다.
+예: TDD guard 는 `Edit`/`Write`/`NotebookEdit` 직접 파일 도구에만 걸리고 Bash 로 만든
+구현 파일에는 매칭 테스트 존재 검사를 하지 않는다.
 
 케이스마다 `정답 k/N` 표가 출력된다. 어떤 케이스든 정답 0회면 exit 1 — 방금 바꾼 지침이 보호를 깨먹었는지 확인한다.
 

--- a/evals/guard_efficacy.py
+++ b/evals/guard_efficacy.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""Deterministic guard-efficacy evaluation suite.
+
+This is a dcNess self-QA command. It exercises existing hook/function entry
+points without invoking an LLM, then reports pass/fail counts by guard category.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import os
+import subprocess  # nosec B404 - deterministic local hook probes only
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Iterable, Literal
+from unittest.mock import patch
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from harness.agent_boundary import (  # noqa: E402
+    check_bash_mutation,
+    check_github_mcp_mutation,
+    check_write_allowed,
+    extract_bash_paths,
+)
+from harness.hooks import handle_pretooluse_agent  # noqa: E402
+from harness.session_state import (  # noqa: E402
+    start_run,
+    update_current_step,
+    update_live,
+    write_pid_current_run,
+    write_pid_session,
+)
+
+
+Decision = Literal["allow", "block"]
+Probe = Callable[[], tuple[Decision, str]]
+
+
+@dataclass(frozen=True)
+class GuardCase:
+    id: str
+    category: str
+    expected: Decision
+    description: str
+    probe: Probe
+
+
+@dataclass(frozen=True)
+class CaseResult:
+    id: str
+    category: str
+    expected: Decision
+    actual: str
+    passed: bool
+    description: str
+    detail: str
+
+
+@contextlib.contextmanager
+def _external_project_boundary() -> Iterable[None]:
+    """Force file-boundary probes to behave like an external activated project."""
+    with (
+        patch("harness.agent_boundary.is_infra_project", return_value=False),
+        patch("harness.agent_boundary.is_opt_out", return_value=False),
+    ):
+        yield
+
+
+def _reason_decision(reason: str | None) -> tuple[Decision, str]:
+    return ("block", reason) if reason else ("allow", "")
+
+
+def _file_write(agent: str, path: str) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        with tempfile.TemporaryDirectory() as td, _external_project_boundary():
+            return _reason_decision(check_write_allowed(agent, path, cwd=Path(td)))
+
+    return probe
+
+
+def _bash_mutation(command: str) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        return _reason_decision(check_bash_mutation(command))
+
+    return probe
+
+
+def _mcp_mutation(tool_name: str) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        return _reason_decision(check_github_mcp_mutation(tool_name))
+
+    return probe
+
+
+def _order_gate(subagent: str, *, current_step: str | None = None) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        sid = "eval-sid"
+        rid = "run-11111111"
+        cc_pid = 45678
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            write_pid_session(cc_pid, sid, base_dir=base)
+            update_live(sid, base_dir=base)
+            start_run(sid, rid, "impl", base_dir=base, lane="lite")
+            write_pid_current_run(cc_pid, rid, base_dir=base)
+            if current_step:
+                update_current_step(sid, rid, current_step, None, base_dir=base)
+            payload = {
+                "sessionId": sid,
+                "tool_input": {"subagent_type": subagent},
+            }
+            stderr = io.StringIO()
+            with contextlib.redirect_stderr(stderr):
+                rc = handle_pretooluse_agent(
+                    stdin_data=payload,
+                    cc_pid=cc_pid,
+                    base_dir=base,
+                )
+            return ("allow" if rc == 0 else "block", stderr.getvalue().strip())
+
+    return probe
+
+
+def _write_file(root: Path, rel: str, content: str = "// fixture\n") -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _tdd_guard(rel_path: str, *, matching_test: bool = False) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            subprocess.run(
+                ["git", "init"],
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            target = _write_file(root, rel_path, "export const value = 1;\n")
+            if matching_test:
+                stem = target.with_suffix("").name
+                _write_file(target.parent, f"{stem}.test.ts", "test('ok', () => {})\n")
+            payload = {
+                "tool_name": "Edit",
+                "tool_input": {"file_path": str(target)},
+            }
+            result = subprocess.run(
+                ["bash", str(ROOT / "hooks" / "tdd-guard.sh")],
+                cwd=root,
+                input=json.dumps(payload),
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env={
+                    **os.environ,
+                    "PYTHONPATH": str(ROOT),
+                    "CLAUDE_PLUGIN_ROOT": str(ROOT),
+                    "DCNESS_FORCE_ENABLE": "1",
+                },
+            )
+            if result.returncode == 0:
+                return ("allow", result.stdout.strip())
+            if result.returncode == 2:
+                return ("block", result.stderr.strip())
+            return ("block", f"unexpected exit {result.returncode}: {result.stderr}")
+
+    return probe
+
+
+def _bash_write_tdd_boundary() -> tuple[Decision, str]:
+    command = "printf 'export const value = 1' > src/untested.ts"
+    with tempfile.TemporaryDirectory() as td, _external_project_boundary():
+        cwd = Path(td)
+        targets = extract_bash_paths(command)
+        reasons = [
+            check_write_allowed("engineer", target, cwd=cwd, shell_context=True)
+            for target in targets
+        ]
+        blocked = [reason for reason in reasons if reason]
+        if blocked:
+            return ("block", "\n".join(blocked))
+        return (
+            "allow",
+            "Bash write path is boundary-checked, but matching-test existence is "
+            "outside tdd-guard scope.",
+        )
+
+
+def build_cases() -> list[GuardCase]:
+    return [
+        GuardCase(
+            "file_boundary_allows_engineer_src",
+            "file-boundary",
+            "allow",
+            "engineer can write implementation source.",
+            _file_write("engineer", "src/service.ts"),
+        ),
+        GuardCase(
+            "file_boundary_blocks_infra",
+            "file-boundary",
+            "block",
+            "engineer cannot write dcNess-controlled hook paths.",
+            _file_write("engineer", "hooks/file-guard.sh"),
+        ),
+        GuardCase(
+            "file_boundary_blocks_code_agent_docs",
+            "file-boundary",
+            "block",
+            "code agents cannot write architect-owned docs.",
+            _file_write("engineer", "docs/architecture.md"),
+        ),
+        GuardCase(
+            "file_boundary_allows_architect_docs",
+            "file-boundary",
+            "allow",
+            "architect-owned docs remain writable by architect.",
+            _file_write("architect", "docs/architecture.md"),
+        ),
+        GuardCase(
+            "bash_mutation_blocks_git_push",
+            "bash-mutation",
+            "block",
+            "direct git push is an external state mutation.",
+            _bash_mutation("git push origin main"),
+        ),
+        GuardCase(
+            "bash_mutation_blocks_nested_pr_merge",
+            "bash-mutation",
+            "block",
+            "common shell nesting still exposes gh PR mutation.",
+            _bash_mutation("bash -lc 'gh pr merge 12'"),
+        ),
+        GuardCase(
+            "bash_mutation_blocks_gh_api_post",
+            "bash-mutation",
+            "block",
+            "gh api field flags default to mutating POST.",
+            _bash_mutation("gh api repos/owner/repo/issues -f title=x"),
+        ),
+        GuardCase(
+            "bash_mutation_allows_readonly_pr_view",
+            "bash-mutation",
+            "allow",
+            "read-only gh commands should not be false positives.",
+            _bash_mutation("gh pr view 12 --json title"),
+        ),
+        GuardCase(
+            "mcp_mutation_blocks_pr_merge",
+            "mcp-mutation",
+            "block",
+            "GitHub MCP PR/repo mutation is main-owned.",
+            _mcp_mutation("mcp__github__merge_pull_request"),
+        ),
+        GuardCase(
+            "mcp_mutation_allows_read_tool",
+            "mcp-mutation",
+            "allow",
+            "GitHub MCP read tools remain usable.",
+            _mcp_mutation("mcp__github__get_pull_request"),
+        ),
+        GuardCase(
+            "mcp_mutation_allows_issue_tool_exception",
+            "mcp-mutation",
+            "allow",
+            "Issue MCP mutations are delegated to per-agent tool grants.",
+            _mcp_mutation("mcp__github__update_issue"),
+        ),
+        GuardCase(
+            "order_gate_blocks_missing_begin_step",
+            "order-gate",
+            "block",
+            "strict impl runs require begin-step before Agent calls.",
+            _order_gate("code-validator"),
+        ),
+        GuardCase(
+            "order_gate_allows_matching_begin_step",
+            "order-gate",
+            "allow",
+            "Agent call matching current_step is allowed.",
+            _order_gate("code-validator", current_step="code-validator"),
+        ),
+        GuardCase(
+            "order_gate_blocks_step_mismatch",
+            "order-gate",
+            "block",
+            "Agent call cannot jump away from current_step.",
+            _order_gate("pr-reviewer", current_step="code-validator"),
+        ),
+        GuardCase(
+            "tdd_guard_blocks_impl_without_test",
+            "tdd-guard",
+            "block",
+            "TS/JS implementation edit without matching test is blocked.",
+            _tdd_guard("src/price.ts"),
+        ),
+        GuardCase(
+            "tdd_guard_allows_impl_with_test",
+            "tdd-guard",
+            "allow",
+            "Matching sibling test satisfies the TDD guard.",
+            _tdd_guard("src/price.ts", matching_test=True),
+        ),
+        GuardCase(
+            "tdd_guard_allows_config_false_positive",
+            "tdd-guard",
+            "allow",
+            "Config files are intentionally outside TDD existence checks.",
+            _tdd_guard("babel.config.js"),
+        ),
+        GuardCase(
+            "known_boundary_tdd_bash_write_not_enforced",
+            "known-bypass-boundary",
+            "allow",
+            "Bash-created implementation files are file-boundary checked, not TDD checked.",
+            _bash_write_tdd_boundary,
+        ),
+        GuardCase(
+            "known_boundary_command_substitution_not_scanned",
+            "known-bypass-boundary",
+            "allow",
+            "Command substitution is a documented best-effort mutation-denylist boundary.",
+            _bash_mutation("echo $(git push origin main)"),
+        ),
+    ]
+
+
+def run_cases(cases: Iterable[GuardCase]) -> list[CaseResult]:
+    results: list[CaseResult] = []
+    for case in cases:
+        try:
+            actual, detail = case.probe()
+        except Exception as exc:  # noqa: BLE001 - eval result should show probe failure
+            actual, detail = "error", f"{type(exc).__name__}: {exc}"
+        results.append(
+            CaseResult(
+                id=case.id,
+                category=case.category,
+                expected=case.expected,
+                actual=actual,
+                passed=actual == case.expected,
+                description=case.description,
+                detail=detail,
+            )
+        )
+    return results
+
+
+def summarize(results: Iterable[CaseResult]) -> dict:
+    results = list(results)
+    categories: dict[str, dict[str, int]] = {}
+    for result in results:
+        bucket = categories.setdefault(
+            result.category,
+            {"passed": 0, "failed": 0, "total": 0},
+        )
+        bucket["total"] += 1
+        bucket["passed" if result.passed else "failed"] += 1
+    total = {
+        "passed": sum(1 for result in results if result.passed),
+        "failed": sum(1 for result in results if not result.passed),
+        "total": len(results),
+    }
+    return {
+        "total": total,
+        "categories": categories,
+        "cases": [
+            {
+                "id": result.id,
+                "category": result.category,
+                "expected": result.expected,
+                "actual": result.actual,
+                "passed": result.passed,
+                "description": result.description,
+                "detail": result.detail,
+            }
+            for result in results
+        ],
+    }
+
+
+def print_human(report: dict) -> None:
+    for category, counts in sorted(report["categories"].items()):
+        print(
+            f"[guard-efficacy] {category}: "
+            f"{counts['passed']}/{counts['total']} passed"
+        )
+    print(
+        f"[guard-efficacy] total: "
+        f"{report['total']['passed']}/{report['total']['total']} passed"
+    )
+    for result in report["cases"]:
+        status = "PASS" if result["passed"] else "FAIL"
+        print(
+            f"  {status} {result['category']}/{result['id']} "
+            f"expected={result['expected']} actual={result['actual']}"
+        )
+        if not result["passed"] and result["detail"]:
+            print(f"    {result['detail']}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Run deterministic dcNess guard-efficacy fixtures."
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    args = parser.parse_args(argv)
+
+    report = summarize(run_cases(build_cases()))
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print_human(report)
+    return 1 if report["total"]["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_guard_efficacy_eval.py
+++ b/tests/test_guard_efficacy_eval.py
@@ -1,0 +1,67 @@
+"""Deterministic guard-efficacy eval runner contract tests.
+
+The runner itself exercises hook/function behavior without an LLM. These tests
+keep the command shape and required coverage categories stable.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "evals" / "guard_efficacy.py"
+
+
+class GuardEfficacyEvalContractTests(unittest.TestCase):
+    def test_runner_reports_required_categories_without_llm(self) -> None:
+        self.assertTrue(RUNNER.is_file())
+
+        result = subprocess.run(
+            ["python3.11", str(RUNNER), "--json"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+        report = json.loads(result.stdout)
+        self.assertEqual(report["total"]["failed"], 0)
+        self.assertGreater(report["total"]["passed"], 0)
+
+        categories = set(report["categories"])
+        for category in (
+            "file-boundary",
+            "bash-mutation",
+            "mcp-mutation",
+            "order-gate",
+            "tdd-guard",
+            "known-bypass-boundary",
+        ):
+            with self.subTest(category=category):
+                self.assertIn(category, categories)
+                self.assertGreater(report["categories"][category]["passed"], 0)
+
+        case_ids = {case["id"] for case in report["cases"]}
+        for case_id in (
+            "file_boundary_blocks_infra",
+            "bash_mutation_blocks_git_push",
+            "mcp_mutation_blocks_pr_merge",
+            "order_gate_blocks_missing_begin_step",
+            "tdd_guard_blocks_impl_without_test",
+            "known_boundary_tdd_bash_write_not_enforced",
+        ):
+            with self.subTest(case_id=case_id):
+                self.assertIn(case_id, case_ids)
+
+    def test_runner_is_documented_in_eval_readme(self) -> None:
+        readme = (ROOT / "evals" / "README.md").read_text(encoding="utf-8")
+        self.assertIn("python3 evals/guard_efficacy.py", readme)
+        self.assertIn("결정적 guard-efficacy", readme)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #783

## 배경 및 문제

기존 행동 eval은 LLM agent 판단 회귀를 보는 소수 케이스 중심이라, file boundary / Bash mutation / MCP mutation / order gate / TDD guard 같은 핵심 guard 효능을 결정적으로 재현하기 어려웠습니다. 이 PR은 LLM 호출 없이 hook/function 진입점을 직접 호출하는 guard-efficacy suite를 추가합니다.

## 원인 (해당 시)

- 기존 `evals/run.sh`는 agent 지침 회귀용 LLM 행동 eval입니다.
- guard 성능 문서는 단위 테스트 수나 작은 행동 eval 케이스만으로 해석될 여지가 있어, 결정적 guard fixture와 LLM 행동 eval의 범위를 분리해 설명할 필요가 있었습니다.

## 작업내용

- `evals/guard_efficacy.py` 추가
  - file-boundary, bash-mutation, mcp-mutation, order-gate, tdd-guard, known-bypass-boundary 범주별 deterministic fixture 실행
  - human output과 `--json` 범주별 pass/fail count 지원
- `tests/test_guard_efficacy_eval.py` 추가
  - runner 실행, 필수 범주, 대표 fixture id, README 문서화를 계약 테스트로 고정
- `evals/README.md`, `docs/plugin/benchmark.md`, `README.md`, `CLAUDE.md` 갱신
  - 결정적 guard-efficacy와 LLM 행동 eval 범위 구분
  - known bypass boundary는 보호 증명이 아니라 문서화된 한계를 드러내는 범주라고 명시

## 결정 근거

- 새 guard 판정 로직을 만들지 않고 기존 `harness.agent_boundary`, `harness.hooks`, `hooks/tdd-guard.sh` 진입점을 그대로 호출했습니다.
- `evals/`는 dcNess self QA 경로라 plug-in runtime 동작을 바꾸지 않습니다.
- `docs/plugin/benchmark.md`에는 배포물에서 빠지는 `evals/`를 깨지는 상대 링크로 두지 않고 source checkout 전용 경로로 설명했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `evals/guard_efficacy.py`, `tests/test_guard_efficacy_eval.py`: dcNess self QA 전용. `scripts/sync_release.sh`가 `evals`를 제외하므로 plug-in 배포물에는 포함되지 않습니다.
- `docs/plugin/benchmark.md`: plug-in 본체 문서 경로. 사용자 환경에는 `claude plugin update dcness@dcness`로 문서 구분 설명이 전달됩니다.
- hooks/commands/agents/init-dcness 복사 파일 변경 없음. runtime hook 동작 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음. `python3 evals/guard_efficacy.py`는 dcNess source checkout self-QA 명령입니다.

## Test Plan

- [x] `python3 evals/guard_efficacy.py`
- [x] `python3.11 -m unittest tests.test_guard_efficacy_eval -v`
- [x] `python3.11 -m unittest tests.test_guard_efficacy_eval tests.test_evals_harness tests.test_agent_boundary tests.test_hooks tests.test_tdd_guard tests.test_surface_docs_sync -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `git commit` pre-commit hook: unittest gate PASS

## 참고

- `python3.11 -m pip install -r requirements-quality.txt`는 PEP 668 externally-managed environment로 실패했습니다. 대신 `/tmp/dcness-quality-venv` 임시 venv에 `requirements-quality.txt`를 설치해 동일한 `scripts/check_static_quality.sh`를 실행했습니다.
