### PR TITLE
[issue-785] 벤치마크 fleet 지표 계측

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ bash scripts/dcness-codex-validator --help # Codex validator wrapper smoke
 | [`CLAUDE.md`](CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일) | 정체성 SSOT (강제 영역 2 + 안티패턴 4) |
 | [`docs/plugin/terms.md`](docs/plugin/terms.md) | 사용자-facing 용어 사전 — 용어·공개 진입점·분기 표현 수정/리뷰 시 lazy read |
 | [`docs/plugin/positioning.md`](docs/plugin/positioning.md) | 공개 workflow 진입점 계약 — 기본/support/고급/유틸리티/내부 agent 분류 |
-| [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현 가이드(measure_main_turns / run-review / guard-efficacy) + turn 절감 실측 샘플 + 한계 |
+| [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현 가이드(measure_main_turns / run-review / fleet aggregate / guard-efficacy) + PR 성공률·review rejection·waste 구분 + 표본 한계 |
 | 각 skill 의 `<skill>-routing.md` ([`impl`](skills/impl/impl-routing.md) / [`design`](skills/design/design-routing.md) / [`impl-loop`](skills/impl-loop/impl-loop-routing.md) 등) | 분기 규칙 진본 (mermaid + enum 표 + retry + escalate) |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md#진입-모델) | loop 실행 절차 — Step 0~8 mechanics (각 loop spec = 해당 skill `## Loop`) |
 | [`docs/plugin/hooks.md`](docs/plugin/hooks.md#catastrophic-gatesh) | 순서 차단 훅 + 8 hook SSOT |

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -2,8 +2,8 @@
 
 > 이 문서는 "화려한 성능 자랑" 이 아니다. dcNess 가 실제로 어디서 비용을 줄이는지,
 > 그 수치를 **누구나 자기 프로젝트에서 직접 재현**할 수 있게 하는 것이 목적이다.
-> 공개된 표본은 작고(아래 한계 참조), 일부 정량 지표(PR 머지 성공률)는 아직 측정
-> 불가다([`#766`](https://github.com/alruminum/dcNess/issues/766) 참조). 과장 없이 있는 그대로 적는다.
+> 공개된 표본은 작다. headline 숫자는 항상 표본 수, 출처 수, 한계를 같은 단락에 둔다.
+> 표본이 작으면 일반 성능 주장이 아니라 pilot / anecdote 로만 다룬다.
 
 ## 무엇을 측정하나
 
@@ -13,7 +13,7 @@ dcNess 는 측정 인프라를 plug-in 본체에 같이 배포한다.
 |---|---|---|
 | [`scripts/measure_main_turns.py`](../../scripts/measure_main_turns.py) | Claude Code 세션의 메인 assistant turn 분포 (tool / text-only / thinking-only) + tool histogram + sub-agent 호출 분포 | 직접 실행 |
 | [`harness/run_review.py`](../../harness/run_review.py) | run 1개의 step별 비용·토큰 + 낭비(waste) finding | `/run-review` skill |
-| [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py) | 여러 run 가로질러 fleet 집계 (FAIL 비율 / escalate / blocked / waste top-N) | 직접 실행 |
+| [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py) | 여러 run 가로질러 fleet 집계 (PR 머지 성공률 / review rejection / escalate / blocked / waste top-N) | 직접 실행 |
 
 guard 효능 재현은 별도다. dcNess 소스 checkout 에서만 제공되는
 `evals/guard_efficacy.py` 는 LLM 없이 hook/function 진입점을 직접 호출해 file boundary,
@@ -50,6 +50,32 @@ denylist 의 best-effort 범위 밖)를 숨기지 않고 측정 표면에 올려
 LLM 행동 eval 은 또 다른 범위다. [`evals/run.sh`](../../evals/run.sh) 는 실제 agent 를
 호출해 지침이 story slicing 같은 판단을 계속 하게 만드는지 보는 회귀 도구이며, guard
 hook/function 의 결정적 allow/block 성능을 대신하지 않는다.
+
+## 지표 구분
+
+한 표에 서로 다른 지표를 섞어 "좋아졌다"로 뭉개지 않는다.
+
+| 지표 | 의미 | 산출 근거 |
+|---|---|---|
+| cost / turn reduction | 메인 turn, token, cost 가 얼마나 줄었는가 | Claude Code session JSONL + `measure_main_turns.py` / `run_review.py` |
+| review rejection | `pr-reviewer` 가 실제로 반려한 비율 | `pr-reviewer` verdict: `FAIL / (PASS + LGTM + FAIL)` |
+| blocked events | run 이 안전하게 멈춘 횟수 | `ledger.jsonl` 의 `blocked` event |
+| escalate | agent 가 자동 진행을 거부하고 사용자/상위 설계로 올린 횟수 | step verdict 에 `ESCALATE` 포함 |
+| waste | 반복 실패, 도구 반복, placeholder 누수 등 비용 낭비 finding | `run_review.py` 의 waste detector |
+| PR merge success | 생성된 PR 중 실제 merge 완료로 확인된 비율 | `pr_created` denominator 중 matching `pr_merged` event |
+
+`pr_merged` 만 있고 matching `pr_created` 가 없으면 성공률을 만들지 않는다. 이 경우
+집계기는 merged event count 와 orphan count 는 보여주지만 ratio 는 `측정 불가`로 둔다.
+빈칸을 synthetic 추정값으로 채우지 않는다.
+
+### 공개 숫자 최소 기준
+
+- **단일 run / n=1**: anecdote. headline 성능 주장 금지.
+- **한 프로젝트만 있는 fleet**: single-project snapshot. 다른 프로젝트 일반화 금지.
+- **cross-project claim**: 최소 2개 프로젝트, 총 20개 이상 finished run, 지표별 denominator
+  명시. cost/turn 비교는 작업 종류가 다른 run 을 섞지 말고 variant 별 n 을 따로 쓴다.
+- 모든 표는 `n`, source count, 측정 날짜 또는 run 범위, 재현 명령, 주요 한계를 표 바로
+  옆에 적는다.
 
 ## 재현 1 — 메인 turn 측정
 
@@ -91,13 +117,14 @@ placeholder 누수 등) finding, 수정 제안을 리포트로 출력한다. 실
 
 ## 실측 샘플 (turn 절감)
 
-아래는 현재 공개 가능한 **단일 표본**이다. 표본이 작다는 점을 먼저 밝힌다.
+아래는 현재 공개 가능한 **단일 표본**이다. n=1 이므로 일반 성능 주장이 아니라
+재현 절차를 보여주는 anecdote 다.
 
 | 지표 | 값 | 비고 |
 |---|---|---|
 | baseline (옛 4-agent 모델) | ~280 turn/task | 외부 활성 프로젝트 impl 1-task 세션 3개 평균 (n=3) |
 | Hybrid A (build-worker 2-step) | 121 turn/task | impl 1-task 측정 (n=1) |
-| 절감 | ~57% | 121 / 280 기준 |
+| 절감 | ~57% | 121 / 280 기준, anecdote |
 
 turn 구성 분석 (Hybrid A 샘플): thinking-only + text-only = 50.7% / sub-agent
 호출 = 3.1% / git+gh 분리 호출 = 13.8%. 즉 sub-agent 가 작업을 흡수해도 메인의
@@ -121,9 +148,9 @@ notes 기록). 측정 스크립트의 재현 정확성은 알려진 두 세션(t
 ## 재현 3 — fleet 집계 (여러 run 가로질러)
 
 위 두 도구가 run 1개를 보는 반면, [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py)
-는 한 프로젝트의 **모든 run 의 `ledger.jsonl` 을 가로질러** 집계한다 — pr-reviewer
-FAIL 비율 / escalate 수 / blocked 수 / waste top-N. `run_review.py` 의 검증된 파서를
-재사용한다.
+는 한 프로젝트의 **모든 run 의 `ledger.jsonl` 을 가로질러** 집계한다 — PR 머지 성공률,
+review rejection, escalate 수, blocked 수, waste top-N. `run_review.py` 의 검증된
+파서를 재사용한다.
 
 ```sh
 # 활성 프로젝트 안에서 (sessions-root 자동 탐색) — $DCN 은 위 "스크립트 위치" 참조
@@ -133,6 +160,40 @@ python3 "$DCN"/harness/benchmark_aggregate.py
 python3 "$DCN"/harness/benchmark_aggregate.py <repo>/.claude/harness-state/.sessions --entry-point impl
 python3 "$DCN"/harness/benchmark_aggregate.py <sessions-root> --json
 ```
+
+### multi-run 측정 recipe
+
+1. 같은 프로젝트에서 `/impl` 또는 `/impl-loop` 로 여러 task 를 처리한다. PR 생성은
+   `scripts/pr-create.sh`, 머지는 `scripts/pr-finalize.sh` 경로를 타야 `pr_created` /
+   `pr_merged` ledger event 가 자동으로 남는다.
+2. 각 run 을 정상 종료한 뒤 프로젝트별 fleet JSON 을 저장한다.
+
+```sh
+cd <activated-project>
+python3 "$DCN"/harness/benchmark_aggregate.py \
+  .claude/harness-state/.sessions \
+  --entry-point impl \
+  --json > /tmp/dcness-fleet-$(basename "$PWD").json
+```
+
+3. 여러 프로젝트를 비교할 때는 프로젝트별 JSON 을 분리 보관하고, 표에는 source count 를
+   직접 적는다.
+
+```sh
+for repo in <project-a> <project-b>; do
+  (
+    cd "$repo"
+    python3 "$DCN"/harness/benchmark_aggregate.py \
+      .claude/harness-state/.sessions \
+      --entry-point impl \
+      --json > "/tmp/dcness-fleet-$(basename "$repo").json"
+  )
+done
+```
+
+4. publish 가능한 표는 다음 항목을 같이 적는다: `run_count`, `pr_created_count`,
+   `pr_merge_success_ratio`, `pr_reviewer_rejection_count/review_count`,
+   `blocked_event_count`, `escalate_count`, `waste_top`, source count, 한계.
 
 ### fleet 실측 (외부 활성 프로젝트 1곳)
 
@@ -148,6 +209,7 @@ python3 "$DCN"/harness/benchmark_aggregate.py <sessions-root> --json
 | escalate 결론 | 2 | 주로 architecture-validator |
 | blocked 이벤트 | 1 | |
 | waste top | TOOL_REPEAT_HIGH 39 / MUST_FIX_LEAK 11 / MISSING_CONCLUSION_ENUM 2 | `/run-review` 가 잡는 낭비 패턴 |
+| PR 머지 성공률 | 측정 불가 | legacy snapshot: `pr_created` denominator 없음 |
 
 해석: pr-reviewer 의 ~42% FAIL 은 "리뷰가 형식적으로 통과만 시키지 않고 실제로
 반려한다"는 뜻이다 — 가드가 동작한다는 신호. waste top 은 어디를 개선하면 비용이
@@ -163,13 +225,14 @@ python3 "$DCN"/harness/benchmark_aggregate.py <sessions-root> --json
   필요하면 `--repo <cwd>` 로 보정한다. 자동 복구(begin-run cwd 기록)는
   [`#766`](https://github.com/alruminum/dcNess/issues/766) 잔여.
 
-### 아직 측정 불가 — PR 머지 성공률 (#766 작업②)
+### PR 머지 성공률 해석
 
-PR 생성/머지까지의 **성공률**은 ledger 의 `pr_merged` 이벤트가 *선택 기록* 이라
-대부분 비어 있어 산출하지 못한다. 집계기도 이 지표는 "측정 불가"로 출력한다.
-GitHub PR 에서 파생하거나 이벤트 계측을 보강하는 작업은
-[`#766`](https://github.com/alruminum/dcNess/issues/766) 에 남아 있다. **synthetic
-추정값으로 빈칸을 채우지 않는다** — 정직한 빈칸이 가짜 숫자보다 낫다.
+신규 run 은 `pr-create.sh` 성공 시 `pr_created`, `pr-finalize.sh` 가 merge 완료를
+확인한 뒤 `pr_merged` 를 기록한다. 집계기는 `pr_created` 를 denominator 로 삼고,
+같은 PR 의 `pr_merged` 가 있을 때만 성공으로 센다.
+
+기존 run 처럼 `pr_created` 가 없으면 PR 성공률은 측정 불가다. `pr_merged` 만 남은
+수동/legacy event 는 orphan 으로 표시하고 성공률 분자에 넣지 않는다.
 
 ## 언제 유리하고 언제 과한가
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -417,9 +417,16 @@ review 리포트의 must-fix / waste finding / per-Agent metric 즉시 인지 + 
 
 `ledger.jsonl` 의 `step_completed` receipt 는 read 시점에 primary ledger 한정으로 `prose_file` 실존 + `sha256` digest match 를 strict 검증한다. 검증 실패 step 은 위조/손상으로 보고 소비처(`run-status` / `run-review` / finalize gate)에서 제외한다. 옛 `.steps.jsonl` 폴백은 마이그레이션 호환 경로라 같은 검증을 걸지 않는다.
 
-**선택 기록 event** (메인/skill 이 `ledger-event` 로 — 강제 X): `pr_created` / `pr_merged` / `task_completed` / `blocked` / `validator_passed` / `validator_failed`.
+**PR lifecycle event**: `scripts/pr-create.sh` 는 PR 생성 성공 뒤 `pr_created`,
+`scripts/pr-finalize.sh` 는 merge 완료 확인 뒤 `pr_merged` 를 자동 기록한다. active
+dcNess run 밖에서 호출되면 ledger 기록은 경고만 내고 PR 작업 자체는 계속된다.
+
+**수동 checkpoint event** (메인/skill 이 `ledger-event` 로 — 강제 X):
+`task_completed` / `blocked` / `validator_passed` / `validator_failed`.
+`pr_created` / `pr_merged` 도 수동 보정이 필요할 때만 직접 기록한다.
 
 ```bash
+"$HELPER" ledger-event pr_created --pr 588 --url <PR_URL>   # pr-create.sh 사용 시 자동
 "$HELPER" ledger-event pr_merged --pr 588 --url <PR_URL>
 "$HELPER" ledger-event blocked --reason "<사유>"
 ```

--- a/harness/benchmark_aggregate.py
+++ b/harness/benchmark_aggregate.py
@@ -10,14 +10,11 @@ N run 을 한 번에 집계한다 — public benchmark (성공률/FAIL/escalate/
 --------
 - run 수 (entry_point 별 분포)
 - agent 별 결론(conclusion enum) 분포
-- pr-reviewer FAIL 비율 (= FAIL / (PASS+FAIL+LGTM))
+- pr-reviewer FAIL 비율 (= review rejection = FAIL / (PASS+FAIL+LGTM))
 - escalate 결론 수 (전 agent)
 - `blocked` 이벤트 수
+- PR 머지 성공률 (= pr_created 중 pr_merged 로 확인된 PR 비율, 이벤트 있을 때만)
 - waste finding top-N (detect_wastes 합산)
-
-PR 머지 **성공률**은 ledger 의 `pr_merged` 이벤트가 *선택 기록* 이라 대부분 비어있다.
-따라서 본 집계기는 성공률을 산출하지 않고 "측정 불가(이벤트 미계측)" 로 정직 표기한다
-(#766 작업② — GitHub PR 파생 — 별도 범위).
 
 사용
 ----
@@ -32,6 +29,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
@@ -89,8 +87,15 @@ class FleetReport:
     by_entry_point: dict
     agent_conclusions: dict  # agent -> {enum: count}
     pr_reviewer_fail_ratio: Optional[float]
+    pr_reviewer_rejection_count: int
+    pr_reviewer_review_count: int
     escalate_count: int
     blocked_event_count: int
+    pr_created_count: int
+    pr_merged_count: int
+    pr_merge_success_count: int
+    pr_merge_orphan_count: int
+    pr_merge_success_ratio: Optional[float]
     waste_top: list  # [(pattern, count), ...] count desc
     success_measurable: bool
     waste_limit: int = 10
@@ -104,17 +109,45 @@ def _run_entry_point(run_dir: Path) -> Optional[str]:
     return None
 
 
-def _run_event_counts(run_dir: Path) -> tuple[int, bool]:
-    """(blocked 이벤트 수, pr_merged 존재 여부) — 1회 스캔."""
+_PR_URL_NUMBER_RE = re.compile(r"/pull/([0-9]+)(?:\b|$)")
+
+
+def _pr_event_key(event: dict, run_dir: Path, index: int) -> str:
+    """PR lifecycle event dedupe/match key.
+
+    `pr_number` 가 있으면 repo 경로와 조합해 cross-project #1 충돌을 피한다.
+    URL 이 있으면 repo slug 가 이미 들어 있으므로 URL 또는 URL 의 PR 번호를 쓴다.
+    둘 다 없으면 ratio 매칭에 쓸 수 없는 orphan event 로 고유화한다.
+    """
+    url = event.get("url")
+    if isinstance(url, str) and url:
+        m = _PR_URL_NUMBER_RE.search(url)
+        if m:
+            return f"url-pr:{url[:url.index('/pull/')]}#pr:{m.group(1)}"
+        return f"url:{url}"
+
+    pr_number = event.get("pr_number")
+    if pr_number is not None and str(pr_number).strip():
+        repo = _repo_path_for_run(run_dir) or run_dir
+        return f"repo:{Path(repo).resolve()}#pr:{pr_number}"
+
+    return f"event:{run_dir}:{index}"
+
+
+def _run_event_counts(run_dir: Path) -> tuple[int, set[str], set[str]]:
+    """(blocked 이벤트 수, pr_created keys, pr_merged keys) — 1회 스캔."""
     blocked = 0
-    pr_merged = False
-    for ev in ledger.read_events_at(run_dir):
+    pr_created: set[str] = set()
+    pr_merged: set[str] = set()
+    for idx, ev in enumerate(ledger.read_events_at(run_dir)):
         e = ev.get("event")
         if e == "blocked":
             blocked += 1
+        elif e == "pr_created":
+            pr_created.add(_pr_event_key(ev, run_dir, idx))
         elif e == "pr_merged":
-            pr_merged = True
-    return blocked, pr_merged
+            pr_merged.add(_pr_event_key(ev, run_dir, idx))
+    return blocked, pr_created, pr_merged
 
 
 def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> FleetReport:
@@ -133,8 +166,9 @@ def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> Flee
     agent_conclusions: dict = defaultdict(Counter)
     escalate_count = 0
     blocked_event_count = 0
+    pr_created_keys: set[str] = set()
+    pr_merged_keys: set[str] = set()
     waste_counter: Counter = Counter()
-    success_measurable = False
 
     run_count = 0
     for run_dir in run_dirs:
@@ -148,10 +182,10 @@ def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> Flee
         if ep:
             by_entry_point[ep] += 1
 
-        blocked, pr_merged = _run_event_counts(run_dir)
+        blocked, created, merged = _run_event_counts(run_dir)
         blocked_event_count += blocked
-        if pr_merged:
-            success_measurable = True
+        pr_created_keys.update(created)
+        pr_merged_keys.update(merged)
 
         # build_report 재사용 — parse_steps + invocation 조립(window/repo_path) +
         # detect_wastes 를 per-run review 와 동일하게 수행. 수동 parse_steps +
@@ -175,15 +209,31 @@ def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> Flee
     fail_n = sum(c for v, c in pr.items() if v in _PR_REVIEWER_FAIL)
     fail_ratio = (fail_n / denom) if denom else None
 
+    pr_success_keys = pr_created_keys & pr_merged_keys
+    pr_created_count = len(pr_created_keys)
+    pr_merged_count = len(pr_merged_keys)
+    pr_merge_success_count = len(pr_success_keys)
+    pr_merge_orphan_count = len(pr_merged_keys - pr_created_keys)
+    pr_merge_success_ratio = (
+        pr_merge_success_count / pr_created_count if pr_created_count else None
+    )
+
     return FleetReport(
         run_count=run_count,
         by_entry_point=dict(by_entry_point),
         agent_conclusions={a: dict(c) for a, c in agent_conclusions.items()},
         pr_reviewer_fail_ratio=fail_ratio,
+        pr_reviewer_rejection_count=fail_n,
+        pr_reviewer_review_count=denom,
         escalate_count=escalate_count,
         blocked_event_count=blocked_event_count,
+        pr_created_count=pr_created_count,
+        pr_merged_count=pr_merged_count,
+        pr_merge_success_count=pr_merge_success_count,
+        pr_merge_orphan_count=pr_merge_orphan_count,
+        pr_merge_success_ratio=pr_merge_success_ratio,
         waste_top=waste_counter.most_common(top),
-        success_measurable=success_measurable,
+        success_measurable=pr_merge_success_ratio is not None,
         waste_limit=top,
     )
 
@@ -212,11 +262,30 @@ def render_markdown(report: FleetReport) -> str:
                         sorted(report.by_entry_point.items(),
                                key=lambda kv: -kv[1]))
         lines.append(f"- entry_point 분포: {ep}")
-    lines.append(f"- pr-reviewer FAIL 비율: "
-                 f"**{_fmt_ratio(report.pr_reviewer_fail_ratio)}**")
+    lines.append(
+        f"- review rejection(pr-reviewer FAIL) 비율: "
+        f"**{_fmt_ratio(report.pr_reviewer_fail_ratio)}** "
+        f"({report.pr_reviewer_rejection_count}/{report.pr_reviewer_review_count})"
+    )
     lines.append(f"- escalate 결론 수: {report.escalate_count}")
     lines.append(f"- blocked 이벤트 수: {report.blocked_event_count}")
-    lines.append("- PR 머지 성공률: 측정 불가 (pr_merged 이벤트 미계측 — #766 작업②)")
+    if report.pr_merge_success_ratio is None:
+        lines.append(
+            "- PR 머지 성공률: 측정 불가 "
+            f"(pr_created 이벤트 0, pr_merged 이벤트 {report.pr_merged_count}; "
+            "synthetic 추정 없음)"
+        )
+    else:
+        lines.append(
+            f"- PR 머지 성공률: **{_fmt_ratio(report.pr_merge_success_ratio)}** "
+            f"({report.pr_merge_success_count}/{report.pr_created_count}; "
+            f"pr_merged 이벤트 {report.pr_merged_count})"
+        )
+    if report.pr_merge_orphan_count:
+        lines.append(
+            f"- PR 머지 orphan 이벤트: {report.pr_merge_orphan_count} "
+            "(matching pr_created 없음 — 성공률 분자에서 제외)"
+        )
     lines.append("")
 
     lines.append("## agent 별 결론 분포")
@@ -281,8 +350,15 @@ def main(argv: Optional[list] = None) -> int:
             "by_entry_point": report.by_entry_point,
             "agent_conclusions": report.agent_conclusions,
             "pr_reviewer_fail_ratio": report.pr_reviewer_fail_ratio,
+            "pr_reviewer_rejection_count": report.pr_reviewer_rejection_count,
+            "pr_reviewer_review_count": report.pr_reviewer_review_count,
             "escalate_count": report.escalate_count,
             "blocked_event_count": report.blocked_event_count,
+            "pr_created_count": report.pr_created_count,
+            "pr_merged_count": report.pr_merged_count,
+            "pr_merge_success_count": report.pr_merge_success_count,
+            "pr_merge_orphan_count": report.pr_merge_orphan_count,
+            "pr_merge_success_ratio": report.pr_merge_success_ratio,
             "waste_top": report.waste_top,
             "success_measurable": report.success_measurable,
         }, ensure_ascii=False, indent=2))

--- a/scripts/pr-create.sh
+++ b/scripts/pr-create.sh
@@ -29,11 +29,32 @@
 
 set -e
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/dcness-helper"
+
 BRANCH=""
 BASE=""
 TITLE=""
 BODY_FILE=""
 COMMIT_MSG_FILE=""
+
+extract_pr_number() {
+  printf '%s\n' "$1" | sed -nE 's#^.*/pull/([0-9]+).*$#\1#p' | head -1
+}
+
+record_pr_created() {
+  local pr_number="$1"
+  local pr_url="$2"
+  if [ -n "$pr_number" ]; then
+    if ! "$HELPER" ledger-event pr_created --pr "$pr_number" --url "$pr_url" >/dev/null 2>&1; then
+      echo "[pr-create] WARN: ledger pr_created 기록 실패 — active dcNess run 밖이면 정상" >&2
+    fi
+  else
+    if ! "$HELPER" ledger-event pr_created --url "$pr_url" >/dev/null 2>&1; then
+      echo "[pr-create] WARN: ledger pr_created 기록 실패 — active dcNess run 밖이면 정상" >&2
+    fi
+  fi
+}
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -107,6 +128,8 @@ git push -u origin "$BRANCH" >&2
 # Step 5: PR 생성
 echo "[pr-create] gh pr create --base $BASE" >&2
 PR_URL=$(gh pr create --base "$BASE" --title "$TITLE" --body-file "$BODY_FILE")
+PR_NUMBER=$(extract_pr_number "$PR_URL")
+record_pr_created "$PR_NUMBER" "$PR_URL"
 
 echo "[pr-create] 완료 — PR 생성: $PR_URL" >&2
 echo "$PR_URL"

--- a/scripts/pr-finalize.sh
+++ b/scripts/pr-finalize.sh
@@ -46,6 +46,14 @@ json_field() {
   python3 -c 'import json,sys; print(json.load(sys.stdin).get(sys.argv[1], ""))' "$1"
 }
 
+record_pr_merged() {
+  local pr_number="$1"
+  local pr_url="$2"
+  if ! "$HELPER" ledger-event pr_merged --pr "$pr_number" --url "$pr_url" >/dev/null 2>&1; then
+    echo "[pr-finalize] WARN: ledger pr_merged 기록 실패 — active dcNess run 밖이면 정상" >&2
+  fi
+}
+
 cleanup_merge_lock() {
   rc=$?
   if [ -n "$MERGE_LOCK_TOKEN" ]; then
@@ -191,6 +199,7 @@ fi
 
 # Step 4: origin/main ref 동기화 (refspec 없이 fetch — worktree 호환)
 PR_URL=$(gh pr view "$PR" --json url -q .url 2>/dev/null)
+record_pr_merged "$PR" "$PR_URL"
 
 if [ -n "$MERGE_LOCK_TOKEN" ]; then
   "$HELPER" merge-lock complete \

--- a/tests/test_benchmark_aggregate.py
+++ b/tests/test_benchmark_aggregate.py
@@ -223,7 +223,7 @@ class TestEscalateAndBlocked(unittest.TestCase):
 
 
 class TestSuccessMeasurable(unittest.TestCase):
-    def test_not_measurable_without_pr_merged(self):
+    def test_not_measurable_without_pr_created(self):
         with tempfile.TemporaryDirectory() as d:
             tmp = Path(d)
             r = _make_run_dir_ledger(
@@ -233,8 +233,13 @@ class TestSuccessMeasurable(unittest.TestCase):
             )
             rep = aggregate_runs([r])
             self.assertFalse(rep.success_measurable)
+            self.assertIsNone(rep.pr_merge_success_ratio)
+            self.assertEqual(rep.pr_created_count, 0)
+            self.assertEqual(rep.pr_merged_count, 0)
 
-    def test_measurable_when_pr_merged_present(self):
+    def test_not_measurable_from_orphan_pr_merged_only(self):
+        # legacy/manual pr_merged 만 있으면 denominator(pr_created)가 없어 성공률을
+        # 합성하지 않는다. merged event count 는 노출하되 ratio 는 None.
         with tempfile.TemporaryDirectory() as d:
             tmp = Path(d)
             r = _make_run_dir_ledger(
@@ -244,7 +249,77 @@ class TestSuccessMeasurable(unittest.TestCase):
                 {"e.md": "구현\nIMPL_DONE\n"},
             )
             rep = aggregate_runs([r])
+            self.assertFalse(rep.success_measurable)
+            self.assertIsNone(rep.pr_merge_success_ratio)
+            self.assertEqual(rep.pr_created_count, 0)
+            self.assertEqual(rep.pr_merged_count, 1)
+            self.assertEqual(rep.pr_merge_orphan_count, 1)
+
+    def test_pr_merge_success_ratio_from_created_and_merged_events(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            r1 = _make_run_dir_ledger(
+                tmp, "s1", "run-h1000001",
+                _run_events("impl", [_step("engineer", "e.md")],
+                            extra=[
+                                {"event": "pr_created", "pr_number": 10,
+                                 "url": "https://github.com/o/r/pull/10",
+                                 "ts": "2026-06-01T00:04:00Z"},
+                                {"event": "pr_merged", "pr_number": 10,
+                                 "url": "https://github.com/o/r/pull/10",
+                                 "ts": "2026-06-01T00:08:00Z"},
+                            ]),
+                {"e.md": "구현\nIMPL_DONE\n"},
+            )
+            r2 = _make_run_dir_ledger(
+                tmp, "s1", "run-h2000002",
+                _run_events("impl", [_step("engineer", "e.md")],
+                            extra=[
+                                {"event": "pr_created", "pr_number": 11,
+                                 "url": "https://github.com/o/r/pull/11",
+                                 "ts": "2026-06-01T00:04:00Z"},
+                            ]),
+                {"e.md": "구현\nIMPL_DONE\n"},
+            )
+            rep = aggregate_runs([r1, r2])
             self.assertTrue(rep.success_measurable)
+            self.assertEqual(rep.pr_created_count, 2)
+            self.assertEqual(rep.pr_merged_count, 1)
+            self.assertEqual(rep.pr_merge_success_count, 1)
+            self.assertEqual(rep.pr_merge_orphan_count, 0)
+            self.assertAlmostEqual(rep.pr_merge_success_ratio, 0.5)
+
+    def test_pr_number_keys_do_not_collide_across_projects(self):
+        # URL 없는 manual events 도 repo path 를 key 에 포함해 project A #1 과
+        # project B #1 을 서로 다른 PR 로 센다.
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            repo_a = tmp / "repo-a"
+            repo_b = tmp / "repo-b"
+            r1 = _make_run_dir_ledger(
+                repo_a, "s1", "run-ha000001",
+                _run_events("impl", [_step("engineer", "e.md")],
+                            extra=[
+                                {"event": "pr_created", "pr_number": 1,
+                                 "ts": "2026-06-01T00:04:00Z"},
+                                {"event": "pr_merged", "pr_number": 1,
+                                 "ts": "2026-06-01T00:08:00Z"},
+                            ]),
+                {"e.md": "구현\nIMPL_DONE\n"},
+            )
+            r2 = _make_run_dir_ledger(
+                repo_b, "s1", "run-hb000002",
+                _run_events("impl", [_step("engineer", "e.md")],
+                            extra=[
+                                {"event": "pr_created", "pr_number": 1,
+                                 "ts": "2026-06-01T00:04:00Z"},
+                            ]),
+                {"e.md": "구현\nIMPL_DONE\n"},
+            )
+            rep = aggregate_runs([r1, r2])
+            self.assertEqual(rep.pr_created_count, 2)
+            self.assertEqual(rep.pr_merge_success_count, 1)
+            self.assertAlmostEqual(rep.pr_merge_success_ratio, 0.5)
 
 
 class TestWasteTop(unittest.TestCase):
@@ -316,8 +391,29 @@ class TestRenderAndCli(unittest.TestCase):
             md = render_markdown(aggregate_runs([r]))
             self.assertIn("pr-reviewer", md)
             self.assertIn("1", md)  # run count
-            # 성공률 미측정 정직 표기
+            # 성공률 미측정 정직 표기 — 합성 placeholder 금지.
             self.assertRegex(md, r"(측정 불가|미측정|이벤트)")
+            self.assertIn("review rejection", md)
+
+    def test_render_markdown_contains_measured_pr_success(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            r = _make_run_dir_ledger(
+                tmp, "s1", "run-k1000001",
+                _run_events("impl", [_step("pr-reviewer", "pr.md")],
+                            extra=[
+                                {"event": "pr_created", "pr_number": 7,
+                                 "url": "https://github.com/o/r/pull/7",
+                                 "ts": "2026-06-01T00:04:00Z"},
+                                {"event": "pr_merged", "pr_number": 7,
+                                 "url": "https://github.com/o/r/pull/7",
+                                 "ts": "2026-06-01T00:08:00Z"},
+                            ]),
+                {"pr.md": "리뷰\nPASS\n"},
+            )
+            md = render_markdown(aggregate_runs([r]))
+            self.assertIn("PR 머지 성공률: **100.0%**", md)
+            self.assertIn("1/1", md)
 
     def test_main_runs_on_sessions_root(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_pr_lifecycle_ledger.py
+++ b/tests/test_pr_lifecycle_ledger.py
@@ -1,0 +1,50 @@
+"""PR lifecycle helper ledger instrumentation tests (#785).
+
+The shell helpers remain integration wrappers around git/gh, so these tests keep
+the contract at the script wiring level: successful PR create/finalize paths must
+record durable ledger checkpoints when an active dcNess run exists.
+"""
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PR_CREATE = REPO_ROOT / "scripts" / "pr-create.sh"
+PR_FINALIZE = REPO_ROOT / "scripts" / "pr-finalize.sh"
+
+
+class PrLifecycleLedgerWiringTests(unittest.TestCase):
+    def test_pr_create_syntax_valid(self) -> None:
+        result = subprocess.run(
+            ["bash", "-n", str(PR_CREATE)], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_pr_create_records_pr_created_after_gh_create(self) -> None:
+        script = PR_CREATE.read_text(encoding="utf-8")
+        self.assertIn("dcness-helper", script)
+        self.assertIn("ledger-event pr_created", script)
+        self.assertIn("--url", script)
+        self.assertIn("--pr", script)
+        self.assertIn("PR_NUMBER", script)
+        self.assertLess(
+            script.index("gh pr create"),
+            script.index("ledger-event pr_created"),
+        )
+
+    def test_pr_finalize_records_pr_merged_after_merged_state(self) -> None:
+        script = PR_FINALIZE.read_text(encoding="utf-8")
+        self.assertIn("ledger-event pr_merged", script)
+        self.assertIn("--url", script)
+        self.assertIn("--pr", script)
+        self.assertLess(
+            script.index('STATE" != "MERGED"'),
+            script.index('record_pr_merged "$PR" "$PR_URL"'),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호
Closes #785

## 배경 및 문제
benchmark 문서와 fleet 집계가 turn 절감, review rejection, blocked/escalate/waste, PR merge success 를 명확히 구분하지 못했다. 특히 PR 성공률은 pr_merged event 부재 때문에 항상 측정 불가로 고정되어 있었고, 작은 표본 수치가 일반 성능 주장처럼 읽힐 여지가 있었다.

## 원인
PR 생성과 머지 helper가 run ledger에 pr_created/pr_merged checkpoint를 자동 기록하지 않았다. fleet 집계기는 pr_merged 존재 여부만 보았고, pr_created denominator 없이 성공률을 계산하지 못했다.

## 작업내용
- scripts/pr-create.sh: gh pr create 성공 뒤 pr_created ledger event 자동 기록.
- scripts/pr-finalize.sh: PR MERGED 확인 뒤 pr_merged ledger event 자동 기록.
- harness/benchmark_aggregate.py: pr_created 기준 PR merge success ratio, orphan pr_merged count, review rejection count/review count를 JSON/Markdown에 노출.
- tests/test_benchmark_aggregate.py: success ratio, orphan merge, cross-project PR number collision 방지 테스트 추가.
- tests/test_pr_lifecycle_ledger.py: PR helper ledger wiring 회귀 테스트 추가.
- docs/plugin/benchmark.md, docs/plugin/loop-procedure.md, README.md: multi-run 측정 recipe, metric 구분, 표본 기준, 배포 문서 설명 갱신.

## 결정 근거
PR 성공률은 pr_created를 denominator로 삼을 때만 의미가 있다. pr_merged만 있는 legacy/manual event는 성공률 분자에 넣지 않고 orphan으로 별도 표시해 synthetic placeholder를 만들지 않는다. URL이 없는 manual event도 repo path와 PR 번호를 함께 key로 써서 cross-project 집계에서 같은 PR 번호가 충돌하지 않게 했다.

## 배포 경로 검증
- plug-in 본체 경로: harness/benchmark_aggregate.py, scripts/pr-create.sh, scripts/pr-finalize.sh, docs/plugin/benchmark.md, docs/plugin/loop-procedure.md, README.md 변경. plug-in 업데이트 시 사용자 환경에 도달한다.
- /init-dcness 복사 파일 추가 없음. 기존 활성화 프로젝트는 plug-in update로 받으면 되고 init 재실행은 필요 없다.
- 사용자-facing 문서 경로도 docs/plugin 및 README라 plug-in 배포물에 포함된다.

## Test Plan
- [x] python3.11 -m unittest discover -s tests -v
- [x] PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] node scripts/check_plugin_manifest.mjs
- [x] git commit pre-commit hook PASS

## 참고
- Project Status: issue #785 In progress 로 이동 완료.