### PR TITLE
[issue-784] fail-open 진단 노출

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -48,6 +48,8 @@ python3 -m harness.hooks <handler> --cc-pid "$CC_PID"
 
 PreToolUse 차단 hook 은 정책 위반만 `exit 2` 로 내보낸다. Claude Code 에서 `exit 2` 는 tool 호출을 막고 stderr 를 모델에게 보여준다. import 오류나 hook 자체 오류는 fail-open 쪽으로 처리해 hook 버그가 전체 작업을 과차단하지 않게 한다.
 
+Fail-open 관측성: 미활성 프로젝트 no-op, main Claude turn, active run 밖 Agent 호출처럼 예상된 benign skip 은 조용히 통과한다. 반대로 활성 프로젝트에서 enforcement hook 이 payload 파싱 실패, session id 부재, state read/write 오류, handler 비정상 종료 때문에 검사를 평가하지 못하고 allow 한 경우는 `<project>/.claude/harness-state/fail-open-events.jsonl` 에 structured event 로 남긴다. `dcness-helper status` 의 `hook fail-open 진단` 항목은 최근 24시간 count 와 reason category 를 WARN 으로 보여준다.
+
 Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision: "block"` JSON 을 stdout 으로 내보내 메인 turn 을 재발화시킨다.
 
 ### session-start.sh

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -28,6 +28,8 @@
 
 > 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다.
 
+`dcness-helper status` 는 설치 상태뿐 아니라 최근 hook fail-open 활동도 `hook fail-open 진단` 항목으로 보여준다. 정상 inactive no-op 은 기록하지 않고, 활성 프로젝트에서 enforcement hook 이 검사를 평가하지 못하고 allow 한 경우만 최근 reason category 를 WARN 으로 노출한다. 자세한 정책은 [`hooks.md`](hooks.md) 가 SSOT 다.
+
 ## Already Automatic
 
 `/init-dcness` 가 whitelist 를 활성화하면 새 Claude Code 세션부터 [`hooks/hooks.json`](../../hooks/hooks.json) 의 CC hooks 가 자동 등록된다. 사용자가 따로 설치할 파일은 없다.

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -36,8 +36,10 @@ from harness.session_state import (
     cleanup_stale_pid_files,
     cleanup_stale_run_dirs,
     cleanup_stale_runs,
+    is_project_active,
     read_live,
     read_pid_current_run,
+    record_fail_open_event,
     run_dir,
     session_dir,
     update_live,
@@ -63,6 +65,21 @@ _STRICT_CONVEYOR_ENTRY_POINTS = frozenset({
     "impl",
     "ux",
 })
+
+
+def _record_fail_open_safe(
+    hook: str,
+    category: str,
+    detail: str = "",
+    *,
+    base_dir: Optional[Path] = None,
+) -> None:
+    record_fail_open_event(
+        hook=hook,
+        category=category,
+        detail=detail,
+        base_dir=base_dir,
+    )
 
 
 # ── DCN-CHG-20260501-11 — agent-trace.jsonl 헬퍼 ──────────────────────
@@ -410,18 +427,42 @@ def handle_pretooluse_agent(
         try:
             raw = sys.stdin.read()
             stdin_data = json.loads(raw) if raw.strip() else {}
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as exc:
+            _record_fail_open_safe(
+                "catastrophic-gate",
+                "payload_unreadable",
+                f"{type(exc).__name__}: {exc}",
+                base_dir=base_dir,
+            )
             return 0  # parse 실패 → silent allow
 
     if not isinstance(stdin_data, dict):
+        _record_fail_open_safe(
+            "catastrophic-gate",
+            "payload_invalid",
+            f"payload type={type(stdin_data).__name__}",
+            base_dir=base_dir,
+        )
         return 0
 
     sid = _extract_sid(stdin_data)
     if not valid_session_id(sid):
+        _record_fail_open_safe(
+            "catastrophic-gate",
+            "payload_missing_session",
+            "missing or invalid session id",
+            base_dir=base_dir,
+        )
         return 0  # sid 없음 → 검사 불가, allow
 
     tool_input = stdin_data.get("tool_input")
     if not isinstance(tool_input, dict):
+        _record_fail_open_safe(
+            "catastrophic-gate",
+            "payload_invalid",
+            "tool_input is not an object",
+            base_dir=base_dir,
+        )
         return 0
     subagent = tool_input.get("subagent_type", "") or ""
     mode = tool_input.get("mode", "") or ""
@@ -470,7 +511,13 @@ def handle_pretooluse_agent(
             if strict_msg:
                 print(strict_msg, file=sys.stderr)
                 return 1
-    except (OSError, ValueError):
+    except (OSError, ValueError) as exc:
+        _record_fail_open_safe(
+            "catastrophic-gate",
+            "state_read_error",
+            f"{type(exc).__name__}: {exc}",
+            base_dir=base_dir,
+        )
         pass  # state 읽기 실패는 fail-open — hook 버그발 과차단 회피.
 
     # engineer 게이트 — engineer 직전 설계 산출물 필수 (effective mode != POLISH).
@@ -557,7 +604,13 @@ def handle_pretooluse_agent(
     if subagent:
         try:
             update_live(sid, base_dir=base_dir, active_agent=subagent, active_mode=(mode or None))
-        except (OSError, ValueError):
+        except (OSError, ValueError) as exc:
+            _record_fail_open_safe(
+                "catastrophic-gate",
+                "state_write_error",
+                f"active_agent update failed: {type(exc).__name__}: {exc}",
+                base_dir=base_dir,
+            )
             pass  # 실패해도 Agent 호출은 통과 — 식별만 누락.
 
     # #272 W3 진짜 fix — PreToolUse Agent 의 tool_use_id + 시작 시각을 써
@@ -646,17 +699,44 @@ def handle_pretooluse_file_op(
         try:
             raw = sys.stdin.read()
             stdin_data = json.loads(raw) if raw.strip() else {}
-        except (json.JSONDecodeError, OSError):
+        except (json.JSONDecodeError, OSError) as exc:
+            _record_fail_open_safe(
+                "file-guard",
+                "payload_unreadable",
+                f"{type(exc).__name__}: {exc}",
+                base_dir=base_dir,
+            )
             return 0
 
     if not isinstance(stdin_data, dict):
+        _record_fail_open_safe(
+            "file-guard",
+            "payload_invalid",
+            f"payload type={type(stdin_data).__name__}",
+            base_dir=base_dir,
+        )
         return 0
 
     sid = _extract_sid(stdin_data)
     if not valid_session_id(sid):
+        _record_fail_open_safe(
+            "file-guard",
+            "payload_missing_session",
+            "missing or invalid session id",
+            base_dir=base_dir,
+        )
         return 0
 
-    live = read_live(sid, base_dir=base_dir) or {}
+    try:
+        live = read_live(sid, base_dir=base_dir) or {}
+    except (OSError, ValueError) as exc:
+        _record_fail_open_safe(
+            "file-guard",
+            "state_read_error",
+            f"{type(exc).__name__}: {exc}",
+            base_dir=base_dir,
+        )
+        return 0
     # issue #598 — acting agent 는 payload agent_type(자기 식별, 동시 sub 안전) 우선,
     # 없으면 live.active_agent 단일 슬롯 폴백 (_resolve_acting_agent).
     acting_agent = _resolve_acting_agent(stdin_data, live)
@@ -666,6 +746,12 @@ def handle_pretooluse_file_op(
     tool_name = stdin_data.get("tool_name", "") or ""
     tool_input = stdin_data.get("tool_input") or {}
     if not isinstance(tool_input, dict):
+        _record_fail_open_safe(
+            "file-guard",
+            "payload_invalid",
+            "tool_input is not an object",
+            base_dir=base_dir,
+        )
         return 0
 
     cwd = Path.cwd()
@@ -1558,9 +1644,15 @@ def _main(argv: Optional[list] = None) -> int:
             rc = handle_subagent_stop()
         else:
             rc = 0
-    except Exception:  # noqa: BLE001 — hook 버그가 도구 호출을 과차단하지 않게 fail-open
+    except Exception as exc:  # noqa: BLE001 — hook 버그가 도구 호출을 과차단하지 않게 fail-open
         import traceback
         traceback.print_exc()
+        if is_project_active():
+            _record_fail_open_safe(
+                args.cmd,
+                "handler_exception",
+                f"{type(exc).__name__}: {exc}",
+            )
         return 0
     # 정책 위반(rc==1)은 blocking hook 에서만 exit 2. 그 외(비-blocking / allow) 는 0.
     if blocking and rc == 1:

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -37,7 +37,7 @@ import shutil
 import subprocess  # nosec B404
 import sys
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -85,6 +85,10 @@ __all__ = [
     "disable_project",
     "list_active_projects",
     "whitelist_path",
+    "fail_open_events_path",
+    "record_fail_open_event",
+    "read_fail_open_events",
+    "collect_fail_open_summary",
 ]
 
 # ── 상수 ─────────────────────────────────────────────────────────────
@@ -99,6 +103,10 @@ LIVE_JSON_VERSION = 1                      # 스키마 진화 추적
 STDIN_TIMEOUT_SEC = 2.0                    # 훅 stdin 읽기 hang 방지
 _ATOMIC_FILE_MODE = 0o600
 _PPID_LOOKUP_TIMEOUT_SEC = 2.0
+FAIL_OPEN_EVENTS_NAME = "fail-open-events.jsonl"
+FAIL_OPEN_RECENT_HOURS = 24
+FAIL_OPEN_RECENT_LIMIT = 5
+_FAIL_OPEN_DETAIL_MAX = 500
 
 
 # ── 경로 유틸 ───────────────────────────────────────────────────────
@@ -1506,6 +1514,173 @@ def list_active_projects() -> list:
     return _load_whitelist()
 
 
+# ── hook fail-open diagnostics (#784) ────────────────────────────────
+
+
+def fail_open_events_path(
+    cwd: Optional[Path] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    """현재 프로젝트의 hook fail-open 진단 JSONL 경로."""
+    if base_dir is not None:
+        return Path(base_dir) / FAIL_OPEN_EVENTS_NAME
+    return _resolve_project_root(cwd) / ".claude" / "harness-state" / FAIL_OPEN_EVENTS_NAME
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_fail_open_ts(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def record_fail_open_event(
+    *,
+    hook: str,
+    category: str,
+    detail: str = "",
+    severity: str = "WARN",
+    cwd: Optional[Path] = None,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """enforcement-relevant hook fail-open 을 JSONL 로 기록한다.
+
+    기록 실패는 hook 본동작을 막지 않는다. inactive-project no-op 같은 benign skip 은
+    호출자가 이 함수를 부르지 않는 방식으로 조용히 유지한다.
+    """
+    try:
+        hook_s = str(hook or "unknown")[:80]
+        category_s = str(category or "unknown")[:120]
+        detail_s = str(detail or "").replace("\n", " ")[:_FAIL_OPEN_DETAIL_MAX]
+        severity_s = str(severity or "WARN").upper()[:20]
+        event: Dict[str, Any] = {
+            "ts": _utc_now_iso(),
+            "hook": hook_s,
+            "category": category_s,
+            "severity": severity_s,
+            "detail": detail_s,
+        }
+        if base_dir is None:
+            try:
+                event["project_root"] = str(_resolve_project_root(cwd).resolve())
+            except (OSError, ValueError):
+                pass
+        target = fail_open_events_path(cwd, base_dir=base_dir)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n"
+        fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 # nosec B110
+        pass
+
+
+def read_fail_open_events(
+    cwd: Optional[Path] = None,
+    *,
+    base_dir: Optional[Path] = None,
+    since_hours: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> list[Dict[str, Any]]:
+    """hook fail-open JSONL 을 읽는다. malformed row 는 진단 자체를 깨지 않게 skip."""
+    target = fail_open_events_path(cwd, base_dir=base_dir)
+    try:
+        if not target.exists():
+            return []
+    except OSError:
+        return []
+
+    cutoff = None
+    if since_hours is not None:
+        cutoff = datetime.now(timezone.utc) - timedelta(hours=since_hours)
+
+    events: list[Dict[str, Any]] = []
+    try:
+        with open(target, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                if cutoff is not None:
+                    parsed = _parse_fail_open_ts(row.get("ts"))
+                    if parsed is None or parsed < cutoff:
+                        continue
+                events.append(row)
+    except OSError:
+        return []
+
+    if limit == 0:
+        return []
+    if limit is not None and limit > 0:
+        return events[-limit:]
+    return events
+
+
+def collect_fail_open_summary(
+    cwd: Optional[Path] = None,
+    *,
+    base_dir: Optional[Path] = None,
+    since_hours: int = FAIL_OPEN_RECENT_HOURS,
+    recent_limit: int = FAIL_OPEN_RECENT_LIMIT,
+) -> Dict[str, Any]:
+    """status 진단용 최근 fail-open count/reason category 요약."""
+    events = read_fail_open_events(cwd, base_dir=base_dir, since_hours=since_hours)
+    by_category: Dict[str, int] = {}
+    by_hook: Dict[str, int] = {}
+    for event in events:
+        category = str(event.get("category") or "unknown")
+        hook = str(event.get("hook") or "unknown")
+        by_category[category] = by_category.get(category, 0) + 1
+        by_hook[hook] = by_hook.get(hook, 0) + 1
+    return {
+        "total": len(events),
+        "since_hours": since_hours,
+        "by_category": by_category,
+        "by_hook": by_hook,
+        "recent": list(reversed(events[-recent_limit:])) if recent_limit > 0 else [],
+    }
+
+
+def _format_fail_open_summary(summary: Dict[str, Any]) -> str:
+    total = int(summary.get("total") or 0)
+    since_hours = int(summary.get("since_hours") or FAIL_OPEN_RECENT_HOURS)
+    if total <= 0:
+        return f"최근 {since_hours}h 0건"
+    by_category = summary.get("by_category") if isinstance(summary, dict) else {}
+    if not isinstance(by_category, dict):
+        by_category = {}
+    category_text = ", ".join(
+        f"{k}={v}" for k, v in sorted(by_category.items(), key=lambda item: str(item[0]))
+    )
+    recent = summary.get("recent") if isinstance(summary, dict) else []
+    latest_text = ""
+    if isinstance(recent, list) and recent:
+        latest = recent[0]
+        if isinstance(latest, dict):
+            hook = latest.get("hook") or "unknown"
+            category = latest.get("category") or "unknown"
+            detail = latest.get("detail") or ""
+            latest_text = f"; latest: {hook}/{category}"
+            if detail:
+                latest_text += f" — {detail}"
+    return f"최근 {since_hours}h {total}건 — {category_text}{latest_text}"
+
+
 # ── CLI (python3 -m harness.session_state <subcommand>) ─────────────
 
 
@@ -2873,6 +3048,17 @@ def _cli_is_active(args: Any) -> int:
     return 0 if is_project_active() else 1
 
 
+def _cli_hook_fail_open(args: Any) -> int:
+    """hook wrapper 내부용 fail-open 이벤트 기록."""
+    record_fail_open_event(
+        hook=args.hook,
+        category=args.category,
+        detail=args.detail or "",
+        severity=args.severity,
+    )
+    return 0
+
+
 # ── status 진단표 (#520) ────────────────────────────────────────────
 #
 # `dcness-helper status` 를 PASS/WARN/FAIL/INFO/NA 진단표로 확장한다. 별도 doctor
@@ -3144,6 +3330,20 @@ def collect_status_diagnostics(
             "인증됨" if gh_ok else "미인증/미설치 — PR·issue 자동화 제한",
             None if gh_ok else "gh auth login",
         )
+
+    fail_open = collect_fail_open_summary(cwd=project_root)
+    fail_open_total = int(fail_open.get("total") or 0)
+    add(
+        "hook_fail_open",
+        "hook fail-open 진단",
+        "WARN" if fail_open_total else "PASS",
+        _format_fail_open_summary(fail_open),
+        (
+            "반복되면 hook stderr 로그와 fail-open reason category 를 확인하고 "
+            "dcness 업데이트 또는 이슈 제보"
+            if fail_open_total else None
+        ),
+    )
 
     status_labels = ("PASS", "WARN", "FAIL")
     summary = {status: 0 for status in status_labels}
@@ -3524,6 +3724,16 @@ def _build_arg_parser() -> Any:
 
     p_ia = sub.add_parser("is-active", help="활성 여부 (silent, exit 0/1) — hook 게이트용")
     p_ia.set_defaults(func=_cli_is_active)
+
+    p_hfo = sub.add_parser(
+        "hook-fail-open",
+        help="internal: enforcement hook fail-open diagnostic append",
+    )
+    p_hfo.add_argument("--hook", required=True)
+    p_hfo.add_argument("--category", required=True)
+    p_hfo.add_argument("--detail", default="")
+    p_hfo.add_argument("--severity", default="WARN")
+    p_hfo.set_defaults(func=_cli_hook_fail_open)
 
     p_st = sub.add_parser("status", help="whitelist + 현재 cwd 상태")
     p_st.set_defaults(func=_cli_status)

--- a/hooks/catastrophic-gate.sh
+++ b/hooks/catastrophic-gate.sh
@@ -22,6 +22,13 @@ set -uo pipefail
 # plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응.
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
 
+record_fail_open() {
+  python3 -m harness.session_state hook-fail-open \
+    --hook catastrophic-gate \
+    --category "$1" \
+    --detail "$2" >/dev/null 2>&1 || true
+}
+
 # 활성화 게이트 — 미활성 프로젝트는 즉시 통과 + suppressOutput.
 if ! python3 -m harness.session_state is-active >/dev/null 2>&1; then
   echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
@@ -42,5 +49,8 @@ fi
 # 그 외 전부 fail-open(allow): RC=0(정상 통과) / RC=1·기타(import·문법 오류 등 파이썬 크래시).
 # 크래시를 exit 2 로 매핑하면 hook 버그가 *모든* Agent 호출을 과차단하므로 반드시 fail-open.
 # (#404 — suppressOutput: true 로 transcript attachment 숨김 시도.)
+if [ "$RC" != "0" ]; then
+  record_fail_open "handler_nonzero" "harness.hooks pretooluse-agent exited ${RC}; allowed"
+fi
 echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
 exit 0

--- a/hooks/file-guard.sh
+++ b/hooks/file-guard.sh
@@ -25,6 +25,13 @@ set -uo pipefail
 # plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응.
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
 
+record_fail_open() {
+  python3 -m harness.session_state hook-fail-open \
+    --hook file-guard \
+    --category "$1" \
+    --detail "$2" >/dev/null 2>&1 || true
+}
+
 # 활성화 게이트 — 미활성 프로젝트는 즉시 통과 + suppressOutput.
 if ! python3 -m harness.session_state is-active >/dev/null 2>&1; then
   echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
@@ -45,5 +52,8 @@ fi
 # 그 외 전부 fail-open(allow): RC=0(정상 통과) / RC=1·기타(import·문법 오류 등 파이썬 크래시).
 # 크래시를 exit 2 로 매핑하면 hook 버그가 *모든* 도구 호출을 과차단하므로 반드시 fail-open.
 # (#404 — suppressOutput: true 로 transcript attachment 숨김 시도. CC 버그 anthropics/claude-code#34859 회피 가설.)
+if [ "$RC" != "0" ]; then
+  record_fail_open "handler_nonzero" "harness.hooks pretooluse-file-op exited ${RC}; allowed"
+fi
 echo '{"suppressOutput": true, "hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
 exit 0

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -23,12 +23,22 @@ allow() {
 # plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응 (다른 wrapper 정합).
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
 
+record_fail_open() {
+  python3 -m harness.session_state hook-fail-open \
+    --hook tdd-guard \
+    --category "$1" \
+    --detail "$2" >/dev/null 2>&1 || true
+}
+
 # 활성화 게이트 (#597 커밋3) — 미활성 프로젝트는 즉시 allow (no-op).
 # 나머지 6 wrapper 는 이미 보유. tdd-guard 만 누락이라 비활성 프로젝트서도 deny 발동하던 결함 수정.
 python3 -m harness.session_state is-active >/dev/null 2>&1 || allow
 
 INPUT=$(cat)
-[ -z "$INPUT" ] && allow
+if [ -z "$INPUT" ]; then
+  record_fail_open "payload_empty" "empty stdin; TDD enforcement skipped"
+  allow
+fi
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
@@ -45,7 +55,7 @@ try:
 except Exception:
     sys.exit(0)
 ti = payload.get("tool_input") or {}
-for key in ("file_path", "path", "filename"):
+for key in ("file_path", "path", "filename", "notebook_path"):
     v = ti.get(key)
     if isinstance(v, str) and v:
         print(v)
@@ -53,7 +63,10 @@ for key in ("file_path", "path", "filename"):
 PY
 )
 
-[ -z "$FILE_PATH" ] && allow
+if [ -z "$FILE_PATH" ]; then
+  record_fail_open "payload_missing_path" "file path not found in hook payload"
+  allow
+fi
 
 # 자동 skip — test/spec 파일 자체 + 표준 test 디렉터리 (#681)
 # 주의: 단순 *test* / *spec* 광역 glob 은 contest.ts / spectrum.ts / latest.ts 같은

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -51,6 +51,7 @@ from harness.agent_trace import read_all as read_trace
 # issue #392 — redo_log 폐기
 from harness.session_state import (
     read_live,
+    read_fail_open_events,
     read_pid_session,
     run_dir,
     session_dir,
@@ -1043,6 +1044,9 @@ class SilentAllowWithoutSessionTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
+        events = read_fail_open_events(base_dir=self.base)
+        self.assertEqual(events[-1]["hook"], "catastrophic-gate")
+        self.assertEqual(events[-1]["category"], "payload_missing_session")
 
 
 # ---------------------------------------------------------------------------
@@ -1058,6 +1062,9 @@ class SilentAllowMalformedInputTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
+        events = read_fail_open_events(base_dir=self.base)
+        self.assertEqual(events[-1]["hook"], "catastrophic-gate")
+        self.assertEqual(events[-1]["category"], "payload_invalid")
 
     def test_non_dict_stdin_silent(self) -> None:
         rc = handle_pretooluse_agent(
@@ -1066,6 +1073,9 @@ class SilentAllowMalformedInputTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
+        events = read_fail_open_events(base_dir=self.base)
+        self.assertEqual(events[-1]["hook"], "catastrophic-gate")
+        self.assertEqual(events[-1]["category"], "payload_invalid")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -26,6 +26,7 @@ from tempfile import TemporaryDirectory
 import subprocess
 
 from harness.session_state import (
+    collect_fail_open_summary,
     _check_ci_workflows,
     _check_git_hooks,
     _check_read_permission,
@@ -35,6 +36,8 @@ from harness.session_state import (
     _resolve_git_hooks_dir,
     collect_status_diagnostics,
     format_status_report,
+    read_fail_open_events,
+    record_fail_open_event,
 )
 
 
@@ -243,6 +246,53 @@ class CollectExternalRepoTests(unittest.TestCase):
             by_key = {c["key"]: c for c in diag["checks"]}
             self.assertEqual(by_key["whitelist"]["status"], "FAIL")
             self.assertIn("enable", (by_key["whitelist"]["fix"] or ""))
+
+
+class FailOpenDiagnosticsTests(unittest.TestCase):
+    def test_no_recent_events_is_pass(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            diag = collect_status_diagnostics(
+                cwd=root, check_gh=False, check_routing=False
+            )
+            by_key = {c["key"]: c for c in diag["checks"]}
+            self.assertEqual(by_key["hook_fail_open"]["status"], "PASS")
+            self.assertIn("0건", by_key["hook_fail_open"]["detail"])
+
+    def test_recent_event_is_status_warn_with_reason_category(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_fail_open_event(
+                hook="file-guard",
+                category="payload_missing_session",
+                detail="session id missing; enforcement skipped",
+                cwd=root,
+            )
+
+            summary = collect_fail_open_summary(cwd=root)
+            self.assertEqual(summary["total"], 1)
+            self.assertEqual(summary["by_category"]["payload_missing_session"], 1)
+
+            diag = collect_status_diagnostics(
+                cwd=root, check_gh=False, check_routing=False
+            )
+            by_key = {c["key"]: c for c in diag["checks"]}
+            check = by_key["hook_fail_open"]
+            self.assertEqual(check["status"], "WARN")
+            self.assertIn("payload_missing_session=1", check["detail"])
+            self.assertIn("file-guard/payload_missing_session", check["detail"])
+            self.assertIn("hook", check["fix"] or "")
+
+    def test_read_events_limit_zero_returns_empty(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_fail_open_event(
+                hook="tdd-guard",
+                category="payload_empty",
+                detail="empty stdin",
+                cwd=root,
+            )
+            self.assertEqual(read_fail_open_events(cwd=root, limit=0), [])
 
 
 class FormatReportTests(unittest.TestCase):

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -25,6 +25,8 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from harness.session_state import read_fail_open_events
+
 ROOT = Path(__file__).resolve().parent.parent
 HOOK_PATH = ROOT / "hooks" / "tdd-guard.sh"
 
@@ -47,6 +49,26 @@ def run_hook(
             # temp cwd 는 whitelist 미등록 → is-active 게이트 우회 강제 활성화 (커밋3)
             "DCNESS_FORCE_ENABLE": "1",
         },
+    )
+
+
+def run_hook_raw(
+    stdin_text: str, cwd: str, *, force_enable: bool = True
+) -> subprocess.CompletedProcess:
+    """tdd-guard.sh raw stdin 호출 — malformed payload/fail-open 진단 검증용."""
+    env = {
+        **os.environ,
+        "PYTHONPATH": str(ROOT),
+    }
+    if force_enable:
+        env["DCNESS_FORCE_ENABLE"] = "1"
+    else:
+        env.pop("DCNESS_FORCE_ENABLE", None)
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=stdin_text,
+        capture_output=True, text=True, cwd=cwd, timeout=10,
+        env=env,
     )
 
 
@@ -194,6 +216,44 @@ class TestRegressionPreserved(unittest.TestCase):
         self._touch("src/biz.test.ts", "test('ok', () => {})\n")
         path = str(Path(self._tmp) / "src/biz.ts")
         self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
+class TestFailOpenDiagnostics(unittest.TestCase):
+    """issue #784 — suspicious tdd-guard fail-open 은 기록, inactive no-op 은 조용히 통과."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_active_empty_payload_records_fail_open_event(self):
+        result = run_hook_raw("", self._tmp, force_enable=True)
+        self.assertEqual(decision(result), "allow")
+
+        events = read_fail_open_events(cwd=Path(self._tmp))
+        self.assertEqual(len(events), 1)
+        self.assertEqual(events[0]["hook"], "tdd-guard")
+        self.assertEqual(events[0]["category"], "payload_empty")
+
+    def test_inactive_empty_payload_does_not_record_event(self):
+        result = run_hook_raw("", self._tmp, force_enable=False)
+        self.assertEqual(decision(result), "allow")
+
+        events = read_fail_open_events(cwd=Path(self._tmp))
+        self.assertEqual(events, [])
+
+    def test_notebook_path_payload_is_not_missing_path(self):
+        payload = {
+            "tool_name": "NotebookEdit",
+            "tool_input": {"notebook_path": "analysis.ipynb"},
+        }
+        result = run_hook_raw(json.dumps(payload), self._tmp, force_enable=True)
+        self.assertEqual(decision(result), "allow")
+
+        events = read_fail_open_events(cwd=Path(self._tmp))
+        self.assertEqual(events, [])
 
 
 class TestBasenameSubstringFalseNegative(unittest.TestCase):


### PR DESCRIPTION
## 관련 이슈 번호

Closes #784

## 배경 및 문제

Issue #784는 hook 버그, malformed payload, stale state, session/run resolution 실패 같은 fail-open 경로가 조용히 사라져 사용자가 guard pass/skip/evaluate-failed 상태를 구분하기 어렵다는 문제를 다룬다.

## 원인 (해당 시)

기존 hook 정책은 과차단을 피하기 위해 fail-open을 유지했지만, enforcement-relevant skip을 장기적으로 확인할 수 있는 structured diagnostic channel이 없었다. `dcness-helper status`도 설치/라우팅 상태 중심이라 최근 hook fail-open 활동을 보여주지 않았다.

## 작업내용

- `fail-open-events.jsonl` append-only 진단 이벤트와 최근 24시간 summary API 추가
- `dcness-helper status`에 `hook fail-open 진단` PASS/WARN 항목 추가
- `catastrophic-gate`, `file-guard`, `tdd-guard`의 suspicious fail-open 경로를 reason category로 기록
- inactive project no-op, main Claude turn, active run 밖 Agent 호출은 조용히 유지
- hook/status 문서와 단위 테스트 보강

## 결정 근거

기존 fail-open 정책은 유지한다. 대신 enforcement-relevant evaluate-failed 경로만 structured event로 남겨 과차단 없이 진단 가능성을 높였다. 새 public command를 추가하지 않고 기존 `dcness-helper status`에 얹어 사용자-facing surface를 늘리지 않았다.

## 배포 경로 검증 (plug-in 영향 시)

- `hooks/*.sh`, `harness/*.py`, `docs/plugin/*.md`는 dcNess plug-in 본체 파일이므로 plug-in update로 활성 프로젝트에 도달한다.
- 사용자 repo에 복사되는 `/init-dcness` 산출물(`.git/hooks/*`, `.github/workflows/*`, seed docs)은 변경하지 않았다.
- 기존 활성 프로젝트는 plug-in update 후 새 hook 본체와 `dcness-helper status` 진단을 받으며, `/init-dcness` 재실행은 필요 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음. 내부 `hook-fail-open` helper subcommand는 hook wrapper 기록용이며 사용자-facing workflow가 아니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_status_diagnostics tests.test_tdd_guard tests.test_hooks tests.test_hook_wrapper_exit -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `PYTHON_BIN=/tmp/dcness-quality-issue784/bin/python bash scripts/check_static_quality.sh`
- [x] `git diff --check`
- [x] commit pre-commit hook PASS (`scripts/check_python_tests.sh` 경유 전체 unittest)

## 참고

- 구현 경로: Lite — kkomkkomImpl 메인 직접 구현 + pr-reviewer PASS
