### PR TITLE
[issue-786] Bash TDD guard 적용

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -356,7 +356,7 @@ EOF
 - SessionStart: sid/live state 초기화와 활성 안내 inject.
 - 순서 차단 훅: Agent 호출 전 작업 순서 보호.
 - file-guard: agent 별 파일 경계와 외부 상태 변경 차단.
-- TDD Guard: `Edit` / `Write` / `NotebookEdit` 직전 TS/JS 구현 파일의 매칭 test 존재 확인. 세부 skip/한계는 [`docs/plugin/hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh).
+- TDD Guard: `Edit` / `Write` / `NotebookEdit` / `Bash` write target 의 TS/JS 구현 파일 매칭 test 존재 확인. 세부 skip/한계는 [`docs/plugin/hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh).
 - Stop hook: run 종료와 continuation signal.
 
 ## 완료 안내

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -27,8 +27,8 @@ python3 evals/guard_efficacy.py --json
 
 이 결정적 suite 의 PASS 는 "fixture 로 박은 guard 계약이 재현된다"는 뜻이다. 보안 증명이나
 악의적 agent 완전 차단 주장이 아니다. `known-bypass-boundary` 범주는 문서화된 한계
-(예: Bash 경유 구현 파일은 TDD 존재 검사를 받지 않음, command substitution 은 외부 변경
-denylist 의 best-effort 범위 밖)를 숨기지 않고 측정 표면에 올려둔다.
+(예: command substitution 은 외부 변경 denylist 의 best-effort 범위 밖)를 숨기지 않고
+측정 표면에 올려둔다.
 
 > **스크립트 위치** — `scripts/` · `harness/` 는 plug-in 본체로 배포된다. 외부 활성
 > 프로젝트는 이 파일들이 repo 안이 아니라 **plug-in 캐시**에 있으므로, 아래 명령은

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -30,7 +30,7 @@ dcNess 의 강제 영역은 두 가지뿐이다.
 | `session-start.sh` | `SessionStart` | 새 세션, resume, `/clear` 직후 | sid/live state 초기화 + 활성 안내 inject | X |
 | `catastrophic-gate.sh` | `PreToolUse / Agent` | sub-agent 호출 직전 | 작업 순서 보호 + 진행 순서 검사 | O |
 | `file-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit|Read|Bash|mcp__.*` | file/bash/MCP tool 호출 직전 | agent 별 파일 경계 + 외부 변경 차단 목록 검사 | O |
-| `tdd-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit` | 파일 수정 직전 | TS/JS 구현 파일에 매칭 test 존재 확인 | O |
+| `tdd-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit|Bash` | 파일 수정 직전 | TS/JS 구현 파일에 매칭 test 존재 확인 | O |
 | `post-agent-clear.sh` | `PostToolUse / Agent` | sub-agent 호출 직후 | active agent clear, prose 자동 staging, histogram inject | X |
 | `post-file-op-trace.sh` | `PostToolUse / Edit|Write|NotebookEdit|Read|Bash|mcp__.*` | file/bash/MCP tool 호출 직후 | agent trace append | X |
 | `subagent-stop-clear.sh` | `SubagentStop` | sub-agent 컨텍스트 종료 직후 | active agent clear 보강 | X |
@@ -148,7 +148,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 ### tdd-guard.sh
 
-**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. **`Bash` 로 만든 파일에는 발화하지 않는다** (아래 한계 참조).
+**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. `Bash` 는 명시적 write target 추출 직후, 각 target 에 같은 검사를 적용한다.
 
 **지원 언어**: TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`). 그 외 확장자는 silent skip — Python·Rust·Go 등 다른 ecosystem 의 TDD 강제는 현재 범위 밖이다.
 
@@ -168,9 +168,9 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **매칭 위치**: 같은 디렉터리, 같은 디렉터리의 `__tests__`, 부모/조부모 `__tests__`, monorepo `src_root/__tests__`, 프로젝트 root `src/__tests__`.
 
-**차단**: test 부재 시 `exit 2` + 한국어 안내.
+**Bash write target 정책**: `Bash` payload 는 [`harness.agent_boundary.extract_bash_paths`](../../harness/agent_boundary.py) 가 추출하는 명시적 write target 에 한해 검사한다. 예: redirect(`>`, `>>`), `tee`, in-place edit(`sed/perl/awk -i`), `cp`/`mv`/`rm` target. 추출된 target 이 TS/JS 구현 파일이면 직접 `Edit`/`Write`/`NotebookEdit` 와 동일한 skip 규칙 및 6-tier matching-test 존재 검사를 탄다. write target 이 없거나 TS/JS 구현 파일이 아니면 silent skip 한다.
 
-**한계 (Bash write 는 범위 밖)**: TDD guard 는 `Edit`/`Write`/`NotebookEdit` 직접 파일 도구에서만 발화한다. `Bash` 로 작성한 구현 파일(`echo > foo.ts`, `cat <<EOF` 등)은 [file-guard.sh](#file-guardsh) 가 검사하지만, file-guard 는 *경로 경계*(agent 가 그 path 를 쓸 수 있는가)만 보고 *매칭 test 존재*는 보지 않는다. 즉 Bash 경유 구현 파일은 현재 TDD 강제가 닿지 않으며, 이 동작을 명시적으로 추가하지 않는 한 그대로다.
+**차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다.
 
 ### post-agent-clear.sh
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -37,7 +37,7 @@
 - `session-start.sh`: 세션 상태 초기화와 활성 안내.
 - `catastrophic-gate.sh`: Agent 호출 전 작업 순서 보호.
 - `file-guard.sh`: file/bash/MCP 경계와 외부 상태 변경 차단.
-- `tdd-guard.sh`: TS/JS 구현 파일 수정 직전 매칭 test 존재 확인. 상세 범위와 한계는 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 가 SSOT.
+- `tdd-guard.sh`: TS/JS 구현 파일 및 Bash write target 수정 직전 매칭 test 존재 확인. 상세 범위와 한계는 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 가 SSOT.
 - `post-agent-clear.sh`, `post-file-op-trace.sh`, `subagent-stop-clear.sh`, `stop-end-run.sh`: run state 보존과 종료 처리.
 
 과거 TDD 관련 CI/commit-msg 방식의 폐기 이력은 release note 기록이며, `/init-dcness` 실행 절차가 아니다. 현행 TDD Guard 계약은 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 만 따른다.

--- a/evals/guard_efficacy.py
+++ b/evals/guard_efficacy.py
@@ -28,7 +28,6 @@ from harness.agent_boundary import (  # noqa: E402
     check_bash_mutation,
     check_github_mcp_mutation,
     check_write_allowed,
-    extract_bash_paths,
 )
 from harness.hooks import handle_pretooluse_agent  # noqa: E402
 from harness.session_state import (  # noqa: E402
@@ -179,23 +178,42 @@ def _tdd_guard(rel_path: str, *, matching_test: bool = False) -> Probe:
     return probe
 
 
-def _bash_write_tdd_boundary() -> tuple[Decision, str]:
-    command = "printf 'export const value = 1' > src/untested.ts"
-    with tempfile.TemporaryDirectory() as td, _external_project_boundary():
-        cwd = Path(td)
-        targets = extract_bash_paths(command)
-        reasons = [
-            check_write_allowed("engineer", target, cwd=cwd, shell_context=True)
-            for target in targets
-        ]
-        blocked = [reason for reason in reasons if reason]
-        if blocked:
-            return ("block", "\n".join(blocked))
-        return (
-            "allow",
-            "Bash write path is boundary-checked, but matching-test existence is "
-            "outside tdd-guard scope.",
+def _tdd_guard_bash_write_without_test() -> tuple[Decision, str]:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        subprocess.run(
+            ["git", "init"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
         )
+        payload = {
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "printf 'export const value = 1' > src/untested.ts",
+            },
+        }
+        result = subprocess.run(
+            ["bash", str(ROOT / "hooks" / "tdd-guard.sh")],
+            cwd=root,
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env={
+                **os.environ,
+                "PYTHONPATH": str(ROOT),
+                "CLAUDE_PLUGIN_ROOT": str(ROOT),
+                "DCNESS_FORCE_ENABLE": "1",
+            },
+        )
+        if result.returncode == 0:
+            return ("allow", result.stdout.strip())
+        if result.returncode == 2:
+            return ("block", result.stderr.strip())
+        return ("block", f"unexpected exit {result.returncode}: {result.stderr}")
 
 
 def build_cases() -> list[GuardCase]:
@@ -320,11 +338,11 @@ def build_cases() -> list[GuardCase]:
             _tdd_guard("babel.config.js"),
         ),
         GuardCase(
-            "known_boundary_tdd_bash_write_not_enforced",
-            "known-bypass-boundary",
-            "allow",
-            "Bash-created implementation files are file-boundary checked, not TDD checked.",
-            _bash_write_tdd_boundary,
+            "tdd_guard_blocks_bash_write_without_test",
+            "tdd-guard",
+            "block",
+            "Bash write target for a TS/JS implementation file is TDD checked.",
+            _tdd_guard_bash_write_without_test,
         ),
         GuardCase(
             "known_boundary_command_substitution_not_scanned",

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -56,7 +56,7 @@
         ]
       },
       {
-        "matcher": "Edit|Write|NotebookEdit",
+        "matcher": "Edit|Write|NotebookEdit|Bash",
         "hooks": [
           {
             "type": "command",

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# dcness TDD Guard Hook — PreToolUse[Edit|Write|NotebookEdit]
+# dcness TDD Guard Hook — PreToolUse[Edit|Write|NotebookEdit|Bash]
 # agent 가 src 파일 작성/편집 시도 시 매칭 test 파일 존재 검사.
 # 없으면 deny + 한국어 안내. 진짜 TDD 강제 (코드 작성 *전* 테스트 먼저).
 #
 # 영감: jha0313/codex-live-demo/.codex/hooks/tdd-guard.sh
 # 차이: dcness 환경 (Claude Code plug-in hook) 매처 정합 + 한국어 메시지 보강
 #
-# 시점: agent Edit/Write tool_use 직전. tool_input.file_path 추출 + 검증.
+# 시점: agent Edit/Write tool_use 직전 또는 Bash write target 추출 직후.
 # 차단 시 stderr 로 reason 출력 + exit 2.
 #   — CC docs: PreToolUse 는 exit 2 라야 차단 + stderr 가 Claude 에 피드백.
 #     (deny JSON + exit 0 은 CC 본체 버그 anthropics/claude-code#37210 영향 가변 →
@@ -46,6 +46,73 @@ deny() {
   # reason 을 stderr 로 — exit 2 (호출부) 와 짝지어 CC 가 Claude 에 피드백.
   printf '%s\n' "$1" >&2
 }
+
+TOOL_NAME=$(python3 - "$INPUT" <<'PY'
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+tool_name = payload.get("tool_name")
+if isinstance(tool_name, str):
+    print(tool_name)
+PY
+)
+
+if [ "$TOOL_NAME" = "Bash" ]; then
+  BASH_TARGETS=$(python3 - "$INPUT" 2>/dev/null <<'PY'
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+    tool_input = payload.get("tool_input") or {}
+    command = tool_input.get("command") or ""
+    if not isinstance(command, str) or not command:
+        sys.exit(0)
+    from harness.agent_boundary import extract_bash_paths
+    for path in extract_bash_paths(command):
+        print(path)
+except Exception as exc:
+    print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+    sys.exit(1)
+PY
+  )
+  _tdd_extract_rc=$?
+  if [ "$_tdd_extract_rc" -ne 0 ]; then
+    record_fail_open "bash_target_extract_error" "Bash write targets could not be extracted"
+    allow
+  fi
+  if [ -z "$BASH_TARGETS" ]; then
+    allow
+  fi
+
+  while IFS= read -r BASH_TARGET; do
+    [ -z "$BASH_TARGET" ] && continue
+    TARGET_PAYLOAD=$(python3 - "$BASH_TARGET" <<'PY'
+import json, sys
+print(json.dumps({
+    "tool_name": "Edit",
+    "tool_input": {"file_path": sys.argv[1]},
+}))
+PY
+    )
+    TARGET_ERR=$(printf '%s' "$TARGET_PAYLOAD" | bash "$0" 2>&1 >/dev/null)
+    _tdd_target_rc=$?
+    if [ "$_tdd_target_rc" -eq 2 ]; then
+      deny "TDD GUARD[Bash]: Bash write target '${BASH_TARGET}' failed matching-test enforcement.
+
+${TARGET_ERR}"
+      exit 2
+    fi
+    if [ "$_tdd_target_rc" -ne 0 ]; then
+      record_fail_open "bash_target_check_error" "unexpected rc=${_tdd_target_rc} for ${BASH_TARGET}"
+      allow
+    fi
+  done <<EOF
+$BASH_TARGETS
+EOF
+
+  allow
+fi
 
 # tool_input.file_path 추출
 FILE_PATH=$(python3 - "$INPUT" <<'PY'

--- a/tests/test_guard_efficacy_eval.py
+++ b/tests/test_guard_efficacy_eval.py
@@ -52,7 +52,7 @@ class GuardEfficacyEvalContractTests(unittest.TestCase):
             "mcp_mutation_blocks_pr_merge",
             "order_gate_blocks_missing_begin_step",
             "tdd_guard_blocks_impl_without_test",
-            "known_boundary_tdd_bash_write_not_enforced",
+            "tdd_guard_blocks_bash_write_without_test",
         ):
             with self.subTest(case_id=case_id):
                 self.assertIn(case_id, case_ids)

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -439,10 +439,11 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("per-agent `tools:` 권한", self.hooks_doc)
 
     def test_hooks_doc_tdd_guard_scope_is_accurate(self) -> None:
-        """#681 AC#2/#3 — tdd-guard 문서가 존재-검사·entry-file·Bash 범위 밖을 명시한다."""
+        """#681/#786 — tdd-guard 문서가 존재-검사·entry-file·Bash write target 정책을 명시한다."""
         self.assertIn("test 의 존재만 검사하고, test 를 실행하지는 않는다", self.hooks_doc)
         self.assertIn("registerRootComponent(", self.hooks_doc)
-        self.assertIn("Bash write 는 범위 밖", self.hooks_doc)
+        self.assertIn("Bash write target 정책", self.hooks_doc)
+        self.assertIn("TDD GUARD[Bash]", self.hooks_doc)
         self.assertIn("contest.ts", self.hooks_doc)
 
     def test_backpressure_loop_is_first_class_across_stages(self) -> None:

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -52,6 +52,25 @@ def run_hook(
     )
 
 
+def run_bash_hook(command: str, cwd: str) -> subprocess.CompletedProcess:
+    """tdd-guard.sh 를 Bash payload 로 호출한다."""
+    payload = {
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+    }
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, cwd=cwd, timeout=10,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(ROOT),
+            "CLAUDE_PLUGIN_ROOT": str(ROOT),
+            "DCNESS_FORCE_ENABLE": "1",
+        },
+    )
+
+
 def run_hook_raw(
     stdin_text: str, cwd: str, *, force_enable: bool = True
 ) -> subprocess.CompletedProcess:
@@ -216,6 +235,85 @@ class TestRegressionPreserved(unittest.TestCase):
         self._touch("src/biz.test.ts", "test('ok', () => {})\n")
         path = str(Path(self._tmp) / "src/biz.ts")
         self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+
+class TestBashWriteTargets(unittest.TestCase):
+    """issue #786 — Bash write target 도 직접 파일 tool 과 같은 TDD 정책을 탄다."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str = "// stub\n") -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_bash_redirect_impl_without_test_denied(self):
+        result = run_bash_hook(
+            "printf 'export const value = 1;' > src/generated.ts",
+            self._tmp,
+        )
+        self.assertEqual(decision(result), "deny")
+        self.assertIn("TDD GUARD", result.stderr)
+        self.assertIn("generated", result.stderr)
+
+    def test_bash_redirect_impl_with_matching_test_allowed(self):
+        self._touch("src/generated.test.ts", "test('ok', () => {})\n")
+        result = run_bash_hook(
+            "printf 'export const value = 1;' > src/generated.ts",
+            self._tmp,
+        )
+        self.assertEqual(decision(result), "allow")
+
+    def test_bash_write_to_test_file_allowed(self):
+        result = run_bash_hook(
+            "printf 'test(\\'ok\\', () => {})' > src/generated.test.ts",
+            self._tmp,
+        )
+        self.assertEqual(decision(result), "allow")
+
+    def test_bash_readonly_command_allowed(self):
+        result = run_bash_hook("npm test 2>&1 | tail -20", self._tmp)
+        self.assertEqual(decision(result), "allow")
+
+    def test_bash_tee_impl_without_test_denied(self):
+        result = run_bash_hook(
+            "printf 'export const value = 1;' | tee src/from-tee.ts",
+            self._tmp,
+        )
+        self.assertEqual(decision(result), "deny")
+        self.assertIn("from-tee", result.stderr)
+
+    def test_bash_heredoc_impl_without_test_denied(self):
+        result = run_bash_hook(
+            "cat <<'EOF' > src/from-heredoc.ts\n"
+            "export const value = 1;\n"
+            "EOF",
+            self._tmp,
+        )
+        self.assertEqual(decision(result), "deny")
+        self.assertIn("from-heredoc", result.stderr)
+
+    def test_hooks_json_registers_tdd_guard_for_bash(self):
+        hooks_json = json.loads(
+            (ROOT / "hooks" / "hooks.json").read_text(encoding="utf-8")
+        )
+        matchers = []
+        for entry in hooks_json["hooks"]["PreToolUse"]:
+            for hook in entry.get("hooks", []):
+                if "tdd-guard.sh" in hook.get("command", ""):
+                    matchers.append(entry.get("matcher", ""))
+
+        self.assertTrue(matchers, "tdd-guard.sh PreToolUse registration missing")
+        self.assertTrue(
+            any("Bash" in matcher.split("|") for matcher in matchers),
+            f"tdd-guard.sh matcher must include Bash, got {matchers!r}",
+        )
 
 
 class TestFailOpenDiagnostics(unittest.TestCase):


### PR DESCRIPTION
## 관련 이슈 번호

Closes #786

## 배경 및 문제

TDD Guard 는 직접 파일 tool(Edit/Write/NotebookEdit)에는 TS/JS 구현 파일의 matching test 존재를 강제했지만, Bash 로 생성/수정되는 구현 파일은 file boundary 검사만 받고 matching-test 검사를 우회할 수 있었다.

## 원인 (해당 시)

`hooks/hooks.json` 의 tdd-guard matcher 가 `Bash` 를 포함하지 않았고, `hooks/tdd-guard.sh` 도 Bash payload 의 write target 을 해석하지 않았다. 반면 Bash write target 추출 로직은 이미 `harness.agent_boundary.extract_bash_paths()` 에 존재했다.

## 작업내용

- `hooks/tdd-guard.sh` 가 Bash payload 에서 write target 을 추출하고, target 별로 기존 직접 파일-tool TDD 판정을 재사용하도록 확장.
- `hooks/hooks.json` tdd-guard matcher 에 `Bash` 추가.
- Bash redirect, `tee`, heredoc, test-file skip, readonly Bash, hook registry matcher 회귀 테스트 추가.
- `evals/guard_efficacy.py` 의 Bash TDD known-gap fixture 를 실제 block fixture 로 전환.
- `docs/plugin/hooks.md`, `/init-dcness` 관련 문서, benchmark 문서의 TDD Guard 범위 설명 갱신.

## 결정 근거

기존 skip 규칙과 6-tier matching-test 탐색 로직을 복제하지 않고, Bash target 마다 같은 script 의 직접 파일-tool 경로를 재사용했다. Bash target 범위는 file-guard 와 동일하게 `extract_bash_paths()` 가 추출하는 명시적 write target 으로 맞춰 문서화했다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체 경로: `hooks/tdd-guard.sh`, `hooks/hooks.json` 변경으로 plug-in 업데이트 시 활성 프로젝트에서 자동 적용.
- 사용자-facing command/docs 경로: `commands/init-dcness.md`, `docs/plugin/hooks.md`, `docs/plugin/init-dcness.md`, `docs/plugin/benchmark.md` 를 함께 갱신해 `/init-dcness` 안내와 hook SSOT 가 새 정책을 설명.
- 사용자 repo 복사 파일: 없음. TDD Guard 는 사용자 repo 로 복사되는 파일이 아니라 plug-in hook 본체에서 발화한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음. 기존 TDD Guard hook 의 matcher/동작 범위 확장이다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_tdd_guard -v`
- [x] `python3.11 -m unittest tests.test_surface_docs_sync -v`
- [x] `python3.11 -m unittest tests.test_public_surface -v`
- [x] `python3.11 -m unittest tests.test_hooks -v`
- [x] `python3.11 -m unittest tests.test_guard_efficacy_eval -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] pre-commit hook on commit: `python3.11 -m unittest discover -s tests` PASS
- [x] `uv run --python 3.11 --with ruff==0.15.17 --with mypy==2.1.0 --with bandit==1.9.4 python -m ruff check .`
- [x] `uv run --python 3.11 --with ruff==0.15.17 --with mypy==2.1.0 --with bandit==1.9.4 python -m mypy`
- [x] `uv run --python 3.11 --with ruff==0.15.17 --with mypy==2.1.0 --with bandit==1.9.4 python -m bandit -c pyproject.toml -r harness scripts -l -i`

## 참고

- pr-reviewer read-only self-review: PASS, MUST FIX 없음.
