### PR TITLE
[issue-793] release 배포물 self 전용 static-quality 게이트 제외

### DIFF
--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -19,6 +19,10 @@ EXCLUDE_PATHS=(
     ".claude-plugin/marketplace.json"
     ".github/workflows/python-tests.yml"
     ".github/workflows/release-sync.yml"
+    ".github/workflows/static-quality.yml"
+    "scripts/check_static_quality.sh"
+    "requirements-quality.txt"
+    "pyproject.toml"
     ".claude"
 )
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #793

## 배경 및 문제

`scripts/sync_release.sh` 의 `EXCLUDE_PATHS` 에 `tests`/`evals`/`python-tests.yml`/`release-sync.yml` 등 dcness self 전용 경로는 제외돼 있으나, PR #788 에서 추가된 static-quality 게이트 4종이 빠져 있었다. 결과적으로 release 브랜치(= plug-in 배포물)에 dcness 자체 QA 인프라(ruff/mypy/bandit 게이트 + 설정 + 버전 pin)가 섞여 들어간다.

## 원인 (해당 시)

PR #788 에서 static-quality 게이트를 추가할 때 `sync_release.sh` 제외목록 동기화가 누락됨.

## 작업내용

`EXCLUDE_PATHS` 에 다음 4종 추가:
- `.github/workflows/static-quality.yml` (self CI)
- `scripts/check_static_quality.sh` (로컬 재현 스크립트)
- `requirements-quality.txt` (ruff/mypy/bandit 버전 pin)
- `pyproject.toml` (ruff/mypy/bandit 설정 전용 — plug-in 배포에 다른 용도 없음)

## 결정 근거

`evals/` 를 예전에 제외한 것과 동일한 이유 — dcness self QA 인프라는 외부 배포물에 불필요. 4종 모두 git-tracked 이라 sync 시 `git rm -r` 로 실제 제거됨을 확인. `pyproject.toml` 은 ruff/mypy/bandit 설정만 담겨 있어 외부 plug-in 배포에 다른 용도가 없음을 직접 확인.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 릴리즈 인프라(`sync_release.sh`) 작업. 외부 활성 프로젝트로 복사되는 파일(`agents/**`/`commands/**`/`hooks/**`/init-dcness 복사 대상/`docs/plugin` SSOT) 변경 없음. 오히려 배포물에서 self 전용 파일을 *제거* 하는 청결도 개선.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public surface 변화 없음.

## Test Plan

- [x] 4종 모두 git-tracked 확인 (`git ls-files --error-unmatch`) — sync 시 실제 제거 보장
- [x] `EXCLUDE_PATHS` 문서화/참조 위치 grep — 동기화 대상 문서 없음 확인
- [ ] 회귀: 다음 release sync 시 release 브랜치에 4종 미포함 확인 (릴리즈 시점)

## 참고

-