### PR TITLE
[feature] remotion 경계 override 이관

### DIFF
--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -105,13 +105,11 @@ RUN_DIR_PROSE_ALLOW: tuple[str, ...] = (
 
 # ── ALLOW_MATRIX (agent 별 Write 허용) ─────────────────────────
 # RWHarness agent-boundary.py:48~84 기반. engineer / test-engineer 는 #694 에서 언어·레이아웃
-# 중립으로 확장 (JS/TS 전용 → Python·Go·Ruby·JVM·C#·PHP·Elixir·remotion 등 비-JS 외부 프로젝트).
+# 중립으로 확장 (JS/TS 전용 → Python·Go·Ruby·JVM·C#·PHP·Elixir 등 비-JS 외부 프로젝트).
 ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
     # engineer — 구현 소스. JS/TS·Python 모노레포(src/·apps/·packages/) + 언어 중립 소스 루트
-    # (lib/·app/·cmd/·internal/·pkg/) + Remotion 비디오 소스(remotion/). docs/ · 루트 비소스
-    # 문서(README 등)는 미매칭으로 차단 — 역할 격리 유지.
-    # ⚠️ remotion/ 같은 프로젝트 고유 디렉토리는 코어 기본값에 둔 임시 — 무한한 비표준 레이아웃은
-    #    프로젝트별 override 로 이관 예정(#696). 그때 코어 기본값 다이어트.
+    # (lib/·app/·cmd/·internal/·pkg/). docs/ · 루트 비소스 문서(README 등)는 미매칭으로
+    # 차단 — 역할 격리 유지. remotion/ 같은 프로젝트 고유 디렉토리는 프로젝트별 override 영역.
     "engineer": (
         # JS/TS·Python 모노레포 관례
         r'(^|/)src/',
@@ -129,7 +127,6 @@ ALLOW_MATRIX: dict[str, tuple[str, ...]] = {
         r'^cmd/',          # Go 엔트리포인트
         r'^internal/',     # Go 내부 패키지
         r'^pkg/',          # Go 공개 패키지
-        r'^remotion/',     # Remotion 비디오 소스 (youTubeGenerator 등) — #696 override 이관 후보
         # 루트 직속 단일 파일 엔트리포인트 — Flask/FastAPI `app.py`·`main.py`, Django
         # `manage.py`, Go 루트 `main.go`, Node `server.js`/`index.js` 등 (#705 실측: 디렉토리
         # 패턴만 있으면 worker 가 루트 엔트리 파일을 못 고쳐 "prose 제시 → 메인 대리 적용"

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -318,6 +318,14 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
     def tearDown(self):
         self._patcher.stop()
 
+    @staticmethod
+    def _write_boundary(root: Path, mapping: dict) -> None:
+        cfg_dir = root / ".dcness"
+        cfg_dir.mkdir(parents=True, exist_ok=True)
+        (cfg_dir / "boundary.json").write_text(
+            json.dumps(mapping), encoding="utf-8"
+        )
+
     # ── test-engineer: 언어 중립 테스트 경로 허용 ──
     def test_test_engineer_python_tests_allowed(self):
         with tempfile.TemporaryDirectory() as td:
@@ -395,10 +403,15 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
                 self.assertIn("ALLOW_MATRIX", reason)
 
     # ── engineer: 언어 중립 소스 레이아웃 허용 ──
-    def test_engineer_remotion_allowed(self):
-        # #694 핵심 — src/ 밖 소스 루트(remotion/) 허용 (youTubeGenerator task 04).
+    def test_engineer_remotion_requires_project_override(self):
+        # #778 — 프로젝트 고유 디렉토리(remotion/)는 코어 기본값이 아니라 프로젝트 override.
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
+            reason = check_write_allowed("engineer", "remotion/shorts-types.ts", cwd=cwd)
+            self.assertIsNotNone(reason)
+            self.assertIn("ALLOW_MATRIX", reason)
+
+            self._write_boundary(cwd, {"engineer": {"add": [r"^remotion/"]}})
             self.assertIsNone(
                 check_write_allowed("engineer", "remotion/shorts-types.ts", cwd=cwd)
             )
@@ -424,11 +437,14 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
             # ./ prefix 소스 — 허용
-            for p in ("./lib/parser.rb", "./remotion/shorts-types.ts", "./cmd/main.go"):
+            for p in ("./lib/parser.rb", "./cmd/main.go"):
                 self.assertIsNone(
                     check_write_allowed("engineer", p, cwd=cwd),
                     f"./ prefix 소스 {p} 허용",
                 )
+            reason = check_write_allowed("engineer", "./remotion/shorts-types.ts", cwd=cwd)
+            self.assertIsNotNone(reason, "프로젝트 override 없는 remotion/ 은 차단되어야 함")
+            self.assertIn("ALLOW_MATRIX", reason)
             # ./ prefix 테스트 — 허용
             self.assertIsNone(
                 check_write_allowed("test-engineer", "./tests/test_x.py", cwd=cwd)
@@ -740,6 +756,7 @@ class LanguageNeutralAllowMatrixTests(unittest.TestCase):
     def test_build_worker_youtube_generator_scenario(self):
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)
+            self._write_boundary(cwd, {"engineer": {"add": [r"^remotion/"]}})
             # 테스트 산출 (test-engineer 영역) — task 01·02·03·07
             self.assertIsNone(
                 check_write_allowed("build-worker", "tests/core/domain/test_shorts.py", cwd=cwd)


### PR DESCRIPTION
## 관련 이슈 번호
Closes #778

## 배경 및 문제
- #696에서 프로젝트별 ALLOW_MATRIX override(.dcness/boundary.json)가 도입됐습니다.
- remotion/은 youTubeGenerator 전용 디렉토리인데 dcNess 코어 engineer ALLOW_MATRIX 기본값에 남아 있어, 코어 기본값과 프로젝트 예외의 책임 경계가 섞여 있었습니다.

## 원인 (해당 시)
-

## 작업내용
- harness/agent_boundary.py engineer ALLOW_MATRIX에서 ^remotion/ 기본 허용 제거
- remotion/은 프로젝트별 boundary override가 있을 때만 engineer가 쓸 수 있도록 테스트 전환
- build-worker의 youTubeGenerator 시나리오 테스트는 engineer add override 전파를 전제로 갱신

## 결정 근거
- 코어 ALLOW_MATRIX는 흔한 언어/레이아웃 기본값만 유지하고, 프로젝트 고유 디렉토리는 활성 프로젝트의 .dcness/boundary.json이 SSOT로 선언하는 편이 #696 설계와 일치합니다.

## 배포 경로 검증
- plug-in 본체 경로: harness/agent_boundary.py 변경은 dcNess 플러그인 업데이트 시 사용자 환경에 반영됩니다.
- /init-dcness 복사 경로: 신규 복사 파일 없음.
- 사용자 SSOT 문서: docs/plugin/hooks.md는 이미 .dcness/boundary.json add/remove와 build-worker 전파 규칙을 설명하므로 추가 문서 배포는 필요 없습니다.
- 순서 의존 대응: youTubeGenerator companion PR을 먼저 준비했습니다: https://github.com/alruminum/youTubeGenerator/pull/278

## Test Plan
- [x] python3.11 -m unittest tests.test_agent_boundary.LanguageNeutralAllowMatrixTests tests.test_agent_boundary.ProjectBoundaryOverrideTests -v (52 tests)
- [x] git pre-commit hook 전체 unittest 통과 (1346 tests)
- [x] youTubeGenerator companion PR pre-commit 전체 게이트 통과

## 참고
- Companion PR: https://github.com/alruminum/youTubeGenerator/pull/278