### PR TITLE
[issue-797] _has_pass occurrence 탐색 off-by-one 수정 — 첫 재호출(-1.md) 누락 차단

### DIFF
--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -1202,11 +1202,14 @@ def _has_pass(rd: Path, agent: str) -> bool:
     """`<agent>.md` 또는 `<agent>-N.md` (occurrence) 안 PASS 마커 확인.
 
     8 agent enum 통일 (PR B-3) 후 모든 catastrophic 검사가 PASS 단일 마커.
-    occurrence 카운터 — `<agent>-2.md` / `-3.md` ... 까지 가장 최근 호출.
+    occurrence 명명 규약(signal_io.signal_path): 첫 호출 = `<agent>.md`,
+    2번째 호출(첫 재호출) = `<agent>-1.md`, 3번째 = `-2.md` ... 이므로 재호출
+    PASS 탐색은 `-1.md` 부터 빠짐없이 봐야 한다. 첫 재호출(`-1.md`)을 건너뛰면
+    "1차 FAIL → 재검증 PASS" 흐름의 게이트가 오차단된다(#797 off-by-one).
     """
     if "PASS" in _read_or_empty(rd / f"{agent}.md"):
         return True
-    for n in range(2, 10):
+    for n in range(1, 10):
         if "PASS" in _read_or_empty(rd / f"{agent}-{n}.md"):
             return True
     return False

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -39,6 +39,7 @@ from tempfile import TemporaryDirectory
 from typing import Any, Dict, Optional
 
 from harness.hooks import (
+    _has_pass,
     handle_posttooluse_agent,
     handle_posttooluse_file_op,
     handle_pretooluse_agent,
@@ -592,6 +593,45 @@ class _DesignLoopBase(unittest.TestCase):
         update_live(self.sid, base_dir=self.base, active_runs=active)
 
 
+class HasPassOccurrenceTests(unittest.TestCase):
+    """#797 — `_has_pass` 의 occurrence PASS 탐색이 첫 재호출(`-1.md`)부터
+    빠짐없이 포함하는지 헬퍼 단위로 고정.
+
+    이 헬퍼는 module-architect 게이트(architecture-validator PASS)와
+    pr-reviewer 게이트(code-validator PASS)가 공유하므로, occurrence off-by-one
+    회귀는 여러 게이트를 동시에 오염시킨다.
+    """
+
+    def setUp(self) -> None:
+        self._td = TemporaryDirectory()
+        self.rd = Path(self._td.name)
+
+    def tearDown(self) -> None:
+        self._td.cleanup()
+
+    def test_pass_in_base_md(self) -> None:
+        # 1번째 호출(한 번에 PASS) — 회귀 없음.
+        (self.rd / "architecture-validator.md").write_text("PASS", encoding="utf-8")
+        self.assertTrue(_has_pass(self.rd, "architecture-validator"))
+
+    def test_pass_in_first_recall_md(self) -> None:
+        # 2번째 호출 = `-1.md` (첫 재호출). 1차는 FAIL → 재검증 PASS 인식 필수.
+        (self.rd / "architecture-validator.md").write_text("FAIL", encoding="utf-8")
+        (self.rd / "architecture-validator-1.md").write_text("PASS", encoding="utf-8")
+        self.assertTrue(_has_pass(self.rd, "architecture-validator"))
+
+    def test_pass_in_later_occurrence_md(self) -> None:
+        # `-2.md` 등 후속 occurrence 도 그대로 인정 — 공유 헬퍼 회귀 방지.
+        (self.rd / "code-validator-2.md").write_text("PASS", encoding="utf-8")
+        self.assertTrue(_has_pass(self.rd, "code-validator"))
+
+    def test_no_pass_when_all_occurrences_fail(self) -> None:
+        # 모든 호출 FAIL 이면 False — 통과 누수 없음.
+        (self.rd / "architecture-validator.md").write_text("FAIL", encoding="utf-8")
+        (self.rd / "architecture-validator-1.md").write_text("FAIL", encoding="utf-8")
+        self.assertFalse(_has_pass(self.rd, "architecture-validator"))
+
+
 class CatastrophicArchitectureValidatorTests(_DesignLoopBase):
     def test_module_architect_first_call_blocked_without_arch_validator(self) -> None:
         self._begin_step("module-architect")
@@ -605,6 +645,27 @@ class CatastrophicArchitectureValidatorTests(_DesignLoopBase):
     def test_module_architect_first_call_allowed_with_arch_validator_pass(self) -> None:
         self._begin_step("module-architect")
         (self.run_path / "architecture-validator.md").write_text(
+            "## 결론\nPASS\n", encoding="utf-8",
+        )
+        rc = handle_pretooluse_agent(
+            stdin_data=self._payload("module-architect"),
+            cc_pid=self.cc_pid,
+            base_dir=self.base,
+        )
+        self.assertEqual(rc, 0)
+
+    def test_module_architect_first_call_allowed_after_arch_validator_revalidation_pass(
+        self,
+    ) -> None:
+        # #797 — 1차 검증 FAIL(`.md`) → 재검증 PASS(`-1.md`, 첫 재호출) 흐름.
+        # occurrence 명명상 2번째 호출 = `-1.md` 이므로, 게이트가 `-1.md` 를
+        # 건너뛰면(옛 range(2,10)) "FAIL → 재검증 PASS" 라는 design 루프의 정상
+        # 분기를 오차단했다(off-by-one). 재검증 PASS 를 인식해 통과해야 한다.
+        self._begin_step("module-architect")
+        (self.run_path / "architecture-validator.md").write_text(
+            "## 결론\nFAIL\n", encoding="utf-8",
+        )
+        (self.run_path / "architecture-validator-1.md").write_text(
             "## 결론\nPASS\n", encoding="utf-8",
         )
         rc = handle_pretooluse_agent(


### PR DESCRIPTION
## 관련 이슈 번호
Closes #797

## 배경 및 문제
`/design` 의 module-architect 순서 차단 게이트는 첫 module-architect 단위 호출 직전 "architecture-validator 1차 PASS" 를 prose 마커로 확인한다. 그런데 PASS 탐색 헬퍼 `_has_pass` 가 occurrence prose 중 첫 재호출(`-1.md`)을 건너뛰어, "architecture-validator 1차 FAIL → 재검증 PASS" 라는 design 루프의 정상 분기를 오차단했다. architecture-validator 1차가 한 번에 PASS 되면 발현하지 않아 그동안 드러나지 않았다 (youTubeGenerator `/design` Story 8 설계 중 실제 발생 — 재검증 PASS prose 를 `-2.md` 로 복사해 우회).

## 원인
occurrence 명명 규약(`signal_io.signal_path`)상 첫 호출 = `<agent>.md`, 2번째 호출(첫 재호출) = `<agent>-1.md`, 3번째 = `-2.md` … 이다. 그런데 `_has_pass` 의 재호출 PASS 탐색이 `for n in range(2, 10)` 으로 `-2.md` 부터만 봐서 첫 재호출 `-1.md` 를 누락했다(off-by-one). 따라서 1차 FAIL(`.md`) + 재검증 PASS(`-1.md`) 상태에서 게이트가 재검증 PASS 를 인식하지 못했다.

## 작업내용
- `harness/hooks.py`: `_has_pass` 의 occurrence 탐색 범위 `range(2, 10)` → `range(1, 10)`. `.md` 부터 모든 재호출 prose(`-1.md`, `-2.md`, …)를 빠짐없이 포함. docstring 에 occurrence 명명 규약 명시.
- 같은 헬퍼를 공유하는 pr-reviewer 게이트(code-validator PASS)도 동일하게 교정됨.
- `tests/test_hooks.py`: `_has_pass` occurrence 직접 단위 테스트(`HasPassOccurrenceTests`: base / `-1` / `-2` / all-fail) + module-architect 게이트 "1차 FAIL → 재검증 PASS" 통합 회귀 테스트 추가.

## Acceptance criteria
- [x] architecture-validator 1차 FAIL → 재검증 PASS 상태에서 module-architect 첫 호출이 차단 없이 통과 (`test_module_architect_first_call_allowed_after_arch_validator_revalidation_pass`).
- [x] 한 번에 PASS 인 기존 케이스도 그대로 통과 — 회귀 없음 (기존 `..._allowed_with_arch_validator_pass` + `test_pass_in_base_md`).
- [x] 첫 재호출 prose(`-1.md`) PASS 인식 검증 회귀 테스트 존재 (`test_pass_in_first_recall_md`).

## 배포 경로 검증
- **경로 1 (plug-in 본체)**: `harness/hooks.py` 는 `hooks/catastrophic-gate.sh` 가 `python3 -m harness.hooks` 로 호출하는 plug-in 번들 파일 → plug-in 업데이트 시 외부 활성 프로젝트에 자동 반영.
- 경로 2(init-dcness 복사) / 경로 3(SSOT 문서) 변경 불필요 — 순수 버그픽스, occurrence 명명 규약 자체는 불변(탐색을 규약에 맞춤). `tests/` 는 dcness self 회귀 게이트.

## Test Plan
- [x] 관련 테스트 추가/갱신 (test_hooks 210 OK)
- [x] 회귀 검증 (전체 unittest discover 1356 OK, commit pytest-gate PASS)
