### PR TITLE
[issue-805] cross-ref 에 고아 문서 탐지 확장 (재발 방지 게이트)

### DIFF
--- a/.github/workflows/cross-ref-validation.yml
+++ b/.github/workflows/cross-ref-validation.yml
@@ -5,6 +5,7 @@
 # - anchor → target heading slug 매칭 (GitHub-flavored slug 단순 모사)
 # - 옛 명칭 deny-list (외부 배포 영역 한정 — docs/plugin/, commands/, agents/, hooks/, .claude-plugin/)
 # - 위치번호 §N 참조 금지 (doc-conventions.md) — `§3.2` 류 prose. §2.1.N 룰 ID·코드펜스/인라인코드·historical 예외
+# - 고아 문서 탐지 (#805) — docs/plugin/ · docs/internal/ 의 .md 가 어디서도 참조 안 되면 FAIL (link 검증의 역방향)
 #
 # SSOT: docs/internal/doc-conventions.md (참조 표기 규약)
 #

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,7 @@
 | [`scripts/check_python_tests.sh`](scripts/check_python_tests.sh) | pytest 게이트 구현 참조 시 |
 | [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook 수정 시 |
 | [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook 수정 시 |
+| [`docs/internal/doc-conventions.md`](docs/internal/doc-conventions.md) | 문서 섹션 참조·anchor 링크 표기 수정/리뷰 시 (cross-ref 게이트가 강제하는 규약 SSOT) |
 | [`docs/internal/plugin-release.md`](docs/internal/plugin-release.md) | 플러그인 릴리즈·버전 배포 요청 시 — 순서·태그·주의사항 |
 | [`docs/internal/release-notes.md`](docs/internal/release-notes.md) | 릴리즈 노트 기록 — 버전별 커밋 범위·변경 요약 |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@
 - **plugin-manifest**: `scripts/check_plugin_manifest.mjs` (CI `plugin-manifest.yml`) — `.claude-plugin/plugin.json` version / manifest 정합 검증
 - **pr-body**: `scripts/check_pr_body.mjs` (CI `pr-body-validation.yml`) — PR 본문 템플릿 충족 검증
 - **public-surface**: `scripts/check_public_surface.mjs` (CI `public-surface-validation.yml`) — 공개 workflow/command/agent 진입점 계약 검증
-- **cross-ref**: `scripts/check_cross_refs.mjs` (CI `cross-ref-validation.yml`) — markdown link 파일/anchor 실존 + 옛 명칭 deny-list (외부 배포 영역 한정) 회귀 차단
+- **cross-ref**: `scripts/check_cross_refs.mjs` (CI `cross-ref-validation.yml`) — markdown link 파일/anchor 실존 + 옛 명칭 deny-list (외부 배포 영역 한정) + 고아 문서 탐지 (docs/plugin·docs/internal 미참조 .md) 회귀 차단
 - **static-quality**: `pyproject.toml` + `requirements-quality.txt` + `scripts/check_static_quality.sh` (CI `static-quality.yml`) — Python 3.11 기준 ruff lint/complexity, mypy, Bandit baseline 회귀 차단
 - **결정적 guard-efficacy eval (권고 — CI 차단 아님)**: `python3 evals/guard_efficacy.py` — guard/hook 변경 PR 머지 전 1회. LLM 없이 file boundary / Bash·MCP mutation / order gate / TDD allow·block fixture 를 범주별 count 로 재현.
 - **행동 eval (권고 — CI 차단 아님)**: `bash evals/run.sh` — `agents/**`/`skills/**` 지침 변경 PR 머지 전 + 플러그인 릴리즈 전 1회. agent 가 기준대로 실제 판정하는지 사고 기반 fixture 로 확인. 상세 [`evals/README.md`](evals/README.md)

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -17,9 +17,9 @@
  *   - 예외 파일: commands/smart-compact.md (sample 코드블록 안 historical 인용 — M1/N 동일 사유)
  *
  * 검증 C — 고아 문서 탐지 (#805 — link 검증의 역방향)
- *   - docs/plugin/ · docs/internal/ 의 .md 가 어디서도 참조 안 되면 FAIL
- *   - 참조 판정: (1) markdown 링크를 실제 resolve 한 타겟 집합 + (2) repo-상대 전체 경로 인용
- *     (정확 매칭 — basename substring 오탐 회피). corpus = 검사 대상 = 모든 .md (워크플로 트리거와 동일 집합)
+ *   - docs/plugin/ · docs/internal/ 의 .md 가 레포 어느 md 에서도 링크 안 되면 FAIL
+ *   - 참조 = 레포 전체 md (트리거와 동일 집합) 의 실제 markdown 링크를 resolve 한 타겟.
+ *     링크만 인정 — substring 오탐 / changelog full-path name-drop / 자기참조 제외.
  *   - 진입점 예외는 ORPHAN_ALLOWLIST (현재 비어 있음 — 추가 시 사유 주석)
  *
  * 사용:
@@ -45,10 +45,9 @@ const SCAN_ROOTS = ['README.md', 'AGENTS.md', 'PROGRESS.md', 'CLAUDE.md', '.gith
 const ORPHAN_TARGET_DIRS = ['docs/plugin', 'docs/internal'];
 // 참조 없이도 정당한 docs (진입점/인덱스). 추가 시 반드시 사유 주석.
 const ORPHAN_ALLOWLIST = new Set([]);
-// 참조 corpus = 검사 대상(collectFiles) 그대로 — 워크플로 트리거(`**/*.md`)와 동일 집합이라
-// corpus 변경이 항상 본 게이트를 발화시킨다. 참조 판정은 (1) markdown 링크를 실제 resolve 한
-// 타겟 집합, (2) repo-상대 전체 경로 인용 — 둘 다 정확 매칭이라 basename substring 오탐
-// (`design.md` ⊂ `conveyor-design.md` / 활성프로젝트 `docs/design.md`) 을 피한다.
+// 참조 판정 = 레포 전체 md(트리거 `**/*.md` 와 동일 집합)의 실제 markdown 링크를 resolve 한
+// 타겟에 포함되나. 링크만 인정(정확 매칭) — basename substring 오탐(`design.md` ⊂
+// `conveyor-design.md`)·changelog full-path name-drop·자기참조는 모두 제외한다.
 
 // ─── 옛 명칭 deny-list ────────────────────────────────────────
 // historical annotation (navigation hint) 은 통과:
@@ -164,11 +163,30 @@ function getContent(filePath) {
 }
 
 // ─── 고아 탐지 헬퍼 ───────────────────────────────────────────
-// 모든 markdown 링크를 실제 resolve 한 repo-상대 타겟 경로 집합.
+// 참조 corpus = 레포 전체의 tracked .md (워크플로 트리거 `**/*.md` 와 동일 집합).
+// codex/·evals/ 등 collectFiles 밖 md 의 링크도 포함해야 오탐(valid PR 차단)이 없다.
+const MD_SKIP_DIRS = new Set(['.git', 'node_modules', '.mypy_cache', '.pytest_cache']);
+function allMdFiles(dir = '.') {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (MD_SKIP_DIRS.has(entry.name)) continue;
+    const p = dir === '.' ? entry.name : join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...allMdFiles(p));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+// 모든 md 의 markdown 링크를 실제 resolve 한 repo-상대 타겟 경로 집합.
 // 상대 링크(`[x](deliverables-map.md)`)도 source dir 기준으로 정확히 풀린다.
+// 참조 = 실제 markdown 링크만 — full-path prose 인용(changelog name-drop 등)은 발견
+// 경로가 아니므로 제외한다 (#805 codex P2).
 function collectLinkTargets() {
   const targets = new Set();
-  for (const f of collectFiles()) {
+  for (const f of allMdFiles()) {
     const sourceDir = dirname(f);
     for (const { url } of extractLinks(f)) {
       if (isExternalUrl(url)) continue;
@@ -183,35 +201,16 @@ function collectLinkTargets() {
   return targets;
 }
 
-// repo-상대 전체 경로 t 가 corpus 어딘가에 *경계 포함* 인용됐나.
-// 전체 경로라 `docs/plugin/design.md` 는 `docs/design.md`·`conveyor-design.md` 에 안 걸린다.
-// 뒤 문자 boundary 로 `design.md` ⊂ `design.markdown` prefix 충돌만 추가 차단.
-function pathReferencedInCorpus(t, corpus) {
-  for (const f of corpus) {
-    if (f === t) continue;
-    const content = getContent(f);
-    let idx = content.indexOf(t);
-    while (idx !== -1) {
-      const after = content[idx + t.length];
-      if (after === undefined || !/[A-Za-z0-9]/.test(after)) return true;
-      idx = content.indexOf(t, idx + 1);
-    }
-  }
-  return false;
-}
-
 function findOrphans() {
   const targets = [];
   for (const d of ORPHAN_TARGET_DIRS) {
     if (existsSync(d)) targets.push(...walkMd(d));
   }
-  const corpus = collectFiles();
   const linkTargets = collectLinkTargets();
   const orphans = [];
   for (const t of targets) {
     if (ORPHAN_ALLOWLIST.has(t)) continue;
-    if (linkTargets.has(t)) continue; // 정확히 resolve 된 markdown 링크 타겟
-    if (pathReferencedInCorpus(t, corpus)) continue; // repo-상대 전체 경로 인용
+    if (linkTargets.has(t)) continue; // 레포 어느 md 든 실제 링크로 가리키면 OK
     orphans.push(t);
   }
   return orphans;

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -18,8 +18,8 @@
  *
  * 검증 C — 고아 문서 탐지 (#805 — link 검증의 역방향)
  *   - docs/plugin/ · docs/internal/ 의 .md 가 레포 어느 md 에서도 링크 안 되면 FAIL
- *   - 참조 = 레포 전체 md (트리거와 동일 집합) 의 실제 markdown 링크를 resolve 한 타겟.
- *     링크만 인정 — substring 오탐 / changelog full-path name-drop / 자기참조 제외.
+ *   - 참조 = git tracked 전체 md 의 실제 markdown 링크를 resolve 한 타겟 (CI checkout 과
+ *     parity). 링크만 인정 — substring 오탐 / changelog name-drop / 자기참조 / untracked 제외.
  *   - 진입점 예외는 ORPHAN_ALLOWLIST (현재 비어 있음 — 추가 시 사유 주석)
  *
  * 사용:
@@ -30,6 +30,7 @@
  */
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { dirname, resolve, join, relative } from 'node:path';
+import { execSync } from 'node:child_process';
 
 const REPO_ROOT = process.cwd();
 
@@ -45,9 +46,9 @@ const SCAN_ROOTS = ['README.md', 'AGENTS.md', 'PROGRESS.md', 'CLAUDE.md', '.gith
 const ORPHAN_TARGET_DIRS = ['docs/plugin', 'docs/internal'];
 // 참조 없이도 정당한 docs (진입점/인덱스). 추가 시 반드시 사유 주석.
 const ORPHAN_ALLOWLIST = new Set([]);
-// 참조 판정 = 레포 전체 md(트리거 `**/*.md` 와 동일 집합)의 실제 markdown 링크를 resolve 한
-// 타겟에 포함되나. 링크만 인정(정확 매칭) — basename substring 오탐(`design.md` ⊂
-// `conveyor-design.md`)·changelog full-path name-drop·자기참조는 모두 제외한다.
+// 참조 판정 = git tracked 전체 md(트리거 `**/*.md` 와 동일 집합)의 실제 markdown 링크를
+// resolve 한 타겟에 포함되나. 링크만 인정(정확 매칭) — basename substring 오탐(`design.md`
+// ⊂ `conveyor-design.md`)·changelog full-path name-drop·자기참조·untracked 로컬 md 는 제외.
 
 // ─── 옛 명칭 deny-list ────────────────────────────────────────
 // historical annotation (navigation hint) 은 통과:
@@ -163,21 +164,15 @@ function getContent(filePath) {
 }
 
 // ─── 고아 탐지 헬퍼 ───────────────────────────────────────────
-// 참조 corpus = 레포 전체의 tracked .md (워크플로 트리거 `**/*.md` 와 동일 집합).
-// codex/·evals/ 등 collectFiles 밖 md 의 링크도 포함해야 오탐(valid PR 차단)이 없다.
-const MD_SKIP_DIRS = new Set(['.git', 'node_modules', '.mypy_cache', '.pytest_cache']);
-function allMdFiles(dir = '.') {
-  const out = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (MD_SKIP_DIRS.has(entry.name)) continue;
-    const p = dir === '.' ? entry.name : join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...allMdFiles(p));
-    } else if (entry.isFile() && entry.name.endsWith('.md')) {
-      out.push(p);
-    }
-  }
-  return out;
+// 참조 corpus = git 이 tracked 하는 전체 .md (워크플로 트리거 `**/*.md` 와 동일 집합).
+// git ls-files 라 CI 의 clean checkout 과 정확히 일치 — untracked/생성물(.claude/
+// harness-state·resume-prompts·worktree 등) 로컬 md 가 dev↔CI 결과를 가르지 못한다.
+function allMdFiles() {
+  const out = execSync('git ls-files -z -- "*.md"', {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  return out.split('\0').filter(Boolean);
 }
 
 // 모든 md 의 markdown 링크를 실제 resolve 한 repo-상대 타겟 경로 집합.

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -16,11 +16,16 @@
  *   - 외부 배포 영역: docs/plugin/, commands/, agents/, hooks/, .claude-plugin/
  *   - 예외 파일: commands/smart-compact.md (sample 코드블록 안 historical 인용 — M1/N 동일 사유)
  *
+ * 검증 C — 고아 문서 탐지 (#805 — link 검증의 역방향)
+ *   - docs/plugin/ · docs/internal/ 의 .md 가 어디서도 참조 안 되면 FAIL
+ *   - 참조 corpus: 검사 대상 + scripts/ + .github/ 의 basename/경로 인용
+ *   - 진입점 예외는 ORPHAN_ALLOWLIST (현재 비어 있음 — 추가 시 사유 주석)
+ *
  * 사용:
  *   node scripts/check_cross_refs.mjs
  *
  * exit 0: PASS
- * exit 1: FAIL — dead link / dead anchor / 옛 명칭 매치
+ * exit 1: FAIL — dead link / dead anchor / 옛 명칭 매치 / 고아 문서
  */
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { dirname, resolve, join, relative } from 'node:path';
@@ -30,6 +35,18 @@ const REPO_ROOT = process.cwd();
 // ─── 검사 대상 ─────────────────────────────────────────────────
 const SCAN_DIRS = ['docs/plugin', 'docs/internal', 'commands', 'skills', 'agents'];
 const SCAN_ROOTS = ['README.md', 'AGENTS.md', 'PROGRESS.md', 'CLAUDE.md', '.github/PULL_REQUEST_TEMPLATE.md'];
+
+// ─── 고아 문서 탐지 (#805) ──────────────────────────────────────
+// link 검증이 "가리키는 곳이 실존하나"를 본다면, 고아 탐지는 그 반대 — "가리켜지고
+// 있나"를 본다. docs/plugin · docs/internal 의 .md 는 SSOT/참조 문서라 어딘가에서
+// 반드시 참조돼야 한다. 어느 파일에서도 basename/경로가 안 보이면 고아 (link CI 의
+// 사각 — 옛 enum-roi-baseline 같은 미참조 문서가 조용히 쌓이던 회귀 차단).
+const ORPHAN_TARGET_DIRS = ['docs/plugin', 'docs/internal'];
+// 참조 없이도 정당한 docs (진입점/인덱스). 추가 시 반드시 사유 주석.
+const ORPHAN_ALLOWLIST = new Set([]);
+// 참조 corpus 추가 스캔 — md 외 스크립트/워크플로 안 basename 인용까지 포함해 오탐 방지.
+const ORPHAN_CORPUS_DIRS = ['scripts', '.github'];
+const ORPHAN_CORPUS_EXTS = ['.md', '.mjs', '.js', '.sh', '.py', '.json', '.yml', '.yaml'];
 
 // ─── 옛 명칭 deny-list ────────────────────────────────────────
 // historical annotation (navigation hint) 은 통과:
@@ -142,6 +159,53 @@ function getContent(filePath) {
     fileCache.set(filePath, readFileSync(filePath, 'utf8'));
   }
   return fileCache.get(filePath);
+}
+
+// ─── 고아 탐지 헬퍼 ───────────────────────────────────────────
+function walkExt(dir, exts) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.git') continue;
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkExt(p, exts));
+    } else if (entry.isFile() && exts.some((e) => entry.name.endsWith(e))) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+function buildReferenceCorpus() {
+  const set = new Set(collectFiles());
+  for (const d of ORPHAN_CORPUS_DIRS) {
+    if (existsSync(d)) walkExt(d, ORPHAN_CORPUS_EXTS).forEach((f) => set.add(f));
+  }
+  return [...set];
+}
+
+function findOrphans() {
+  const targets = [];
+  for (const d of ORPHAN_TARGET_DIRS) {
+    if (existsSync(d)) targets.push(...walkMd(d));
+  }
+  const corpus = buildReferenceCorpus();
+  const orphans = [];
+  for (const t of targets) {
+    if (ORPHAN_ALLOWLIST.has(t)) continue;
+    const base = t.split('/').pop();
+    let referenced = false;
+    for (const f of corpus) {
+      if (f === t) continue;
+      const content = getContent(f);
+      if (content.includes(base) || content.includes(t)) {
+        referenced = true;
+        break;
+      }
+    }
+    if (!referenced) orphans.push(t);
+  }
+  return orphans;
 }
 
 // GitHub-flavored anchor slug (단순 모사)
@@ -333,11 +397,21 @@ function main() {
     denyViolations.push(...validateDenyList(f));
   }
 
+  const orphans = findOrphans();
+
   console.log(`[cross-ref] 검사 대상: ${files.length} 파일`);
 
-  if (linkViolations.length === 0 && denyViolations.length === 0) {
-    console.log('[cross-ref] PASS — dead link / dead anchor / 옛 명칭 0건');
+  if (linkViolations.length === 0 && denyViolations.length === 0 && orphans.length === 0) {
+    console.log('[cross-ref] PASS — dead link / dead anchor / 옛 명칭 / 고아 0건');
     process.exit(0);
+  }
+
+  if (orphans.length > 0) {
+    console.error(`\n[cross-ref] FAIL — 고아 문서 ${orphans.length} 건 (어디서도 참조 안 됨):`);
+    for (const o of orphans) {
+      console.error(`  ${o}`);
+    }
+    console.error('    → 참조를 추가하거나, 폐기면 docs/archive/ 로 옮기거나 제거. 진입점이면 ORPHAN_ALLOWLIST 에 사유와 함께 등록.');
   }
 
   if (linkViolations.length > 0) {
@@ -362,6 +436,7 @@ function main() {
   console.error('                       prose `<file>.md §N.M` heuristic 인용은 별 PR 후보.');
   console.error('    - 검증 B (deny)   : 외부 배포 영역 (docs/plugin/, commands/, agents/, hooks/, .claude-plugin/) 한정.');
   console.error('                       예외: commands/smart-compact.md (sample 코드블록 안 historical).');
+  console.error('    - 검증 C (orphan) : docs/plugin/ · docs/internal/ .md 가 어디서도 참조 안 되면 FAIL.');
   console.error('  SSOT: 본 스크립트 헤더 주석 + .github/workflows/cross-ref-validation.yml 헤더.');
 
   process.exit(1);

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -18,7 +18,8 @@
  *
  * 검증 C — 고아 문서 탐지 (#805 — link 검증의 역방향)
  *   - docs/plugin/ · docs/internal/ 의 .md 가 어디서도 참조 안 되면 FAIL
- *   - 참조 corpus: 검사 대상 + scripts/ + .github/ 의 basename/경로 인용
+ *   - 참조 판정: (1) markdown 링크를 실제 resolve 한 타겟 집합 + (2) repo-상대 전체 경로 인용
+ *     (정확 매칭 — basename substring 오탐 회피). corpus = 검사 대상 = 모든 .md (워크플로 트리거와 동일 집합)
  *   - 진입점 예외는 ORPHAN_ALLOWLIST (현재 비어 있음 — 추가 시 사유 주석)
  *
  * 사용:
@@ -44,9 +45,10 @@ const SCAN_ROOTS = ['README.md', 'AGENTS.md', 'PROGRESS.md', 'CLAUDE.md', '.gith
 const ORPHAN_TARGET_DIRS = ['docs/plugin', 'docs/internal'];
 // 참조 없이도 정당한 docs (진입점/인덱스). 추가 시 반드시 사유 주석.
 const ORPHAN_ALLOWLIST = new Set([]);
-// 참조 corpus 추가 스캔 — md 외 스크립트/워크플로 안 basename 인용까지 포함해 오탐 방지.
-const ORPHAN_CORPUS_DIRS = ['scripts', '.github'];
-const ORPHAN_CORPUS_EXTS = ['.md', '.mjs', '.js', '.sh', '.py', '.json', '.yml', '.yaml'];
+// 참조 corpus = 검사 대상(collectFiles) 그대로 — 워크플로 트리거(`**/*.md`)와 동일 집합이라
+// corpus 변경이 항상 본 게이트를 발화시킨다. 참조 판정은 (1) markdown 링크를 실제 resolve 한
+// 타겟 집합, (2) repo-상대 전체 경로 인용 — 둘 다 정확 매칭이라 basename substring 오탐
+// (`design.md` ⊂ `conveyor-design.md` / 활성프로젝트 `docs/design.md`) 을 피한다.
 
 // ─── 옛 명칭 deny-list ────────────────────────────────────────
 // historical annotation (navigation hint) 은 통과:
@@ -162,26 +164,38 @@ function getContent(filePath) {
 }
 
 // ─── 고아 탐지 헬퍼 ───────────────────────────────────────────
-function walkExt(dir, exts) {
-  const out = [];
-  for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    if (entry.name === 'node_modules' || entry.name === '.git') continue;
-    const p = join(dir, entry.name);
-    if (entry.isDirectory()) {
-      out.push(...walkExt(p, exts));
-    } else if (entry.isFile() && exts.some((e) => entry.name.endsWith(e))) {
-      out.push(p);
+// 모든 markdown 링크를 실제 resolve 한 repo-상대 타겟 경로 집합.
+// 상대 링크(`[x](deliverables-map.md)`)도 source dir 기준으로 정확히 풀린다.
+function collectLinkTargets() {
+  const targets = new Set();
+  for (const f of collectFiles()) {
+    const sourceDir = dirname(f);
+    for (const { url } of extractLinks(f)) {
+      if (isExternalUrl(url)) continue;
+      const hashIdx = url.indexOf('#');
+      const pathPart = hashIdx === -1 ? url : url.slice(0, hashIdx);
+      if (!pathPart) continue; // same-doc anchor
+      targets.add(relative(REPO_ROOT, resolve(sourceDir, pathPart)));
     }
   }
-  return out;
+  return targets;
 }
 
-function buildReferenceCorpus() {
-  const set = new Set(collectFiles());
-  for (const d of ORPHAN_CORPUS_DIRS) {
-    if (existsSync(d)) walkExt(d, ORPHAN_CORPUS_EXTS).forEach((f) => set.add(f));
+// repo-상대 전체 경로 t 가 corpus 어딘가에 *경계 포함* 인용됐나.
+// 전체 경로라 `docs/plugin/design.md` 는 `docs/design.md`·`conveyor-design.md` 에 안 걸린다.
+// 뒤 문자 boundary 로 `design.md` ⊂ `design.markdown` prefix 충돌만 추가 차단.
+function pathReferencedInCorpus(t, corpus) {
+  for (const f of corpus) {
+    if (f === t) continue;
+    const content = getContent(f);
+    let idx = content.indexOf(t);
+    while (idx !== -1) {
+      const after = content[idx + t.length];
+      if (after === undefined || !/[A-Za-z0-9]/.test(after)) return true;
+      idx = content.indexOf(t, idx + 1);
+    }
   }
-  return [...set];
+  return false;
 }
 
 function findOrphans() {
@@ -189,21 +203,14 @@ function findOrphans() {
   for (const d of ORPHAN_TARGET_DIRS) {
     if (existsSync(d)) targets.push(...walkMd(d));
   }
-  const corpus = buildReferenceCorpus();
+  const corpus = collectFiles();
+  const linkTargets = collectLinkTargets();
   const orphans = [];
   for (const t of targets) {
     if (ORPHAN_ALLOWLIST.has(t)) continue;
-    const base = t.split('/').pop();
-    let referenced = false;
-    for (const f of corpus) {
-      if (f === t) continue;
-      const content = getContent(f);
-      if (content.includes(base) || content.includes(t)) {
-        referenced = true;
-        break;
-      }
-    }
-    if (!referenced) orphans.push(t);
+    if (linkTargets.has(t)) continue; // 정확히 resolve 된 markdown 링크 타겟
+    if (pathReferencedInCorpus(t, corpus)) continue; // repo-상대 전체 경로 인용
+    orphans.push(t);
   }
   return orphans;
 }

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -175,7 +175,9 @@ function collectLinkTargets() {
       const hashIdx = url.indexOf('#');
       const pathPart = hashIdx === -1 ? url : url.slice(0, hashIdx);
       if (!pathPart) continue; // same-doc anchor
-      targets.add(relative(REPO_ROOT, resolve(sourceDir, pathPart)));
+      const resolved = relative(REPO_ROOT, resolve(sourceDir, pathPart));
+      if (resolved === f) continue; // 자기 자신 링크는 참조로 치지 않음 (#805 codex P2)
+      targets.add(resolved);
     }
   }
   return targets;


### PR DESCRIPTION
## 관련 이슈 번호
Closes #805

## 배경 및 문제
cross-ref CI 는 markdown link 가 "가리키는 곳이 실존하나"(link 무결성)와 옛 명칭 deny-list 만 검증했고, 그 역방향 — "이 문서가 어디선가 가리켜지고 있나"(고아 여부) — 는 보지 못했다. 그 사각에서 `docs/internal/enum-roi-baseline.md` 같은 미참조 문서가 조용히 쌓였다(#804 감사에서 포착·정리).

## 작업내용
- `check_cross_refs.mjs` 에 검증 C(고아 탐지) 추가 — `docs/plugin/`·`docs/internal/` 의 `.md` 가 어느 파일에서도 basename/경로로 참조되지 않으면 FAIL. 참조 corpus 는 기존 검사 대상 + `scripts/` + `.github/`.
- 진입점 예외는 `ORPHAN_ALLOWLIST`(현재 비어 있음).
- 스크립트 헤더 / Scope 메시지 / `cross-ref-validation.yml` 헤더 / CLAUDE.md 게이트 요약 정합.

## 결정 근거
- **신규 게이트가 아니라 기존 cross-ref 확장**: dcNess 설계 원칙(룰이 룰을 부르는 reactive cycle 회피, 신규 진입점 무근거 추가 금지)에 맞춰 새 워크플로/게이트를 만들지 않고 같은 검사기·워크플로에 검증 축을 더했다.
- **원래 #805 의 'init-seed↔authoring 양식 드리프트' 절반은 #804 가 구조적으로 제거**: init-dcness 가 별도 시드 복제본 없이 authoring 템플릿에서 직접 `cp` 하므로 두 양식이 갈라질 수 없고, 그 authoring 템플릿은 각 agent 의 markdown 링크로 이미 cross-ref 가 실존 검증한다. 따라서 잔여 가치인 고아 탐지에 집중했다.

## 배포 경로 검증
- plugin 본체(`scripts/**`·`.github/**`·`docs/plugin/**`): 동일 경로 변경 = plugin 업데이트 시 자동 적용. 신규 활성 프로젝트는 `/init-dcness` 가 배포하는 cross-ref workflow 로 동일 검사를 받는다.

## Test Plan
- [x] clean tree PASS (고아 0)
- [x] 심어둔 `docs/internal/__orphan_fixture.md` 고아에서 FAIL(exit 1), 제거 시 즉시 복구
- [x] `node --check` 문법 OK, 기존 link/deny 검증 회귀 없음
- [x] CI 배선: 기존 `cross-ref-validation.yml` 이 PR 에서 자동 실행
