### PR TITLE
[feature] next 진입점 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ high-risk trigger 나 새 epic/product feature 는 impl *내부 구현 경로가
 support/advanced 진입점은 기본 생명주기 공개 진입점 밖의 보조 흐름이다.
 
 - `/to-issue` — 메인 주도 Issue Brief 초안 + 승인 후 GitHub issue/Project 등록
+- `/next` — GitHub Project 보드의 In progress 와 다음 Todo 후보를 read-only 조회
 - `/tech-review` — high-risk 설계 선행에서 `/spec` 내부 preflight 로 쓰는 선행 기술 검증
 - `/impl-loop` — deep impl task 파일용 legacy/advanced runner
 - `/ux` — 화면 UX / 디자인 핸드오프 전문 흐름
@@ -184,6 +185,7 @@ escalate) 가 진본이다 — 예: [`skills/impl/impl-routing.md`](skills/impl/
 | 고급 workflow | `/impl-loop` | deep impl task 파일용 legacy/advanced runner |
 | 고급 workflow | `/ux` | 화면 UX 플로우 + 디자인 시안 핸드오프 |
 | 유틸리티 | `/init-dcness` | 현 프로젝트를 plugin 활성 whitelist 에 등록 |
+| 유틸리티 | `/next` | GitHub Project 보드에서 In progress 와 다음 Todo 후보를 read-only 조회 |
 | 유틸리티 | `/run-review` | run 사후 분석 — step별 비용·차단 검출 |
 | 유틸리티 | `/smart-compact` | 컨텍스트 압축 + 다음 세션 resume prompt 자동 생성 |
 | 유틸리티 | `/efficiency` | 세션 토큰/캐시/비용 분석 + HTML 대시보드 |

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -193,6 +193,7 @@ support:
 - /ux — 화면 UX / 디자인 핸드오프
 
 유틸리티:
+- /next — GitHub Project 보드에서 In progress 와 다음 Todo 후보 조회
 - /smart-compact — 컨텍스트 압축 + resume prompt
 - /run-review — run 사후 분석
 - /efficiency — 세션 토큰/비용 분석

--- a/commands/next.md
+++ b/commands/next.md
@@ -1,0 +1,39 @@
+---
+name: next
+description: GitHub Project 보드에서 현재 In progress 항목과 다음 Todo 후보를 조회하는 read-only 유틸리티. 사용자가 "/next", "다음 작업", "뭐부터 하지", "진행 중 작업", "콜드스타트 시작점" 등을 말할 때 사용한다.
+---
+
+# Next — 다음 작업 read-only 조회
+
+> GitHub Project Status 를 읽어 cold-start 세션의 시작점을 확인한다. Project/issue 상태를 쓰거나 변경하지 않는다.
+
+## 언제 사용
+
+- 새 세션에서 다음 작업이나 시작점을 확인할 때
+- 현재 In progress 항목과 Todo 후보를 빠르게 보고 싶을 때
+- `docs/index.md` 의 정적 포인터만으로는 live 상태를 알 수 없을 때
+
+## 절차
+
+```bash
+SCRIPT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)/scripts/github_project_lifecycle.mjs"
+node "$SCRIPT" next
+```
+
+사용자가 repo / Project 좌표를 명시한 경우에만 flag 를 그대로 전달한다.
+
+```bash
+node "$SCRIPT" next --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER
+```
+
+## 동작 계약
+
+- read-only: `--apply` 를 쓰지 않고, Project/issue/PR 상태를 변경하지 않는다.
+- 좌표 해석: flag → `DCNESS_PROJECT_*` env → repo variable → repo owner fallback 순서.
+- Project 좌표가 없으면 실패로 끝내지 않고 `/init-dcness` bootstrap 안내를 출력한다.
+- 출력은 `In progress` 와 `Next Todo` 요약이다. 필요하면 사용자는 GitHub Project 보드에서 live 상태를 직접 확인한다.
+
+## 참조
+
+- [`issue-lifecycle.md` Project lifecycle](../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle)
+- [`positioning.md` Utility 공개 노출 범위](../docs/plugin/positioning.md#utility-공개-노출-범위)

--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -61,6 +61,8 @@ docs/
 
 `docs/architecture.md` 는 epic 이 늘 때마다 append-growing map 으로 갱신한다. 상세 설계 본문을 전역에 복제하지 않고, 전역 모듈/의존/결정 anchor 와 epic 문서 링크를 추가한다.
 
+`docs/index.md` 는 cold-start agent 의 정적 entrypoint 다. live 진행상태를 문서에 복제하지 않고, 수동 섹션 `## 진행 상태 · 다음 작업` 에서 GitHub Project 보드, epic/story issue, `/next` 를 가리킨다.
+
 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 는 각 `docs/epics/epic-NN-<slug>/architecture.md` 의 `## 모듈 목록` 표와 `## Contract Ledger` 표를 수집해 전역 `docs/architecture.md` 의 `에픽 간 지도`, `전역 모듈 토폴로지`, `공유 계약 인덱스` 섹션을 생성/갱신한다. 이 세 섹션은 파생물이며 수동 편집하지 않는다. epic architecture 템플릿의 표 헤더는 도구의 파싱 계약이므로 변경하려면 도구와 테스트를 함께 갱신한다.
 
 기술 스택, naming, formatter, runtime, package manager, dependency policy 같은 반복 입력은 `docs/conventions.md` 에 둔다. 전역 architecture 는 시스템 topology 와 cross-epic map 에 집중한다.

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -62,6 +62,7 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 - 상태 위생 청소 (세션당 1회, fail-open): stale by-pid 파일(24h) + 본 세션의 만료 run 슬롯(24h) + 전 세션의 run 디렉토리(prose/ledger, 7d — `/run-review` 원자료라 슬롯보다 길게 보관). TTL 상수 SSOT = `harness/session_state.py`
 - `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
 - 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
+- 프로젝트 상태나 다음 작업 질문에는 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 포인터와 `/next` 를 쓰라고 안내함
 - 설치된 plug-in 버전과 `main` 의 최신 버전을 비교(하루 1회 캐시)해 더 높은 버전이 있을 때만 `claude plugin update` 알림을 함께 inject — 외부 활성 프로젝트가 옛 plug-in 버전 운영 룰에 묶이는 drift 회피
 
 **차단**: 없음. 실패해도 세션 시작을 막지 않는다.

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -69,6 +69,19 @@ node scripts/github_project_lifecycle.mjs register-issue \
 
 보드 좌표 (owner/number) 는 repo 변수 `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` 에 저장한다 — GitHub Actions `vars.*` 와 동일 저장소라 CI lifecycle workflow 와 단일 SSOT 다. `/init-dcness` bootstrap 이 `gh variable set` 으로 저장하고, 등록 경로는 `gh variable get` 으로 읽는다. 조회 우선순위: `--project`/`--owner` 플래그 → `DCNESS_PROJECT_*` env → `gh variable get` → owner 는 repo owner fallback.
 
+### 다음 작업 조회 — read-only
+
+`/next` 는 같은 Project 좌표 해석 경로를 사용해 현재 보드의 `In progress` 항목과 다음 `Todo` 후보를 요약한다. 이 명령은 read-only 유틸리티라 `--apply` 를 받지 않고 Project item, issue, PR 상태를 변경하지 않는다.
+
+```bash
+node scripts/github_project_lifecycle.mjs next \
+  --repo OWNER/REPO \
+  --owner OWNER \
+  --project PROJECT_NUMBER
+```
+
+Project 좌표가 저장되지 않은 환경에서는 크래시하지 않고 `/init-dcness` bootstrap 으로 보드 좌표를 저장하라는 안내를 출력한 뒤 정상 종료한다. `docs/index.md` 는 live 상태를 복제하지 않고 GitHub Project 보드, epic/story issue, `/next` 를 가리키는 정적 포인터만 둔다.
+
 ### 작업 시작 — Status=In progress
 
 특정 GitHub issue 를 대상으로 `/spec`, `/design`, `/impl`, `/ux` 같은 설계나 구현 흐름을 실제 시작하면 메인은 시작 직전에 Project item 을 `Status=In progress` 로 이동한다. Project 번호와 owner 를 알 수 없으면 추측하지 말고 `/init-dcness` bootstrap 을 먼저 수행한다.

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -12,7 +12,7 @@ skill 트리거 또는 직접 발화 → 메인 Claude 가 **해당 skill 의 `#
 
 - **skill 경유**: skill 본문이 loop spec 진본 (예: impl-task-loop = [`skills/impl-loop/SKILL.md`](../../skills/impl-loop/SKILL.md)). skill 은 input 정형화 + 분기 추천. 절차는 본 SSOT.
 - **직접 발화** ("이거 impl 로 가자"): 각 loop skill 의 `## Loop` + `<skill>-routing.md` 보고 메인이 자율 구성. 단 `begin-run` 이후 active run 안의 `Agent` 호출은 아래 표준 1 step 시퀀스가 PreToolUse hook 으로 강제된다.
-- **SessionStart inject** (#596): *최소 활성 안내만* 매 세션 노출 — dcness 활성 사실 + 코드 강제 gate 가 켜져 있다는 안내 + hook-first recovery 원칙. 문서 진입 매트릭스·절차·분기 규칙은 **미주입** (skill 진입 시 해당 skill 이 안내, 위반 복구는 각 blocking hook 메시지가 그 자리에서 제공). 첫 응답 첫 줄 `[dcness 활성 확인]` 토큰.
+- **SessionStart inject** (#596): *최소 활성 안내만* 매 세션 노출 — dcness 활성 사실 + 코드 강제 gate 가 켜져 있다는 안내 + hook-first recovery 원칙. 문서 진입 매트릭스·절차·분기 규칙은 **미주입** (skill 진입 시 해당 skill 이 안내, 위반 복구는 각 blocking hook 메시지가 그 자리에서 제공). 예외적으로 프로젝트 상태나 다음 작업 질문에는 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 포인터와 `/next` 를 쓰라고 안내한다. 첫 응답 첫 줄 `[dcness 활성 확인]` 토큰.
 
 ---
 

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -45,6 +45,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 | 유틸리티 | 역할 |
 |---|---|
 | `/init-dcness` | 프로젝트 활성화 |
+| `/next` | GitHub Project 보드에서 In progress 와 다음 Todo 후보를 read-only 조회 |
 | `/run-review` | 끝난 run 사후 분석 |
 | `/smart-compact` | resume prompt 포함 context compact 보조 |
 | `/efficiency` | 세션 토큰/비용 분석 |

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -85,6 +85,8 @@ msg = header + '''## [dcness 활성 환경]
 - 테스트 선행 (구현 전 테스트 먼저): tdd-guard
 - run 종료 자동화: stop-end-run
 
+프로젝트 상태나 다음 작업을 물으면 \`docs/index.md\` 의 \`## 진행 상태 · 다음 작업\` 포인터를 확인하고, live 보드 상태는 \`/next\` 로 조회한다.
+
 hook 이 차단할 때만 그 메시지가 가리키는 doc/path 를 읽어 복구한다. SessionStart 에서 dcness 문서를 미리 통독하지 말 것 — 절차·분기는 skill 진입 시 해당 skill 이 안내한다.
 '''
 print(json.dumps({

--- a/scripts/check_public_surface.mjs
+++ b/scripts/check_public_surface.mjs
@@ -15,7 +15,7 @@ const EXPECTED = {
   supportSkills: ['to-issue'],
   advancedSkills: ['impl-loop', 'tech-review', 'ux'],
   internalSkills: ['compact-design'],
-  utilityCommands: ['efficiency', 'init-dcness', 'run-review', 'smart-compact'],
+  utilityCommands: ['efficiency', 'init-dcness', 'next', 'run-review', 'smart-compact'],
   internalAgents: [
     'architecture-validator',
     'build-worker',

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -2,6 +2,8 @@
 import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
+export const GH_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
 export const PROJECT_FIELDS = Object.freeze({
   Status: Object.freeze(['Todo', 'In progress', 'Done']),
   IssueType: Object.freeze(['epic', 'feature', 'story', 'task', 'subTask', 'bug']),
@@ -289,6 +291,7 @@ function gh(args, { json = false, allowFailure = false } = {}) {
   try {
     const output = execFileSync('gh', args, {
       encoding: 'utf8',
+      maxBuffer: GH_MAX_BUFFER_BYTES,
       stdio: ['ignore', 'pipe', 'pipe'],
     }).trim();
     if (!json) return output;
@@ -313,6 +316,67 @@ function detectRepo(repoArg) {
 
 function repoOwner(repo, ownerArg) {
   return ownerArg || repo.split('/')[0];
+}
+
+function firstNonEmpty(...values) {
+  for (const value of values) {
+    if (value !== null && value !== undefined && String(value).trim() !== '') {
+      return String(value).trim();
+    }
+  }
+  return null;
+}
+
+function readRepoVariable(name, repo) {
+  const args = ['variable', 'get', name];
+  if (repo) args.push('--repo', repo);
+  return gh(args, { allowFailure: true });
+}
+
+export function resolveProjectCoordinatesFromSources({
+  repo,
+  ownerArg = null,
+  projectArg = null,
+  env = process.env,
+  variables = {},
+}) {
+  const project = firstNonEmpty(
+    projectArg,
+    env?.DCNESS_PROJECT_NUMBER,
+    variables?.DCNESS_PROJECT_NUMBER,
+  );
+  const owner = firstNonEmpty(
+    ownerArg,
+    env?.DCNESS_PROJECT_OWNER,
+    variables?.DCNESS_PROJECT_OWNER,
+    repoOwner(repo),
+  );
+  return { repo, owner, project };
+}
+
+export function resolveProjectCoordinates(args, { requireProject = false } = {}) {
+  const repo = detectRepo(args.repo);
+  const variables = {};
+  if (!firstNonEmpty(args.project, process.env.DCNESS_PROJECT_NUMBER)) {
+    variables.DCNESS_PROJECT_NUMBER = readRepoVariable('DCNESS_PROJECT_NUMBER', repo);
+  }
+  if (!firstNonEmpty(args.owner, process.env.DCNESS_PROJECT_OWNER)) {
+    variables.DCNESS_PROJECT_OWNER = readRepoVariable('DCNESS_PROJECT_OWNER', repo);
+  }
+  const resolved = resolveProjectCoordinatesFromSources({
+    repo,
+    ownerArg: args.owner,
+    projectArg: args.project,
+    env: process.env,
+    variables,
+  });
+  if (requireProject && !resolved.project) {
+    throw new Error(
+      '--project <number> is required. Set --project, DCNESS_PROJECT_NUMBER, '
+        + 'or repo variable DCNESS_PROJECT_NUMBER.',
+    );
+  }
+  return resolved;
 }
 
 function normalizeRepoName(value) {
@@ -394,6 +458,35 @@ export function projectItemFieldValue(item, fieldName) {
   const fieldValues = asArray(item?.fieldValues ?? item?.field_values);
   const value = fieldValues.find((entry) => entry?.field?.name === fieldName || entry?.name === fieldName);
   return value?.name ?? value?.value ?? value?.text ?? value?.optionName ?? null;
+}
+
+export function projectItemSummary(item) {
+  const content = item?.content ?? item;
+  const rawNumber = content?.number ?? item?.number;
+  const parsedNumber = rawNumber === null || rawNumber === undefined || rawNumber === ''
+    ? null
+    : Number(rawNumber);
+  return {
+    repo: itemRepositoryName(item),
+    number: Number.isInteger(parsedNumber) ? parsedNumber : null,
+    title: String(content?.title ?? item?.title ?? '<untitled>'),
+    url: content?.url ?? item?.url ?? null,
+    status: projectItemFieldValue(item, 'Status'),
+    issueType: projectItemFieldValue(item, 'IssueType'),
+    priority: projectItemFieldValue(item, 'Priority'),
+  };
+}
+
+export function summarizeBoard(itemsInput) {
+  const summary = { inProgress: [], todo: [], done: [] };
+  for (const item of asArray(itemsInput)) {
+    const status = projectItemFieldValue(item, 'Status');
+    const entry = projectItemSummary(item);
+    if (status === 'In progress') summary.inProgress.push(entry);
+    if (status === 'Todo') summary.todo.push(entry);
+    if (status === 'Done') summary.done.push(entry);
+  }
+  return summary;
 }
 
 function projectItemIssueType(item) {
@@ -498,8 +591,7 @@ function printBootstrapRecovery({ repo, owner, project }) {
 }
 
 function commandBootstrap(args) {
-  const repo = detectRepo(args.repo);
-  const owner = repoOwner(repo, args.owner);
+  const { repo, owner, project: projectNumber } = resolveProjectCoordinates(args);
   const apply = Boolean(args.apply);
 
   const labels = gh(['label', 'list', '--repo', repo, '--limit', '200', '--json', 'name'], { json: true });
@@ -512,14 +604,14 @@ function commandBootstrap(args) {
     }
   }
 
-  if (!args.project) {
+  if (!projectNumber) {
     console.error('[dcness-project] Project number is required for field validation.');
     printBootstrapRecovery({ repo, owner, project: null });
     return 1;
   }
 
   const fields = gh(
-    ['project', 'field-list', args.project, '--owner', owner, '--format', 'json'],
+    ['project', 'field-list', projectNumber, '--owner', owner, '--format', 'json'],
     { json: true },
   );
   const fieldValidation = validateProjectFields(fields);
@@ -533,7 +625,7 @@ function commandBootstrap(args) {
         gh([
           'project',
           'field-create',
-          args.project,
+          projectNumber,
           '--owner',
           owner,
           '--name',
@@ -549,7 +641,7 @@ function commandBootstrap(args) {
         console.error('[dcness-project] existing Project fields with missing options need manual repair.');
       }
     } else {
-      printBootstrapRecovery({ repo, owner, project: args.project });
+      printBootstrapRecovery({ repo, owner, project: projectNumber });
     }
   }
 
@@ -557,7 +649,7 @@ function commandBootstrap(args) {
     ? gh(['label', 'list', '--repo', repo, '--limit', '200', '--json', 'name'], { json: true })
     : labels;
   const finalFields = apply && fieldValidation.missingFields.length
-    ? gh(['project', 'field-list', args.project, '--owner', owner, '--format', 'json'], { json: true })
+    ? gh(['project', 'field-list', projectNumber, '--owner', owner, '--format', 'json'], { json: true })
     : fields;
   const ok = validateIssueTypeLabels(finalLabels).ok && validateProjectFields(finalFields).ok;
   console.log(ok ? '[dcness-project] bootstrap PASS' : '[dcness-project] bootstrap FAIL');
@@ -565,34 +657,91 @@ function commandBootstrap(args) {
 }
 
 function projectContext(args) {
-  const repo = detectRepo(args.repo);
-  const owner = repoOwner(repo, args.owner);
-  if (!args.project) throw new Error('--project <number> is required.');
-  const project = gh(['project', 'view', args.project, '--owner', owner, '--format', 'json'], { json: true });
-  const fields = gh(['project', 'field-list', args.project, '--owner', owner, '--format', 'json'], { json: true });
-  return { repo, owner, project, fields };
+  const { repo, owner, project: projectNumber } = resolveProjectCoordinates(args, { requireProject: true });
+  const project = gh(['project', 'view', projectNumber, '--owner', owner, '--format', 'json'], { json: true });
+  const fields = gh(['project', 'field-list', projectNumber, '--owner', owner, '--format', 'json'], { json: true });
+  return { repo, owner, projectNumber, project, fields };
 }
 
 function getIssue(repo, issueNumber) {
   return gh(['issue', 'view', String(issueNumber), '--repo', repo, '--json', 'number,labels,url'], { json: true });
 }
 
-function getProjectItem({ owner, projectNumber, repo, issueNumber }) {
-  const items = gh(
+function getProjectItems({ owner, projectNumber }) {
+  return gh(
     ['project', 'item-list', String(projectNumber), '--owner', owner, '--format', 'json', '--limit', '1000'],
     { json: true },
   );
+}
+
+function getProjectItem({ owner, projectNumber, repo, issueNumber }) {
+  const items = getProjectItems({ owner, projectNumber });
   return findProjectItem(items, { repo, number: issueNumber });
+}
+
+function formatBoardEntry(entry) {
+  const ref = entry.number ? `#${entry.number}` : '<no-issue-number>';
+  const meta = [entry.issueType, entry.priority].filter(Boolean).join(', ');
+  const metaText = meta ? ` (${meta})` : '';
+  const repoText = entry.repo ? ` [${entry.repo}]` : '';
+  const urlText = entry.url ? ` ${entry.url}` : '';
+  return `- ${ref}${repoText} ${entry.title}${metaText}${urlText}`;
+}
+
+function formatBoardSection(title, entries, { limit = null, emptyText = '없음' } = {}) {
+  const visible = limit ? entries.slice(0, limit) : entries;
+  const lines = [`## ${title}`];
+  if (visible.length === 0) {
+    lines.push(`- ${emptyText}`);
+  } else {
+    lines.push(...visible.map(formatBoardEntry));
+  }
+  if (limit && entries.length > limit) {
+    lines.push(`- 외 ${entries.length - limit}건`);
+  }
+  return lines.join('\n');
+}
+
+function formatNextReport({ repo, owner, projectNumber, summary, todoLimit }) {
+  return [
+    `[dcness-next] Project #${projectNumber} (owner=${owner}, repo=${repo})`,
+    '[dcness-next] read-only: Project/issue 상태를 변경하지 않았습니다.',
+    '',
+    formatBoardSection('In progress', summary.inProgress),
+    '',
+    formatBoardSection('Next Todo', summary.todo, {
+      limit: todoLimit,
+      emptyText: 'Todo 후보 없음',
+    }),
+    '',
+    `[dcness-next] Done: ${summary.done.length}건`,
+  ].join('\n');
+}
+
+function commandNext(args) {
+  const { repo, owner, project: projectNumber } = resolveProjectCoordinates(args);
+  if (!projectNumber) {
+    console.log('[dcness-next] 보드 미설정 — /init-dcness bootstrap 으로 GitHub Project 좌표를 저장한 뒤 다시 실행하세요.');
+    console.log('[dcness-next] read-only: 외부 상태 변경 없음.');
+    return 0;
+  }
+  const todoLimit = Number.isInteger(Number(args.limit)) && Number(args.limit) > 0
+    ? Number(args.limit)
+    : 5;
+  const items = getProjectItems({ owner, projectNumber });
+  const summary = summarizeBoard(items);
+  console.log(formatNextReport({ repo, owner, projectNumber, summary, todoLimit }));
+  return 0;
 }
 
 function commandValidateIssue(args) {
   if (!args.issue) throw new Error('--issue <number> is required.');
-  const { repo, owner } = projectContext(args);
+  const { repo, owner, projectNumber } = projectContext(args);
   const issue = getIssue(repo, args.issue);
-  const item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: args.issue });
+  const item = getProjectItem({ owner, projectNumber, repo, issueNumber: args.issue });
 
   if (!item) {
-    console.error(`issue #${args.issue}: Project item missing in Project ${args.project}.`);
+    console.error(`issue #${args.issue}: Project item missing in Project ${projectNumber}.`);
     return 1;
   }
 
@@ -613,10 +762,10 @@ function commandValidateIssue(args) {
 
 function commandStartWork(args) {
   if (!args.issue) throw new Error('--issue <number> is required.');
-  const { repo, owner, project, fields } = projectContext(args);
-  const item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: args.issue });
+  const { repo, owner, projectNumber, project, fields } = projectContext(args);
+  const item = getProjectItem({ owner, projectNumber, repo, issueNumber: args.issue });
   if (!item?.id) {
-    console.error(`issue #${args.issue}: Project item missing in Project ${args.project}.`);
+    console.error(`issue #${args.issue}: Project item missing in Project ${projectNumber}.`);
     return 1;
   }
   if (!args.apply) {
@@ -643,7 +792,7 @@ function commandStartWork(args) {
 function commandRegisterIssue(args) {
   if (!args.issue) throw new Error('--issue <number> is required.');
   if (!args['issue-type']) throw new Error('--issue-type <epic|story|...> is required.');
-  const { repo, owner, project, fields } = projectContext(args);
+  const { repo, owner, projectNumber, project, fields } = projectContext(args);
   const issueType = args['issue-type'];
   const expectedStatus = args.status ?? 'Todo';
   const expectedPriority = args.priority ?? 'major';
@@ -651,7 +800,7 @@ function commandRegisterIssue(args) {
   const preserveExisting = Boolean(args['preserve-existing']);
   const issue = getIssue(repo, args.issue);
 
-  let item = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: issue.number });
+  let item = getProjectItem({ owner, projectNumber, repo, issueNumber: issue.number });
   // 검증 완화는 *필드 단위* + *apply 전 원본 item* 기준 — 원래 값이 있던 필드만 보존('any'),
   // 원래 비어있던 필드는 strict 로 두어 채우기 실패/부분 백필을 잡는다. IssueType 은 항상 strict.
   const { validateStatus, validatePriority } = resolveValidationExpectations({
@@ -662,7 +811,7 @@ function commandRegisterIssue(args) {
 
   if (!args.apply) {
     if (!item) {
-      console.log(`issue #${issue.number}: missing in Project ${args.project} (needs item-add).`);
+      console.log(`issue #${issue.number}: missing in Project ${projectNumber} (needs item-add).`);
     }
     const validation = validateIssueProjectRegistration({
       repo,
@@ -681,7 +830,7 @@ function commandRegisterIssue(args) {
 
   if (plan.needsAdd) {
     item = gh(
-      ['project', 'item-add', String(args.project), '--owner', owner, '--url', issue.url, '--format', 'json'],
+      ['project', 'item-add', String(projectNumber), '--owner', owner, '--url', issue.url, '--format', 'json'],
       { json: true },
     );
   }
@@ -698,7 +847,7 @@ function commandRegisterIssue(args) {
     });
   }
 
-  const verifyItem = getProjectItem({ owner, projectNumber: args.project, repo, issueNumber: issue.number }) ?? item;
+  const verifyItem = getProjectItem({ owner, projectNumber, repo, issueNumber: issue.number }) ?? item;
   const validation = validateIssueProjectRegistration({
     repo,
     issueNumber: issue.number,
@@ -747,20 +896,20 @@ function commandPrMerged(args) {
     console.log('[dcness-project] no completion issue candidates. Part of #N is not a Done signal.');
     return 0;
   }
-  const { repo, owner, project, fields } = projectContext(args);
+  const { repo, owner, projectNumber, project, fields } = projectContext(args);
   const resolvedRefs = resolveCompletionRefsForProject(body, args.repo, repo);
 
   let failures = 0;
   for (const ref of resolvedRefs) {
     const item = getProjectItem({
       owner,
-      projectNumber: args.project,
+      projectNumber,
       repo: ref.repo,
       issueNumber: ref.number,
     });
     if (!item?.id) {
       failures += 1;
-      console.error(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Project item missing in Project ${args.project}.`);
+      console.error(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Project item missing in Project ${projectNumber}.`);
       continue;
     }
     const actual = projectItemFieldValue(item, 'Status');
@@ -793,6 +942,7 @@ function commandPrMerged(args) {
 function help() {
   console.log(`Usage:
   node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project N [--apply]
+  node scripts/github_project_lifecycle.mjs next [--repo OWNER/REPO] [--owner OWNER] [--project N] [--limit N]
   node scripts/github_project_lifecycle.mjs validate-issue --repo OWNER/REPO --owner OWNER --project N --issue N [--expected-status Todo|In progress|Done|any] [--expected-issue-type TYPE] [--expected-priority PRIORITY]
   node scripts/github_project_lifecycle.mjs start-work --repo OWNER/REPO --owner OWNER --project N --issue N [--apply]
   node scripts/github_project_lifecycle.mjs register-issue --repo OWNER/REPO --owner OWNER --project N --issue N --issue-type epic|story|... [--status Todo] [--priority major] [--preserve-existing] [--apply]
@@ -810,6 +960,8 @@ function main() {
   switch (command) {
     case 'bootstrap':
       return commandBootstrap(args);
+    case 'next':
+      return commandNext(args);
     case 'validate-issue':
       return commandValidateIssue(args);
     case 'start-work':

--- a/skills/spec/templates/index.md
+++ b/skills/spec/templates/index.md
@@ -20,6 +20,12 @@
 |---|---|---|---|---|---|---|
 |  |  |  |  |  |  |  |
 
+## 진행 상태 · 다음 작업
+
+- 진행 상태 진본: GitHub Project 보드의 Status(Todo / In progress / Done)
+- 작업 단위: GitHub epic/story issue 와 PR
+- 콜드스타트 다음 작업 확인: `/next`
+
 ## 작업 영역
 
 - 휘발 evidence / handoff: `.dcness-work/`

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -359,6 +359,106 @@ class GithubProjectLifecycleScriptTests(unittest.TestCase):
             result,
         )
 
+    def test_project_coordinate_resolution_uses_flag_env_variable_default_order(self) -> None:
+        result = run_node(
+            "lifecycle.resolveProjectCoordinatesFromSources({"
+            "repo: 'Daeguk-Sun/dcNess',"
+            "ownerArg: 'flag-owner',"
+            "projectArg: '9',"
+            "env: {DCNESS_PROJECT_NUMBER: '8', DCNESS_PROJECT_OWNER: 'env-owner'},"
+            "variables: {DCNESS_PROJECT_NUMBER: '7', DCNESS_PROJECT_OWNER: 'var-owner'}"
+            "})"
+        )
+
+        self.assertEqual(
+            {"repo": "Daeguk-Sun/dcNess", "owner": "flag-owner", "project": "9"},
+            result,
+        )
+
+    def test_project_coordinate_resolution_falls_back_to_env_variable_repo_owner(self) -> None:
+        result = run_node(
+            "lifecycle.resolveProjectCoordinatesFromSources({"
+            "repo: 'Daeguk-Sun/dcNess',"
+            "env: {DCNESS_PROJECT_NUMBER: '8'},"
+            "variables: {DCNESS_PROJECT_NUMBER: '7'}"
+            "})"
+        )
+
+        self.assertEqual(
+            {"repo": "Daeguk-Sun/dcNess", "owner": "Daeguk-Sun", "project": "8"},
+            result,
+        )
+
+    def test_project_coordinate_resolution_uses_repo_variable_when_env_missing(self) -> None:
+        result = run_node(
+            "lifecycle.resolveProjectCoordinatesFromSources({"
+            "repo: 'Daeguk-Sun/dcNess',"
+            "env: {},"
+            "variables: {DCNESS_PROJECT_NUMBER: '7', DCNESS_PROJECT_OWNER: 'var-owner'}"
+            "})"
+        )
+
+        self.assertEqual(
+            {"repo": "Daeguk-Sun/dcNess", "owner": "var-owner", "project": "7"},
+            result,
+        )
+
+    def test_project_coordinate_resolution_allows_missing_project_for_readonly_next(self) -> None:
+        result = run_node(
+            "lifecycle.resolveProjectCoordinatesFromSources({"
+            "repo: 'Daeguk-Sun/dcNess',"
+            "env: {},"
+            "variables: {}"
+            "})"
+        )
+
+        self.assertEqual(
+            {"repo": "Daeguk-Sun/dcNess", "owner": "Daeguk-Sun", "project": None},
+            result,
+        )
+
+    def test_summarize_board_groups_in_progress_todo_done_items(self) -> None:
+        items = {
+            "items": [
+                {
+                    "content": {
+                        "number": 824,
+                        "title": "Next entrypoint",
+                        "repository": "Daeguk-Sun/dcNess",
+                        "url": "https://github.com/Daeguk-Sun/dcNess/issues/824",
+                    },
+                    "status": "In progress",
+                    "issueType": "feature",
+                    "priority": "major",
+                },
+                {
+                    "content": {"number": 825, "title": "Todo candidate"},
+                    "fieldValues": [
+                        {"field": {"name": "Status"}, "name": "Todo"},
+                        {"field": {"name": "IssueType"}, "name": "story"},
+                    ],
+                },
+                {
+                    "content": {"number": 700, "title": "Done item"},
+                    "status": "Done",
+                },
+            ]
+        }
+
+        result = run_node(f"lifecycle.summarizeBoard({json.dumps(items)})")
+
+        self.assertEqual([824], [item["number"] for item in result["inProgress"]])
+        self.assertEqual([825], [item["number"] for item in result["todo"]])
+        self.assertEqual([700], [item["number"] for item in result["done"]])
+        self.assertEqual("feature", result["inProgress"][0]["issueType"])
+
+    def test_gh_calls_use_large_output_buffer_for_big_project_boards(self) -> None:
+        self.assertGreaterEqual(
+            run_node("({maxBuffer: lifecycle.GH_MAX_BUFFER_BYTES})")["maxBuffer"],
+            64 * 1024 * 1024,
+        )
+        self.assertIn("maxBuffer: GH_MAX_BUFFER_BYTES", SCRIPT.read_text())
+
     def test_registration_validation_requires_todo_status(self) -> None:
         item = {
             "status": "In progress",

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -147,8 +147,8 @@ class BashPipelineSmokeTests(unittest.TestCase):
 
     def test_session_start_inject_is_slim(self) -> None:
         """#596 — additionalContext 는 최소 활성 안내 (활성 토큰 + 코드 강제 gate
-        + hook-first recovery) 만 담고, 문서 진입 매트릭스 / docs preload 지시는
-        담지 않는다.
+        + hook-first recovery + next-work pointer) 만 담고, 문서 진입 매트릭스 /
+        docs preload 지시는 담지 않는다.
 
         하네스 모델 = "문서 선독 기반 compliance" 가 아니라 "hook 차단 → 그 자리 복구".
         따라서 SessionStart 가 docs 통독을 지시하면 회귀 (본 테스트가 차단)."""
@@ -173,6 +173,8 @@ class BashPipelineSmokeTests(unittest.TestCase):
         self.assertIn("file-guard", ctx)
         self.assertIn("tdd-guard", ctx)
         self.assertIn("stop-end-run", ctx)
+        self.assertIn("docs/index.md", ctx)
+        self.assertIn("/next", ctx)
 
         # 제거: 문서 진입 매트릭스 / docs preload 지시 / soft 필수·안티패턴 본문
         for forbidden in (


### PR DESCRIPTION
## 관련 이슈 번호

Closes #824

## 배경 및 문제

콜드스타트 세션이 다음 작업을 찾을 때 in-repo 기준점이 약했다. 진행상태 진본은 GitHub Project Status 이지만 기존 공개 진입점은 이를 읽는 read-only 경로가 없었고, `docs/index.md` 도 live 상태가 어디에 있는지 가리키지 않았다.

또한 같은 Project lifecycle 조회 경로가 큰 보드에서 `gh project item-list --limit 1000` 출력 버퍼 한계로 `ENOBUFS` 를 낼 수 있어 `/next` 와 기존 register/validate/status 전이 경로가 같은 실패를 공유할 위험이 있었다.

## 원인 (해당 시)

- read-only 상태 조회 공개 command 부재
- Project 좌표 fallback 은 문서화되어 있었지만 `github_project_lifecycle.mjs` 의 공통 context 경로는 `--project` flag 를 직접 요구
- Node `execFileSync` 기본 `maxBuffer` 로 큰 Project item-list 출력 처리

## 작업내용

- `commands/next.md` 추가: GitHub Project 보드의 `In progress` 와 다음 `Todo` 후보를 read-only 로 조회
- `scripts/github_project_lifecycle.mjs` 갱신: 좌표 해석 fallback(flag -> env -> repo variable -> repo owner), 64MB `gh` 출력 버퍼, `summarizeBoard()` 및 `next` subcommand 추가
- `skills/spec/templates/index.md` 에 `## 진행 상태 · 다음 작업` 포인터 추가
- SessionStart 안내에 프로젝트 상태/다음 작업 질문 시 `docs/index.md` 포인터와 `/next` 를 사용하도록 조건부 안내 추가
- README / positioning / issue-lifecycle / deliverables-map / hooks / init-dcness 안내와 public-surface gate 갱신
- lifecycle 및 SessionStart 회귀 테스트 추가

## 결정 근거

`/status` 는 Claude Code 내장 명령과 충돌 가능성이 있어 `/next` 로 둔다. live Project 상태는 외부 runtime 상태라 CI 게이트로 강제하지 않고 read-time utility 로 조회한다. `docs/index.md` 는 live 상태를 복제하지 않고 GitHub Project, issue, `/next` 를 가리키는 정적 포인터만 가진다.

## 배포 경로 검증 (plug-in 영향 시)

- 경로1 plug-in 본체: `commands/next.md`, `scripts/github_project_lifecycle.mjs`, `hooks/session-start.sh`, `commands/init-dcness.md` 는 plug-in update 로 사용자 환경에 도달한다.
- 경로2 init-dcness 복사물: `skills/spec/templates/index.md` 는 `/init-dcness` 가 새 프로젝트 또는 `docs/index.md` 부재 프로젝트에 `docs/index.md` 로 시드한다. 기존 활성 프로젝트는 기존 `docs/index.md` 를 overwrite 하지 않으므로 `## 진행 상태 · 다음 작업` 섹션을 수동 반영해야 한다.
- 경로3 SSOT 문서: `docs/plugin/positioning.md`, `docs/plugin/issue-lifecycle.md`, `docs/plugin/deliverables-map.md`, `docs/plugin/hooks.md`, `README.md` 에 공개 surface/동작 계약을 반영했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

- 기존 risk router lane 으로 흡수 불가: `/spec`, `/design`, `/impl`, `/acceptance` 는 행위 workflow 이고 live 보드 상태를 읽어 cold-start 시작점을 알려주는 read-only 조회가 아니다.
- 기존 validator/reviewer 로 검증 불가: 검증 대상 구현 산출물이 아니라 GitHub Project runtime 상태 요약이다.
- 새 public 발화 필요: 콜드세션에서 사용자가 “다음 작업”을 물을 때 외울 단일 read-only 명령이 필요하다. 내부 로직은 기존 lifecycle script 를 재사용하고 새 agent/gate 는 추가하지 않는다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node --check scripts/github_project_lifecycle.mjs`
- [x] `node scripts/github_project_lifecycle.mjs next --repo Daeguk-Sun/dcNess --owner Daeguk-Sun --project 3 --limit 3`
- [x] `env -u DCNESS_PROJECT_NUMBER -u DCNESS_PROJECT_OWNER node scripts/github_project_lifecycle.mjs next --repo definitely-not-a-real-owner/definitely-not-a-real-repo`
- [x] git pre-commit hook pytest gate PASS during commit

## 참고

- Issue #824