### PR TITLE
[issue-832] 설계 산출물 계약 감사 추가

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -12,6 +12,8 @@
 # - scripts/check_git_naming.mjs / docs/plugin/git-spec.md 변경 시 (test_git_naming 게이트 회귀 차단)
 # - scripts/check_doc_path_integrity.mjs / .github/actions/doc-path-integrity 변경 시
 #   (test_doc_path_integrity 게이트 회귀 차단)
+# - scripts/check_design_artifact_structure.mjs 변경 시
+#   (test_design_artifact_audit 게이트 회귀 차단)
 # - docs/plugin/loop-procedure.md 변경 시 (test_loop_procedure_base_ref base-ref 회귀 차단)
 # - paths 필터로 docs-only PR 에서 불필요 실행 회피
 # - DCN-CHG-20260501-06: branch protection 폐기 후 paths 필터 복구
@@ -34,6 +36,7 @@ on:
       - 'evals/**'
       - 'scripts/check_git_naming.mjs'
       - 'scripts/check_doc_path_integrity.mjs'
+      - 'scripts/check_design_artifact_structure.mjs'
       - '.github/actions/doc-path-integrity/**'
       - 'docs/plugin/git-spec.md'
       - 'docs/plugin/loop-procedure.md'
@@ -50,6 +53,7 @@ on:
       - 'evals/**'
       - 'scripts/check_git_naming.mjs'
       - 'scripts/check_doc_path_integrity.mjs'
+      - 'scripts/check_design_artifact_structure.mjs'
       - '.github/actions/doc-path-integrity/**'
       - 'docs/plugin/git-spec.md'
       - 'docs/plugin/loop-procedure.md'

--- a/scripts/check_design_artifact_structure.mjs
+++ b/scripts/check_design_artifact_structure.mjs
@@ -1,0 +1,668 @@
+#!/usr/bin/env node
+/**
+ * Audit generated `/design` artifacts for contract-ledger pointer semantics.
+ *
+ * This is intentionally read-only. It verifies that new impl/compact artifacts
+ * refer to Contract Ledger row keys instead of copying ledger detail tables, and
+ * it provides a deterministic cold-session lookup for a requested contract key.
+ *
+ * Usage:
+ *   node scripts/check_design_artifact_structure.mjs --root /path/to/project
+ *   node scripts/check_design_artifact_structure.mjs --json --contract AuthSession
+ */
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from 'node:fs';
+import { join, relative, resolve, sep } from 'node:path';
+
+const DESIGN_PACK_LINE_TARGET = 1500;
+const DESIGN_PACK_LINE_HARD_WARNING = 2000;
+const LEGACY_CONTRACT_DETAIL_COLUMNS = new Set([
+  'invariant',
+  'ordering',
+  'error mode',
+  'config',
+  'forbidden alternative',
+]);
+
+function usage() {
+  return [
+    'Usage: node scripts/check_design_artifact_structure.mjs [--root <path>] [--json] [--contract <rowKey>]',
+    '',
+    'Audits docs/epics/* design artifacts for Contract Ledger row-key pointers.',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const args = {
+    root: process.cwd(),
+    json: false,
+    contract: '',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--root') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--root requires a path');
+      args.root = value;
+      i += 1;
+    } else if (arg === '--json') {
+      args.json = true;
+    } else if (arg === '--contract') {
+      const value = argv[i + 1];
+      if (!value) throw new Error('--contract requires a Contract Ledger row key');
+      args.contract = value;
+      i += 1;
+    } else if (arg === '-h' || arg === '--help') {
+      console.log(usage());
+      process.exit(0);
+    } else {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+  }
+
+  args.root = resolve(args.root);
+  return args;
+}
+
+function slash(path) {
+  return path.split(sep).join('/');
+}
+
+function rel(root, path) {
+  return slash(relative(root, path));
+}
+
+function readText(path) {
+  return readFileSync(path, 'utf8');
+}
+
+function isBlankish(value) {
+  const text = String(value ?? '').trim();
+  return text === '' || text === '-' || text === '—';
+}
+
+function splitTableLine(line) {
+  const trimmed = line.trim();
+  const withoutEdges = trimmed.replace(/^\|/, '').replace(/\|$/, '');
+  return withoutEdges.split('|').map((cell) => cell.trim());
+}
+
+function isSeparatorRow(cells) {
+  return cells.every((cell) => /^:?-{3,}:?$/.test(cell.trim()));
+}
+
+function extractSection(content, heading) {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = content.match(new RegExp(`^##\\s+${escaped}\\s*$`, 'm'));
+  if (!match || match.index === undefined) return '';
+
+  const start = match.index + match[0].length;
+  const rest = content.slice(start);
+  const next = rest.search(/\n##\s+/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+function parseMarkdownTable(section) {
+  const tables = parseMarkdownTables(section);
+  return tables[0]?.rows ?? [];
+}
+
+function parseMarkdownTables(content) {
+  const lines = content.split(/\r?\n/);
+  const tables = [];
+
+  for (let i = 0; i < lines.length - 1; i += 1) {
+    const current = lines[i].trim();
+    const next = lines[i + 1].trim();
+    if (!current.startsWith('|') || !next.startsWith('|')) continue;
+
+    const separatorCells = splitTableLine(next);
+    if (!isSeparatorRow(separatorCells)) continue;
+
+    const header = splitTableLine(current);
+    const rows = [];
+    let cursor = i + 2;
+    for (; cursor < lines.length; cursor += 1) {
+      const line = lines[cursor].trim();
+      if (!line.startsWith('|')) break;
+      const cells = splitTableLine(line);
+      if (cells.every(isBlankish)) continue;
+
+      const row = {};
+      for (let c = 0; c < header.length; c += 1) {
+        row[header[c]] = cells[c] ?? '';
+      }
+      rows.push(row);
+    }
+
+    tables.push({ header, rows });
+    i = Math.max(i, cursor - 1);
+  }
+
+  return tables;
+}
+
+function normalizeHeader(value) {
+  return String(value ?? '')
+    .replace(/[`*_]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function pick(row, names) {
+  const lowerNames = new Set(names.map((name) => name.toLowerCase()));
+  for (const [key, value] of Object.entries(row)) {
+    if (names.includes(key) || lowerNames.has(key.toLowerCase())) {
+      return value;
+    }
+  }
+  return '';
+}
+
+function isContractDetailTable(table) {
+  const headers = new Set(table.header.map(normalizeHeader));
+  if (!headers.has('contract')) return false;
+  for (const column of LEGACY_CONTRACT_DETAIL_COLUMNS) {
+    if (headers.has(column)) return true;
+  }
+  return false;
+}
+
+function containsContractDetailTable(content) {
+  return parseMarkdownTables(content).some(isContractDetailTable);
+}
+
+function hasContractReferencesSection(content) {
+  return /^##\s+Contract References\s*$/m.test(content);
+}
+
+function extractFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  return match?.[1] ?? '';
+}
+
+function cleanKeyToken(value) {
+  return String(value ?? '')
+    .replace(/#.*/, '')
+    .replace(/^[\s"'`]+|[\s"',`]+$/g, '')
+    .trim();
+}
+
+function isEmptyKey(value) {
+  const text = cleanKeyToken(value).toLowerCase();
+  return text === '' || text === '-' || text === '—' || text === 'none' || text === 'n/a' || text === '[]';
+}
+
+function parseScalarList(value) {
+  const text = String(value ?? '').trim();
+  if (isEmptyKey(text)) return [];
+  if (text.startsWith('[') && text.endsWith(']')) {
+    return text
+      .slice(1, -1)
+      .split(',')
+      .map(cleanKeyToken)
+      .filter((item) => !isEmptyKey(item));
+  }
+  return text
+    .split(',')
+    .map(cleanKeyToken)
+    .filter((item) => !isEmptyKey(item));
+}
+
+function extractContractKeysFromFrontmatter(content) {
+  const frontmatter = extractFrontmatter(content);
+  if (!frontmatter) return [];
+
+  const keys = new Set();
+  const lines = frontmatter.split(/\r?\n/);
+  let inContract = false;
+  let contractIndent = 0;
+  let activeList = false;
+
+  for (const line of lines) {
+    const indent = line.match(/^\s*/)?.[0].length ?? 0;
+    if (/^\s*contract\s*:\s*$/.test(line)) {
+      inContract = true;
+      contractIndent = indent;
+      activeList = false;
+      continue;
+    }
+
+    if (!inContract) continue;
+    if (line.trim() && indent <= contractIndent) break;
+
+    const field = line.match(/^\s*(produces|consumes)\s*:\s*(.*)$/);
+    if (field) {
+      activeList = field[2].trim() === '';
+      for (const key of parseScalarList(field[2])) keys.add(key);
+      continue;
+    }
+
+    const item = line.match(/^\s*-\s*(.+)$/);
+    if (activeList && item) {
+      for (const key of parseScalarList(item[1])) keys.add(key);
+    } else if (line.trim()) {
+      activeList = false;
+    }
+  }
+
+  return Array.from(keys);
+}
+
+function extractContractKeysFromReferences(content) {
+  const section = extractSection(content, 'Contract References');
+  if (!section) return [];
+
+  const keys = new Set();
+  for (const row of parseMarkdownTable(section)) {
+    const key = pick(row, [
+      'Ledger row key',
+      'ledger row key',
+      'Contract Ledger row key',
+      'contract',
+      'Contract',
+    ]);
+    for (const value of parseScalarList(key)) keys.add(value);
+  }
+
+  if (keys.size === 0) {
+    for (const line of section.split(/\r?\n/)) {
+      const item = line.match(/^\s*[-*]\s*(?:produces|consumes)?\s*:?\s*(.+)$/i);
+      if (!item) continue;
+      for (const key of parseScalarList(item[1])) keys.add(key);
+    }
+  }
+
+  return Array.from(keys);
+}
+
+function countLines(path) {
+  if (!existsSync(path)) return 0;
+  const content = readText(path);
+  if (content === '') return 0;
+  return content.split(/\r?\n/).length;
+}
+
+function listMarkdownFiles(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => join(dir, entry.name))
+    .sort();
+}
+
+function parseEpic(root, epicDirName) {
+  const epicDir = join(root, 'docs', 'epics', epicDirName);
+  const architecturePath = join(epicDir, 'architecture.md');
+  const content = readText(architecturePath);
+  const contractRows = parseMarkdownTable(extractSection(content, 'Contract Ledger'))
+    .map((row) => ({
+      contract: pick(row, ['contract', 'Contract']),
+      owner: pick(row, ['owner', 'Owner']),
+      producer: pick(row, ['producer', 'Producer']),
+      consumer: pick(row, ['consumer', 'Consumer']),
+      invariant: pick(row, ['invariant', 'Invariant']),
+      refs: pick(row, ['refs', 'Refs']),
+    }))
+    .filter((row) => !isBlankish(row.contract));
+
+  const implPaths = listMarkdownFiles(join(epicDir, 'impl'));
+  const designPackPaths = [
+    join(epicDir, 'stories.md'),
+    architecturePath,
+    join(epicDir, 'domain-model.md'),
+    join(epicDir, 'ux-flow.md'),
+    join(epicDir, 'tech-review.md'),
+    ...implPaths,
+  ];
+  const designPackLineCount = designPackPaths.reduce(
+    (total, path) => total + countLines(path),
+    0
+  );
+
+  return {
+    name: epicDirName,
+    dir: epicDir,
+    architecturePath,
+    contractRows,
+    implPaths,
+    designPackLineCount,
+  };
+}
+
+function collectEpics(root) {
+  const epicsRoot = join(root, 'docs', 'epics');
+  if (!existsSync(epicsRoot)) return [];
+
+  return readdirSync(epicsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => /^epic-\d+-[a-z0-9][a-z0-9_-]*$/.test(name))
+    .filter((name) => existsSync(join(epicsRoot, name, 'architecture.md')))
+    .sort()
+    .map((name) => parseEpic(root, name));
+}
+
+function collectCompactPlanPaths(root) {
+  const compactPlanRoot = join(root, 'docs', 'compact-plans');
+  if (!existsSync(compactPlanRoot)) return [];
+  return readdirSync(compactPlanRoot, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.md'))
+    .map((entry) => join(compactPlanRoot, entry.name))
+    .sort();
+}
+
+function makeProblem(code, file, message, extra = {}) {
+  return {
+    code,
+    file,
+    message,
+    ...extra,
+  };
+}
+
+function auditArtifact({ root, path, epicName, ledgerKeys, globalLedgerKeys, violations, warnings }) {
+  const content = readText(path);
+  const frontmatterKeys = extractContractKeysFromFrontmatter(content);
+  const referenceKeys = extractContractKeysFromReferences(content);
+  const referencedKeys = Array.from(new Set([...frontmatterKeys, ...referenceKeys])).sort();
+  const hasPointerMetadata = hasContractReferencesSection(content) || frontmatterKeys.length > 0;
+  const hasDetailTable = containsContractDetailTable(content);
+  const relativePath = rel(root, path);
+
+  if (hasPointerMetadata && hasDetailTable) {
+    violations.push(
+      makeProblem(
+        'contract-detail-copy',
+        relativePath,
+        'new pointer-style artifact must not copy Contract Ledger detail tables',
+        { epic: epicName }
+      )
+    );
+  } else if (!hasPointerMetadata && hasDetailTable) {
+    warnings.push(
+      makeProblem(
+        'legacy-contract-table',
+        relativePath,
+        'legacy contract detail table retained for backward compatibility',
+        { epic: epicName }
+      )
+    );
+  }
+
+  for (const key of referencedKeys) {
+    if (!globalLedgerKeys.has(key)) {
+      violations.push(
+        makeProblem(
+          'unknown-ledger-row-key',
+          relativePath,
+          `Contract Ledger row key is not defined: ${key}`,
+          { epic: epicName, contract: key }
+        )
+      );
+    } else if (epicName && !ledgerKeys.has(key)) {
+      warnings.push(
+        makeProblem(
+          'external-ledger-row-key',
+          relativePath,
+          `Contract Ledger row key is defined outside this epic: ${key}`,
+          { epic: epicName, contract: key }
+        )
+      );
+    }
+  }
+
+  return { path, epicName, referencedKeys };
+}
+
+function buildLedger(root, epics, violations) {
+  const entries = [];
+  const byKey = new Map();
+
+  for (const epic of epics) {
+    for (const row of epic.contractRows) {
+      const key = row.contract.trim();
+      const entry = {
+        contract: key,
+        epic: epic.name,
+        ledgerPath: epic.architecturePath,
+        row,
+      };
+      entries.push(entry);
+      if (!byKey.has(key)) byKey.set(key, []);
+      byKey.get(key).push(entry);
+    }
+  }
+
+  for (const [key, matches] of byKey.entries()) {
+    if (matches.length <= 1) continue;
+    violations.push(
+      makeProblem(
+        'duplicate-ledger-row-key',
+        rel(root, matches[0].ledgerPath),
+        `Contract Ledger row key is duplicated: ${key}`,
+        {
+          contract: key,
+          locations: matches.map((match) => rel(root, match.ledgerPath)),
+        }
+      )
+    );
+  }
+
+  return { entries, byKey, keys: new Set(byKey.keys()) };
+}
+
+function auditDesignPackBudgets(root, epics, warnings) {
+  for (const epic of epics) {
+    if (epic.designPackLineCount > DESIGN_PACK_LINE_TARGET) {
+      warnings.push(
+        makeProblem(
+          'design-pack-over-target',
+          rel(root, epic.dir),
+          `design pack line count exceeds ${DESIGN_PACK_LINE_TARGET}`,
+          {
+            epic: epic.name,
+            line_count: epic.designPackLineCount,
+            limit: DESIGN_PACK_LINE_TARGET,
+          }
+        )
+      );
+    }
+    if (epic.designPackLineCount > DESIGN_PACK_LINE_HARD_WARNING) {
+      warnings.push(
+        makeProblem(
+          'design-pack-over-hard-warning',
+          rel(root, epic.dir),
+          `design pack line count exceeds ${DESIGN_PACK_LINE_HARD_WARNING}`,
+          {
+            epic: epic.name,
+            line_count: epic.designPackLineCount,
+            limit: DESIGN_PACK_LINE_HARD_WARNING,
+          }
+        )
+      );
+    }
+  }
+}
+
+function buildRecovery({ root, contract, ledger, artifacts, violations, warnings }) {
+  const indexPath = join(root, 'docs', 'index.md');
+  if (!existsSync(indexPath)) {
+    violations.push(
+      makeProblem(
+        'cold-session-index-missing',
+        rel(root, indexPath),
+        'docs/index.md is required as the cold-session entrypoint',
+        { contract }
+      )
+    );
+    return null;
+  }
+
+  const matches = ledger.byKey.get(contract) ?? [];
+  if (matches.length === 0) {
+    violations.push(
+      makeProblem(
+        'contract-not-found',
+        rel(root, indexPath),
+        `Contract Ledger row key was not found: ${contract}`,
+        { contract }
+      )
+    );
+    return null;
+  }
+  if (matches.length > 1) {
+    violations.push(
+      makeProblem(
+        'contract-ambiguous',
+        rel(root, indexPath),
+        `Contract Ledger row key is ambiguous: ${contract}`,
+        { contract, locations: matches.map((match) => rel(root, match.ledgerPath)) }
+      )
+    );
+    return null;
+  }
+
+  const match = matches[0];
+  const indexContent = readText(indexPath);
+  if (!indexContent.includes(match.epic) && !indexContent.includes(`epics/${match.epic}`)) {
+    warnings.push(
+      makeProblem(
+        'cold-session-index-missing-epic-link',
+        rel(root, indexPath),
+        `docs/index.md does not visibly link the contract epic: ${match.epic}`,
+        { contract, epic: match.epic }
+      )
+    );
+  }
+
+  return {
+    contract,
+    index_path: rel(root, indexPath),
+    epic: match.epic,
+    ledger_path: rel(root, match.ledgerPath),
+    referencing_impl: artifacts
+      .filter((artifact) => artifact.referencedKeys.includes(contract))
+      .map((artifact) => rel(root, artifact.path))
+      .sort(),
+    validation_paths: [
+      'agents/architecture-validator/architecture-validator-agent.md',
+      'agents/module-architect/templates/impl-task.md',
+    ],
+  };
+}
+
+function audit(root, contract = '') {
+  const violations = [];
+  const warnings = [];
+  const epics = collectEpics(root);
+  const ledger = buildLedger(root, epics, violations);
+  const artifacts = [];
+
+  auditDesignPackBudgets(root, epics, warnings);
+
+  for (const epic of epics) {
+    const ledgerKeys = new Set(epic.contractRows.map((row) => row.contract.trim()));
+    for (const implPath of epic.implPaths) {
+      artifacts.push(
+        auditArtifact({
+          root,
+          path: implPath,
+          epicName: epic.name,
+          ledgerKeys,
+          globalLedgerKeys: ledger.keys,
+          violations,
+          warnings,
+        })
+      );
+    }
+  }
+
+  for (const compactPlanPath of collectCompactPlanPaths(root)) {
+    artifacts.push(
+      auditArtifact({
+        root,
+        path: compactPlanPath,
+        epicName: '',
+        ledgerKeys: ledger.keys,
+        globalLedgerKeys: ledger.keys,
+        violations,
+        warnings,
+      })
+    );
+  }
+
+  const recovery = contract
+    ? buildRecovery({ root, contract, ledger, artifacts, violations, warnings })
+    : null;
+
+  return {
+    ok: violations.length === 0,
+    root,
+    epics: epics.map((epic) => ({
+      name: epic.name,
+      ledger_path: rel(root, epic.architecturePath),
+      contract_count: epic.contractRows.length,
+      impl_count: epic.implPaths.length,
+      design_pack_line_count: epic.designPackLineCount,
+    })),
+    violations,
+    warnings,
+    recovery,
+  };
+}
+
+function renderProblem(problem) {
+  const target = problem.file ? `${problem.file}: ` : '';
+  return `${target}${problem.code} - ${problem.message}`;
+}
+
+function renderText(result) {
+  for (const warning of result.warnings) {
+    console.error(`[design-artifact] WARN ${renderProblem(warning)}`);
+  }
+
+  if (!result.ok) {
+    console.error(`[design-artifact] FAIL - ${result.violations.length} violation(s)`);
+    for (const violation of result.violations) {
+      console.error(`[design-artifact] ${renderProblem(violation)}`);
+    }
+    return;
+  }
+
+  const contractMessage = result.recovery
+    ? `, contract ${result.recovery.contract} -> ${result.recovery.ledger_path}`
+    : '';
+  console.log(
+    `[design-artifact] PASS - ${result.epics.length} epic(s), ${result.warnings.length} warning(s)${contractMessage}`
+  );
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!existsSync(args.root) || !statSync(args.root).isDirectory()) {
+    throw new Error(`--root is not a directory: ${args.root}`);
+  }
+
+  const result = audit(args.root, args.contract);
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    renderText(result);
+  }
+
+  process.exit(result.ok ? 0 : 1);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(`[design-artifact] ERROR ${error.message}`);
+  process.exit(2);
+}

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -4,7 +4,7 @@
 #
 # 동작:
 #   1. staged 파일 목록 추출 (git diff --cached --name-only)
-#   2. harness/ | tests/ | agents/ | skills/ | commands/ | templates/github-workflows/ | doc-path/doc-sync action/script | .github/workflows/python-tests.yml 매칭 시만 실행
+#   2. harness/ | tests/ | agents/ | skills/ | commands/ | templates/github-workflows/ | audited scripts | doc-path/doc-sync action/script | .github/workflows/python-tests.yml 매칭 시만 실행
 #   3. python3.11/python3 -m unittest discover -s tests
 #
 # 종료 코드:
@@ -26,7 +26,7 @@ if [ -z "$CHANGED" ]; then
   exit 0
 fi
 
-if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|skills/|commands/|templates/github-workflows/|evals/|\.github/actions/(doc-path-integrity|doc-sync)/|scripts/check_git_naming\.mjs$|scripts/check_doc_path_integrity\.mjs$|scripts/aggregate_(index|architecture)_map\.mjs$|docs/plugin/git-spec\.md$|docs/plugin/loop-procedure\.md$|\.github/workflows/python-tests\.yml$)'; then
+if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|skills/|commands/|templates/github-workflows/|evals/|\.github/actions/(doc-path-integrity|doc-sync)/|scripts/check_git_naming\.mjs$|scripts/check_doc_path_integrity\.mjs$|scripts/check_design_artifact_structure\.mjs$|scripts/aggregate_(index|architecture)_map\.mjs$|docs/plugin/git-spec\.md$|docs/plugin/loop-procedure\.md$|\.github/workflows/python-tests\.yml$)'; then
   # 미매칭 — skip
   exit 0
 fi

--- a/tests/test_design_artifact_audit.py
+++ b/tests/test_design_artifact_audit.py
@@ -1,0 +1,225 @@
+"""Regression tests for design artifact structure audit (#832)."""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check_design_artifact_structure.mjs"
+NODE = shutil.which("node")
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(textwrap.dedent(text).lstrip(), encoding="utf-8")
+
+
+def _run(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [NODE, str(SCRIPT), "--root", str(root), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _seed_project(root: Path, *, impl_body: str, architecture_extra: str = "") -> None:
+    _write(
+        root / "docs/index.md",
+        """
+        # Project Index
+
+        ## 에픽
+
+        | 에픽 | 마일스톤 | Stories | Architecture | Domain Model | UX Flow | Tech Review |
+        |---|---|---|---|---|---|---|
+        | [epic-01-alpha](epics/epic-01-alpha/) | v01 | [stories.md](epics/epic-01-alpha/stories.md) | [architecture.md](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | — | — |
+        """,
+    )
+    _write(root / "docs/architecture.md", "# Root Architecture\n")
+    _write(root / "docs/epics/epic-01-alpha/stories.md", "# Stories\n")
+    _write(root / "docs/epics/epic-01-alpha/domain-model.md", "# Domain\n")
+    _write(
+        root / "docs/epics/epic-01-alpha/architecture.md",
+        f"""
+        # Epic Architecture
+
+        ## Contract Ledger
+
+        | contract | owner | producer | consumer | invariant | ordering | error mode | config | forbidden alternative | refs |
+        |---|---|---|---|---|---|---|---|---|---|
+        | AuthSession | AuthCore | LoginForm | AuthCore | session id stable | login before refresh | reject | env | global mutable session | [ADR-0001](../../decisions/0001-auth.md) |
+        {architecture_extra}
+        """,
+    )
+    _write(root / "docs/epics/epic-01-alpha/impl/01-auth.md", impl_body)
+
+
+@unittest.skipUnless(NODE, "node not installed - design artifact audit is a node script")
+class DesignArtifactAuditTests(unittest.TestCase):
+    def test_pointer_artifacts_pass_and_recover_contract_from_index(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_project(
+                root,
+                impl_body="""
+                ---
+                contract:
+                  produces: [AuthSession]
+                  consumes: []
+                ---
+
+                # Auth task
+
+                ## Contract References
+
+                | kind | Ledger row key | action | note |
+                |---|---|---|---|
+                | produces | AuthSession | new | Ledger updated |
+                """,
+            )
+
+            proc = _run(root, "--json", "--contract", "AuthSession")
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["violations"], [])
+        self.assertEqual(payload["recovery"]["contract"], "AuthSession")
+        self.assertEqual(
+            payload["recovery"]["ledger_path"],
+            "docs/epics/epic-01-alpha/architecture.md",
+        )
+        self.assertIn(
+            "docs/epics/epic-01-alpha/impl/01-auth.md",
+            payload["recovery"]["referencing_impl"],
+        )
+
+    def test_new_pointer_artifact_fails_when_contract_detail_is_copied(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_project(
+                root,
+                impl_body="""
+                ---
+                contract:
+                  produces: [AuthSession]
+                  consumes: []
+                ---
+
+                # Auth task
+
+                ## Contract References
+
+                | kind | Ledger row key | action | note |
+                |---|---|---|---|
+                | produces | AuthSession | new | Ledger updated |
+
+                ## Contract
+
+                | contract | owner | producer | consumer | invariant | ordering | error mode | config | forbidden alternative |
+                |---|---|---|---|---|---|---|---|---|
+                | AuthSession | AuthCore | LoginForm | AuthCore | duplicated | duplicated | duplicated | duplicated | duplicated |
+                """,
+            )
+
+            proc = _run(root)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("contract-detail-copy", proc.stderr)
+        self.assertIn("01-auth.md", proc.stderr)
+
+    def test_unknown_ledger_row_key_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_project(
+                root,
+                impl_body="""
+                ---
+                contract:
+                  produces: [MissingContract]
+                  consumes: []
+                ---
+
+                # Auth task
+
+                ## Contract References
+
+                | kind | Ledger row key | action | note |
+                |---|---|---|---|
+                | produces | MissingContract | new | wrong key |
+                """,
+            )
+
+            proc = _run(root)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("unknown-ledger-row-key", proc.stderr)
+        self.assertIn("MissingContract", proc.stderr)
+
+    def test_legacy_contract_table_warns_but_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_project(
+                root,
+                impl_body="""
+                # Legacy task
+
+                ## Contract
+
+                | contract | owner | producer | consumer | invariant | ordering | error mode | config | forbidden alternative |
+                |---|---|---|---|---|---|---|---|---|
+                | AuthSession | AuthCore | LoginForm | AuthCore | old | old | old | old | old |
+                """,
+            )
+
+            proc = _run(root, "--json")
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["violations"], [])
+        self.assertEqual(payload["warnings"][0]["code"], "legacy-contract-table")
+
+    def test_budget_warning_reports_full_pack_over_target(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_project(
+                root,
+                impl_body="# Auth task\n\n## Contract References\n\n- none\n",
+            )
+            noisy_lines = "\n".join(f"- line {i}" for i in range(1510))
+            _write(root / "docs/epics/epic-01-alpha/stories.md", f"# Stories\n{noisy_lines}\n")
+
+            proc = _run(root, "--json")
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        payload = json.loads(proc.stdout)
+        self.assertTrue(payload["ok"])
+        self.assertTrue(
+            any(w["code"] == "design-pack-over-target" for w in payload["warnings"])
+        )
+
+    def test_contract_recovery_requires_index_entrypoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _seed_project(
+                root,
+                impl_body="# Auth task\n\n## Contract References\n\n- none\n",
+            )
+            (root / "docs/index.md").unlink()
+
+            proc = _run(root, "--contract", "AuthSession")
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("cold-session-index-missing", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `scripts/check_design_artifact_structure.mjs` for Contract Ledger row-key pointer audits on generated design artifacts.
- Cover copied contract detail failures, unknown row keys, legacy warning compatibility, design-pack line budget warnings, and cold-session contract recovery.
- Wire the new audit script into local python-test gate matching and the GitHub Actions path filter.

Part of #832

## Verification
- `node --check scripts/check_design_artifact_structure.mjs`
- `python3.11 -m unittest tests.test_design_artifact_audit tests.test_git_naming tests.test_doc_path_integrity -v`
- `python3.11 -m unittest discover -s tests -v` (1443 tests)
- `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- `node scripts/check_public_surface.mjs`
- `node scripts/check_plugin_manifest.mjs`
- `node scripts/check_cross_refs.mjs`
- `node scripts/aggregate_index_map.mjs --check`
- `node scripts/aggregate_architecture_map.mjs --check`
