### PR TITLE
[issue-847] architecture map 열 정렬 수정

### DIFF
--- a/scripts/aggregate_architecture_map.mjs
+++ b/scripts/aggregate_architecture_map.mjs
@@ -226,6 +226,13 @@ function collectEpics(root) {
 }
 
 function table(header, rows) {
+  const mismatchedRow = rows.find((row) => row.length !== header.length);
+  if (mismatchedRow) {
+    throw new Error(
+      `table row width mismatch: header has ${header.length} cells but row has ${mismatchedRow.length} cells`
+    );
+  }
+
   const lines = [
     `| ${header.join(' | ')} |`,
     `| ${header.map(() => '---').join(' | ')} |`,
@@ -240,7 +247,8 @@ function placeholderRow(width) {
 
 function buildSections(rootArchitecturePath, epics) {
   const epicMapRows = epics.map((epic) => [
-    mdLink(epic.name, rootArchitecturePath, epic.architecturePath),
+    mdLink(epic.name, rootArchitecturePath, dirname(epic.architecturePath)),
+    mdLink('architecture.md', rootArchitecturePath, epic.architecturePath),
     existsSync(epic.domainModelPath)
       ? mdLink('domain-model.md', rootArchitecturePath, epic.domainModelPath)
       : '-',

--- a/tests/test_architecture_map_aggregate.py
+++ b/tests/test_architecture_map_aggregate.py
@@ -28,6 +28,27 @@ def _run(root: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def _section(content: str, heading: str) -> str:
+    marker = f"## {heading}"
+    start = content.index(marker) + len(marker)
+    rest = content[start:]
+    next_heading = rest.find("\n## ")
+    return rest if next_heading == -1 else rest[:next_heading]
+
+
+def _table_cell_counts(section: str) -> list[int]:
+    counts: list[int] = []
+    for line in section.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = stripped.strip("|").split("|")
+        if all(set(cell.strip()) <= {"-", ":"} for cell in cells):
+            continue
+        counts.append(len(cells))
+    return counts
+
+
 @unittest.skipUnless(NODE, "node not installed — architecture map tool is a node script")
 class ArchitectureMapAggregateTests(unittest.TestCase):
     def test_generates_root_map_from_epic_architecture_tables(self) -> None:
@@ -66,8 +87,14 @@ class ArchitectureMapAggregateTests(unittest.TestCase):
 
             root_map = (project / "docs/architecture.md").read_text(encoding="utf-8")
             self.assertIn("## 에픽 간 지도", root_map)
+            epic_map_counts = _table_cell_counts(_section(root_map, "에픽 간 지도"))
+            self.assertGreaterEqual(len(epic_map_counts), 2)
+            self.assertTrue(
+                all(count == epic_map_counts[0] for count in epic_map_counts[1:]),
+                f"generated epic map row widths differ from header: {epic_map_counts}",
+            )
             self.assertIn(
-                "| [epic-01-alpha](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | AuthCore, TokenStore | [ADR-0001](decisions/0001-auth.md) |",
+                "| [epic-01-alpha](epics/epic-01-alpha) | [architecture.md](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | AuthCore, TokenStore | [ADR-0001](decisions/0001-auth.md) |",
                 root_map,
             )
             self.assertIn(
@@ -112,6 +139,51 @@ class ArchitectureMapAggregateTests(unittest.TestCase):
             check = _run(project, "--check")
             self.assertEqual(check.returncode, 1)
             self.assertIn("stale", check.stderr)
+
+    def test_rerun_corrects_legacy_four_cell_epic_map_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(
+                project / "docs/architecture.md",
+                """
+                # 전역 아키텍처 지도
+
+                ## 에픽 간 지도
+
+                <!-- dcness-architecture-map:generated -->
+                <!-- 수정하지 말고 plugin script `aggregate_architecture_map.mjs` 로 갱신한다. -->
+                | 에픽 | Architecture | Domain Model | 핵심 모듈 | 결정 |
+                |---|---|---|---|---|
+                | [epic-01-alpha](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | AuthCore | - |
+                """,
+            )
+            _write(project / "docs/epics/epic-01-alpha/domain-model.md", "# Domain\n")
+            _write(
+                project / "docs/epics/epic-01-alpha/architecture.md",
+                """
+                # Epic Architecture
+
+                ## 모듈 목록
+
+                | 모듈 | 책임 | 의존 모듈 | 공개 API | 테스트 단위 |
+                |---|---|---|---|---|
+                | AuthCore | login orchestration | - | `authenticate()` | auth contract |
+                """,
+            )
+
+            proc = _run(project)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            root_map = (project / "docs/architecture.md").read_text(encoding="utf-8")
+            epic_map_counts = _table_cell_counts(_section(root_map, "에픽 간 지도"))
+            self.assertTrue(
+                all(count == epic_map_counts[0] for count in epic_map_counts[1:]),
+                f"generated epic map row widths differ from header: {epic_map_counts}",
+            )
+            self.assertIn(
+                "| [epic-01-alpha](epics/epic-01-alpha) | [architecture.md](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | AuthCore | - |",
+                root_map,
+            )
 
     def test_preserves_manual_root_sections_while_updating_generated_sections(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 관련 이슈 번호
Closes #847

## 배경 및 문제
- `agents/system-architect/templates/root-architecture.md` 의 `## 에픽 간 지도` 헤더는 `에픽 / Architecture / Domain Model / 핵심 모듈 / 결정` 5열 계약이다.
- `scripts/aggregate_architecture_map.mjs` 는 이 섹션의 생성 행에서 Architecture 셀을 따로 만들지 않아 행당 4셀만 출력했다.
- 결과적으로 외부 활성 프로젝트가 전역 architecture map 을 재생성하면 self-consistent 하지만 markdown 표 구조가 깨진 파생 섹션이 생겼다.

## 원인 (해당 시)
- `buildSections()` 의 epic map row 생성이 에픽 이름 링크를 `architecture.md` 에 직접 연결했고, 별도 `Architecture` 열 값을 채우지 않았다.
- 기존 테스트는 출력 문자열 존재만 확인해 헤더 셀 수와 데이터 행 셀 수 불일치를 검출하지 못했다.

## 작업내용
- `에픽 간 지도` 생성 행을 `에픽` 디렉터리 링크와 `architecture.md` 링크로 분리해 5열 헤더 계약에 맞췄다.
- 공통 `table()` 생성 함수에 header/row width mismatch 가 있으면 즉시 실패하는 가드를 추가했다.
- 회귀 테스트에 generated table cell-count 검증과 기존 4셀 구표가 도구 1회 재실행으로 5셀 표로 교정되는 fixture 를 추가했다.

## 결정 근거
- 템플릿의 5열 계약을 유지하고 생성기를 맞추는 방식이 기존 사용자-facing 문서 계약과 가장 작게 정렬된다.
- `에픽` 셀은 `aggregate_index_map.mjs` 와 같은 디렉터리 링크 패턴을 쓰고, `Architecture` 셀은 명시적으로 `architecture.md` 를 가리키게 했다.
- row width mismatch guard 를 생성 함수에 둬서 같은 클래스의 silent corruption 이 다른 generated table 에 재발해도 즉시 실패한다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in script 경로: `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 변경. 활성 프로젝트는 plug-in 업데이트 후 동일 스크립트를 실행하거나 doc-sync 경로에서 실행될 때 교정된 `docs/architecture.md` generated 표를 받는다.
- `/init-dcness` 가 사용자 repo 로 복사하는 파일 변경은 없다. 기존 활성 프로젝트의 커밋된 구표는 `node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"` 1회 재실행으로 교정되는 테스트를 추가했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public surface 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_architecture_map_aggregate -v`
- [x] `python3.11 -m unittest discover -s tests -v` (1449 tests)
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `git diff --check`

## 참고
- `scripts/check.sh` 는 이 체크아웃에 없어 실행 대상에서 제외.