### PR TITLE
[issue-844] acceptance UI 목업 정합 검수 추가

### DIFF
--- a/agents/product-acceptance/product-acceptance-agent.md
+++ b/agents/product-acceptance/product-acceptance-agent.md
@@ -12,6 +12,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 검수 단위: spec / story / epic / release 식별자
 - 기준 문서: `docs/index.md`, `docs/prd.md`, `docs/decisions/`, `docs/epics/<epic>/stories.md`, epic architecture/impl 문서, issue 본문 중 호출자가 제공한 경로
 - 구현 증거: PR URL, 변경 파일 목록, 테스트 결과, smoke 결과, 정적 타입검사/compile 결과, 실데이터(non-mock) 통합 테스트, UI 자동화, 화면/API/CLI 동작 설명 중 호출자가 제공한 항목
+- UI 검수 증거: UI story/epic 이면 호출자가 제공한 확정 목업 경로(`docs/design-variants/<screen-id>.html`), canvas 경로, 핵심 `data-node-id` 매핑, 구현 화면 스크린샷 또는 동등한 화면 증거 경로
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제 제품 경계 실행 여부
 - 이전 acceptance 결과가 있으면 gap 재검수 맥락
 
@@ -35,6 +36,17 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - UI 자동화는 브라우저/앱 자동화, component interaction, screenshot/assertion, visual smoke 같은 증거를 포함한다. 사람의 수동 E2E만 요구하지 않는다.
 - mock/stub/fake 기반 unit test 는 보조 증거다. 핵심 AC가 mock-only green으로만 뒷받침되고 API/CLI/UI/통합 wiring/compile-time contract 중 어떤 실제 경계도 확인되지 않았으면 gap 이다.
 - TypeScript, typed Python, Rust, Go 처럼 정적 타입검사나 compile gate 가 의미 있는 stack 에서 typecheck/compile 증거가 전혀 없으면 품질 게이트 warning 으로 보고한다. warning 자체만으로 FAIL 을 만들지는 않지만, 그 부재 때문에 핵심 AC의 wiring/contract 동작을 증명할 수 없으면 FAIL gap 이다.
+
+### UI 목업 정합 판정 (STORY / EPIC 공통)
+
+UI story/epic 에서 호출자가 확정 목업과 구현 화면 증거를 제공하면, 양쪽을 Read 로 열어 구조적으로 대조한다. 이 축은 pixel-diff 하드 게이트가 아니라 제품 검수 판단 축이다.
+
+- 확정 목업은 `docs/design-variants/<screen-id>.html` 또는 호출자가 제공한 동등한 기준이다. 구현 화면 증거는 스크린샷, 브라우저/앱 자동화 결과 이미지, visual smoke 산출물처럼 실제 실행 화면을 볼 수 있는 경로다.
+- 확정 목업과 화면 증거를 함께 받은 경우 레이아웃 계층, 주요 상태(default/empty/error/loading 등), 핵심 `data-node-id` 의도, 디자인 토큰·색·간격·타이포 수준 대응이 구조적으로 일치하는지 본다.
+- pixel-diff 수치가 없다는 이유만으로 FAIL 하지 않는다. 반대로 자동 테스트가 green 이어도 확정 목업과 화면 증거의 구조가 명확히 어긋나면 `목업 불일치` gap 으로 분리한다.
+- UI story 인데 실제 실행 화면을 볼 수 있는 화면 증거가 없으면 `화면 증거 부재` gap 으로 분리한다. 이는 mock-only green 과 동급의 검수 gap 이며, 확정 목업만 있거나 구현자가 "맞췄다"고 설명한 것만으로 PASS 하지 않는다.
+- 목업 불일치의 원인이 구현 누락이면 `/impl`, 사용자 흐름·시각 선택 재정의가 필요하면 `/ux` 후속 후보로 쓴다.
+- 확정 목업이 없는 UI story 는 그 부재 자체를 기준 문서/설계 증거 부족으로 보고한다. 단, 호출자가 시각 구조 불변 또는 목업 없이 진행하는 결정 근거를 제공했으면 그 범위 안에서 동작 증거와 사용자 동선만 판정한다.
 
 ### 사용자 동선 적합성 판정 (STORY / EPIC 공통)
 
@@ -68,6 +80,7 @@ story 구현 완료 직후 호출된다. 해당 story 의 수용 기준이 구�
 - 핵심 AC 의 입력/진행 동선이 대상 사용자에게 적합한 제품 언어로 닫힌다.
 - 테스트나 smoke 증거가 실제 실행 결과로 남아 있다.
 - mock-only green 으로만 닫힌 핵심 AC 를 gap 으로 분리한다.
+- UI story 이면 확정 목업과 구현 화면 증거를 Read 로 열어 대조하고, 화면 증거 부재와 목업 불일치를 gap 으로 분리한다.
 - 내부 계약을 사용자가 직접 조립해야만 수행되는 핵심 흐름을 gap 으로 분리한다.
 - 설명만 있고 검수 가능한 증거가 없는 항목을 gap 으로 분리한다.
 - 정적 타입검사/compile gate 부재가 무음 통과하지 않고 warning 또는 gap 으로 드러난다.
@@ -80,6 +93,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 PRD Must,
 - PRD Must AC 가 하나 이상의 story/PR/test evidence 로 닫혔다.
 - story 사이의 흐름, 상태, 권한, 데이터 ownership 이 서로 어긋나지 않는다.
 - 여러 PR/story 경계를 넘는 통합 동작이 동작 증거로 닫혔다. 각 PR 의 mock-only green 이 모여 있어도 실제 사용자 흐름이 한 번도 검증되지 않았으면 cross-story gap 이다.
+- UI epic 이면 story 별 확정 목업과 최종 구현 화면 증거가 서로 이어지는지 보고, 화면 증거 부재나 cross-story 목업 불일치를 gap 으로 분리한다.
 - 여러 story 가 합쳐진 사용자 흐름이 내부 schema/payload 조립이 아니라 대상 사용자의 자연스러운 입력/진행 동선으로 이어진다.
 - 보안/권한/데이터 리스크가 새로 생겼는데 별도 후속 없이 묻히지 않았다.
 - 비용, 성능, migration, 배포 설정 같은 운영 리스크가 출시 판단을 막지 않는지 확인한다.
@@ -101,7 +115,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 PRD Must,
 2. 기준 문서에서 Must AC, 완료 기준, story 목적, release readiness 기준을 추출한다.
 3. 구현 증거를 읽고 각 기준이 어떤 PR, 테스트, smoke, 정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, 화면/API/CLI 설명과 연결되는지 대조한다.
 4. 대상 사용자를 식별하고 핵심 입력/진행 동선이 제품 언어인지, 내부 구현 계약을 사용자에게 떠넘기는지 대조한다.
-5. 충족된 기준, mock-only green 인 기준, 사용자 동선 부적합 기준, 증거 없는 기준을 분리한다.
+5. 충족된 기준, mock-only green 인 기준, 화면 증거 부재 기준, 목업 불일치 기준, 사용자 동선 부적합 기준, 증거 없는 기준을 분리한다.
 6. gap 이 있으면 기준 문서, 증거, 누락 사실, 후속 분기를 함께 쓴다.
 7. 판단에 필요한 문서나 권한이 없으면 추측하지 않고 ESCALATE한다.
 
@@ -110,6 +124,8 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 PRD Must,
 - 증거 없이 PASS 하지 않는다.
 - 구현했다는 주장보다 문서 경로, PR, 테스트 결과, smoke 결과, 정적 타입검사/compile 결과, 실데이터 통합 테스트, UI 자동화, 화면/API/CLI 동작 설명을 우선한다.
 - 핵심 AC가 mock-only green으로만 닫혔으면 PASS 하지 않는다.
+- UI story 에서 화면 증거 부재가 있으면 PASS 하지 않는다.
+- 확정 목업과 구현 화면 증거의 레이아웃 계층·상태(default/empty/error 등)·토큰 대응이 구조적으로 어긋나면 `목업 불일치` gap 으로 보고한다.
 - 핵심 AC가 대상 사용자에게 부적합한 입력/진행 동선으로만 수행되면 PASS 하지 않는다.
 - 내부 schema/payload/config shape 노출은 대상 사용자와 공개 계약에 비추어 gap, warning, 정당한 개발자 계약 중 하나로 명시한다.
 - gap 은 제품 기준에서 Must 인지, 후속으로 분리 가능한지 구분한다.
@@ -133,6 +149,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 PRD Must,
 - 충족된 핵심 AC 또는 완료 기준
 - 미충족 gap 과 근거
 - gap 별 후속 분기
+- UI story/epic 이면 확정 목업 경로, 구현 화면 스크린샷 또는 화면 증거 경로, UI 목업 정합 판정 결과
 - STORY / EPIC 검수 보고에는 사용자가 지금 직접 확인할 수 있는 실행 동선(실행 명령, 화면 진입 경로 등) 안내. 호출자 제공 증거에서 확인된 동선만 쓰고, 불명이면 불명이라고 쓴다. 확인 가능한 동작이 아직 없으면 그 사실을 쓴다.
 
 마지막 단락에는 `PASS`, `FAIL`, `ESCALATE` 중 하나를 쓴다.

--- a/skills/acceptance/SKILL.md
+++ b/skills/acceptance/SKILL.md
@@ -21,6 +21,7 @@ description: story 또는 epic 구현 완료 후 제품 단위 검수를 수행�
 - 필요한 `docs/decisions/` decision, 전역/epic architecture, impl 문서 경로
 - 구현 PR 목록
 - 핵심 AC별 동작 증거: 정적 타입검사/compile, 실데이터(non-mock) 통합 테스트, UI 자동화, API/CLI smoke, 화면/API/CLI 동작 기록 중 해당하는 것
+- UI story/epic 이면 확정 목업 경로(`docs/design-variants/<screen-id>.html`), canvas 경로, 핵심 `data-node-id` 매핑, 구현 화면 스크린샷 또는 동등한 화면 증거 경로
 - 대상 사용자와 핵심 입력/진행 동선
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제로 실행된 제품 경계
 - 이전 acceptance gap 이 있으면 그 결과와 재검수 대상
@@ -44,6 +45,16 @@ Lite `/impl` 단발 작업은 불필요하게 `/acceptance` 로 강제하지 않
 - 동작 증거는 사람 E2E만 뜻하지 않는다. AC 성격에 맞으면 정적 타입검사/compile, 실데이터(non-mock) 통합 테스트, UI 자동화, API/CLI smoke, 실제 앱 진입점 실행 기록도 동작 증거로 인정한다.
 - mock/stub/fake 기반 unit test 는 보조 증거가 될 수 있다. 그러나 핵심 AC가 mock-only green으로만 뒷받침되고 실제 제품 경계(API/CLI/UI/통합 wiring/compile-time contract)가 한 번도 확인되지 않았으면 gap이다.
 - 정적 타입검사나 compile gate 가 의미 있는 stack(TypeScript, typed Python, Rust, Go 등)인데 증거에 없으면 품질 게이트 warning 으로 보고한다. 이 warning 자체만으로 FAIL 로 만들지는 않지만, 그 부재 때문에 핵심 AC의 wiring/contract 동작을 증명할 수 없으면 검수 증거 gap 이다.
+
+## UI 목업 정합 원칙
+
+UI story/epic 검수에서 확정 목업과 구현 화면 증거가 주입되면 product-acceptance 는 양쪽을 Read 로 열어 구조적 일치를 판정한다. pixel-diff 자동화는 MVP 범위 밖이며 하드 게이트가 아니다.
+
+- 확정 목업 경로는 `docs/design-variants/<screen-id>.html` 또는 호출자가 제공한 동등한 기준이다.
+- 구현 화면 증거는 구현 화면 스크린샷, UI 자동화 산출 이미지, visual smoke 결과처럼 실제 실행 화면을 확인할 수 있는 경로다.
+- 판정 축은 UI 목업 정합: 레이아웃 계층, 상태(default/empty/error/loading 등), 핵심 `data-node-id`, 토큰·간격·타이포 대응이 구조적으로 맞는가다.
+- UI story 인데 구현 화면 스크린샷 또는 동등한 화면 증거가 없으면 `화면 증거 부재` gap 이다. 확정 목업만 있거나 mock-only/component-only green 만 있으면 PASS 하지 않는다.
+- 확정 목업과 화면 증거가 구조적으로 어긋나면 `목업 불일치` gap 이며, 후속은 원인에 따라 `/ux` 또는 `/impl` 로 제안한다.
 
 ## 사용자 동선 적합성 원칙
 
@@ -71,6 +82,7 @@ mode: STORY_ACCEPTANCE
 구현 증거:
 - <구현 PR 목록>
 - <테스트/smoke/동작 증거: 타입검사/compile, 실데이터 통합 테스트, UI 자동화, API/CLI smoke 등>
+- <UI story 인 경우: 확정 목업 경로 + 구현 화면 스크린샷 또는 화면 증거 경로 + 핵심 data-node-id 매핑>
 - <mock/stub/fake 사용 범위와 실제 제품 경계 실행 여부>
 - <대상 사용자와 핵심 입력/진행 동선: 제품 언어인지, 내부 계약 조립을 요구하는지>
 """)
@@ -81,6 +93,8 @@ mode: STORY_ACCEPTANCE
 - story 목적과 구현 PR 이 연결됐는가.
 - story AC / REQ 가 구현 파일, 테스트, smoke 증거 중 하나 이상과 연결됐는가.
 - 핵심 AC 가 동작 증거와 연결됐는가, 아니면 mock-only green 인가.
+- UI story 이면 확정 목업과 구현 화면 증거가 주입됐는가, 그리고 레이아웃 계층·상태(default/empty/error 등)·토큰 수준의 UI 목업 정합이 맞는가.
+- UI story 인데 화면 증거가 없으면 화면 증거 부재 gap 으로, 확정 목업과 화면 증거가 어긋나면 목업 불일치 gap 으로 드러나는가.
 - 핵심 AC 가 대상 사용자에게 적합한 입력/진행 동선으로 닫혔는가, 아니면 내부 계약 조립을 요구하는가.
 - 설명만 있고 검수 가능한 증거가 없는 항목과 mock-only 증거만 있는 항목이 gap 으로 드러나는가.
 - 정적 타입검사/compile gate 부재가 무음 통과하지 않고 warning 또는 gap 으로 보고되는가.
@@ -102,6 +116,7 @@ mode: EPIC_ACCEPTANCE
 구현 증거:
 - <story별 구현 PR 목록>
 - <story별 테스트/smoke/동작 증거>
+- <UI epic 인 경우: story별 확정 목업 경로 + 최종 구현 화면 스크린샷 또는 화면 증거 경로>
 - <cross-story 통합 동작 증거: 타입검사/compile, 실데이터 통합 테스트, UI 자동화, API/CLI smoke 등>
 - <cross-story 사용자 입력/진행 동선: 대상 사용자에게 자연스러운 흐름인지>
 """)
@@ -112,6 +127,7 @@ mode: EPIC_ACCEPTANCE
 - PRD Must 가 story/PR/test evidence 로 닫혔는가.
 - story 사이 상태, 권한, 데이터 흐름이 어긋나 cross-story gap 을 만들지 않는가.
 - 여러 PR/story 를 합쳤을 때 핵심 사용자 흐름이 동작 증거로 닫혔는가, 아니면 각 PR의 mock-only green만 남았는가.
+- UI epic 이면 story별 확정 목업과 최종 구현 화면 증거의 구조적 흐름이 이어지는가, 아니면 화면 증거 부재나 목업 불일치가 남았는가.
 - 여러 PR/story 를 합친 핵심 사용자 흐름이 내부 schema/payload 조립이 아니라 대상 사용자의 작업 언어로 진행되는가.
 - security/ops risk 가 새로 생겼는데 후속 없이 묻히지 않았는가.
 

--- a/skills/acceptance/acceptance-routing.md
+++ b/skills/acceptance/acceptance-routing.md
@@ -37,9 +37,9 @@ flowchart TB
 | 입력 | 다음 |
 |---|---|
 | `product-acceptance:STORY_ACCEPTANCE` `PASS` | story 완료 후보로 보고. 자동 close 는 하지 않는다. |
-| `product-acceptance:STORY_ACCEPTANCE` `FAIL` | AC / PR / test evidence gap, 동작 증거 부족, mock-only green, 사용자 동선 부적합을 보고하고 `/impl`, `/design`, `/ux` 회수 후보를 제안한다. |
+| `product-acceptance:STORY_ACCEPTANCE` `FAIL` | AC / PR / test evidence gap, 동작 증거 부족, mock-only green, 화면 증거 부재, 목업 불일치, 사용자 동선 부적합을 보고하고 `/impl`, `/design`, `/ux` 회수 후보를 제안한다. |
 | `product-acceptance:EPIC_ACCEPTANCE` `PASS` | epic 완료 후보로 보고. 자동 close 는 하지 않는다. |
-| `product-acceptance:EPIC_ACCEPTANCE` `FAIL` | PRD Must, cross-story 동작 gap, mock-only green, cross-story 사용자 동선 부적합, security/ops risk 를 보고하고 후속 분기를 제안한다. |
+| `product-acceptance:EPIC_ACCEPTANCE` `FAIL` | PRD Must, cross-story 동작 gap, mock-only green, 화면 증거 부재, 목업 불일치, cross-story 사용자 동선 부적합, security/ops risk 를 보고하고 후속 분기를 제안한다. |
 | `ESCALATE` | 기준 문서, 구현 PR 목록, 권한, 사용자 결정 부족을 보고하고 대기한다. |
 
 ## 깊이 차이
@@ -55,6 +55,12 @@ Epic acceptance 는 PRD Must, cross-story gap, security/ops risk 를 포함한�
 mock/stub/fake 기반 unit test 는 보조 증거다. 핵심 AC가 mock-only green으로만 닫히고 실제 제품 경계(API/CLI/UI/통합 wiring/compile-time contract)가 확인되지 않았으면 `검수 증거 부족 / 스모크 실패` 계열 gap 으로 보고한다.
 
 정적 타입검사나 compile gate 가 의미 있는 stack 인데 증거에 없으면 품질 게이트 warning 으로 보고한다. warning 자체는 자동 FAIL 이 아니지만, 그 부재 때문에 핵심 AC의 wiring/contract 동작을 증명할 수 없으면 FAIL gap 이다.
+
+## UI 목업 정합 판정
+
+UI story/epic 에서 호출자가 확정 목업 경로와 구현 화면 스크린샷 또는 동등한 화면 증거 경로를 제공하면, product-acceptance 는 양쪽을 Read 로 열어 레이아웃 계층, 상태(default/empty/error 등), 핵심 `data-node-id`, 토큰 대응의 구조적 일치를 본다. pixel-diff 자동화는 하드 게이트가 아니다.
+
+UI story 인데 실제 실행 화면을 확인할 화면 증거가 없으면 `화면 증거 부재` gap 으로 보고한다. 확정 목업과 화면 증거가 구조적으로 어긋나면 `목업 불일치` gap 으로 보고한다.
 
 ## 사용자 동선 적합성 판정
 
@@ -72,12 +78,14 @@ mock/stub/fake 기반 unit test 는 보조 증거다. 핵심 AC가 mock-only gre
 | 설계 결함 / 범위 재정의 필요 | `/design` 또는 `/spec` |
 | 검수 증거 부족 / 스모크 실패 | gap 또는 bug `/to-issue` 후보 + `/impl` |
 | mock-only green / 동작 증거 부족 | gap 또는 bug `/to-issue` 후보 + `/impl` |
+| 화면 증거 부재 | gap 또는 bug `/to-issue` 후보 + `/impl` |
+| 목업 불일치 | gap 또는 bug `/to-issue` 후보 + `/ux` 또는 `/impl` |
 | 사용자 동선 부적합 / 내부 계약 노출 | gap 또는 bug `/to-issue` 후보 + `/ux` 또는 `/impl` 또는 `/design` |
 | UX 미완성 | `/ux` |
 | 성능 병목 / 리팩토링 필요 | `/to-issue` 후보 + `/impl` 또는 `/design` |
 | 보안 / 권한 / 데이터 리스크 | `/to-issue` 후보 + `/design` 또는 사용자 위임 |
 
-story acceptance 는 주로 PRD / AC 미충족, 검수 증거 부족 / 스모크 실패, mock-only green / 동작 증거 부족, 사용자 동선 부적합 / 내부 계약 노출을 만든다. epic acceptance 는 cross-story gap, cross-story 사용자 동선 부적합, 성능 병목 / 리팩토링 필요, 보안 / 권한 / 데이터 리스크까지 같이 본다.
+story acceptance 는 주로 PRD / AC 미충족, 검수 증거 부족 / 스모크 실패, mock-only green / 동작 증거 부족, 화면 증거 부재, 목업 불일치, 사용자 동선 부적합 / 내부 계약 노출을 만든다. epic acceptance 는 cross-story gap, 화면 증거 부재, cross-story 목업 불일치, cross-story 사용자 동선 부적합, 성능 병목 / 리팩토링 필요, 보안 / 권한 / 데이터 리스크까지 같이 본다.
 
 품질 게이트 warning 은 gap 과 별개로 남길 수 있다. 예를 들어 TypeScript 프로젝트에 `tsc --noEmit` 또는 그에 준하는 compile/typecheck 증거가 전혀 없으면 warning 으로 보고하고, 핵심 AC 검증에도 영향을 주는 경우에만 위 gap taxonomy 로 승격한다.
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -303,7 +303,15 @@ story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후
 
 **시점 — pr-reviewer PASS 후 · `pr-finalize.sh`(머지) *전*, 단 story 구현 증거가 모두 모인 뒤**. `Closes #story` auto-close 는 머지 시 발동하므로, 머지 전에 검수해야 (1) story/epic issue close = 검수 통과와 동기화되고 (2) gap 수정이 *열려 있는 같은 PR* 에 commit 추가로 들어간다 (gap fix PR 난립 X). 엔진별 삽입점: 엔진 A 는 `pr-create.sh` 로 PR 생성까지 마친 뒤 pr-finalize 전, 엔진 B 는 pr-reviewer PASS 후 pr-finalize 전 — 두 경우 모두 open PR 번호가 검수 증거에 들어간다. **병렬 peer 세션의 마감 task 는 같은 story 의 prior sibling task 가 *모두 완료(머지)* 됐음을 `wave-status` 로 먼저 확인한 후** acceptance 를 수행하고, 그 다음 `pr-finalize.sh`(merge lock + order gate) 를 호출한다 — sibling 미완료 상태의 검수는 불완전 증거 검수라 금지. sibling 이 아직 진행 중이면 완료를 기다렸다가 검수한다 (직렬 chain 은 순서상 자동 충족).
 
-**책임 소재**: code-validator 는 계획 대비 구현 정합, pr-reviewer 는 이번 PR diff 위험을 본다. 여러 PR 이 모인 story 동작과 여러 story 가 모인 epic 동작은 이 마감 product-acceptance 가 맡는다. product-acceptance prompt 에는 핵심 AC별 동작 증거(정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, API/CLI smoke 등)와 mock/stub/fake 경계를 메인이 직접 넣는다.
+**책임 소재**: code-validator 는 계획 대비 구현 정합, pr-reviewer 는 이번 PR diff 위험을 본다. 여러 PR 이 모인 story 동작과 여러 story 가 모인 epic 동작은 이 마감 product-acceptance 가 맡는다. product-acceptance prompt 에는 핵심 AC별 동작 증거(정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, API/CLI smoke 등)와 mock/stub/fake 경계를 메인이 직접 넣는다. UI story/epic 이면 메인은 impl 문서의 `## 디자인 참조` 에서 확정 목업 경로와 핵심 `data-node-id` 매핑을 수집하고, 실제 구현 화면 스크린샷 또는 동등한 화면 증거 경로를 함께 넣는다. 증거 생성 수단은 각 프로젝트 몫이며 dcNess 는 자동 스크린샷 생성 도구를 배포하지 않는다.
+
+**UI 화면 증거 수집**: 마감 acceptance 호출 직전에 메인은 UI task 여부를 확인한다. `design: required`, `## 디자인 참조` 의 확정 목업 경로, 또는 `docs/design-variants/<screen-id>.html` 참조가 있으면 UI 검수 대상으로 본다. 이때 product-acceptance prompt 에 아래를 명시한다.
+
+- 확정 목업 경로: `docs/design-variants/<screen-id>.html`
+- 구현 화면 스크린샷 또는 화면 증거 경로: `<프로젝트가 생성한 screenshot/visual smoke artifact>`
+- 핵심 `data-node-id` → 구현 컴포넌트/상태 매핑
+- 화면 증거가 없으면 `화면 증거 부재` gap 후보라고 명시
+- 확정 목업과 화면 증거가 레이아웃 계층·상태(default/empty/error 등)·토큰 대응에서 어긋나면 `목업 불일치` gap 후보라고 명시
 
 **호출** (conveyor step 기록 — harness 는 `product-acceptance` 를 read-only validator 로 이미 인지. mode 를 positional 로 기록해 STORY/EPIC step 을 분리한다). `current_step` 은 1개뿐이므로 **직전 step(pr-reviewer)을 `end-step` 으로 닫은 뒤에** `begin-step product-acceptance` 를 연다 — 안 닫으면 pr-reviewer step 기록이 덮여 clean 게이트의 pr-reviewer PASS 흔적이 깨진다:
 
@@ -315,18 +323,19 @@ mode: STORY_ACCEPTANCE
 기준 문서: <epic stories.md> + <story 의 impl 파일들>   # EPIC 은 docs/prd.md + architecture 추가
 구현 증거: <story 의 머지된 PR 목록(번호+제목)> + <현재 open 마감 PR 번호 + 변경 파일 목록> + <lint/build/test 결과>
 동작 증거: <핵심 AC별 타입검사/compile, 실데이터 통합 테스트, UI 자동화, API/CLI smoke 등> + <mock/stub/fake 사용 범위>
+UI 목업 정합 증거: <UI story 이면 확정 목업 경로 + 구현 화면 스크린샷 또는 화면 증거 경로 + 핵심 data-node-id 매핑. 비 UI 이면 해당 없음>
 """)
 end-step product-acceptance STORY_ACCEPTANCE --prose-file <file>
 ```
 
 end-step 의 positional 인자는 **mode** 다 — 결론(`PASS`/`FAIL`/`ESCALATE`)은 end-step 인자가 아니라 **agent prose 마지막 단락**에 적힌다 (본 skill 의 다른 step 과 동일 규약). epic 마감은 `STORY_ACCEPTANCE` step 을 닫은 뒤 `begin-step product-acceptance EPIC_ACCEPTANCE` 로 두 번째 step 을 따로 기록한다 — mode 별 step 분리가 있어야 clean 게이트가 STORY/EPIC 각각의 PASS prose 를 확인할 수 있다.
 
-product-acceptance 는 read-only(Read/Glob/Grep) 라 `gh` 호출 불가 — PR 목록·검증 결과·동작 증거는 **메인이 prompt 에 직접 담는다**. chain 진행 중 메인이 이미 갖고 있는 정보(각 task 의 PR URL·5줄 요약·검증 결과)와 CI/test 결과를 사용한다. 핵심 AC 증거가 mock-only 인지 판단하려면 mock/stub/fake 경계도 같이 담는다.
+product-acceptance 는 read-only(Read/Glob/Grep) 라 `gh` 호출 불가 — PR 목록·검증 결과·동작 증거·UI 목업 정합 증거는 **메인이 prompt 에 직접 담는다**. chain 진행 중 메인이 이미 갖고 있는 정보(각 task 의 PR URL·5줄 요약·검증 결과)와 CI/test 결과를 사용한다. 핵심 AC 증거가 mock-only 인지 판단하려면 mock/stub/fake 경계도 같이 담는다. UI story 에서 화면 증거가 없으면 비워 두지 말고 "화면 증거 없음" 으로 적어 product-acceptance 가 `화면 증거 부재` gap 으로 판정할 수 있게 한다.
 
 **결론 분기** (상세 = 분기 규칙 SSOT):
 
 - `PASS` → `pr-finalize.sh` 머지 진행 (epic 마감은 STORY → EPIC 2회 모두 PASS 후).
-- `FAIL` → **gap 수정 루프** (자동, round ≤ 3): auto-fixable gap(PRD/AC 미충족 · 검수 증거 부족 · 스모크 실패 · mock-only green / 동작 증거 부족 · 명확한 구현 보강으로 닫히는 사용자 동선 부적합)을 **`engineer:IMPL` 재진입**으로 수정한다 — POLISH 가 아니다 (POLISH 는 pr-reviewer finding 전용·로직 변경 금지 모드라 AC gap 수정에 부적합). engineer 입력 = story 의 impl 문서 + acceptance prose 의 gap 목록. 엔진 B 도 run 시작 때 `--design-doc <task 의 impl 문서 경로>` 를 기록하므로 이 `engineer:IMPL` 재진입은 engineer gate 를 통과한다. `IMPL_DONE` → code-validator `PASS` → lint/build/test green → 메인이 변경을 PR 브랜치에 commit/push → pr-reviewer 재리뷰 → product-acceptance 재검수. **gap 수정 commit 이 생겼으면 재검수는 마감 시퀀스 처음부터** — epic 마감에서 EPIC FAIL 수정 후엔 이전 STORY PASS 가 stale 이므로 `STORY_ACCEPTANCE` 부터 다시 돌린다. round 초과, 또는 설계 결함·범위 재정의·사용자/UX 선택 필요·보안/권한/데이터 리스크 gap → 정지 + 사용자 위임 (gap 분류 기준 = [`acceptance-routing.md`](../acceptance/acceptance-routing.md) gap taxonomy).
+- `FAIL` → **gap 수정 루프** (자동, round ≤ 3): auto-fixable gap(PRD/AC 미충족 · 검수 증거 부족 · 스모크 실패 · mock-only green / 동작 증거 부족 · 화면 증거 부재 · 구현 누락이 명확한 목업 불일치 · 명확한 구현 보강으로 닫히는 사용자 동선 부적합)을 **`engineer:IMPL` 재진입**으로 수정한다 — POLISH 가 아니다 (POLISH 는 pr-reviewer finding 전용·로직 변경 금지 모드라 AC gap 수정에 부적합). engineer 입력 = story 의 impl 문서 + acceptance prose 의 gap 목록. 엔진 B 도 run 시작 때 `--design-doc <task 의 impl 문서 경로>` 를 기록하므로 이 `engineer:IMPL` 재진입은 engineer gate 를 통과한다. `IMPL_DONE` → code-validator `PASS` → lint/build/test green → 메인이 변경을 PR 브랜치에 commit/push → pr-reviewer 재리뷰 → product-acceptance 재검수. **gap 수정 commit 이 생겼으면 재검수는 마감 시퀀스 처음부터** — epic 마감에서 EPIC FAIL 수정 후엔 이전 STORY PASS 가 stale 이므로 `STORY_ACCEPTANCE` 부터 다시 돌린다. round 초과, 또는 설계 결함·범위 재정의·사용자/UX 선택 필요·보안/권한/데이터 리스크 gap → 정지 + 사용자 위임 (gap 분류 기준 = [`acceptance-routing.md`](../acceptance/acceptance-routing.md) gap taxonomy).
 - `ESCALATE` (기준 문서·구현 증거·사용자 결정 부족) → 정지 + 사용자 위임.
 
 acceptance FAIL 미해소 상태로 pr-finalize 강행 금지 — 마감 task 의 `clean` 판정 게이트에 product-acceptance PASS 흔적이 포함된다 ([chain 모드 task 경계 분기](impl-loop-routing.md#chain-모드-task-경계-분기)). 진행 뷰에는 마감 task 의 sub-step 으로 `product-acceptance` 를 추가한다 (epic 마감은 `product-acceptance:STORY` / `product-acceptance:EPIC` 2개).

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -126,7 +126,7 @@ flowchart TB
 
 story/epic 마감 task (PR 트레일러 `Closes #story` / `Closes #epic` 대상) 의 pr-reviewer `PASS` 후 · pr-finalize(머지) *전* 에 product-acceptance 검수를 끼운다 (절차·경계 판정·시점 전제조건 = [`SKILL.md` 마감 acceptance](SKILL.md#마감-acceptance) — 병렬 peer 는 같은 story sibling 완료 확인 후, 통합 브랜치 모드는 sub-PR 이 아니라 마지막 main 머지 PR 전). 기본 ON, `--no-acceptance` 명시 run 만 비대상. epic 마감 task 는 `STORY_ACCEPTANCE` → `EPIC_ACCEPTANCE` 직렬 2회 — 앞이 PASS 못 닫으면 뒤로 진행하지 않는다.
 
-책임 소재: code-validator 는 계획 대비 구현 정합, pr-reviewer 는 이번 PR diff 위험을 본다. 여러 PR 이 합쳐진 story 동작과 여러 story 가 합쳐진 epic 동작·사용자 동선은 마감 product-acceptance 가 맡는다. 핵심 AC 가 mock-only green 으로만 뒷받침되고 실제 제품 경계(API/CLI/UI/통합 wiring/compile-time contract)가 확인되지 않았으면 gap 이다. 핵심 AC 가 실행되더라도 non-developer 대상 사용자가 내부 schema/payload/config shape 를 조립해야만 수행할 수 있으면 사용자 동선 부적합 gap 이다.
+책임 소재: code-validator 는 계획 대비 구현 정합, pr-reviewer 는 이번 PR diff 위험을 본다. 여러 PR 이 합쳐진 story 동작과 여러 story 가 합쳐진 epic 동작·사용자 동선은 마감 product-acceptance 가 맡는다. 핵심 AC 가 mock-only green 으로만 뒷받침되고 실제 제품 경계(API/CLI/UI/통합 wiring/compile-time contract)가 확인되지 않았으면 gap 이다. UI story/epic 은 확정 목업 경로와 구현 화면 스크린샷 또는 동등한 화면 증거 경로를 prompt 에 담아 product-acceptance 가 Read 로 양쪽을 열고 레이아웃 계층·상태(default/empty/error 등)·토큰 대응을 판정하게 한다. 화면 증거가 없으면 `화면 증거 부재`, 확정 목업과 구조적으로 어긋나면 `목업 불일치` gap 이다. 핵심 AC 가 실행되더라도 non-developer 대상 사용자가 내부 schema/payload/config shape 를 조립해야만 수행할 수 있으면 사용자 동선 부적합 gap 이다.
 
 마감 acceptance 대상 run 은 `begin-run impl --acceptance-required` 또는 `next-task --acceptance-required` marker 를 기록한다. 이 marker 가 있어야 Stop hook 이 pr-reviewer 를 종료 agent 로 보지 않고 product-acceptance 분기 turn 을 재발화한다. 비대상 run / `--no-acceptance` / verify-only 는 marker 를 기록하지 않아 기존 종료 동작을 유지한다.
 
@@ -138,6 +138,9 @@ standalone `/acceptance` 의 분기 규칙([`acceptance-routing.md`](../acceptan
 |---|---|
 | PRD / AC 미충족 · 검수 증거 부족 · 스모크 실패 (auto-fixable) | engineer:IMPL 재진입(gap 수정 — POLISH 아님: POLISH 는 pr-reviewer finding 전용·로직 변경 금지 모드, [`engineer-agent.md`](../../agents/engineer/engineer-agent.md) 정합). build-worker 엔진도 run 시작 시 `--design-doc <task impl 문서>` 를 기록하므로 engineer gate 를 통과한다. → `IMPL_DONE` → code-validator `PASS` → lint/build/test green → 메인 commit/push to PR branch → pr-reviewer 재리뷰 → product-acceptance 재검수 (round ≤3) |
 | mock-only green / 동작 증거 부족 (auto-fixable) | engineer:IMPL 재진입. 핵심 AC 를 닫을 수 있는 자동 동작 증거를 추가한다. 사람 E2E 만 요구하지 않고 정적 타입검사/compile, 실데이터(non-mock) 통합 테스트, UI 자동화, API/CLI smoke 중 AC 성격에 맞는 증거를 보강한다. |
+| 화면 증거 부재 (auto-fixable) | engineer:IMPL 재진입. 프로젝트가 선택한 UI 자동화, visual smoke, 스크린샷 산출물 등 실제 구현 화면 증거를 추가한다. dcNess 는 스크린샷 생성 도구를 배포하지 않고, 증거 요구와 판정만 담당한다. |
+| 목업 불일치 (구현 보강으로 닫힘) | engineer:IMPL 재진입. 확정 목업 대비 레이아웃 계층, 상태(default/empty/error 등), 토큰 대응을 맞추거나 의도적 차이를 구현/검수 증거에 명시한다. |
+| 목업 불일치 (사용자/UX 선택 필요) | 정지 + 사용자 위임 (`/ux` 후보 제시) |
 | 사용자 동선 부적합 / 내부 계약 노출 (명확한 구현 보강) | engineer:IMPL 재진입. 대상 사용자에게 맞는 제품 언어의 입력/진행 동선을 추가하고, 내부 schema/payload/config shape 조립을 사용자 흐름 밖으로 숨기거나 공개 계약으로 정리한다. |
 | 사용자 동선 부적합 / 내부 계약 노출 (사용자/UX 선택 필요) | 정지 + 사용자 위임 (`/ux`·`/design`·`/spec` 회수 후보 제시) |
 | 설계 결함 / 범위 재정의 필요 | 정지 + 사용자 위임 (`/design`·`compact-design` 회수 후보 제시) |

--- a/tests/test_acceptance_gap_routing.py
+++ b/tests/test_acceptance_gap_routing.py
@@ -22,6 +22,8 @@ class AcceptanceGapRoutingContractTests(unittest.TestCase):
             "설계 결함 / 범위 재정의 필요": "`/design` 또는 `/spec`",
             "검수 증거 부족 / 스모크 실패": "gap 또는 bug `/to-issue` 후보 + `/impl`",
             "mock-only green / 동작 증거 부족": "gap 또는 bug `/to-issue` 후보 + `/impl`",
+            "화면 증거 부재": "gap 또는 bug `/to-issue` 후보 + `/impl`",
+            "목업 불일치": "gap 또는 bug `/to-issue` 후보 + `/ux` 또는 `/impl`",
             "사용자 동선 부적합 / 내부 계약 노출": "gap 또는 bug `/to-issue` 후보 + `/ux` 또는 `/impl` 또는 `/design`",
             "UX 미완성": "`/ux`",
             "성능 병목 / 리팩토링 필요": "`/to-issue` 후보 + `/impl` 또는 `/design`",
@@ -54,6 +56,8 @@ class AcceptanceGapRoutingContractTests(unittest.TestCase):
             "UI 자동화",
             "API/CLI smoke",
             "mock-only green",
+            "화면 증거 부재",
+            "목업 불일치",
             "품질 게이트 warning",
         ):
             self.assertIn(needle, text)

--- a/tests/test_acceptance_skill.py
+++ b/tests/test_acceptance_skill.py
@@ -66,6 +66,21 @@ class AcceptanceSkillContractTests(unittest.TestCase):
             self.assertIn("사람 E2E", text)
             self.assertIn("mock-only green", text)
 
+    def test_acceptance_accepts_ui_mock_and_screen_evidence_inputs(self) -> None:
+        text = self.skill.read_text(encoding="utf-8")
+        for needle in (
+            "확정 목업 경로",
+            "구현 화면 스크린샷",
+            "화면 증거",
+            "UI 목업 정합",
+            "레이아웃 계층",
+            "상태(default/empty/error",
+            "토큰",
+            "화면 증거 부재",
+            "목업 불일치",
+        ):
+            self.assertIn(needle, text)
+
     def test_acceptance_recognizes_user_flow_fit_as_separate_axis(self) -> None:
         skill = self.skill.read_text(encoding="utf-8")
         routing = self.routing.read_text(encoding="utf-8")
@@ -85,6 +100,19 @@ class AcceptanceSkillContractTests(unittest.TestCase):
         self.assertIn("product-acceptance 가 맡는다", text)
         self.assertIn("mock-only green / 동작 증거 부족", text)
         self.assertIn("사용자 동선 부적합 / 내부 계약 노출", text)
+
+    def test_inline_acceptance_injects_ui_mock_and_screen_evidence(self) -> None:
+        text = (ROOT / "skills" / "impl-loop" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        for needle in (
+            "확정 목업 경로",
+            "구현 화면 스크린샷",
+            "화면 증거",
+            "화면 증거 부재",
+            "목업 불일치",
+        ):
+            self.assertIn(needle, text)
 
     def test_lite_impl_is_not_forced_into_acceptance(self) -> None:
         text = self.skill.read_text(encoding="utf-8")

--- a/tests/test_product_acceptance_agent.py
+++ b/tests/test_product_acceptance_agent.py
@@ -101,6 +101,23 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         self.assertIn("warning 자체만으로 FAIL", text)
         self.assertIn("핵심 AC의 wiring/contract 동작을 증명할 수 없으면 FAIL gap", text)
 
+    def test_prompt_classifies_ui_mock_alignment_and_screen_evidence_gap(self) -> None:
+        text = self.prompt.read_text(encoding="utf-8")
+        for needle in (
+            "UI 목업 정합 판정",
+            "확정 목업",
+            "화면 증거",
+            "스크린샷",
+            "Read 로 열어",
+            "레이아웃 계층",
+            "상태(default/empty/error",
+            "토큰",
+            "pixel-diff",
+            "화면 증거 부재",
+            "목업 불일치",
+        ):
+            self.assertIn(needle, text)
+
     def test_prompt_classifies_user_flow_fit_and_internal_contract_exposure(self) -> None:
         text = self.prompt.read_text(encoding="utf-8")
         for needle in (


### PR DESCRIPTION
## 관련 이슈 번호
Closes #844

## 배경 및 문제
product-acceptance 는 동작 증거와 mock-only gap 은 구분하지만, #843에서 확보된 확정 목업과 실제 구현 화면 증거를 검수 단계에서 구조적으로 대조하는 계약이 없었습니다. UI story 에서 스크린샷 같은 화면 증거가 없어도 기존 taxonomy 로는 mock-only green 과 별도 gap 으로 드러나지 않았습니다.

## 원인 (해당 시)
UI 자동화나 screenshot 은 동작 증거의 예시로만 언급됐고, 확정 목업 경로와 구현 화면 증거를 product-acceptance prompt 에 주입해 Read 로 열어 판정하는 절차가 acceptance/impl-loop 계약에 없었습니다.

## 작업내용
- product-acceptance STORY/EPIC 공통 판단 축에 UI 목업 정합 판정을 추가했습니다.
- /acceptance 입력과 prompt 규약에 확정 목업 경로, 구현 화면 스크린샷 또는 화면 증거, node-id 매핑을 추가했습니다.
- /impl-loop 마감 acceptance 절차에 UI 화면 증거 수집과 prompt 주입 계약을 명시했습니다.
- gap taxonomy 에 `화면 증거 부재`, `목업 불일치`를 추가하고 후속 라우팅을 고정했습니다.
- 관련 자연어 계약 테스트를 추가했습니다.

## 결정 근거
pixel-diff 자동화나 스크린샷 생성 도구 배포는 #844 out of scope 이므로 dcNess 는 증거 요구와 판정 계약만 맡도록 했습니다. #843의 `docs/design-variants/<screen-id>.html` 확정본 규약을 소비하되, 화면 증거 생성 수단은 각 프로젝트가 선택하게 했습니다.

## 배포 경로 검증 (plug-in 영향 시)
- 배포 경로 1: `agents/product-acceptance/**`, `skills/acceptance/**`, `skills/impl-loop/**`는 plug-in 본체 파일입니다. 사용자는 plug-in 업데이트 후 새 acceptance 계약을 받습니다.
- 배포 경로 2: `/init-dcness` 복사 파일 변경은 없습니다.
- 배포 경로 3: `docs/plugin` 사용자 SSOT 변경은 없습니다. #843의 `docs/design-variants/**` 확정본 규약을 소비하는 변경입니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_product_acceptance_agent tests.test_acceptance_skill tests.test_acceptance_gap_routing -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `bash scripts/check_python_tests.sh`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-issue844/bin/python bash scripts/check_static_quality.sh`

## 참고
- Static quality 기본 실행은 전역 Python의 PEP 668 정책과 `ruff` 미설치로 막혀 `/tmp/dcness-quality-issue844` 임시 venv에 `requirements-quality.txt`를 설치해 동일 gate를 실행했습니다.
