### PR TITLE
[issue-845] /ux commit 경로 보강

### DIFF
--- a/agents/designer/designer-agent.md
+++ b/agents/designer/designer-agent.md
@@ -9,7 +9,7 @@
 - 대상 화면 또는 컴포넌트
 - UX 목표와 문제점
 - 있으면 대상 epic `ux-flow.md`, `docs/design.md`, PRD
-- `ux-flow.md` 화면 인벤토리가 있으면 `hi-fi 목업 필요` 가 `필요 로 표시된 화면`
+- `ux-flow.md` 화면 인벤토리가 있으면 `hi-fi 목업 필요` 가 `필요로 표시된 화면`
 - 있으면 추적 이슈 번호
 
 ## 먼저 읽을 문서
@@ -31,7 +31,7 @@
 
 1. 대상 화면과 UX 목표를 확인한다.
 2. UX 목표와 디자인 가이드를 읽는다.
-3. `ux-flow.md` 화면 인벤토리가 있으면 `hi-fi 목업 필요` 가 `필요 로 표시된 화면` 만 작업한다. 전 화면 일괄 목업화 금지.
+3. `ux-flow.md` 화면 인벤토리가 있으면 `hi-fi 목업 필요` 가 `필요로 표시된 화면` 만 작업한다. 전 화면 일괄 목업화 금지.
 4. 한 가지 완성된 draft 를 만든다.
 5. `docs/design-variants/drafts/<screen-id>-draft<N>.html` 단독 파일로 저장하고, 주요 `data-node-id`와 토큰 의도를 보고한다.
 6. 사용자 PICK 이후의 `docs/design-variants/<screen-id>.html` 확정본 승격과 `canvas.html` frame 등록은 메인이 한다.

--- a/agents/ux-architect/ux-architect-agent.md
+++ b/agents/ux-architect/ux-architect-agent.md
@@ -53,7 +53,7 @@ PRD와 현재 UI 상태를 화면 흐름, wireframe, interaction, system-level d
 
 ## 결론과 보고
 
-마지막 단락에 `UX_FLOW_READY`, `UX_FLOW_PATCHED`, `UX_REFINE_READY`, `UX_FLOW_ESCALATE` 중 하나를 쓴다. 보고에는 갱신 문서, 화면 범위, self-check 결과, 다음 designer가 만들 HTML 시안 범위를 포함한다. designer 범위에는 `hi-fi 목업 필요` 가 `필요 로 표시된 화면` 만 적고, 전 화면 일괄 목업화 금지 원칙을 어기지 않는다.
+마지막 단락에 `UX_FLOW_READY`, `UX_FLOW_PATCHED`, `UX_REFINE_READY`, `UX_FLOW_ESCALATE` 중 하나를 쓴다. 보고에는 갱신 문서, 화면 범위, self-check 결과, 다음 designer가 만들 HTML 시안 범위를 포함한다. designer 범위에는 `hi-fi 목업 필요` 가 `필요로 표시된 화면` 만 적고, 전 화면 일괄 목업화 금지 원칙을 어기지 않는다.
 
 ## 템플릿과 참고 문서
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -20,10 +20,10 @@ skill 트리거 또는 직접 발화 → 메인 Claude 가 **해당 skill 의 `#
 
 ### worktree 분기 (action 루프 한정)
 
-**worktree 격리로 산출물을 커밋하는 action 루프 (`/impl` · `/impl-loop` · `/design`) 진입 시 Step 0 에서 EnterWorktree 자동 호출** — 동시 다중 세션 충돌 회피 + 메인 working tree 보호. `/spec` / `/tech-review` / `/ux` / `/to-issue` (commit 없음) 는 commit 격리 목적 부재라 워크트리 X (메인 working tree 에서 직접 또는 별 branch). loop 별 적용 여부는 각 skill 본문 (예: [`impl/SKILL.md`](../../skills/impl/SKILL.md) · [`design/SKILL.md`](../../skills/design/SKILL.md) 워크트리 절 · [`impl-loop/SKILL.md`](../../skills/impl-loop/SKILL.md)).
+**worktree 격리로 산출물을 커밋하는 action 루프 (`/impl` · `/impl-loop` · `/design` · `/ux`) 진입 시 Step 0 에서 EnterWorktree 자동 호출** — 동시 다중 세션 충돌 회피 + 메인 working tree 보호. `/ux` 는 git-tracked 확정 목업(`docs/design-variants/<screen-id>.html` + `canvas.html`)을 만들므로 action 루프다. `/spec` / `/tech-review` / `/to-issue` (commit 없음) 는 commit 격리 목적 부재라 워크트리 X (메인 working tree 에서 직접 또는 별 branch). loop 별 적용 여부는 각 skill 본문 (예: [`impl/SKILL.md`](../../skills/impl/SKILL.md) · [`design/SKILL.md`](../../skills/design/SKILL.md) 워크트리 절 · [`impl-loop/SKILL.md`](../../skills/impl-loop/SKILL.md) · [`ux/SKILL.md`](../../skills/ux/SKILL.md)).
 
 ```
-EnterWorktree(name="<skill>-{ts_short}")   # action 루프 (impl / impl-loop / design)
+EnterWorktree(name="<skill>-{ts_short}")   # action 루프 (impl / impl-loop / design / ux)
 ```
 
 - **거부 표현 시에만 건너뜀** — 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시 EnterWorktree 호출 0, 일반 cwd 그대로 진행.
@@ -81,7 +81,7 @@ TaskUpdate("<task>", completed)
 ```
 
 begin-step stdout 에 `[PROMPT_SLOT_CHECK]` 가 있으면 **Agent prompt 작성 전 먼저 읽고 self-check** 한다. 이 섹션은 메인 Claude 용 호출 직전 reminder 다. `[INSIGHTS: <agent>/<mode>]` 또는 `[PREVIOUS_TASKS]` 섹션이 있으면 Agent prompt 끝에 그대로 포함시킨다.
-- `[PROMPT_SLOT_CHECK]` — `/impl`·`/impl-loop`·`/design` action loop 에서 3슬롯 self-check 를 호출 순간에 노출한다. worktree 활성 시 worktree 절대경로를 prompt 에 넣고, 슬롯3에는 미기록 제약·신호만 두며 agent 본업의 방법(정규식·구현 단계·알고리즘·테스트 assert 방식)을 처방하지 않는다. 권고 신호이며 hook block 이 아니다. 출력의 `template` 경로는 [`agent-prompt-slots.md`](templates/agent-prompt-slots.md) 를 가리킨다.
+- `[PROMPT_SLOT_CHECK]` — `/impl`·`/impl-loop`·`/design`·`/ux` action loop 에서 3슬롯 self-check 를 호출 순간에 노출한다. worktree 활성 시 worktree 절대경로를 prompt 에 넣고, 슬롯3에는 미기록 제약·신호만 두며 agent 본업의 방법(정규식·구현 단계·알고리즘·테스트 assert 방식)을 처방하지 않는다. 권고 신호이며 hook block 이 아니다. 출력의 `template` 경로는 [`agent-prompt-slots.md`](templates/agent-prompt-slots.md) 를 가리킨다.
 - `[INSIGHTS]` — 해당 agent 의 과거 루프 학습 ("하지 말 것" / "잘 됐던 것"), 프로젝트 레벨 누적.
 - `[PREVIOUS_TASKS]` — `/impl-loop` chain 의 직전 task 산출 요약 list (build-worker 진입 시만, #525). 인접 task 인터페이스 정합 참고용 — build-worker 가 phase 3 통과 시 `prev-tasks-append` 로 자기 산출을 누적한 것.
 
@@ -121,7 +121,7 @@ fi
 
 **MUST.** 호출 직전 해당 `agent.md` 의 "입력" / "호출자가 prompt 로 전달하는 정보" 항목 read 후 prompt 작성 (형식 자유, 정보 명시 의무). prompt 에는 **(1) 읽을 SSOT 문서 포인터 (agent 가 자체 read 할 경로) (2) 대상 단위 (어떤 task / Story / 모듈) (3) 그 호출에 특유한 제약·주의 (4) 산출 경로·번호 규약·write 경계** 만 담는다.
 
-**호출 직전 self-check (#780).** `/impl`·`/impl-loop`·`/design` action loop 의 `begin-step` stdout 에 `[PROMPT_SLOT_CHECK]` 가 나오면 Agent prompt 를 쓰기 전에 아래 3가지를 확인한다. (a) 대상+읽을 진본이 슬롯 1에 있는가, (b) worktree 활성 시 worktree 절대경로가 슬롯 2에 있는가, (c) 슬롯 3이 방법 처방이 아니라 이 호출 특유의 미기록 제약·신호만 담는가. 이 신호는 적용 누락을 줄이는 reminder 이며, 코드 hook 으로 prompt 내용을 판정하거나 차단하지 않는다.
+**호출 직전 self-check (#780).** `/impl`·`/impl-loop`·`/design`·`/ux` action loop 의 `begin-step` stdout 에 `[PROMPT_SLOT_CHECK]` 가 나오면 Agent prompt 를 쓰기 전에 아래 3가지를 확인한다. (a) 대상+읽을 진본이 슬롯 1에 있는가, (b) worktree 활성 시 worktree 절대경로가 슬롯 2에 있는가, (c) 슬롯 3이 방법 처방이 아니라 이 호출 특유의 미기록 제약·신호만 담는가. 이 신호는 적용 누락을 줄이는 reminder 이며, 코드 hook 으로 prompt 내용을 판정하거나 차단하지 않는다.
 
 - ❌ **이미 SSOT 문서에 기록된 결정의 사본을 prompt 에 재기입 금지** — 합의 스택·계약·설계 결정은 agent 가 자기 "먼저 읽을 문서" 규약대로 SSOT 문서를 직접 읽어 획득한다. 같은 결정이 prompt 와 문서 두 곳에 살면 진본이 둘이 되어, 한쪽만 갱신될 때 어느 쪽이 맞는지 모르는 drift 가 생긴다 (dcNess 가 본래 막으려는 사본 drift 를 절차 자신이 유발).
 - ❌ **agent 본업을 "뭐뭐 해라"로 절차 재지시 금지** — 판단 축·작업 흐름·완료 기준은 각 `agent.md` 가 소유한다. 메인은 컨텍스트·제약·사실관계만 넘기고 *어떻게 할지* 는 agent 가 정한다 (아래 [finding 수용 원칙](#finding-수용-원칙-점-패치-금지-근본-수정) 의 relay 와 동형 — "해법 메커니즘은 메인이 처방하지 말 것").
@@ -350,7 +350,7 @@ end-run 안전망 (`session_state.py`) 이 자동으로 `finalize-run --auto-rev
 
 > **impl-task-loop 제외**: [impl-task-loop commit 구조](#impl-task-loop-commit-구조) 에서 branch/commit/push/PR 이미 완료 → Step 7a = merge only.
 
-clean 판정 통과 시 사용자 확인 없이 자동 진행 (**impl-task-loop 외** 루프): branch (`<prefix>/<short-slug>`, prefix = 해당 loop 의 branch_prefix — [`git-spec.md` 브랜치](git-spec.md#브랜치) valid 패턴) → **변경 파일 commit** → push → PR create → merge → main sync. **commit 대상 = 해당 loop 가 실제 변경한 파일** — design = `docs/**` 설계 산출물, ux = epic `ux-flow.md` 와 `docs/design.md` 아티팩트라 src-only 아님 (src-only 제한은 impl-task-loop 전용, [impl-task-loop commit 구조](#impl-task-loop-commit-구조)). **stray untracked 휩쓸기 주의**: impl 루프와 달리 비-impl loop 은 worktree 권한 경계가 src-only 가 아니고 clean 매트릭스가 untracked ≤ 10 을 허용하므로, `pr-create.sh` 의 `git add -A` 는 무관한 로컬 아티팩트까지 stage 한다 → 호출 *전* 산출물 외 파일을 정리하거나, 해당 loop 산출물만 명시 pathspec 으로 직접 stage 후 commit. 네이밍·본문·트레일러 = [`git-spec.md`](git-spec.md), 커밋 trailer 의 모델 표기는 글로벌 `~/.claude/CLAUDE.md` 기준. 실행 = [`scripts/pr-create.sh`](../../scripts/pr-create.sh) + [`scripts/pr-finalize.sh`](../../scripts/pr-finalize.sh).
+clean 판정 통과 시 사용자 확인 없이 자동 진행 (**impl-task-loop 외** 루프): branch (`<prefix>/<short-slug>`, prefix = 해당 loop 의 branch_prefix — [`git-spec.md` 브랜치](git-spec.md#브랜치) valid 패턴) → **변경 파일 commit** → push → PR create → merge → main sync. **commit 대상 = 해당 loop 가 실제 변경한 파일** — design = `docs/**` 설계 산출물, ux = epic `ux-flow.md`, `docs/design.md`, `docs/design-variants/<screen-id>.html`, `docs/design-variants/canvas.html`, 필요 시 `docs/design-variants/_lib/**` seed 라 src-only 아님 (src-only 제한은 impl-task-loop 전용, [impl-task-loop commit 구조](#impl-task-loop-commit-구조)). **stray untracked 휩쓸기 주의**: impl 루프와 달리 비-impl loop 은 worktree 권한 경계가 src-only 가 아니고 clean 매트릭스가 untracked ≤ 10 을 허용하므로, `pr-create.sh` 의 `git add -A` 는 무관한 로컬 아티팩트까지 stage 한다 → 호출 *전* 산출물 외 파일을 정리하거나, 해당 loop 산출물만 명시 pathspec 으로 직접 stage 후 commit. 네이밍·본문·트레일러 = [`git-spec.md`](git-spec.md), 커밋 trailer 의 모델 표기는 글로벌 `~/.claude/CLAUDE.md` 기준. 실행 = [`scripts/pr-create.sh`](../../scripts/pr-create.sh) + [`scripts/pr-finalize.sh`](../../scripts/pr-finalize.sh).
 
 worktree 진입 시 squash 흡수 검사 후 `ExitWorktree(action="<keep|remove>")` ([worktree 분기](#worktree-분기-action-루프-한정)).
 

--- a/skills/ux/SKILL.md
+++ b/skills/ux/SKILL.md
@@ -5,7 +5,7 @@ description: 구현 없이 목업과 흐름을 먼저 탐색하는 선행 디자
 
 # UX Skill — 선행 디자인 탐색 wrapper
 
-> `/ux` 는 구현 없이 디자인만 먼저 굴리고 싶을 때 쓰는 선행 탐색 경로다. 목업 생성·수정·확정은 내부 [`canvas-design`](../canvas-design/SKILL.md) 을 감싸는 얇은 wrapper 한 경로로만 수행한다. 산출 계약은 `docs/design-variants/` 확정본 규약과 동일하다: drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록. `/impl` 은 그 확정본을 기준 있음 으로 이어받는다.
+> `/ux` 는 구현 없이 디자인만 먼저 굴리고 싶을 때 쓰는 선행 탐색 경로다. 목업 생성·수정·확정은 내부 [`canvas-design`](../canvas-design/SKILL.md) 을 감싸는 얇은 wrapper 한 경로로만 수행한다. 산출 계약은 `docs/design-variants/` 확정본 규약과 동일하다: drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록. 후속 `/impl` 은 머지된 확정본만 `기준 있음` 으로 이어받는다.
 
 > 🔴 **분기 규칙 SSOT** — ux-architect / designer 결론 → 다음 호출 / 모드 전환 / cycle 한도 / escalate / 후속은 [`ux-routing.md`](ux-routing.md) 가 본 skill 의 단일 진본. 본 파일은 *진행 절차(Step)* 만 담는다. 분기·재진입·escalate 판단이 필요하면 그 파일을 읽는다. 용어·공개 진입점·분기 표현을 수정하거나 리뷰할 때만 [`terms.md`](../../docs/plugin/terms.md) 를 확인한다.
 
@@ -19,6 +19,14 @@ description: 구현 없이 목업과 흐름을 먼저 탐색하는 선행 디자
 - **분기 규칙**: [`ux-routing.md`](ux-routing.md)
 
 본 skill 은 공개 workflow 가 아니라 utility 다. `/design` 은 product/technical design 을 다루고, `/impl` 은 구현한다. `/ux` 는 구현 PR 전에 목업과 흐름만 선행 탐색한다.
+
+## worktree + commit/PR 계약
+
+`/ux` 는 git-tracked 디자인 확정본을 만드는 action loop 다. Step 0 에서 공통 [`loop-procedure`](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정) 의 worktree 분기를 따른다. 사용자가 명시적으로 워크트리 제외를 요청하지 않는 한 worktree 에서 진행한다.
+
+canvas-design `PASS` 뒤 clean 이면 Step 7a 가 `/ux` 산출물만 명시 pathspec 으로 stage 해서 docs-only branch + PR 을 만든다. 포함 대상은 `docs/epics/<epic>/ux-flow.md`, 변경된 `docs/design.md`, `docs/design-variants/<screen-id>.html`, `docs/design-variants/canvas.html`, 새로 seed 된 `docs/design-variants/_lib/**` 이다.
+
+PR merge 와 main sync 를 확인한 뒤에만 완료를 보고한다. 후속 `/impl` 은 머지된 확정본만 `기준 있음` 으로 이어받는다. PR/CI/merge 실패 시 `/impl` 기준 있음으로 안내하지 않고 중지한다. 확정본을 uncommitted 상태로 남긴 채 종료하지 않는다.
 
 ## 모드 판정 (진입 시)
 
@@ -47,7 +55,7 @@ UX_FLOW 산출 `docs/epics/<epic>/ux-flow.md` 의 화면 인벤토리는 `hi-fi 
 
 - `필요`: 제품 첫 인상, 핵심 변환, 복잡한 상태, 구현자가 레이아웃을 오해하기 쉬운 화면. `canvas-design` 이 designer draft 를 만들 수 있다.
 - `불필요`: 부수 화면, 단순 목록/설정/확인, 기존 패턴 반복. text wireframe 과 상태 설명으로 충분하다.
-- 전 화면 일괄 목업화 금지. designer 는 `hi-fi 목업 필요` 가 `필요 로 표시된 화면` 만 목업화한다.
+- 전 화면 일괄 목업화 금지. designer 는 `hi-fi 목업 필요` 가 `필요로 표시된 화면` 만 목업화한다.
 
 UX_REFINE 은 기존 화면 섹션을 갱신할 때도 같은 열을 유지하고, 실제 visual draft 가 필요한 화면만 `필요` 로 표시한다.
 
@@ -65,12 +73,12 @@ designer 를 호출하는 모든 경로(UX_FLOW, UX_REFINE 사용자 승인 후,
 2. **Step 2 — ux-architect:UX_FLOW** → `UX_FLOW_READY`. 산출 = `docs/epics/epic-NN-<slug>/ux-flow.md` (+ 조건부 `docs/design.md` 시스템 토큰). 화면 인벤토리에 `hi-fi 목업 필요` 값을 표시한다.
    - `UX_REFINE_READY` → UX_REFINE 모드로 전환
    - `UX_FLOW_ESCALATE` → 사용자 위임
-3. **Step 3 — canvas-design wrapper** — `hi-fi 목업 필요` 가 `필요 로 표시된 화면` 만 내부 `canvas-design` 에 넘긴다. canvas-design 은 seed 보장, 필요 시 `begin-step designer`, draft 생성, 사용자 PICK, `docs/design-variants/<screen-id>.html` 확정본 승격, `docs/design-variants/canvas.html` canvas 등록까지 수행한다.
+3. **Step 3 — canvas-design wrapper** — `hi-fi 목업 필요` 가 `필요로 표시된 화면` 만 내부 `canvas-design` 에 넘긴다. canvas-design 은 seed 보장, 필요 시 `begin-step designer`, draft 생성, 사용자 PICK, `docs/design-variants/<screen-id>.html` 확정본 승격, `docs/design-variants/canvas.html` canvas 등록까지 수행한다.
    - draft 산출물은 `docs/design-variants/drafts/<screen-id>-draft<N>.html`, `data-node-id`, `:root` CSS custom property 토큰을 포함한다.
    - 사용자 PICK NG → 공통 preflight 를 다시 확인한 뒤 `designer-ROUND-<n>` 으로 재생성한다. round 한도는 없다.
    - `PASS` → 확정 목업 경로와 핵심 node-id 매핑을 기록하고 종료
    - `ESCALATE` → 사용자 위임
-4. **Step 종료** — `end-run`. 후속 구현은 `/impl`.
+4. **Step 종료** — `end-run` 뒤 clean 이면 commit/PR → merge → main sync. 후속 구현은 `/impl`.
 
 ## 절차 — UX_REFINE
 

--- a/skills/ux/ux-routing.md
+++ b/skills/ux/ux-routing.md
@@ -67,7 +67,7 @@ flowchart TB
 - **모드 전환** — UX_FLOW 진행 중 ux-architect 가 기존 화면 개선이 맞다고 판단해 `UX_REFINE_READY` 로 끝나면 UX_REFINE 절차로 전환한다.
 - **hi-fi 목업 범위** — 화면 인벤토리에서 `hi-fi 목업 필요` 가 `필요` 인 화면만 designer 대상이다. 전 화면 일괄 목업화 금지. `불필요` 화면은 `ux-flow.md` text wireframe 으로 충분하다.
 - **designer 재생성** — 사용자 PICK NG 는 round 한도가 없다 (사용자 자유 결정, sub_cycle `designer-ROUND-<n>`). 재생성 전에도 design-variants seed 보장을 다시 확인한다. cycle 한도는 self-check FAIL / 승인 거절 경로에만 적용한다.
-- **확정본 계약** — 완료 산출은 `docs/design-variants/<screen-id>.html` + `docs/design-variants/canvas.html` + 핵심 node-id 매핑이다. `/impl` 은 이 결과를 `기준 있음` 으로 이어받는다.
+- **확정본 계약** — 완료 산출은 `docs/design-variants/<screen-id>.html` + `docs/design-variants/canvas.html` + 핵심 node-id 매핑이다. `/ux` 는 산출물 PR merge 와 main sync 뒤 종료하며, `/impl` 은 머지된 결과만 `기준 있음` 으로 이어받는다.
 
 ## cycle 한도
 

--- a/tests/test_canvas_design_workflow.py
+++ b/tests/test_canvas_design_workflow.py
@@ -63,6 +63,9 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
         self.init_ref = (
             ROOT / "docs" / "plugin" / "init-dcness.md"
         ).read_text(encoding="utf-8")
+        self.loop_procedure = (
+            ROOT / "docs" / "plugin" / "loop-procedure.md"
+        ).read_text(encoding="utf-8")
         self.positioning = (
             ROOT / "docs" / "plugin" / "positioning.md"
         ).read_text(encoding="utf-8")
@@ -127,7 +130,7 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
             "canvas 등록",
             "docs/design-variants/<screen-id>.html",
             "docs/design-variants/canvas.html",
-            "`/impl` 은 그 확정본을 기준 있음",
+            "후속 `/impl` 은 머지된 확정본만 `기준 있음`",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.ux)
@@ -150,8 +153,43 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
         for text in (self.ux, self.designer):
             with self.subTest(text=text[:30]):
                 self.assertIn("hi-fi 목업 필요", text)
-                self.assertIn("필요 로 표시된 화면", text)
+                self.assertIn("필요로 표시된 화면", text)
+                self.assertNotIn("필요 로 표시된 화면", text)
                 self.assertIn("전 화면 일괄 목업화 금지", text)
+
+        self.assertNotIn("필요 로 표시된 화면", self.ux_architect)
+
+    def test_ux_standalone_run_commits_confirmed_artifacts_via_pr(self) -> None:
+        for needle in (
+            "`/impl` · `/impl-loop` · `/design` · `/ux`",
+            "EnterWorktree(name=\"<skill>-{ts_short}\")",
+            "impl / impl-loop / design / ux",
+            "`/impl`·`/impl-loop`·`/design`·`/ux` action loop",
+            "`/spec` / `/tech-review` / `/to-issue` (commit 없음)",
+            "ux = epic `ux-flow.md`, `docs/design.md`, "
+            "`docs/design-variants/<screen-id>.html`, "
+            "`docs/design-variants/canvas.html`",
+            "해당 loop 산출물만 명시 pathspec",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.loop_procedure)
+
+        self.assertNotIn(
+            "`/spec` / `/tech-review` / `/ux` / `/to-issue` (commit 없음)",
+            self.loop_procedure,
+        )
+
+        for needle in (
+            "worktree",
+            "commit/PR",
+            "docs-only branch + PR",
+            "후속 `/impl` 은 머지된 확정본만 `기준 있음` 으로 이어받는다",
+            "merge",
+            "main sync",
+            "확정본을 uncommitted 상태로 남긴 채 종료하지 않는다",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.ux)
 
     def test_canvas_design_bootstraps_seed_and_requires_routing_enum(self) -> None:
         skill = (ROOT / "skills" / "canvas-design" / "SKILL.md").read_text(


### PR DESCRIPTION
## Summary
- Promote standalone `/ux` to the action-loop worktree/commit/PR contract so confirmed design artifacts are merged before `/impl` consumes them.
- Document the `/ux` output pathspec for `ux-flow.md`, `docs/design.md`, confirmed `docs/design-variants/*.html`, `canvas.html`, and seed files.
- Fix the `필요 로 표시된 화면` wording typo in UX/designer guidance and add regression coverage.

## Tests
- `python3.11 -m unittest tests.test_canvas_design_workflow tests.test_surface_docs_sync -v`
- `node scripts/check_cross_refs.mjs`
- `node scripts/check_public_surface.mjs`
- `git diff --check`
- `python3.11 -m unittest discover -s tests -v` (1471 tests)
- `node scripts/check_doc_path_integrity.mjs`
- `node scripts/check_plugin_manifest.mjs`
- `node scripts/check_design_artifact_structure.mjs`
- `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- `bash evals/run.sh` completed with one stochastic `shorts-real-spec` miss; isolated `shorts-real-spec` rerun returned `OK E1`, `OK E2`, `RESULT: PASS`
- pre-commit pytest gate reran `python3.11 -m unittest discover -s tests -v` (1471 tests)

Part of #845