### PR TITLE
[docs] 문서 중복 참조 정비

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,9 +101,6 @@
 
 ## 문서 지도
 
-
-
-
 ### 작업 시 읽기 (lazy — 해당 작업 직전에만)
 
 | 파일 | 언제 읽나 |
@@ -111,13 +108,19 @@
 | [`docs/plugin/terms.md`](docs/plugin/terms.md) | 용어·공개 진입점·분기 표현·사용자 표시 메시지 수정/리뷰 시 |
 | [`docs/plugin/positioning.md`](docs/plugin/positioning.md) | 공개 workflow 진입점의 기본/고급/유틸리티/내부 agent 분류 수정 시 |
 | [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md) | 자유 형식 작업 요청을 어떤 workflow 로 보낼지 (구현 경로 — gate 축 × shape 축) 판단 시 |
+| [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현·효율 benchmark 문구 수정 시 |
+| [`docs/plugin/design.md`](docs/plugin/design.md) | `design.md` 토큰 규격·Static HTML 시안 규약 수정 시 |
 | [`docs/plugin/git-spec.md`](docs/plugin/git-spec.md) | 브랜치·커밋·PR 네이밍 규칙 SSOT — 모든 커밋 작업에 적용 |
+| [`docs/plugin/github-project.md`](docs/plugin/github-project.md) | GitHub Project `Status` / `IssueType` / `Priority` 축과 repo label 의미 수정 시 |
+| [`docs/plugin/init-dcness.md`](docs/plugin/init-dcness.md) | `/init-dcness` 배포 inventory·activation seed·선택형 확장 설명 수정 시 |
 | 각 skill 의 `<skill>-routing.md` ([`impl`](skills/impl/impl-routing.md) / [`design`](skills/design/design-routing.md) / [`impl-loop`](skills/impl-loop/impl-loop-routing.md) 등) | 분기 규칙 진본 (mermaid + enum 표) + retry 한도 + escalate — agent 결론 → 다음 호출 매핑 수정 시 |
 | [`scripts/check_public_surface.mjs`](scripts/check_public_surface.mjs) | 공개 workflow 진입점 gate 기대값 수정 시 |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md) | Step 0~8 mechanics (begin-run → begin-step → Agent → end-step → finalize-run) 수정 시 |
 | [`docs/plugin/hooks.md`](docs/plugin/hooks.md) | hook 시스템 (SessionStart / PreToolUse / PostToolUse / SubagentStop / Stop = 8 hook) 수정 시 SSOT. dcness self 작업용 `scripts/hooks/cc-pre-commit.sh` 는 별 항목 |
 | [`docs/plugin/issue-lifecycle.md`](docs/plugin/issue-lifecycle.md) | 외부 활성 프로젝트의 epic / story / impl 흐름 변경 시 SSOT (본 저장소 자체엔 미적용 — [dcness 자체는 init-dcness 미적용](#dcness-자체는-init-dcness-미적용-자기-규격-미얽매임) 참조) |
 | [`docs/plugin/deliverables-map.md`](docs/plugin/deliverables-map.md) | 외부 활성 프로젝트의 docs 산출물 위치·양식·계층 (`docs/index.md`, 전역 anchors, epic 산출물, `docs/decisions/`, `.dcness-work/`, 시드=산출 양식) SSOT — 산출물 경로/템플릿 수정 시 |
+| [`docs/plugin/parallel-policy.md`](docs/plugin/parallel-policy.md) | 병렬 peer 세션·claim board·merge lock 정책 수정 시 |
+| [`docs/plugin/templates/agent-prompt-slots.md`](docs/plugin/templates/agent-prompt-slots.md) | Agent prompt 3-slot 템플릿과 prompt 작성 checkpoint 수정 시 |
 | [`PROGRESS.md`](PROGRESS.md) | 현재 상태·TODO·Blockers 확인 시 |
 | [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 수정 시 |
 | [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md) | PR 체크리스트 확인 시 |

--- a/commands/smart-compact.md
+++ b/commands/smart-compact.md
@@ -174,7 +174,7 @@ EOF
 
 # 컨텍스트
 - 핵심: harness/session_state.py, harness/hooks.py, hooks/*.sh, commands/*.md
-- spec: docs/archive/conveyor-design.md (v2 Task tool 패턴, 역사 자료), docs/plugin/loop-procedure.md
+- spec: docs/plugin/loop-procedure.md (Task/Agent/helper/hook loop mechanics)
 - agents/*.md 12개 모두 자유서술 방식 (DCN-CHG-27)
 - 기준: CLAUDE.md 강제 원칙 + docs/plugin/workflow-router.md
 

--- a/docs/plugin/design.md
+++ b/docs/plugin/design.md
@@ -1,6 +1,7 @@
 # design.md 규격
 
-> dcness 디자인 시스템 SSOT.
+> **Status**: ACTIVE
+> **Scope**: dcness 디자인 시스템 토큰과 `design.md` 파일 규격의 SSOT. 본 문서는 `/design` workflow skill 이 아니라 프로젝트 디자인 토큰 문서의 작성·검증 기준이다. 설계 루프 절차는 [`../../skills/design/SKILL.md`](../../skills/design/SKILL.md)가 소유한다.
 > Google `design.md` 공식 spec 채택 + dcness 적용 룰 추가.
 > 원본: https://github.com/google-labs-code/design.md `docs/spec.md`
 

--- a/docs/plugin/github-project.md
+++ b/docs/plugin/github-project.md
@@ -36,11 +36,15 @@ repo label 6종은 `epic`, `feature`, `story`, `task`, `subTask`, `bug` 이며 I
 | `minor` | 유용하지만 낮은 긴급도의 작업. | 작은 UX polish, 낮은 영향의 개선. |
 | `trivial` | 영향이 제한적인 작은 정리. | 문구, 소규모 cleanup. |
 
+Priority 처리는 경로별로 다르다. 단발 `/to-issue` 는 Priority 를 맥락에서 추론해 명시한다 (기본값 없음 — [`../../skills/to-issue/issue-fields.md`](../../skills/to-issue/issue-fields.md) 의 Priority 추론 가이드). epic/story 일괄 생성은 전부 `major` 고정이다. `register-issue` 의 `--priority` 생략 시 `major` fallback 은 일괄 경로를 위한 동작이며, 단발 등록은 추론값을 항상 명시해 그 fallback 에 의존하지 않는다.
+
 ## Lifecycle
 
 이슈 등록 직후 Project `Status=Todo` 이다. 특정 issue 를 대상으로 설계나 구현 흐름을 실제 시작하면 `Status=In progress` 로 이동한다. default branch 에 merge 된 PR 이 `Closes #N`, `Fixes #N`, `Resolves #N` 또는 GitHub 의 실제 closing issue reference 로 issue 를 완료하면 `Status=Done` 으로 이동한다.
 
 `Part of #N` 은 중간 연결일 뿐 완료 신호가 아니다. `Part of #N` 만 있는 PR 은 issue 를 `Done` 으로 옮기지 않는다.
+
+등록 명령, 보드 좌표 해석, 멱등 backfill, PR merge 후처리 같은 실행 메커니즘은 [`issue-lifecycle.md#github-project-status-lifecycle`](issue-lifecycle.md#github-project-status-lifecycle) 가 소유한다. 본 문서는 Project 축과 drift 메시지의 의미만 정의한다.
 
 ## Drift Messages
 
@@ -76,19 +80,3 @@ gh project create --owner OWNER --title "dcNess" --format json
 gh project link PROJECT_NUMBER --owner OWNER --repo REPO
 node scripts/github_project_lifecycle.mjs bootstrap --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER --apply
 ```
-
-## Issue 등록 (register-issue) + 좌표 저장
-
-issue 를 Project item 으로 추가하고 `Status=Todo` + `IssueType` + `Priority` 를 설정하는 경로는 `register-issue` 다. 단발 (`/to-issue`) 과 epic/story 일괄 생성이 같이 쓴다.
-
-Priority 처리는 두 경로가 다르다. 단발 `/to-issue` 는 Priority 를 맥락에서 추론해 `--priority` 로 명시한다 (기본값 없음 — [`../../skills/to-issue/issue-fields.md`](../../skills/to-issue/issue-fields.md) 의 Priority 추론 가이드). epic/story 일괄 생성은 전부 `major` 고정이다 (의도된 결정, 유지). `register-issue` 의 `--priority` 생략 시 `major` fallback 은 후자의 일괄 경로를 위한 동작이며, 단발 등록은 추론값을 항상 명시해 그 fallback 에 의존하지 않는다.
-
-```bash
-node scripts/github_project_lifecycle.mjs register-issue \
-  --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER \
-  --issue ISSUE_NUMBER --issue-type epic|story [--priority major] --apply
-```
-
-item 이 없으면 추가 (멱등), 있으면 field 만 set 후 drift 검증. 보드/field 가 없거나 불완전해도 issue 생성은 막지 않는다 — 메인이 셋업을 물어보고 거부 시 보드 없이 진행하며, 일괄 스크립트는 좌표가 없으면 등록만 skip 한다.
-
-보드 좌표 (owner/number) 는 repo 변수 `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` 에 저장한다 (GitHub Actions `vars.*` 와 동일 저장소 = 단일 SSOT). `/init-dcness` 가 `gh variable set` 으로 저장하고, 등록 경로는 `gh variable get` 으로 읽는다. 조회 우선순위: `--project`/`--owner` 플래그 → `DCNESS_PROJECT_*` env → `gh variable get` → owner 는 repo owner fallback.

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -57,6 +57,8 @@ Project 축 정의의 SSOT 는 [`github-project.md`](github-project.md) 이다. 
 
 issue 등록 직후 Project item 으로 추가하고 `Status=Todo` + `IssueType` + `Priority` 를 설정한다. 단발 등록 (`/to-issue`) 과 epic/story 일괄 생성 ([`scripts/create_epic_story_issues.sh`](../../scripts/create_epic_story_issues.sh)) 이 같은 경로 `register-issue` 를 쓴다. epic → `IssueType=epic`, story → `IssueType=story`, 둘 다 `Priority=major` (일괄 기본).
 
+Priority 값과 단발/일괄 정책은 [`github-project.md#priority`](github-project.md#priority) 가 소유한다. 실행 경로에서는 단발 `/to-issue` 가 추론한 Priority 를 `--priority` 로 넘기고, epic/story 일괄 생성은 `major` 를 적용한다.
+
 ```bash
 node scripts/github_project_lifecycle.mjs register-issue \
   --repo OWNER/REPO --owner OWNER --project PROJECT_NUMBER \

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -11,14 +11,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 | `/impl` | 구현, 수정, 버그픽스, 작은 리팩터링을 실제 PR 로 끝낼 때 | 구현 경로(설계도 유무 — Lite / Standard) + 엔진(풀4/경량)을 내부 판정 |
 | `/acceptance` | PRD / Epic / Story 기준 제품 검수와 gap 후속 연결이 필요할 때 | story/epic acceptance. 핵심 AC별 동작 증거와 mock-only gap 을 구분한다. 사람 full E2E 는 MVP 범위 밖 |
 
-사용자는 구현 경로 이름을 외울 필요가 없다. `/impl` 은 설계를 하지 않고 **설계도를 보고 구현만** 하며, 구현 경로(설계도 유무)와 엔진(풀4/경량)을 직교로 고른다.
-
-| 내부 구현 경로 | 조건 | 실행 |
-|---|---|---|
-| Lite | 설계 문서가 없고 파일, symbol, 승인된 issue, 테스트 명령처럼 구현 경계가 이미 concrete (high-risk 0개) | 메인 직접 `test -> impl -> test pass -> pr-reviewer -> PR` |
-| Standard | 설계 문서(경로)가 들어옴 | `--design-doc` 기록 후 받은 설계도로 구현 — 엔진 풀4(디폴트) / 경량 build-worker |
-
-엔진(풀4/경량 build-worker)은 구현 경로와 직교 축이고 사용자 우선·미지정 시 메인 추천이다. 이번 범위에서 엔진 선택은 Standard 에 적용한다(Lite 는 메인 직접 구현). high-risk trigger 나 새 epic/product feature 는 impl *내부 구현 경로가 아니라* impl 진입 *전* 설계 선행(`/spec` 내부 tech-review preflight 필요 시 / `/design`)으로 분기되고, 산출된 설계도를 들고 Standard 로 진입한다.
+사용자는 구현 경로 이름을 외울 필요가 없다. `/impl` 은 설계를 하지 않고 **설계도를 보고 구현만** 하며, 구현 경로(설계도 유무)와 엔진(풀4/경량)을 직교로 고른다. high-risk trigger 나 새 epic/product feature 는 impl 내부 구현 경로가 아니라 impl 진입 전 설계 선행(`/spec` 내부 tech-review preflight 필요 시 / `/design`)으로 분기된다. Lite / Standard 조건, high-risk 선행, 되돌림 기준은 [`workflow-router.md#구현-경로-표`](workflow-router.md#구현-경로-표) 가 소유한다. 본 문서는 공개 진입점과 사용자-facing 노출 범위만 소유한다.
 
 ## Support Entrypoints
 

--- a/scripts/setup_branch_protection.mjs
+++ b/scripts/setup_branch_protection.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * dcNess main branch protection 적용 스크립트 (현재 비활성 — 옵션 도구)
- * 규칙 정의: docs/internal/governance.md §2.8 (SSOT)
+ * 참고: docs/plugin/hooks.md 의 CI workflow / branch protection 관계.
  *
  * ⚠️ 현재 상태 (DCN-CHG-20260501-06 이후): main protection OFF.
  *   doc-sync 만 실질 강제하면 충분 + paths 필터 폐기 트레이드오프 회피.
@@ -20,7 +20,7 @@
  *
  * 의존: gh CLI 인증 + 본 저장소 admin 권한.
  *   - 비-admin 실행 시: HTTP 403 / "Resource not accessible by integration".
- *   - 그 경우 GitHub UI 에서 동일 설정 수동 적용 (docs/internal/branch-protection-setup.md 참조).
+ *   - 그 경우 GitHub Settings > Branches/Rulesets 에서 required check 를 수동 설정한다 (docs/plugin/hooks.md 참조).
  */
 import { execSync } from 'node:child_process';
 
@@ -96,7 +96,7 @@ try {
   console.error(`  ${e.stderr?.toString() || e.message}`);
   console.error('');
   console.error('가능한 원인:');
-  console.error('  1. admin 권한 부족 → GitHub UI 에서 수동 적용 (docs/archive/branch-protection-setup.md)');
+  console.error('  1. admin 권한 부족 → GitHub Settings > Branches/Rulesets 에서 수동 적용 (docs/plugin/hooks.md)');
   console.error('  2. 필수 check 이름 mismatch → 실제 워크플로우 jobs.<id>.name 확인');
   console.error('  3. branch protection plan 제한 (private repo + free plan 일부 기능 제한)');
   process.exit(1);

--- a/skills/spec/SKILL.md
+++ b/skills/spec/SKILL.md
@@ -9,7 +9,7 @@ description: 새 기능 / PRD 변경 / 큰 기획을 받아 메인 Claude 가 �
 
 흐름 요약: PRD 초안 → 사용자 초안 확인 → 기술 검토 필요 영역에 항목이 있으면 `/tech-review` preflight → PRD 최종화 → stories.md → `product-acceptance:SPEC_ACCEPTANCE` → PR 머지 → 이슈 등록 여부 확인 → `/design`.
 
-분기 규칙 SSOT 는 [`spec-routing.md`](spec-routing.md) 다. 본 파일은 Step 운전 절차만 담는다. 용어·공개 진입점·분기 표현을 수정하거나 리뷰할 때만 [`terms.md`](../../docs/plugin/terms.md) 를 확인한다.
+Step 내부 분기는 본 파일이 소유한다. skill 간 이동·재진입은 [`spec-routing.md`](spec-routing.md)가 소유한다. 본 파일은 Step 운전 절차와 체크포인트 응답을 담는다. 용어·공개 진입점·분기 표현을 수정하거나 리뷰할 때만 [`terms.md`](../../docs/plugin/terms.md) 를 확인한다.
 
 ## References
 
@@ -24,7 +24,7 @@ description: 새 기능 / PRD 변경 / 큰 기획을 받아 메인 Claude 가 �
 
 ### Step 0 — 사전 read
 
-정상 흐름은 본 파일과 필요한 reference 만 읽고 진행한다. 분기 판단이 필요하면 [`spec-routing.md`](spec-routing.md)를 확인한다.
+정상 흐름은 본 파일과 필요한 reference 만 읽고 진행한다. Step 내부 체크포인트는 아래 절차를 따르고, skill 간 이동·재진입 경계가 필요할 때만 [`spec-routing.md`](spec-routing.md)를 확인한다.
 
 ### Step 1 — 사용자와 그릴 대화
 

--- a/skills/spec/spec-delivery-reference.md
+++ b/skills/spec/spec-delivery-reference.md
@@ -35,7 +35,7 @@ bash "$PLUGIN_ROOT/scripts/pr-finalize.sh" <PR_NUMBER>
 
 PR 머지 완료 후 사용자가 Y 를 선택하면 메인이 자동화 스크립트를 호출한다.
 
-이슈 생성 전에 보드(Project) 상태를 점검한다. 좌표(owner/number)는 `gh variable get DCNESS_PROJECT_NUMBER` 로 조회하거나 `--project`/`--owner` 로 넘긴다. 보드나 field/option 이 없거나 불완전하면 사용자에게 "지금 보드를 만들/채울까요?" 를 물어보고, 동의하면 `github_project_lifecycle.mjs bootstrap --apply` (보드 자체가 없으면 `gh project create` + `gh project link` 를 먼저) 로 셋업한 뒤 좌표를 `gh variable set` 으로 저장한다. 거부하면 보드 없이 진행한다. 어떤 경우에도 이슈 생성은 막지 않는다.
+이슈 생성 전에 보드(Project) 상태를 점검한다. Project 좌표 해석, field/option bootstrap, 등록 skip/backfill 정책은 [`docs/plugin/issue-lifecycle.md#github-project-status-lifecycle`](../../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle) 를 따른다. 어떤 경우에도 이슈 생성은 막지 않는다.
 
 ```bash
 bash "$PLUGIN_ROOT/scripts/create_epic_story_issues.sh" docs/epics/epic-NN-<slug>/stories.md --project <number> --owner <owner>
@@ -48,7 +48,7 @@ bash "$PLUGIN_ROOT/scripts/create_epic_story_issues.sh" docs/epics/epic-NN-<slug
 3. epic issue 생성 → stories.md 에 번호 기록
 4. story issue N개 생성 → stories.md 에 번호와 하단 표 기록
 5. sub-issue API 호출
-6. GitHub Project 보드 등록 — epic(`Status=Todo`, `IssueType=epic`, `Priority=major`) / story(`Status=Todo`, `IssueType=story`, `Priority=major`). 좌표 없으면 등록 skip + 경고(이슈는 생성됨). 멱등 재실행 시 이슈 생성은 skip 하고 보드 등록만 backfill
+6. GitHub Project 보드 등록 — epic(`Status=Todo`, `IssueType=epic`, `Priority=major`) / story(`Status=Todo`, `IssueType=story`, `Priority=major`). 좌표·backfill 정책은 [`docs/plugin/issue-lifecycle.md#github-project-status-lifecycle`](../../docs/plugin/issue-lifecycle.md#github-project-status-lifecycle) 포인터를 따른다
 7. 결과 prose 출력
 
 스크립트 실패 시 메인이 사용자에게 보고하고 [`docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#sub-issue-연결-epic-story-gh-api-메커니즘)에 따라 수동 처리한다. 보드 등록이 partial 이면 어떤 issue 가 미반영인지 보고하고 보드/field 셋업 후 재실행으로 backfill 한다. 이슈 등록 후 stories.md 변경분은 별도 commit + PR 또는 사용자 자율이다.

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -110,6 +110,19 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.deliverables_map = (
             ROOT / "docs" / "plugin" / "deliverables-map.md"
         ).read_text(encoding="utf-8")
+        self.claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        self.github_project = (
+            ROOT / "docs" / "plugin" / "github-project.md"
+        ).read_text(encoding="utf-8")
+        self.design_tokens_doc = (
+            ROOT / "docs" / "plugin" / "design.md"
+        ).read_text(encoding="utf-8")
+        self.smart_compact = (
+            ROOT / "commands" / "smart-compact.md"
+        ).read_text(encoding="utf-8")
+        self.branch_protection_script = (
+            ROOT / "scripts" / "setup_branch_protection.mjs"
+        ).read_text(encoding="utf-8")
 
     def test_removed_alias_skill_directories_do_not_exist(self) -> None:
         self.assertFalse((ROOT / "skills" / "product-plan").exists())
@@ -166,6 +179,73 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.pr_reviewer)
+
+    def test_project_registration_mechanics_have_single_owner(self) -> None:
+        """#853 — GitHub Project axis doc points to lifecycle mechanics instead of restating them."""
+        self.assertIn(
+            "node scripts/github_project_lifecycle.mjs register-issue",
+            self.issue_lifecycle,
+        )
+        self.assertIn(
+            "조회 우선순위: `--project`/`--owner` 플래그",
+            self.issue_lifecycle,
+        )
+        self.assertNotIn(
+            "node scripts/github_project_lifecycle.mjs register-issue",
+            self.github_project,
+        )
+        self.assertNotIn(
+            "조회 우선순위: `--project`/`--owner` 플래그",
+            self.github_project,
+        )
+        self.assertIn("issue-lifecycle.md#github-project-status-lifecycle", self.github_project)
+        self.assertNotIn("좌표(owner/number)", self.spec_delivery_reference)
+        self.assertIn(
+            "issue-lifecycle.md#github-project-status-lifecycle",
+            self.spec_delivery_reference,
+        )
+
+    def test_workflow_router_owns_impl_lane_conditions(self) -> None:
+        """#853 — positioning owns public surface; workflow-router owns Lite/Standard conditions."""
+        self.assertIn("## 구현 경로 표", self.router)
+        self.assertIn("concrete signal", self.router)
+        self.assertNotIn("| 내부 구현 경로 | 조건 | 실행 |", self.positioning)
+        self.assertIn("workflow-router.md#구현-경로-표", self.positioning)
+
+    def test_claude_doc_map_reaches_current_plugin_docs(self) -> None:
+        """#853 — CLAUDE.md doc map reaches every current docs/plugin markdown file."""
+        plugin_docs = sorted(
+            path.relative_to(ROOT).as_posix()
+            for path in (ROOT / "docs" / "plugin").rglob("*.md")
+        )
+        missing = [path for path in plugin_docs if path not in self.claude]
+        self.assertEqual([], missing)
+        self.assertNotIn("## 문서 지도\n\n\n\n", self.claude)
+
+    def test_design_token_doc_is_disambiguated_from_design_workflow(self) -> None:
+        """#853 — docs/plugin/design.md is token/spec guidance, not the /design workflow."""
+        self.assertIn("본 문서는 `/design` workflow skill 이 아니라", self.design_tokens_doc)
+        self.assertIn("skills/design/SKILL.md", self.design_tokens_doc)
+
+    def test_external_runtime_docs_do_not_point_at_archive_paths(self) -> None:
+        """#853 — deployed command/script guidance should not require release-pruned archive docs."""
+        self.assertNotIn("docs/archive/", self.smart_compact)
+        self.assertNotIn("docs/archive/branch-protection-setup.md", self.branch_protection_script)
+        self.assertNotIn("docs/internal/branch-protection-setup.md", self.branch_protection_script)
+        self.assertIn("docs/plugin/hooks.md", self.branch_protection_script)
+
+    def test_spec_skill_wording_matches_step_ownership_split(self) -> None:
+        """#857 follow-up — SKILL owns Step-internal branches; routing owns inter-skill movement."""
+        self.assertIn("Step 내부 분기는 본 파일이 소유", self.spec_skill)
+        self.assertIn("skill 간 이동·재진입은 [`spec-routing.md`](spec-routing.md)", self.spec_skill)
+        self.assertNotIn(
+            "분기 규칙 SSOT 는 [`spec-routing.md`](spec-routing.md) 다.",
+            self.spec_skill,
+        )
+        self.assertNotIn(
+            "분기 판단이 필요하면 [`spec-routing.md`](spec-routing.md)를 확인한다.",
+            self.spec_skill,
+        )
 
     def test_readme_uses_lifecycle_defaults_without_compat_aliases(self) -> None:
         basic_table = self._section(self.readme, r"\| 기본 진입점 \|", r"\n`/impl`")


### PR DESCRIPTION
## 관련 이슈 번호

Closes #853

## 배경 및 문제

- #853 문서 정비 AC에서 register-issue / GitHub Project 좌표, Lite/Standard 조건 표, release-pruned archive 참조, 문서 지도 누락, design token 문서 모호성 정리를 요구했습니다.
- PR #857 리뷰에서 skills/spec/SKILL.md가 spec-routing.md를 Step 내부 분기 SSOT처럼 설명하는 잔여 문구도 후속 후보로 지적되어 함께 반영했습니다.

## 원인 (해당 시)

- 동일 운영 설명이 docs/plugin, spec delivery reference, workflow router/positioning에 분산되어 문서 소유권이 흐려졌습니다.
- release 정리로 제거된 archive/internal 문서 경로가 일부 예시와 스크립트 안내에 남아 있었습니다.
- spec-routing.md의 소유권 분리 선언 이후 skills/spec/SKILL.md의 상단 문구와 Step 0 안내가 갱신되지 않았습니다.

## 작업내용

- GitHub Project 등록 실행 절차와 좌표 lifecycle은 issue-lifecycle.md로 단일화하고, github-project.md는 Priority 정책과 lifecycle 링크만 남겼습니다.
- Lite/Standard 구현 경로 조건 표는 workflow-router.md 소유로 정리하고 positioning.md에는 공개 surface 방향과 링크만 유지했습니다.
- CLAUDE.md 문서 지도에 현재 docs/plugin 문서를 보강하고, docs/plugin/design.md가 design token spec 문서임을 명시했습니다.
- stale archive/internal 경로 참조를 현행 docs/plugin 문서로 교체했습니다.
- skills/spec/SKILL.md의 소유권 문구를 Step 내부 분기와 skill 간 routing 분리 모델에 맞게 수정했습니다.
- #853 및 PR #857 잔여 문구 회귀를 막는 surface docs sync 테스트를 추가했습니다.

## 결정 근거

- 실행 절차는 실제 command와 lifecycle을 설명하는 issue-lifecycle.md가 소유하고, 정책/개념 문서는 해당 소유 문서로 링크하는 방식이 중복 drift를 줄입니다.
- workflow-router.md가 구현 lane 조건의 SSOT라서 positioning.md에는 public surface 방향만 두는 편이 역할 경계와 맞습니다.
- spec-routing.md는 skill 간 이동과 re-entry를 설명하고, Step 내부 운전은 SKILL.md가 설명하도록 문구를 분리했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- docs/plugin 및 skills/spec 문서 변경이 포함됩니다.
- cross-ref, public-surface, plugin manifest, aggregate map, static quality, 전체 unittest gate를 통과시켜 배포 대상 문서와 운영 surface의 참조 무결성을 확인했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] python3.11 -m unittest discover -s tests -v
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] node scripts/check_plugin_manifest.mjs
- [x] node scripts/aggregate_index_map.mjs --check
- [x] node scripts/aggregate_architecture_map.mjs --check
- [x] PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh
- [x] git diff --check

## 참고

- Commit: d050b52f24b881cf7119947a2b2ee8fa57283c97
- Local review round: 1/3 PASS