### PR TITLE
[issue-852] worktree 종료 discard 조건 보강

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -28,7 +28,7 @@ EnterWorktree(name="<skill>-{ts_short}")   # action 루프 (impl / impl-loop / d
 
 - **거부 표현 시에만 건너뜀** — 사용자 발화에 정규식 `워크트리\s*(빼|없|말)` 매치 시 EnterWorktree 호출 0, 일반 cwd 그대로 진행.
 - 수동 `git worktree add` 우회 금지 — CC permission 시스템이 EnterWorktree 만 자동 권한 처리. 수동 워크트리는 sub-agent Write 거부 회귀 (#255 W1). **예외 = 통합 브랜치 모드** ([base-ref 분기](#base-ref-분기-통합-브랜치-모드-424) — 사전 `git worktree add` 후 `EnterWorktree(path=)` 진입, CC 가 path= 도 권한 처리).
-- **종료 시 ExitWorktree (squash 흡수 자동 분기)** — `main..<worktree-branch>` diff (`.claude` 제외) 가 비면 이미 머지 흡수된 것 → `ExitWorktree(action="remove", discard_changes=true)`, 남아있으면 `ExitWorktree(action="keep")`.
+- **종료 시 ExitWorktree (커밋 diff 흡수 + clean worktree 자동 분기)** — 자동 remove/discard 조건은 **커밋 diff 흡수 확인 + working tree clean** 둘 다다. 먼저 `main..<worktree-branch>` diff (`.claude` 제외) 가 비어 이미 머지 흡수됐는지 확인하고, 이어서 worktree cwd 에서 `git status --porcelain --untracked-files=all` 이 빈 값인지 확인한다. 두 조건을 모두 만족할 때만 `ExitWorktree(action="remove", discard_changes=true)` 를 호출한다. 커밋 diff 가 남아 있거나 `uncommitted/untracked` 파일이 하나라도 있으면 `ExitWorktree(action="keep")` 으로 강등하며, dirty 상태 자동 discard 금지.
 
 ### base-ref 분기 (통합 브랜치 모드, #424)
 
@@ -352,7 +352,7 @@ end-run 안전망 (`session_state.py`) 이 자동으로 `finalize-run --auto-rev
 
 clean 판정 통과 시 사용자 확인 없이 자동 진행 (**impl-task-loop 외** 루프): branch (`<prefix>/<short-slug>`, prefix = 해당 loop 의 branch_prefix — [`git-spec.md` 브랜치](git-spec.md#브랜치) valid 패턴) → **변경 파일 commit** → push → PR create → merge → main sync. **commit 대상 = 해당 loop 가 실제 변경한 파일** — design = `docs/**` 설계 산출물, ux = epic `ux-flow.md`, `docs/design.md`, `docs/design-variants/<screen-id>.html`, `docs/design-variants/canvas.html`, 필요 시 `docs/design-variants/_lib/**` seed 라 src-only 아님 (src-only 제한은 impl-task-loop 전용, [impl-task-loop commit 구조](#impl-task-loop-commit-구조)). **stray untracked 휩쓸기 주의**: impl 루프와 달리 비-impl loop 은 worktree 권한 경계가 src-only 가 아니고 clean 매트릭스가 untracked ≤ 10 을 허용하므로, `pr-create.sh` 의 `git add -A` 는 무관한 로컬 아티팩트까지 stage 한다 → 호출 *전* 산출물 외 파일을 정리하거나, 해당 loop 산출물만 명시 pathspec 으로 직접 stage 후 commit. 네이밍·본문·트레일러 = [`git-spec.md`](git-spec.md), 커밋 trailer 의 모델 표기는 글로벌 `~/.claude/CLAUDE.md` 기준. 실행 = [`scripts/pr-create.sh`](../../scripts/pr-create.sh) + [`scripts/pr-finalize.sh`](../../scripts/pr-finalize.sh).
 
-worktree 진입 시 squash 흡수 검사 후 `ExitWorktree(action="<keep|remove>")` ([worktree 분기](#worktree-분기-action-루프-한정)).
+worktree 진입 시 [worktree 분기](#worktree-분기-action-루프-한정) 의 커밋 diff 흡수 + working tree clean 검사를 완료한 뒤 `ExitWorktree(action="<keep|remove>")` 를 호출한다.
 
 ### 7b — 주의사항 확인
 

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -143,7 +143,7 @@ Lite 는 `/impl-loop` 경량 모드가 아니다. impl 계획 파일 없이 메�
    - git-spec 이 있으면 [`git-spec.md`](../../docs/plugin/git-spec.md) 패턴을 따른다.
    - 사용자가 "워크트리 없이"라고 하지 않으면 worktree 격리를 기본으로 한다.
    - worktree 진입 후 Read/Edit/Write 대상은 worktree 절대경로 또는 worktree cwd 상대경로로 다시 잡는다. 진입 전에 읽은 main repo 절대경로를 그대로 Edit 하지 않는다.
-   - 종료 정리 규칙은 [`loop-procedure` worktree 분기](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정) 를 따른다. `ExitWorktree(action="remove", discard_changes=true)` 는 커밋 diff 흡수 확인 + working tree clean 둘 다 만족할 때만 호출하고, uncommitted/untracked 파일이 있으면 keep 으로 강등한다.
+   - 종료 시 `ExitWorktree` 정리 판단은 [`loop-procedure` worktree 분기](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정) 를 따른다.
 2. 테스트 선작성
    - 테스트 가능한 코드 변경은 구현 전에 실패 테스트를 먼저 쓴다.
    - docs-only / 단순 설정 변경은 TDD skip 사유를 명시한다.

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -143,6 +143,7 @@ Lite 는 `/impl-loop` 경량 모드가 아니다. impl 계획 파일 없이 메�
    - git-spec 이 있으면 [`git-spec.md`](../../docs/plugin/git-spec.md) 패턴을 따른다.
    - 사용자가 "워크트리 없이"라고 하지 않으면 worktree 격리를 기본으로 한다.
    - worktree 진입 후 Read/Edit/Write 대상은 worktree 절대경로 또는 worktree cwd 상대경로로 다시 잡는다. 진입 전에 읽은 main repo 절대경로를 그대로 Edit 하지 않는다.
+   - 종료 정리 규칙은 [`loop-procedure` worktree 분기](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정) 를 따른다. `ExitWorktree(action="remove", discard_changes=true)` 는 커밋 diff 흡수 확인 + working tree clean 둘 다 만족할 때만 호출하고, uncommitted/untracked 파일이 있으면 keep 으로 강등한다.
 2. 테스트 선작성
    - 테스트 가능한 코드 변경은 구현 전에 실패 테스트를 먼저 쓴다.
    - docs-only / 단순 설정 변경은 TDD skip 사유를 명시한다.

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -549,6 +549,25 @@ class SurfaceDocsSyncTests(unittest.TestCase):
                 self.assertIn(needle, self.design_skill)
         self.assertIn("end-run/metrics freeze 후 Step 7 PR", self.design_routing)
 
+    def test_issue_852_worktree_remove_requires_clean_worktree(self) -> None:
+        """#852 — auto discard requires absorbed commits and no local dirty files."""
+        for needle in (
+            "커밋 diff 흡수 확인 + working tree clean",
+            "git status --porcelain --untracked-files=all",
+            "uncommitted/untracked",
+            'ExitWorktree(action="remove", discard_changes=true)',
+            'ExitWorktree(action="keep")',
+            "자동 discard 금지",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.loop_procedure)
+
+        self.assertIn(
+            "../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정",
+            self.impl_skill,
+        )
+        self.assertIn("ExitWorktree", self.impl_skill)
+
     def test_issue_832_design_runs_mechanical_artifact_audit(self) -> None:
         """#832 — design loop runs the artifact audit before final validator/PR."""
         for needle in (


### PR DESCRIPTION
## 관련 이슈 번호

Closes #852

## 배경 및 문제

- ExitWorktree 자동 remove 규칙이 커밋 diff 흡수만 말하고 uncommitted/untracked 파일 clean 확인을 요구하지 않아 dirty worktree에서 discard_changes=true 경로가 열려 있었다.
- /impl 스킬에서 worktree 종료 SSOT로 바로 가는 링크가 없어 외부 활성 프로젝트 agent가 정리 규칙에 1-hop으로 도달하기 어려웠다.

## 원인 (해당 시)

- loop-procedure의 종료 조건이 `main..<worktree-branch>` diff만 기준으로 문서화되어 working tree dirty 상태를 별도 remove 차단 조건으로 못 박지 않았다.
- impl skill의 worktree 절차가 진입/편집 위치만 설명하고 종료 정리 규칙 링크를 빠뜨렸다.

## 작업내용

- `docs/plugin/loop-procedure.md`: 자동 remove/discard 조건을 `커밋 diff 흡수 확인 + working tree clean`으로 명문화하고 dirty 상태는 keep으로 강등.
- `skills/impl/SKILL.md`: worktree 종료 정리 규칙 SSOT anchor 링크 추가.
- `tests/test_surface_docs_sync.py`: #852 문서 계약 회귀 테스트 추가.

## 결정 근거

- `git status --porcelain --untracked-files=all`은 staged, unstaged, untracked 상태를 한 번에 잡아 dirty worktree 자동 discard를 차단한다.
- ExitWorktree 자체가 repo 구현 코드가 아니라 loop 운전 계약이므로 SSOT 문서와 문서 sync 테스트로 회귀를 막는 방식이 현재 구조에 맞다.

## 배포 경로 검증 (plug-in 영향 시)

- `skills/impl/SKILL.md`: plug-in 본체 skill 파일 변경. 사용자는 plug-in 업데이트 후 /impl 실행 시 새 링크를 본다.
- `docs/plugin/loop-procedure.md`: plug-in 사용자용 SSOT 문서 변경. `skills/impl/SKILL.md`에서 1-hop 링크로 도달한다.
- `/init-dcness` 복사 파일 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_surface_docs_sync.SurfaceDocsSyncTests.test_issue_852_worktree_remove_requires_clean_worktree -v`
- [x] `python3.11 -m unittest discover -s tests -q`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`

## 참고

- Issue Project Status: In progress