### PR TITLE
[issue-859] provider-agnostic guard 복원

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -15,7 +15,7 @@ dcNess 의 강제 영역은 두 가지뿐이다.
 
 | Layer | 실행 주체 | 발화 시점 | 주 역할 | 대표 차단 |
 |---|---|---|---|---|
-| **1. CC hooks** | Claude Code plug-in hook | Claude 가 tool 을 쓰기 전/후, sub-agent 종료, 메인 응답 종료 | 작업 순서, 파일 경계, TDD, run state 보존 | 잘못된 agent 순서, out-of-bound file write, test 없는 TS/JS 구현 |
+| **1. runtime hooks/helpers** | Claude Code plug-in hook + dcness helper/wrapper | Claude 가 tool 을 쓰기 전/후, helper step 시작, headless worker 종료, sub-agent 종료, 메인 응답 종료 | 작업 순서, 파일 경계, TDD, run state 보존 | 잘못된 agent 순서, out-of-bound file write, test 없는 TS/JS 구현 |
 | **2. git hooks** | local git | commit / checkout / push lifecycle | 로컬 git 조작 조기 차단 | 커밋 제목 위반, main 직접 push, 브랜치명 위반 |
 | **3. CI/CD workflows** | GitHub Actions | PR / issue / merge event | 로컬 우회와 원격 상태 drift 검증 | PR 제목/body 위반, 문서 경로 위반, Project lifecycle drift |
 
@@ -71,14 +71,14 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 
 사용자-facing 용어: **순서 차단 훅**. 파일명과 hook command 는 호환성을 위해 `catastrophic-gate.sh` 를 유지한다.
 
-**시점**: 메인 Claude 가 `Agent` tool 로 sub-agent 를 호출하기 직전.
+**시점**: 메인 Claude 가 `Agent` tool 로 sub-agent 를 호출하기 직전, 그리고 `dcness-helper begin-step` 이 step 시작을 기록하기 직전. Claude Agent provider 는 전자를 타고, Codex/headless provider 는 후자를 탄다.
 
-**역할**: 작업 순서 보호와 active run 의 `begin-step -> Agent -> end-step` 물리 순서를 강제한다.
+**역할**: 작업 순서 보호와 active run 의 `begin-step -> Agent/headless worker -> end-step` 물리 순서를 강제한다. engineer/build-worker / pr-reviewer / module-architect 순서 불변식은 provider 와 무관하게 같은 판정 함수를 쓴다.
 
 | Gate | 차단 조건 |
 |---|---|
 | pr-reviewer gate | engineer 산출물이 있는데 code-validator PASS 없이 pr-reviewer 호출 |
-| engineer gate | 설계 산출물 없이 engineer 가 src 구현으로 진입 — 같은 run 의 module-architect PASS *또는* `begin-run --design-doc` 으로 기록된 설계 문서 실존 *또는* `begin-run --lane lite` 로 기록된 Lite 구현 경로(#714), 셋 중 하나로 충족 |
+| engineer gate | 설계 산출물 없이 engineer/build-worker 가 src 구현으로 진입 — 같은 run 의 module-architect PASS *또는* `begin-run --design-doc` 으로 기록된 설계 문서 실존 *또는* `begin-run --lane lite` 로 기록된 Lite 구현 경로(#714), 셋 중 하나로 충족 |
 | module-architect gate | architecture-validator 1차 PASS 없이 design 의 module-architect 반복 진입 |
 | 진행 순서 검사 | active run 안에서 직전 `begin-step` 과 다른 agent/mode 호출, `current_step` 부재, 이미 staged 된 stale step |
 
@@ -86,11 +86,11 @@ Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision:
 
 **engineer gate 의 design_doc 경로**: 설계(impl 문서 / compact plan)가 *별도 run* 에서 작성·머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서는 같은 run 안에 module-architect prose 가 없다. 이때 `begin-run impl --design-doc <머지된 설계 문서 경로>` 로 run 에 설계 산출물을 기록하면 engineer gate 가 그 실존을 사전 조건 증거로 인정한다. 경로는 설계 산출물 규약(`docs/epics/**` / `docs/compact-plans/**`) 안의 실존 `.md` 만 허용 — 기록 시점에 resolve 절대경로로 fail-fast 검증(traversal / repo 밖 경로 거부)하고, 게이트 시점에 실존을 재확인한다. `--design-doc` 은 `entry_point=impl` run 에서만 수용된다(다른 entry_point 는 begin-run 이 거부) — design / architect-loop run 의 기존 module-architect PASS 강제는 코드 보장으로 유지된다.
 
-**engineer gate 의 구현 경로 면제 (#714)**: `/impl` 2축 모델의 Lite 구현 경로(설계도 없음)에 sub-agent 엔진(풀4 / 경량 build-worker)을 붙이는 4번째 조합용 면제 경로다. Lite 는 정의상 설계도가 없어 module-architect PASS 도 design_doc 도 없으므로, `begin-run impl --lane lite` 로 run 슬롯에 구현 경로를 기록하면 engineer gate 가 그 기록을 설계 산출물 사전 조건 면제 신호로 인정한다. **면제 경계** — (1) `--lane` 값은 닫힌 enum(`lite` / `standard`)만 수용(임의 문자열 거부), (2) `--lane lite` 는 `entry_point=impl` run 에서만 수용(다른 entry_point 는 begin-run 이 거부)되어 design / architect-loop 의 module-architect PASS 강제는 영향받지 않음, (3) 면제는 *명시적으로 기록된* `lane=lite` 한정 — 값 미기록(impl-loop 풀4 / 기본)과 `lane=standard` 는 종전대로 설계 산출물을 요구(면제 누수 차단), (4) 면제는 engineer gate *하나만* 푼다 — engineer 산출물 이후 `pr-reviewer ← code-validator PASS` 잔존 보호는 구현 경로와 무관하게 그대로 강제된다(풀4 경로의 중대 차단 보호 불변).
+**engineer gate 의 구현 경로 면제 (#714)**: `/impl` 2축 모델의 Lite 구현 경로(설계도 없음)에 sub-agent 엔진(풀4 / 경량 build-worker)을 붙이는 4번째 조합용 면제 경로다. Lite 는 정의상 설계도가 없어 module-architect PASS 도 design_doc 도 없으므로, `begin-run impl --lane lite` 로 run 슬롯에 구현 경로를 기록하면 engineer gate 가 그 기록을 engineer/build-worker 설계 산출물 사전 조건 면제 신호로 인정한다. **면제 경계** — (1) `--lane` 값은 닫힌 enum(`lite` / `standard`)만 수용(임의 문자열 거부), (2) `--lane lite` 는 `entry_point=impl` run 에서만 수용(다른 entry_point 는 begin-run 이 거부)되어 design / architect-loop 의 module-architect PASS 강제는 영향받지 않음, (3) 면제는 *명시적으로 기록된* `lane=lite` 한정 — 값 미기록(impl-loop 풀4 / 기본)과 `lane=standard` 는 종전대로 설계 산출물을 요구(면제 누수 차단), (4) 면제는 engineer gate *하나만* 푼다 — engineer 산출물 이후 `pr-reviewer ← code-validator PASS` 잔존 보호는 구현 경로와 무관하게 그대로 강제된다(풀4 경로의 중대 차단 보호 불변).
 
 **tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. /design 도중 미검증 새 외부 의존이 발견되면 design 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 
-**차단**: 위반 시 `exit 2` + stderr. engineer / pr-reviewer / module-architect 게이트 위반은 `[순서 차단 훅: <gate>]`, 진행 순서 검사 위반은 `[진행 순서 검사]` 접두사를 포함한다.
+**차단**: Claude Code PreToolUse 에서는 위반 시 `exit 2` + stderr, helper `begin-step` 에서는 비-0 종료 + stderr. engineer / pr-reviewer / module-architect 게이트 위반은 `[순서 차단 훅: <gate>]`, 진행 순서 검사 위반은 `[진행 순서 검사]` 접두사를 포함한다. 게이트 자체 예외는 fail-open 계측으로 남기고 과차단하지 않는다.
 
 ### file-guard.sh
 
@@ -149,7 +149,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 ### tdd-guard.sh
 
-**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. `Bash` 는 명시적 write target 추출 직후, 각 target 에 같은 검사를 적용한다.
+**시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. `Bash` 는 명시적 write target 추출 직후, 각 target 에 같은 검사를 적용한다. Codex/headless 구현 worker 는 Codex 성공 종료 후 `end-step` 저장 전에 변경 파일 목록에 같은 검사를 적용한다.
 
 **지원 언어**: TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`). 그 외 확장자는 silent skip — Python·Rust·Go 등 다른 ecosystem 의 TDD 강제는 현재 범위 밖이다.
 
@@ -171,7 +171,9 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **Bash write target 정책**: `Bash` payload 는 [`harness.agent_boundary.extract_bash_paths`](../../harness/agent_boundary.py) 가 추출하는 명시적 write target 에 한해 검사한다. 예: redirect(`>`, `>>`), `tee`, in-place edit(`sed/perl/awk -i`), `cp`/`mv`/`rm` target. 추출된 target 이 TS/JS 구현 파일이면 직접 `Edit`/`Write`/`NotebookEdit` 와 동일한 skip 규칙 및 6-tier matching-test 존재 검사를 탄다. write target 이 없거나 TS/JS 구현 파일이 아니면 silent skip 한다.
 
-**차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다.
+**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
+
+**차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다. Headless worker 차단 메시지는 `[dcness-codex-worker] BLOCKED: TDD GUARD ...` 로 시작하고 위반 파일 목록을 포함한다.
 
 ### post-agent-clear.sh
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -445,7 +445,7 @@ dcNess run 밖에서 호출되면 ledger 기록은 경고만 내고 PR 작업 �
 
 ## 순서 차단 훅 정합
 
-각 loop 의 entry_point / task_list / advance / expected_steps 진본 = 해당 skill 의 `## Loop` contract. 그 시퀀스가 중대 차단 룰을 자연 충족한다 — 순서 차단 훅 진본 = [`hooks.md`](hooks.md#catastrophic-gatesh) (`hooks/catastrophic-gate.sh` 강제): code-validator → pr-reviewer 직전 PASS / engineer 직전 module-architect `PASS` enum / `/design` 첫 module-architect 단위 진입 직전 architecture-validator 1차 PASS. (tech-review 진입 gate = PRD 변경 후 사용자 2 차 OK · `/design` 진입 후 tech-reviewer 재호출 비권장 = 코드 강제 아닌 자연어 관례.) 8 hook 전체 시점·차단·우회 = [`hooks.md`](hooks.md).
+각 loop 의 entry_point / task_list / advance / expected_steps 진본 = 해당 skill 의 `## Loop` contract. 그 시퀀스가 중대 차단 룰을 자연 충족한다 — 순서 차단 훅 진본 = [`hooks.md`](hooks.md#catastrophic-gatesh) (`hooks/catastrophic-gate.sh` 강제): code-validator → pr-reviewer 직전 PASS / engineer·build-worker 직전 module-architect `PASS` enum 또는 동등 설계 산출물 / `/design` 첫 module-architect 단위 진입 직전 architecture-validator 1차 PASS. (tech-review 진입 gate = PRD 변경 후 사용자 2 차 OK · `/design` 진입 후 tech-reviewer 재호출 비권장 = 코드 강제 아닌 자연어 관례.) 8 hook 전체 시점·차단·우회 = [`hooks.md`](hooks.md).
 
 ---
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -4,8 +4,9 @@ dcness 자체 QA 도구다. plug-in 배포물이 아니다.
 
 eval 은 두 종류로 나눈다.
 
-- **결정적 guard-efficacy** — hook/function 진입점을 LLM 없이 호출해 file boundary,
-  Bash/MCP mutation, order gate, TDD guard 의 allow/block 동작을 fixture 로 확인한다.
+- **결정적 guard-efficacy** — hook/function/wrapper 진입점을 LLM 없이 호출해 file boundary,
+  Bash/MCP mutation, order gate, TDD guard, headless provider 경로의 allow/block 동작을
+  fixture 로 확인한다.
 - **LLM 행동 eval** — agent 지침 변경이 기존 보호를 깨먹는지, 실제 agent 실행으로
   "agent 가 그 기준대로 실제 판정하는가"를 확인한다.
 
@@ -35,10 +36,10 @@ EVAL_RUNS=3 bash evals/run.sh        # 케이스당 3회 반복 (릴리즈 전 �
 EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonnet)
 ```
 
-`guard_efficacy.py` 는 범주별 pass/fail count 를 출력한다. `known-bypass-boundary`
-범주는 "보호됨" 이 아니라 문서화된 한계가 실제로 한계로 남아 있음을 드러내는 항목이다.
-예: TDD guard 는 `Edit`/`Write`/`NotebookEdit` 직접 파일 도구에만 걸리고 Bash 로 만든
-구현 파일에는 매칭 테스트 존재 검사를 하지 않는다.
+`guard_efficacy.py` 는 범주별 pass/fail count 를 출력한다. `provider-agnostic-order-gate`
+와 `provider-agnostic-tdd` 범주는 Claude Agent hook 이 아닌 `begin-step`/headless worker
+경로에서도 같은 불변식이 발화하는지 재현한다. `known-bypass-boundary` 범주는 "보호됨" 이
+아니라 문서화된 한계가 실제로 한계로 남아 있음을 드러내는 항목이다.
 
 케이스마다 `정답 k/N` 표가 출력된다. 어떤 케이스든 정답 0회면 exit 1 — 방금 바꾼 지침이 보호를 깨먹었는지 확인한다.
 

--- a/evals/guard_efficacy.py
+++ b/evals/guard_efficacy.py
@@ -33,6 +33,7 @@ from harness.hooks import handle_pretooluse_agent  # noqa: E402
 from harness.session_state import (  # noqa: E402
     start_run,
     update_current_step,
+    evaluate_order_gate_for_step,
     update_live,
     write_pid_current_run,
     write_pid_session,
@@ -128,11 +129,122 @@ def _order_gate(subagent: str, *, current_step: str | None = None) -> Probe:
     return probe
 
 
+def _begin_step_order_gate(
+    agent: str,
+    *,
+    mode: str | None = None,
+    lane: str | None = None,
+    engineer_output: bool = False,
+    code_validator_pass: bool = False,
+) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        sid = "eval-sid"
+        rid = "run-22222222"
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            update_live(sid, base_dir=base)
+            start_run(sid, rid, "impl", base_dir=base, lane=lane)
+            rd = base / ".sessions" / sid / "runs" / rid
+            if engineer_output:
+                _write_file(rd, "engineer.md", "implementation\n\nPASS\n")
+            if code_validator_pass:
+                _write_file(rd, "code-validator.md", "validated\n\nPASS\n")
+            message = evaluate_order_gate_for_step(
+                sid, rid, agent, mode, base_dir=base,
+            )
+            return ("block", message or "") if message else ("allow", "")
+
+    return probe
+
+
 def _write_file(root: Path, rel: str, content: str = "// fixture\n") -> Path:
     path = root / rel
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
     return path
+
+
+def _headless_worker_tdd(changed_files: dict[str, str]) -> Probe:
+    def probe() -> tuple[Decision, str]:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(
+                ["git", "init", "-q"],
+                cwd=project,
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            prompt = tmp / "prompt.md"
+            prompt.write_text("Implement the fixture task.\n", encoding="utf-8")
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                """#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import sys
+
+if len(sys.argv) > 1 and sys.argv[1] == "--help":
+    print("Usage: codex")
+    raise SystemExit(0)
+
+out = ""
+for idx, arg in enumerate(sys.argv[1:], start=1):
+    if arg == "--output-last-message" and idx + 1 < len(sys.argv):
+        out = sys.argv[idx + 1]
+sys.stdin.read()
+root = pathlib.Path.cwd()
+for rel, content in json.loads(os.environ["CODEX_WRITE_SPEC"]).items():
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+pathlib.Path(out).write_text("Worker prose\\n\\nPASS\\n", encoding="utf-8")
+""",
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            helper.chmod(0o755)
+
+            env = {
+                **os.environ,
+                "CODEX_WRITE_SPEC": json.dumps(changed_files),
+                "DCNESS_RUN_ID": "run-33333333",
+                "DCNESS_SESSION_ID": "eval-sid",
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}",
+            }
+            result = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "dcness-codex-worker"),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+                timeout=20,
+            )
+            if result.returncode == 0:
+                return ("allow", result.stdout.strip())
+            if result.returncode == 1 and "TDD GUARD" in result.stderr:
+                return ("block", result.stderr.strip())
+            return ("block", f"unexpected exit {result.returncode}: {result.stderr}")
+
+    return probe
 
 
 def _tdd_guard(rel_path: str, *, matching_test: bool = False) -> Probe:
@@ -317,6 +429,59 @@ def build_cases() -> list[GuardCase]:
             _order_gate("pr-reviewer", current_step="code-validator"),
         ),
         GuardCase(
+            "begin_step_blocks_engineer_without_design_artifact",
+            "provider-agnostic-order-gate",
+            "block",
+            "headless begin-step blocks engineer without design artifact or Lite lane.",
+            _begin_step_order_gate("engineer", mode="IMPL"),
+        ),
+        GuardCase(
+            "begin_step_blocks_build_worker_without_design_artifact",
+            "provider-agnostic-order-gate",
+            "block",
+            "headless begin-step blocks build-worker without design artifact or Lite lane.",
+            _begin_step_order_gate("build-worker"),
+        ),
+        GuardCase(
+            "begin_step_blocks_pr_reviewer_without_code_validator_pass",
+            "provider-agnostic-order-gate",
+            "block",
+            "headless begin-step blocks pr-reviewer after engineer output without code-validator PASS.",
+            _begin_step_order_gate("pr-reviewer", engineer_output=True),
+        ),
+        GuardCase(
+            "begin_step_allows_engineer_lite_lane",
+            "provider-agnostic-order-gate",
+            "allow",
+            "Lite lane exemption is preserved in headless begin-step.",
+            _begin_step_order_gate("engineer", mode="IMPL", lane="lite"),
+        ),
+        GuardCase(
+            "begin_step_allows_build_worker_lite_lane",
+            "provider-agnostic-order-gate",
+            "allow",
+            "Lite lane exemption is preserved for build-worker headless begin-step.",
+            _begin_step_order_gate("build-worker", lane="lite"),
+        ),
+        GuardCase(
+            "begin_step_allows_engineer_polish",
+            "provider-agnostic-order-gate",
+            "allow",
+            "POLISH mode remains exempt from engineer design precondition.",
+            _begin_step_order_gate("engineer", mode="POLISH"),
+        ),
+        GuardCase(
+            "begin_step_allows_pr_reviewer_after_code_validator_pass",
+            "provider-agnostic-order-gate",
+            "allow",
+            "pr-reviewer starts after code-validator PASS in headless path.",
+            _begin_step_order_gate(
+                "pr-reviewer",
+                engineer_output=True,
+                code_validator_pass=True,
+            ),
+        ),
+        GuardCase(
             "tdd_guard_blocks_impl_without_test",
             "tdd-guard",
             "block",
@@ -343,6 +508,53 @@ def build_cases() -> list[GuardCase]:
             "block",
             "Bash write target for a TS/JS implementation file is TDD checked.",
             _tdd_guard_bash_write_without_test,
+        ),
+        GuardCase(
+            "headless_tdd_blocks_worker_success_without_test",
+            "provider-agnostic-tdd",
+            "block",
+            "Codex worker cannot successfully end a step after TS implementation change without matching test.",
+            _headless_worker_tdd({"src/price.ts": "export const price = 1;\n"}),
+        ),
+        GuardCase(
+            "headless_tdd_allows_worker_success_with_matching_test",
+            "provider-agnostic-tdd",
+            "allow",
+            "Codex worker succeeds when the matching test exists.",
+            _headless_worker_tdd(
+                {
+                    "src/price.ts": "export const price = 1;\n",
+                    "src/price.test.ts": "test('price', () => {});\n",
+                }
+            ),
+        ),
+        GuardCase(
+            "headless_tdd_allows_test_file_self",
+            "provider-agnostic-tdd",
+            "allow",
+            "Test/spec files themselves remain TDD-skip in headless worker post-check.",
+            _headless_worker_tdd({"src/price.test.ts": "test('price', () => {});\n"}),
+        ),
+        GuardCase(
+            "headless_tdd_allows_standard_test_dir",
+            "provider-agnostic-tdd",
+            "allow",
+            "Standard test directories remain TDD-skip in headless worker post-check.",
+            _headless_worker_tdd({"tests/price.ts": "test('price', () => {});\n"}),
+        ),
+        GuardCase(
+            "headless_tdd_allows_type_file",
+            "provider-agnostic-tdd",
+            "allow",
+            "Type-only files remain TDD-skip in headless worker post-check.",
+            _headless_worker_tdd({"src/types.ts": "export type Price = number;\n"}),
+        ),
+        GuardCase(
+            "headless_tdd_allows_entry_boilerplate",
+            "provider-agnostic-tdd",
+            "allow",
+            "Entry boilerplate remains TDD-skip in headless worker post-check.",
+            _headless_worker_tdd({"src/main.ts": "console.log('boot');\n"}),
         ),
         GuardCase(
             "known_boundary_command_substitution_not_scanned",

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -36,11 +36,11 @@ from harness.session_state import (
     cleanup_stale_pid_files,
     cleanup_stale_run_dirs,
     cleanup_stale_runs,
+    evaluate_order_gate_for_step,
     is_project_active,
     read_live,
     read_pid_current_run,
     record_fail_open_event,
-    run_dir,
     session_dir,
     update_live,
     valid_cc_pid,
@@ -480,8 +480,6 @@ def handle_pretooluse_agent(
     if not rid:
         return 0  # active run 외부 — 그 외 agent 는 통과
 
-    rd = run_dir(sid, rid, base_dir=base_dir)
-
     # issue #604 — active run 안에서는 begin-step 없이 Agent 직접 호출 금지.
     # PostToolUse staging 이후 같은 step 재호출, end-step 완료 후 stale current_step 도
     # PreToolUse 시점에서 차단해 `.steps.jsonl` 누락을 실행 전에 막는다.
@@ -520,67 +518,27 @@ def handle_pretooluse_agent(
         )
         pass  # state 읽기 실패는 fail-open — hook 버그발 과차단 회피.
 
-    # engineer 게이트 — engineer 직전 설계 산출물 필수 (effective mode != POLISH).
-    # #700 — namespaced 우회 차단을 위해 norm_subagent 비교(codex P1).
-    # #701 — 사전 조건 = 같은-run module-architect PASS ∪ begin-run 에 기록된
-    # 머지된 설계 문서(design_doc) 실존. impl-loop 풀 4-agent 는 설계가 별도 run
-    # 에서 머지된 뒤 진입하므로 같은-run prose 단일 기준이면 구조적으로 차단된다.
-    # #714 — /impl 2축 모델의 Lite lane(설계도 없음)에 sub-agent 엔진을 붙이는
-    # 4번째 조합. lane="lite"(begin-run --lane lite 로 start_run 에 기록)는 정의상
-    # 설계도가 없으므로 module-architect PASS / design_doc 둘 다 없다. 면제 경계는
-    # *명시적으로 기록된* lane="lite" 한정 — lane 미기록(impl-loop 풀4 / 기본)과
-    # lane="standard" 는 종전대로 설계 산출물을 요구한다(면제 누수 차단). lane 은
-    # entry_point=impl 에서만 기록 가능(start_run 강제)하므로 design/architect-loop
-    # run 의 module-architect PASS 강제는 영향받지 않는다. 이 면제는 engineer 게이트
-    # *만* 푼다 — 뒤따르는 pr-reviewer←code-validator 잔존 보호는 lane 무관 불변.
+    # provider-agnostic 순서 게이트 (#859) — Claude Agent 경로는 여기서, headless
+    # provider 는 `dcness-helper begin-step` 에서 같은 함수를 호출한다.
     # #709 — effective mode = tool_input.mode ∪ current_step.mode. Agent 도구 스키마에
-    # mode 파라미터가 없는 CC 빌드에선 tool_input.mode 가 안 실려, POLISH 면제가
-    # tool_input.mode 단독이면 죽는다(impl-loop engine B 의 pr-reviewer→engineer:POLISH 가
-    # design_doc·MA PASS 둘 다 없어 구조적 차단). begin-step 이 CLI 로 확실히 기록한
-    # current_step.mode 를 fallback 으로 봐 환경 무관하게 면제를 복원한다. 진행 순서 검사가
-    # begin-step↔Agent(agent) 정합을 이미 보장하므로 current_step.mode=POLISH 는 신뢰 신호.
+    # mode 파라미터가 없는 CC 빌드에선 tool_input.mode 가 안 실리므로 begin-step 이
+    # 기록한 current_step.mode 를 fallback 으로 본다.
     effective_mode = _mode_or_none(mode) or step_mode
-    if norm_subagent == "engineer" and effective_mode != "POLISH":
-        lane_lite = _run_lane(sid, rid, base_dir=base_dir) == "lite"
-        if (
-            not lane_lite
-            and not _has_module_architect_pass(rd)
-            and not _run_design_doc_exists(sid, rid, base_dir=base_dir)
-        ):
-            print(
-                "[순서 차단 훅: engineer 게이트] engineer 호출은 설계 산출물 확보 후만 — "
-                "같은 run 의 module-architect PASS prose (module-architect*.md 안 "
-                "PASS 마커) 또는 begin-run --design-doc 으로 기록된 설계 문서 실존",
-                file=sys.stderr,
-            )
-            return 1
-
-    # pr-reviewer 게이트 — engineer sub-agent 산출물 이후 code-validator PASS 필수.
-    # Lite lane 은 메인 직접 구현 경로라 engineer prose 가 없고, pr-reviewer 단독 허용.
-    if norm_subagent == "pr-reviewer":
-        if _has_engineer_write(rd) and not _has_pass(rd, "code-validator"):
-            print(
-                "[순서 차단 훅: pr-reviewer 게이트] engineer 산출물 이후 "
-                "pr-reviewer 호출은 code-validator PASS 후만",
-                file=sys.stderr,
-            )
-            return 1
-
-    # module-architect 게이트 — design 안 첫 module-architect 단위 호출 직전
-    # architecture-validator PASS 필수. jajang Spike Gate 사단 회피.
-    if (
-        norm_subagent == "module-architect"
-        and _is_design_loop(sid, rid, base_dir=base_dir)
-        and _module_architect_first_call(rd)
-    ):
-        if not _has_pass(rd, "architecture-validator"):
-            print(
-                "[순서 차단 훅: module-architect 게이트] 첫 module-architect 단위 호출은 "
-                "architecture-validator 1차 PASS 후만 "
-                "(architecture-validator.md 안 PASS 마커)",
-                file=sys.stderr,
-            )
-            return 1
+    try:
+        order_gate_msg = evaluate_order_gate_for_step(
+            sid, rid, norm_subagent, effective_mode, base_dir=base_dir,
+        )
+    except Exception as exc:  # noqa: BLE001
+        _record_fail_open_safe(
+            "catastrophic-gate",
+            "order_gate_exception",
+            f"{type(exc).__name__}: {exc}",
+            base_dir=base_dir,
+        )
+        order_gate_msg = None
+    if order_gate_msg:
+        print(order_gate_msg, file=sys.stderr)
+        return 1
 
     # tech-reviewer 재호출 (design 진입 후) 은 *tech-reviewer 전용* 코드 강제로
     # 차단하지 않는다 (#609). tech-review 는 design 진입 *전* 단방향 선행 단계라

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -75,6 +75,7 @@ __all__ = [
     "start_run",
     "update_current_step",
     "clear_current_step",
+    "evaluate_order_gate_for_step",
     "set_pending_agent",
     "clear_pending_agent",
     "complete_run",
@@ -737,6 +738,170 @@ def clear_current_step(
     active[run_id] = slot
     update_live(session_id, base_dir=base_dir, active_runs=active)
     return True
+
+
+def _read_or_empty(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8") if path.exists() else ""
+    except OSError:
+        return ""
+
+
+def _run_prose_has_pass(rd: Path, agent: str) -> bool:
+    """`<agent>.md` 또는 occurrence prose 안 PASS 마커 확인."""
+    if "PASS" in _read_or_empty(rd / f"{agent}.md"):
+        return True
+    for n in range(1, 10):
+        if "PASS" in _read_or_empty(rd / f"{agent}-{n}.md"):
+            return True
+    return False
+
+
+def _run_has_engineer_output(rd: Path) -> bool:
+    """engineer 계열 prose 산출물 실존 여부."""
+    if (rd / "engineer.md").exists():
+        return True
+    try:
+        return any(rd.glob("engineer-*.md"))
+    except OSError:
+        return False
+
+
+def _run_has_module_architect_pass(rd: Path) -> bool:
+    """module-architect prose PASS — 무모드 / occurrence / mode-suffixed 모두 인정."""
+    if "PASS" in _read_or_empty(rd / "module-architect.md"):
+        return True
+    try:
+        for prose in rd.glob("module-architect-*.md"):
+            if "PASS" in _read_or_empty(prose):
+                return True
+    except OSError:
+        pass
+    return False
+
+
+def _slot_for_run(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> dict:
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {}) if isinstance(live, dict) else {}
+    slot = active.get(run_id, {}) if isinstance(active, dict) else {}
+    return slot if isinstance(slot, dict) else {}
+
+
+def _run_design_doc_exists(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> bool:
+    """현재 run 슬롯에 기록된 design_doc 이 디스크에 실존하는지."""
+    try:
+        doc = _slot_for_run(session_id, run_id, base_dir=base_dir).get("design_doc")
+        if not isinstance(doc, str) or not doc:
+            return False
+        return Path(doc).is_file()
+    except (OSError, ValueError):
+        return False
+
+
+def _run_lane(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Optional[str]:
+    """현재 run 슬롯에 기록된 lane(설계도 유무) 반환."""
+    try:
+        lane = _slot_for_run(session_id, run_id, base_dir=base_dir).get("lane")
+        return lane if isinstance(lane, str) else None
+    except (OSError, ValueError):
+        return None
+
+
+def _run_entry_point(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> str:
+    try:
+        entry = _slot_for_run(session_id, run_id, base_dir=base_dir).get("entry_point")
+        return entry if isinstance(entry, str) else ""
+    except (OSError, ValueError):
+        return ""
+
+
+def _module_architect_first_call(rd: Path) -> bool:
+    """module-architect 첫 호출인지 — 기존 prose 파일 부재 검사."""
+    return not (rd / "module-architect.md").exists()
+
+
+_IMPLEMENTATION_ORDER_GATE_AGENTS = frozenset({"engineer", "build-worker"})
+
+
+def evaluate_order_gate_for_step(
+    session_id: str,
+    run_id: str,
+    agent: str,
+    mode: Optional[str] = None,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Optional[str]:
+    """provider-independent step start order gate.
+
+    Claude Agent 경로는 PreToolUse hook 에서, Codex/headless 경로는 helper
+    `begin-step` 에서 같은 불변식을 평가한다. 반환값이 있으면 차단 메시지다.
+    """
+    from harness.agent_names import normalize_agent_type
+
+    norm_agent = normalize_agent_type(agent) or agent
+    effective_mode = mode if isinstance(mode, str) and mode else None
+    rd = run_dir(session_id, run_id, base_dir=base_dir)
+
+    if norm_agent in _IMPLEMENTATION_ORDER_GATE_AGENTS and effective_mode != "POLISH":
+        lane_lite = _run_lane(session_id, run_id, base_dir=base_dir) == "lite"
+        if (
+            not lane_lite
+            and not _run_has_module_architect_pass(rd)
+            and not _run_design_doc_exists(session_id, run_id, base_dir=base_dir)
+        ):
+            return (
+                "[순서 차단 훅: engineer 게이트] engineer/build-worker 호출은 "
+                "설계 산출물 확보 후만 — "
+                "같은 run 의 module-architect PASS prose (module-architect*.md 안 "
+                "PASS 마커) 또는 begin-run --design-doc 으로 기록된 설계 문서 실존. "
+                "충족 방법: module-architect step 을 PASS 로 완료하거나, 구현 run 을 "
+                "시작할 때 `begin-run impl --design-doc <설계문서>` 를 기록하세요. "
+                "명시적 Lite 구현 경로라면 `begin-run impl --lane lite` 로 시작하세요."
+            )
+
+    if norm_agent == "pr-reviewer":
+        if _run_has_engineer_output(rd) and not _run_prose_has_pass(rd, "code-validator"):
+            return (
+                "[순서 차단 훅: pr-reviewer 게이트] engineer 산출물 이후 "
+                "pr-reviewer 호출은 code-validator PASS 후만. 충족 방법: "
+                "`begin-step code-validator` → code-validator PASS → "
+                "`end-step code-validator` 를 먼저 완료하세요."
+            )
+
+    if (
+        norm_agent == "module-architect"
+        and _run_entry_point(session_id, run_id, base_dir=base_dir) == "design"
+        and _module_architect_first_call(rd)
+    ):
+        if not _run_prose_has_pass(rd, "architecture-validator"):
+            return (
+                "[순서 차단 훅: module-architect 게이트] 첫 module-architect 단위 호출은 "
+                "architecture-validator 1차 PASS 후만 (architecture-validator.md 안 "
+                "PASS 마커). 충족 방법: architecture-validator step 을 PASS 로 "
+                "완료한 뒤 module-architect 를 시작하세요."
+            )
+
+    return None
 
 
 def _is_dcness_worktree_path(path: Path) -> bool:
@@ -2148,6 +2313,18 @@ def _cli_begin_step(args: Any) -> int:
     # ledger checkpoint / engineer hint 까지 같은 표기로 일관시킨다.
     from harness.agent_names import normalize_agent_type
     agent = normalize_agent_type(args.agent) or args.agent
+    try:
+        gate_message = evaluate_order_gate_for_step(sid, rid, agent, mode)
+    except Exception as exc:  # noqa: BLE001
+        record_fail_open_event(
+            hook="begin-step-order-gate",
+            category="gate_exception",
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+        gate_message = None
+    if gate_message:
+        print(gate_message, file=sys.stderr)
+        return 1
     update_current_step(sid, rid, agent, mode)
     # 이슈 #587 — ledger step_started checkpoint. 기록 실패가 begin-step 막지 않게 silent.
     try:

--- a/scripts/dcness-codex-worker
+++ b/scripts/dcness-codex-worker
@@ -26,7 +26,8 @@ Environment:
 The wrapper runs Codex in workspace-write mode:
   codex exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE"
 
-On success it validates changed paths against dcNess agent_boundary and stores:
+On success it validates changed paths against dcNess agent_boundary, reuses
+tdd-guard matching-test enforcement for Codex-changed implementation files, and stores:
   dcness-helper end-step <agent> [MODE] --prose-file "$TMP_PROSE"
 
 On Codex infrastructure failure with no workspace mutation, callers may fall
@@ -312,6 +313,59 @@ PY
 if [ -n "$BOUNDARY_PROBLEMS" ]; then
   echo "[dcness-codex-worker] BLOCKED: Codex changed files outside ${AGENT} boundary." >&2
   printf '%s\n' "$BOUNDARY_PROBLEMS" >&2
+  exit 1
+fi
+
+TDD_CHANGED_PATHS="$(
+  {
+    git -C "$PROJECT_ROOT" diff --name-only --diff-filter=ACMRT 2>/dev/null || true
+    git -C "$PROJECT_ROOT" diff --cached --name-only --diff-filter=ACMRT 2>/dev/null || true
+    git -C "$PROJECT_ROOT" ls-files --others --exclude-standard 2>/dev/null || true
+  } | sort -u
+)"
+TDD_PROBLEMS="$(
+  _tdd_found=0
+  while IFS= read -r _tdd_path; do
+    [ -n "$_tdd_path" ] || continue
+    [ -e "$PROJECT_ROOT/$_tdd_path" ] || continue
+    _tdd_payload="$(
+      python3 - "$PROJECT_ROOT/$_tdd_path" <<'PY'
+import json
+import sys
+
+print(json.dumps({
+    "tool_name": "Edit",
+    "tool_input": {"file_path": sys.argv[1]},
+}))
+PY
+    )"
+    _tdd_err="$(
+      printf '%s' "$_tdd_payload" \
+        | CLAUDE_PLUGIN_ROOT="$SCRIPT_DIR/.." \
+          PYTHONPATH="$SCRIPT_DIR/..:${PYTHONPATH:-}" \
+          DCNESS_FORCE_ENABLE=1 \
+          bash "$SCRIPT_DIR/../hooks/tdd-guard.sh" 2>&1 >/dev/null
+    )"
+    _tdd_rc=$?
+    if [ "$_tdd_rc" -eq 2 ]; then
+      _tdd_found=1
+      printf '  - %s\n' "$_tdd_path"
+      printf '%s\n' "$_tdd_err" | sed 's/^/    /'
+    elif [ "$_tdd_rc" -ne 0 ]; then
+      PYTHONPATH="$SCRIPT_DIR/.." python3 -m harness.session_state hook-fail-open \
+        --hook headless-tdd-guard \
+        --category tdd_check_error \
+        --detail "tdd-guard exited ${_tdd_rc} for ${_tdd_path}; allowed" >/dev/null 2>&1 || true
+    fi
+  done <<EOF
+$TDD_CHANGED_PATHS
+EOF
+  exit "$_tdd_found"
+)"
+TDD_RC=$?
+if [ "$TDD_RC" -eq 1 ]; then
+  echo "[dcness-codex-worker] BLOCKED: TDD GUARD failed for Codex-changed implementation files." >&2
+  printf '%s\n' "$TDD_PROBLEMS" >&2
   exit 1
 fi
 

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -580,6 +580,185 @@ class CodexWorkerWrapperTests(unittest.TestCase):
             self.assertIn("outside build-worker boundary", result.stderr)
             self.assertFalse(helper_args.exists())
 
+    def test_worker_success_blocks_ts_impl_without_matching_test(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement the task.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "--help" ]; then
+                      echo "Usage: codex"
+                      exit 0
+                    fi
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    mkdir -p src
+                    printf 'export const price = 1;\\n' > src/price.ts
+                    printf 'Worker prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" > "$HELPER_ARGS"
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_RUN_ID": "run-tddblock",
+                    "DCNESS_SESSION_ID": "sid-worker",
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(WORKER),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("TDD GUARD", result.stderr)
+            self.assertIn("src/price.ts", result.stderr)
+            self.assertFalse(helper_args.exists())
+
+    def test_worker_success_allows_ts_impl_with_matching_test(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement the task.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "--help" ]; then
+                      echo "Usage: codex"
+                      exit 0
+                    fi
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    mkdir -p src
+                    printf 'export const price = 1;\\n' > src/price.ts
+                    printf 'test("price", () => {});\\n' > src/price.test.ts
+                    printf 'Worker prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    printf '%s\\n' "$*" > "$HELPER_ARGS"
+                    exit 0
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_RUN_ID": "run-tddallow",
+                    "DCNESS_SESSION_ID": "sid-worker",
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(WORKER),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(
+                helper_args.read_text(encoding="utf-8")
+                .strip()
+                .startswith("end-step build-worker --prose-file "),
+            )
+
     def test_worker_failure_after_mutation_does_not_fallback_or_end_step(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)

--- a/tests/test_guard_efficacy_eval.py
+++ b/tests/test_guard_efficacy_eval.py
@@ -39,6 +39,8 @@ class GuardEfficacyEvalContractTests(unittest.TestCase):
             "mcp-mutation",
             "order-gate",
             "tdd-guard",
+            "provider-agnostic-order-gate",
+            "provider-agnostic-tdd",
             "known-bypass-boundary",
         ):
             with self.subTest(category=category):
@@ -51,8 +53,12 @@ class GuardEfficacyEvalContractTests(unittest.TestCase):
             "bash_mutation_blocks_git_push",
             "mcp_mutation_blocks_pr_merge",
             "order_gate_blocks_missing_begin_step",
+            "begin_step_blocks_engineer_without_design_artifact",
+            "begin_step_blocks_build_worker_without_design_artifact",
+            "begin_step_blocks_pr_reviewer_without_code_validator_pass",
             "tdd_guard_blocks_impl_without_test",
             "tdd_guard_blocks_bash_write_without_test",
+            "headless_tdd_blocks_worker_success_without_test",
         ):
             with self.subTest(case_id=case_id):
                 self.assertIn(case_id, case_ids)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -51,6 +52,7 @@ from harness.agent_trace import append as trace_append
 from harness.agent_trace import read_all as read_trace
 # issue #392 — redo_log 폐기
 from harness.session_state import (
+    evaluate_order_gate_for_step,
     read_live,
     read_fail_open_events,
     read_pid_session,
@@ -417,6 +419,152 @@ class CatastrophicEngineerTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertEqual(rc, 0)
+
+
+class ProviderAgnosticBeginStepOrderGateTests(_PreToolBase):
+    """#859 — begin-step itself blocks provider-independent order violations."""
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._set_slot(entry_point="impl")
+
+    def _set_slot(
+        self,
+        *,
+        entry_point: str = "impl",
+        lane: Optional[str] = None,
+        design_doc: Optional[str] = None,
+    ) -> None:
+        live = read_live(self.sid, base_dir=self.base)
+        active = live.get("active_runs", {})
+        slot = dict(active[self.rid])
+        slot["entry_point"] = entry_point
+        slot["lane"] = lane
+        slot["design_doc"] = design_doc
+        active[self.rid] = slot
+        update_live(self.sid, base_dir=self.base, active_runs=active)
+
+    def test_begin_step_blocks_engineer_without_design_artifact(self) -> None:
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "engineer",
+            "IMPL",
+            base_dir=self.base,
+        )
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: engineer 게이트]", message or "")
+        self.assertIn("begin-run --design-doc", message or "")
+
+    def test_begin_step_blocks_build_worker_without_design_artifact(self) -> None:
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: engineer 게이트]", message or "")
+        self.assertIn("engineer/build-worker", message or "")
+
+    def test_begin_step_cli_exits_nonzero_on_order_violation(self) -> None:
+        project = self.base / "project"
+        project.mkdir()
+        state_base = project / ".claude" / "harness-state"
+        update_live(self.sid, base_dir=state_base)
+        start_run(self.sid, "run-99999999", "impl", base_dir=state_base)
+
+        root = Path(__file__).resolve().parents[1]
+        result = subprocess.run(
+            [
+                "python3.11",
+                "-m",
+                "harness.session_state",
+                "begin-step",
+                "engineer",
+                "IMPL",
+            ],
+            cwd=project,
+            capture_output=True,
+            env={
+                **os.environ,
+                "DCNESS_RUN_ID": "run-99999999",
+                "DCNESS_SESSION_ID": self.sid,
+                "PYTHONPATH": str(root),
+            },
+            text=True,
+            timeout=10,
+        )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("[순서 차단 훅: engineer 게이트]", result.stderr)
+        live = read_live(self.sid, base_dir=state_base)
+        slot = live["active_runs"]["run-99999999"]
+        self.assertIsNone(slot["current_step"])
+
+    def test_begin_step_allows_engineer_lite_lane(self) -> None:
+        self._set_slot(lane="lite")
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "engineer",
+            "IMPL",
+            base_dir=self.base,
+        )
+        self.assertIsNone(message)
+
+    def test_begin_step_allows_build_worker_lite_lane(self) -> None:
+        self._set_slot(lane="lite")
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+        self.assertIsNone(message)
+
+    def test_begin_step_allows_engineer_polish_without_design_artifact(self) -> None:
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "engineer",
+            "POLISH",
+            base_dir=self.base,
+        )
+        self.assertIsNone(message)
+
+    def test_begin_step_blocks_pr_reviewer_without_code_validator_pass(self) -> None:
+        (self.run_path / "engineer.md").write_text(
+            "구현 완료\n\nPASS\n", encoding="utf-8",
+        )
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "pr-reviewer",
+            None,
+            base_dir=self.base,
+        )
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: pr-reviewer 게이트]", message or "")
+        self.assertIn("code-validator PASS", message or "")
+
+    def test_begin_step_allows_pr_reviewer_after_code_validator_pass(self) -> None:
+        (self.run_path / "engineer.md").write_text(
+            "구현 완료\n\nPASS\n", encoding="utf-8",
+        )
+        (self.run_path / "code-validator.md").write_text(
+            "검증 완료\n\nPASS\n", encoding="utf-8",
+        )
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "pr-reviewer",
+            None,
+            base_dir=self.base,
+        )
+        self.assertIsNone(message)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1031,6 +1031,14 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         else:
             os.environ["DCNESS_LLM_TELEMETRY"] = self._prev_telemetry
 
+    def _write_module_architect_pass(self) -> None:
+        from harness.session_state import run_dir
+        rd = run_dir(self.sid, self.rid)
+        rd.mkdir(parents=True, exist_ok=True)
+        (rd / "module-architect.md").write_text(
+            "설계 완료\n\nPASS\n", encoding="utf-8",
+        )
+
     def test_begin_step_updates_current_step(self) -> None:
         from harness.session_state import _cli_begin_step, read_live
         from types import SimpleNamespace
@@ -1053,7 +1061,7 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         from contextlib import redirect_stdout
 
         action_rid = "run-87654321"
-        start_run(self.sid, action_rid, "impl")
+        start_run(self.sid, action_rid, "impl", lane="lite")
         write_pid_current_run(self.cc_pid, action_rid)
 
         out = StringIO()
@@ -1184,6 +1192,7 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         from contextlib import redirect_stdout, redirect_stderr
 
         clear_pid_current_run(self.cc_pid)
+        self._write_module_architect_pass()
 
         out = StringIO()
         with redirect_stdout(out):
@@ -1249,6 +1258,7 @@ class CliBeginStepEndStepTests(unittest.TestCase):
 
         clear_pid_current_run(self.cc_pid)
         pid_session_path(self.cc_pid).unlink()
+        self._write_module_architect_pass()
 
         with redirect_stdout(StringIO()):
             rc = _cli_begin_step(SimpleNamespace(agent="build-worker", mode=None))
@@ -1490,6 +1500,7 @@ class CliBeginStepEndStepTests(unittest.TestCase):
 
         jsonl = self._setup_fake_cc_jsonl(self.sid, [50, 87])  # 직전 = 87
         try:
+            self._write_module_architect_pass()
             err = StringIO()
             with redirect_stderr(err):
                 rc = _cli_begin_step(SimpleNamespace(agent="engineer", mode="IMPL"))
@@ -1509,6 +1520,7 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         from contextlib import redirect_stderr
 
         err = StringIO()
+        self._write_module_architect_pass()
         with redirect_stderr(err):
             rc = _cli_begin_step(SimpleNamespace(agent="engineer", mode="IMPL"))
         self.assertEqual(rc, 0)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #859

## 배경 및 문제

- #859 지적처럼 순서 차단 훅과 TDD guard 일부가 Claude Code hook 경로에만 묶여 있어, Codex/headless provider 가 `dcness-helper begin-step` 또는 worker wrapper 를 통해 진행하면 같은 불변식이 보장되지 않았다.
- 특히 설계 산출물 없는 구현 step 시작, engineer 산출물 이후 code-validator PASS 없는 pr-reviewer 시작, Codex worker 의 테스트 없는 TS/JS 구현 성공 종료가 provider 별로 다르게 처리될 수 있었다.

## 원인 (해당 시)

- engineer/pr-reviewer/module-architect 순서 판정 로직이 `harness/hooks.py` 의 PreToolUse handler 내부에만 있었고, helper `begin-step` 경로에서는 동일 판정을 재사용하지 않았다.
- `scripts/dcness-codex-worker` 는 성공 후 boundary 검사는 했지만, 기존 `tdd-guard.sh` 의 matching-test 존재 검사를 headless worker 완료 경로에 적용하지 않았다.

## 작업내용

- `harness.session_state.evaluate_order_gate_for_step` 를 추가해 Claude hook 과 helper begin-step 이 같은 순서 게이트를 사용하도록 했다.
- engineer/build-worker 구현 step 의 설계 산출물 사전조건, engineer 산출물 이후 pr-reviewer 전 code-validator PASS, design 첫 module-architect 전 architecture-validator PASS 를 provider-independent 하게 강제했다.
- `scripts/dcness-codex-worker` 에 성공 종료 전 changed TS/JS 구현 파일 TDD 재검사를 추가하고, guard 자체 오류는 fail-open 이벤트로 남기도록 했다.
- guard-efficacy eval, wrapper tests, hook/session_state tests, docs 를 갱신해 headless/provider-agnostic 경로를 회귀 테스트로 고정했다.

## 결정 근거

- 새 hook 을 늘리지 않고 기존 판정 함수를 helper와 hook에서 공유해 provider 차이를 줄였다.
- `build-worker` 는 실제 구현 mutation provider 이므로 engineer gate 의 설계 사전조건 대상에 포함했다. 다만 pr-reviewer 전 code-validator PASS 게이트는 기존 수용조건대로 engineer prose 산출물이 있을 때만 적용해 build-worker self-validate 경량 흐름을 과차단하지 않았다.
- TDD는 기존 `tdd-guard.sh` 를 synthetic `Edit` payload 로 재사용해 skip/matching-test 규칙을 중복 구현하지 않았다.

## 배포 경로 검증 (plug-in 영향 시)

- 변경 런타임 경로: `harness/hooks.py`, `harness/session_state.py`, `scripts/dcness-codex-worker`
- 변경 문서 경로: `docs/plugin/hooks.md`, `docs/plugin/loop-procedure.md`, `evals/README.md`
- init copy 파일이나 신규 public command/agent/skill 추가는 없다. 기존 plugin runtime/helper/wrapper 배포 경로를 통해 반영된다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public skill/command/agent/gate 를 추가하지 않고 기존 순서 차단 훅과 Codex worker wrapper 동작만 강화했다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_hooks.ProviderAgnosticBeginStepOrderGateTests tests.test_codex_validator_wrapper.CodexWorkerWrapperTests tests.test_guard_efficacy_eval tests.test_session_state.CliBeginStepEndStepTests -v`
- [x] `python3.11 evals/guard_efficacy.py`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `PYTHON_BIN=/private/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `git diff --check`

## 참고

- 개발 중 원 작업트리에서 별도 실험 변경이 관측되어, #859 patch 만 clean worktree에 적용해 검증/커밋했다. 최종 작업트리는 PR branch 기준 clean 상태다.
