### PR TITLE
[feature] impl 엔진 기본값 build-worker 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,16 +76,18 @@ claude plugin install dcness@dcness
 
 ## 작업 흐름
 
-기본으로 기억할 흐름은 `/spec → /design → /impl → /acceptance` 넷이면 된다.
+기본으로 기억할 흐름은 `/spec → /design → /impl → /acceptance` 넷이면 된다. 공개 lifecycle 표기 기준은 `/spec -> /design -> /impl -> /acceptance` 다.
 
-| 진입점 | 언제 쓰나 |
+| 기본 진입점 | 언제 쓰나 |
 |---|---|
 | `/spec` | 새 기능·큰 기획·PRD 변경처럼 무엇을 만들지 먼저 합의해야 할 때 |
-| `/design` | 구현 전에 화면 흐름·시스템·모듈 설계가 필요할 때 (구현 없이 시안만 먼저 보려면 `/ux`) |
+| `/design` | PRD 이후 구현 전 product/technical design, 즉 화면 흐름·시스템·모듈 설계가 필요할 때 (구현 없이 visual design 만 먼저 보려면 `/ux`) |
 | `/impl` | 구현·수정·버그픽스를 실제 PR 로 끝낼 때 |
 | `/acceptance` | PRD / Epic / Story 기준으로 "정말 다 됐는지" 제품 검수할 때 |
 
-`/impl` 은 설계도를 직접 그리지 않고, 들어온 요청을 보고 **가장 작은 안전한 경로** 를 스스로 고른다. 설계 문서가 없고 파일·이슈 같은 구체적 단서가 명확하면 메인이 바로 `테스트 → 구현 → 리뷰 → PR` 로 끝내고(Lite), 설계도가 있으면 그 설계도대로 구현한다(Standard). 새 기능이나 위험이 큰 작업은 `/impl` 안에서 처리하지 않고 `/spec`·`/design` 으로 먼저 돌린 뒤, 나온 설계도를 들고 다시 들어온다.
+`/impl` 은 설계도를 직접 그리지 않고, 들어온 요청을 보고 **가장 작은 안전한 경로** 를 스스로 고른다. 설계 문서가 없고 파일·이슈 같은 구체적 단서가 명확하면 메인이 바로 `테스트 → 구현 → 리뷰 → PR` 로 끝내고(Lite), 설계도가 있으면 그 설계도대로 구현한다(Standard). Standard 의 sub-agent 엔진 미지정 기본은 `build-worker → pr-reviewer` 이고, 풀 4-agent 는 고위험 trigger 나 사용자 엄정 override 때만 승격한다. 새 기능이나 위험이 큰 작업은 `/impl` 안에서 처리하지 않고 `/spec`·`/design` 으로 먼저 돌린 뒤, 나온 설계도를 들고 다시 들어온다.
+
+`/impl` 이 내부적으로 구현 경로(설계도 유무 — Lite / Standard)와 엔진(build-worker 기본 / 풀 4-agent 승격)을 직교로 고른다.
 
 보조 진입점 — `/to-issue`(자연어를 GitHub 이슈로), `/next`(보드에서 다음 할 일 조회), `/tech-review`(위험한 설계의 사전 기술 검증), `/impl-loop`(deep task 파일 단위 구현 러너), `/ux`(구현 없이 시안·흐름 먼저).
 
@@ -101,12 +103,13 @@ claude plugin install dcness@dcness
 
 **엔진 무관 게이트** — 순서·TDD 강제가 Claude 서브에이전트뿐 아니라 headless(Codex 등) 경로에서도 똑같이 걸리도록 강제 지점을 재배치했다. 예전에는 순서·TDD 게이트가 Claude 서브에이전트 경로에서만 발화하고, 자기 프로세스 안에서 직접 파일을 쓰는 headless 경로는 게이트 밖이었다. 이제 어느 엔진으로 구현·검증을 돌려도 같은 규칙이 적용된다. ([#859](https://github.com/alruminum/dcNess/issues/859))
 
+**구현 엔진 기본값 전환** — `/impl`·`/impl-loop` 의 sub-agent 엔진 미지정 기본을 build-worker 로 통일했다. 풀 4-agent 는 frontmatter, 고위험 trigger, 사용자 엄정 override 승격 전용으로 남는다. ([#861](https://github.com/alruminum/dcNess/issues/861))
+
 ## 진행 중 (로드맵)
 
 게이트를 엔진 무관하게 만든 작업([#859](https://github.com/alruminum/dcNess/issues/859))에 이어, 그 위에서 실행 엔진의 선택폭을 넓히는 단계다.
 
 - **구현 엔진 3단 폴백** ([#860](https://github.com/alruminum/dcNess/issues/860)) — codex headless → claude headless → claude 메인. Codex 가 안 깔린 사람도 격리 실행 혜택을 받게 한다.
-- **기본 엔진을 경량 build-worker 로** ([#861](https://github.com/alruminum/dcNess/issues/861)) — 풀 4-agent 는 위험이 큰 작업 승격 전용으로 남긴다.
 
 ## 핵심 특징
 
@@ -120,13 +123,15 @@ claude plugin install dcness@dcness
 
 ## 공개 진입점
 
+기본/support/고급/유틸리티/내부 agent 분류는 public surface gate 의 계약이다.
+
 | 분류 | 발화 | 역할 |
 |---|---|---|
-| 기본 | `/spec` | 새 기능 spec + 검수 체크포인트 |
-| 기본 | `/design` | 화면·시스템·모듈 설계 |
-| 기본 | `/impl` | 구현 진입 — 경로(Lite/Standard)와 엔진을 내부 판정 |
-| 기본 | `/acceptance` | story/epic 제품 검수 |
-| 보조 | `/to-issue` | 자연어 → Issue Brief 초안 → 승인 후 GitHub 등록 |
+| 기본 workflow | `/spec` | 새 기능 spec + 검수 체크포인트 |
+| 기본 workflow | `/design` | 화면·시스템·모듈 설계 |
+| 기본 workflow | `/impl` | 구현 진입 — 경로(Lite/Standard)와 엔진을 내부 판정 |
+| 기본 workflow | `/acceptance` | story/epic 제품 검수 |
+| support | `/to-issue` | 자연어 → Issue Brief 초안 → 승인 후 GitHub 등록 |
 | 고급 | `/tech-review` | 위험한 설계의 사전 기술 검증 |
 | 고급 | `/impl-loop` | deep impl task 파일 단위 구현 러너 |
 | 유틸 | `/ux` | 구현 없이 목업·흐름 먼저 탐색, PICK 확정본은 canvas 에 등록 |

--- a/docs/plugin/parallel-policy.md
+++ b/docs/plugin/parallel-policy.md
@@ -39,7 +39,7 @@ dcness-helper wave-plan --register <impl-glob-or-dir> \
 - `wave-plan` 은 `depends_on` + Scope 파일집합 disjoint 로 후보 wave 를 계산한다.
 - `--register` 를 붙인 경우 computed `parallel` step 에 속한 impl 파일의 **canonical impl path** 만 claim board 에 등록한다. serial / high-risk / 의존 대기 task 는 등록하지 않는다. 이 등록이 peer mode activation 신호다.
 - 사용자에게 peer 세션 입력은 `wave-id` 가 아니라 `/impl-loop <canonical-impl-path>` 로 안내한다.
-- 안내에는 각 task 의 엔진을 명시한다: single 기본은 풀 4-agent, chain 기본은 build-worker, high-risk task 는 풀 4-agent 승격.
+- 안내에는 각 task 의 엔진을 명시한다: engine 미지정 기본은 single/chain 모두 build-worker, high-risk task 와 사용자 엄정 override 는 풀 4-agent 승격.
 
 ## 4. task claim board
 

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -11,7 +11,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 | `/impl` | 구현, 수정, 버그픽스, 작은 리팩터링을 실제 PR 로 끝낼 때 | 구현 경로(설계도 유무 — Lite / Standard) + 엔진(풀4/경량)을 내부 판정 |
 | `/acceptance` | PRD / Epic / Story 기준 제품 검수와 gap 후속 연결이 필요할 때 | story/epic acceptance. 핵심 AC별 동작 증거와 mock-only gap 을 구분한다. 사람 full E2E 는 MVP 범위 밖 |
 
-사용자는 구현 경로 이름을 외울 필요가 없다. `/impl` 은 설계를 하지 않고 **설계도를 보고 구현만** 하며, 구현 경로(설계도 유무)와 엔진(풀4/경량)을 직교로 고른다. high-risk trigger 나 새 epic/product feature 는 impl 내부 구현 경로가 아니라 impl 진입 전 설계 선행(`/spec` 내부 tech-review preflight 필요 시 / `/design`)으로 분기된다. Lite / Standard 조건, high-risk 선행, 되돌림 기준은 [`workflow-router.md#구현-경로-표`](workflow-router.md#구현-경로-표) 가 소유한다. 경량 build-worker 엔진을 선택해도 `pr-reviewer` gate 는 유지한다. 본 문서는 공개 진입점과 사용자-facing 노출 범위만 소유한다.
+사용자는 구현 경로 이름을 외울 필요가 없다. `/impl` 은 설계를 하지 않고 **설계도를 보고 구현만** 하며, 구현 경로(설계도 유무)와 엔진(풀4/경량)을 직교로 고른다. sub-agent 엔진 미지정 기본은 build-worker 이고, 풀4는 high-risk trigger 나 사용자 엄정 override 같은 승격 전용이다. high-risk trigger 나 새 epic/product feature 는 impl 내부 구현 경로가 아니라 impl 진입 전 설계 선행(`/spec` 내부 tech-review preflight 필요 시 / `/design`)으로 분기된다. Lite / Standard 조건, high-risk 선행, 되돌림 기준은 [`workflow-router.md#구현-경로-표`](workflow-router.md#구현-경로-표) 가 소유한다. 경량 build-worker 엔진을 선택해도 `pr-reviewer` gate 는 유지한다. 본 문서는 공개 진입점과 사용자-facing 노출 범위만 소유한다.
 
 ## Support Entrypoints
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -75,7 +75,7 @@ flowchart TB
 | 구현 경로 | 트리거 | 진입점 | 왜 이 경로 |
 |---|---|---|---|
 | **Lite** | concrete signal(파일 path · 함수/클래스/symbol · 이미 분류·승인된 issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only · 작은 refactor) 1개 이상 AND high-risk trigger 0개 AND 구현 경계/테스트 기준 명확 | `/impl` — 메인 직접 `test -> impl -> test pass -> pr-reviewer -> PR` | 의도·범위·수용 기준이 신호로 이미 명확 → 사전 계획 gate 만 비용. `code-validator` 는 계획 파일이 없어서 호출하지 않음 |
-| **Standard** | 설계 문서(경로)가 들어옴, 또는 경량 설계 필요 → `compact-design` 산출 후 진입 | `/impl` — `--design-doc` 기록 후 받은 설계도로 구현 (풀4 또는 build-worker → pr-reviewer) | impl 은 설계 생성 X — 설계도 충실 구현. 경량 엔진도 review gate 는 유지 |
+| **Standard** | 설계 문서(경로)가 들어옴, 또는 경량 설계 필요 → `compact-design` 산출 후 진입 | `/impl` — `--design-doc` 기록 후 받은 설계도로 구현 (기본 build-worker → pr-reviewer, 풀4는 고위험/엄정 승격) | impl 은 설계 생성 X — 설계도 충실 구현. 경량 엔진도 review gate 는 유지 |
 | **high-risk → 설계 선행** (impl 내부 구현 경로 아님) | high-risk trigger 1개 이상 또는 새 epic/product feature | impl 진입 *전* `/spec` 내부 tech-review preflight 필요 시 → `/design` → `/impl` → `/acceptance` (deep task 파일이 있으면 `/impl-loop` advanced 위임) | 되돌리기 비싼 결정 → 설계·검증 consensus 필요 |
 | **shape: chain** | 구현 경로 판정 후 여러 task/PR 로 분할 · resume/handoff/audit · long-running | deep task list 는 `/impl-loop` chain, Standard 는 compact plan 분할 후 순차 PR | 실행 형태. risk 구현 경로가 아님 |
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: impl-loop
-description: deep impl task 파일(design 의 Story/공통 module-architect 단위 산출물)을 받아 정식 impl 루프로 구현하는 legacy/advanced runner. task 1개(single) 또는 여러 개(chain) 를 처리 — 기본은 한 세션 직렬, opt-in 병렬은 별도 interactive 세션들이 각자 single task 를 수행. 각 task = 1 PR + 1 이슈 close. 엔진은 풀 4-agent (test-engineer → engineer → code-validator → pr-reviewer, 엄정) 또는 build-worker (2/3-step, 경량) 를 개수·발화로 선택. story/epic 마감 task 는 머지 전 product-acceptance 검수가 기본으로 끼며 PASS 후에만 마감 PR 을 머지한다. 사용자가 "/impl-loop <task>", "이 deep task 구현", "전부 구현", "task 다 돌려", "epic 전체 구현", "끝까지 구현", "/design 후 자동"처럼 impl task 경로/목록을 명시할 때 사용한다. 일반 구현·버그픽스·한 줄 수정은 기본 진입점 `/impl`.
+description: deep impl task 파일(design 의 Story/공통 module-architect 단위 산출물)을 받아 정식 impl 루프로 구현하는 legacy/advanced runner. task 1개(single) 또는 여러 개(chain) 를 처리 — 기본은 한 세션 직렬, opt-in 병렬은 별도 interactive 세션들이 각자 single task 를 수행. 각 task = 1 PR + 1 이슈 close. 엔진 미지정 시 기본은 build-worker (2/3-step, 경량) 이고, 풀 4-agent (test-engineer → engineer → code-validator → pr-reviewer, 엄정)는 frontmatter/고위험/사용자 엄정 승격 전용이다. story/epic 마감 task 는 머지 전 product-acceptance 검수가 기본으로 끼며 PASS 후에만 마감 PR 을 머지한다. 사용자가 "/impl-loop <task>", "이 deep task 구현", "전부 구현", "task 다 돌려", "epic 전체 구현", "끝까지 구현", "/design 후 자동"처럼 impl task 경로/목록을 명시할 때 사용한다. 일반 구현·버그픽스·한 줄 수정은 기본 진입점 `/impl`.
 ---
 
 # Impl Loop Skill — deep impl task 구현 루프 (single / chain × 풀 / build-worker)
@@ -13,7 +13,7 @@ description: deep impl task 파일(design 의 Story/공통 module-architect 단�
 
 - **loop**: `impl-task-loop` (UI 감지 시 `impl-ui-design-loop` — engine 무관 `canvas-design` 선두 추가, 아래 `## UI 작업 시 canvas-design 선두`)
 - **entry_point**: `impl`
-- **task_list** (Step 1): (풀 4-agent, default=single) test-engineer → engineer:IMPL → code-validator → pr-reviewer · (build-worker, default=chain) build-worker → pr-reviewer · (advanced fallback: deep task 보강 필요 시 module-architect 선두 추가) · (impl-ui-design-loop) canvas-design 선두
+- **task_list** (Step 1): (build-worker, 기본) build-worker → pr-reviewer · (풀 4-agent, 승격 전용) test-engineer → engineer:IMPL → code-validator → pr-reviewer · (advanced fallback: deep task 보강 필요 시 module-architect 선두 추가) · (impl-ui-design-loop) canvas-design 선두
 - **advance**: `PASS` → `IMPL_DONE` → `PASS` → `PASS` (풀 4-agent) · `PASS` → `PASS` (build-worker) · `PASS`(canvas-design) → 각 엔진 구현 step (impl-ui-design-loop)
 - **expected_steps**: 4 (풀) / 5 (advanced fallback) / 2 (build-worker) · UI 풀 4-agent = 5 / UI build-worker = 3 / UI build-worker-deep = 4 / UI advanced fallback = 6 · story 마감 task +1 / epic 마감 task +2 (`product-acceptance`, 아래 `## 마감 acceptance`)
 - **분기 규칙**: [`impl-loop-routing.md`](impl-loop-routing.md)
@@ -45,17 +45,17 @@ UI expected_steps 의 `canvas-design` 은 진행 뷰용 main-owned checkpoint �
 - **glob / 복수 / epic 경로** → `chain` (impl-task-loop × N run)
 
 **엔진 축** — 각 run 안의 시퀀스를 정한다.
-- **frontmatter 우선 (진본, #703)**: impl 문서 frontmatter 의 `risk` / `engine` 이 **유효한 단일 값일 때만** 추론하지 말고 그 값을 쓴다 — `engine: 4agent` → 풀 4-agent · `engine: 2agent` → build-worker, `risk: high` → 풀 4-agent 승격(아래 자동 승격과 동치). 🔴 **placeholder 가드 (MUST)**: 유효한 단일 값 = `risk` ∈ {`normal`,`high`,`low`} / `engine` ∈ {`2agent`,`4agent`} 정확히 하나. 템플릿 미작성 잔재(`risk: normal|high|low`·`engine: 2agent|4agent` 처럼 `|` 포함)·빈 값·`<…>`·미해석 토큰은 **값이 아니라 부재로 간주**해 아래 추론 fallback 으로 떨어진다. 안 그러면 안 채운 고위험 task 가 placeholder 때문에 `normal`/경량/병렬로 새어 `_parse_risk_marker` 직렬 강등도 우회한다. 유효 값이 박혔으면 설계자(module-architect)가 이미 판정한 진본이라 진입마다 재추론하지 않는다. frontmatter 필드가 **없거나 placeholder 일 때만** 아래 디폴트·추론 fallback(하위호환).
-- **디폴트** (frontmatter 부재 시): `single` → 풀 4-agent (엄정) · `chain` → build-worker (경량). 개수가 적으면 컨텍스트 여유 → 엄정, 많으면 누적 절감 → 경량 (#446 의도된 티어링을 디폴트로 보존).
-- **고위험 task 자동 승격** (frontmatter `risk` 부재 시 추론 fallback): chain 기본이 build-worker 여도 task 가 고위험 trigger — [`workflow-router.md`](../../docs/plugin/workflow-router.md) high-risk trigger 표(auth·PII / migration·destructive / public API breakage / cross-module·cross-story interface / 외부 dependency) + impl-loop 런타임 고위험(외부 HTTP·네트워크 어댑터 / URL·파일·사용자 입력 파싱 / 도메인 invariant 변경) — 를 포함하면 그 task만 풀 4-agent로 올린다 — frontmatter `risk: high` 가 명시돼 있으면 추론 없이 그 값으로 승격한다. self-grading drift 비용이 과승격 비용보다 크다. 단순 UI/문구/순수 내부 도메인 task는 경량 유지한다.
-- **override (사용자 발화)**: `엄정|꼼꼼|제대로|풀|rigor` 매치 → **풀 4-agent 강제** · `빠르게|경량|worker|가볍게` 매치 → **build-worker 선호**. 개수와 무관하게 적용 (1개를 worker 로 빠르게, N개를 풀로 엄정하게도 가능). 단, 고위험 trigger 는 build-worker 선호보다 우선한다. 사용자가 고위험 사유를 인지하고도 경량 강행을 명시한 경우에만 `reason` 에 그 결정을 남긴다.
+- **frontmatter 우선 (진본, #703)**: impl 문서 frontmatter 의 `risk` / `engine` 이 **유효한 단일 값일 때만** 추론하지 말고 그 값을 쓴다 — frontmatter `engine: 4agent` → 풀 4-agent · `engine: 2agent` → build-worker, frontmatter `risk: high` → 풀 4-agent 승격(아래 자동 승격과 동치). 🔴 **placeholder 가드 (MUST)**: 유효한 단일 값 = `risk` ∈ {`normal`,`high`,`low`} / `engine` ∈ {`2agent`,`4agent`} 정확히 하나. 템플릿 미작성 잔재(`risk: normal|high|low`·`engine: 2agent|4agent` 처럼 `|` 포함)·빈 값·`<…>`·미해석 토큰은 **값이 아니라 부재로 간주**해 아래 추론 fallback 으로 떨어진다. 안 그러면 안 채운 고위험 task 가 placeholder 때문에 `normal`/경량/병렬로 새어 `_parse_risk_marker` 직렬 강등도 우회한다. 유효 값이 박혔으면 설계자(module-architect)가 이미 판정한 진본이라 진입마다 재추론하지 않는다. frontmatter 필드가 **없거나 placeholder 일 때만** 아래 디폴트·추론 fallback(하위호환).
+- **디폴트**: frontmatter 부재 시 기본 엔진 = build-worker, 개수와 무관. single 도 chain 도 engine 미지정이면 build-worker 로 시작하고, dry preview 의 `reason` 에 디폴트 근거(`engine 미지정 + 고위험 trigger 없음`)를 남긴다.
+- **고위험 task 자동 승격** (frontmatter `risk` 부재 시 추론 fallback): 기본이 build-worker 여도 task 가 고위험 trigger — [`workflow-router.md`](../../docs/plugin/workflow-router.md) high-risk trigger 표(auth·PII / migration·destructive / public API breakage / cross-module·cross-story interface / 외부 dependency) + impl-loop 런타임 고위험(외부 HTTP·네트워크 어댑터 / URL·파일·사용자 입력 파싱 / 도메인 invariant 변경) — 를 포함하면 그 task만 풀 4-agent로 올린다 — frontmatter `risk: high` 가 명시돼 있으면 추론 없이 그 값으로 승격한다. self-grading drift 비용이 과승격 비용보다 크다. 단순 UI/문구/순수 내부 도메인 task는 경량 유지한다.
+- **override (사용자 발화)**: 사용자 엄정 발화(`엄정|꼼꼼|제대로|풀|rigor`) 매치 → **풀 4-agent 강제** · `빠르게|경량|worker|가볍게` 매치 → **build-worker 선호**. 개수와 무관하게 적용 (1개를 worker 로 빠르게, N개를 풀로 엄정하게도 가능). 단, 고위험 trigger 는 build-worker 선호보다 우선한다. 사용자가 고위험 사유를 인지하고도 경량 강행을 명시한 경우에만 `reason` 에 그 결정을 남긴다.
 
 | 개수 \ 엔진 | 풀 4-agent | build-worker |
 |---|---|---|
-| **single (1 task)** | 디폴트 | override (`빠르게`) |
-| **chain (N task)** | override (`엄정하게`) 또는 고위험 task 자동 승격 | 디폴트 |
+| **single (1 task)** | frontmatter `risk: high`/`engine: 4agent`, 고위험 trigger, 사용자 엄정 override | 디폴트 |
+| **chain (N task)** | frontmatter `risk: high`/`engine: 4agent`, 고위험 trigger, 사용자 엄정 override | 디폴트 |
 
-판정 결과를 진입 시 사용자에게 1줄 echo (예: `single · 풀 4-agent (엄정)` / `chain 7 task · build-worker (경량)` / `chain 7 task · 일부 task 풀 4-agent 승격 (외부 HTTP)`). chain 은 아래 dry preview 표에도 task 별 `risk / engine / reason` 을 남긴다.
+판정 결과를 진입 시 사용자에게 1줄 echo (예: `single · build-worker (디폴트 — engine 미지정 + 고위험 trigger 없음)` / `chain 7 task · build-worker (디폴트)` / `chain 7 task · 일부 task 풀 4-agent 승격 (외부 HTTP)`). chain 은 아래 dry preview 표에도 task 별 `risk / engine / reason` 을 남긴다. 풀 4-agent 승격 세 경로(frontmatter `risk: high`/`engine: 4agent`, 고위험 trigger, 사용자 엄정 override)는 모두 echo 와 dry preview `reason` 에 남긴다.
 
 ### verify-only task
 
@@ -236,9 +236,9 @@ fi
 
 ---
 
-## 엔진 A — 풀 4-agent (default = single)
+## 엔진 A — 풀 4-agent (승격 전용)
 
-default 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → pr-reviewer**. 4 단계 *모두 호출* 의무 (MUST — false-clean 차단, #431).
+승격 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → pr-reviewer**. 4 단계 *모두 호출* 의무 (MUST — false-clean 차단, #431).
 
 🔴 **begin-run 에 `--design-doc` 필수**: 엔진 A 는 설계(impl 문서)가 별도 run 에서 머지된 *뒤* 진입하므로 같은 run 안에 module-architect prose 가 없다 — `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 머지된 설계 문서를 run 에 기록해야 engineer 게이트(순서 차단 훅)가 IMPL 진입을 허용한다 ([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). story/epic 마감 task 이고 acceptance 기본 ON 이면 같은 begin-run 에 `--acceptance-required` 도 붙인다. 이 marker 는 Stop hook 이 pr-reviewer 직후 run 을 자동 종료하지 않고 product-acceptance 진입 turn 을 재발화하게 하는 신호다. chain 에서 다음 task 도 풀 4-agent 면 `next-task --design-doc <다음 task 의 impl 문서 경로>` 로 동일 기록하고, 다음 task 가 마감 acceptance 대상이면 `--acceptance-required` 도 함께 기록한다. advanced fallback 으로 module-architect 를 선두 추가한 run 은 같은-run PASS prose 가 생기므로 생략 가능하나, task 의 impl 문서가 이미 있으면 기록을 권장한다.
 
@@ -350,13 +350,13 @@ chain = 위 공통 골격 + 엔진을 **task 한 개씩** 반복. task N 이 완
 
 `impl/NN-*.md` prefix 기준 직렬 순서 확정 후, **task1 진입 *전* 실행 계획을 1회 표로 echo** (사용자 가시성 + 잘못된 순서·범위 사전 포착, #526). 각 task frontmatter (`story:` / `task_index:` / `risk:` / `engine:` / `risk_reason:`) awk 추출 + PR 트레일러 판정 = [`git-spec.md`](../../docs/plugin/git-spec.md#적용-절차-pr-생성-직전-사전-체크-impl-파일-frontmatter-기반) + [`loop-procedure.md`](../../docs/plugin/loop-procedure.md#impl-task-loop-commit-구조) 재사용.
 
-각 task 는 dry preview 단계에서 `risk` / `engine` / `reason` 을 남긴다. **frontmatter 에 `risk`/`engine`/`risk_reason` 이 유효한 단일 값으로 채워져 있으면 추론하지 말고 그 값을 그대로 옮긴다 (#703)**: `risk` ∈ `normal`/`high`/`low`, `engine` = `2agent`(build-worker) / `4agent`(풀 4-agent), `reason` = frontmatter `risk_reason`. **placeholder 가드 (위 진입 분기와 동일, MUST)**: 템플릿 미작성 잔재(`|` 포함된 `normal|high|low`)·빈 값·`<…>` 는 부재로 간주해 추론으로 떨어진다. frontmatter risk 가 **없거나 placeholder 인 task 만** 메인이 본문에서 추론한다 — 그 경우 `risk` 는 `normal`/`high`, `reason` 은 고위험 trigger 가 없으면 `고위험 trigger 없음`, 고위험이면 `외부 HTTP`/`URL 파싱`/`auth`/`PII`/`도메인 invariant` 처럼 task 본문에서 확인한 근거를 적는다. 어느 경로든 `reason` 은 비워 두지 않는다 (frontmatter `risk_reason` 또는 추론 근거 중 하나는 항상 채운다). `risk: high` row 의 기본 `engine` 은 `4agent`(풀 4-agent) 이며, chain 전체 기본이 build-worker 여도 해당 row 만 승격한다. (verify-only task 는 risk 와 별개로 `task_type` 으로 판정 — 위 `### verify-only task`.)
+각 task 는 dry preview 단계에서 `risk` / `engine` / `reason` 을 남긴다. **frontmatter 에 `risk`/`engine`/`risk_reason` 이 유효한 단일 값으로 채워져 있으면 추론하지 말고 그 값을 그대로 옮긴다 (#703)**: `risk` ∈ `normal`/`high`/`low`, `engine` = `2agent`(build-worker) / `4agent`(풀 4-agent), `reason` = frontmatter `risk_reason`. **placeholder 가드 (위 진입 분기와 동일, MUST)**: 템플릿 미작성 잔재(`|` 포함된 `normal|high|low`)·빈 값·`<…>` 는 부재로 간주해 추론으로 떨어진다. frontmatter risk 가 **없거나 placeholder 인 task 만** 메인이 본문에서 추론한다 — 그 경우 `risk` 는 `normal`/`high`, 고위험 trigger 가 없으면 `engine=build-worker`, `reason=engine 미지정 + 고위험 trigger 없음`, 고위험이면 `engine=4agent`, `reason=외부 HTTP`/`URL 파싱`/`auth`/`PII`/`도메인 invariant` 처럼 task 본문에서 확인한 승격 근거를 적는다. 어느 경로든 `reason` 은 비워 두지 않는다 (frontmatter `risk_reason` 또는 추론 근거 중 하나는 항상 채운다). `risk: high` row 의 기본 `engine` 은 `4agent`(풀 4-agent) 이며, chain 전체 기본이 build-worker 여도 해당 row 만 승격한다. (verify-only task 는 risk 와 별개로 `task_type` 으로 판정 — 위 `### verify-only task`.)
 
 ```
 📋 실행 계획 (K task · 엔진 <풀 4-agent | build-worker | mixed>)
 | # | 모듈 | impl 파일 | task_index | PR 트레일러 | risk | engine | reason | sub-step |
 |---|------|----------|-----------|-----------|------|--------|--------|----------|
-| 1 | <slug> | `NN-<slug>.md` | <i/total 또는 —> | Part of #<story> | normal | build-worker | 고위험 trigger 없음 | <sub-step> |
+| 1 | <slug> | `NN-<slug>.md` | <i/total 또는 —> | Part of #<story> | normal | build-worker | engine 미지정 + 고위험 trigger 없음 | <sub-step> |
 전체: K task · 예상 PR K개
 acceptance 경계: task<i> (story #<M>) · task<K> (story #<M'> + epic #<E>)   ← 머지 전 검수 대상 (기본 ON, --no-acceptance 시 생략)
 ```

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -12,13 +12,13 @@ agent 는 일을 마치면 prose 마지막 단락에 *어떤 결과로 끝났는
 
 **개수 vs 엔진** — 개수(single/chain)는 절차 골격(1 run vs N run), 엔진(풀 4-agent / build-worker)은 각 run 안의 시퀀스를 정한다 ([진입 분기](SKILL.md#진입-분기-개수-엔진-직교)). 본 분기 규칙은 *엔진별* 시퀀스 안의 결론→다음을 다룬다. chain 의 task 경계 분기(`clean`/`error`/`blocked`)는 [chain 모드 task 경계 분기](#chain-모드-task-경계-분기).
 
-**고위험 task 승격** — build-worker 는 비용 절감 엔진이지 보안 경계가 아니다. 고위험 trigger([`workflow-router.md`](../../docs/plugin/workflow-router.md) high-risk trigger 표 — auth·PII / migration·destructive / public API breakage / cross-module·cross-story interface / 외부 dependency — 에 impl-loop 런타임 고위험인 외부 HTTP·네트워크 어댑터 / URL·파일·사용자 입력 파싱 / 도메인 invariant 변경을 더한 집합) task 는 chain 안에서도 해당 task만 풀 4-agent 경로로 분기한다. 일반 UI/문구/순수 내부 도메인 task 는 build-worker 경량 경로를 유지한다. **이 판정의 진본 = impl 문서 frontmatter 의 `risk`/`engine` (#703)**: `risk: high` → 풀 4-agent 승격, `engine: 4agent` → 풀 4-agent · `engine: 2agent` → build-worker. 설계자(module-architect)가 task 를 자르는 시점에 박은 값이라 진입마다 재추론하지 않는다. 단 **유효한 단일 값일 때만** 신뢰한다 — 템플릿 placeholder(`risk: normal|high|low` 처럼 `|` 포함)·빈 값은 부재로 간주해 추론으로 떨어진다([`SKILL.md`](SKILL.md) placeholder 가드). frontmatter 에 risk 필드가 **없거나 placeholder 일 때만** 메인이 위 고위험 trigger 기준으로 추론한다(하위호환). 어느 경로든 결과를 task1 진입 전 dry preview 표의 `risk / engine / reason` 열에 남기고, `risk: high` slug 를 `wave-plan --high-risk` 입력으로 도출한다([병렬 wave](SKILL.md#병렬-wave-opt-in-chain-한정)). 고위험 trigger 는 build-worker 선호보다 우선하며, 사용자가 고위험 사유를 인지하고도 경량 강행을 명시한 경우에만 그 결정을 `reason` 에 기록한다.
+**엔진 디폴트와 고위험 task 승격** — frontmatter 부재 시 기본 엔진 = build-worker 이며 개수와 무관하다. build-worker 는 비용 절감 엔진이지 보안 경계가 아니다. 고위험 trigger([`workflow-router.md`](../../docs/plugin/workflow-router.md) high-risk trigger 표 — auth·PII / migration·destructive / public API breakage / cross-module·cross-story interface / 외부 dependency — 에 impl-loop 런타임 고위험인 외부 HTTP·네트워크 어댑터 / URL·파일·사용자 입력 파싱 / 도메인 invariant 변경을 더한 집합) task 는 single/chain 어디서든 해당 task만 풀 4-agent 경로로 분기한다. 일반 UI/문구/순수 내부 도메인 task 는 build-worker 경량 경로를 유지한다. **이 판정의 진본 = impl 문서 frontmatter 의 `risk`/`engine` (#703)**: frontmatter `risk: high` → 풀 4-agent 승격, frontmatter `engine: 4agent` → 풀 4-agent · `engine: 2agent` → build-worker. 설계자(module-architect)가 task 를 자르는 시점에 박은 값이라 진입마다 재추론하지 않는다. 단 **유효한 단일 값일 때만** 신뢰한다 — 템플릿 placeholder(`risk: normal|high|low` 처럼 `|` 포함)·빈 값은 부재로 간주해 추론으로 떨어진다([`SKILL.md`](SKILL.md) placeholder 가드). frontmatter 에 risk 필드가 **없거나 placeholder 일 때만** 메인이 위 고위험 trigger 기준으로 추론한다(하위호환). 어느 경로든 결과를 task1 진입 전 dry preview 표의 `risk / engine / reason` 열에 남기고, `risk: high` slug 를 `wave-plan --high-risk` 입력으로 도출한다([병렬 wave](SKILL.md#병렬-wave-opt-in-chain-한정)). 고위험 trigger 는 build-worker 선호보다 우선하며, 사용자 엄정 발화 override(`엄정|꼼꼼|제대로|풀|rigor`)도 풀 4-agent 승격 사유다. build-worker 디폴트는 디폴트 근거(`reason=engine 미지정 + 고위험 trigger 없음`)를, 풀 4-agent 승격은 `reason` 에 승격 근거를 기록한다.
 
 **verify-only 예외** — task 산출물이 코드 변경이 아니라 검증 결과이고 검증 exit 0 + 변경 0 이면 PR 생성이 정상적으로 생략된다. 이때 `code-validator:VERIFY_ONLY` prose `PASS` 기록을 clean 증거로 삼고 `pr-create.sh` 를 호출하지 않는다. 검증 실패나 BROKEN 확인 시 일반 impl 수정 경로로 전환한다.
 
 ## 분기 그래프
 
-### 엔진 A — 풀 4-agent (default = single)
+### 엔진 A — 풀 4-agent (승격 전용)
 
 ```mermaid
 flowchart TB
@@ -49,7 +49,7 @@ flowchart TB
 
 > advanced fallback (deep task 보강 필요) → MA 선두 1 step 추가. 이것은 Lite direct 구현이 아니라 deep task 보강 경로다. UI 감지 → engine 무관 canvas-design 선두. canvas-design 은 main-owned checkpoint 이며 helper begin/end-step 비대상이다. draft 가 필요할 때 실제 Agent 호출은 별도 `begin-step designer` 로 연다. 사용자 PICK 은 draft 가 실제 생성된 경우 canvas-design 내부에서만 수행하며, canvas-design `PASS` → 선택 엔진 구현 step.
 
-### 엔진 B — build-worker (default = chain)
+### 엔진 B — build-worker (디폴트)
 
 ```mermaid
 flowchart TB

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -26,10 +26,10 @@ description: 구현 요청을 받아 가장 작은 안전 workflow 로 PR 까지
 
 | 엔진 | 시퀀스 | 언제 |
 |---|---|---|
-| 풀 4-agent | `test-engineer → engineer:IMPL → code-validator → pr-reviewer` | 디폴트 (엄정) |
-| 경량 build-worker | build-worker 1 step (테스트·구현·자체검증) | 사용자 "빠르게/경량" 발화 또는 메인 추천 |
+| 경량 build-worker | build-worker 1 step (테스트·구현·자체검증) → `pr-reviewer` | sub-agent 엔진 미지정 시 디폴트 |
+| 풀 4-agent | `test-engineer → engineer:IMPL → code-validator → pr-reviewer` | 승격 전용 |
 
-엔진 선택은 **사용자 우선, 미지정 시 메인 추천**이고 구현 경로와 직교다 — 구현 경로 × 엔진 4조합이 모두 유효하다. 구현 경로별로 engineer 게이트 사전 조건 충족 메커니즘이 다르다:
+엔진 선택은 **사용자 우선, 미지정 시 build-worker 기본**이고 구현 경로와 직교다 — 구현 경로 × 엔진 4조합이 모두 유효하다. 풀 4-agent 는 승격 전용이며 다음 세 경우에만 들어간다: `risk: high` 또는 `engine: 4agent` frontmatter, 고위험 trigger 자동 승격, 사용자 엄정 발화 override(`엄정|꼼꼼|제대로|풀|rigor`). 경량 발화(`빠르게|경량|worker|가볍게`)는 build-worker 선호지만 고위험 trigger 가 우선한다. 메인은 판정 echo 에 엔진과 디폴트 근거 또는 승격 근거 1줄을 남긴다. 구현 경로별로 engineer 게이트 사전 조건 충족 메커니즘이 다르다:
 
 - **Standard + sub-agent 엔진**: 설계도(`begin-run impl --design-doc <경로>`)가 engineer 게이트 사전 조건이다.
 - **Lite + sub-agent 엔진**: Lite 는 정의상 설계도가 없으므로 `begin-run impl --lane lite` 로 구현 경로를 기록해 engineer 게이트의 설계 산출물 사전 조건을 면제한다(#714). 면제 경계는 *명시적으로 기록된* `lane=lite` 한정이며, 뒤따르는 `pr-reviewer ← code-validator PASS` 잔존 보호는 구현 경로와 무관하게 그대로 강제된다([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)).
@@ -43,8 +43,16 @@ concrete signal: 파일 path, 함수/클래스/symbol, 이미 분류·승인된 
 ## Loop
 
 - **Lite 구현 경로 — 메인 직접 (기본)**: 코드/문서 변경은 메인이 수행하고, review step 만 `begin-run impl` 안에서 `pr-reviewer` 로 기록한다. `code-validator` 는 호출하지 않는다.
-- **Lite 구현 경로 — sub-agent 엔진 (#714)**: 사용자/메인이 풀4·경량 엔진을 명시 선택하면 `begin-run impl --lane lite` 로 진입한다. `lane=lite` 기록이 engineer 게이트 설계 산출물 사전 조건을 면제한다. 엔진 시퀀스는 Standard 와 동일(풀4: test-engineer → engineer:IMPL → code-validator → pr-reviewer / 경량: build-worker 1 step). 잔존 보호(`pr-reviewer ← code-validator PASS`)는 그대로 강제된다.
-- **Standard 구현 경로 — 풀 4-agent 엔진 (디폴트)**
+- **Lite 구현 경로 — sub-agent 엔진 (#714)**: 사용자/메인이 sub-agent 엔진을 명시 선택하거나 메인이 추천하면 `begin-run impl --lane lite` 로 진입한다. 미지정 기본은 build-worker 이고, 풀4는 `risk: high` / `engine: 4agent` / 고위험 trigger / 사용자 엄정 override 때만 승격한다. `lane=lite` 기록이 engineer 게이트 설계 산출물 사전 조건을 면제한다. 엔진 시퀀스는 Standard 와 동일(풀4: test-engineer → engineer:IMPL → code-validator → pr-reviewer / 경량: build-worker 1 step → pr-reviewer). 잔존 보호(`pr-reviewer ← code-validator PASS`)는 그대로 강제된다.
+- **Standard 구현 경로 — 경량 build-worker 엔진 (디폴트)**
+  - **loop**: `impl-standard`
+  - **entry_point**: `impl`
+  - **사전 조건**: 설계 문서 경로 — `begin-run impl --design-doc <경로>` 로 기록 (engineer 게이트 사전 조건, [`hooks.md`](../../docs/plugin/hooks.md#catastrophic-gatesh))
+  - **task_list**: build-worker → pr-reviewer
+  - **advance**: `PASS` → `PASS`
+  - **expected_steps**: 2
+  - **분기 규칙**: [`impl-routing.md`](impl-routing.md)
+- **Standard 구현 경로 — 풀 4-agent 엔진 (승격 전용)**
   - **loop**: `impl-standard`
   - **entry_point**: `impl`
   - **사전 조건**: 설계 문서 경로 — `begin-run impl --design-doc <경로>` 로 기록 (engineer 게이트 사전 조건, [`hooks.md`](../../docs/plugin/hooks.md#catastrophic-gatesh))
@@ -52,7 +60,8 @@ concrete signal: 파일 path, 함수/클래스/symbol, 이미 분류·승인된 
   - **advance**: `TESTS_WRITTEN` → `IMPL_DONE` → `PASS` → `PASS`
   - **expected_steps**: 4
   - **분기 규칙**: [`impl-routing.md`](impl-routing.md)
-- **Standard 구현 경로 — 경량 build-worker 엔진**: 사용자 "빠르게/경량" 발화 또는 메인 추천 시. 동일하게 `begin-run impl --design-doc <경로>` 로 설계도를 기록한 뒤 build-worker 가 테스트·구현·자체검증을 한 step 으로 수행한다. 경량 build-worker 엔진도 `build-worker → pr-reviewer` 순서이며, Standard 경량 경로도 pr-reviewer PASS 전 commit/PR/merge 로 가지 않는다. 엔진은 구현 경로와 직교다.
+- **풀 4-agent 승격 사유**: `risk: high` 또는 `engine: 4agent` frontmatter, 고위험 trigger 자동 승격, 사용자 엄정 발화 override. 세 경로 모두 판정 echo 에 사유를 남긴다.
+- **경량 build-worker 엔진도 `build-worker → pr-reviewer`** 순서이며, Standard 경량 경로도 pr-reviewer PASS 전 commit/PR/merge 로 가지 않는다.
 - **high-risk → impl 밖**: high-risk trigger 가 있으면 impl 이 직접 처리하지 않는다. impl 진입 *전* 분기 규칙([`workflow-router`](../../docs/plugin/workflow-router.md))이 설계 선행(`/spec`·`/design`)으로 보내고, deep impl task 파일이 이미 있으면 `/impl-loop <task>` 로 위임한다.
 
 ## Step 0 — 실존 검증
@@ -120,8 +129,8 @@ UI 기준: 시각 구조 불변 — 목업 없이 구현
 
 ```
 구현 경로: Lite — 설계도 없음, concrete signal = <파일/이슈/테스트>, 엔진 = 메인 직접, 검증 gate = test + pr-reviewer
-구현 경로: Standard — 설계도 = <경로>, 엔진 = 풀4(디폴트), 검증 gate = test + code-validator + pr-reviewer
-구현 경로: Standard — 설계도 = <경로>, 엔진 = 경량 build-worker, 검증 gate = test + build-worker self-validate + pr-reviewer
+구현 경로: Standard — 설계도 = <경로>, 엔진 = build-worker(디폴트), 근거 = engine 미지정 + 고위험 trigger 없음, 검증 gate = test + build-worker self-validate + pr-reviewer
+구현 경로: Standard — 설계도 = <경로>, 엔진 = 풀4(승격), 근거 = <risk: high|engine: 4agent|고위험 trigger|사용자 엄정>, 검증 gate = test + code-validator + pr-reviewer
 ```
 
 ## Sub-agent prompt 작성 checkpoint (#780)
@@ -178,7 +187,7 @@ Codex implementation routing 이 `codex-first` 이면 Lite 기본 구현도 메�
 
 ## Lite 구현 경로 — sub-agent 엔진 (#714)
 
-메인 직접 구현 대신 sub-agent 엔진(풀4 / 경량 build-worker)으로 Lite 를 돌리는 변형이다. 사용자가 "에이전트로/풀4로/경량 엔진으로" 류로 명시 선택하거나 메인이 추천할 때 쓴다. Lite 는 정의상 설계도가 없으므로 Standard 의 `--design-doc` 대신 **구현 경로 기록**으로 engineer 게이트를 충족한다.
+메인 직접 구현 대신 sub-agent 엔진(풀4 / 경량 build-worker)으로 Lite 를 돌리는 변형이다. 사용자가 "에이전트로/풀4로/경량 엔진으로" 류로 명시 선택하거나 메인이 추천할 때 쓴다. sub-agent 엔진 미지정 시 기본은 build-worker 이고, 풀 4-agent 는 승격 전용이다. Lite 는 정의상 설계도가 없으므로 Standard 의 `--design-doc` 대신 **구현 경로 기록**으로 engineer 게이트를 충족한다.
 
 진입 시 `begin-run impl --lane lite` 로 구현 경로를 기록한다 — 이 기록이 engineer 게이트의 설계 산출물 사전 조건 면제 신호다([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). 면제 경계는 *명시적으로 기록된* `lane=lite` 한정이고, 구현 경로 값은 `entry_point=impl` 에서만 기록되므로 design/architect-loop 의 module-architect PASS 강제는 영향받지 않는다.
 
@@ -193,9 +202,11 @@ Standard 는 **설계 문서(경로)가 들어온** 구현 경로다. impl 은 �
 
 진입 시 `begin-run impl --design-doc <설계 문서 경로>` 로 설계도를 기록한다 — 이것이 engineer 게이트의 설계 산출물 사전 조건 증거다([`hooks.md`](../../docs/plugin/hooks.md#catastrophic-gatesh)). 설계도가 (a) 이전에 머지된 설계 문서든 (b) `compact-design` 이 방금 산출한 compact plan 이든, impl 은 같은 run 에서 설계를 생성하지 않으므로 Standard 는 **항상 `--design-doc` 기록 하나로** 진입한다 (same-run module-architect step 없음).
 
-엔진(풀4/경량)은 구현 경로와 직교로 별도 판정한다 — 사용자 우선, 미지정 시 메인 추천.
+엔진(풀4/경량)은 구현 경로와 직교로 별도 판정한다 — 사용자 우선, 미지정 시 build-worker 기본이다.
 
-**풀 4-agent 엔진 (디폴트) 실행:**
+**경량 build-worker 엔진 (디폴트) 실행:** 동일하게 `--design-doc` 으로 설계도를 기록한 뒤 build-worker 가 테스트·구현·자체검증을 한 step 으로 수행한다. 그 다음 `pr-reviewer` 가 local diff 를 읽기 전용으로 리뷰하며, Standard 경량 경로도 pr-reviewer PASS 전 commit/PR/merge 로 가지 않는다. worker 가 commit message·PR body 초안을 남겨도 실제 commit/PR/merge 는 메인이 pr-reviewer PASS 뒤 수행한다.
+
+**풀 4-agent 엔진 (승격 전용) 실행:** `risk: high` 또는 `engine: 4agent` frontmatter, 고위험 trigger 자동 승격, 사용자 엄정 발화 override 일 때만 사용한다. 메인은 판정 echo 에 승격 사유를 남긴다.
 
 1. `test-engineer`
    - 설계도의 테스트 기준을 실패 테스트로 만든다.
@@ -207,8 +218,6 @@ Standard 는 **설계 문서(경로)가 들어온** 구현 경로다. impl 은 �
    - local diff 를 리뷰한다.
 5. 단위 commit + PR 생성
 6. CI / merge policy
-
-**경량 build-worker 엔진:** 사용자 "빠르게/경량" 발화 또는 메인 추천 시. 동일하게 `--design-doc` 으로 설계도를 기록한 뒤 build-worker 가 테스트·구현·자체검증을 한 step 으로 수행한다. 그 다음 `pr-reviewer` 가 local diff 를 읽기 전용으로 리뷰하며, Standard 경량 경로도 pr-reviewer PASS 전 commit/PR/merge 로 가지 않는다. worker 가 commit message·PR body 초안을 남겨도 실제 commit/PR/merge 는 메인이 pr-reviewer PASS 뒤 수행한다.
 
 구현 중 설계가 또 부족하면 `compact-design`/`/design` 으로 되돌려 설계도를 보강한다 — 되돌림은 정상 루프다. 새 외부 의존·high-risk 가 드러나면 impl *밖* 설계 선행으로 escalate 한다(경량 범위를 넘어섰다는 신호).
 

--- a/skills/impl/impl-routing.md
+++ b/skills/impl/impl-routing.md
@@ -57,19 +57,21 @@ UI 기준: 시각 구조 불변 — 목업 없이 구현
 
 ## 구현 경로 × 엔진 실행 매핑
 
-구현 경로(설계도 유무)와 엔진(풀4/경량)은 직교다 — 구현 경로 × 엔진 4조합이 모두 유효하다(#714). 구현 경로별 engineer 게이트 사전 조건 충족 메커니즘만 다르다: Standard 는 `--design-doc`, Lite 는 `--lane lite`(설계도 면제).
+구현 경로(설계도 유무)와 엔진(풀4/경량)은 직교다 — 구현 경로 × 엔진 4조합이 모두 유효하다(#714). sub-agent 엔진 미지정 시 기본은 build-worker 이고, 풀 4-agent 승격은 `risk: high` 또는 `engine: 4agent` frontmatter, 고위험 trigger 자동 승격, 사용자 엄정 발화 override 때만 수행한다. 구현 경로별 engineer 게이트 사전 조건 충족 메커니즘만 다르다: Standard 는 `--design-doc`, Lite 는 `--lane lite`(설계도 면제).
 
 | 경로 | 다음 |
 |---|---|
 | Lite · 메인 직접 (기본) | 메인 직접 `test -> impl -> test pass` 후 `begin-run impl` → `pr-reviewer` local diff. `code-validator` 없음 |
-| Lite · 풀 4-agent | `begin-run impl --lane lite` 기록 후 `test-engineer -> engineer:IMPL -> code-validator -> pr-reviewer` |
-| Lite · 경량 build-worker | `begin-run impl --lane lite` 기록 후 `build-worker` 1 step (테스트·구현·자체검증) → `pr-reviewer` |
-| Standard · 풀 4-agent (디폴트) | `begin-run impl --design-doc <경로>` 기록 후 `test-engineer -> engineer:IMPL -> code-validator -> pr-reviewer` |
-| Standard · 경량 build-worker | `begin-run impl --design-doc <경로>` 기록 후 `build-worker` 1 step (테스트·구현·자체검증) → `pr-reviewer` |
+| Lite · 경량 build-worker (sub-agent 디폴트) | `begin-run impl --lane lite` 기록 후 `build-worker` 1 step (테스트·구현·자체검증) → `pr-reviewer` |
+| Lite · 풀 4-agent 승격 | `begin-run impl --lane lite` 기록 후 `test-engineer -> engineer:IMPL -> code-validator -> pr-reviewer` |
+| Standard · 경량 build-worker (디폴트) | `begin-run impl --design-doc <경로>` 기록 후 `build-worker` 1 step (테스트·구현·자체검증) → `pr-reviewer` |
+| Standard · 풀 4-agent 승격 | `begin-run impl --design-doc <경로>` 기록 후 `test-engineer -> engineer:IMPL -> code-validator -> pr-reviewer` |
 
 Standard 의 설계도는 (a) 이미 머지된 설계 문서이거나 (b) `compact-design` 이 방금 산출한 compact plan 이다. 두 경우 모두 메인이 `begin-run impl --design-doc <경로>` 로 같은 경로를 기록하며, Standard 는 same-run module-architect step 없이 받은 설계도로 구현만 한다 — `--design-doc` 이 Standard engineer 게이트 사전 조건의 단일 메커니즘이다.
 
 Standard 경량 build-worker 경로도 build-worker self-validate 뒤 `pr-reviewer` 를 거친다. 경량은 구현 step 수를 줄이는 선택이지 review gate 를 생략하는 선택이 아니다.
+
+풀 4-agent 승격 사유는 판정 echo 에 남긴다: frontmatter `risk: high`, frontmatter `engine: 4agent`, 고위험 trigger, 사용자 엄정 발화. build-worker 디폴트 근거도 echo 에 남긴다: engine 미지정 + 고위험 trigger 없음.
 
 Lite 에 sub-agent 엔진을 붙일 때는 설계도가 없으므로 `begin-run impl --lane lite` 로 구현 경로를 기록해 engineer 게이트의 설계 산출물 사전 조건을 면제한다(#714). 면제는 *명시적으로 기록된* `lane=lite` 한정이며 engineer 게이트 *하나만* 푼다 — engineer 산출물 이후 `pr-reviewer ← code-validator PASS` 잔존 보호는 구현 경로와 무관하게 불변(풀4 경로). 구현 경로 값은 `entry_point=impl` 에서만 기록되므로 design/architect-loop 의 module-architect PASS 강제는 영향받지 않는다.
 

--- a/tests/test_impl_cost_aware.py
+++ b/tests/test_impl_cost_aware.py
@@ -117,11 +117,26 @@ class TestImplLoopRiskPreview(unittest.TestCase):
         self.assertGreaterEqual(skill.count("placeholder"), 2)
         self.assertIn("placeholder", routing)
 
-    def test_high_risk_routes_to_full_agent_even_when_chain_defaults_worker(self):
+    def test_unspecified_engine_defaults_to_build_worker_for_single_and_chain(self):
+        # #861 — 개수(single/chain)와 무관하게 engine 미지정 기본값은 build-worker.
+        skill = read_impl_skill()
+        routing = read_impl_routing()
+        for body in (skill, routing):
+            self.assertIn("frontmatter 부재 시 기본 엔진 = build-worker", body)
+            self.assertIn("개수와 무관", body)
+            self.assertIn("디폴트 근거", body)
+            self.assertIn("engine 미지정 + 고위험 trigger 없음", body)
+        self.assertNotIn("`single` → 풀 4-agent", skill)
+        self.assertNotIn("default = single", routing)
+
+    def test_high_risk_routes_to_full_agent_from_build_worker_default(self):
         skill = read_impl_skill()
         routing = read_impl_routing()
         for body in (skill, routing):
             self.assertIn("고위험 trigger 는 build-worker 선호보다 우선", body)
+            self.assertIn("frontmatter `risk: high`", body)
+            self.assertIn("frontmatter `engine: 4agent`", body)
+            self.assertIn("사용자 엄정", body)
             self.assertIn("풀 4-agent", body)
             self.assertIn("reason", body)
 

--- a/tests/test_skill_scenarios.py
+++ b/tests/test_skill_scenarios.py
@@ -49,9 +49,32 @@ class SkillScenarioRegressionTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-    # ----- 시나리오 1 — /impl default 4-agent 시퀀스 -----
-    def test_impl_default_sequence_keeps_four_agent_order(self) -> None:
-        """/impl Standard happy path = test-engineer → engineer → code-validator → pr-reviewer 순서 보존.
+    # ----- 시나리오 1 — /impl 기본 build-worker + 풀4 승격 시퀀스 -----
+    def test_impl_default_engine_is_build_worker(self) -> None:
+        """/impl Standard engine unspecified path defaults to build-worker, not 풀 4-agent."""
+        for needle in (
+            "엔진 = build-worker(디폴트)",
+            "디폴트 근거",
+            "풀 4-agent 는 승격 전용",
+            "risk: high",
+            "engine: 4agent",
+            "고위험 trigger",
+            "사용자 엄정",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.impl_skill)
+
+        for needle in (
+            "Standard · 경량 build-worker (디폴트)",
+            "풀 4-agent 승격",
+            "고위험 trigger",
+            "사용자 엄정",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.impl_routing)
+
+    def test_escalated_four_agent_sequence_keeps_order(self) -> None:
+        """/impl 풀 4-agent escalation path preserves test → impl → validate → review.
 
         4 단계 중 하나라도 빠지거나 순서가 바뀌면 false-clean 회귀(#431)로 직결된다.
         """


### PR DESCRIPTION
## 관련 이슈 번호

Closes #861

## 배경 및 문제

- sub-agent 엔진 미지정 기본값이 `/impl` Standard 및 `/impl-loop` single/chain 표면에서 서로 다르게 설명되어 비용 큰 풀 4-agent가 기본처럼 남아 있었다.
- 이슈 #861의 목표는 engine 미지정 기본을 build-worker로 통일하고, 풀 4-agent는 고위험/엄정 승격 전용으로 남기는 것이다.

## 원인 (해당 시)

-

## 작업내용

- `/impl` Standard sub-agent 엔진 기본을 `build-worker -> pr-reviewer`로 문서화하고, 풀 4-agent는 `risk: high`, `engine: 4agent`, 고위험 trigger, 사용자 엄정 발화 승격으로 한정했다.
- `/impl-loop` single/chain의 engine 미지정 기본을 개수와 무관하게 build-worker로 통일하고, dry preview/echo reason에 디폴트 근거와 승격 근거를 남기도록 지침을 갱신했다.
- README 및 plugin docs의 오래된 single=풀4, chain=worker 설명을 새 기본값 계약으로 정리했다.
- 회귀 테스트를 추가/갱신해 `/impl` 기본 build-worker, 풀4 승격 순서, `/impl-loop` single/chain 기본값, 고위험 승격 사유를 고정했다.

## 결정 근거

- build-worker 기본 경로도 별도 read-only `pr-reviewer` gate를 유지하므로 worker self-validate가 격리 리뷰를 대체하지 않는다.
- 기존 frontmatter placeholder guard와 고위험 trigger 계약은 유지하고 디폴트만 변경했다.

## 배포 경로 검증 (plug-in 영향 시)

- `skills/impl*`, `skills/impl-loop*`, `docs/plugin/*`, `README.md` 노출면을 함께 갱신했다.
- 신규 deploy shim/source 추가 없음.
- `node scripts/check_public_surface.mjs`, `node scripts/check_cross_refs.mjs`, index/architecture map check 통과.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public skill/command/agent/gate 없음.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
  - `python3.11 -m unittest tests.test_skill_scenarios tests.test_impl_cost_aware -v`
  - `python3.11 -m unittest tests.test_surface_docs_sync tests.test_canvas_design_workflow tests.test_public_surface -v`
  - `python3.11 -m unittest discover -s tests -v` (latest main rebase 후 1496 tests OK)
- [x] 회귀 검증
  - `node scripts/check_public_surface.mjs`
  - `node scripts/check_cross_refs.mjs`
  - `node scripts/aggregate_index_map.mjs --check`
  - `node scripts/aggregate_architecture_map.mjs --check`
  - `python3 evals/guard_efficacy.py` (32/32 passed)
  - `git diff --check`

## 참고

- `bash evals/run.sh` 1회 실행에서 `shorts-real-spec` judge가 `MISS E1`로 전체 FAIL 처리했으나, 같은 케이스 단일 재실행+채점은 `OK E1`, `OK E2`, `RESULT: PASS`였다. 보고서 원문도 Story 3까지 walking skeleton이 밀린 순서 결함을 명시해 이번 엔진 기본값 변경과 무관한 LLM/judge 변동으로 판단했다.