### PR TITLE
[feature] implementation provider headless chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ claude plugin install dcness@dcness
 
 > 갱신: `claude plugin update dcness@dcness` (문서·skill·hook 만 받는 경우 `/init-dcness` 재실행 불필요)
 
-검증·구현·리뷰 단계를 어느 엔진으로 돌릴지는 프로젝트별로 고를 수 있다(Claude 서브에이전트 / Codex). 엔진을 바꿔도 순서·파일 경계 규칙은 그대로 걸린다. 엔진 구성을 새로 켜거나 바꿀 때만 `/init-dcness` 를 다시 실행한다.
+검증·구현·리뷰 단계를 어느 엔진으로 돌릴지는 프로젝트별로 고를 수 있다(Claude 서브에이전트 / Codex headless / Claude headless). 엔진을 바꿔도 순서·파일 경계 규칙은 그대로 걸린다. 구현 기본값은 `headless-chain`(Codex headless → Claude headless → Claude main)이고, 엔진 구성을 새로 켜거나 바꿀 때만 `/init-dcness` 를 다시 실행한다.
 
 ## 작업 흐름
 
@@ -117,11 +117,11 @@ claude plugin install dcness@dcness
 
 **구현 엔진 기본값 전환** — `/impl`·`/impl-loop` 의 sub-agent 엔진 미지정 기본을 build-worker 로 통일했다. 풀 4-agent 는 frontmatter, 고위험 trigger, 사용자 엄정 override 승격 전용으로 남는다. ([#861](https://github.com/alruminum/dcNess/issues/861))
 
+**구현 provider 3단 체인** — implementation provider 기본값을 `headless-chain` 으로 바꿨다. 실행 순서는 Codex headless → Claude headless → Claude main 이며, workspace 변경 전 인프라 실패만 다음 provider 로 넘어간다. headless raw log 는 run 디렉터리의 `headless-logs/` 파일로 보존하고, ledger step receipt 에 실제 provider 를 남긴다. ([#860](https://github.com/alruminum/dcNess/issues/860))
+
 ## 진행 중 (로드맵)
 
-게이트를 엔진 무관하게 만든 작업([#859](https://github.com/alruminum/dcNess/issues/859))에 이어, 그 위에서 실행 엔진의 선택폭을 넓히는 단계다.
-
-- **구현 엔진 3단 폴백** ([#860](https://github.com/alruminum/dcNess/issues/860)) — codex headless → claude headless → claude 메인. Codex 가 안 깔린 사람도 격리 실행 혜택을 받게 한다.
+다음 릴리즈 후보 이슈는 GitHub Issue와 Project board를 기준으로 갱신한다.
 
 ## 핵심 특징
 

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -53,9 +53,8 @@ core activation 의 성공 기준은 다음 항목까지다.
 - `~/.claude/settings.json` Read 권한
 - git hook shim 3종 설치
 - Codex validator skill 배포
-- Codex routing 상태 확인
+- Provider routing 상태 확인
 - `dcness-helper status` 기준 FAIL 0
-
 선택형 확장은 core activation 성공 조건이 아니다. CI workflow, project docs seed, design seed, GitHub Project lifecycle, workflow 변경 PR 은 INFO/WARN 으로 남아도 core 성공 메시지를 흐리지 않는다.
 
 ### Core Step 1 - 상태 진단
@@ -72,7 +71,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 - `Read 권한` FAIL → Core Step 3.
 - `git hook shim 3종` FAIL → Core Step 4.
 - `Codex validator skills` FAIL → Core Step 5 재실행.
-- `Codex routing` 은 INFO 로 상태만 확인한다. validation 이 이미 enabled 면 다시 쓰지 않고, implementation 은 custom 선택 때만 명시 변경한다.
+- `Provider routing` 은 INFO 로 상태만 확인한다. validation 이 이미 enabled 면 다시 쓰지 않고, implementation 은 custom 선택 때만 명시 변경한다.
 - `선택형 CI workflow` 는 INFO 다. core activation 성공/실패 판정에 넣지 않는다.
 
 ### Core Step 2 - 활성화
@@ -142,7 +141,7 @@ fi
 
 ### Core Step 5 - Codex skill 배포와 routing 상태 확인
 
-`code-validator` / `architecture-validator` / `pr-reviewer` 는 Codex read-only 실행으로 보낼 수 있다. `test-engineer` / `engineer` / `build-worker` 는 Codex-first implementation 실행으로 보낼 수 있다. 사용자 repo 에 provider config 를 만들지 않는다.
+`code-validator` / `architecture-validator` / `pr-reviewer` 는 Codex read-only 실행으로 보낼 수 있다. `test-engineer` / `engineer` / `build-worker` 는 headless-chain implementation 실행으로 보낼 수 있다. 사용자 repo 에 provider config 를 만들지 않는다.
 
 ```bash
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
@@ -154,7 +153,7 @@ for DIR in dcness-code-validator dcness-architecture-validator dcness-pr-reviewe
 done
 ```
 
-이미 Codex validation routing 이 enabled 면 질문하지 않고 현재 값을 유지한다. implementation routing 은 미설정 기본값이 `codex-first` 이며, Claude-only 사용자는 core completion 뒤 선택형 확장 custom 경로에서 `claude` 로 바꾼다.
+이미 Codex validation routing 이 enabled 면 질문하지 않고 현재 값을 유지한다. implementation routing 은 미설정 기본값이 `headless-chain` 이며, Claude-only 사용자는 core completion 뒤 선택형 확장 custom 경로에서 `claude` 로 바꾼다.
 
 ```bash
 "$HELPER" routing status
@@ -224,7 +223,7 @@ core activation 완료 뒤에만 진행한다. 기본 경로에서 선택형 항
 - UI 흔적이 있어도 `docs/design-variants/` 는 기본 skip. 특히 단일 `app/page.tsx` 정도만으로 design kit 를 설치하지 않는다.
 - GitHub Project lifecycle 은 기본 skip. `gh` 인증, Project number, PAT/secrets, field/label 복구가 얽히므로 custom 에서만 진행한다.
 - Codex validation routing 이 이미 enabled 면 skip. disabled/미설정이면 추천 bundle 에서 enable 대상으로 표시하고, custom 에서는 명시 선택으로 다룬다.
-- Codex implementation routing 이 명시 `claude` 가 아니면 추천 bundle 에서 `codex-first` 유지 대상으로 표시한다. custom 에서는 `codex-first` / `claude` 중 하나를 명시 선택한다.
+- Implementation routing 이 명시 `claude` 가 아니면 추천 bundle 에서 `headless-chain` 유지 대상으로 표시한다. custom 에서는 `headless-chain` / `codex-first` / `claude-headless` / `claude` 중 하나를 명시 선택한다.
 - workflow 변경 PR 은 GitHub remote 가 있고, `gh auth status` 가 통과하고, `.github/workflows/*.yml` 변경이 있고, 현재 branch 가 `main` 이면 추천 ON. Y 선택 시 별도 질문 없이 branch 생성, workflow 파일만 stage, commit, push, PR 생성까지 진행한다. `gh` 미설치/미인증이면 자동 PR 은 skip 하고 custom/manual 안내만 남긴다.
 
 추천 출력 예시:
@@ -237,7 +236,7 @@ core activation 완료 뒤에만 진행한다. 기본 경로에서 선택형 항
  - design kit: skip
  - Project lifecycle: skip
  - Codex validation routing: enable
- - Codex implementation routing: codex-first
+ - Implementation routing: headless-chain
  - workflow PR: gh 인증 + main branch + workflow 변경 시 자동 생성
 적용할까요? (Y/n/custom)
 ```
@@ -302,12 +301,14 @@ if ! grep -qxF '.dcness-work/' "$PROJECT_ROOT/.gitignore"; then
 fi
 ```
 
-#### Codex routing
+#### Provider routing
 
 ```bash
 "$HELPER" routing enable-codex-validation        # 추천 ON 이고 현재 enabled 가 아닐 때 1회
+"$HELPER" routing enable-headless-implementation   # custom 에서 3단 headless-chain 복귀 시
+"$HELPER" routing enable-claude-headless-implementation  # custom 에서 Claude headless 우선 선택 시
+"$HELPER" routing enable-codex-implementation   # custom 에서 legacy Codex-first 선택 시
 "$HELPER" routing disable-codex-implementation  # custom 에서 Claude-only 선택 시
-"$HELPER" routing enable-codex-implementation   # custom 에서 Codex-first 복귀 시
 "$HELPER" routing status
 ```
 
@@ -405,7 +406,7 @@ custom 은 기존 세부 기능을 유지하되 이미 결정 가능한 항목�
 - docs seed: 이미 존재하는 파일은 묻지 않는다. 단 기존 `docs/index.md` 에 진행 상태 섹션이 없으면 append 보강한다. 루트 `architecture.md` 가 있으면 `docs/architecture.md` 생성 질문을 생략하고 `root architecture.md 감지로 docs/architecture.md skip` 을 남긴다.
 - design seed: UI 프로젝트 여부가 불명확할 때만 묻는다. `docs/design.md` 는 부재 시 [`docs/plugin/design.md`](../docs/plugin/design.md) 기준 minimal template 생성 여부를 선택한다. `docs/design-variants/` 는 사용자가 명시 선택한 경우에만 설치한다. draft 는 `docs/design-variants/drafts/` 에 두고 gitignore 한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 custom design seed 를 재실행하거나 아래 파일들을 `docs/design-variants/` 로 복사해 재배포한다.
 - Codex validation routing: 현재 enabled 면 묻지 않는다. disabled/미설정이면 enable/disable 중 하나를 명시 선택한다.
-- Codex implementation routing: `codex-first` / `claude` 중 하나를 명시 선택한다. Claude-only 사용자는 `claude` 를 고른다.
+- Implementation routing: `headless-chain` / `codex-first` / `claude-headless` / `claude` 중 하나를 명시 선택한다. Claude-only 사용자는 `claude` 를 고른다.
 - GitHub Project lifecycle: custom 에서만 진행한다. 세부 계약은 [`docs/plugin/github-project.md`](../docs/plugin/github-project.md) 와 [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) 가 SSOT 다.
 - workflow 변경 PR: `.github/workflows/*.yml` 변경이 있고 현재 branch 가 `main` 이고 `gh auth status` 가 통과할 때만 선택한다. 선택 시 workflow 파일만 stage 한다.
 
@@ -473,7 +474,7 @@ record_dcness_workflow_change ".github/workflows/github-project-lifecycle.yml"
 
 - plugin uninstall/reinstall 로 whitelist 가 사라진 경우
 - 선택형 CI workflow 를 새로 깔거나 갱신하는 경우
-- Codex validation 분기를 새로 opt-in 하거나 implementation routing 을 Claude-only/Codex-first 로 바꾸는 경우
+- Codex validation 분기를 새로 opt-in 하거나 implementation routing 을 headless-chain / Claude-only / legacy Codex-first 등으로 바꾸는 경우
 - Project lifecycle bootstrap 또는 project-local seed 가 필요한 경우
 
 ```bash

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -171,9 +171,9 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **Bash write target 정책**: `Bash` payload 는 [`harness.agent_boundary.extract_bash_paths`](../../harness/agent_boundary.py) 가 추출하는 명시적 write target 에 한해 검사한다. 예: redirect(`>`, `>>`), `tee`, in-place edit(`sed/perl/awk -i`), `cp`/`mv`/`rm` target. 추출된 target 이 TS/JS 구현 파일이면 직접 `Edit`/`Write`/`NotebookEdit` 와 동일한 skip 규칙 및 6-tier matching-test 존재 검사를 탄다. write target 이 없거나 TS/JS 구현 파일이 아니면 silent skip 한다.
 
-**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
+**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 와 [`scripts/dcness-claude-worker`](../../scripts/dcness-claude-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
 
-**차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다. Headless worker 차단 메시지는 `[dcness-codex-worker] BLOCKED: TDD GUARD ...` 로 시작하고 위반 파일 목록을 포함한다.
+**차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다. Headless worker 차단 메시지는 `[dcness-codex-worker] BLOCKED: TDD GUARD ...` 또는 `[dcness-claude-worker] BLOCKED: TDD GUARD ...` 로 시작하고 위반 파일 목록을 포함한다.
 
 ### post-agent-clear.sh
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -39,7 +39,7 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 | design seed | `docs/design.md` | `docs/plugin/design.md` minimal 예시 | custom 선택 | 부재 시만 생성 | X |
 | design preview seed | `docs/design-variants/**` | `templates/design-variants/**` | custom 선택 | 부재 시만 생성 | X |
 | Codex validation routing 변경 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-codex-validation` / `disable-codex-validation` | disabled/미설정일 때 추천 bundle 또는 custom | opt-in 값으로 갱신 | X |
-| Codex implementation routing 변경 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-codex-implementation` / `disable-codex-implementation` | 추천 bundle 또는 custom | 기본 `codex-first`, custom 에서 Claude-only 가능 | X |
+| Implementation routing 변경 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-headless-implementation` / `enable-claude-headless-implementation` / `enable-codex-implementation` / `disable-codex-implementation` | 추천 bundle 또는 custom | 기본 `headless-chain`, custom 에서 legacy Codex-first / Claude-headless / Claude-only 가능 | X |
 | Project coordinates | repo variables `DCNESS_PROJECT_NUMBER`, `DCNESS_PROJECT_OWNER` | `gh variable set` | Project bootstrap 선택 | 값 갱신 | X |
 
 > 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다.
@@ -72,7 +72,7 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 - `docs/design-variants/` 는 기본 skip. 단일 `app/page.tsx` 정도의 UI 흔적만으로 design kit 를 설치하지 않는다.
 - GitHub Project lifecycle 은 기본 skip. `gh` 인증, Project number, PAT/secrets, field/label 복구가 얽히므로 custom 에서만 진행한다.
 - Codex validation routing 이 이미 enabled 면 skip. disabled/미설정이면 추천 bundle 또는 custom 에서 명시적으로 다룬다.
-- Codex implementation routing 은 기본 `codex-first` 다. 추천 bundle 은 이 값을 유지하고, custom 에서 Claude-only 사용자가 `claude` 로 바꿀 수 있다.
+- Implementation routing 은 기본 `headless-chain` 이다. 추천 bundle 은 이 값을 유지하고, custom 에서 legacy Codex-first / Claude-headless / Claude-only 로 바꿀 수 있다.
 - workflow 변경 PR 은 GitHub remote 가 있고, `gh auth status` 가 통과하고, 이번 `/init-dcness` run 이 쓴 `.github/workflows/*.yml` 변경이 있고, 현재 branch 가 `main` 이면 추천 ON. Y 선택 시 별도 질문 없이 해당 파일만 stage 해서 branch/commit/push/PR 을 진행한다. `gh` 미설치/미인증이면 자동 PR 은 skip 하고 custom/manual 안내만 남긴다. 기존 dirty workflow 파일은 자동 포함하지 않는다.
 
 ## Already Automatic
@@ -162,7 +162,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | `.git/hooks/*` thin shim 갱신 | 예 | 사용자 repo `.git/hooks/` 파일은 plugin update 만으로 바뀌지 않는다. |
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 이 있는 프로젝트는 doc-sync 채택 직후 index/architecture 집계기를 1회 실행해야 한다. |
 | Codex validation routing opt-in 변경 | 예 | local plugin data 와 `$CODEX_HOME/skills` 를 갱신해야 한다. |
-| Codex implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |
+| Implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |
 | Project lifecycle 좌표 저장/변경 | 예 | repo variables 와 선택형 workflow 를 갱신해야 한다. |
 | docs/design + docs/design-variants seed 추가 | 예 | 부재 파일 seed 는 사용자 repo 에 직접 생성된다. draft 는 `docs/design-variants/drafts/` 에 두고 `.gitignore` 로 무시하되 `drafts/.gitkeep` 으로 디렉터리를 보존한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 `/init-dcness` custom design seed 를 재실행하거나 `templates/design-variants/{.gitignore,canvas.html,_lib/*,drafts/.gitkeep}` 를 `docs/design-variants/` 로 복사한다. |
 | TDD Guard 정책 갱신 | 아니오 | 사용자 repo 파일이 아니라 plug-in hook 본체가 갱신된다. |

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -101,21 +101,28 @@ else
 fi
 ```
 
-Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
+Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
 
-**implementation provider 분기 (Codex-first 기본)**: `test-engineer` / `engineer` / `build-worker` 는 호출 직전 provider 를 resolve 한다.
+**implementation provider 분기 (headless-chain 기본)**: `test-engineer` / `engineer` / `build-worker` 는 호출 직전 provider 를 resolve 한다.
 
 ```bash
 PROVIDER=$("$HELPER" routing resolve <agent>)
-if [ "$PROVIDER" = "codex-first" ]; then
-  "$PLUGIN_ROOT/scripts/dcness-codex-worker" <agent> [MODE] --prompt-file "$PROMPT_FILE"
-else
+if [ "$PROVIDER" = "claude" ]; then
   Agent(subagent_type="<agent>", ...)
-  "$HELPER" end-step <agent> [MODE]
+  "$HELPER" end-step <agent> [MODE] --provider claude-main
+else
+  rc=0
+  "$PLUGIN_ROOT/scripts/dcness-implementation-chain" <agent> [MODE] --provider "$PROVIDER" --prompt-file "$PROMPT_FILE" || rc=$?
+  if [ "$rc" -eq 75 ]; then
+    Agent(subagent_type="<agent>", ...)
+    "$HELPER" end-step <agent> [MODE] --provider claude-main
+  elif [ "$rc" -ne 0 ]; then
+    exit "$rc"
+  fi
 fi
 ```
 
-`dcness-codex-worker` 는 agent 지침을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s workspace-write` 로 실행한다. 성공하면 마지막 응답을 저장하고 `end-step` 까지 수행한다. Codex CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패한 경우에만 메인이 기존 Claude Agent 경로로 폴백할 수 있다. Codex 가 파일을 변경한 뒤 실패하거나 boundary 밖 파일을 변경하면 자동 폴백하지 않는다. implementation 기본값은 `codex-first` 이며 `dcness-helper routing disable-codex-implementation` 으로 Claude-only 모드로 바꾼다.
+`dcness-implementation-chain` 은 `headless-chain`(Codex headless → Claude headless → Claude main), `codex-first`(legacy), `claude-headless`, `claude` 를 같은 routing config 로 실행한다. Headless wrapper 가 성공하면 마지막 응답을 저장하고 `end-step` 까지 수행한다. CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패한 경우에만 다음 provider 로 넘어간다. Headless provider 가 파일을 변경한 뒤 실패하거나 boundary 밖 파일을 변경하면 자동 폴백하지 않는다. chain 이 Claude main 에 도달하면 `FALLBACK_TO_CLAUDE_MAIN` 과 exit 75 를 반환하므로 메인이 기존 Agent 경로를 실행한 뒤 `--provider claude-main` 으로 `end-step` 을 기록한다. raw headless session log 는 run 디렉터리의 `headless-logs/` 파일로 보존한다.
 
 #### 호출 prompt 슬림 포인터 규약
 

--- a/evals/cases/headless-prose-quality/expected.md
+++ b/evals/cases/headless-prose-quality/expected.md
@@ -1,0 +1,5 @@
+- [HPQ-1][MUST] `worker-bad.md` is reported as insufficient because it lacks concrete reasons/evidence and branch-decision material such as changed files, tests, provider/fallback state, or remaining risk.
+- [HPQ-2][MUST] `validator-bad.md` is reported as insufficient because it lacks a clear conclusion enum and concrete file/line or evidence-backed reasons.
+- [HPQ-3][MUST] `worker-good.md` is not rejected merely for being prose or for not following JSON/table/marker formatting.
+- [HPQ-4][MUST] The report mentions that raw headless session logs should be preserved as files, not dumped wholesale into the main context.
+- [HPQ-5][MUST_NOT] The report must not require status JSON, `---MARKER:X---`, or another rigid output schema as the fix.

--- a/evals/cases/headless-prose-quality/prompt.md
+++ b/evals/cases/headless-prose-quality/prompt.md
@@ -1,0 +1,20 @@
+You are validating dcNess headless worker/validator prose quality.
+
+Use `{{REPO_ROOT}}` only if you need repository guidance; the case fixtures are
+in `{{CASE_DIR}}`.
+
+Read the files in `{{CASE_DIR}}`:
+
+- `worker-good.md`
+- `worker-bad.md`
+- `validator-bad.md`
+
+Assess whether each prose report gives the main orchestrator enough information
+to make the next branch decision. Do not require JSON, a fixed table, markers,
+or any rigid schema. Free prose is allowed.
+
+Report concrete issues with file names and specific missing facts. Also mention
+whether raw headless session logs should be preserved as files instead of being
+dumped into the main context.
+
+End your report with one conclusion enum word: PASS, FAIL, or ESCALATE.

--- a/evals/cases/headless-prose-quality/validator-bad.md
+++ b/evals/cases/headless-prose-quality/validator-bad.md
@@ -1,0 +1,1 @@
+Looks fine overall. I did not see any problem.

--- a/evals/cases/headless-prose-quality/worker-bad.md
+++ b/evals/cases/headless-prose-quality/worker-bad.md
@@ -1,0 +1,5 @@
+Done.
+
+It should work now.
+
+PASS

--- a/evals/cases/headless-prose-quality/worker-good.md
+++ b/evals/cases/headless-prose-quality/worker-good.md
@@ -1,0 +1,17 @@
+# build-worker result
+
+Provider: codex-headless. No fallback was used.
+
+Changed files:
+- `harness/agent_routing.py`: added `headless-chain` routing.
+- `tests/test_agent_routing.py`: covered default resolution and legacy `codex-first`.
+
+Validation:
+- `python3 -m unittest tests.test_agent_routing -v` passed.
+
+Branch decision material:
+- Workspace mutation happened only after tests were written.
+- No unresolved design gap found.
+- Raw session log was saved under `headless-logs/codex-headless-build-worker.log`.
+
+PASS

--- a/harness/agent_routing.py
+++ b/harness/agent_routing.py
@@ -5,8 +5,8 @@ projects opt in via /init-dcness, which writes:
 
     ~/.claude/plugins/data/dcness-dcness/routing.json
 
-Validation agents can be sent to Codex read-only. Implementation agents can be
-run Codex-first with Claude fallback.
+Validation agents can be sent to Codex read-only. Implementation agents default
+to a headless chain: Codex headless, Claude headless, then Claude main fallback.
 """
 from __future__ import annotations
 
@@ -23,22 +23,26 @@ __all__ = [
     "VALID_IMPLEMENTATION_PROVIDERS",
     "VALID_PROVIDERS",
     "VALID_VALIDATION_PROVIDERS",
+    "IMPLEMENTATION_PROVIDER_CHAINS",
     "routing_path",
     "load_routing",
     "save_routing",
     "resolve_provider",
+    "implementation_provider_chain",
     "set_provider",
     "set_implementation_provider",
     "enable_codex_validation",
     "disable_codex_validation",
+    "enable_headless_implementation",
+    "enable_claude_headless_implementation",
     "enable_codex_implementation",
     "disable_codex_implementation",
     "doctor",
     "format_status",
 ]
 
-CONFIG_VERSION = 2
-SUPPORTED_CONFIG_VERSIONS = (1, 2)
+CONFIG_VERSION = 3
+SUPPORTED_CONFIG_VERSIONS = (1, 2, 3)
 ROUTABLE_VALIDATION_AGENTS = (
     "code-validator",
     "architecture-validator",
@@ -50,11 +54,22 @@ ROUTABLE_IMPLEMENTATION_AGENTS = (
     "build-worker",
 )
 VALID_VALIDATION_PROVIDERS = ("claude", "codex")
-VALID_IMPLEMENTATION_PROVIDERS = ("claude", "codex-first")
+VALID_IMPLEMENTATION_PROVIDERS = (
+    "claude",
+    "codex-first",
+    "claude-headless",
+    "headless-chain",
+)
+IMPLEMENTATION_PROVIDER_CHAINS = {
+    "headless-chain": ("codex-headless", "claude-headless", "claude-main"),
+    "codex-first": ("codex-headless", "claude-main"),
+    "claude-headless": ("claude-headless", "claude-main"),
+    "claude": ("claude-main",),
+}
 # Backward-compatible export for callers that only know validation routing.
 VALID_PROVIDERS = VALID_VALIDATION_PROVIDERS
 DEFAULT_VALIDATION_PROVIDER = "claude"
-DEFAULT_IMPLEMENTATION_PROVIDER = "codex-first"
+DEFAULT_IMPLEMENTATION_PROVIDER = "headless-chain"
 SAFE_FALLBACK_PROVIDER = "claude"
 
 _DEFAULT_ROUTING_PATH = (
@@ -103,7 +118,8 @@ def _atomic_write_json(target: Path, payload: Dict[str, Any]) -> None:
 def load_routing(*, path: Optional[Path] = None) -> Dict[str, Any]:
     """Load routing config.
 
-    Missing config is not an error; it means all agents resolve to Claude.
+    Missing config is not an error; validation agents resolve to Claude and
+    implementation agents resolve to the default headless chain.
     Invalid JSON raises ValueError so `routing doctor` can fail loudly.
     """
     target = Path(path) if path is not None else routing_path()
@@ -168,7 +184,8 @@ def resolve_provider(agent: str, *, path: Optional[Path] = None) -> str:
     """Resolve provider for an agent.
 
     Validation agents default to Claude for backward compatibility.
-    Implementation agents default to Codex-first, with explicit Claude opt-out.
+    Implementation agents default to the 3-stage headless chain. Explicit legacy
+    values keep their previous meaning.
     Unknown agents always resolve to Claude.
     """
     if agent not in ROUTABLE_VALIDATION_AGENTS + ROUTABLE_IMPLEMENTATION_AGENTS:
@@ -191,6 +208,13 @@ def resolve_provider(agent: str, *, path: Optional[Path] = None) -> str:
     )
 
 
+def implementation_provider_chain(provider: str) -> tuple[str, ...]:
+    """Return execution stages for an implementation provider value."""
+    if provider not in IMPLEMENTATION_PROVIDER_CHAINS:
+        return IMPLEMENTATION_PROVIDER_CHAINS[SAFE_FALLBACK_PROVIDER]
+    return IMPLEMENTATION_PROVIDER_CHAINS[provider]
+
+
 def set_provider(agent: str, provider: str, *, path: Optional[Path] = None) -> Path:
     if agent not in ROUTABLE_VALIDATION_AGENTS:
         allowed = ", ".join(ROUTABLE_VALIDATION_AGENTS)
@@ -211,9 +235,10 @@ def set_implementation_provider(
         allowed = ", ".join(ROUTABLE_IMPLEMENTATION_AGENTS)
         raise ValueError(f"unsupported implementation agent: {agent} (allowed: {allowed})")
     if provider not in VALID_IMPLEMENTATION_PROVIDERS:
+        allowed_providers = "|".join(VALID_IMPLEMENTATION_PROVIDERS)
         raise ValueError(
             f"unsupported implementation provider: {provider} "
-            "(allowed: claude|codex-first)"
+            f"(allowed: {allowed_providers})"
         )
     cfg = load_routing(path=path)
     routes = dict(cfg.get("implementation_routes", {}))
@@ -237,11 +262,33 @@ def disable_codex_validation(*, path: Optional[Path] = None) -> Path:
 
 
 def enable_codex_implementation(*, path: Optional[Path] = None) -> Path:
+    """Legacy Codex-first implementation route.
+
+    This intentionally keeps the old two-stage meaning: Codex headless, then
+    Claude main. New installs should normally use enable_headless_implementation.
+    """
+    cfg = load_routing(path=path)
+    routes = {
+        agent: "codex-first"
+        for agent in ROUTABLE_IMPLEMENTATION_AGENTS
+    }
+    cfg["implementation_routes"] = routes
+    return save_routing(cfg, path=path)
+
+
+def enable_headless_implementation(*, path: Optional[Path] = None) -> Path:
     cfg = load_routing(path=path)
     routes = {
         agent: DEFAULT_IMPLEMENTATION_PROVIDER
         for agent in ROUTABLE_IMPLEMENTATION_AGENTS
     }
+    cfg["implementation_routes"] = routes
+    return save_routing(cfg, path=path)
+
+
+def enable_claude_headless_implementation(*, path: Optional[Path] = None) -> Path:
+    cfg = load_routing(path=path)
+    routes = {agent: "claude-headless" for agent in ROUTABLE_IMPLEMENTATION_AGENTS}
     cfg["implementation_routes"] = routes
     return save_routing(cfg, path=path)
 
@@ -312,7 +359,7 @@ def format_status(*, path: Optional[Path] = None) -> str:
     if not target.exists():
         lines.append(
             "[dcness routing] file: missing "
-            "(default validation Claude, implementation Codex-first)"
+            "(default validation Claude, implementation headless-chain)"
         )
     lines.append("[dcness routing] validation:")
     for agent in ROUTABLE_VALIDATION_AGENTS:

--- a/harness/ledger.py
+++ b/harness/ledger.py
@@ -502,6 +502,8 @@ def build_receipt(
     enum: str,
     prose: str,
     prose_path: Any,
+    *,
+    provider: Optional[str] = None,
 ) -> Dict[str, Any]:
     """저장된 prose + known state 에서 receipt dict 생성 (helper-generated).
 
@@ -514,7 +516,7 @@ def build_receipt(
     hint_enum = enum
     if agent == "product-acceptance" and enum == "PROSE_LOGGED":
         hint_enum = "FAIL" if _product_acceptance_fail_from_prose(prose) else enum
-    return {
+    receipt = {
         "agent": agent,
         "mode": mode,
         "enum": enum,
@@ -525,6 +527,9 @@ def build_receipt(
         "evidence_paths": extract_evidence_paths(prose),
         "next_action": infer_next_action(agent, mode, must_fix=must_fix, enum=hint_enum),
     }
+    if provider:
+        receipt["provider"] = provider
+    return receipt
 
 
 def append_step_completed(
@@ -537,6 +542,7 @@ def append_step_completed(
     prose_path: Any,
     *,
     base_dir: Optional[Path] = None,
+    provider: Optional[str] = None,
 ) -> Dict[str, Any]:
     """end-step 시점: prose 에서 receipt 생성 → step_completed event append.
 
@@ -544,7 +550,7 @@ def append_step_completed(
     evidence_paths) 를 동반해 _append_event_raw 로 기록한다. public append_event 는
     step_completed 를 거부하므로 위조 경로가 없다 (codex review).
     """
-    receipt = build_receipt(agent, mode, enum, prose, prose_path)
+    receipt = build_receipt(agent, mode, enum, prose, prose_path, provider=provider)
     return _append_event_raw(
         sid, rid, "step_completed", base_dir=base_dir, **receipt
     )

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -2991,7 +2991,14 @@ def _cli_end_step(args: Any) -> int:
         print(summary, file=sys.stderr)
     # step status append — finalize-run / 회고용
     _append_step_status(
-        sid, rid, agent, mode, "PROSE_LOGGED", prose, prose_path,
+        sid,
+        rid,
+        agent,
+        mode,
+        "PROSE_LOGGED",
+        prose,
+        prose_path,
+        provider=getattr(args, "provider", None),
     )
     clear_current_step(sid, rid, agent=agent, mode=mode)
     return 0
@@ -3085,6 +3092,8 @@ def _append_step_status(
     enum: str,
     prose: str,
     prose_path: "Path",
+    *,
+    provider: Optional[str] = None,
 ) -> None:
     """end-step 호출마다 ledger.jsonl 에 step_completed event append (이슈 #587).
 
@@ -3094,7 +3103,9 @@ def _append_step_status(
     """
     from harness import ledger
 
-    ledger.append_step_completed(sid, rid, agent, mode, enum, prose, prose_path)
+    ledger.append_step_completed(
+        sid, rid, agent, mode, enum, prose, prose_path, provider=provider
+    )
 
 
 def _record_design_run_if_applicable(sid: str, rid: str) -> None:
@@ -3663,7 +3674,7 @@ def collect_status_diagnostics(
             f"설치됨: {', '.join(installed)}" if installed else "없음 (선택 사항)",
         )
 
-    # Codex routing (self / 외부 공통 — INFO)
+    # Provider routing (self / 외부 공통 — INFO)
     if check_routing:
         try:
             from harness import agent_routing
@@ -3671,7 +3682,7 @@ def collect_status_diagnostics(
             routing_detail = agent_routing.format_status().strip().replace("\n", " | ")
         except Exception:
             routing_detail = "조회 실패"
-        add("routing", "Codex routing", "INFO", routing_detail)
+        add("routing", "Provider routing", "INFO", routing_detail)
 
     # gh CLI 인증 (self / 외부 공통 — WARN)
     if check_gh:
@@ -3782,6 +3793,16 @@ def _cli_routing(args: Any) -> int:
     if action == "enable-codex-implementation":
         path = agent_routing.enable_codex_implementation()
         print(f"[dcness routing] enabled Codex implementation: {path}")
+        print(agent_routing.format_status())
+        return 0
+    if action == "enable-headless-implementation":
+        path = agent_routing.enable_headless_implementation()
+        print(f"[dcness routing] enabled headless implementation chain: {path}")
+        print(agent_routing.format_status())
+        return 0
+    if action == "enable-claude-headless-implementation":
+        path = agent_routing.enable_claude_headless_implementation()
+        print(f"[dcness routing] enabled Claude headless implementation: {path}")
         print(agent_routing.format_status())
         return 0
     if action == "disable-codex-implementation":
@@ -3925,6 +3946,10 @@ def _build_arg_parser() -> Any:
     p_es.add_argument(
         "--prose-file", required=False, default=None,
         help="prose 본문 파일 경로 (미제공 시 hook auto-stage 경로 사용)",
+    )
+    p_es.add_argument(
+        "--provider", required=False, default=None,
+        help="실제 실행 provider 기록 (예: codex-headless / claude-headless / claude-main)",
     )
     p_es.set_defaults(func=_cli_end_step)
 
@@ -4158,9 +4183,21 @@ def _build_arg_parser() -> Any:
 
     rt_enable_impl = rt_sub.add_parser(
         "enable-codex-implementation",
-        help="test-engineer / engineer / build-worker 를 Codex-first 로 보냄",
+        help="legacy: test-engineer / engineer / build-worker 를 Codex-first 로 보냄",
     )
     rt_enable_impl.set_defaults(func=_cli_routing)
+
+    rt_enable_headless = rt_sub.add_parser(
+        "enable-headless-implementation",
+        help="implementation agent 를 Codex headless → Claude headless → Claude main 체인으로 보냄",
+    )
+    rt_enable_headless.set_defaults(func=_cli_routing)
+
+    rt_enable_claude_headless = rt_sub.add_parser(
+        "enable-claude-headless-implementation",
+        help="implementation agent 를 Claude headless → Claude main 체인으로 보냄",
+    )
+    rt_enable_claude_headless.set_defaults(func=_cli_routing)
 
     rt_disable_impl = rt_sub.add_parser(
         "disable-codex-implementation",
@@ -4173,7 +4210,10 @@ def _build_arg_parser() -> Any:
         help="특정 implementation agent provider 설정",
     )
     rt_set_impl.add_argument("agent")
-    rt_set_impl.add_argument("provider", choices=("claude", "codex-first"))
+    rt_set_impl.add_argument(
+        "provider",
+        choices=("claude", "codex-first", "claude-headless", "headless-chain"),
+    )
     rt_set_impl.set_defaults(func=_cli_routing)
 
     rt_resolve = rt_sub.add_parser("resolve", help="agent provider resolve")

--- a/scripts/dcness-claude-validator
+++ b/scripts/dcness-claude-validator
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Run a dcNess read-only validation agent through Claude headless and store
+# prose via dcness-helper end-step. Hooks/plugins stay enabled; read-only is
+# enforced by tool restrictions plus post-run git status checks.
+
+set -uo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  dcness-claude-validator <agent> [MODE] --prompt-file <file> [--project-root <dir>]
+
+Agents:
+  code-validator
+  architecture-validator
+  pr-reviewer
+
+Options:
+  --prompt-file, -p   File containing the caller prompt.
+  --project-root, -C  Repository root. Default: git rev-parse --show-toplevel.
+  --helper            dcness-helper path. Default: sibling script.
+  --help, -h          Show this help.
+
+Environment:
+  DCNESS_CLAUDE_TIMEOUT  Seconds per Claude attempt. Default: 600.
+
+The wrapper runs Claude Code in print mode with hooks/plugins enabled:
+  claude -p --permission-mode dontAsk --allowedTools Read,Grep,Glob --output-format text
+
+It stores raw headless logs under the active run directory and only sends the
+final prose through end-step. If git status changes, the wrapper exits non-zero.
+USAGE
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ $# -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+AGENT="$1"
+shift
+
+case "$AGENT" in
+  code-validator|architecture-validator|pr-reviewer) ;;
+  *)
+    echo "[dcness-claude-validator] unsupported agent: $AGENT" >&2
+    exit 2
+    ;;
+esac
+
+MODE=""
+if [ $# -gt 0 ] && [[ "${1:-}" != -* ]]; then
+  MODE="$1"
+  shift
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT=""
+PROMPT_FILE=""
+HELPER="$SCRIPT_DIR/dcness-helper"
+CLAUDE_TIMEOUT="${DCNESS_CLAUDE_TIMEOUT:-600}"
+
+abs_path() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$(pwd)" "$1" ;;
+  esac
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt-file|-p)
+      PROMPT_FILE="${2:-}"
+      shift 2
+      ;;
+    --project-root|-C)
+      PROJECT_ROOT="${2:-}"
+      shift 2
+      ;;
+    --helper)
+      HELPER="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[dcness-claude-validator] unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$PROMPT_FILE" ] || [ ! -f "$PROMPT_FILE" ]; then
+  echo "[dcness-claude-validator] --prompt-file is required and must exist" >&2
+  exit 2
+fi
+PROMPT_FILE="$(abs_path "$PROMPT_FILE")"
+
+if [ -z "$PROJECT_ROOT" ]; then
+  PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+if [ ! -d "$PROJECT_ROOT" ]; then
+  echo "[dcness-claude-validator] project root not found: $PROJECT_ROOT" >&2
+  exit 2
+fi
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
+HELPER="$(abs_path "$HELPER")"
+
+if [ ! -x "$HELPER" ]; then
+  echo "[dcness-claude-validator] helper not executable: $HELPER" >&2
+  exit 2
+fi
+
+case "$CLAUDE_TIMEOUT" in
+  ''|*[!0-9]*)
+    echo "[dcness-claude-validator] DCNESS_CLAUDE_TIMEOUT must be a positive integer: $CLAUDE_TIMEOUT" >&2
+    exit 2
+    ;;
+esac
+if [ "$CLAUDE_TIMEOUT" -lt 1 ]; then
+  echo "[dcness-claude-validator] DCNESS_CLAUDE_TIMEOUT must be >= 1" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[dcness-claude-validator] python3 not found; required for timeout and context resolution" >&2
+  exit 127
+fi
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[dcness-claude-validator] claude CLI not found" >&2
+  exit 127
+fi
+
+cd "$PROJECT_ROOT"
+
+CONTEXT="$(
+  PYTHONPATH="$SCRIPT_DIR/.." python3 -c '
+import sys
+from harness.session_state import (
+    auto_detect_run_id,
+    auto_detect_session_id,
+    diagnose_sid_rid_resolution,
+)
+
+sid = auto_detect_session_id()
+rid = auto_detect_run_id()
+if not sid or not rid:
+    print(diagnose_sid_rid_resolution(mode="both"), file=sys.stderr)
+    sys.exit(1)
+print(f"{sid}\t{rid}")
+'
+)"
+if [ $? -ne 0 ]; then
+  echo "[dcness-claude-validator] sid/rid resolve failed before Claude launch" >&2
+  exit 1
+fi
+IFS="$(printf '\t')" read -r RESOLVED_SID RESOLVED_RID <<EOF
+$CONTEXT
+EOF
+export DCNESS_SESSION_ID="$RESOLVED_SID"
+export DCNESS_RUN_ID="$RESOLVED_RID"
+
+RAW_LOG_DIR="$(
+  PYTHONPATH="$SCRIPT_DIR/.." python3 - "$RESOLVED_SID" "$RESOLVED_RID" <<'PY'
+import sys
+from harness.session_state import run_dir
+
+print(run_dir(sys.argv[1], sys.argv[2]) / "headless-logs")
+PY
+)"
+mkdir -p "$RAW_LOG_DIR"
+
+git_status_without_harness_state() {
+  git -C "$PROJECT_ROOT" status --porcelain=v1 -uall 2>/dev/null \
+    | sed '/^.. \.claude\/harness-state\//d' || true
+}
+
+BEFORE_STATUS="$(git_status_without_harness_state)"
+BASELINE_CLEAN=0
+if git -C "$PROJECT_ROOT" diff --quiet --no-ext-diff 2>/dev/null \
+  && git -C "$PROJECT_ROOT" diff --cached --quiet --no-ext-diff 2>/dev/null; then
+  BASELINE_CLEAN=1
+fi
+
+TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-validator-${AGENT}.XXXXXX")"
+TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-validator-prompt-${AGENT}.XXXXXX")"
+RAW_LOG="$RAW_LOG_DIR/claude-headless-${AGENT}${MODE:+-$MODE}-$$.log"
+trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
+
+AGENT_DOC="$SCRIPT_DIR/../agents/$AGENT.md"
+AGENT_DETAIL="$SCRIPT_DIR/../agents/$AGENT/$AGENT-agent.md"
+
+{
+  echo "dcNess validation agent: $AGENT"
+  if [ -n "$MODE" ]; then
+    echo "dcNess validation mode: $MODE"
+  else
+    echo "dcNess validation mode: default"
+  fi
+  echo "project/worktree root: $PROJECT_ROOT"
+  echo "session id: $DCNESS_SESSION_ID"
+  echo "run id: $DCNESS_RUN_ID"
+  echo
+  echo "You are executing this dcNess validation step through Claude headless."
+  echo "Run with hooks and plugins enabled; do not use safe-mode, bare mode, or hook-skipping modes."
+  echo "Read-only request. Do not edit files, create files inside the repo, commit, push, or open PRs."
+  echo "Return prose only. The final paragraph must contain exactly one conclusion word: PASS, FAIL, or ESCALATE."
+  echo
+  if [ -f "$AGENT_DOC" ]; then
+    echo "----- BEGIN agents/$AGENT.md -----"
+    cat "$AGENT_DOC"
+    echo "----- END agents/$AGENT.md -----"
+    echo
+  fi
+  if [ -f "$AGENT_DETAIL" ]; then
+    echo "----- BEGIN agents/$AGENT/$AGENT-agent.md -----"
+    cat "$AGENT_DETAIL"
+    echo "----- END agents/$AGENT/$AGENT-agent.md -----"
+    echo
+  fi
+  echo "----- BEGIN CALLER PROMPT -----"
+  cat "$PROMPT_FILE"
+  echo "----- END CALLER PROMPT -----"
+} > "$TMP_PROMPT"
+
+CLAUDE_CMD=(
+  claude -p
+  --permission-mode dontAsk
+  --allowedTools Read,Grep,Glob
+  --output-format text
+)
+
+run_claude_once() {
+  python3 -c '
+import os
+import signal
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+prompt = sys.argv[2]
+output = sys.argv[3]
+log = sys.argv[4]
+cmd = sys.argv[5:]
+with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") as raw:
+    raw.write(("COMMAND: " + " ".join(cmd) + "\n").encode("utf-8", "replace"))
+    proc = subprocess.Popen(
+        cmd,
+        stdin=stdin,
+        stdout=stdout,
+        stderr=raw,
+        start_new_session=True,
+    )
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGTERM)
+        except ProcessLookupError:
+            pass
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait()
+        sys.exit(124)
+    sys.exit(proc.returncode)
+' "$CLAUDE_TIMEOUT" "$TMP_PROMPT" "$TMP_PROSE" "$RAW_LOG" "${CLAUDE_CMD[@]}"
+}
+
+CLAUDE_RC=0
+run_claude_once
+CLAUDE_RC=$?
+
+{
+  echo
+  echo "----- STDOUT / FINAL PROSE -----"
+  cat "$TMP_PROSE" 2>/dev/null || true
+} >> "$RAW_LOG"
+
+AFTER_STATUS="$(git_status_without_harness_state)"
+
+if [ "$CLAUDE_RC" -ne 0 ]; then
+  if [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]; then
+    echo "[dcness-claude-validator] BLOCKED: Claude failed after changing git status. Automatic revert is forbidden." >&2
+    echo "[dcness-claude-validator] raw log: $RAW_LOG" >&2
+    git -C "$PROJECT_ROOT" status --short >&2 || true
+    exit 1
+  fi
+  echo "[dcness-claude-validator] claude -p failed before workspace mutation (exit $CLAUDE_RC); raw log: $RAW_LOG" >&2
+  exit "$CLAUDE_RC"
+fi
+
+if [ ! -s "$TMP_PROSE" ]; then
+  if [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]; then
+    echo "[dcness-claude-validator] BLOCKED: Claude changed git status but produced empty prose." >&2
+    echo "[dcness-claude-validator] raw log: $RAW_LOG" >&2
+    git -C "$PROJECT_ROOT" status --short >&2 || true
+    exit 1
+  fi
+  echo "[dcness-claude-validator] Claude produced empty prose; raw log: $RAW_LOG" >&2
+  exit 1
+fi
+
+if [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]; then
+  echo "[dcness-claude-validator] BLOCKED: Claude run changed git status. Automatic revert is forbidden." >&2
+  echo "[dcness-claude-validator] raw log: $RAW_LOG" >&2
+  git -C "$PROJECT_ROOT" status --short >&2 || true
+  exit 1
+fi
+
+if [ "$BASELINE_CLEAN" = "1" ]; then
+  if ! git -C "$PROJECT_ROOT" diff --quiet --no-ext-diff \
+    || ! git -C "$PROJECT_ROOT" diff --cached --quiet --no-ext-diff; then
+    echo "[dcness-claude-validator] BLOCKED: git diff appeared after Claude run. Automatic revert is forbidden." >&2
+    echo "[dcness-claude-validator] raw log: $RAW_LOG" >&2
+    exit 1
+  fi
+fi
+
+if [ -n "$MODE" ]; then
+  "$HELPER" end-step "$AGENT" "$MODE" --provider claude-headless --prose-file "$TMP_PROSE"
+else
+  "$HELPER" end-step "$AGENT" --provider claude-headless --prose-file "$TMP_PROSE"
+fi

--- a/scripts/dcness-claude-worker
+++ b/scripts/dcness-claude-worker
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
-# Run a dcNess implementation worker through Codex and store prose via
-# dcness-helper end-step. The caller still owns begin-step and fallback policy.
+# Run a dcNess implementation worker through Claude headless and store prose via
+# dcness-helper end-step. Hooks/plugins must stay enabled; do not use --bare or
+# --safe-mode for worker execution.
 
 set -uo pipefail
 
 usage() {
   cat <<'USAGE'
 Usage:
-  dcness-codex-worker <agent> [MODE] --prompt-file <file> [--project-root <dir>]
+  dcness-claude-worker <agent> [MODE] --prompt-file <file> [--project-root <dir>]
 
 Agents:
   test-engineer
@@ -15,27 +16,25 @@ Agents:
   build-worker
 
 Options:
-  --prompt-file, -p   File containing the Codex prompt.
+  --prompt-file, -p   File containing the caller prompt.
   --project-root, -C  Repository root. Default: git rev-parse --show-toplevel.
   --helper            dcness-helper path. Default: sibling script.
   --help, -h          Show this help.
 
 Environment:
-  DCNESS_CODEX_TIMEOUT  Seconds per Codex attempt. Default: 1200.
+  DCNESS_CLAUDE_TIMEOUT  Seconds per Claude attempt. Default: 1200.
 
-The wrapper runs Codex in workspace-write mode:
-  codex exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE"
+The wrapper runs Claude Code in print mode with hooks/plugins enabled:
+  claude -p --permission-mode acceptEdits --output-format text
 
 On success it validates changed paths against dcNess agent_boundary, reuses
-tdd-guard matching-test enforcement for Codex-changed implementation files, and stores:
-  dcness-helper end-step <agent> [MODE] --provider codex-headless --prose-file "$TMP_PROSE"
+tdd-guard matching-test enforcement for Claude-changed implementation files,
+and stores:
+  dcness-helper end-step <agent> [MODE] --provider claude-headless --prose-file ...
 
-Raw Codex session logs are preserved under the active run directory. The main
-context only receives short status messages and the final prose receipt.
-
-On Codex infrastructure failure with no workspace mutation, callers may fall
-back to the existing Claude Agent path. If Codex changed files and then failed,
-this wrapper exits non-zero and does not auto-revert.
+If Claude changes the workspace and then fails, automatic fallback/revert is
+forbidden. If it fails before workspace mutation, callers may continue the
+provider chain.
 USAGE
 }
 
@@ -55,7 +54,7 @@ shift
 case "$AGENT" in
   test-engineer|engineer|build-worker) ;;
   *)
-    echo "[dcness-codex-worker] unsupported agent: $AGENT" >&2
+    echo "[dcness-claude-worker] unsupported agent: $AGENT" >&2
     exit 2
     ;;
 esac
@@ -70,7 +69,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT=""
 PROMPT_FILE=""
 HELPER="$SCRIPT_DIR/dcness-helper"
-CODEX_TIMEOUT="${DCNESS_CODEX_TIMEOUT:-1200}"
+CLAUDE_TIMEOUT="${DCNESS_CLAUDE_TIMEOUT:-1200}"
 
 abs_path() {
   case "$1" in
@@ -98,7 +97,7 @@ while [ $# -gt 0 ]; do
       exit 0
       ;;
     *)
-      echo "[dcness-codex-worker] unknown argument: $1" >&2
+      echo "[dcness-claude-worker] unknown argument: $1" >&2
       usage >&2
       exit 2
       ;;
@@ -106,7 +105,7 @@ while [ $# -gt 0 ]; do
 done
 
 if [ -z "$PROMPT_FILE" ] || [ ! -f "$PROMPT_FILE" ]; then
-  echo "[dcness-codex-worker] --prompt-file is required and must exist" >&2
+  echo "[dcness-claude-worker] --prompt-file is required and must exist" >&2
   exit 2
 fi
 PROMPT_FILE="$(abs_path "$PROMPT_FILE")"
@@ -115,35 +114,35 @@ if [ -z "$PROJECT_ROOT" ]; then
   PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 fi
 if [ ! -d "$PROJECT_ROOT" ]; then
-  echo "[dcness-codex-worker] project root not found: $PROJECT_ROOT" >&2
+  echo "[dcness-claude-worker] project root not found: $PROJECT_ROOT" >&2
   exit 2
 fi
 PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
 HELPER="$(abs_path "$HELPER")"
 
 if [ ! -x "$HELPER" ]; then
-  echo "[dcness-codex-worker] helper not executable: $HELPER" >&2
+  echo "[dcness-claude-worker] helper not executable: $HELPER" >&2
   exit 2
 fi
 
-case "$CODEX_TIMEOUT" in
+case "$CLAUDE_TIMEOUT" in
   ''|*[!0-9]*)
-    echo "[dcness-codex-worker] DCNESS_CODEX_TIMEOUT must be a positive integer: $CODEX_TIMEOUT" >&2
+    echo "[dcness-claude-worker] DCNESS_CLAUDE_TIMEOUT must be a positive integer: $CLAUDE_TIMEOUT" >&2
     exit 2
     ;;
 esac
-if [ "$CODEX_TIMEOUT" -lt 1 ]; then
-  echo "[dcness-codex-worker] DCNESS_CODEX_TIMEOUT must be >= 1" >&2
+if [ "$CLAUDE_TIMEOUT" -lt 1 ]; then
+  echo "[dcness-claude-worker] DCNESS_CLAUDE_TIMEOUT must be >= 1" >&2
   exit 2
 fi
 
 if ! command -v python3 >/dev/null 2>&1; then
-  echo "[dcness-codex-worker] python3 not found; required for timeout and context resolution" >&2
+  echo "[dcness-claude-worker] python3 not found; required for timeout and context resolution" >&2
   exit 127
 fi
 
-if ! command -v codex >/dev/null 2>&1; then
-  echo "[dcness-codex-worker] codex CLI not found" >&2
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[dcness-claude-worker] claude CLI not found" >&2
   exit 127
 fi
 
@@ -167,7 +166,7 @@ print(f"{sid}\t{rid}")
 '
 )"
 if [ $? -ne 0 ]; then
-  echo "[dcness-codex-worker] sid/rid resolve failed before Codex launch" >&2
+  echo "[dcness-claude-worker] sid/rid resolve failed before Claude launch" >&2
   exit 1
 fi
 IFS="$(printf '\t')" read -r RESOLVED_SID RESOLVED_RID <<EOF
@@ -193,9 +192,9 @@ git_status_without_harness_state() {
 
 BEFORE_STATUS="$(git_status_without_harness_state)"
 
-TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-worker-${AGENT}.XXXXXX")"
-TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-worker-prompt-${AGENT}.XXXXXX")"
-RAW_LOG="$RAW_LOG_DIR/codex-headless-${AGENT}${MODE:+-$MODE}-$$.log"
+TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-worker-${AGENT}.XXXXXX")"
+TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-worker-prompt-${AGENT}.XXXXXX")"
+RAW_LOG="$RAW_LOG_DIR/claude-headless-${AGENT}${MODE:+-$MODE}-$$.log"
 trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
 
 AGENT_DOC="$SCRIPT_DIR/../agents/$AGENT.md"
@@ -212,7 +211,8 @@ AGENT_DETAIL="$SCRIPT_DIR/../agents/$AGENT/$AGENT-agent.md"
   echo "session id: $DCNESS_SESSION_ID"
   echo "run id: $DCNESS_RUN_ID"
   echo
-  echo "You are executing this dcNess implementation worker step through Codex headless."
+  echo "You are executing this dcNess implementation worker step through Claude headless."
+  echo "Run with hooks and plugins enabled; do not use safe-mode, bare mode, or hook-skipping modes."
   echo "You may edit files in the project/worktree only within the embedded agent boundary."
   echo "Do not run git commit, git push, gh pr create, gh pr merge, gh issue mutation, or call other agents."
   echo "Return prose only. Use the conclusion enum required by the embedded agent instructions."
@@ -234,13 +234,9 @@ AGENT_DETAIL="$SCRIPT_DIR/../agents/$AGENT/$AGENT-agent.md"
   echo "----- END CALLER PROMPT -----"
 } > "$TMP_PROMPT"
 
-CODEX_CMD=(codex)
-if codex --help 2>/dev/null | grep -Eq -- '(^|[[:space:]])-a,|--ask-for-approval|--approval-policy'; then
-  CODEX_CMD+=( -a never )
-fi
-CODEX_ARGS=(exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE" -)
+CLAUDE_CMD=(claude -p --permission-mode acceptEdits --output-format text)
 
-run_codex_once() {
+run_claude_once() {
   python3 -c '
 import os
 import signal
@@ -249,15 +245,16 @@ import sys
 
 timeout = int(sys.argv[1])
 prompt = sys.argv[2]
-log = sys.argv[3]
-cmd = sys.argv[4:]
-with open(prompt, "rb") as stdin, open(log, "ab") as raw:
+output = sys.argv[3]
+log = sys.argv[4]
+cmd = sys.argv[5:]
+with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") as raw:
     raw.write(("COMMAND: " + " ".join(cmd) + "\n").encode("utf-8", "replace"))
     proc = subprocess.Popen(
         cmd,
         stdin=stdin,
-        stdout=raw,
-        stderr=subprocess.STDOUT,
+        stdout=stdout,
+        stderr=raw,
         start_new_session=True,
     )
     try:
@@ -277,7 +274,7 @@ with open(prompt, "rb") as stdin, open(log, "ab") as raw:
             proc.wait()
         sys.exit(124)
     sys.exit(proc.returncode)
-' "$CODEX_TIMEOUT" "$TMP_PROMPT" "$RAW_LOG" "${CODEX_CMD[@]}" "${CODEX_ARGS[@]}"
+' "$CLAUDE_TIMEOUT" "$TMP_PROMPT" "$TMP_PROSE" "$RAW_LOG" "${CLAUDE_CMD[@]}"
 }
 
 workspace_changed() {
@@ -285,29 +282,35 @@ workspace_changed() {
   [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]
 }
 
-CODEX_RC=0
-run_codex_once
-CODEX_RC=$?
+CLAUDE_RC=0
+run_claude_once
+CLAUDE_RC=$?
 
-if [ "$CODEX_RC" -ne 0 ]; then
+{
+  echo
+  echo "----- STDOUT / FINAL PROSE -----"
+  cat "$TMP_PROSE" 2>/dev/null || true
+} >> "$RAW_LOG"
+
+if [ "$CLAUDE_RC" -ne 0 ]; then
   if workspace_changed; then
-    echo "[dcness-codex-worker] BLOCKED: Codex failed after changing workspace. Automatic Claude fallback/revert is forbidden." >&2
-    echo "[dcness-codex-worker] raw log: $RAW_LOG" >&2
+    echo "[dcness-claude-worker] BLOCKED: Claude failed after changing workspace. Automatic fallback/revert is forbidden." >&2
+    echo "[dcness-claude-worker] raw log: $RAW_LOG" >&2
     git -C "$PROJECT_ROOT" status --short >&2 || true
     exit 1
   fi
-  echo "[dcness-codex-worker] codex exec failed before workspace mutation (exit $CODEX_RC); raw log: $RAW_LOG" >&2
-  exit "$CODEX_RC"
+  echo "[dcness-claude-worker] claude -p failed before workspace mutation (exit $CLAUDE_RC); raw log: $RAW_LOG" >&2
+  exit "$CLAUDE_RC"
 fi
 
 if [ ! -s "$TMP_PROSE" ]; then
   if workspace_changed; then
-    echo "[dcness-codex-worker] BLOCKED: Codex changed workspace but produced empty prose." >&2
-    echo "[dcness-codex-worker] raw log: $RAW_LOG" >&2
+    echo "[dcness-claude-worker] BLOCKED: Claude changed workspace but produced empty prose." >&2
+    echo "[dcness-claude-worker] raw log: $RAW_LOG" >&2
     git -C "$PROJECT_ROOT" status --short >&2 || true
     exit 1
   fi
-  echo "[dcness-codex-worker] Codex produced empty prose; raw log: $RAW_LOG" >&2
+  echo "[dcness-claude-worker] Claude produced empty prose; raw log: $RAW_LOG" >&2
   exit 1
 fi
 
@@ -344,8 +347,8 @@ for path in sorted(paths):
 PY
 )"
 if [ -n "$BOUNDARY_PROBLEMS" ]; then
-  echo "[dcness-codex-worker] BLOCKED: Codex changed files outside ${AGENT} boundary." >&2
-  echo "[dcness-codex-worker] raw log: $RAW_LOG" >&2
+  echo "[dcness-claude-worker] BLOCKED: Claude changed files outside ${AGENT} boundary." >&2
+  echo "[dcness-claude-worker] raw log: $RAW_LOG" >&2
   printf '%s\n' "$BOUNDARY_PROBLEMS" >&2
   exit 1
 fi
@@ -398,14 +401,14 @@ EOF
 )"
 TDD_RC=$?
 if [ "$TDD_RC" -eq 1 ]; then
-  echo "[dcness-codex-worker] BLOCKED: TDD GUARD failed for Codex-changed implementation files." >&2
-  echo "[dcness-codex-worker] raw log: $RAW_LOG" >&2
+  echo "[dcness-claude-worker] BLOCKED: TDD GUARD failed for Claude-changed implementation files." >&2
+  echo "[dcness-claude-worker] raw log: $RAW_LOG" >&2
   printf '%s\n' "$TDD_PROBLEMS" >&2
   exit 1
 fi
 
 if [ -n "$MODE" ]; then
-  "$HELPER" end-step "$AGENT" "$MODE" --provider codex-headless --prose-file "$TMP_PROSE"
+  "$HELPER" end-step "$AGENT" "$MODE" --provider claude-headless --prose-file "$TMP_PROSE"
 else
-  "$HELPER" end-step "$AGENT" --provider codex-headless --prose-file "$TMP_PROSE"
+  "$HELPER" end-step "$AGENT" --provider claude-headless --prose-file "$TMP_PROSE"
 fi

--- a/scripts/dcness-codex-validator
+++ b/scripts/dcness-codex-validator
@@ -31,7 +31,10 @@ Before running Codex, it embeds the installed dcness Codex skill from
 $CODEX_HOME/skills or the plugin bundle when available.
 
 Then it stores the final prose with:
-  dcness-helper end-step <agent> [MODE] --prose-file "$TMP_PROSE"
+  dcness-helper end-step <agent> [MODE] --provider codex-headless --prose-file "$TMP_PROSE"
+
+Raw Codex session logs are preserved under the active run directory. The main
+context only receives short status messages and the final prose receipt.
 USAGE
 }
 
@@ -172,7 +175,22 @@ EOF
 export DCNESS_SESSION_ID="$RESOLVED_SID"
 export DCNESS_RUN_ID="$RESOLVED_RID"
 
-BEFORE_STATUS="$(git -C "$PROJECT_ROOT" status --porcelain=v1 2>/dev/null || true)"
+RAW_LOG_DIR="$(
+  PYTHONPATH="$SCRIPT_DIR/.." python3 - "$RESOLVED_SID" "$RESOLVED_RID" <<'PY'
+import sys
+from harness.session_state import run_dir
+
+print(run_dir(sys.argv[1], sys.argv[2]) / "headless-logs")
+PY
+)"
+mkdir -p "$RAW_LOG_DIR"
+
+git_status_without_harness_state() {
+  git -C "$PROJECT_ROOT" status --porcelain=v1 -uall 2>/dev/null \
+    | sed '/^.. \.claude\/harness-state\//d' || true
+}
+
+BEFORE_STATUS="$(git_status_without_harness_state)"
 BASELINE_CLEAN=0
 if git -C "$PROJECT_ROOT" diff --quiet --no-ext-diff 2>/dev/null \
   && git -C "$PROJECT_ROOT" diff --cached --quiet --no-ext-diff 2>/dev/null; then
@@ -185,6 +203,7 @@ fi
 # 끝나야 한다 (GNU mktemp 는 embedded X 도 처리하므로 Linux CI 에선 안 드러남).
 TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-${AGENT}.XXXXXX")"
 TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-prompt-${AGENT}.XXXXXX")"
+RAW_LOG="$RAW_LOG_DIR/codex-headless-${AGENT}${MODE:+-$MODE}-$$.log"
 trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
 
 SKILL_NAME="dcness-${AGENT}"
@@ -240,26 +259,36 @@ import subprocess
 import sys
 
 timeout = int(sys.argv[1])
-cmd = sys.argv[2:]
-proc = subprocess.Popen(cmd, stdin=sys.stdin.buffer, start_new_session=True)
-try:
-    proc.wait(timeout=timeout)
-except subprocess.TimeoutExpired:
+prompt = sys.argv[2]
+log = sys.argv[3]
+cmd = sys.argv[4:]
+with open(prompt, "rb") as stdin, open(log, "ab") as raw:
+    raw.write(("COMMAND: " + " ".join(cmd) + "\n").encode("utf-8", "replace"))
+    proc = subprocess.Popen(
+        cmd,
+        stdin=stdin,
+        stdout=raw,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
     try:
-        os.killpg(proc.pid, signal.SIGTERM)
-    except ProcessLookupError:
-        pass
-    try:
-        proc.wait(timeout=1)
+        proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
         try:
-            os.killpg(proc.pid, signal.SIGKILL)
+            os.killpg(proc.pid, signal.SIGTERM)
         except ProcessLookupError:
             pass
-        proc.wait()
-    sys.exit(124)
-sys.exit(proc.returncode)
-' "$CODEX_TIMEOUT" "${CODEX_CMD[@]}" "${CODEX_ARGS[@]}" < "$TMP_PROMPT"
+        try:
+            proc.wait(timeout=1)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            proc.wait()
+        sys.exit(124)
+    sys.exit(proc.returncode)
+' "$CODEX_TIMEOUT" "$TMP_PROMPT" "$RAW_LOG" "${CODEX_CMD[@]}" "${CODEX_ARGS[@]}"
 }
 
 write_timeout_prose() {
@@ -286,7 +315,7 @@ while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
     break
   fi
   if [ "$CODEX_RC" -eq 124 ]; then
-    echo "[dcness-codex-validator] codex exec timed out after ${CODEX_TIMEOUT}s (attempt ${ATTEMPT}/${MAX_ATTEMPTS})" >&2
+    echo "[dcness-codex-validator] codex exec timed out after ${CODEX_TIMEOUT}s (attempt ${ATTEMPT}/${MAX_ATTEMPTS}); raw log: $RAW_LOG" >&2
     if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
       ATTEMPT=$((ATTEMPT + 1))
       continue
@@ -294,28 +323,29 @@ while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
     TIMED_OUT=1
     break
   fi
-  echo "[dcness-codex-validator] codex exec failed (exit $CODEX_RC)" >&2
+  echo "[dcness-codex-validator] codex exec failed (exit $CODEX_RC); raw log: $RAW_LOG" >&2
   exit 1
 done
 
 if [ "$TIMED_OUT" = "1" ]; then
   write_timeout_prose
   if [ -n "$MODE" ]; then
-    "$HELPER" end-step "$AGENT" "$MODE" --prose-file "$TMP_PROSE" || true
+    "$HELPER" end-step "$AGENT" "$MODE" --provider codex-headless --prose-file "$TMP_PROSE" || true
   else
-    "$HELPER" end-step "$AGENT" --prose-file "$TMP_PROSE" || true
+    "$HELPER" end-step "$AGENT" --provider codex-headless --prose-file "$TMP_PROSE" || true
   fi
   exit 124
 fi
 
 if [ ! -s "$TMP_PROSE" ]; then
-  echo "[dcness-codex-validator] Codex produced empty prose" >&2
+  echo "[dcness-codex-validator] Codex produced empty prose; raw log: $RAW_LOG" >&2
   exit 1
 fi
 
-AFTER_STATUS="$(git -C "$PROJECT_ROOT" status --porcelain=v1 2>/dev/null || true)"
+AFTER_STATUS="$(git_status_without_harness_state)"
 if [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]; then
   echo "[dcness-codex-validator] BLOCKED: Codex run changed git status. Automatic revert is forbidden." >&2
+  echo "[dcness-codex-validator] raw log: $RAW_LOG" >&2
   git -C "$PROJECT_ROOT" status --short >&2 || true
   exit 1
 fi
@@ -324,12 +354,13 @@ if [ "$BASELINE_CLEAN" = "1" ]; then
   if ! git -C "$PROJECT_ROOT" diff --quiet --no-ext-diff \
     || ! git -C "$PROJECT_ROOT" diff --cached --quiet --no-ext-diff; then
     echo "[dcness-codex-validator] BLOCKED: git diff appeared after Codex run. Automatic revert is forbidden." >&2
+    echo "[dcness-codex-validator] raw log: $RAW_LOG" >&2
     exit 1
   fi
 fi
 
 if [ -n "$MODE" ]; then
-  "$HELPER" end-step "$AGENT" "$MODE" --prose-file "$TMP_PROSE"
+  "$HELPER" end-step "$AGENT" "$MODE" --provider codex-headless --prose-file "$TMP_PROSE"
 else
-  "$HELPER" end-step "$AGENT" --prose-file "$TMP_PROSE"
+  "$HELPER" end-step "$AGENT" --provider codex-headless --prose-file "$TMP_PROSE"
 fi

--- a/scripts/dcness-implementation-chain
+++ b/scripts/dcness-implementation-chain
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# Run a dcNess implementation step through the configured provider chain.
+#
+# Headless fallback is only allowed when a provider fails before workspace
+# mutation. If a provider changes the workspace and then fails, this script
+# stops without revert or fallback so the caller can inspect the diff.
+
+set -uo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage:
+  dcness-implementation-chain <agent> [MODE] --prompt-file <file> [--provider <provider>] [--project-root <dir>]
+
+Agents:
+  test-engineer
+  engineer
+  build-worker
+
+Providers:
+  headless-chain    Codex headless -> Claude headless -> Claude main fallback
+  codex-first       Codex headless -> Claude main fallback (legacy)
+  claude-headless   Claude headless -> Claude main fallback
+  claude            Claude main fallback only
+
+Options:
+  --prompt-file, -p   File containing the caller prompt.
+  --provider          Override local implementation routing.
+  --project-root, -C  Repository root. Default: git rev-parse --show-toplevel.
+  --helper            dcness-helper path. Default: sibling script.
+  --help, -h          Show this help.
+
+Exit codes:
+  0   Headless provider completed and recorded end-step.
+  75  Chain reached Claude main. Caller must run the main Agent path and record
+      end-step with --provider claude-main.
+
+Raw provider logs are preserved under the active run directory in headless-logs/.
+USAGE
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ $# -lt 1 ]; then
+  usage >&2
+  exit 2
+fi
+
+AGENT="$1"
+shift
+
+case "$AGENT" in
+  test-engineer|engineer|build-worker) ;;
+  *)
+    echo "[dcness-implementation-chain] unsupported agent: $AGENT" >&2
+    exit 2
+    ;;
+esac
+
+MODE=""
+if [ $# -gt 0 ] && [[ "${1:-}" != -* ]]; then
+  MODE="$1"
+  shift
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT=""
+PROMPT_FILE=""
+HELPER="$SCRIPT_DIR/dcness-helper"
+PROVIDER=""
+
+abs_path() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s/%s\n' "$(pwd)" "$1" ;;
+  esac
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prompt-file|-p)
+      PROMPT_FILE="${2:-}"
+      shift 2
+      ;;
+    --provider)
+      PROVIDER="${2:-}"
+      shift 2
+      ;;
+    --project-root|-C)
+      PROJECT_ROOT="${2:-}"
+      shift 2
+      ;;
+    --helper)
+      HELPER="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "[dcness-implementation-chain] unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$PROMPT_FILE" ] || [ ! -f "$PROMPT_FILE" ]; then
+  echo "[dcness-implementation-chain] --prompt-file is required and must exist" >&2
+  exit 2
+fi
+PROMPT_FILE="$(abs_path "$PROMPT_FILE")"
+
+if [ -z "$PROJECT_ROOT" ]; then
+  PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+if [ ! -d "$PROJECT_ROOT" ]; then
+  echo "[dcness-implementation-chain] project root not found: $PROJECT_ROOT" >&2
+  exit 2
+fi
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
+HELPER="$(abs_path "$HELPER")"
+
+if [ ! -x "$HELPER" ]; then
+  echo "[dcness-implementation-chain] helper not executable: $HELPER" >&2
+  exit 2
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[dcness-implementation-chain] python3 not found; required for routing and context resolution" >&2
+  exit 127
+fi
+
+cd "$PROJECT_ROOT"
+
+CONTEXT="$(
+  PYTHONPATH="$SCRIPT_DIR/.." python3 -c '
+import sys
+from harness.session_state import (
+    auto_detect_run_id,
+    auto_detect_session_id,
+    diagnose_sid_rid_resolution,
+)
+
+sid = auto_detect_session_id()
+rid = auto_detect_run_id()
+if not sid or not rid:
+    print(diagnose_sid_rid_resolution(mode="both"), file=sys.stderr)
+    sys.exit(1)
+print(f"{sid}\t{rid}")
+'
+)"
+if [ $? -ne 0 ]; then
+  echo "[dcness-implementation-chain] sid/rid resolve failed before provider launch" >&2
+  exit 1
+fi
+IFS="$(printf '\t')" read -r RESOLVED_SID RESOLVED_RID <<EOF
+$CONTEXT
+EOF
+export DCNESS_SESSION_ID="$RESOLVED_SID"
+export DCNESS_RUN_ID="$RESOLVED_RID"
+
+RAW_LOG_DIR="$(
+  PYTHONPATH="$SCRIPT_DIR/.." python3 - "$RESOLVED_SID" "$RESOLVED_RID" <<'PY'
+import sys
+from harness.session_state import run_dir
+
+print(run_dir(sys.argv[1], sys.argv[2]) / "headless-logs")
+PY
+)"
+mkdir -p "$RAW_LOG_DIR"
+
+git_status_without_harness_state() {
+  git -C "$PROJECT_ROOT" status --porcelain=v1 -uall 2>/dev/null \
+    | sed '/^.. \.claude\/harness-state\//d' || true
+}
+
+ROUTING_INFO="$(
+  PYTHONPATH="$SCRIPT_DIR/.." python3 - "$AGENT" "$PROVIDER" <<'PY'
+import sys
+
+from harness.agent_routing import (
+    VALID_IMPLEMENTATION_PROVIDERS,
+    implementation_provider_chain,
+    resolve_provider,
+)
+
+agent = sys.argv[1]
+requested = sys.argv[2]
+provider = requested or resolve_provider(agent)
+if provider not in VALID_IMPLEMENTATION_PROVIDERS:
+    allowed = "|".join(VALID_IMPLEMENTATION_PROVIDERS)
+    print(
+        f"[dcness-implementation-chain] unsupported implementation provider: "
+        f"{provider} (allowed: {allowed})",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+print(provider)
+for stage in implementation_provider_chain(provider):
+    print(stage)
+PY
+)"
+ROUTING_RC=$?
+if [ "$ROUTING_RC" -ne 0 ]; then
+  exit "$ROUTING_RC"
+fi
+
+PROVIDER="$(printf '%s\n' "$ROUTING_INFO" | sed -n '1p')"
+STAGES_RAW="$(printf '%s\n' "$ROUTING_INFO" | sed '1d')"
+STAGES=()
+while IFS= read -r STAGE_LINE; do
+  [ -n "$STAGE_LINE" ] || continue
+  STAGES+=("$STAGE_LINE")
+done <<EOF
+$STAGES_RAW
+EOF
+
+if [ "${#STAGES[@]}" -eq 0 ]; then
+  echo "[dcness-implementation-chain] provider resolved to empty chain: $PROVIDER" >&2
+  exit 2
+fi
+
+run_headless_stage() {
+  local stage="$1"
+  local wrapper=""
+  local before_status=""
+  local after_status=""
+  local log=""
+  local rc=0
+  local cmd=()
+
+  case "$stage" in
+    codex-headless)
+      wrapper="$SCRIPT_DIR/dcness-codex-worker"
+      ;;
+    claude-headless)
+      wrapper="$SCRIPT_DIR/dcness-claude-worker"
+      ;;
+    *)
+      echo "[dcness-implementation-chain] unsupported headless stage: $stage" >&2
+      return 2
+      ;;
+  esac
+
+  log="$RAW_LOG_DIR/chain-${stage}-${AGENT}${MODE:+-$MODE}-$$.log"
+  before_status="$(git_status_without_harness_state)"
+
+  cmd=("$wrapper" "$AGENT")
+  if [ -n "$MODE" ]; then
+    cmd+=("$MODE")
+  fi
+  cmd+=(--prompt-file "$PROMPT_FILE" --project-root "$PROJECT_ROOT" --helper "$HELPER")
+
+  {
+    printf 'PROVIDER: %s\n' "$stage"
+    printf 'COMMAND:'
+    printf ' %s' "${cmd[@]}"
+    printf '\n'
+  } >> "$log"
+
+  "${cmd[@]}" >> "$log" 2>&1
+  rc=$?
+
+  after_status="$(git_status_without_harness_state)"
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+
+  if [ "$before_status" != "$after_status" ]; then
+    echo "[dcness-implementation-chain] BLOCKED: provider $stage changed workspace and failed; no fallback." >&2
+    echo "[dcness-implementation-chain] raw log: $log" >&2
+    git -C "$PROJECT_ROOT" status --short >&2 || true
+    exit 1
+  fi
+
+  echo "[dcness-implementation-chain] provider $stage failed before workspace mutation (exit $rc); continuing. raw log: $log" >&2
+  return "$rc"
+}
+
+for STAGE in "${STAGES[@]}"; do
+  case "$STAGE" in
+    codex-headless|claude-headless)
+      run_headless_stage "$STAGE"
+      STAGE_RC=$?
+      if [ "$STAGE_RC" -eq 0 ]; then
+        exit 0
+      fi
+      ;;
+    claude-main)
+      echo "[dcness-implementation-chain] FALLBACK_TO_CLAUDE_MAIN: provider $PROVIDER reached Claude main for ${AGENT}${MODE:+ $MODE}." >&2
+      echo "[dcness-implementation-chain] Run the normal Claude Agent path, then record end-step with --provider claude-main." >&2
+      exit 75
+      ;;
+    *)
+      echo "[dcness-implementation-chain] unknown provider chain stage: $STAGE" >&2
+      exit 2
+      ;;
+  esac
+done
+
+echo "[dcness-implementation-chain] provider chain exhausted without success: $PROVIDER" >&2
+exit 1

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -217,22 +217,31 @@ else
 fi
 ```
 
-wrapper 가 Codex 마지막 응답을 `/tmp` 에 받고 `dcness-helper end-step <agent> --prose-file ...` 까지 수행하므로 Codex 분기 경로에서는 별도 `end-step` 중복 호출 금지.
+wrapper 가 Codex 마지막 응답을 `/tmp` 에 받고 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 까지 수행하므로 Codex 분기 경로에서는 별도 `end-step` 중복 호출 금지.
 
-### implementation provider resolve (Codex-first 기본)
+### implementation provider resolve (headless-chain 기본)
 
-`test-engineer` / `engineer` / `build-worker` 호출 직전 implementation provider 를 같은 local routing config 로 resolve 한다. 기본값은 `codex-first` 이며, Claude-only 사용자는 `/init-dcness` custom 또는 중간 CLI 로 `claude` 로 바꾼다.
+`test-engineer` / `engineer` / `build-worker` 호출 직전 implementation provider 를 같은 local routing config 로 resolve 한다. 기본값은 `headless-chain` 이며, Claude-only 사용자는 `/init-dcness` custom 또는 중간 CLI 로 `claude` 로 바꾼다.
 
 ```bash
 PROVIDER=$("$HELPER" routing resolve <agent>)
-if [ "$PROVIDER" = "codex-first" ]; then
-  "$PLUGIN_ROOT/scripts/dcness-codex-worker" <agent> [MODE] --prompt-file "$PROMPT_FILE"
-else
+if [ "$PROVIDER" = "claude" ]; then
   # 기존 Claude Agent(subagent_type="<agent>") 경로.
+  "$HELPER" end-step <agent> [MODE] --provider claude-main
+else
+  rc=0
+  "$PLUGIN_ROOT/scripts/dcness-implementation-chain" <agent> [MODE] --provider "$PROVIDER" --prompt-file "$PROMPT_FILE" || rc=$?
+  if [ "$rc" -eq 75 ]; then
+    # 기존 Claude Agent(subagent_type="<agent>") 경로.
+    Agent(subagent_type="<agent>", ...)
+    "$HELPER" end-step <agent> [MODE] --provider claude-main
+  elif [ "$rc" -ne 0 ]; then
+    exit "$rc"
+  fi
 fi
 ```
 
-`dcness-codex-worker` 성공 경로는 마지막 응답 저장과 `end-step` 까지 수행한다. Codex CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패한 경우에만 기존 Claude Agent 경로로 폴백할 수 있다. Codex 가 파일을 변경한 뒤 실패하거나 agent boundary 밖 파일을 변경하면 자동 폴백·자동 revert 없이 정지한다.
+`dcness-implementation-chain` 성공 경로는 마지막 응답 저장과 `end-step` 까지 수행한다. CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패한 경우에만 다음 provider 로 폴백할 수 있다. Headless provider 가 파일을 변경한 뒤 실패하거나 agent boundary 밖 파일을 변경하면 자동 폴백·자동 revert 없이 정지한다. Claude main handoff 는 `FALLBACK_TO_CLAUDE_MAIN`/exit 75 이므로 메인이 기존 Agent 경로를 실행한 뒤 `--provider claude-main` 으로 기록한다.
 
 ---
 

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -183,7 +183,7 @@ Lite 는 `/impl-loop` 경량 모드가 아니다. impl 계획 파일 없이 메�
 
 메인 직접 경로에서 `code-validator` 를 호출하지 않는 이유: 검증 대상인 impl/compact 계획 파일이 없다. 최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, `pr-reviewer`, 단위 commit/PR, CI, false-clean 방지다.
 
-Codex implementation routing 이 `codex-first` 이면 Lite 기본 구현도 메인이 직접 Edit 하기 전에 구현 provider 를 확인할 수 있다. 메인이 Codex headless 실행을 선택하면 `build-worker` step 으로 기록하고 `dcness-codex-worker build-worker` 를 호출한다. Codex CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패하면 기존 메인 직접 구현 또는 Claude sub-agent 엔진으로 되돌린다. Codex 가 파일을 바꾼 뒤 실패하면 자동 폴백하지 않고 현재 diff 를 보고 정지한다.
+Implementation routing 이 headless 계열이면 Lite 기본 구현도 메인이 직접 Edit 하기 전에 구현 provider 를 확인할 수 있다. 메인이 headless 실행을 선택하면 `build-worker` step 으로 기록하고 `dcness-implementation-chain build-worker` 를 호출한다. CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패하면 다음 provider 로 넘어가고, Claude main handoff 는 메인 직접 구현 또는 Claude sub-agent 엔진으로 처리한다. Headless provider 가 파일을 바꾼 뒤 실패하면 자동 폴백하지 않고 현재 diff 를 보고 정지한다.
 
 ## Lite 구현 경로 — sub-agent 엔진 (#714)
 
@@ -245,23 +245,30 @@ else
 fi
 ```
 
-Codex 분기는 review provider 구현일 뿐 별도 public workflow 가 아니다.
+Codex 분기는 review provider 구현일 뿐 별도 public workflow 가 아니다. Codex wrapper 가 저장하는 receipt 는 실제 provider 를 `codex-headless` 로 기록한다.
 
 ## Implementation Provider
 
-`test-engineer` / `engineer` / `build-worker` 는 implementation provider 분기 대상이다. 기본값은 `codex-first` 이고, Claude-only 사용자는 `/init-dcness` custom 또는 중간 CLI 로 `claude` 로 바꿀 수 있다.
+`test-engineer` / `engineer` / `build-worker` 는 implementation provider 분기 대상이다. 기본값은 `headless-chain`(Codex headless → Claude headless → Claude main)이고, Claude-only 사용자는 `/init-dcness` custom 또는 중간 CLI 로 `claude` 로 바꿀 수 있다.
 
 ```bash
 PROVIDER=$("$HELPER" routing resolve build-worker)   # 또는 test-engineer / engineer
-if [ "$PROVIDER" = "codex-first" ]; then
-  "$PLUGIN_ROOT/scripts/dcness-codex-worker" build-worker --prompt-file "$PROMPT_FILE"
-  # 실패 시 stderr/status 를 확인한다. "changed workspace" 실패는 자동 폴백 금지.
-else
+if [ "$PROVIDER" = "claude" ]; then
   Agent(subagent_type="build-worker", ...)
+  "$HELPER" end-step build-worker --provider claude-main
+else
+  rc=0
+  "$PLUGIN_ROOT/scripts/dcness-implementation-chain" build-worker --provider "$PROVIDER" --prompt-file "$PROMPT_FILE" || rc=$?
+  if [ "$rc" -eq 75 ]; then
+    Agent(subagent_type="build-worker", ...)
+    "$HELPER" end-step build-worker --provider claude-main
+  elif [ "$rc" -ne 0 ]; then
+    exit "$rc"
+  fi
 fi
 ```
 
-Codex wrapper 가 성공하면 마지막 응답을 `end-step` 으로 저장한다. Codex 가 workspace 를 변경한 뒤 실패한 경우에는 wrapper 가 non-zero 로 멈추며 자동 Claude 폴백 금지다. 메인이 diff 를 확인하고 계속 진행/수정/폐기 여부를 판단한다.
+Headless wrapper 가 성공하면 마지막 응답을 `end-step` 으로 저장하고 실제 provider(`codex-headless` / `claude-headless`)를 ledger receipt 에 남긴다. Headless provider 가 workspace 를 변경한 뒤 실패한 경우에는 chain 이 non-zero 로 멈추며 자동 Claude 폴백 금지다. 메인이 diff 를 확인하고 계속 진행/수정/폐기 여부를 판단한다. workspace 변경 전 인프라 실패만 다음 provider 로 넘어가며, Claude main handoff 는 `FALLBACK_TO_CLAUDE_MAIN`/exit 75 로 표시된다.
 
 ## 종료 보고
 

--- a/tests/test_agent_routing.py
+++ b/tests/test_agent_routing.py
@@ -29,7 +29,7 @@ class AgentRoutingTests(unittest.TestCase):
 
     def test_missing_config_defaults_to_claude(self) -> None:
         self.assertEqual(agent_routing.resolve_provider("code-validator"), "claude")
-        self.assertEqual(agent_routing.resolve_provider("engineer"), "codex-first")
+        self.assertEqual(agent_routing.resolve_provider("engineer"), "headless-chain")
         self.assertEqual(agent_routing.resolve_provider("unknown-agent"), "claude")
         self.assertFalse(self.path.exists())
 
@@ -37,7 +37,7 @@ class AgentRoutingTests(unittest.TestCase):
         agent_routing.enable_codex_validation()
         for agent in agent_routing.ROUTABLE_VALIDATION_AGENTS:
             self.assertEqual(agent_routing.resolve_provider(agent), "codex")
-        self.assertEqual(agent_routing.resolve_provider("engineer"), "codex-first")
+        self.assertEqual(agent_routing.resolve_provider("engineer"), "headless-chain")
 
     def test_disable_codex_validation_returns_validators_to_claude(self) -> None:
         agent_routing.enable_codex_validation()
@@ -53,11 +53,16 @@ class AgentRoutingTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             agent_routing.set_provider("pr-reviewer", "openai")
 
-    def test_implementation_routes_can_disable_and_enable_codex_first(self) -> None:
+    def test_implementation_routes_can_disable_and_enable_headless_chain(self) -> None:
         agent_routing.disable_codex_implementation()
         for agent in agent_routing.ROUTABLE_IMPLEMENTATION_AGENTS:
             self.assertEqual(agent_routing.resolve_provider(agent), "claude")
 
+        agent_routing.enable_headless_implementation()
+        for agent in agent_routing.ROUTABLE_IMPLEMENTATION_AGENTS:
+            self.assertEqual(agent_routing.resolve_provider(agent), "headless-chain")
+
+    def test_legacy_enable_codex_implementation_keeps_codex_first_semantics(self) -> None:
         agent_routing.enable_codex_implementation()
         for agent in agent_routing.ROUTABLE_IMPLEMENTATION_AGENTS:
             self.assertEqual(agent_routing.resolve_provider(agent), "codex-first")
@@ -65,6 +70,10 @@ class AgentRoutingTests(unittest.TestCase):
     def test_set_implementation_provider_validates_agent_and_provider(self) -> None:
         agent_routing.set_implementation_provider("build-worker", "claude")
         self.assertEqual(agent_routing.resolve_provider("build-worker"), "claude")
+        agent_routing.set_implementation_provider("build-worker", "claude-headless")
+        self.assertEqual(agent_routing.resolve_provider("build-worker"), "claude-headless")
+        agent_routing.set_implementation_provider("build-worker", "headless-chain")
+        self.assertEqual(agent_routing.resolve_provider("build-worker"), "headless-chain")
         with self.assertRaises(ValueError):
             agent_routing.set_implementation_provider("pr-reviewer", "claude")
         with self.assertRaises(ValueError):
@@ -83,6 +92,7 @@ class AgentRoutingTests(unittest.TestCase):
                     },
                     "implementation_routes": {
                         "build-worker": "codex",
+                        "engineer": "unknown-chain",
                         "designer": "codex-first",
                     },
                 }
@@ -101,6 +111,9 @@ class AgentRoutingTests(unittest.TestCase):
         self.assertTrue(
             any("unknown implementation agent route: designer" in p for p in problems)
         )
+        self.assertTrue(
+            any("invalid implementation provider for engineer" in p for p in problems)
+        )
 
     def test_status_includes_effective_routes(self) -> None:
         agent_routing.set_provider("architecture-validator", "codex")
@@ -112,9 +125,9 @@ class AgentRoutingTests(unittest.TestCase):
         self.assertIn("architecture-validator: codex", text)
         self.assertIn("code-validator: claude", text)
         self.assertIn("build-worker: claude", text)
-        self.assertIn("engineer: codex-first", text)
+        self.assertIn("engineer: headless-chain", text)
 
-    def test_v1_config_is_supported_and_defaults_implementation_to_codex_first(self) -> None:
+    def test_v1_config_is_supported_and_defaults_implementation_to_headless_chain(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self.path.write_text(
             json.dumps(
@@ -129,6 +142,21 @@ class AgentRoutingTests(unittest.TestCase):
         )
         self.assertEqual(agent_routing.doctor(), [])
         self.assertEqual(agent_routing.resolve_provider("code-validator"), "codex")
+        self.assertEqual(agent_routing.resolve_provider("build-worker"), "headless-chain")
+
+    def test_v2_explicit_codex_first_keeps_legacy_chain(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            json.dumps(
+                {
+                    "version": 2,
+                    "routes": {},
+                    "implementation_routes": {"build-worker": "codex-first"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(agent_routing.doctor(), [])
         self.assertEqual(agent_routing.resolve_provider("build-worker"), "codex-first")
 
 
@@ -156,11 +184,11 @@ class AgentRoutingCliTests(unittest.TestCase):
         self.assertEqual(ns.agent, "code-validator")
 
         ns = parser.parse_args(
-            ["routing", "set-implementation", "build-worker", "claude"]
+            ["routing", "set-implementation", "build-worker", "claude-headless"]
         )
         self.assertEqual(ns.routing_cmd, "set-implementation")
         self.assertEqual(ns.agent, "build-worker")
-        self.assertEqual(ns.provider, "claude")
+        self.assertEqual(ns.provider, "claude-headless")
 
     def test_cli_enable_and_resolve(self) -> None:
         from harness.session_state import _cli_routing
@@ -179,7 +207,7 @@ class AgentRoutingCliTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertEqual(out.getvalue().strip(), "codex")
 
-    def test_cli_disable_implementation_and_resolve(self) -> None:
+    def test_cli_implementation_modes_and_resolve(self) -> None:
         from harness.session_state import _cli_routing
 
         out = StringIO()
@@ -195,6 +223,36 @@ class AgentRoutingCliTests(unittest.TestCase):
             )
         self.assertEqual(rc, 0)
         self.assertEqual(out.getvalue().strip(), "claude")
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(SimpleNamespace(routing_cmd="enable-headless-implementation"))
+        self.assertEqual(rc, 0)
+        self.assertIn("enabled headless implementation chain", out.getvalue())
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(
+                SimpleNamespace(routing_cmd="resolve", agent="build-worker")
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "headless-chain")
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(
+                SimpleNamespace(routing_cmd="enable-claude-headless-implementation")
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("enabled Claude headless implementation", out.getvalue())
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(
+                SimpleNamespace(routing_cmd="resolve", agent="build-worker")
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.getvalue().strip(), "claude-headless")
 
         out = StringIO()
         with redirect_stdout(out):

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -139,7 +139,10 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             self.assertTrue(
                 helper_args.read_text(encoding="utf-8")
                 .strip()
-                .startswith("end-step architecture-validator SECOND --prose-file "),
+                .startswith(
+                    "end-step architecture-validator SECOND "
+                    "--provider codex-headless --prose-file "
+                ),
             )
             self.assertEqual(
                 prose_capture.read_text(encoding="utf-8"),
@@ -360,7 +363,9 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             self.assertTrue(
                 helper_args.read_text(encoding="utf-8")
                 .strip()
-                .startswith("end-step pr-reviewer --prose-file "),
+                .startswith(
+                    "end-step pr-reviewer --provider codex-headless --prose-file "
+                ),
             )
             prose = prose_capture.read_text(encoding="utf-8")
             self.assertIn("did not finish within 1s", prose)
@@ -486,7 +491,9 @@ class CodexWorkerWrapperTests(unittest.TestCase):
             self.assertTrue(
                 helper_args.read_text(encoding="utf-8")
                 .strip()
-                .startswith("end-step build-worker --prose-file "),
+                .startswith(
+                    "end-step build-worker --provider codex-headless --prose-file "
+                ),
             )
             self.assertEqual(
                 prose_capture.read_text(encoding="utf-8"),
@@ -756,7 +763,9 @@ class CodexWorkerWrapperTests(unittest.TestCase):
             self.assertTrue(
                 helper_args.read_text(encoding="utf-8")
                 .strip()
-                .startswith("end-step build-worker --prose-file "),
+                .startswith(
+                    "end-step build-worker --provider codex-headless --prose-file "
+                ),
             )
 
     def test_worker_failure_after_mutation_does_not_fallback_or_end_step(self) -> None:

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -453,7 +453,9 @@ class BuildReceiptTests(unittest.TestCase):
     def test_receipt_fields(self) -> None:
         prose = "## 결론\ncode-validator PASS. MUST FIX 없음.\n수용 기준 충족."
         prose_path = "/tmp/code-validator.md"
-        r = ledger.build_receipt("code-validator", None, "PROSE_LOGGED", prose, prose_path)
+        r = ledger.build_receipt(
+            "code-validator", None, "PROSE_LOGGED", prose, prose_path
+        )
         self.assertEqual(r["agent"], "code-validator")
         self.assertEqual(r["prose_file"], prose_path)
         self.assertEqual(r["sha256"], ledger.sha256_text(prose))
@@ -464,9 +466,28 @@ class BuildReceiptTests(unittest.TestCase):
 
     def test_no_format_enforcement(self) -> None:
         """agent prose 형식 강제 안 함 — 임의 텍스트도 receipt 생성."""
-        r = ledger.build_receipt("engineer", "IMPL", "PROSE_LOGGED", "아무 자유 텍스트", "/tmp/x.md")
+        r = ledger.build_receipt(
+            "engineer", "IMPL", "PROSE_LOGGED", "아무 자유 텍스트", "/tmp/x.md"
+        )
         self.assertEqual(r["sha256"], ledger.sha256_text("아무 자유 텍스트"))
         self.assertIsInstance(r["evidence_paths"], list)
+
+    def test_provider_field_is_optional(self) -> None:
+        prose = "## 결론\n구현 완료."
+        r = ledger.build_receipt(
+            "engineer",
+            "IMPL",
+            "PROSE_LOGGED",
+            prose,
+            "/tmp/engineer.md",
+            provider="claude-headless",
+        )
+        self.assertEqual(r["provider"], "claude-headless")
+
+        legacy = ledger.build_receipt(
+            "engineer", "IMPL", "PROSE_LOGGED", prose, "/tmp/engineer.md"
+        )
+        self.assertNotIn("provider", legacy)
 
 
 class AppendStepCompletedTests(unittest.TestCase):
@@ -478,7 +499,7 @@ class AppendStepCompletedTests(unittest.TestCase):
             prose_path = _write_prose_file(base, "engineer-IMPL.md", prose)
             rec = ledger.append_step_completed(
                 _SID, _RID, "engineer", "IMPL", "PROSE_LOGGED",
-                prose, prose_path, base_dir=base,
+                prose, prose_path, base_dir=base, provider="codex-headless",
             )
             # 옛 .steps.jsonl row 필드명 호환
             for k in ("ts", "agent", "mode", "enum", "prose_excerpt", "must_fix", "prose_file"):
@@ -488,6 +509,7 @@ class AppendStepCompletedTests(unittest.TestCase):
                 self.assertIn(k, rec, f"receipt 필드 누락: {k}")
             self.assertEqual(rec["event"], "step_completed")
             self.assertEqual(rec["sha256"], ledger.sha256_text(prose))
+            self.assertEqual(rec["provider"], "codex-headless")
 
     def test_product_acceptance_prose_only_fail_sets_next_action(self) -> None:
         with TemporaryDirectory() as d:

--- a/tests/test_provider_chain.py
+++ b/tests/test_provider_chain.py
@@ -1,0 +1,410 @@
+"""Tests for implementation provider chain and Claude headless wrappers."""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_VALIDATOR = ROOT / "scripts" / "dcness-claude-validator"
+CLAUDE_WORKER = ROOT / "scripts" / "dcness-claude-worker"
+CHAIN = ROOT / "scripts" / "dcness-implementation-chain"
+
+
+def _write_executable(path: Path, text: str) -> None:
+    path.write_text(textwrap.dedent(text), encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _write_helper(path: Path, helper_args: Path, prose_capture: Path) -> None:
+    _write_executable(
+        path,
+        """\
+        #!/bin/sh
+        printf '%s\\n' "$*" > "$HELPER_ARGS"
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --prose-file)
+              cp "$2" "$PROSE_CAPTURE"
+              exit 0
+              ;;
+          esac
+          shift
+        done
+        exit 1
+        """,
+    )
+    os.environ["HELPER_ARGS"] = str(helper_args)
+    os.environ["PROSE_CAPTURE"] = str(prose_capture)
+
+
+class ClaudeHeadlessWrapperTests(unittest.TestCase):
+    def test_worker_uses_hook_loading_claude_print_mode_and_records_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement this task.\n", encoding="utf-8")
+            args_capture = tmp / "claude-args.txt"
+            prompt_capture = tmp / "prompt-capture.md"
+            prose_capture = tmp / "prose.md"
+            helper_args = tmp / "helper-args.txt"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(
+                bin_dir / "claude",
+                """\
+                #!/bin/sh
+                printf '%s\\n' "$@" > "$ARGS_CAPTURE"
+                cat > "$PROMPT_CAPTURE"
+                mkdir -p src
+                printf 'print("ok")\\n' > src/generated.py
+                printf 'Claude worker prose\\n\\nPASS\\n'
+                """,
+            )
+            helper = tmp / "dcness-helper"
+            _write_helper(helper, helper_args, prose_capture)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "ARGS_CAPTURE": str(args_capture),
+                    "DCNESS_RUN_ID": "run-facefeed",
+                    "DCNESS_SESSION_ID": "sid-claude-worker",
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                    "PROMPT_CAPTURE": str(prompt_capture),
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(CLAUDE_WORKER),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            args = args_capture.read_text(encoding="utf-8")
+            self.assertIn("-p", args)
+            self.assertIn("acceptEdits", args)
+            self.assertNotIn("--bare", args)
+            self.assertNotIn("--safe-mode", args)
+            prompt = prompt_capture.read_text(encoding="utf-8")
+            self.assertIn("Claude headless", prompt)
+            self.assertIn("hooks and plugins enabled", prompt)
+            self.assertTrue((project / "src" / "generated.py").exists())
+            self.assertTrue(
+                helper_args.read_text(encoding="utf-8")
+                .strip()
+                .startswith("end-step build-worker --provider claude-headless "),
+            )
+            self.assertEqual(
+                prose_capture.read_text(encoding="utf-8"),
+                "Claude worker prose\n\nPASS\n",
+            )
+            logs = list(
+                (
+                    project
+                    / ".claude"
+                    / "harness-state"
+                    / ".sessions"
+                    / "sid-claude-worker"
+                    / "runs"
+                    / "run-facefeed"
+                    / "headless-logs"
+                ).glob("claude-headless-build-worker-*.log")
+            )
+            self.assertEqual(len(logs), 1)
+            self.assertIn("Claude worker prose", logs[0].read_text(encoding="utf-8"))
+
+    def test_validator_blocks_workspace_mutation_without_end_step(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Review only.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+            prose_capture = tmp / "prose.md"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(
+                bin_dir / "claude",
+                """\
+                #!/bin/sh
+                cat >/dev/null
+                mkdir -p src
+                printf 'bad\\n' > src/mutated.py
+                printf 'Claude validator prose\\n\\nPASS\\n'
+                """,
+            )
+            helper = tmp / "dcness-helper"
+            _write_helper(helper, helper_args, prose_capture)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_RUN_ID": "run-abcddcba",
+                    "DCNESS_SESSION_ID": "sid-claude-validator",
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(CLAUDE_VALIDATOR),
+                    "pr-reviewer",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("changed git status", result.stderr)
+            self.assertFalse(helper_args.exists())
+
+
+class ImplementationChainTests(unittest.TestCase):
+    def test_codex_missing_falls_back_to_claude_headless(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement through chain.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+            prose_capture = tmp / "prose.md"
+            claude_called = tmp / "claude-called.txt"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(
+                bin_dir / "claude",
+                """\
+                #!/bin/sh
+                printf called > "$CLAUDE_CALLED"
+                cat >/dev/null
+                mkdir -p src
+                printf 'ok\\n' > src/generated.py
+                printf 'Claude fallback prose\\n\\nPASS\\n'
+                """,
+            )
+            helper = tmp / "dcness-helper"
+            _write_helper(helper, helper_args, prose_capture)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "CLAUDE_CALLED": str(claude_called),
+                    "DCNESS_RUN_ID": "run-12344321",
+                    "DCNESS_SESSION_ID": "sid-chain",
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(CHAIN),
+                    "build-worker",
+                    "--provider",
+                    "headless-chain",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(claude_called.exists())
+            self.assertIn("provider codex-headless failed before workspace mutation", result.stderr)
+            self.assertEqual(
+                prose_capture.read_text(encoding="utf-8"),
+                "Claude fallback prose\n\nPASS\n",
+            )
+            log_dir = (
+                project
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-chain"
+                / "runs"
+                / "run-12344321"
+                / "headless-logs"
+            )
+            self.assertTrue(list(log_dir.glob("chain-codex-headless-build-worker-*.log")))
+            self.assertTrue(list(log_dir.glob("claude-headless-build-worker-*.log")))
+
+    def test_codex_failure_after_mutation_stops_chain(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement through chain.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+            prose_capture = tmp / "prose.md"
+            claude_called = tmp / "claude-called.txt"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(
+                bin_dir / "codex",
+                """\
+                #!/bin/sh
+                if [ "$1" = "--help" ]; then
+                  echo "Usage: codex"
+                  exit 0
+                fi
+                cat >/dev/null
+                mkdir -p src
+                printf 'partial\\n' > src/partial.py
+                exit 42
+                """,
+            )
+            _write_executable(
+                bin_dir / "claude",
+                """\
+                #!/bin/sh
+                printf called > "$CLAUDE_CALLED"
+                cat >/dev/null
+                printf 'should not run\\n'
+                """,
+            )
+            helper = tmp / "dcness-helper"
+            _write_helper(helper, helper_args, prose_capture)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "CLAUDE_CALLED": str(claude_called),
+                    "DCNESS_RUN_ID": "run-42424242",
+                    "DCNESS_SESSION_ID": "sid-chain",
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(CHAIN),
+                    "engineer",
+                    "IMPL",
+                    "--provider",
+                    "headless-chain",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("changed workspace", result.stderr)
+            self.assertFalse(claude_called.exists())
+            self.assertFalse(helper_args.exists())
+
+    def test_claude_headless_pre_mutation_failure_hands_off_to_main_agent(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement through chain.\n", encoding="utf-8")
+            helper = tmp / "dcness-helper"
+            _write_executable(helper, "#!/bin/sh\nexit 0\n")
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(
+                bin_dir / "claude",
+                """\
+                #!/bin/sh
+                cat >/dev/null
+                exit 43
+                """,
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_RUN_ID": "run-56565656",
+                    "DCNESS_SESSION_ID": "sid-chain",
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(CHAIN),
+                    "build-worker",
+                    "--provider",
+                    "claude-headless",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 75)
+            self.assertIn("FALLBACK_TO_CLAUDE_MAIN", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1730,6 +1730,24 @@ class CliBeginStepEndStepTests(unittest.TestCase):
                 ["end-step", "code-validator", "--allowed-enums", "PASS,FAIL"]
             )
 
+    def test_end_step_argparse_accepts_provider_receipt_hint(self) -> None:
+        from harness.session_state import _build_arg_parser
+
+        parser = _build_arg_parser()
+        ns = parser.parse_args(
+            [
+                "end-step",
+                "build-worker",
+                "--provider",
+                "claude-headless",
+                "--prose-file",
+                "/tmp/prose.md",
+            ]
+        )
+
+        self.assertEqual(ns.provider, "claude-headless")
+        self.assertEqual(ns.prose_file, "/tmp/prose.md")
+
 
 class DefaultBaseWorktreeTests(unittest.TestCase):
     """`_default_base()` γ 설계 — main repo `.claude/harness-state/` 단일 source 검증.


### PR DESCRIPTION
## 관련 이슈 번호

Closes #860

## 배경 및 문제

- #859로 headless 경로에도 guard가 걸리게 됐고, #861로 기본 구현 엔진이 build-worker로 정리됐다.
- 그 위에서 implementation provider 기본값을 Codex headless 단일 우선 경로가 아니라 `codex-headless -> claude-headless -> claude-main` 3단 체인으로 확장해야 한다.
- workspace mutation 뒤 실패한 provider를 자동 fallback하면 diff 소유권과 원인 판단이 흐려지므로, mutation 전 인프라 실패만 다음 provider로 넘겨야 한다.

## 원인 (해당 시)

- 기존 implementation routing은 `codex-first` / `claude` 두 값만 알고, run receipt에 실제 실행 provider를 남기지 않았다.
- Codex wrapper는 raw session output을 직접 프로세스 output으로 흘릴 수 있었고, Claude headless worker/validator 경로는 없었다.

## 작업내용

- implementation routing config v3 기본값을 `headless-chain`으로 변경하고, `codex-first`, `claude-headless`, `claude` chain mapping을 추가했다.
- `dcness-implementation-chain`, `dcness-claude-worker`, `dcness-claude-validator`를 추가했다.
- Codex/Claude headless wrappers가 raw logs를 active run의 `headless-logs/` 파일로 보존하고, main context에는 짧은 status와 end-step receipt만 남기도록 정리했다.
- `end-step --provider`와 ledger receipt provider 필드를 추가해 실제 실행 provider를 기록한다.
- headless worker TDD guard parity와 raw log infra path filtering을 추가했다.
- init/docs/skills/README를 `headless-chain` 기본값과 Claude main handoff 계약에 맞게 갱신했다.
- headless prose quality behavior eval fixture를 추가했다.

## 결정 근거

- `codex-first`는 legacy 의미를 유지해 기존 opt-in 프로젝트의 명시 설정을 깨지 않는다.
- `headless-chain`은 새 기본값으로만 적용해 Codex 미설치 환경도 Claude headless 격리 실행을 얻는다.
- `FALLBACK_TO_CLAUDE_MAIN`/exit 75는 shell wrapper가 Claude main Agent를 직접 호출하지 못하는 경계를 명확히 한다.
- raw logs는 파일로 보존하고 git status/boundary/TDD mutation 판정에서는 `.claude/harness-state/` infra 산출물을 제외했다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/**`: `agent_routing`, `session_state`, `ledger`는 plugin body로 배포되는 helper runtime 변경이다.
- `scripts/**`: 신규 `dcness-implementation-chain`, `dcness-claude-worker`, `dcness-claude-validator`와 기존 Codex wrappers는 plugin body script 변경이다. 사용자 repo 복사 대상이 아니다.
- `commands/init-dcness.md`, `docs/plugin/**`, `skills/impl*/SKILL.md`, `README.md`: plugin 문서/skill cache 갱신으로 배포된다.
- `evals/cases/headless-prose-quality/**`: repo behavior eval fixture이며 사용자 repo 배포 대상이 아니다.
- 사용자 repo에 새 파일을 복사하지 않는다. routing state는 기존처럼 `~/.claude/plugins/data/dcness-dcness/routing.json`만 사용한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public workflow/skill/agent surface 추가 없음. 내부 helper script와 routing provider 값만 확장.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- `python3 -m unittest tests.test_agent_routing tests.test_ledger tests.test_provider_chain tests.test_codex_validator_wrapper -v`
- `python3 -m unittest tests.test_agent_routing tests.test_session_state tests.test_provider_chain tests.test_codex_validator_wrapper tests.test_ledger -v`
- `python3.11 -m unittest discover -s tests -v` (1505 tests)
- `bash scripts/check_python_tests.sh`
- `node scripts/check_public_surface.mjs`
- `node scripts/check_cross_refs.mjs`
- `node scripts/check_doc_path_integrity.mjs`
- `node scripts/check_plugin_manifest.mjs`
- `node scripts/check_design_artifact_structure.mjs`
- `PYTHON_BIN=/tmp/dcness-quality-venv-860/bin/python bash scripts/check_static_quality.sh`
- `git diff --check`
- `bash -n scripts/dcness-codex-worker scripts/dcness-codex-validator scripts/dcness-claude-worker scripts/dcness-claude-validator scripts/dcness-implementation-chain`
- `EVAL_RUNS=1 bash evals/run.sh` 실행: 신규 `headless-prose-quality`는 1/1 통과. 전체 eval suite는 기존 `flow-ownership-entrypoint-bad`가 0/1로 실패해 runner exit 1.

## 참고

- pre-commit hook 실행 완료: pytest-gate PASS, git-naming PASS.
