### PR TITLE
[feature] 활성 프로젝트 CLAUDE.md seed 감사

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -19,7 +19,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 본 문서는 사용자가 지금 선택하거나 실행해야 하는 bootstrap 절차만 다룬다. hook 정책, TDD Guard skip 룰, workflow template inventory, 배경 히스토리는 reference 로 내린다.
 
 - 상세 bootstrap inventory / workflow template inventory: [`docs/plugin/init-dcness.md`](../docs/plugin/init-dcness.md)
-- hook 정책 SSOT: [`docs/plugin/hooks.md`](../docs/plugin/hooks.md)
+- hook 정책 SSOT: [`docs/plugin/hooks.md`](../docs/plugin/hooks.md), TDD Guard: [`hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh)
 - git / PR naming SSOT: [`docs/plugin/git-spec.md`](../docs/plugin/git-spec.md)
 - Project lifecycle SSOT: [`docs/plugin/github-project.md`](../docs/plugin/github-project.md)
 
@@ -41,6 +41,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
 HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+CONTEXT_DOCS="$PLUGIN_ROOT/scripts/dcness-context-docs"
 ```
 
 `PLUGIN_ROOT` 또는 `PROJECT_ROOT` 가 비면 중단하고 plugin 설치 상태와 git repo 여부를 먼저 확인한다.
@@ -53,6 +54,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 - `~/.claude/settings.json` Read 권한
 - git hook shim 3종 설치
 - Codex validator skill 배포
+- `CLAUDE.md` seed/migration 감사
 - Provider routing 상태 확인
 - `dcness-helper status` 기준 FAIL 0
 선택형 확장은 core activation 성공 조건이 아니다. CI workflow, project docs seed, design seed, GitHub Project lifecycle, workflow 변경 PR 은 INFO/WARN 으로 남아도 core 성공 메시지를 흐리지 않는다.
@@ -71,6 +73,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 - `Read 권한` FAIL → Core Step 3.
 - `git hook shim 3종` FAIL → Core Step 4.
 - `Codex validator skills` FAIL → Core Step 5 재실행.
+- `CLAUDE.md` 부재 또는 cold-start 앵커 부재 → Core Step 6.
 - `Provider routing` 은 INFO 로 상태만 확인한다. validation 이 이미 enabled 면 다시 쓰지 않고, implementation 은 custom 선택 때만 명시 변경한다.
 - `선택형 CI workflow` 는 INFO 다. core activation 성공/실패 판정에 넣지 않는다.
 
@@ -80,11 +83,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 "$HELPER" enable
 ```
 
-결과:
-
-- 현재 cwd 의 main repo root 를 whitelist 에 추가.
-- whitelist: `~/.claude/plugins/data/dcness-dcness/projects.json`
-- 다음 Claude Code 세션부터 SessionStart / PreToolUse hook 이 활성 프로젝트로 인식.
+결과: 현재 cwd 의 main repo root 를 whitelist 에 추가하고 다음 세션부터 hook 활성 프로젝트로 인식한다.
 
 ### Core Step 3 - Read 권한 부여
 
@@ -159,7 +158,15 @@ done
 "$HELPER" routing status
 ```
 
-### Core Step 6 - 완료 선언
+### Core Step 6 - CLAUDE.md seed/migration
+
+부재 시 공식 구조 기반 `CLAUDE.md` 를 생성한다. 기존 파일은 재작성하지 않고 dcNess cold-start 앵커만 없을 때 append 하며, 6축 quality audit 결과와 개선 후보를 출력한다.
+
+```bash
+"$CONTEXT_DOCS" --ensure --repo "$PROJECT_ROOT"
+```
+
+### Core Step 7 - 완료 선언
 
 core 작업 뒤 `status` 를 재실행한다. FAIL 이 0 이면 INFO·NA 행과 선택 WARN 이 남아도 즉시 완료를 먼저 출력한다.
 
@@ -199,8 +206,7 @@ support:
 비활성화:
 - "$HELPER" disable
 
-Claude Code 세션 재시작 권장:
-- SessionStart 훅은 현재 세션에는 소급 적용되지 않는다.
+Claude Code 세션 재시작 권장: SessionStart 훅은 현재 세션에는 소급 적용되지 않는다.
 ```
 
 ## 선택형 확장
@@ -462,13 +468,7 @@ record_dcness_workflow_change ".github/workflows/github-project-lifecycle.yml"
 
 ## 이미 자동 적용되는 것
 
-활성화 후 새 Claude Code 세션에서 plug-in hook 이 자동 발화한다. 사용자 repo 에 별도 파일을 설치하지 않는다.
-
-- SessionStart: sid/live state 초기화와 활성 안내 inject.
-- 순서 차단 훅: Agent 호출 전 작업 순서 보호.
-- file-guard: agent 별 파일 경계와 외부 상태 변경 차단.
-- TDD Guard: `Edit` / `Write` / `NotebookEdit` / `Bash` write target 의 TS/JS 구현 파일 매칭 test 존재 확인. 세부 skip/한계는 [`docs/plugin/hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh).
-- Stop hook: run 종료와 continuation signal.
+활성화 후 새 Claude Code 세션에서 plug-in hook 이 자동 발화한다. 사용자 repo 에 별도 파일을 설치하지 않는다. 세부 hook 정책은 [`docs/plugin/hooks.md`](../docs/plugin/hooks.md) 가 SSOT 다.
 
 ## 추가 안내 — 재실행이 필요한 경우
 

--- a/commands/run-review.md
+++ b/commands/run-review.md
@@ -27,7 +27,7 @@ description: dcness loop run (begin-run / end-run 사이클) 사후 분석 스�
 1. **단계별 비용** — run 시작/종료 timestamp 내 assistant turn cost 합산 (price_for util 재사용)
 2. **잘한 점** (GOOD findings) — ENUM_CLEAN / PROSE_ECHO_OK / DDD_PHASE_A / DEPENDENCY_CAUSAL / EXTERNAL_VERIFIED_PRESENT
 3. **잘못한 점** (WASTE findings) — RETRY_SAME_FAIL / ECHO_VIOLATION / PLACEHOLDER_LEAK / MUST_FIX_GHOST / SPEC_GAP_LOOP / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_MISSING
-4. **CLAUDE.md/AGENTS.md 현행화 후보** — context 문서 존재, AGENTS.md 의 CLAUDE.md SSOT 참조, run-review finding 기반 세션 학습 환류 후보. 자동 수정하지 않고 제안만 출력한다.
+4. **CLAUDE.md/AGENTS.md 현행화 후보** — context 문서 존재, AGENTS.md 의 CLAUDE.md SSOT 참조, CLAUDE.md 공식 구조·6축 rubric·dcNess cold-start 앵커, run-review finding 기반 세션 학습 환류 후보. 자동 수정하지 않고 제안만 출력한다.
 
 ## 절차
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -19,6 +19,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 | local git hook | `.git/hooks/commit-msg` | `scripts/hooks/commit-msg` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/post-checkout` | `scripts/hooks/post-checkout` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | 항상 | always-overwrite | X |
+| project context seed/migration | `CLAUDE.md` | `scripts/dcness-context-docs` / `harness/context_docs.py` | 항상 | 부재 시 생성. 기존 파일은 cold-start 앵커만 없을 때 append | X |
 | Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite | X |
 | Codex provider routing 상태 확인 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing status` | 항상 확인 | read-only | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
@@ -45,6 +46,8 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 > 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다.
 
 `dcness-helper status` 는 설치 상태뿐 아니라 최근 hook fail-open 활동도 `hook fail-open 진단` 항목으로 보여준다. 정상 inactive no-op 은 기록하지 않고, 활성 프로젝트에서 enforcement hook 이 검사를 평가하지 못하고 allow 한 경우만 최근 reason category 를 WARN 으로 노출한다. 자세한 정책은 [`hooks.md`](hooks.md) 가 SSOT 다.
+
+`CLAUDE.md` seed/migration 은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-context-docs`) 로 처리한다. 부재 시 Anthropic 공식 구조 기반 템플릿을 만들고, 기존 파일은 cold-start 앵커만 additive append 한다. 6축 quality audit 결과는 출력하지만 구조 개선·삭제·재배치는 후보만 제안한다.
 
 `docs/index.md` 의 epic 표, 전역 `docs/architecture.md` 의 집계 섹션, 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
@@ -160,6 +163,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | plugin 본체 문서/skill/hook 만 갱신 | 아니오 | `claude plugin update dcness@dcness` 로 plug-in cache 가 갱신된다. |
 | plugin uninstall/reinstall | 예 | plugin data 디렉토리가 정리되어 whitelist 가 사라진다. |
 | `.git/hooks/*` thin shim 갱신 | 예 | 사용자 repo `.git/hooks/` 파일은 plugin update 만으로 바뀌지 않는다. |
+| `CLAUDE.md` seed/migration 로직 갱신 | 예 | 기존 활성 프로젝트의 root `CLAUDE.md` 생성·cold-start 앵커 append 는 `/init-dcness` 재실행 때 적용된다. |
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 이 있는 프로젝트는 doc-sync 채택 직후 index/architecture 집계기를 1회 실행해야 한다. |
 | Codex validation routing opt-in 변경 | 예 | local plugin data 와 `$CODEX_HOME/skills` 를 갱신해야 한다. |
 | Implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |

--- a/harness/context_docs.py
+++ b/harness/context_docs.py
@@ -1,0 +1,433 @@
+"""CLAUDE.md seed, migration, and quality audit helpers."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+RECOMMENDED_SECTIONS = (
+    "Commands",
+    "Architecture",
+    "Key Files",
+    "Code Style",
+    "Environment",
+    "Testing",
+    "Gotchas",
+    "Workflow",
+)
+
+COLD_START_SECTION_TITLE = "## dcNess Cold Start"
+
+
+@dataclass(frozen=True)
+class AxisScore:
+    name: str
+    score: int
+    maximum: int
+    note: str
+
+
+@dataclass(frozen=True)
+class ClaudeAudit:
+    path: Path
+    exists: bool
+    total_score: int
+    grade: str
+    line_count: int
+    axis_scores: list[AxisScore] = field(default_factory=list)
+    missing_sections: list[str] = field(default_factory=list)
+    has_cold_start_anchor: bool = False
+    broken_references: list[str] = field(default_factory=list)
+    improvement_candidates: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class EnsureResult:
+    path: Path
+    actions: list[str]
+    audit: ClaudeAudit
+
+
+def has_cold_start_anchor(text: str) -> bool:
+    return bool(re.search(r"(?im)^##\s+dcNess\s+Cold\s+Start\s*$", text))
+
+
+def build_cold_start_anchor() -> str:
+    return "\n".join([
+        COLD_START_SECTION_TITLE,
+        "- 다음 작업 후보 확인: `/next`",
+        "- 진행 상태 문서: docs/index.md 의 진행 상태 섹션을 사용합니다.",
+        "- live 보드 좌표 확인: `gh variable get DCNESS_PROJECT_OWNER`",
+        "- live 보드 번호 확인: `gh variable get DCNESS_PROJECT_NUMBER`",
+        "- 보드 좌표가 없으면 `/init-dcness` custom Project bootstrap 을 실행합니다.",
+    ])
+
+
+def _package_manager(root: Path) -> str:
+    if (root / "pnpm-lock.yaml").exists():
+        return "pnpm"
+    if (root / "yarn.lock").exists():
+        return "yarn"
+    return "npm"
+
+
+def _detect_package_commands(root: Path) -> list[str]:
+    package_json = root / "package.json"
+    if not package_json.exists():
+        return []
+    try:
+        data = json.loads(package_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    scripts = data.get("scripts")
+    if not isinstance(scripts, dict):
+        return []
+    manager = _package_manager(root)
+    commands: list[str] = []
+    for script in ("dev", "build", "lint", "test"):
+        if script in scripts:
+            commands.append(f"- `{manager} run {script}`")
+    return commands
+
+
+def _detect_python_commands(root: Path) -> list[str]:
+    commands: list[str] = []
+    if (root / "tests").exists():
+        commands.append("- `python3.11 -m unittest discover -s tests -v`")
+    if (root / "scripts" / "check_static_quality.sh").exists():
+        commands.append("- `bash scripts/check_static_quality.sh`")
+    return commands
+
+
+def _detect_commands(root: Path) -> list[str]:
+    commands = _detect_package_commands(root)
+    commands.extend(_detect_python_commands(root))
+    if commands:
+        return commands
+    return [
+        "- 실제 build/test/lint 명령을 확인한 뒤 copy-paste 가능한 형태로 기록합니다.",
+    ]
+
+
+def build_claude_seed(repo_path: Path) -> str:
+    command_lines = "\n".join(_detect_commands(repo_path))
+    return "\n".join([
+        "# Project Instructions",
+        "",
+        "## Commands",
+        command_lines,
+        "",
+        "## Architecture",
+        "- 코드베이스 구조와 주요 런타임 경계를 짧게 유지합니다.",
+        "- dcNess 문서 seed 를 쓰는 프로젝트는 docs/index.md 를 cold-start entrypoint 로 둡니다.",
+        "",
+        "## Key Files",
+        "- `CLAUDE.md`: 모든 세션에 로드되는 프로젝트 지침입니다.",
+        "- AGENTS.md: 외부 에이전트용 얇은 안내가 필요할 때 CLAUDE.md 를 참조합니다.",
+        "",
+        "## Code Style",
+        "- formatter, linter, naming convention 은 확인된 사실만 기록합니다.",
+        "- 모순되는 규칙은 남기지 말고 현재 코드와 일치하는 규칙만 유지합니다.",
+        "",
+        "## Environment",
+        "- 필수 런타임, 패키지 매니저, 환경변수, 로컬 서비스만 기록합니다.",
+        "- 개인 환경값은 공유 파일 대신 로컬 설정에 둡니다.",
+        "",
+        "## Testing",
+        "- 테스트 명령은 실패 시 재현 가능한 copy-paste 형태로 유지합니다.",
+        "- 회귀 검증에 필요한 fixture, seed data, 외부 서비스 조건을 기록합니다.",
+        "",
+        "## Gotchas",
+        "- 반복 실수, 비직관적 설계 이유, 알려진 제한만 짧게 기록합니다.",
+        "- 일회성 문제나 추측은 넣지 않습니다.",
+        "",
+        "## Workflow",
+        "- dcNess 시작: `/spec`, `/design`, `/impl`, `/acceptance` 중 작업 성격에 맞게 진입합니다.",
+        "- 다음 작업 확인은 `/next` 를 우선 사용합니다.",
+        "",
+        build_cold_start_anchor(),
+        "",
+    ])
+
+
+def _grade(score: int) -> str:
+    if score >= 90:
+        return "A"
+    if score >= 70:
+        return "B"
+    if score >= 50:
+        return "C"
+    if score >= 30:
+        return "D"
+    return "F"
+
+
+def _has_section(text: str, section: str) -> bool:
+    return bool(re.search(rf"(?im)^##\s+{re.escape(section)}\s*$", text))
+
+
+def _has_command_signal(text: str) -> bool:
+    command_re = re.compile(
+        r"```(?:bash|sh|shell)|"
+        r"`[^`\n]*(?:/(?:next|spec|design|impl|acceptance|to-issue|run-review|"
+        r"smart-compact|tech-review|impl-loop)|npm|pnpm|yarn|node|python3?(?:\.\d+)?|pytest|ruff|mypy|"
+        r"make|go test|cargo|bash)[^`\n]*`",
+        re.IGNORECASE,
+    )
+    return bool(command_re.search(text))
+
+
+def _has_path_signal(text: str) -> bool:
+    return bool(re.search(r"`(?:[A-Za-z0-9_.-]+/[^`\s]+|[A-Z_]+\.md)`", text))
+
+
+def _score_commands(text: str) -> AxisScore:
+    if _has_command_signal(text):
+        return AxisScore("Commands", 20, 20, "copy-paste 가능한 명령이 있습니다.")
+    if _has_section(text, "Commands"):
+        return AxisScore("Commands", 10, 20, "Commands 섹션은 있으나 실제 명령이 부족합니다.")
+    return AxisScore("Commands", 0, 20, "build/test/lint workflow 명령이 없습니다.")
+
+
+def _score_architecture(text: str) -> AxisScore:
+    has_arch = re.search(r"(?i)architecture|아키텍처|구조", text) is not None
+    has_map = re.search(r"(?i)entrypoint|boundary|module|docs/index\.md", text) is not None
+    if has_arch and has_map:
+        return AxisScore("Architecture", 20, 20, "구조와 entrypoint 단서가 있습니다.")
+    if _has_section(text, "Architecture") or has_arch:
+        return AxisScore("Architecture", 10, 20, "구조 개요는 있으나 관계 설명이 부족합니다.")
+    return AxisScore("Architecture", 0, 20, "코드베이스 구조 설명이 없습니다.")
+
+
+def _score_gotchas(text: str) -> AxisScore:
+    if re.search(r"(?i)^##\s+Gotchas\s*$|주의|함정|quirk|known issue", text, re.MULTILINE):
+        return AxisScore("Gotchas", 15, 15, "비직관적 패턴을 담을 위치가 있습니다.")
+    return AxisScore("Gotchas", 0, 15, "반복 실수와 비직관적 패턴 섹션이 없습니다.")
+
+
+def _score_conciseness(line_count: int) -> AxisScore:
+    if line_count < 200:
+        return AxisScore("Conciseness", 15, 15, "200줄 미만입니다.")
+    if line_count < 300:
+        return AxisScore("Conciseness", 10, 15, "200줄 목표를 넘었습니다.")
+    return AxisScore("Conciseness", 5, 15, "긴 파일이라 세션 준수율 저하 후보입니다.")
+
+
+def _clean_candidate(value: str) -> str:
+    out = value.strip().strip("'\"")
+    out = re.sub(r"[),.;:!?]+$", "", out)
+    out = out.split("#", 1)[0].split("?", 1)[0]
+    if out.startswith("./"):
+        out = out[2:]
+    return out
+
+
+def _should_ignore_candidate(value: str) -> bool:
+    if not value or value.startswith(("#", "/", "~", "$", "@", "-")):
+        return True
+    if re.match(r"(?i)^(https?:|mailto:|tel:|ftp:)", value):
+        return True
+    if re.search(r"[\s<>{}*]", value):
+        return True
+    return False
+
+
+def _looks_like_repo_path(value: str) -> bool:
+    if value in {"CLAUDE.md", "AGENTS.md", "README.md", "PROGRESS.md"}:
+        return True
+    return bool(re.match(r"^(?:\.github|agents|app|commands|docs|harness|hooks|lib|"
+                         r"scripts|skills|src|templates|tests)/", value))
+
+
+def _candidate_paths(text: str) -> list[str]:
+    candidates: list[str] = []
+    for match in re.finditer(r"!?\[[^\]]*\]\(([^)\n]+)\)", text):
+        candidates.append(match.group(1).split()[0])
+    for match in re.finditer(r"`([^`\n]+)`", text):
+        candidates.append(match.group(1))
+    cleaned: list[str] = []
+    for value in candidates:
+        candidate = _clean_candidate(value)
+        if _should_ignore_candidate(candidate) or not _looks_like_repo_path(candidate):
+            continue
+        cleaned.append(candidate)
+    return cleaned
+
+
+def _broken_references(repo_path: Path, text: str) -> list[str]:
+    broken: list[str] = []
+    for candidate in sorted(set(_candidate_paths(text))):
+        target = (repo_path / candidate).resolve()
+        try:
+            target.relative_to(repo_path.resolve())
+        except ValueError:
+            broken.append(candidate)
+            continue
+        if not target.exists():
+            broken.append(candidate)
+    return broken
+
+
+def _score_currency(text: str, broken_references: list[str]) -> AxisScore:
+    if broken_references:
+        return AxisScore("Currency", 5, 15, "존재하지 않는 path 참조가 있습니다.")
+    if _candidate_paths(text):
+        return AxisScore("Currency", 15, 15, "확인 가능한 path 참조가 깨지지 않았습니다.")
+    return AxisScore("Currency", 10, 15, "검증 가능한 path 참조가 적어 freshness 판단이 제한됩니다.")
+
+
+def _score_actionability(text: str) -> AxisScore:
+    has_command = _has_command_signal(text)
+    has_path = _has_path_signal(text) or bool(_candidate_paths(text))
+    if has_command and has_path:
+        return AxisScore("Actionability", 15, 15, "명령과 경로가 모두 구체적입니다.")
+    if has_command or has_path:
+        return AxisScore("Actionability", 10, 15, "구체 명령 또는 경로가 일부 있습니다.")
+    return AxisScore("Actionability", 5, 15, "실행 가능한 명령과 경로가 부족합니다.")
+
+
+def audit_claude_text(text: str, repo_path: Path, path: Optional[Path] = None) -> ClaudeAudit:
+    path = path or (repo_path / "CLAUDE.md")
+    line_count = len(text.splitlines())
+    missing_sections = [section for section in RECOMMENDED_SECTIONS if not _has_section(text, section)]
+    broken = _broken_references(repo_path, text)
+    axis_scores = [
+        _score_commands(text),
+        _score_architecture(text),
+        _score_gotchas(text),
+        _score_conciseness(line_count),
+        _score_currency(text, broken),
+        _score_actionability(text),
+    ]
+    total = sum(axis.score for axis in axis_scores)
+    candidates = _improvement_candidates(
+        axis_scores=axis_scores,
+        missing_sections=missing_sections,
+        line_count=line_count,
+        has_anchor=has_cold_start_anchor(text),
+        broken_references=broken,
+    )
+    return ClaudeAudit(
+        path=path,
+        exists=True,
+        total_score=total,
+        grade=_grade(total),
+        line_count=line_count,
+        axis_scores=axis_scores,
+        missing_sections=missing_sections,
+        has_cold_start_anchor=has_cold_start_anchor(text),
+        broken_references=broken,
+        improvement_candidates=candidates,
+    )
+
+
+def _improvement_candidates(
+    *,
+    axis_scores: list[AxisScore],
+    missing_sections: list[str],
+    line_count: int,
+    has_anchor: bool,
+    broken_references: list[str],
+) -> list[str]:
+    candidates: list[str] = []
+    if missing_sections:
+        candidates.append("권장 섹션 추가 후보: " + ", ".join(missing_sections))
+    if not has_anchor:
+        candidates.append("dcNess Cold Start 앵커 additive append 후보")
+    if line_count >= 200:
+        candidates.append("200줄 미만으로 압축 후보")
+    if broken_references:
+        candidates.append("깨진 path 참조 수정 후보: " + ", ".join(broken_references[:5]))
+    for axis in axis_scores:
+        if axis.score < axis.maximum:
+            candidates.append(f"{axis.name} {axis.score}/{axis.maximum}: {axis.note}")
+    return candidates
+
+
+def audit_claude_md_file(repo_path: Path) -> ClaudeAudit:
+    repo_path = repo_path.resolve()
+    path = repo_path / "CLAUDE.md"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return ClaudeAudit(
+            path=path,
+            exists=False,
+            total_score=0,
+            grade="F",
+            line_count=0,
+            missing_sections=list(RECOMMENDED_SECTIONS),
+            improvement_candidates=["CLAUDE.md 생성 후보"],
+        )
+    return audit_claude_text(text, repo_path, path)
+
+
+def ensure_claude_context(repo_path: Path) -> EnsureResult:
+    repo_path = repo_path.resolve()
+    path = repo_path / "CLAUDE.md"
+    actions: list[str] = []
+    if not path.exists():
+        path.write_text(build_claude_seed(repo_path), encoding="utf-8")
+        actions.append("created")
+    else:
+        text = path.read_text(encoding="utf-8")
+        if not has_cold_start_anchor(text):
+            separator = "\n" if text.endswith("\n") else "\n\n"
+            path.write_text(f"{text}{separator}{build_cold_start_anchor()}\n", encoding="utf-8")
+            actions.append("appended-cold-start")
+    if not actions:
+        actions.append("noop")
+    return EnsureResult(path=path, actions=actions, audit=audit_claude_md_file(repo_path))
+
+
+def render_claude_audit(audit: ClaudeAudit, *, actions: Optional[list[str]] = None) -> str:
+    action_text = ", ".join(actions or ["read-only"])
+    lines = [
+        "## CLAUDE.md seed/migration",
+        "",
+        f"- path: `{audit.path.name}`",
+        f"- action: {action_text}",
+        f"- score: {audit.total_score}/100 ({audit.grade})",
+        f"- lines: {audit.line_count}",
+        f"- cold-start anchor: {'present' if audit.has_cold_start_anchor else 'missing'}",
+        "",
+        "| axis | score | note |",
+        "|---|---:|---|",
+    ]
+    for axis in audit.axis_scores:
+        lines.append(f"| {axis.name} | {axis.score}/{axis.maximum} | {axis.note} |")
+    lines.append("")
+    if audit.improvement_candidates:
+        lines.append("### Improvement Candidates")
+        for candidate in audit.improvement_candidates:
+            lines.append(f"- {candidate}")
+    else:
+        lines.append("- improvement candidate 없음")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="dcness-context-docs")
+    parser.add_argument("--repo", default=".", help="target repository root")
+    parser.add_argument("--ensure", action="store_true", help="seed or append allowed safe context")
+    parser.add_argument("--audit", action="store_true", help="read-only audit")
+    args = parser.parse_args(argv)
+
+    repo_path = Path(args.repo).resolve()
+    if args.ensure:
+        result = ensure_claude_context(repo_path)
+        print(render_claude_audit(result.audit, actions=result.actions))
+        return 0
+    audit = audit_claude_md_file(repo_path)
+    print(render_claude_audit(audit))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/context_docs.py
+++ b/harness/context_docs.py
@@ -6,7 +6,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Optional
 
 
@@ -22,6 +22,42 @@ RECOMMENDED_SECTIONS = (
 )
 
 COLD_START_SECTION_TITLE = "## dcNess Cold Start"
+
+_PLAIN_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_./:-])"
+    r"((?:[A-Za-z0-9_.-]+/)+[A-Za-z0-9_.-]+\.[A-Za-z0-9][A-Za-z0-9_.-]*)"
+    r"(?![A-Za-z0-9_./-])"
+)
+
+_REPO_PATH_PREFIXES = (
+    ".github",
+    "agents",
+    "app",
+    "apps",
+    "cmd",
+    "commands",
+    "config",
+    "configs",
+    "docs",
+    "harness",
+    "hooks",
+    "infra",
+    "internal",
+    "lib",
+    "packages",
+    "pkg",
+    "scripts",
+    "services",
+    "skills",
+    "src",
+    "templates",
+    "tests",
+    "tools",
+    "web",
+)
+_REPO_PATH_PREFIX_RE = re.compile(
+    rf"^(?:{'|'.join(re.escape(prefix) for prefix in _REPO_PATH_PREFIXES)})/"
+)
 
 
 @dataclass(frozen=True)
@@ -232,6 +268,8 @@ def _should_ignore_candidate(value: str) -> bool:
         return True
     if re.match(r"(?i)^(https?:|mailto:|tel:|ftp:)", value):
         return True
+    if re.match(r"(?i)^[a-z0-9.-]+\.[a-z]{2,}/", value):
+        return True
     if re.search(r"[\s<>{}*]", value):
         return True
     return False
@@ -240,8 +278,9 @@ def _should_ignore_candidate(value: str) -> bool:
 def _looks_like_repo_path(value: str) -> bool:
     if value in {"CLAUDE.md", "AGENTS.md", "README.md", "PROGRESS.md"}:
         return True
-    return bool(re.match(r"^(?:\.github|agents|app|commands|docs|harness|hooks|lib|"
-                         r"scripts|skills|src|templates|tests)/", value))
+    if _REPO_PATH_PREFIX_RE.match(value):
+        return True
+    return "/" in value and bool(PurePosixPath(value).suffix)
 
 
 def _candidate_paths(text: str) -> list[str]:
@@ -249,6 +288,8 @@ def _candidate_paths(text: str) -> list[str]:
     for match in re.finditer(r"!?\[[^\]]*\]\(([^)\n]+)\)", text):
         candidates.append(match.group(1).split()[0])
     for match in re.finditer(r"`([^`\n]+)`", text):
+        candidates.append(match.group(1))
+    for match in _PLAIN_PATH_RE.finditer(text):
         candidates.append(match.group(1))
     cleaned: list[str] = []
     for value in candidates:

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -28,6 +28,8 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional
 
+from harness.context_docs import audit_claude_md_file
+
 # Reuse existing pricing util.
 try:
     from harness.efficiency.analyze_sessions import price_for
@@ -315,7 +317,7 @@ def audit_context_docs(
             severity="WARN",
             source=str(claude_path.relative_to(repo_path)),
             detail="프로젝트 루트에 CLAUDE.md 가 없어 세션 규칙 SSOT 를 찾을 수 없습니다.",
-            suggestion="/init-dcness 보강 또는 사용자 승인 기반 docs PR 로 CLAUDE.md 생성 후보를 검토합니다.",
+            suggestion="/init-dcness 가 공식 구조 기반 CLAUDE.md seed 를 생성할 수 있습니다.",
         ))
     elif _doc_has_placeholder(claude_text):
         findings.append(ContextAuditFinding(
@@ -325,6 +327,45 @@ def audit_context_docs(
             detail="CLAUDE.md 안에 TODO/TBD/미기록 계열 placeholder 가 남아 있습니다.",
             suggestion="placeholder 가 현재 프로젝트 규칙 공백이면 사용자 승인 후 구체 규칙으로 바꾸는 docs PR 후보입니다.",
         ))
+    if has_claude:
+        claude_audit = audit_claude_md_file(repo_path)
+        if claude_audit.missing_sections:
+            findings.append(ContextAuditFinding(
+                pattern="CLAUDE_STRUCTURE_GAP",
+                severity="CANDIDATE",
+                source="CLAUDE.md",
+                detail="공식 권장 섹션 누락: " + ", ".join(claude_audit.missing_sections),
+                suggestion="Commands / Architecture / Key Files / Code Style / Environment / Testing / Gotchas / Workflow 중 프로젝트에 필요한 섹션을 보강합니다.",
+            ))
+        if not claude_audit.has_cold_start_anchor:
+            findings.append(ContextAuditFinding(
+                pattern="CLAUDE_COLD_START_ANCHOR_MISSING",
+                severity="CANDIDATE",
+                source="CLAUDE.md",
+                detail="dcNess Cold Start 앵커가 없어 다음 작업과 live 보드 조회 경로가 세션 시작 문서에 없습니다.",
+                suggestion="/init-dcness 는 기존 내용을 변경하지 않고 앵커만 append 할 수 있습니다.",
+            ))
+        if claude_audit.total_score < 90:
+            axis_summary = ", ".join(
+                f"{axis.name} {axis.score}/{axis.maximum}"
+                for axis in claude_audit.axis_scores
+                if axis.score < axis.maximum
+            )
+            findings.append(ContextAuditFinding(
+                pattern="CLAUDE_QUALITY_GAP",
+                severity="CANDIDATE",
+                source="CLAUDE.md",
+                detail=f"CLAUDE.md quality score {claude_audit.total_score}/100 ({claude_audit.grade}); {axis_summary}",
+                suggestion="6축 rubric 결과를 보고 파괴적 재작성 없이 targeted addition 후보로 분리합니다.",
+            ))
+        if claude_audit.broken_references:
+            findings.append(ContextAuditFinding(
+                pattern="CLAUDE_STALE_REFERENCE",
+                severity="CANDIDATE",
+                source="CLAUDE.md",
+                detail="존재하지 않는 path 참조: " + ", ".join(claude_audit.broken_references[:5]),
+                suggestion="path 를 현재 파일 구조와 맞추거나 참조가 필요 없으면 사용자 승인 후 제거합니다.",
+            ))
 
     if not has_agents:
         findings.append(ContextAuditFinding(

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3731,6 +3731,15 @@ def collect_status_diagnostics(
                     f"dcNess Cold Start 앵커 없음; score={claude_audit.total_score}/100",
                     "init-dcness Core Step 6 로 기존 파일에 앵커만 append",
                 )
+            elif claude_audit.missing_sections:
+                missing = ", ".join(claude_audit.missing_sections)
+                add(
+                    "claude_context",
+                    "CLAUDE.md context",
+                    "INFO",
+                    f"권장 섹션 누락: {missing}; "
+                    f"score={claude_audit.total_score}/100 ({claude_audit.grade})",
+                )
             elif claude_audit.total_score < 90:
                 add(
                     "claude_context",

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3652,6 +3652,7 @@ def collect_status_diagnostics(
             ("whitelist", "whitelist 활성"),
             ("read_perm", "Read 권한 (~/.claude/settings.json)"),
             ("git_hooks", "git hook shim 3종"),
+            ("claude_context", "CLAUDE.md context"),
             ("codex_skills", "Codex validator skills"),
             ("ci_workflows", "선택형 CI workflow"),
         ):
@@ -3710,6 +3711,48 @@ def collect_status_diagnostics(
             ", ".join(f"{k}={v}" for k, v in codex_skills.items()),
             None if codex_all_ok else "init-dcness Core Step 5 로 Codex validator skills 재배포",
         )
+        try:
+            from harness.context_docs import audit_claude_md_file
+
+            claude_audit = audit_claude_md_file(project_root)
+            if not claude_audit.exists:
+                add(
+                    "claude_context",
+                    "CLAUDE.md context",
+                    "WARN",
+                    "CLAUDE.md 없음",
+                    "init-dcness Core Step 6 로 공식 구조 기반 CLAUDE.md seed 생성",
+                )
+            elif not claude_audit.has_cold_start_anchor:
+                add(
+                    "claude_context",
+                    "CLAUDE.md context",
+                    "WARN",
+                    f"dcNess Cold Start 앵커 없음; score={claude_audit.total_score}/100",
+                    "init-dcness Core Step 6 로 기존 파일에 앵커만 append",
+                )
+            elif claude_audit.total_score < 90:
+                add(
+                    "claude_context",
+                    "CLAUDE.md context",
+                    "INFO",
+                    f"score={claude_audit.total_score}/100 ({claude_audit.grade}); 개선 후보 있음",
+                )
+            else:
+                add(
+                    "claude_context",
+                    "CLAUDE.md context",
+                    "PASS",
+                    f"score={claude_audit.total_score}/100 ({claude_audit.grade})",
+                )
+        except Exception as exc:
+            add(
+                "claude_context",
+                "CLAUDE.md context",
+                "WARN",
+                f"진단 실패: {exc}",
+                "init-dcness Core Step 6 재실행 또는 dcness 업데이트 확인",
+            )
         # 선택형 CI workflow (선택 — INFO)
         ci = _check_ci_workflows(project_root)
         installed = [k for k, present in ci.items() if present]

--- a/scripts/dcness-context-docs
+++ b/scripts/dcness-context-docs
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# dcness-context-docs wrapper — PYTHONPATH 자동 설정 후 harness.context_docs CLI 실행.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+export PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}"
+
+exec python3 -m harness.context_docs "$@"

--- a/tests/test_context_docs.py
+++ b/tests/test_context_docs.py
@@ -75,6 +75,40 @@ class ContextDocsTests(unittest.TestCase):
             self.assertFalse(audit.has_cold_start_anchor)
             self.assertEqual(claude.read_text(encoding="utf-8"), original)
 
+    def test_audit_detects_common_monorepo_broken_paths(self) -> None:
+        from harness.context_docs import audit_claude_md_file
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            existing = root / "packages" / "core" / "existing.ts"
+            existing.parent.mkdir(parents=True)
+            existing.write_text("export const ok = true;\n", encoding="utf-8")
+            (root / "CLAUDE.md").write_text(
+                "\n".join([
+                    "# Project Instructions",
+                    "",
+                    "## Commands",
+                    "- `npm run test`",
+                    "",
+                    "## Architecture",
+                    "- packages/core/existing.ts is the module boundary.",
+                    "- packages/core/missing.ts is stale.",
+                    "",
+                    "## Gotchas",
+                    "- Keep generated files out of source.",
+                    "",
+                    COLD_START_TITLE,
+                    "- 다음 작업 후보 확인: `/next`",
+                    "",
+                ]),
+                encoding="utf-8",
+            )
+
+            audit = audit_claude_md_file(root)
+
+            self.assertIn("packages/core/missing.ts", audit.broken_references)
+            self.assertNotIn("packages/core/existing.ts", audit.broken_references)
+
     def test_cli_ensure_prints_quality_report(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_context_docs.py
+++ b/tests/test_context_docs.py
@@ -1,0 +1,96 @@
+"""CLAUDE.md seed/migration helper tests."""
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "dcness-context-docs"
+COLD_START_TITLE = "## dcNess Cold Start"
+
+
+class ContextDocsTests(unittest.TestCase):
+    def test_missing_claude_md_is_seeded_with_official_structure(self) -> None:
+        from harness.context_docs import ensure_claude_context
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+
+            result = ensure_claude_context(root)
+
+            claude = root / "CLAUDE.md"
+            self.assertTrue(claude.exists())
+            text = claude.read_text(encoding="utf-8")
+            self.assertIn("## Commands", text)
+            self.assertIn("## Architecture", text)
+            self.assertIn("## Key Files", text)
+            self.assertIn("## Code Style", text)
+            self.assertIn("## Environment", text)
+            self.assertIn("## Testing", text)
+            self.assertIn("## Gotchas", text)
+            self.assertIn("## Workflow", text)
+            self.assertIn(COLD_START_TITLE, text)
+            self.assertIn("`/next`", text)
+            self.assertIn("gh variable get DCNESS_PROJECT_NUMBER", text)
+            self.assertLess(len(text.splitlines()), 200)
+            self.assertNotRegex(text, r"TODO|TBD|<TODO>|<TBD>")
+            self.assertIn("created", result.actions)
+            self.assertGreaterEqual(result.audit.total_score, 90)
+
+    def test_existing_claude_md_gets_additive_idempotent_cold_start_anchor(self) -> None:
+        from harness.context_docs import ensure_claude_context
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            claude = root / "CLAUDE.md"
+            original = "# Existing Rules\n\n- Keep this exact content.\n"
+            claude.write_text(original, encoding="utf-8")
+
+            first = ensure_claude_context(root)
+            second = ensure_claude_context(root)
+
+            text = claude.read_text(encoding="utf-8")
+            self.assertTrue(text.startswith(original))
+            self.assertEqual(text.count(COLD_START_TITLE), 1)
+            self.assertIn("appended-cold-start", first.actions)
+            self.assertEqual(second.actions, ["noop"])
+
+    def test_audit_reports_rubric_gaps_without_mutating_existing_doc(self) -> None:
+        from harness.context_docs import audit_claude_md_file
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            claude = root / "CLAUDE.md"
+            original = "# Project Notes\n\nGeneral prose only.\n"
+            claude.write_text(original, encoding="utf-8")
+
+            audit = audit_claude_md_file(root)
+
+            self.assertLess(audit.total_score, 100)
+            self.assertIn("Commands", audit.missing_sections)
+            self.assertFalse(audit.has_cold_start_anchor)
+            self.assertEqual(claude.read_text(encoding="utf-8"), original)
+
+    def test_cli_ensure_prints_quality_report(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            proc = subprocess.run(
+                [str(SCRIPT), "--ensure", "--repo", str(root)],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertIn("## CLAUDE.md seed/migration", proc.stdout)
+            self.assertIn("score", proc.stdout)
+            self.assertTrue((root / "CLAUDE.md").exists())
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -712,7 +712,19 @@ class ContextAuditTests(unittest.TestCase):
     def test_render_report_includes_context_audit_section(self):
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
-            (tmp / "CLAUDE.md").write_text("# Rules\n", encoding="utf-8")
+            (tmp / "CLAUDE.md").write_text(
+                "# Project Instructions\n\n"
+                "## Commands\n- `python3.11 -m unittest discover -s tests -v`\n\n"
+                "## Architecture\n- Entry point and module boundary are recorded in `CLAUDE.md`.\n\n"
+                "## Key Files\n- `CLAUDE.md`: project instructions.\n\n"
+                "## Code Style\n- Keep formatter and naming rules specific.\n\n"
+                "## Environment\n- Record required runtime versions.\n\n"
+                "## Testing\n- Keep test commands copy-pasteable.\n\n"
+                "## Gotchas\n- Capture repeated mistakes and known issues.\n\n"
+                "## Workflow\n- Use `/next` before choosing follow-up work.\n\n"
+                "## dcNess Cold Start\n- 다음 작업 후보 확인: `/next`\n",
+                encoding="utf-8",
+            )
             (tmp / "AGENTS.md").write_text(
                 "작업 규칙 SSOT: [`CLAUDE.md`](CLAUDE.md)\n",
                 encoding="utf-8",
@@ -747,6 +759,28 @@ class ContextAuditTests(unittest.TestCase):
                 agents.read_text(encoding="utf-8"),
                 "# Agent Rules\n별도 규칙을 여기에 적음\n",
             )
+
+    def test_context_audit_reports_claude_quality_and_anchor_candidates(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            claude = tmp / "CLAUDE.md"
+            agents = tmp / "AGENTS.md"
+            original = "# Project Notes\n\nGeneral prose only.\n"
+            claude.write_text(original, encoding="utf-8")
+            agents.write_text("SSOT: [`CLAUDE.md`](CLAUDE.md)\n", encoding="utf-8")
+
+            findings = audit_context_docs(tmp)
+
+            self.assertTrue(
+                any(f.pattern == "CLAUDE_STRUCTURE_GAP" for f in findings)
+            )
+            self.assertTrue(
+                any(f.pattern == "CLAUDE_COLD_START_ANCHOR_MISSING" for f in findings)
+            )
+            self.assertTrue(
+                any(f.pattern == "CLAUDE_QUALITY_GAP" for f in findings)
+            )
+            self.assertEqual(claude.read_text(encoding="utf-8"), original)
 
     def test_context_audit_surfaces_run_waste_as_feedback_candidate(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -327,6 +327,46 @@ class CollectExternalRepoTests(unittest.TestCase):
             self.assertIn("missing", by_key["codex_skills"]["detail"])
             self.assertIn("Core Step 5", by_key["codex_skills"]["fix"] or "")
 
+    def test_claude_context_missing_sections_is_info_even_with_a_score(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            plugin_root = root / "plugin"
+            codex_home = root / "codex-home"
+            _write(root / "docs" / "index.md", "# Index\n")
+            _write(
+                root / "CLAUDE.md",
+                "\n".join([
+                    "# Project Instructions",
+                    "",
+                    "## Commands",
+                    "- `npm run test`",
+                    "",
+                    "## Architecture",
+                    "- docs/index.md is the entrypoint and module boundary.",
+                    "",
+                    "## Gotchas",
+                    "- Known issue records stay concise.",
+                    "",
+                    "## dcNess Cold Start",
+                    "- 다음 작업 후보 확인: `/next`",
+                    "- `docs/index.md`",
+                    "",
+                ]),
+            )
+
+            diag = collect_status_diagnostics(
+                cwd=root,
+                plugin_root=plugin_root,
+                codex_home=codex_home,
+                check_gh=False,
+                check_routing=False,
+            )
+
+            by_key = {c["key"]: c for c in diag["checks"]}
+            check = by_key["claude_context"]
+            self.assertEqual(check["status"], "INFO")
+            self.assertIn("권장 섹션 누락", check["detail"])
+
 
 class FailOpenDiagnosticsTests(unittest.TestCase):
     def test_no_recent_events_is_pass(self) -> None:

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -728,6 +728,18 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("진행 상태 섹션", self.init_doc)
         self.assertIn("진행 상태 섹션", self.init_reference)
 
+    def test_issue_885_claude_md_seed_and_audit_stays_inside_existing_surfaces(self) -> None:
+        """#885 — CLAUDE.md seed/migration and audit wire into init/run-review only."""
+        helper = "scripts/dcness-context-docs"
+        self.assertTrue((ROOT / helper).exists())
+        self.assertTrue((ROOT / "harness" / "context_docs.py").exists())
+        self.assertIn(helper, self.init_doc)
+        self.assertIn(helper, self.init_reference)
+        self.assertIn("CLAUDE.md seed/migration", self.init_doc)
+        self.assertIn("6축 quality audit", self.init_reference)
+        self.assertIn("6축 rubric", self.run_review_skill)
+        self.assertIn("cold-start 앵커", self.run_review_skill)
+
     def test_init_dcness_completion_precedes_optional_bundle(self) -> None:
         """#799 — core 활성화 완료를 먼저 선언하고 선택형 확장은 bundle 1질문으로 둔다."""
         for needle in (


### PR DESCRIPTION
## 관련 이슈 번호
Closes #885

## 배경 및 문제

활성 프로젝트는 세션 시작마다 root `CLAUDE.md`를 가장 먼저 읽지만, 기존 `/init-dcness`는 `docs/*` seed만 제공하고 root `CLAUDE.md`는 만들거나 감사하지 않았습니다. #881 이후 종료 감사는 `CLAUDE.md` 존재·placeholder·AGENTS 참조 정도만 보았고, 공식 CLAUDE.md 구조나 6축 품질 기준은 확인하지 못했습니다.

## 원인 (해당 시)

`CLAUDE.md` seed/migration/audit 기준이 공용 코드로 없어서 `/init-dcness`와 `/run-review`가 같은 품질 기준을 공유할 수 없었습니다.

## 작업내용

- `harness/context_docs.py`와 `scripts/dcness-context-docs` 추가: 공식 권장 섹션 기반 `CLAUDE.md` seed, 기존 파일 additive cold-start anchor append, 6축 quality audit, CLI report 제공.
- `/init-dcness` Core Step에 `CLAUDE.md` seed/migration 실행을 추가하고, reference inventory와 re-run matrix에 배포 경로를 기록.
- `/run-review` context audit과 `dcness-helper status`가 같은 audit 기준으로 structure gap, quality gap, cold-start anchor, stale reference 후보를 보고하도록 연결.
- seed가 새 활성 프로젝트의 doc-path gate를 깨지 않도록 실제 존재 파일만 inline path로 두고 smoke 검증 추가.

## 결정 근거

- 새 public surface를 만들지 않고 기존 `/init-dcness`와 `/run-review`에 흡수했습니다.
- 기존 `CLAUDE.md`는 재작성·삭제·재배치하지 않고, cold-start anchor만 없을 때 append합니다. 구조 개선은 후보로만 보고합니다.
- 공식 문서의 200줄 미만·구체 명령·markdown 구조 기준과 공식 `claude-md-management` 6축 rubric을 로컬 deterministic audit로 옮겼습니다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체: `harness/context_docs.py`, `scripts/dcness-context-docs`, `commands/run-review.md`는 plugin update로 배포됩니다.
- init-dcness seed/migration: `commands/init-dcness.md`가 활성 프로젝트 root `CLAUDE.md`를 생성/보강합니다. 기존 활성 프로젝트는 plugin update 후 `/init-dcness` 재실행 시 적용됩니다.
- 사용자용 SSOT: `docs/plugin/init-dcness.md`에 inventory와 re-run matrix를 갱신했습니다.
- 신규 공개 진입점은 없습니다. helper script는 `/init-dcness` 내부 실행 경로입니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v` — 1520 tests PASS
- [x] `bash scripts/check_python_tests.sh`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv-885/bin/python bash scripts/check_static_quality.sh`
- [x] `scripts/dcness-context-docs --ensure` smoke + `node scripts/check_doc_path_integrity.mjs --root <tmp>`

## 참고

- Anthropic Claude Code memory docs: https://code.claude.com/docs/en/memory
- Anthropic official `claude-md-management` rubric: https://github.com/anthropics/claude-plugins-official/blob/main/plugins/claude-md-management/skills/claude-md-improver/references/quality-criteria.md