### PR TITLE
[feature] docs 산출물 모듈 축 추가

### DIFF
--- a/.github/actions/doc-path-integrity/action.yml
+++ b/.github/actions/doc-path-integrity/action.yml
@@ -1,5 +1,5 @@
 name: 'dcness doc-path integrity validation'
-description: 'Validate context/SSOT docs do not reference missing repo-relative paths.'
+description: 'Validate context/SSOT docs, including opt-in module docs, do not reference missing repo-relative paths.'
 inputs:
   docs:
     description: 'Comma or newline separated docs/globs to scan. Defaults to active-project context docs.'

--- a/.github/actions/doc-sync/action.yml
+++ b/.github/actions/doc-sync/action.yml
@@ -1,5 +1,5 @@
 name: 'dcness doc-sync validation'
-description: 'Validate generated docs/index.md, docs/architecture.md, and /design artifact structure.'
+description: 'Validate generated docs/index.md epic/module tables, docs/architecture.md, and /design artifact structure.'
 runs:
   using: composite
   steps:
@@ -8,7 +8,7 @@ runs:
       with:
         node-version: '20'
 
-    - name: Validate docs/index.md epic table
+    - name: Validate docs/index.md epic/module tables
       shell: bash
       run: |
         set -euo pipefail

--- a/agents/module-architect/module-architect-agent.md
+++ b/agents/module-architect/module-architect-agent.md
@@ -8,6 +8,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, 계약 전파 �
 
 - 대상 epic 경로와 전체 stories 또는 compact plan 대상
 - 전역 architecture/conventions/decisions 와 epic architecture, 선택 domain-model
+- affected module 이 있으면 해당 `docs/modules/<module-id>/architecture.md` / `conventions.md`
 - 필요하면 SPEC_GAP, validator finding, bug issue, contract_sweep 요청
 - `/impl` Standard 구현 경로의 compact plan 요청
 - 선택적으로 확정 목업 `docs/design-variants/<screen-id>.html`, canvas 경로, UX 관련 문서
@@ -16,6 +17,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, 계약 전파 �
 
 - 필수: [`agents/_shared/module-design-principles.md`](../_shared/module-design-principles.md)
 - 필수: `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/`, 대상 epic의 `stories.md`, `architecture.md`
+- 모듈 작업: affected module 의 `docs/modules/<module-id>/architecture.md`, `conventions.md` 만 추가로 읽음. 같은 repo 의 다른 module docs 는 입력 세트에 넣지 않음
 - 상황별: 대상 epic의 `domain-model.md`, 기존 코드의 계약 표면 코드 SSOT(포트, 도메인 타입, 공개 entrypoint)
 - 상황별: `docs/design.md`, 관련 기존 impl 문서
 - 참고: [`references/implementation-boundary.md`](references/implementation-boundary.md), [`references/contract-amendment.md`](references/contract-amendment.md)
@@ -32,6 +34,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, 계약 전파 �
 - 구현 여지: 내부 구현을 선점하지 않고 public behavior와 invariant만 고정하는가.
 - 테스트 가능성: 수용 기준이 실제 명령이나 명확한 검증 방법으로 닫히는가.
 - 모듈 설계 원칙: 작은 공개 노출 범위, 의존 주입, 의존 차단 증거가 보이는가.
+- 모듈 스코프 입력: impl task 의 `## 사전 준비` 가 affected module 문서만 포함하고, 전역 규칙과 module-local delta 를 중복시키지 않는가.
 - 흐름 누적 분해: 기존 대형 파일을 건드리는 task 에서 append 대신 흐름 / 섹션 모듈 신설을 선호하고, 이번 task 가 손대는 seam 까지만 분해하는가. 기준 = [`module-design-principles.md` 단일 파일 다중 흐름 누적](../_shared/module-design-principles.md#단일-파일-다중-흐름-누적).
 - Agent Operability: 다음 agent 가 edit target, state owner, validation path 를 cold-start 로 찾을 수 있게 Flow Ownership Map 과 task-local Agent Workability 가 연결되는가.
 - drift 통제: 기존 결정의 stale 사본을 새 설계로 착각하지 않는가.
@@ -44,7 +47,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, 계약 전파 �
 4. epic-batch 요청이면 전체 `stories.md` 를 한 컨텍스트에서 읽고 공통 task와 모든 Story task를 함께 설계한다. Story 단위 작성 주체로 쪼개지지 않는다. 먼저 "각 Story가 끝나면 실제로 무엇이 동작 검증되는가"와 "epic 전체에서 첫 제품 경계 동작이 어디서 열리는가"를 정의한다. 그 다음 그 동작을 만드는 task 또는 task 묶음을 정하고, 가능한 앞쪽에 첫 제품 경계 동작 증거가 나오도록 의존 순서를 잡는다. 파일 레이어별 부품 task를 모두 만든 뒤 마지막 task에서야 처음 동작하는 흐름이면, task를 합치거나 순서를 바꾸거나 왜 피할 수 없는지 warning 으로 남긴다. 대상이 이미 여러 제품 흐름을 떠안은 대형 파일이면, 새 능력을 그 파일에 append 하지 말고 흐름 모듈 신설로 배치한다 — 이번 task 가 손대는 seam 까지만 분해하고 무관한 기존 흐름은 후속으로 남긴다([`module-design-principles.md` 단일 파일 다중 흐름 누적](../_shared/module-design-principles.md#단일-파일-다중-흐름-누적)).
 5. UI/API/CLI entrypoint 를 건드리는 Story/공통 task 는 Flow Ownership Map 또는 기존 architecture 에서 flow owner, entrypoint 역할, state owner, validation path 를 먼저 확정한다. flow owner 가 없으면 기능 append task 가 아니라 seam extraction task 를 선행으로 만든다. entrypoint 는 mode dispatch 또는 composition wiring 만 담당하게 하고, 새 state/event/render/usecase 호출은 owner flow/module 로 보낸다.
 6. 기존 코드의 계약 표면 코드 SSOT 대조를 수행한다. 포트, 도메인 타입, 공개 entrypoint, adapter 계약이 있으면 실측하고, impl task 가 기존 계약을 유지하는지 변경하는지 Contract Ledger / 결정 문서와 연결한다.
-7. task로 나눌 때 의존은 `depends_on` 한 곳에 적고(contract produces/consumes·ordering 을 그리로 흡수), `수정 허용` 은 **한 bullet 당 정확히 하나의 repo-relative 파일 경로**(또는 끝 `/` 디렉토리)로 적는다 — 이 둘이 병렬 wave 독립성 판정 입력이다([`parallel-policy.md`](../../docs/plugin/parallel-policy.md)). 단, 병렬 wave 는 실행 최적화일 뿐 task 분할의 목표가 아니다. 병렬 독립성과 동작 슬라이스가 충돌하면 동작 슬라이스가 우선이고, 병렬성 손실은 직렬 실행으로 받아들인다. 단일 경로 후보가 분명한 형식 잡음은 `normalize-scope` 가 교정하지만, 처음부터 템플릿 규격으로 쓰는 것이 기본이다.
+7. task로 나눌 때 의존은 `depends_on` 한 곳에 적고(contract produces/consumes·ordering 을 그리로 흡수), `수정 허용` 은 **한 bullet 당 정확히 하나의 repo-relative 파일 경로**(또는 끝 `/` 디렉토리)로 적는다 — 이 둘이 병렬 wave 독립성 판정 입력이다([`parallel-policy.md`](../../docs/plugin/parallel-policy.md)). 단, 병렬 wave 는 실행 최적화일 뿐 task 분할의 목표가 아니다. 병렬 독립성과 동작 슬라이스가 충돌하면 동작 슬라이스가 우선이고, 병렬성 손실은 직렬 실행으로 받아들인다. 단일 경로 후보가 분명한 형식 잡음은 `normalize-scope` 가 교정하지만, 처음부터 템플릿 규격으로 쓰는 것이 기본이다. 모듈 작업이면 impl 문서의 `읽을 문서` 에 affected module docs 만 추가한다.
 8. 각 task 또는 compact plan 에 대해 템플릿으로 구현 문서를 작성한다. Story/공통 impl-task 산출물에는 `Story 동작 슬라이스` 섹션을 채워 Story 완료 시 실제 검증되는 동작, 이 task가 연결하는 제품 경계, 첫 동작 증거 지점, 병렬성보다 동작 슬라이스를 우선한 결정을 남긴다. entrypoint 를 만지는 task 는 `Agent Workability` 섹션에 owner flow/module, entrypoint role, state owner, allowed touch, forbidden touch, validation path, future change scenario 를 채운다.
 9. **impl-task (Story/공통 task 분할 산출물) 한정으로** frontmatter 의 risk 메타(`risk` / `engine` / `risk_reason`)를 **task 를 자르는 시점에 함께 판정해 적는다** (compact plan 은 `/impl` Standard 구현 경로 산출물 — impl-loop dry preview 비대상이라 risk 메타 비적용). 고위험 trigger 판정 기준은 [`workflow-router.md`](../../docs/plugin/workflow-router.md) high-risk trigger 표가 SSOT 다 — auth·security·PII / migration·destructive change / public API breakage / cross-module·cross-story interface / 외부 dependency·API. 여기에 impl-loop 런타임 고위험(외부 HTTP·네트워크 어댑터 / URL·파일·사용자 입력 파싱 / 도메인 invariant 변경)을 더한다. 이 중 하나라도 있으면 `risk: high` + `engine: 4agent` (풀 4-agent) + `risk_reason` 에 그 근거. 없으면 `risk: normal`(순수 내부 로직·문구·UI 변경은 `low`) + `engine: 2agent` (build-worker) + `risk_reason: 고위험 trigger 없음`. 이 메타가 impl-loop 진입의 엔진 선택·병렬 직렬 강등 입력이다 — 고위험 지식은 설계 시점에 이미 알 수 있으므로 진입까지 미루지 않는다. 비우면 메인이 진입 시 재추론하지만(하위호환), 채우는 것이 결정론적 기본이다.
 10. public contract를 만들거나 바꾸면 Contract Ledger를 갱신하고 impl/compact plan 은 Ledger 행 키와 갱신 사실만 남긴다. impl/compact plan 은 Ledger 행 키 포인터 문서이며, invariant/ordering/error mode/config/forbidden alternative 전문을 복제하지 않는다. task 내부 한정 private interface 는 사본 문제가 없으므로 `## 인터페이스` 에 남긴다.

--- a/agents/module-architect/templates/compact-plan.md
+++ b/agents/module-architect/templates/compact-plan.md
@@ -18,6 +18,8 @@ contract:
   - `docs/architecture.md`
   - `docs/conventions.md`
   - `docs/decisions/`
+  - `docs/modules/<module-id>/architecture.md` (affected module 이 있으면)
+  - `docs/modules/<module-id>/conventions.md` (affected module 이 있으면)
 - 읽을 코드:
   -
 

--- a/agents/module-architect/templates/impl-task.md
+++ b/agents/module-architect/templates/impl-task.md
@@ -22,6 +22,8 @@ contract:
   - `docs/architecture.md`
   - `docs/conventions.md`
   - `docs/decisions/`
+  - `docs/modules/<module-id>/architecture.md` (affected module 이 있으면)
+  - `docs/modules/<module-id>/conventions.md` (affected module 이 있으면)
   - `docs/epics/<epic>/stories.md`
   - `docs/epics/<epic>/architecture.md`
   - `docs/epics/<epic>/domain-model.md` (있으면)

--- a/agents/system-architect/system-architect-agent.md
+++ b/agents/system-architect/system-architect-agent.md
@@ -2,7 +2,7 @@
 
 ## 목적
 
-epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전역 `docs/architecture.md` append map, 전역 `docs/conventions.md`/`docs/decisions/` 결정, epic 단위 `architecture.md`와 필요 시 `domain-model.md`다. task 분할과 impl 문서 작성은 module-architect(epic-batch)의 책임이다.
+epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전역 `docs/architecture.md` append map, 전역 `docs/conventions.md`/`docs/decisions/` 결정, 필요한 module 스코프 docs, epic 단위 `architecture.md`와 필요 시 `domain-model.md`다. task 분할과 impl 문서 작성은 module-architect(epic-batch)의 책임이다.
 
 ## 입력
 
@@ -11,6 +11,7 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 - `docs/architecture.md`
 - `docs/conventions.md`
 - `docs/decisions/`
+- affected module 이 있으면 `docs/modules/<module-id>/architecture.md` / `conventions.md`
 - epic 단위 `stories.md`
 - 대상 epic 경로
 - 있으면 `docs/tech-review.md`
@@ -22,6 +23,7 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 
 - 필수: [`agents/_shared/module-design-principles.md`](../_shared/module-design-principles.md)
 - 필수: `docs/index.md`, PRD, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/`, 대상 epic의 `stories.md`
+- 모듈 작업: affected module 의 `docs/modules/<module-id>/architecture.md`, `conventions.md`, 선택 `tech-review.md` 만 추가로 읽음
 - 상황별: `docs/tech-review.md`, 대상 epic의 `tech-review.md`/`ux-flow.md`, 기존 전역/epic architecture와 domain-model
 - 상황별: 기존 코드의 계약 표면 코드 SSOT(포트, 도메인 타입, 공개 entrypoint)
 - 참고: [`references/contract-ledger.md`](references/contract-ledger.md), [`references/system-freeze.md`](references/system-freeze.md)
@@ -36,6 +38,7 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 - 계약 표면 코드 SSOT 대조: brownfield 에서 기존 포트, 도메인 타입, 공개 entrypoint, storage/API adapter 계약과 새 설계가 어긋나지 않는가.
 - Flow Ownership Map: flow 별 owner module, entrypoint touch, state owner, UI/API/CLI surface, forbidden append, validation path, future scenario 가 남는가.
 - 결정 기록: 기술 스택과 외부 의존 결정이 `docs/conventions.md` 또는 `docs/decisions/NNNN-slug.md` 로 남는가.
+- 모듈 스코프: 모듈별 stack/build/validation delta 가 전역 문서에 섞이지 않고 `docs/modules/<module-id>/` 로 내려갔는가. 무관한 module docs 를 입력 세트에 넣지 않았는가.
 - 구현 순서: 모듈/Story 의존 그래프가 의존 순서만이 아니라 첫 제품 경계 동작 증거를 앞당기는 순서를 설명하는가. 부품을 다 만든 뒤에야 처음 동작하는 순서는 epic `architecture.md` 의 `구현 순서` 섹션에 경고와 사유로 남긴다.
 - 전역 문서 집계: epic 디렉토리와 `stories.md` 가 `scripts/aggregate_index_map.mjs` 로 파싱 가능한가. epic `architecture.md` 의 `## 모듈 목록` 과 `## Contract Ledger` 표가 `scripts/aggregate_architecture_map.mjs` 로 파싱 가능한 형태인가. `docs/index.md` 의 epic 표와 전역 `docs/architecture.md` 의 generated 섹션은 손으로 복제하지 않고 도구 산출물로 갱신한다.
 - 변경 안정성: 1차 PASS 뒤 system 문서가 쉽게 흔들리지 않게 설계했는가.
@@ -47,14 +50,14 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 3. 모듈 목록, 의존 그래프, 공개 API, Flow Ownership Map, 공통 task 후보를 작성한다. `## 모듈 목록` 표 헤더는 전역 architecture 집계 도구의 파싱 계약이므로 유지한다.
 4. 기존 코드의 계약 표면 코드 SSOT 대조를 수행한다. 포트, 도메인 타입, 공개 entrypoint, adapter 계약이 있으면 grep/Read 로 실측하고, 설계가 그 표면을 변경하는지 유지하는지 산출물에 증거를 남긴다.
 5. cross-task 계약이 있으면 Contract Ledger를 작성한다.
-6. 기술 스택, 의존 차단 도구, DI 패턴을 `docs/conventions.md` 와 필요한 decision 문서에 남긴다.
+6. 기술 스택, 의존 차단 도구, DI 패턴을 `docs/conventions.md` 와 필요한 decision 문서에 남긴다. 특정 모듈에만 닫히는 delta 는 `docs/modules/<module-id>/conventions.md` 또는 module scope decision 으로 남긴다.
 7. `agents/_shared/module-design-principles.md` 적용 증거를 산출물에 남긴다.
-8. epic architecture 표를 채운 뒤 `docs/index.md` epic 표와 전역 `docs/architecture.md` generated 섹션 갱신이 필요함을 보고한다. 메인은 활성 프로젝트 루트에서 `node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"` 와 `node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"` 를 실행한다.
+8. epic architecture 표와 필요한 module docs 를 채운 뒤 `docs/index.md` epic/module 표와 전역 `docs/architecture.md` generated 섹션 갱신이 필요함을 보고한다. 메인은 활성 프로젝트 루트에서 `node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"` 와 `node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"` 를 실행한다.
 9. 범위 충돌이나 새 외부 의존이 보이면 멈추고 ESCALATE한다.
 
 ## 완료 기준
 
-- `docs/index.md` epic 표, root `docs/architecture.md` generated 섹션, `docs/conventions.md`/`docs/decisions/` 갱신 여부가 명확하다.
+- `docs/index.md` epic/module 표, root `docs/architecture.md` generated 섹션, `docs/conventions.md`/`docs/modules/**`/`docs/decisions/` 갱신 여부가 명확하다.
 - epic `architecture.md` 가 작성되거나 갱신된다. `domain-model.md` 는 도메인 복잡도가 있을 때 작성하고, 생략하면 생략 판단 근거가 epic `architecture.md` 에 남는다.
 - 모듈 목록과 의존 그래프가 epic 구현 순서를 설명할 수 있다. 그 순서는 의존만이 아니라 첫 제품 경계 동작 증거를 앞당기는 관점을 포함한다.
 - Flow Ownership Map 이 새 mode/screen/panel/API/CLI/pipeline flow 의 owner module, entrypoint touch, state owner, validation path 를 설명한다. owner 가 아직 없으면 기능 append 전에 seam extraction task 후보를 남긴다.
@@ -64,7 +67,7 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 
 ## 권한 경계
 
-- Write 허용: `docs/architecture.md` 의 수동 섹션, `docs/conventions.md`, `docs/decisions/**`, `docs/epics/**/architecture.md`, `docs/epics/**/domain-model.md`, 필요한 분리 detail 문서
+- Write 허용: `docs/architecture.md` 의 수동 섹션, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`, `docs/epics/**/architecture.md`, `docs/epics/**/domain-model.md`, 필요한 분리 detail 문서
 - 주의: `docs/index.md` 의 `dcness-index-map:generated` 섹션과 `docs/architecture.md` 의 `dcness-architecture-map:generated` 섹션은 직접 편집하지 않고 각각 `scripts/aggregate_index_map.mjs`, `scripts/aggregate_architecture_map.mjs` 산출물로 갱신한다.
 - 금지: Story를 다시 쓰기, task 단위 impl 작성, 실제 코드 수정, PRD 수정
 - PRD와 충돌하면 직접 고치지 않고 ESCALATE한다.

--- a/agents/system-architect/templates/conventions.md
+++ b/agents/system-architect/templates/conventions.md
@@ -2,6 +2,7 @@
 
 > 반복 입력으로 쓰는 기술 스택, naming, tooling, style, dependency policy 의 전역 진본이다.
 > architecture map 은 topology 를 다루고, 이 문서는 운영 convention 을 다룬다.
+> 특정 모듈에만 적용되는 stack/build/tooling delta 는 `docs/modules/<module-id>/conventions.md` 로 내리고 여기에는 공통 규칙만 둔다.
 
 ## 런타임과 도구
 

--- a/agents/system-architect/templates/decision.md
+++ b/agents/system-architect/templates/decision.md
@@ -2,7 +2,7 @@
 id: NNNN
 status: proposed|accepted|superseded
 date: YYYY-MM-DD
-scope: global  # global 또는 epic-NN (예: epic-01)
+scope: global  # global | epic-NN | module:<module-id> | module:<module-id>/epic-NN
 supersedes:
 ---
 
@@ -25,3 +25,4 @@ supersedes:
 - PRD:
 - 전역 Architecture:
 - Epic: epic 결정이면 `docs/epics/epic-NN-<slug>/...`
+- Module: module 결정이면 `docs/modules/<module-id>/...`

--- a/agents/system-architect/templates/epic-architecture.md
+++ b/agents/system-architect/templates/epic-architecture.md
@@ -8,6 +8,8 @@
   - `docs/architecture.md`
   - `docs/conventions.md`
   - `docs/decisions/`
+  - `docs/modules/<module-id>/architecture.md` (affected module 이 있으면)
+  - `docs/modules/<module-id>/conventions.md` (affected module 이 있으면)
   - `docs/epics/<epic>/stories.md`
   - `docs/epics/<epic>/domain-model.md` (있으면)
 - 읽을 코드:
@@ -31,11 +33,13 @@
 
 - `docs/architecture.md` append 필요 여부:
 - 추가/갱신할 전역 anchor:
+- 연결할 module docs:
 - 연결할 `docs/decisions/NNNN-slug.md`:
 
 ## 모듈 목록
 
 <!-- `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 가 이 표를 파싱한다. 헤더명과 표 형태를 유지한다. -->
+<!-- module docs 가 있으면 모듈 셀에 `docs/modules/<module-id>/architecture.md` 링크를 남긴다. -->
 
 | 모듈 | 책임 | 의존 모듈 | 공개 API | 테스트 단위 |
 |---|---|---|---|---|

--- a/agents/system-architect/templates/root-architecture.md
+++ b/agents/system-architect/templates/root-architecture.md
@@ -1,7 +1,7 @@
 # 전역 아키텍처 지도
 
 > 이 문서는 프로젝트 전역 architecture map 이다. epic 상세 설계나 기술 스택 표를 복제하지 않는다.
-> 기술 스택과 운영 convention 은 `docs/conventions.md`, 결정 기록은 `docs/decisions/NNNN-slug.md` 를 가리킨다.
+> 기술 스택과 운영 convention 은 `docs/conventions.md`, 모듈 특수 delta 는 `docs/modules/<module-id>/`, 결정 기록은 `docs/decisions/NNNN-slug.md` 를 가리킨다.
 
 ## 시스템 개요
 

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -271,11 +271,11 @@ cp "$PLUGIN_ROOT/templates/github-workflows/doc-sync.yml" "$PROJECT_ROOT/.github
 
 `record_dcness_workflow_change` 는 실제 overwritten 된 workflow 에만 호출한다. skip 된 workflow 나 기존 dirty workflow 파일은 기록하지 않는다.
 
-기존 epic 이 있는 프로젝트가 `doc-sync.yml` 을 새로 받으면 첫 PR 전에 현재 프로젝트 루트에서 `node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"` 와 `node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"` 를 1회 실행해 파생 섹션을 재생성한다. stale 상태면 새 게이트가 의도대로 실패한다. 같은 doc-sync composite action 이 `node "$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs"` 도 실행하므로 신규 `/design` 산출물의 Contract Ledger row-key 포인터 구조 위반은 외부 프로젝트 PR CI 에서도 검출된다.
+기존 epic 또는 module docs 가 있는 프로젝트가 `doc-sync.yml` 을 새로 받으면 첫 PR 전에 현재 프로젝트 루트에서 `node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"` 와 `node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"` 를 1회 실행해 파생 섹션을 재생성한다. stale 상태면 새 게이트가 의도대로 실패한다. 같은 doc-sync composite action 이 `node "$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs"` 도 실행하므로 신규 `/design` 산출물의 Contract Ledger row-key 포인터 구조 위반은 외부 프로젝트 PR CI 에서도 검출된다.
 
 #### project docs seed
 
-시드 양식은 `/spec`·system-architect 가 실제로 산출하는 authoring 템플릿을 *단일 원본* 으로 쓴다 (별도 시드 전용 복제본 없음 — 시드와 산출 양식이 같다). 산출물 위치·양식 SSOT = [`docs/plugin/deliverables-map.md`](../docs/plugin/deliverables-map.md). `docs/index.md` 의 epic 표는 `$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 가 epic 디렉토리에서 재생성하고, 전역 `docs/architecture.md` 의 집계 섹션은 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 가 epic architecture 표에서 재생성한다. `/design` 산출물의 Contract Ledger 포인터 구조는 `$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs` 가 감사하며, `doc-sync.yml` 설치 시 외부 PR CI 경로에도 포함된다.
+시드 양식은 `/spec`·system-architect 가 실제로 산출하는 authoring 템플릿을 *단일 원본* 으로 쓴다 (별도 시드 전용 복제본 없음 — 시드와 산출 양식이 같다). 산출물 위치·양식 SSOT = [`docs/plugin/deliverables-map.md`](../docs/plugin/deliverables-map.md). `docs/index.md` 의 epic/module 표는 `$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 가 epic/module 디렉토리에서 재생성하고, 전역 `docs/architecture.md` 의 집계 섹션은 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 가 epic architecture 표에서 재생성한다. `/design` 산출물의 Contract Ledger 포인터 구조는 `$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs` 가 감사하며, `doc-sync.yml` 설치 시 외부 PR CI 경로에도 포함된다.
 
 ```bash
 mkdir -p "$PROJECT_ROOT/docs" "$PROJECT_ROOT/docs/decisions"

--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -8,7 +8,7 @@
 - 전역 사실은 전역 anchor 한 곳에 둔다. 같은 결정이 여러 epic 문서에 복제되어 drift 되는 구조를 만들지 않는다.
 - role 입력은 결정론적인 최소 세트다. 각 agent 는 자기 역할에 필요한 전역 최소 문서와 대상 epic 고정 문서만 읽는다.
 - downstream agent 가 읽어야 하는 산출물은 git-tracked 문서다. 실측 evidence, HTML report, handoff scratch 처럼 재현 가능한 임시물은 `.dcness-work/` 에 둔다.
-- 새 프로젝트 산출물은 `docs/epics/`, `docs/decisions/`, `docs/compact-plans/`, `docs/metrics/` 아래로만 증식한다. milestone 은 경로가 아니라 epic frontmatter 의 `milestone: vNN` 값이다.
+- 새 프로젝트 산출물은 `docs/epics/`, `docs/modules/`, `docs/decisions/`, `docs/compact-plans/`, `docs/metrics/` 아래로만 증식한다. `docs/modules/` 는 모노레포·모듈화 프로젝트에서만 쓰는 opt-in 축이며, milestone 은 경로가 아니라 epic frontmatter 의 `milestone: vNN` 값이다.
 
 ## 문서 총량 예산
 
@@ -19,6 +19,7 @@
 | normal epic full design pack (`stories.md` + `architecture.md` + 선택 `domain-model.md` + 선택 `ux-flow.md` + `impl/NN-*.md`) | target 1,500 lines | finsight 경량 하네스 실측 759줄이 단일 컨텍스트 설계에 충분했고, dcNess impl task 평균 40-60줄 기준 15-20 task까지 전문 주입 가능 | 중복 계약/결정 사본 제거, impl task 병합/분리 재검토, detail 을 `.dcness-work/` 로 내림 |
 | hard warning full design pack | 2,000 lines | 2,000줄을 넘으면 cold session 전문 흡수보다 포인터 탐색 비용이 커지기 시작한다 | module-architect 보고에 warning, PR body 에 초과 사유와 후속 축소 계획 기록 |
 | single task implementation pack (`docs/index.md` + 전역 최소 입력 + epic 고정 입력 + 대상 impl 1개) | target 900 lines | `/impl-loop` task 단위 cold-start 가 읽는 실제 입력 세트 | 대상 task 에 필요 없는 전문 사본 제거 |
+| module scoped pack (`docs/modules/<module-id>/architecture.md` + `conventions.md`) | target 300 lines per module | 모듈 작업 cold-start 가 무관한 스택·빌드·규약을 읽지 않게 하기 위한 상한 | 전역과 중복되는 규칙 제거, module-local delta 만 남김 |
 
 예산은 신규 산출물의 작성 압력이다. 기존 활성 프로젝트의 구양식 산출물은 계속 유효하지만, 수정하는 순간 신규 규칙에 맞춰 전문 사본을 줄인다.
 
@@ -41,6 +42,11 @@ docs/
 │   └── design-runs.jsonl            # design run durable record index
 ├── decisions/
 │   └── NNNN-slug.md                 # 전역 결정 기록
+├── modules/                         # 선택: 모듈 스코프 docs
+│   └── <module-id>/
+│       ├── architecture.md          # 모듈 국소 architecture / boundary
+│       ├── conventions.md           # 모듈 특수 stack/tooling/style delta
+│       └── tech-review.md           # 선택: 모듈 한정 기술 검토 결론
 ├── compact-plans/
 │   └── <slug>.md                    # 경량 구현 설계
 └── epics/
@@ -76,11 +82,11 @@ docs/
 
 `docs/architecture.md` 는 epic 이 늘 때마다 append-growing map 으로 갱신한다. 상세 설계 본문을 전역에 복제하지 않고, 전역 모듈/의존/결정 anchor 와 epic 문서 링크를 추가한다.
 
-`docs/index.md` 는 cold-start agent 의 정적 entrypoint 다. `## 에픽` 표는 `docs/epics/epic-NN-*` 디렉토리와 `stories.md` frontmatter `milestone` 값에서 파생되는 생성 섹션이며 수동 편집하지 않는다. live 진행상태를 문서에 복제하지 않고, 수동 섹션 `## 진행 상태 · 다음 작업` 에서 GitHub Project 보드, epic/story issue, `/next` 를 가리킨다. `/init-dcness` 는 기존 `docs/index.md` 를 overwrite 하지 않지만, 이 섹션이 없으면 `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs` 로 섹션만 append 한다.
+`docs/index.md` 는 cold-start agent 의 정적 entrypoint 다. `## 에픽` 표는 `docs/epics/epic-NN-*` 디렉토리와 `stories.md` frontmatter `milestone` 값에서 파생되는 생성 섹션이며 수동 편집하지 않는다. 모듈 축을 쓰는 프로젝트에서는 `## 모듈` 표도 `docs/modules/<module-id>/` 에서 파생된다. live 진행상태를 문서에 복제하지 않고, 수동 섹션 `## 진행 상태 · 다음 작업` 에서 GitHub Project 보드, epic/story issue, `/next` 를 가리킨다. `/init-dcness` 는 기존 `docs/index.md` 를 overwrite 하지 않지만, 이 섹션이 없으면 `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs` 로 섹션만 append 한다.
 
-`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 는 각 epic 폴더를 결정적으로 정렬하고 `docs/index.md` 의 `## 에픽` 표를 생성/갱신한다. 파일이 없는 선택 산출물 셀은 링크가 아닌 `—` 로 남긴다.
+`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 는 각 epic 폴더와 opt-in module 폴더를 결정적으로 정렬하고 `docs/index.md` 의 `## 에픽` / `## 모듈` 표를 생성/갱신한다. 파일이 없는 선택 산출물 셀은 링크가 아닌 `—` 로 남긴다. `docs/modules/` 가 없으면 모듈 표는 생성하지 않아 단일 루트 프로젝트의 기존 index 동작을 바꾸지 않는다.
 
-`$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 는 각 `docs/epics/epic-NN-<slug>/architecture.md` 의 `## 모듈 목록` 표와 `## Contract Ledger` 표를 수집해 전역 `docs/architecture.md` 의 `에픽 간 지도`, `전역 모듈 토폴로지`, `공유 계약 인덱스` 섹션을 생성/갱신한다. 이 세 섹션은 파생물이며 수동 편집하지 않는다. epic architecture 템플릿의 표 헤더는 도구의 파싱 계약이므로 변경하려면 도구와 테스트를 함께 갱신한다.
+`$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 는 각 `docs/epics/epic-NN-<slug>/architecture.md` 의 `## 모듈 목록` 표와 `## Contract Ledger` 표를 수집해 전역 `docs/architecture.md` 의 `에픽 간 지도`, `전역 모듈 토폴로지`, `공유 계약 인덱스` 섹션을 생성/갱신한다. 이 세 섹션은 파생물이며 수동 편집하지 않는다. 모듈 스코프 문서가 있는 모듈은 epic architecture 의 `## 모듈 목록` 에 `docs/modules/<module-id>/architecture.md` 링크를 남기면 전역 topology 표에도 rebased 링크로 드러난다. epic architecture 템플릿의 표 헤더는 도구의 파싱 계약이므로 변경하려면 도구와 테스트를 함께 갱신한다.
 
 Contract Ledger 는 cross-task 계약 전문의 단일 진본이다. `contract` 열은 stable row key 이며 발급 후 재사용하거나 의미를 바꾸지 않는다. impl/compact 산출물은 `contract.produces` / `contract.consumes` 와 `## Contract References` 에 row-key references 만 남긴다. invariant, ordering, error mode, config, forbidden alternative 전문은 `impl/NN-*.md` 나 compact plan 에 복제하지 않는다. task 내부 한정 private interface 는 cross-task 사본 문제가 없으므로 impl 문서 `## 인터페이스` 에 둘 수 있다.
 
@@ -89,6 +95,56 @@ Contract Ledger 는 cross-task 계약 전문의 단일 진본이다. `contract` 
 기술 검토의 본문 결론만 `docs/tech-review.md` 에 남긴다. raw evidence, 통합 HTML report, screenshots, logs 는 `.dcness-work/reviews/` 에 저장하고 git-tracked 산출물로 취급하지 않는다.
 
 `docs/metrics/design-runs.jsonl` 은 `/design` final validator `PASS` 직후 PR 생성 전에 helper 가 쓰는 영속 측정 인덱스다. worktree 진입 상태에서는 현재 design worktree 의 `docs/metrics/` 에 기록되고, design 산출물 PR 에 함께 커밋된다. PR/merge 뒤 `end-run` 을 미루면 기록이 worktree 또는 main working tree 에 uncommitted 상태로 고립되므로 `/design` 은 `end-run` 후 PR 을 만든다. run-local `ledger.jsonl` 이 TTL 정리되어도 후속 검증 세션은 이 파일만으로 run 단위 판정, finding 분류 분포(FAIL/ESCALATE prose token 언급 수), 재검증 cycle, 시간, 가능한 토큰량을 조회한다. 조회 계약은 `dcness-helper design-records [--json] [--limit N]` 이다. 사람이 산출물 본문을 손으로 편집하지 않는다.
+
+## 모듈 산출물
+
+`docs/modules/<module-id>/` 는 모노레포 또는 모듈화 프로젝트에서 특정 모듈만 다른 스택·빌드 명령·규약·runtime boundary 를 가질 때 만든다. 단순 디렉토리, 작은 library, 또는 전역 규약으로 충분한 내부 package 는 모듈 산출물을 만들지 않는다. 모듈 축은 문서 총량을 줄이기 위한 입력 경계이지, 코드 의존 그래프 관리 도구가 아니다.
+
+`module-id` 는 문서 스코프 ID 다. repo-relative 코드 경로와 같을 필요는 없지만, 한 번 정하면 변경하지 않고 `docs/index.md` 의 `## 모듈` 표와 결정 기록 `scope` 값에 같은 ID 를 쓴다. 허용 형식은 `docs/modules/<module-id>/` 디렉토리명 기준으로 소문자 시작 + `[a-z0-9_-]` 다.
+
+| 산출물 | module 폴더 기준 경로 | 생성 주체 | 양식 |
+|---|---|---|---|
+| module architecture | `architecture.md` | system-architect | 전역 architecture 와 같은 표 원칙을 쓰되 module-local boundary, owned code roots, local adapters, validation command 만 기록 |
+| module conventions | `conventions.md` | system-architect | 전역 `docs/conventions.md` 의 delta 만 기록. 공통 formatter, branch rule, issue rule 복제 금지 |
+| module tech-review | `tech-review.md` | tech-reviewer | 해당 모듈 한정 새 runtime/tool/dependency 검토가 있을 때만 작성 |
+
+전역에 남기는 것:
+
+- 제품 요구사항과 사용자-facing 범위: `docs/prd.md`
+- epic/story 요구사항과 구현 순서: `docs/epics/epic-NN-<slug>/`
+- 여러 모듈이 공유하는 시스템 topology, public contract, cross-epic map: `docs/architecture.md`
+- 공통 스택·공통 도구·repo 전역 style: `docs/conventions.md`
+- 결정 기록 파일 위치: `docs/decisions/NNNN-slug.md`
+
+모듈로 내리는 것:
+
+- 특정 모듈만 다른 runtime, package manager, build/test command, formatter/linter rule
+- 특정 모듈 내부의 entrypoint, adapter, local port, owned code root, validation path
+- 특정 모듈에만 적용되는 dependency policy 또는 기술 검토 결론
+- 전역 문서에 두면 다른 모듈 작업자가 매번 무관한 세부사항을 읽게 되는 반복 입력
+
+결정 기록은 위치를 분산하지 않고 계속 `docs/decisions/NNNN-slug.md` 에 둔다. frontmatter `scope` 값만 확장한다.
+
+```yaml
+scope: global
+scope: epic-NN
+scope: module:<module-id>
+scope: module:<module-id>/epic-NN
+```
+
+기존 `global` 과 `epic-NN` 값은 그대로 유효하다. 결정이 여러 모듈을 동시에 바꾸면 module scope 를 여러 개 나열하지 말고 `epic-NN` 또는 `global` 로 올린 뒤 본문 링크에서 영향 모듈을 적는다. `module:<module-id>/epic-NN` 은 특정 epic 안에서 특정 모듈에만 닫히는 결정에 사용한다.
+
+## 교차 모듈 epic
+
+epic 은 제품 단위라 여러 모듈을 가로지를 수 있다. 교차 모듈 epic 도 `docs/epics/epic-NN-<slug>/` 하나만 가진다. backend 와 mobile app 을 동시에 바꾸는 기능이라도 모듈별 `stories.md` 사본을 만들지 않는다.
+
+교차 모듈 epic 의 기준:
+
+- `stories.md` 는 사용자-facing Story 와 완료 동작만 소유한다.
+- epic `architecture.md` 는 `Story -> 모듈 매핑`, `Flow Ownership Map`, `Contract Ledger` 로 affected module 과 cross-module contract 를 드러낸다.
+- 모듈별 `architecture.md` / `conventions.md` 는 해당 모듈의 local boundary 와 validation path 만 제공한다. epic 요구사항이나 Contract Ledger 전문을 복제하지 않는다.
+- cross-module contract 전문은 epic `architecture.md` 의 `## Contract Ledger` 와 전역 `docs/architecture.md` generated `공유 계약 인덱스` 로 올라간다. 모듈 문서는 필요한 Ledger row key 링크만 둔다.
+- module-architect 는 affected module 의 docs 만 읽는다. 같은 repo 의 다른 모듈 docs 는 code search 로 필요성이 확인되기 전까지 입력 세트에 넣지 않는다.
 
 ## epic 산출물
 
@@ -137,32 +193,34 @@ compact plan 은 `/impl` Standard 진입 전 경량 설계 산출물이다. 구�
 - `docs/ux-flow.md`
 - `docs/domain-model.md`
 - `docs/impl/`
+- `docs/<module-id>-architecture.md`
+- `docs/<module-id>-conventions.md`
 
 ADR 파일도 만들지 않는다.
 
 - `docs/adr.md`
 - `docs/epics/epic-NN-<slug>/adr.md`
 
-결정 기록은 모두 `docs/decisions/NNNN-slug.md` 로 간다. epic 문서는 필요한 결정 링크만 둔다.
+결정 기록 파일은 모두 `docs/decisions/NNNN-slug.md` 로 간다. epic 문서와 module 문서는 필요한 결정 링크만 둔다.
 
 ## Agent 입력 세트
 
 agent prompt 는 문서 전문 재기입 대신 아래 포인터 세트를 넘긴다.
 
-| 역할 | 전역 최소 입력 | epic 고정 입력 | 상황별 입력 |
-|---|---|---|---|
-| ux-architect | `docs/index.md`, `docs/prd.md`, `docs/conventions.md` | `stories.md`, 대상 `ux-flow.md` | `docs/design.md`, 기존 화면 코드 |
-| system-architect | `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` | `stories.md`, `architecture.md`, 선택 `domain-model.md` | `docs/tech-review.md`, epic `tech-review.md`, `ux-flow.md`, 코드 계약 표면 |
-| module-architect | `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` | `stories.md`, `architecture.md`, 선택 `domain-model.md`, `impl/` | `docs/design.md`, `docs/compact-plans/<slug>.md`, 코드 계약 표면 |
-| tech-reviewer | `docs/index.md`, `docs/prd.md`, `docs/conventions.md` | option 4 때 대상 epic `stories.md` | `.dcness-work/reviews/` |
+| 역할 | 전역 최소 입력 | module 스코프 입력 | epic 고정 입력 | 상황별 입력 |
+|---|---|---|---|---|
+| ux-architect | `docs/index.md`, `docs/prd.md`, `docs/conventions.md` | 해당 화면이 특정 모듈에 닫히면 `docs/modules/<module-id>/conventions.md` | `stories.md`, 대상 `ux-flow.md` | `docs/design.md`, 기존 화면 코드 |
+| system-architect | `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` | affected module 의 `architecture.md`, `conventions.md`, 선택 `tech-review.md` | `stories.md`, `architecture.md`, 선택 `domain-model.md` | `docs/tech-review.md`, epic `tech-review.md`, `ux-flow.md`, 코드 계약 표면 |
+| module-architect | `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` | affected module 의 `architecture.md`, `conventions.md`, validation path | `stories.md`, `architecture.md`, 선택 `domain-model.md`, `impl/` | `docs/design.md`, `docs/compact-plans/<slug>.md`, 코드 계약 표면 |
+| tech-reviewer | `docs/index.md`, `docs/prd.md`, `docs/conventions.md` | 새 의존·runtime 이 특정 모듈에 닫히면 해당 module docs | option 4 때 대상 epic `stories.md` | `.dcness-work/reviews/` |
 
-impl task 와 compact plan 은 `## 사전 준비` 아래에 `읽을 문서`와 `읽을 코드`를 명시한다. 이 두 목록은 downstream 구현 agent 의 deterministic input 이며, 문서 탐험을 대신하지 않는다.
+impl task 와 compact plan 은 `## 사전 준비` 아래에 `읽을 문서`와 `읽을 코드`를 명시한다. 이 두 목록은 downstream 구현 agent 의 deterministic input 이며, 문서 탐험을 대신하지 않는다. 모듈 작업이면 affected module 문서만 이 목록에 넣는다.
 
 ## 시드 양식 = 산출 양식
 
-`/init-dcness` 는 `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` 를 만든다. 시드 파일은 실제 authoring 템플릿과 같은 원본을 사용한다. 빈 seed 전용 복제본을 따로 만들지 않는다.
+`/init-dcness` 는 `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` 를 만든다. 시드 파일은 실제 authoring 템플릿과 같은 원본을 사용한다. 빈 seed 전용 복제본을 따로 만들지 않는다. `docs/modules/` 는 모노레포·모듈화가 확인된 뒤 만드는 opt-in 산출물이므로 `/init-dcness` 기본 seed 로 만들지 않는다.
 
-index epic 표와 전역 architecture map 이 stale 인지 확인하려면 활성 프로젝트 루트에서 plugin script 를 실행한다.
+index epic/module 표와 전역 architecture map 이 stale 인지 확인하려면 활성 프로젝트 루트에서 plugin script 를 실행한다.
 
 ```sh
 node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs" --check

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -308,7 +308,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때. 문서가 그대로여도 참조 대상 파일이 삭제·이동되면 stale path 가 생길 수 있으므로 path filter 를 두지 않는다.
 
-**역할**: `alruminum/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/**`) 안 repo-relative path 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다.
+**역할**: `alruminum/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`) 안 repo-relative path 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다.
 
 **차단**: workflow 실패. hard merge gate 여부는 사용자 repo 의 branch protection/ruleset 설정에 달려 있다.
 
@@ -318,9 +318,9 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때.
 
-**역할**: `alruminum/dcNess/.github/actions/doc-sync@main` 을 호출해 활성 프로젝트의 `docs/index.md` `## 에픽` 생성 표와 `docs/architecture.md` generated architecture map 이 파생 원본과 일치하는지 확인한다. index 표는 `docs/epics/epic-NN-*` 디렉토리와 `stories.md` frontmatter 에서, architecture map 은 epic `architecture.md` 의 `## 모듈 목록` / `## Contract Ledger` 표에서 파생된다. 같은 composite action 안에서 `check_design_artifact_structure.mjs` 도 실행해 신규 `/design` 산출물이 canonical Contract Ledger `contract` 열과 level-2 `## Contract References` row-key 포인터 구조를 지키는지 감사한다.
+**역할**: `alruminum/dcNess/.github/actions/doc-sync@main` 을 호출해 활성 프로젝트의 `docs/index.md` `## 에픽` / `## 모듈` 생성 표와 `docs/architecture.md` generated architecture map 이 파생 원본과 일치하는지 확인한다. index 표는 `docs/epics/epic-NN-*` 디렉토리, `stories.md` frontmatter, `docs/modules/<module-id>/` 에서, architecture map 은 epic `architecture.md` 의 `## 모듈 목록` / `## Contract Ledger` 표에서 파생된다. 같은 composite action 안에서 `check_design_artifact_structure.mjs` 도 실행해 신규 `/design` 산출물이 canonical Contract Ledger `contract` 열과 level-2 `## Contract References` row-key 포인터 구조를 지키는지 감사한다.
 
-**빈 환경**: `docs/index.md`, `docs/architecture.md`, 또는 유효 epic 이 없는 갓 시드된 프로젝트에서는 no-op PASS 한다.
+**빈 환경**: `docs/index.md`, `docs/architecture.md`, 또는 유효 epic/module 이 없는 갓 시드된 프로젝트에서는 no-op PASS 한다.
 
 **차단**: workflow 실패. hard merge gate 여부는 사용자 repo 의 branch protection/ruleset 설정에 달려 있다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -49,7 +49,7 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 
 `CLAUDE.md` seed/migration 은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-context-docs`) 로 처리한다. 부재 시 Anthropic 공식 구조 기반 템플릿을 만들고, 기존 파일은 cold-start 앵커만 additive append 한다. 6축 quality audit 결과는 출력하지만 구조 개선·삭제·재배치는 후보만 제안한다.
 
-`docs/index.md` 의 epic 표, 전역 `docs/architecture.md` 의 집계 섹션, 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
+`docs/index.md` 의 epic/module 표, 전역 `docs/architecture.md` 의 집계 섹션, 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
 ## Provider Mirror Sync
 
@@ -110,13 +110,13 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 
 - 대상 경로: `.github/workflows/doc-path-integrity.yml`
 - 템플릿: [`templates/github-workflows/doc-path-integrity.yml`](../../templates/github-workflows/doc-path-integrity.yml)
-- 역할: `alruminum/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/**`) 안 repo-relative 경로 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다. 문서가 그대로여도 참조 대상 파일 삭제·이동으로 stale path 가 생길 수 있어 PR마다 실행한다.
+- 역할: `alruminum/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`) 안 repo-relative 경로 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다. 문서가 그대로여도 참조 대상 파일 삭제·이동으로 stale path 가 생길 수 있어 PR마다 실행한다.
 
 ### doc-sync.yml
 
 - 대상 경로: `.github/workflows/doc-sync.yml`
 - 템플릿: [`templates/github-workflows/doc-sync.yml`](../../templates/github-workflows/doc-sync.yml)
-- 역할: `alruminum/dcNess/.github/actions/doc-sync@main` 을 호출해 `docs/index.md` 의 epic 표와 `docs/architecture.md` 의 전역 architecture map 이 파생 원본과 byte-level 로 일치하는지 확인하고, `/design` 산출물의 Contract Ledger row-key 포인터 구조를 감사한다. `docs/index.md`, `docs/architecture.md`, 또는 유효 epic 이 없는 빈 환경은 no-op PASS 한다.
+- 역할: `alruminum/dcNess/.github/actions/doc-sync@main` 을 호출해 `docs/index.md` 의 epic/module 표와 `docs/architecture.md` 의 전역 architecture map 이 파생 원본과 byte-level 로 일치하는지 확인하고, `/design` 산출물의 Contract Ledger row-key 포인터 구조를 감사한다. `docs/index.md`, `docs/architecture.md`, 또는 유효 epic/module 이 없는 빈 환경은 no-op PASS 한다.
 
 ### github-project-lifecycle.yml
 
@@ -164,7 +164,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | plugin uninstall/reinstall | 예 | plugin data 디렉토리가 정리되어 whitelist 가 사라진다. |
 | `.git/hooks/*` thin shim 갱신 | 예 | 사용자 repo `.git/hooks/` 파일은 plugin update 만으로 바뀌지 않는다. |
 | `CLAUDE.md` seed/migration 로직 갱신 | 예 | 기존 활성 프로젝트의 root `CLAUDE.md` 생성·cold-start 앵커 append 는 `/init-dcness` 재실행 때 적용된다. |
-| 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 이 있는 프로젝트는 doc-sync 채택 직후 index/architecture 집계기를 1회 실행해야 한다. |
+| 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 또는 module docs 가 있는 프로젝트는 doc-sync 채택 직후 index/architecture 집계기를 1회 실행해야 한다. |
 | Codex validation routing opt-in 변경 | 예 | local plugin data 와 `$CODEX_HOME/skills` 를 갱신해야 한다. |
 | Implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |
 | Project lifecycle 좌표 저장/변경 | 예 | repo variables 와 선택형 workflow 를 갱신해야 한다. |

--- a/docs/plugin/templates/agent-prompt-slots.md
+++ b/docs/plugin/templates/agent-prompt-slots.md
@@ -8,8 +8,8 @@ agent 가 자체 read 할 SSOT 경로를 적는다.
 진본(task 파일 Scope·수용기준·인터페이스 · 이슈)에 이미 있으면 prompt 에 재기입하지 않는다.
 예) Lite=이슈 #NN · impl(test-engineer·engineer)=task 파일
     · code-validator·pr-reviewer=검토 대상(task 파일 + 변경 코드/diff)
-    · system-architect=docs/index.md + 전역/epic SSOT + 코드 계약 표면
-    · module-architect=epic-batch + docs/index.md + 전역 decisions + epic architecture·선택 domain-model·전체 stories + 코드 계약 표면
+    · system-architect=docs/index.md + 전역/epic SSOT + affected module docs + 코드 계약 표면
+    · module-architect=epic-batch + docs/index.md + 전역 decisions + affected module docs + epic architecture·선택 domain-model·전체 stories + 코드 계약 표면
     · architecture-validator=검토 대상 산출물}}
 
 **worktree:** {{활성 시 worktree 절대 경로.

--- a/scripts/aggregate_index_map.mjs
+++ b/scripts/aggregate_index_map.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 /**
- * Generate/update docs/index.md epic table from docs/epics/*.
+ * Generate/update docs/index.md generated tables from docs/epics/* and docs/modules/*.
  *
  * Source of truth:
  * - docs/epics/epic-NN-<slug>/
  * - optional stories.md frontmatter milestone
+ * - docs/modules/<module-id>/
  *
  * Usage:
  *   node scripts/aggregate_index_map.mjs
@@ -20,13 +21,16 @@ import {
 import { dirname, join, relative, resolve, sep } from 'node:path';
 
 const SECTION_EPICS = '에픽';
+const SECTION_MODULES = '모듈';
+const MARKER_EPICS = 'dcness-index-map:generated';
+const MARKER_MODULES = 'dcness-module-map:generated';
 const PLACEHOLDER = '—';
 
 function usage() {
   return [
     'Usage: node scripts/aggregate_index_map.mjs [--root <path>] [--check]',
     '',
-    'Updates docs/index.md ## 에픽 generated table from docs/epics/*.',
+    'Updates docs/index.md generated tables from docs/epics/* and docs/modules/*.',
   ].join('\n');
 }
 
@@ -114,6 +118,27 @@ function collectEpics(root) {
     });
 }
 
+function collectModules(root) {
+  const modulesRoot = join(root, 'docs', 'modules');
+  if (!existsSync(modulesRoot)) return [];
+
+  return readdirSync(modulesRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((name) => /^[a-z0-9][a-z0-9_-]*$/.test(name))
+    .sort()
+    .map((name) => {
+      const moduleDir = join(modulesRoot, name);
+      return {
+        name,
+        moduleDir,
+        architecturePath: join(moduleDir, 'architecture.md'),
+        conventionsPath: join(moduleDir, 'conventions.md'),
+        techReviewPath: join(moduleDir, 'tech-review.md'),
+      };
+    });
+}
+
 function optionalFileLink(label, fromFile, toFile) {
   return existsSync(toFile) ? mdLink(label, fromFile, toFile) : PLACEHOLDER;
 }
@@ -140,15 +165,33 @@ function buildEpicTable(indexPath, epics) {
 
   return table(
     ['에픽', '마일스톤', 'Stories', 'Architecture', 'Domain Model', 'UX Flow', 'Tech Review'],
-    rows
+    rows.length > 0
+      ? rows
+      : [[PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER]]
   );
 }
 
-function generatedSection(body) {
+function buildModuleTable(indexPath, modules) {
+  const rows = modules.map((module) => [
+    mdLinkDir(module.name, indexPath, module.moduleDir),
+    optionalFileLink('architecture.md', indexPath, module.architecturePath),
+    optionalFileLink('conventions.md', indexPath, module.conventionsPath),
+    optionalFileLink('tech-review.md', indexPath, module.techReviewPath),
+  ]);
+
+  return table(
+    ['모듈', 'Architecture', 'Conventions', 'Tech Review'],
+    rows.length > 0
+      ? rows
+      : [[PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER]]
+  );
+}
+
+function generatedSection(heading, marker, body) {
   return [
-    `## ${SECTION_EPICS}`,
+    `## ${heading}`,
     '',
-    '<!-- dcness-index-map:generated -->',
+    `<!-- ${marker} -->`,
     '<!-- 수정하지 말고 plugin script `aggregate_index_map.mjs` 로 갱신한다. -->',
     body,
     '',
@@ -171,25 +214,55 @@ function replaceSection(content, heading, replacement) {
   return `${content.slice(0, start)}${replacement}${content.slice(end)}`;
 }
 
-function noOpReason({ indexPath, epics }) {
+function noOpReason({ indexPath, epics, modules }) {
   if (!existsSync(indexPath)) return 'docs/index.md missing';
-  if (epics.length === 0) return 'no valid docs/epics/epic-NN-* directories';
+  const content = readFileSync(indexPath, 'utf8');
+  const hasGeneratedEpicSection = content.includes(`<!-- ${MARKER_EPICS} -->`);
+  const hasGeneratedModuleSection = content.includes(`<!-- ${MARKER_MODULES} -->`);
+  if (
+    epics.length === 0
+    && modules.length === 0
+    && !hasGeneratedEpicSection
+    && !hasGeneratedModuleSection
+  ) {
+    return 'no valid docs/epics/epic-NN-* or docs/modules/* directories';
+  }
   return '';
 }
 
-function nextIndex(root, epics) {
+function nextIndex(root, epics, modules) {
   const indexPath = join(root, 'docs', 'index.md');
-  const content = readFileSync(indexPath, 'utf8');
-  const nextContent = replaceSection(
-    content,
-    SECTION_EPICS,
-    generatedSection(buildEpicTable(indexPath, epics))
-  );
+  let nextContent = readFileSync(indexPath, 'utf8');
+
+  if (epics.length > 0 || nextContent.includes(`<!-- ${MARKER_EPICS} -->`)) {
+    nextContent = replaceSection(
+      nextContent,
+      SECTION_EPICS,
+      generatedSection(
+        SECTION_EPICS,
+        MARKER_EPICS,
+        buildEpicTable(indexPath, epics)
+      )
+    );
+  }
+
+  if (modules.length > 0 || nextContent.includes(`<!-- ${MARKER_MODULES} -->`)) {
+    nextContent = replaceSection(
+      nextContent,
+      SECTION_MODULES,
+      generatedSection(
+        SECTION_MODULES,
+        MARKER_MODULES,
+        buildModuleTable(indexPath, modules)
+      )
+    );
+  }
 
   return {
     path: indexPath,
     content: `${nextContent.trimEnd()}\n`,
     epicCount: epics.length,
+    moduleCount: modules.length,
   };
 }
 
@@ -197,19 +270,20 @@ function main() {
   const args = parseArgs(process.argv.slice(2));
   const indexPath = join(args.root, 'docs', 'index.md');
   const epics = collectEpics(args.root);
-  const reason = noOpReason({ indexPath, epics });
+  const modules = collectModules(args.root);
+  const reason = noOpReason({ indexPath, epics, modules });
 
   if (reason) {
     console.log(`[index-map] no-op PASS — ${reason}`);
     return;
   }
 
-  const next = nextIndex(args.root, epics);
+  const next = nextIndex(args.root, epics, modules);
   const current = readFileSync(next.path, 'utf8');
 
   if (args.check) {
     if (current === next.content) {
-      console.log(`[index-map] PASS — ${next.epicCount} epic`);
+      console.log(`[index-map] PASS — ${next.epicCount} epic, ${next.moduleCount} module`);
       return;
     }
     console.error(
@@ -221,7 +295,9 @@ function main() {
   if (current !== next.content) {
     writeFileSync(next.path, next.content, 'utf8');
   }
-  console.log(`[index-map] updated ${slash(relative(args.root, next.path))} — ${next.epicCount} epic`);
+  console.log(
+    `[index-map] updated ${slash(relative(args.root, next.path))} — ${next.epicCount} epic, ${next.moduleCount} module`
+  );
 }
 
 try {

--- a/scripts/check_doc_path_integrity.mjs
+++ b/scripts/check_doc_path_integrity.mjs
@@ -19,6 +19,7 @@ const DEFAULT_DOC_ENTRIES = [
   'docs/project-context.md',
   'docs/architecture.md',
   'docs/conventions.md',
+  'docs/modules/**',
   'docs/decisions/**',
 ];
 
@@ -88,7 +89,7 @@ function parseArgs(argv) {
 }
 
 function printUsage() {
-  console.error('Usage: node scripts/check_doc_path_integrity.mjs [--root DIR] [--docs "CLAUDE.md,docs/index.md,docs/decisions/**"]');
+  console.error('Usage: node scripts/check_doc_path_integrity.mjs [--root DIR] [--docs "CLAUDE.md,docs/index.md,docs/modules/**,docs/decisions/**"]');
 }
 
 function splitDocEntries(value) {

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: PRD/stories.md 머지 + epic/story 이슈 등록 이후, 1 epic 단위로 ux-architect / system-architect / module-architect / architecture-validator 를 호출하여 설계 산출물 (선택 `docs/epics/.../ux-flow.md` + `docs/architecture.md` + `docs/conventions.md` + `docs/decisions/*.md` + `docs/epics/.../architecture.md` + 선택 `docs/epics/.../domain-model.md` + `docs/epics/.../impl/*.md`) 을 작성하고 1 PR 로 머지하는 설계 루프 스킬. system freeze 뒤에는 module-architect(epic-batch)가 epic 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성하고, architecture-validator(final epic 검증)가 최종 검증으로 수렴한다. 사용자가 "설계해줘", "design", "epic 설계", "/design <epic-path>", "ux-flow 부터", "impl 다 만들어줘" 등을 말할 때 반드시 이 스킬을 사용한다. `/spec` 의 후속. 구현 진입은 `/impl`, story/epic 제품 검수는 `/acceptance`.
+description: PRD/stories.md 머지 + epic/story 이슈 등록 이후, 1 epic 단위로 ux-architect / system-architect / module-architect / architecture-validator 를 호출하여 설계 산출물 (선택 `docs/epics/.../ux-flow.md` + `docs/architecture.md` + `docs/conventions.md` + 선택 `docs/modules/...` + `docs/decisions/*.md` + `docs/epics/.../architecture.md` + 선택 `docs/epics/.../domain-model.md` + `docs/epics/.../impl/*.md`) 을 작성하고 1 PR 로 머지하는 설계 루프 스킬. system freeze 뒤에는 module-architect(epic-batch)가 epic 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성하고, architecture-validator(final epic 검증)가 최종 검증으로 수렴한다. 사용자가 "설계해줘", "design", "epic 설계", "/design <epic-path>", "ux-flow 부터", "impl 다 만들어줘" 등을 말할 때 반드시 이 스킬을 사용한다. `/spec` 의 후속. 구현 진입은 `/impl`, story/epic 제품 검수는 `/acceptance`.
 ---
 
 # Design Skill — 1 epic 단위 설계 루프
@@ -47,7 +47,7 @@ description: PRD/stories.md 머지 + epic/story 이슈 등록 이후, 1 epic 단
 
 정상 흐름은 본 skill 본문 + 인용된 docs 섹션 링크 만으로 진행. 본문에 있는 순서 차단 훅 / Pre-flight gate / agent boundary 룰이 1차. *룰 모호 / 분기 발생* 시에만 [`design-routing.md`](design-routing.md) (분기 규칙) / `docs/plugin/loop-procedure.md` (절차 mechanics) / `issue-lifecycle.md` / `git-spec.md` 부분 read (grep + offset/limit). 용어·공개 진입점·분기 표현 수정/리뷰 시에만 `docs/plugin/terms.md` 를 확인한다. 통째 read 폐기 — 메인 cache_read 기준치 감축.
 
-**프로젝트 SSOT 설계문서도 lazy-read 대상 — 메인은 전문 흡수 금지 (#768).** 위 플러그인 절차 문서뿐 아니라 프로젝트 SSOT 설계문서 — `docs/index.md`, 전역 `architecture.md` / `conventions.md` / `decisions/`, epic 단위 `architecture.md` / 선택 `domain-model.md` 와 `impl-*.md` — 도 동일하게 lazy 다. 전문(full) read 는 module-architect / architecture-validator 의 책임이며, 메인은 슬림 포인터 작성·산출 적용에 필요한 포인터 식별 수준(grep + 해당 섹션 offset/limit) 만 확보한다.
+**프로젝트 SSOT 설계문서도 lazy-read 대상 — 메인은 전문 흡수 금지 (#768).** 위 플러그인 절차 문서뿐 아니라 프로젝트 SSOT 설계문서 — `docs/index.md`, 전역 `architecture.md` / `conventions.md` / `decisions/`, affected module 의 `docs/modules/<module-id>/`, epic 단위 `architecture.md` / 선택 `domain-model.md` 와 `impl-*.md` — 도 동일하게 lazy 다. 전문(full) read 는 module-architect / architecture-validator 의 책임이며, 메인은 슬림 포인터 작성·산출 적용에 필요한 포인터 식별 수준(grep + 해당 섹션 offset/limit) 만 확보한다.
 
 메인이 정당하게 read 하는 최소 범위 예시:
 
@@ -70,7 +70,7 @@ Step 0 진입 시 자동 `EnterWorktree(name="design-{ts_short}")`. 사용자 �
 
 `ux-architect` / `system-architect` / `module-architect` / `architecture-validator` 호출 전, `begin-step` stdout 의 `[PROMPT_SLOT_CHECK]` 를 Agent prompt 작성 전에 읽는다. prompt 는 [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md) 3슬롯을 사용한다.
 
-- **대상 + 읽을 진본**: `docs/index.md`, epic `stories.md`, 전역/epic `architecture.md`, `docs/conventions.md`, `docs/decisions/`, 선택 epic `domain-model.md`, 검토 대상 산출물, 기존 코드의 계약 표면 코드 SSOT(포트, 도메인 타입, 공개 entrypoint) 포인터만 둔다. 요구사항·계약·설계 결정을 prompt 에 전문 재기입하지 않는다.
+- **대상 + 읽을 진본**: `docs/index.md`, epic `stories.md`, 전역/epic `architecture.md`, `docs/conventions.md`, affected module 의 `docs/modules/<module-id>/architecture.md` / `conventions.md`, `docs/decisions/`, 선택 epic `domain-model.md`, 검토 대상 산출물, 기존 코드의 계약 표면 코드 SSOT(포트, 도메인 타입, 공개 entrypoint) 포인터만 둔다. 요구사항·계약·설계 결정을 prompt 에 전문 재기입하지 않는다. 모듈 docs 는 affected module 에 한정하고 무관한 모듈은 넣지 않는다.
 - **worktree**: design worktree 활성 시 worktree 절대경로를 넣는다. main repo 절대경로를 worktree 경로처럼 넘기지 않는다.
 - **이 호출 특유**: Step 2.9 그릴미 합의 또는 기록된 스택 결정 확인-후-skip 사실, artifact audit 결과, wave-plan 신호처럼 아직 진본에 없는 신호만 둔다. 모듈 분할 방식·알고리즘·검증 assert 방식 같은 방법 처방은 넣지 않는다.
 
@@ -106,9 +106,9 @@ TaskCreate 직전 메인이 `docs/prd.md` 의 "화면 인벤토리 + 대략적 �
 3. **Step 2 — ux-architect:UX_FLOW** (UI epic 한정) → `UX_FLOW_READY` → commit 1 (epic 단위 `docs/epics/epic-NN-*/ux-flow.md`)
    - `UX_REFINE_READY` 로 `/design` 안에서 designer 후속이 필요하면, designer 호출 전 `/ux` 의 "designer 진입 공통 preflight" 와 동일하게 `docs/design-variants/` seed 보장 후 designer 로 진행한다.
 4. **Step 2.9 — 기술 스택 그릴미 또는 기록된 스택 결정 확인-후-skip** — 메인 직접, helper begin/end-step 비대상. 미기록 합의 또는 skip 사실만 Step 3 prompt 로 전달한다.
-5. **Step 3 — system-architect** — 전역 append map, `docs/conventions.md`/`docs/decisions/**`, epic `architecture.md` 를 작성한다. domain 복잡도가 낮으면 `domain-model.md 생략 가능` 이며, 생략 판단 근거를 epic `architecture.md` 에 남긴다. 도메인 invariant / entity / value object / aggregate / domain service 가 구현 판단에 필요하면 `domain-model.md` 를 작성한다. system-architect 는 계약 표면 코드 SSOT 대조를 수행해 기존 포트, 도메인 타입, 공개 entrypoint 와 설계가 어긋나지 않는지 확인하고 그 증거를 산출물에 남긴다. → `PASS`
+5. **Step 3 — system-architect** — 전역 append map, `docs/conventions.md`/`docs/decisions/**`, 필요한 module scope docs, epic `architecture.md` 를 작성한다. domain 복잡도가 낮으면 `domain-model.md 생략 가능` 이며, 생략 판단 근거를 epic `architecture.md` 에 남긴다. 도메인 invariant / entity / value object / aggregate / domain service 가 구현 판단에 필요하면 `domain-model.md` 를 작성한다. system-architect 는 계약 표면 코드 SSOT 대조를 수행해 기존 포트, 도메인 타입, 공개 entrypoint 와 설계가 어긋나지 않는지 확인하고 그 증거를 산출물에 남긴다. → `PASS`
 6. **Step 3.5 — architecture-validator 1차/system freeze** — system 산출물 기준으로 요구사항 출처, 설계 표준, Contract Ledger 충분성, 구현 순서(첫 제품 경계 동작 앞당김), Flow Ownership Map, domain-model 작성/생략 근거, 계약 표면 코드 SSOT 대조 증거를 검토한다. → `PASS` → commit 2. 이후 system 문서 freeze — final epic 검증 FAIL 이 와도 finding 분류가 `SYSTEM_BOUNDARY` 가 아니면 system-architect 재진입 X.
-7. **Step 4 — module-architect(epic-batch)** — epic 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성한다. Story 단위 작성 주체로 쪼개지 않는다. 입력은 전체 `stories.md`, frozen epic `architecture.md`, 선택 `domain-model.md`, UI epic 이면 `ux-flow.md`, `docs/conventions.md`, `docs/decisions/**`, 계약 표면 코드 SSOT 포인터다. 산출물은 공통 task 와 모든 Story 의 `impl/NN-*.md` 전체이며, 각 impl task 는 `risk / engine / depends_on`, `수정 허용`, Contract Ledger row-key references, Story 동작 수직 슬라이스, 각 Story 완료 시 실제로 검증되는 동작, 첫 제품 경계 동작 증거 지점, Agent Workability 를 계속 충족해야 한다. 공통 task 가 있으면 같은 batch 안에서 먼저 필요한 기반 task 로 배치한다.
+7. **Step 4 — module-architect(epic-batch)** — epic 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성한다. Story 단위 작성 주체로 쪼개지 않는다. 입력은 전체 `stories.md`, frozen epic `architecture.md`, 선택 `domain-model.md`, UI epic 이면 `ux-flow.md`, `docs/conventions.md`, affected module docs, `docs/decisions/**`, 계약 표면 코드 SSOT 포인터다. 산출물은 공통 task 와 모든 Story 의 `impl/NN-*.md` 전체이며, 각 impl task 는 `risk / engine / depends_on`, `수정 허용`, Contract Ledger row-key references, Story 동작 수직 슬라이스, 각 Story 완료 시 실제로 검증되는 동작, 첫 제품 경계 동작 증거 지점, Agent Workability 를 계속 충족해야 한다. 공통 task 가 있으면 같은 batch 안에서 먼저 필요한 기반 task 로 배치한다.
    - **규모 preflight**: Step 4 진입 전 메인이 Story 수와 예상 full design pack 규모를 [`deliverables-map.md`](../../docs/plugin/deliverables-map.md) 의 target 1,500줄 / hard warning 2,000줄 예산에 맞춰 빠르게 추정한다. 2,000줄 초과가 예상되거나 impl task 수가 한 sub-agent 출력 한계에 몰릴 정도로 크면 자동으로 얇은 batch 를 진행하지 말고 사용자에게 epic 분할 또는 예외적 batch 2분할을 위임한다. batch 2분할을 선택해도 Story 단위 작성/검증 기본값 복원이 아니며, 분할 경계·공유 계약을 epic architecture/Contract Ledger 에 먼저 남기고 final epic 검증은 전체 산출물 기준으로 한 번 더 수행한다.
    - **기본값 금지**: 모든 Story 에 단위 검증을 기본값으로 복원하지 않는다. 고위험 신호가 뒤늦게 드러나면 메인 판단으로 추가 검증 또는 사용자 위임을 선택할 수 있지만, 기본 루프는 epic-batch 생산 + final epic 검증이다.
    - **계약 변경**: public contract 를 만들거나 바꾸면 Contract Ledger 를 갱신하고 impl 문서는 row key 만 가리킨다.

--- a/tests/test_architecture_map_aggregate.py
+++ b/tests/test_architecture_map_aggregate.py
@@ -140,6 +140,33 @@ class ArchitectureMapAggregateTests(unittest.TestCase):
             self.assertEqual(check.returncode, 1)
             self.assertIn("stale", check.stderr)
 
+    def test_rebases_module_doc_links_from_epic_module_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(project / "docs/architecture.md", "# 전역 아키텍처 지도\n")
+            _write(project / "docs/modules/android/architecture.md", "# Android\n")
+            _write(
+                project / "docs/epics/epic-01-mobile/architecture.md",
+                """
+                # Epic Architecture
+
+                ## 모듈 목록
+
+                | 모듈 | 책임 | 의존 모듈 | 공개 API | 테스트 단위 |
+                |---|---|---|---|---|
+                | [android](../../modules/android/architecture.md) | mobile UI shell | - | `MainActivity` | android smoke |
+                """,
+            )
+
+            proc = _run(project)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            root_map = (project / "docs/architecture.md").read_text(encoding="utf-8")
+            self.assertIn(
+                "| [android](modules/android/architecture.md) | mobile UI shell | - | `MainActivity` | [epic-01-mobile](epics/epic-01-mobile/architecture.md) |",
+                root_map,
+            )
+
     def test_rerun_corrects_legacy_four_cell_epic_map_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)

--- a/tests/test_doc_path_integrity.py
+++ b/tests/test_doc_path_integrity.py
@@ -174,6 +174,20 @@ class DocPathIntegrityTests(unittest.TestCase):
         self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
         self.assertIn("src/removed.ts", proc.stderr)
 
+    def test_module_docs_are_part_of_default_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "docs" / "modules" / "android").mkdir(parents=True)
+            (root / "docs" / "modules" / "android" / "conventions.md").write_text(
+                "Android module implementation path: `app/removed.kt`.\n",
+                encoding="utf-8",
+            )
+
+            proc = _run(root)
+
+        self.assertEqual(proc.returncode, 1, proc.stdout + proc.stderr)
+        self.assertIn("app/removed.kt", proc.stderr)
+
     def test_root_architecture_is_part_of_default_scan(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/tests/test_index_map_aggregate.py
+++ b/tests/test_index_map_aggregate.py
@@ -1,4 +1,4 @@
-"""Regression tests for the docs/index.md epic table aggregation tool (#823)."""
+"""Regression tests for the docs/index.md generated table aggregation tool."""
 from __future__ import annotations
 
 import shutil
@@ -116,6 +116,59 @@ class IndexMapAggregateTests(unittest.TestCase):
             check = _run(project, "--check")
             self.assertEqual(check.returncode, 1)
             self.assertIn("stale", check.stderr)
+
+    def test_generates_module_table_from_module_directories(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(
+                project / "docs/index.md",
+                """
+                # 프로젝트 문서 인덱스
+
+                ## 개요
+
+                수동 개요.
+                """,
+            )
+            _write(project / "docs/modules/android/architecture.md", "# Android Architecture\n")
+            _write(project / "docs/modules/android/conventions.md", "# Android Conventions\n")
+            _write(project / "docs/modules/backend/conventions.md", "# Backend Conventions\n")
+
+            proc = _run(project)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            index = (project / "docs/index.md").read_text(encoding="utf-8")
+            self.assertIn("수동 개요.", index)
+            self.assertIn("## 모듈", index)
+            self.assertIn("<!-- dcness-module-map:generated -->", index)
+            self.assertIn(
+                "| [android](modules/android/) | [architecture.md](modules/android/architecture.md) | [conventions.md](modules/android/conventions.md) | — |",
+                index,
+            )
+            self.assertIn(
+                "| [backend](modules/backend/) | — | [conventions.md](modules/backend/conventions.md) | — |",
+                index,
+            )
+
+            check = _run(project, "--check")
+            self.assertEqual(check.returncode, 0, check.stderr)
+
+    def test_generated_module_table_becomes_stale_when_module_removed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(project / "docs/index.md", "# Index\n")
+            _write(project / "docs/modules/android/architecture.md", "# Android\n")
+            self.assertEqual(_run(project).returncode, 0)
+
+            shutil.rmtree(project / "docs/modules/android")
+
+            check = _run(project, "--check")
+            self.assertEqual(check.returncode, 1)
+            self.assertIn("stale", check.stderr)
+
+            self.assertEqual(_run(project).returncode, 0)
+            index = (project / "docs/index.md").read_text(encoding="utf-8")
+            self.assertIn("| — | — | — | — |", index)
 
     def test_no_epics_or_missing_index_is_noop_pass(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -649,7 +649,10 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("# 전역 규약", conventions)
         self.assertIn("# 전역 아키텍처 지도", root_architecture)
         self.assertIn("# 결정 NNNN", decision)
-        self.assertIn("scope: global  # global 또는 epic-NN", decision)
+        self.assertIn(
+            "scope: global  # global | epic-NN | module:<module-id> | module:<module-id>/epic-NN",
+            decision,
+        )
 
     def test_init_doc_drops_removed_tdd_gate_references(self) -> None:
         """#681 — /init-dcness 가 폐기된 TDD CI/pre-commit flow 를 더는 언급하지 않는다.


### PR DESCRIPTION
## 관련 이슈 번호

Closes #884

## 배경 및 문제

활성 프로젝트가 모노레포·모듈화될 때 기존 docs 산출물 체계는 단일 루트 전역 문서만 전제했다. 그 결과 모듈별 stack/build/runtime delta 를 전역 conventions/architecture 에 섞거나, 모듈 작업 agent 가 무관한 모듈 문서까지 읽는 구조가 되기 쉬웠다.

## 원인 (해당 시)

-

## 작업내용

- `docs/plugin/deliverables-map.md`에 opt-in `docs/modules/<module-id>/` 축, 전역 유지 vs module scope 판단 기준, cross-module epic 처리 기준을 추가했다.
- decision frontmatter `scope` 예시를 `module:<module-id>` / `module:<module-id>/epic-NN`까지 확장하고 기존 `global` / `epic-NN` 호환을 문서화했다.
- system/module architect agent와 template, `/design` skill prompt slot 기준에 affected module docs 입력 규칙을 반영했다.
- `aggregate_index_map.mjs`가 `docs/modules/*`에서 `docs/index.md`의 `## 모듈` 생성 표를 만들고 stale check를 수행하도록 확장했다.
- `check_doc_path_integrity.mjs` 기본 스캔에 `docs/modules/**`를 포함하고 관련 action/init/hook 문서를 갱신했다.
- module table 생성, module 삭제 drift, module doc path scan, epic module link rebasing 회귀 테스트를 추가했다.

## 결정 근거

- module docs는 기본 seed로 만들지 않고, 모노레포·모듈화가 확인된 프로젝트에서만 opt-in으로 생성한다. 기존 단일 루트 활성 프로젝트의 no-op 동작을 유지하기 위해 `docs/modules/`가 없으면 module table을 새로 만들지 않는다.
- decision 파일 위치는 `docs/decisions/`로 유지하고 `scope` 값만 확장했다. 결정 기록 위치가 분산되면 검색/집계/하위 호환 비용이 커지기 때문이다.
- cross-module epic은 제품 단위 epic 하나로 유지하고, module docs에는 local boundary/delta만 둔다. cross-module contract 전문은 epic Contract Ledger와 root generated contract index가 소유한다.
- #882의 CLAUDE.md 분할 권고는 사용자 소유물 영역이라 이번 PR에서는 건드리지 않았다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체: `agents/**`, `skills/design/SKILL.md`, `commands/init-dcness.md`, `scripts/*.mjs`, `.github/actions/**`, `docs/plugin/**` 변경으로 배포된다.
- `/init-dcness` copied files: workflow template 사본은 변경하지 않았다. `docs/modules/`는 opt-in 산출물이므로 기본 seed로 만들지 않는다.
- 사용자-facing SSOT: `docs/plugin/deliverables-map.md`, `docs/plugin/init-dcness.md`, `docs/plugin/hooks.md`, `docs/plugin/templates/agent-prompt-slots.md`에 반영했다.
- 기존 public surface: 새 skill/command/agent/gate 추가 없이 기존 doc-sync/doc-path/design 흐름을 확장했다.
- drift gate: 기존 `doc-sync` composite action이 호출하는 `aggregate_index_map.mjs --check`가 epic/module table을 함께 검증한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음.

## Test Plan

- [x] python3.11 -m unittest discover -s tests -v
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] node scripts/aggregate_index_map.mjs --check
- [x] node scripts/aggregate_architecture_map.mjs --check
- [x] node scripts/check_doc_path_integrity.mjs
- [x] PYTHON_BIN=/tmp/dcness-quality-venv-884/bin/python bash scripts/check_static_quality.sh
- [x] git diff --check
- [x] git commit hook: pytest-gate + git-naming PASS

## 참고

- 별도 워크트리: `/private/tmp/dcness-884-docs-module-axis`
- Local self-review round 1: no findings.
