### PR TITLE
[issue-884] index seed doc-sync 회귀 수정

### DIFF
--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -84,7 +84,7 @@ docs/
 
 `docs/index.md` 는 cold-start agent 의 정적 entrypoint 다. `## 에픽` 표는 `docs/epics/epic-NN-*` 디렉토리와 `stories.md` frontmatter `milestone` 값에서 파생되는 생성 섹션이며 수동 편집하지 않는다. 모듈 축을 쓰는 프로젝트에서는 `## 모듈` 표도 `docs/modules/<module-id>/` 에서 파생된다. live 진행상태를 문서에 복제하지 않고, 수동 섹션 `## 진행 상태 · 다음 작업` 에서 GitHub Project 보드, epic/story issue, `/next` 를 가리킨다. `/init-dcness` 는 기존 `docs/index.md` 를 overwrite 하지 않지만, 이 섹션이 없으면 `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs` 로 섹션만 append 한다.
 
-`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 는 각 epic 폴더와 opt-in module 폴더를 결정적으로 정렬하고 `docs/index.md` 의 `## 에픽` / `## 모듈` 표를 생성/갱신한다. 파일이 없는 선택 산출물 셀은 링크가 아닌 `—` 로 남긴다. `docs/modules/` 가 없으면 모듈 표는 생성하지 않아 단일 루트 프로젝트의 기존 index 동작을 바꾸지 않는다.
+`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 는 각 epic 폴더와 opt-in module 폴더를 결정적으로 정렬하고 `docs/index.md` 의 `## 에픽` / `## 모듈` 표를 생성/갱신한다. 파일이 없는 선택 산출물 셀은 링크가 아닌 `—` 로 남긴다. `docs/modules/` 가 없으면 모듈 표는 생성하지 않아 단일 루트 프로젝트의 기존 index 동작을 바꾸지 않는다. 기존 `docs/index.md` 에 수동 `## 모듈` 섹션이 있으면 모듈 축 활성화 시 생성 섹션으로 교체되므로, 수동 설명은 다른 heading 으로 옮긴 뒤 집계기를 실행한다.
 
 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 는 각 `docs/epics/epic-NN-<slug>/architecture.md` 의 `## 모듈 목록` 표와 `## Contract Ledger` 표를 수집해 전역 `docs/architecture.md` 의 `에픽 간 지도`, `전역 모듈 토폴로지`, `공유 계약 인덱스` 섹션을 생성/갱신한다. 이 세 섹션은 파생물이며 수동 편집하지 않는다. 모듈 스코프 문서가 있는 모듈은 epic architecture 의 `## 모듈 목록` 에 `docs/modules/<module-id>/architecture.md` 링크를 남기면 전역 topology 표에도 rebased 링크로 드러난다. epic architecture 템플릿의 표 헤더는 도구의 파싱 계약이므로 변경하려면 도구와 테스트를 함께 갱신한다.
 

--- a/scripts/aggregate_index_map.mjs
+++ b/scripts/aggregate_index_map.mjs
@@ -125,7 +125,7 @@ function collectModules(root) {
   return readdirSync(modulesRoot, { withFileTypes: true })
     .filter((entry) => entry.isDirectory())
     .map((entry) => entry.name)
-    .filter((name) => /^[a-z0-9][a-z0-9_-]*$/.test(name))
+    .filter((name) => /^[a-z][a-z0-9_-]*$/.test(name))
     .sort()
     .map((name) => {
       const moduleDir = join(modulesRoot, name);

--- a/skills/spec/templates/index.md
+++ b/skills/spec/templates/index.md
@@ -19,7 +19,7 @@
 <!-- dcness-index-map:generated -->
 <!-- 수정하지 말고 plugin script `aggregate_index_map.mjs` 로 갱신한다. -->
 | 에픽 | 마일스톤 | Stories | Architecture | Domain Model | UX Flow | Tech Review |
-|---|---|---|---|---|---|---|
+| --- | --- | --- | --- | --- | --- | --- |
 | — | — | — | — | — | — | — |
 
 ## 진행 상태 · 다음 작업

--- a/tests/test_index_map_aggregate.py
+++ b/tests/test_index_map_aggregate.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "aggregate_index_map.mjs"
+INDEX_TEMPLATE = ROOT / "skills" / "spec" / "templates" / "index.md"
 NODE = shutil.which("node")
 
 
@@ -117,6 +118,17 @@ class IndexMapAggregateTests(unittest.TestCase):
             self.assertEqual(check.returncode, 1)
             self.assertIn("stale", check.stderr)
 
+    def test_seeded_index_template_is_fresh_without_epics_or_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            (project / "docs").mkdir()
+            shutil.copyfile(INDEX_TEMPLATE, project / "docs" / "index.md")
+
+            check = _run(project, "--check")
+
+        self.assertEqual(check.returncode, 0, check.stderr)
+        self.assertIn("PASS", check.stdout)
+
     def test_generates_module_table_from_module_directories(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
@@ -152,6 +164,23 @@ class IndexMapAggregateTests(unittest.TestCase):
 
             check = _run(project, "--check")
             self.assertEqual(check.returncode, 0, check.stderr)
+
+    def test_ignores_module_directories_that_do_not_match_module_id_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(project / "docs/index.md", "# 프로젝트 문서 인덱스\n")
+            _write(project / "docs/modules/android/architecture.md", "# Android\n")
+            _write(project / "docs/modules/3d-engine/architecture.md", "# 3D Engine\n")
+
+            proc = _run(project)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            index = (project / "docs/index.md").read_text(encoding="utf-8")
+            self.assertIn(
+                "| [android](modules/android/) | [architecture.md](modules/android/architecture.md) | — | — |",
+                index,
+            )
+            self.assertNotIn("3d-engine", index)
 
     def test_generated_module_table_becomes_stale_when_module_removed(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 관련 이슈 번호

Part of #884

## 배경 및 문제

#889 머지 후 리뷰에서 갓 시드된 활성 프로젝트가 첫 epic/module 생성 전 `doc-sync` CI 에서 실패할 수 있다는 회귀가 확인됐다. 원인은 seed template 의 빈 epic table separator 스타일과 `aggregate_index_map.mjs` 생성 출력이 달라, marker 가 있는 `docs/index.md`가 byte-level stale 로 판정되는 점이다.

## 원인 (해당 시)

- `skills/spec/templates/index.md` 의 seeded `## 에픽` 표는 `|---|` separator 를 사용했다.
- `aggregate_index_map.mjs` 의 `table()` helper 는 `| --- |` separator 를 생성한다.
- #889 이후 marker 가 있는 index 는 epic 0개여도 비교 경로로 들어가므로, 갓 시드된 프로젝트가 `--check`에서 stale 판정을 받았다.

## 작업내용

- seeded `docs/index.md` template 의 빈 epic table separator 를 생성기 출력과 동일한 `| --- |` 스타일로 맞췄다.
- seed template 을 그대로 복사한 빈 프로젝트에서 `aggregate_index_map.mjs --check`가 PASS 하는 회귀 테스트를 추가했다.
- `docs/modules/<module-id>/` 수집 정규식을 문서 계약과 맞춰 소문자 시작으로 제한했다.
- 기존 수동 `## 모듈` 섹션이 모듈 축 활성화 시 생성 표로 교체되는 동작을 `deliverables-map.md`에 경고로 남겼다.

## 결정 근거

- 생성기 출력 대신 seed template 을 맞췄다. 이미 생성기 table helper 가 epic/module 표 모두에서 같은 스타일을 쓰고 있어, seed template 을 generated artifact 형식에 맞추는 편이 가장 작은 수정이다.
- module-id 는 문서에 이미 “소문자 시작 + `[a-z0-9_-]`”로 정의되어 있으므로 코드가 숫자 시작 디렉토리를 수집하지 않게 좁혔다.
- 수동 `## 모듈` 덮어쓰기는 기존 `## 에픽`과 같은 heading 기반 생성 섹션 동작이라 차단하지 않고 문서 경고로 처리했다.

## 배포 경로 검증 (plug-in 영향 시)

- `skills/spec/templates/index.md`: `/init-dcness`와 `/spec`가 사용하는 seeded index template에 반영된다.
- `scripts/aggregate_index_map.mjs`: 기존 doc-sync composite action이 `@main` 스크립트를 호출하므로 merge 즉시 활성 프로젝트 gate에 반영된다.
- `docs/plugin/deliverables-map.md`: 사용자-facing SSOT에 수동 `## 모듈` 섹션 교체 경고를 반영했다.
- 새 public surface 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음.

## Test Plan

- [x] python3.11 -m unittest tests.test_index_map_aggregate.IndexMapAggregateTests.test_seeded_index_template_is_fresh_without_epics_or_modules tests.test_index_map_aggregate.IndexMapAggregateTests.test_ignores_module_directories_that_do_not_match_module_id_contract -v
- [x] python3.11 -m unittest tests.test_index_map_aggregate tests.test_surface_docs_sync -v
- [x] python3.11 -m unittest discover -s tests -v
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] node scripts/aggregate_index_map.mjs --check
- [x] node scripts/aggregate_architecture_map.mjs --check
- [x] node scripts/check_doc_path_integrity.mjs
- [x] PYTHON_BIN=/tmp/dcness-quality-venv-884/bin/python bash scripts/check_static_quality.sh
- [x] git diff --check
- [x] git commit hook: pytest-gate + git-naming PASS

## 참고

- Follow-up to merged PR #889 review feedback.
