### PR TITLE
[feature] 보드 미러 best-effort 처리

### DIFF
--- a/.github/actions/github-project-lifecycle/action.yml
+++ b/.github/actions/github-project-lifecycle/action.yml
@@ -1,5 +1,5 @@
 name: 'dcness GitHub Project lifecycle'
-description: 'Validate or update dcNess issue/label lifecycle with optional GitHub Project v2 compatibility.'
+description: 'Validate or update dcNess issue/label lifecycle with optional best-effort GitHub Project v2 mirroring.'
 inputs:
   mode:
     description: 'bootstrap, validate-issue, start-work, or pr-merged'
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: 'false'
   gh-token:
-    description: 'GitHub token with issues write; project scope is only needed for optional Project v2 compatibility.'
+    description: 'GitHub token with issues write; project scope is only needed for optional best-effort Project v2 mirroring.'
     required: false
     default: ''
 runs:

--- a/docs/plugin/github-project.md
+++ b/docs/plugin/github-project.md
@@ -3,7 +3,7 @@
 > **Status**: ACTIVE
 > **Scope**: dcNess 표준 issue/label lifecycle, 선택적 GitHub Project v2 축, repo label, 상태 전이의 SSOT. 실행 메커니즘은 [`issue-lifecycle.md`](issue-lifecycle.md), git/PR trailer 룰은 [`git-spec.md`](git-spec.md), `/to-issue` 입력 필드 요약은 [`../../skills/to-issue/issue-fields.md`](../../skills/to-issue/issue-fields.md)를 함께 본다.
 
-dcNess 활성 repo 의 기계 SSOT 는 GitHub issue 자체다. `IssueType` 은 repo label 6종 중 정확히 1개, `Priority` 는 Issue Brief 본문 줄, `Status` 는 issue open/closed 상태와 `in-progress` label 로 판정한다. GitHub Project v2 의 `Status`, `IssueType`, `Priority` 세 축은 원하는 프로젝트가 쓰는 사람용 파생 뷰이며, 전환기 호환 보정 대상이다. `/init-dcness` bootstrap 은 선택 시 Project 축과 lifecycle repo label 7종(`IssueType` 6종 + `in-progress`)을 점검하고, `--apply` 경로에서는 부족한 repo label 과 새 Project field 를 만들 수 있다. 기존 Project field 에 option 이 빠진 경우는 GitHub CLI 가 option 추가를 직접 지원하지 않으므로 명확한 복구 안내를 낸다.
+dcNess 활성 repo 의 기계 SSOT 는 GitHub issue 자체다. `IssueType` 은 repo label 6종 중 정확히 1개, `Priority` 는 Issue Brief 본문 줄, `Status` 는 issue open/closed 상태와 `in-progress` label 로 판정한다. GitHub Project v2 의 `Status`, `IssueType`, `Priority` 세 축은 원하는 프로젝트가 쓰는 사람용 파생 뷰이며, dcNess 는 좌표가 설정된 repo 에서만 best-effort 로 보드 상태를 미러한다. Project 좌표 부재는 정상 skip 이고, Project item 부재·권한 실패·field/option 불일치·API 실패는 warning 으로 보고하되 issue/label lifecycle 의 성패를 바꾸지 않는다. `/init-dcness` bootstrap 은 선택 시 Project 축과 lifecycle repo label 7종(`IssueType` 6종 + `in-progress`)을 점검하고, `--apply` 경로에서는 부족한 repo label 과 새 Project field 를 만들 수 있다. 기존 Project field 에 option 이 빠진 경우는 GitHub CLI 가 option 추가를 직접 지원하지 않으므로 명확한 복구 안내를 낸다.
 
 ## Status
 
@@ -56,7 +56,7 @@ label drift 는 어떤 issue 의 lifecycle label 이 계약과 다른지 보여�
 issue #663: closed issue retains in-progress label; remove in-progress.
 ```
 
-IssueType / repo label drift 는 어떤 issue 에서 어떤 값이 어긋났는지 보여준다. Project 좌표가 있는 경우 전환기 호환을 위해 Project field drift 도 함께 보고한다.
+IssueType / repo label drift 는 어떤 issue 에서 어떤 label 계약이 어긋났는지 보여준다. Project 좌표가 있는 경우 보드를 best-effort 로 읽어 Project field drift 도 warning 으로 보고할 수 있다. 이 warning 은 사람이 보드를 미러로 정리할 때 쓰는 정보이며, drift 실패 판정은 IssueType label 유일성, `in-progress` label 유일성, closed issue 의 `in-progress` 잔존 같은 issue/label 규칙만 본다.
 
 예:
 

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -274,7 +274,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 | `.github/workflows/pr-body-validation.yml` | `pull_request` opened/synchronize/reopened/edited | PR 생성/수정/동기화 | PR body issue trailer 검증 | 선택형 CI gate |
 | `.github/workflows/doc-path-integrity.yml` | `pull_request` opened/synchronize/reopened/edited | PR 생성/수정/동기화 | repo-relative 경로 참조 실존 검증 | 선택형 CI gate |
 | `.github/workflows/doc-sync.yml` | `pull_request` opened/synchronize/reopened/edited | PR 생성/수정/동기화 | index epic 표 + architecture map 파생물 drift 검증 + `/design` 산출물 구조 감사 | 선택형 CI gate |
-| `.github/workflows/github-project-lifecycle.yml` | `issues`, `pull_request closed` | issue 변경 또는 PR merge | Project field/label drift 검출, merged PR Done 보정 | 선택형 CI/CD |
+| `.github/workflows/github-project-lifecycle.yml` | `issues`, `pull_request closed` | issue 변경 또는 PR merge | issue/label drift 검출, merged PR `in-progress` label cleanup, 선택적 Project 미러 warning | 선택형 CI/CD |
 
 ### .github/workflows/git-naming-validation.yml
 
@@ -335,13 +335,13 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **역할**:
 
-- issue label drift 검출. Project 좌표가 있으면 Project IssueType drift 도 함께 검출
-- merged PR body 의 close keyword 대상 issue 에서 `in-progress` label 제거. Project 좌표가 있으면 Project Status `Done` 도 전환기 호환으로 보정
+- issue/label drift 검출. Project 좌표가 있으면 Project field drift 는 warning 으로만 보고
+- merged PR body 의 close keyword 대상 issue 에서 `in-progress` label 제거. Project 좌표가 있으면 Project Status `Done` 도 best-effort 미러
 - `Part of #N` 만 있는 PR 은 cleanup 후보로 보지 않음
 
-**필수 설정**: label cleanup 에는 workflow `issues: write` 권한이 필요하다. Project v2 보정까지 쓰려면 `secrets.DCNESS_PROJECT_TOKEN`, `vars.DCNESS_PROJECT_NUMBER`, `vars.DCNESS_PROJECT_OWNER` 가 필요하다.
+**필수 설정**: label cleanup 에는 workflow `issues: write` 권한이 필요하다. Project v2 미러까지 쓰려면 `secrets.DCNESS_PROJECT_TOKEN`, `vars.DCNESS_PROJECT_NUMBER`, `vars.DCNESS_PROJECT_OWNER` 가 필요하다.
 
-**차단/보정**: issue drift 는 workflow 실패로 드러나고, merged PR 보정은 `apply: "true"` 로 label 과 선택적 Project 상태를 수정한다.
+**차단/보정**: issue/label drift 는 workflow 실패로 드러난다. Project field drift 와 미러 실패는 warning 으로만 보고한다. merged PR 보정은 `apply: "true"` 로 label 을 수정하고, 좌표가 있으면 선택적 Project 상태를 best-effort 로 미러한다.
 
 ## 문서 동기화 게이트
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -122,9 +122,9 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 
 - 대상 경로: `.github/workflows/github-project-lifecycle.yml`
 - 템플릿: [`templates/github-workflows/github-project-lifecycle.yml`](../../templates/github-workflows/github-project-lifecycle.yml)
-- 역할: `alruminum/dcNess/.github/actions/github-project-lifecycle@main` 을 호출해 issue drift 를 검출하고 merged PR 의 완료 후보 issue 에서 `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 전환기 호환으로 Project Status `Done` 보정도 함께 수행한다.
+- 역할: `alruminum/dcNess/.github/actions/github-project-lifecycle@main` 을 호출해 issue/label drift 를 검출하고 merged PR 의 완료 후보 issue 에서 `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 Project Status `Done` 미러를 best-effort 로 함께 시도한다.
 
-`in-progress` label 제거에는 `issues: write` 권한이 필요하다. Project v2 쓰기에는 `secrets.DCNESS_PROJECT_TOKEN` 에 classic PAT `project` + `read:org` scope 가 필요하다. token 이 없으면 Project 보정은 graceful degrade 하되 issue/label lifecycle 은 GitHub token 권한으로 계속 동작한다.
+`in-progress` label 제거에는 `issues: write` 권한이 필요하다. Project v2 미러에는 `secrets.DCNESS_PROJECT_TOKEN` 에 classic PAT `project` + `read:org` scope 가 필요하다. token 이 없거나 Project API 가 실패하면 Project 미러만 warning 으로 skip 되고 issue/label lifecycle 은 GitHub token 권한으로 계속 동작한다.
 
 ## Project Bootstrap Commands
 
@@ -186,6 +186,6 @@ seed 문서는 사용자 프로젝트 내용물이므로 사용자가 별도 작
 - [`hooks.md`](hooks.md) - CC hook / git hook / CI layer policy
 - [`git-spec.md`](git-spec.md) - branch / commit / PR naming
 - [`github-project.md`](github-project.md) - Project v2 fields and bootstrap
-- [`issue-lifecycle.md`](issue-lifecycle.md) - issue hierarchy and Project lifecycle
+- [`issue-lifecycle.md`](issue-lifecycle.md) - issue hierarchy, label lifecycle, optional Project mirror
 - [`design.md`](design.md) - `docs/design.md` format
 - [`hooks/hooks.json`](../../hooks/hooks.json) - CC hook registration

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -57,7 +57,7 @@ gh issue create --title "<title>" --body-file <brief.md> --label "<IssueType>"
 
 issue 생성 시 `epic`, `feature`, `story`, `task`, `subTask`, `bug` 중 정확히 하나의 IssueType label 을 붙인다. Priority 는 Issue Brief 본문의 `Priority` 줄이 진본이며 priority label 은 만들지 않는다. 새 issue 의 Status 의미는 `open` + `in-progress` label 없음, 즉 `Todo` 다.
 
-선택적으로 Project 보드를 쓰는 repo 는 전환기 호환을 위해 `register-issue` 로 Project item 을 backfill 할 수 있다. 이 경로는 item 이 없으면 추가하고 `Status=Todo` + `IssueType` + `Priority` 를 설정한다.
+선택적으로 Project 보드를 쓰는 repo 는 사람용 보드 미러를 위해 `register-issue` 로 Project item 을 backfill 할 수 있다. 이 경로는 item 이 없으면 추가하고 `Status=Todo` + `IssueType` + `Priority` 를 설정한다.
 
 ```bash
 node scripts/github_project_lifecycle.mjs register-issue \
@@ -84,7 +84,7 @@ GitHub 조회가 실패하면 실패를 명시하고 로컬 대안 경로를 안
 
 ### 작업 시작 — in-progress label
 
-특정 GitHub issue 를 대상으로 `/spec`, `/design`, `/impl`, `/ux` 같은 설계나 구현 흐름을 실제 시작하면 메인은 시작 직전에 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 전환기 호환으로 Project item `Status=In progress` 도 함께 보정한다.
+특정 GitHub issue 를 대상으로 `/spec`, `/design`, `/impl`, `/ux` 같은 설계나 구현 흐름을 실제 시작하면 메인은 시작 직전에 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 label 전이 뒤에 Project item `Status=In progress` 이동을 best-effort 로 1회 시도한다. 좌표 부재는 정상 skip 이고, item 부재·권한 실패·field/option 불일치·API 실패는 warning 으로만 보고한다.
 
 ```bash
 node scripts/github_project_lifecycle.mjs start-work \
@@ -93,11 +93,11 @@ node scripts/github_project_lifecycle.mjs start-work \
   --apply
 ```
 
-Project 보정까지 원하면 기존처럼 `--owner` / `--project` 를 명시하거나 repo variable `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` 를 둔다. `--apply` 없이 실행하면 `in-progress` label 잔존 여부와, Project 좌표가 있는 경우 Status drift 를 함께 보고한다.
+Project 미러까지 원하면 `--owner` / `--project` 를 명시하거나 repo variable `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` 를 둔다. `--apply` 없이 실행하면 `in-progress` label 잔존 여부와, Project 좌표가 있는 경우 Status drift warning 을 함께 보고한다. 이때 명령의 실패 판정은 label 상태만 본다.
 
 ### PR merge 후처리 — close + label cleanup
 
-default branch 로 PR merge 가 끝난 뒤 GitHub closing reference 가 issue close 를 발동한다. 후처리 경로는 PR body 또는 GitHub closing issue reference 에서 완료 후보 issue 를 찾고, `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 전환기 호환으로 Project item `Status=Done` 도 함께 보정한다.
+default branch 로 PR merge 가 끝난 뒤 GitHub closing reference 가 issue close 를 발동한다. 후처리 경로는 PR body 또는 GitHub closing issue reference 에서 완료 후보 issue 를 찾고, `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 label 제거 뒤에 Project item `Status=Done` 이동을 best-effort 로 1회 시도한다. 보드 미러 실패는 warning 으로만 보고하고 label cleanup 성공을 실패로 바꾸지 않는다.
 
 ```bash
 node scripts/github_project_lifecycle.mjs pr-merged \
@@ -110,7 +110,7 @@ node scripts/github_project_lifecycle.mjs pr-merged \
 
 ### IssueType / repo label drift
 
-issue 는 IssueType repo label 을 정확히 하나 가져야 하며, closed issue 에 `in-progress` label 이 남아 있으면 drift 다. Project 좌표가 있는 경우 선택적 Project `IssueType`/`Status`/`Priority` drift 도 함께 보고한다.
+issue 는 IssueType repo label 을 정확히 하나 가져야 하며, closed issue 에 `in-progress` label 이 남아 있으면 drift 다. `/next-work` 후보 선정과 drift 실패 판정은 보드를 읽지 않는다. 단, Project 좌표가 설정된 경우 drift 리포트는 보드 상태를 best-effort 로 읽어 Project `IssueType`/`Status`/`Priority` 불일치를 warning 으로만 출력할 수 있다.
 
 ```bash
 node scripts/github_project_lifecycle.mjs validate-issue \
@@ -122,12 +122,12 @@ node scripts/github_project_lifecycle.mjs validate-issue \
 
 ```text
 issue #663: closed issue retains in-progress label; remove in-progress.
-issue #663: Project IssueType=feature, repo label=bug. Set Project IssueType and exactly one matching repo label to the same value.
+[dcness-project] WARN: issue #663: Project IssueType=feature, repo label=bug. Set Project IssueType and exactly one matching repo label to the same value.
 ```
 
 ### CI/CD harness
 
-`/init-dcness` 는 선택적으로 `github-project-lifecycle` thin workflow 를 활성 repo 에 설치한다. 이 workflow 는 본 repo 의 composite action 을 호출해 issue label/type drift 를 PR/issue 이벤트에서 검증하고, merge 된 PR 의 완료 후보 issue 에서 `in-progress` label 을 제거한다. Project v2 보정을 쓰는 repo 만 `DCNESS_PROJECT_TOKEN` secret 과 `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` variables 가 필요하다. token 이 없으면 Project 보정은 graceful degrade 하며 issue/label lifecycle 은 GitHub token 권한으로 계속 동작한다.
+`/init-dcness` 는 선택적으로 `github-project-lifecycle` thin workflow 를 활성 repo 에 설치한다. 이 workflow 는 본 repo 의 composite action 을 호출해 issue label/type drift 를 PR/issue 이벤트에서 검증하고, merge 된 PR 의 완료 후보 issue 에서 `in-progress` label 을 제거한다. Project v2 미러를 쓰는 repo 만 `DCNESS_PROJECT_TOKEN` secret 과 `DCNESS_PROJECT_NUMBER` / `DCNESS_PROJECT_OWNER` variables 가 필요하다. token 이 없거나 Project API 가 실패하면 Project 미러만 warning 으로 skip 되고 issue/label lifecycle 은 GitHub token 권한으로 계속 동작한다.
 
 ## 미등록 허용 모드
 

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -857,14 +857,92 @@ function projectContext(args) {
   return { repo, owner, projectNumber, project, fields };
 }
 
-function projectContextIfConfigured(args) {
+function projectCoordinates(args) {
   const { repo, owner, project: projectNumber } = resolveProjectCoordinates(args);
+  return { repo, owner, projectNumber };
+}
+
+function warnProjectMirror(message) {
+  console.error(`[dcness-project] WARN: ${message}`);
+}
+
+function loadProjectMirrorContext({ owner, projectNumber }) {
   if (!projectNumber) {
-    return { repo, owner, projectNumber: null, project: null, fields: null };
+    return { available: false, project: null, fields: null };
   }
-  const project = gh(['project', 'view', projectNumber, '--owner', owner, '--format', 'json'], { json: true });
-  const fields = gh(['project', 'field-list', projectNumber, '--owner', owner, '--format', 'json'], { json: true });
-  return { repo, owner, projectNumber, project, fields };
+  try {
+    const project = gh(['project', 'view', projectNumber, '--owner', owner, '--format', 'json'], { json: true });
+    const fields = gh(['project', 'field-list', projectNumber, '--owner', owner, '--format', 'json'], { json: true });
+    return { available: true, project, fields };
+  } catch (error) {
+    warnProjectMirror(`Project ${projectNumber} mirror unavailable: ${error.message}`);
+    return { available: false, project: null, fields: null };
+  }
+}
+
+function getProjectItemForMirror({ owner, projectNumber, repo, issueNumber }) {
+  try {
+    const item = getProjectItem({ owner, projectNumber, repo, issueNumber });
+    if (!item?.id) {
+      warnProjectMirror(`issue ${repo ?? '<unknown-repo>'}#${issueNumber}: Project item missing in Project ${projectNumber}.`);
+      return null;
+    }
+    return item;
+  } catch (error) {
+    warnProjectMirror(`issue ${repo ?? '<unknown-repo>'}#${issueNumber}: Project item lookup failed in Project ${projectNumber}: ${error.message}`);
+    return null;
+  }
+}
+
+function reportProjectStatusForMirror({
+  owner,
+  projectNumber,
+  repo,
+  issueNumber,
+  expectedStatus,
+  apply = false,
+  mirrorContext = undefined,
+}) {
+  if (!projectNumber) {
+    console.log('[dcness-project] Project 좌표 없음 — Status board update skipped; issue/label state is SSOT.');
+    return;
+  }
+
+  const { available, project, fields } = mirrorContext ?? loadProjectMirrorContext({ owner, projectNumber });
+  if (!available) return;
+
+  const item = getProjectItemForMirror({ owner, projectNumber, repo, issueNumber });
+  if (!item?.id) return;
+
+  const actual = projectItemFieldValue(item, 'Status');
+  if (actual === expectedStatus) {
+    console.log(`issue ${repo ?? '<unknown-repo>'}#${issueNumber}: Status=${expectedStatus}`);
+    return;
+  }
+
+  const drift = statusDriftMessage({
+    repo,
+    issueNumber,
+    expected: expectedStatus,
+    actual,
+  });
+  if (!apply) {
+    warnProjectMirror(drift);
+    return;
+  }
+
+  try {
+    setProjectSingleSelect({
+      projectId: project.id,
+      itemId: item.id,
+      fields,
+      fieldName: 'Status',
+      optionName: expectedStatus,
+    });
+    console.log(`issue ${repo ?? '<unknown-repo>'}#${issueNumber}: Status=${expectedStatus}`);
+  } catch (error) {
+    warnProjectMirror(`issue ${repo ?? '<unknown-repo>'}#${issueNumber}: Project Status mirror failed: ${error.message}`);
+  }
 }
 
 function getIssue(repo, issueNumber) {
@@ -1007,7 +1085,7 @@ function commandNext(args) {
 
 function commandValidateIssue(args) {
   if (!args.issue) throw new Error('--issue <number> is required.');
-  const { repo, owner, projectNumber } = projectContextIfConfigured(args);
+  const { repo, owner, projectNumber } = projectCoordinates(args);
   const issue = getIssue(repo, args.issue);
   const labelValidation = validateLifecycleIssueLabels({
     issueNumber: issue.number,
@@ -1021,11 +1099,12 @@ function commandValidateIssue(args) {
     return labelValidation.ok ? 0 : 1;
   }
 
-  const item = getProjectItem({ owner, projectNumber, repo, issueNumber: args.issue });
-  if (!item) {
-    console.error(`issue #${args.issue}: Project item missing in Project ${projectNumber}.`);
-    return 1;
-  }
+  const { available } = loadProjectMirrorContext({ owner, projectNumber });
+  if (!available) return labelValidation.ok ? 0 : 1;
+
+  const item = getProjectItemForMirror({ owner, projectNumber, repo, issueNumber: args.issue });
+  if (!item) return labelValidation.ok ? 0 : 1;
+
   const validation = validateIssueProjectRegistration({
     repo,
     issueNumber: issue.number,
@@ -1036,14 +1115,14 @@ function commandValidateIssue(args) {
     expectedPriority: args['expected-priority'] ?? 'any',
   });
   for (const message of validation.messages) {
-    console.log(message);
+    warnProjectMirror(message);
   }
-  return labelValidation.ok && validation.ok ? 0 : 1;
+  return labelValidation.ok ? 0 : 1;
 }
 
 function commandStartWork(args) {
   if (!args.issue) throw new Error('--issue <number> is required.');
-  const { repo, owner, projectNumber, project, fields } = projectContextIfConfigured(args);
+  const { repo, owner, projectNumber } = projectCoordinates(args);
   const issue = getIssue(repo, args.issue);
   const hasInProgressLabel = issueHasLabel(issue, IN_PROGRESS_LABEL);
   if (!args.apply) {
@@ -1054,24 +1133,27 @@ function commandStartWork(args) {
         : `issue #${args.issue}: missing label ${IN_PROGRESS_LABEL}`,
     );
     if (projectNumber) {
-      const item = getProjectItem({ owner, projectNumber, repo, issueNumber: args.issue });
-      if (!item?.id) {
-        console.error(`issue #${args.issue}: Project item missing in Project ${projectNumber}.`);
-        ok = false;
-      } else {
-        const actual = projectItemFieldValue(item, 'Status');
-        if (actual !== 'In progress') ok = false;
-        console.log(statusDriftMessage({
-          repo,
-          issueNumber: args.issue,
-          expected: 'In progress',
-          actual,
-        }));
+      const { available } = loadProjectMirrorContext({ owner, projectNumber });
+      if (available) {
+        const item = getProjectItemForMirror({ owner, projectNumber, repo, issueNumber: args.issue });
+        if (item?.id) {
+          const actual = projectItemFieldValue(item, 'Status');
+          if (actual === 'In progress') {
+            console.log(`issue ${repo}#${args.issue}: Status=In progress`);
+          } else {
+            warnProjectMirror(statusDriftMessage({
+              repo,
+              issueNumber: args.issue,
+              expected: 'In progress',
+              actual,
+            }));
+          }
+        }
       }
     } else {
       console.log('[dcness-project] Project 좌표 없음 — label 상태만 검사했습니다.');
     }
-    console.log(`Run again with --apply to add label ${IN_PROGRESS_LABEL} and set Project Status when configured.`);
+    console.log(`Run again with --apply to add label ${IN_PROGRESS_LABEL} and best-effort mirror Project Status when configured.`);
     return ok ? 0 : 1;
   }
   ensureLabel(repo, IN_PROGRESS_LABEL);
@@ -1079,27 +1161,14 @@ function commandStartWork(args) {
     addIssueLabel({ repo, issueNumber: args.issue, labelName: IN_PROGRESS_LABEL });
   }
   console.log(`issue #${args.issue}: label ${IN_PROGRESS_LABEL}`);
-  if (!projectNumber) {
-    console.log('[dcness-project] Project 좌표 없음 — Status board update skipped; label state is SSOT.');
-    return 0;
-  }
-  const item = getProjectItem({ owner, projectNumber, repo, issueNumber: args.issue });
-  if (!item?.id) {
-    console.error(`issue #${args.issue}: Project item missing in Project ${projectNumber}.`);
-    return 1;
-  }
-  if (projectItemFieldValue(item, 'Status') === 'In progress') {
-    console.log(`issue #${args.issue}: Status=In progress`);
-    return 0;
-  }
-  setProjectSingleSelect({
-    projectId: project.id,
-    itemId: item.id,
-    fields,
-    fieldName: 'Status',
-    optionName: 'In progress',
+  reportProjectStatusForMirror({
+    owner,
+    projectNumber,
+    repo,
+    issueNumber: args.issue,
+    expectedStatus: 'In progress',
+    apply: true,
   });
-  console.log(`issue #${args.issue}: Status=In progress`);
   return 0;
 }
 
@@ -1210,8 +1279,10 @@ function commandPrMerged(args) {
     console.log('[dcness-project] no completion issue candidates. Part of #N is not a Done signal.');
     return 0;
   }
-  const { repo, owner, projectNumber, project, fields } = projectContextIfConfigured(args);
+  const { repo, owner, projectNumber } = projectCoordinates(args);
   const resolvedRefs = resolveCompletionRefsForProject(body, args.repo, repo);
+  let mirrorContext;
+  let mirrorContextLoaded = false;
 
   let failures = 0;
   for (const ref of resolvedRefs) {
@@ -1230,44 +1301,19 @@ function commandPrMerged(args) {
       console.log(`issue ${labelRepo}#${ref.number}: label ${IN_PROGRESS_LABEL} absent`);
     }
 
-    if (projectNumber) {
-      const item = getProjectItem({
-        owner,
-        projectNumber,
-        repo: ref.repo,
-        issueNumber: ref.number,
-      });
-      if (!item?.id) {
-        failures += 1;
-        console.error(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Project item missing in Project ${projectNumber}.`);
-        continue;
-      }
-      const actual = projectItemFieldValue(item, 'Status');
-      if (actual === 'Done') {
-        console.log(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Status=Done`);
-        continue;
-      }
-      if (!args.apply) {
-        failures += 1;
-        console.error(statusDriftMessage({
-          repo: ref.repo,
-          issueNumber: ref.number,
-          expected: 'Done',
-          actual,
-        }));
-        continue;
-      }
-      setProjectSingleSelect({
-        projectId: project.id,
-        itemId: item.id,
-        fields,
-        fieldName: 'Status',
-        optionName: 'Done',
-      });
-      console.log(`issue ${ref.repo ?? '<unknown-repo>'}#${ref.number}: Status=Done`);
-    } else {
-      console.log('[dcness-project] Project 좌표 없음 — Status board update skipped; issue close state is SSOT.');
+    if (projectNumber && !mirrorContextLoaded) {
+      mirrorContext = loadProjectMirrorContext({ owner, projectNumber });
+      mirrorContextLoaded = true;
     }
+    reportProjectStatusForMirror({
+      owner,
+      projectNumber,
+      repo: labelRepo,
+      issueNumber: ref.number,
+      expectedStatus: 'Done',
+      apply: Boolean(args.apply),
+      mirrorContext,
+    });
   }
   return failures === 0 ? 0 : 1;
 }
@@ -1308,25 +1354,11 @@ function main() {
   }
 }
 
-// 토큰/권한 부재로 추정되는 실패 패턴 — gh project 가 인증 실패를 "unknown owner type" 으로 표시하는 것 포함.
-// 이 부류는 CI 를 깨지 않고 graceful degrade (warn + exit 0): lifecycle 자동화는 best-effort 이고,
-// project scope 토큰이 없는 외부 활성 프로젝트의 PR CI 를 빨갛게 만들지 않기 위함.
-const TOKEN_DEGRADE_RE =
-  /unknown owner type|bad credentials|HTTP 40[13]|resource not accessible|requires .*scope|read:project|gh auth|not logged in|authentication/i;
-
 if (import.meta.url === `file://${process.argv[1]}`) {
   try {
     process.exitCode = main();
   } catch (error) {
     console.error(`[dcness-project] ${error.message}`);
-    if (TOKEN_DEGRADE_RE.test(error.message)) {
-      console.error(
-        '[dcness-project] WARN: GitHub Project 토큰/권한 부재로 추정 — lifecycle 자동화를 건너뜁니다 (graceful degrade). ' +
-          'project scope 토큰(secrets.DCNESS_PROJECT_TOKEN)을 설정하면 활성화됩니다. CI 는 실패시키지 않습니다.',
-      );
-      process.exitCode = 0;
-    } else {
-      process.exitCode = 1;
-    }
+    process.exitCode = 1;
   }
 }

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -75,7 +75,7 @@ concrete signal: 파일 path, 함수/클래스/symbol, 이미 분류·승인된 
 
 GitHub issue 등록이 목표인 요청이면 `/to-issue` 로 보내고, 수정/구현이 목표인 버그 신고는 아래 구현 경로 판정으로 처리한다.
 
-GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#issuelabel-status-lifecycle)에 따라 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 전환기 호환으로 Project `Status=In progress` 도 함께 보정된다.
+GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#issuelabel-status-lifecycle)에 따라 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 Project `Status=In progress` 도 best-effort 로 함께 미러된다.
 
 ## Step 0.4 — UI 기준 확보 분기
 

--- a/skills/to-issue/issue-fields.md
+++ b/skills/to-issue/issue-fields.md
@@ -47,5 +47,5 @@ When repo labels diverge from this file, stop before creating the issue and repo
 - A newly registered issue is `Todo` by open state + no `in-progress` label.
 - Add `in-progress` when a target workflow starts.
 - Remove `in-progress` after `Closes`, `Fixes`, `Resolves`, or GitHub closing references close the issue on default-branch merge. `Part of #N` is not a Done signal.
-- If a Project board is configured, mirror `IssueType`, `Priority`, and `Status` as a compatibility view only.
+- If a Project board is configured, mirror `IssueType`, `Priority`, and `Status` as an optional best-effort view only.
 - If a parent issue exists, reference it only. `/to-issue` does not close or rewrite the parent.

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -2,7 +2,9 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
+import tempfile
 import textwrap
 import unittest
 from pathlib import Path
@@ -71,6 +73,45 @@ def run_node(expression: str) -> dict:
 
 
 class GithubProjectLifecycleScriptTests(unittest.TestCase):
+    def run_cli_with_fake_gh(self, args: list[str], fake_gh_body: str) -> tuple[subprocess.CompletedProcess[str], list[list[str]]]:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            log_path = tmp / "gh-calls.jsonl"
+            fake_gh = bin_dir / "gh"
+            fake_gh.write_text(
+                "#!/usr/bin/env python3\n"
+                "import json, os, sys\n"
+                "from pathlib import Path\n"
+                "log_path = Path(os.environ['GH_FAKE_LOG'])\n"
+                "with log_path.open('a', encoding='utf-8') as handle:\n"
+                "    handle.write(json.dumps(sys.argv[1:]) + '\\n')\n"
+                + textwrap.dedent(fake_gh_body).lstrip(),
+                encoding="utf-8",
+            )
+            fake_gh.chmod(0o755)
+            env = {
+                **os.environ,
+                "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                "GH_FAKE_LOG": str(log_path),
+            }
+            completed = subprocess.run(
+                ["node", str(SCRIPT), *args],
+                cwd=ROOT,
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=env,
+            )
+            calls = [
+                json.loads(line)
+                for line in log_path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+            return completed, calls
+
     def test_standard_project_fields_require_all_options(self) -> None:
         fields = [
             {
@@ -963,6 +1004,275 @@ class GithubProjectLifecycleScriptTests(unittest.TestCase):
         self.assertEqual(
             {"validateStatus": "Todo", "validatePriority": "major"}, result
         )
+
+    def test_start_work_apply_keeps_label_success_when_project_lookup_fails(self) -> None:
+        completed, calls = self.run_cli_with_fake_gh(
+            [
+                "start-work",
+                "--repo",
+                "Daeguk-Sun/dcNess",
+                "--owner",
+                "Daeguk-Sun",
+                "--project",
+                "7",
+                "--issue",
+                "891",
+                "--apply",
+            ],
+            """
+            args = sys.argv[1:]
+            if args[:2] == ['issue', 'view']:
+                print(json.dumps({
+                    'number': 891,
+                    'labels': [{'name': 'feature'}],
+                    'state': 'OPEN',
+                    'url': 'https://github.com/Daeguk-Sun/dcNess/issues/891',
+                }))
+                sys.exit(0)
+            if args[:2] == ['label', 'create']:
+                sys.exit(0)
+            if args[:2] == ['issue', 'edit']:
+                sys.exit(0)
+            if args[:2] == ['project', 'view']:
+                print('HTTP 403: resource not accessible', file=sys.stderr)
+                sys.exit(1)
+            print('unexpected gh call: ' + ' '.join(args), file=sys.stderr)
+            sys.exit(2)
+            """,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertIn("WARN", completed.stderr)
+        self.assertIn(["issue", "edit", "891", "--repo", "Daeguk-Sun/dcNess", "--add-label", "in-progress"], calls)
+        self.assertLess(
+            calls.index(["issue", "edit", "891", "--repo", "Daeguk-Sun/dcNess", "--add-label", "in-progress"]),
+            calls.index(["project", "view", "7", "--owner", "Daeguk-Sun", "--format", "json"]),
+        )
+
+    def test_start_work_apply_fails_when_label_transition_fails(self) -> None:
+        completed, calls = self.run_cli_with_fake_gh(
+            [
+                "start-work",
+                "--repo",
+                "Daeguk-Sun/dcNess",
+                "--owner",
+                "Daeguk-Sun",
+                "--project",
+                "7",
+                "--issue",
+                "891",
+                "--apply",
+            ],
+            """
+            args = sys.argv[1:]
+            if args[:2] == ['issue', 'view']:
+                print(json.dumps({
+                    'number': 891,
+                    'labels': [{'name': 'feature'}],
+                    'state': 'OPEN',
+                    'url': 'https://github.com/Daeguk-Sun/dcNess/issues/891',
+                }))
+                sys.exit(0)
+            if args[:2] == ['label', 'create']:
+                sys.exit(0)
+            if args[:2] == ['issue', 'edit']:
+                print('HTTP 403: resource not accessible', file=sys.stderr)
+                sys.exit(1)
+            if args[:2] == ['project', 'view']:
+                print(json.dumps({'id': 'project-id'}))
+                sys.exit(0)
+            print('unexpected gh call: ' + ' '.join(args), file=sys.stderr)
+            sys.exit(2)
+            """,
+        )
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("gh issue edit 891", completed.stderr)
+        self.assertNotIn(["project", "view", "7", "--owner", "Daeguk-Sun", "--format", "json"], calls)
+
+    def test_pr_merged_apply_warns_but_succeeds_when_project_item_missing(self) -> None:
+        completed, calls = self.run_cli_with_fake_gh(
+            [
+                "pr-merged",
+                "--repo",
+                "Daeguk-Sun/dcNess",
+                "--owner",
+                "Daeguk-Sun",
+                "--project",
+                "7",
+                "--body",
+                "Closes #891",
+                "--apply",
+            ],
+            """
+            args = sys.argv[1:]
+            if args[:2] == ['project', 'view']:
+                print(json.dumps({'id': 'project-id'}))
+                sys.exit(0)
+            if args[:2] == ['project', 'field-list']:
+                print(json.dumps({'fields': []}))
+                sys.exit(0)
+            if args[:2] == ['issue', 'view']:
+                print(json.dumps({
+                    'number': int(args[2]),
+                    'labels': [{'name': 'feature'}, {'name': 'in-progress'}],
+                    'state': 'CLOSED',
+                    'url': 'https://github.com/Daeguk-Sun/dcNess/issues/' + args[2],
+                }))
+                sys.exit(0)
+            if args[:2] == ['issue', 'edit']:
+                sys.exit(0)
+            if args[:2] == ['project', 'item-list']:
+                print(json.dumps({'items': []}))
+                sys.exit(0)
+            print('unexpected gh call: ' + ' '.join(args), file=sys.stderr)
+            sys.exit(2)
+            """,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertIn("WARN", completed.stderr)
+        self.assertIn(["issue", "edit", "891", "--repo", "Daeguk-Sun/dcNess", "--remove-label", "in-progress"], calls)
+        self.assertLess(
+            calls.index(["issue", "edit", "891", "--repo", "Daeguk-Sun/dcNess", "--remove-label", "in-progress"]),
+            calls.index(["project", "view", "7", "--owner", "Daeguk-Sun", "--format", "json"]),
+        )
+        self.assertNotIn("item-edit", " ".join(" ".join(call) for call in calls))
+
+    def test_pr_merged_apply_fails_when_label_cleanup_fails(self) -> None:
+        completed, calls = self.run_cli_with_fake_gh(
+            [
+                "pr-merged",
+                "--repo",
+                "Daeguk-Sun/dcNess",
+                "--owner",
+                "Daeguk-Sun",
+                "--project",
+                "7",
+                "--body",
+                "Closes #891",
+                "--apply",
+            ],
+            """
+            args = sys.argv[1:]
+            if args[:2] == ['issue', 'view']:
+                print(json.dumps({
+                    'number': int(args[2]),
+                    'labels': [{'name': 'feature'}, {'name': 'in-progress'}],
+                    'state': 'CLOSED',
+                    'url': 'https://github.com/Daeguk-Sun/dcNess/issues/' + args[2],
+                }))
+                sys.exit(0)
+            if args[:2] == ['issue', 'edit']:
+                print('HTTP 403: resource not accessible', file=sys.stderr)
+                sys.exit(1)
+            if args[:2] == ['project', 'view']:
+                print(json.dumps({'id': 'project-id'}))
+                sys.exit(0)
+            print('unexpected gh call: ' + ' '.join(args), file=sys.stderr)
+            sys.exit(2)
+            """,
+        )
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("gh issue edit 891", completed.stderr)
+        self.assertNotIn(["project", "view", "7", "--owner", "Daeguk-Sun", "--format", "json"], calls)
+
+    def test_validate_issue_reports_project_drift_as_warning_without_failing(self) -> None:
+        completed, _calls = self.run_cli_with_fake_gh(
+            [
+                "validate-issue",
+                "--repo",
+                "Daeguk-Sun/dcNess",
+                "--owner",
+                "Daeguk-Sun",
+                "--project",
+                "7",
+                "--issue",
+                "891",
+                "--expected-status",
+                "In progress",
+            ],
+            """
+            args = sys.argv[1:]
+            if args[:2] == ['project', 'view']:
+                print(json.dumps({'id': 'project-id'}))
+                sys.exit(0)
+            if args[:2] == ['project', 'field-list']:
+                print(json.dumps({'fields': []}))
+                sys.exit(0)
+            if args[:2] == ['issue', 'view']:
+                print(json.dumps({
+                    'number': 891,
+                    'labels': [{'name': 'feature'}],
+                    'state': 'OPEN',
+                    'url': 'https://github.com/Daeguk-Sun/dcNess/issues/891',
+                }))
+                sys.exit(0)
+            if args[:2] == ['project', 'item-list']:
+                print(json.dumps({'items': [{
+                    'id': 'item-id',
+                    'content': {'number': 891, 'repository': 'Daeguk-Sun/dcNess'},
+                    'status': 'Todo',
+                    'issueType': 'feature',
+                    'priority': 'major',
+                }]}))
+                sys.exit(0)
+            print('unexpected gh call: ' + ' '.join(args), file=sys.stderr)
+            sys.exit(2)
+            """,
+        )
+
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertIn("IssueType label=feature", completed.stdout)
+        self.assertIn("WARN", completed.stderr)
+        self.assertIn("expected=In progress", completed.stderr)
+
+    def test_validate_issue_still_fails_on_label_contract_violation(self) -> None:
+        completed, _calls = self.run_cli_with_fake_gh(
+            [
+                "validate-issue",
+                "--repo",
+                "Daeguk-Sun/dcNess",
+                "--owner",
+                "Daeguk-Sun",
+                "--project",
+                "7",
+                "--issue",
+                "891",
+            ],
+            """
+            args = sys.argv[1:]
+            if args[:2] == ['project', 'view']:
+                print(json.dumps({'id': 'project-id'}))
+                sys.exit(0)
+            if args[:2] == ['project', 'field-list']:
+                print(json.dumps({'fields': []}))
+                sys.exit(0)
+            if args[:2] == ['issue', 'view']:
+                print(json.dumps({
+                    'number': 891,
+                    'labels': [{'name': 'feature'}, {'name': 'bug'}],
+                    'state': 'OPEN',
+                    'url': 'https://github.com/Daeguk-Sun/dcNess/issues/891',
+                }))
+                sys.exit(0)
+            if args[:2] == ['project', 'item-list']:
+                print(json.dumps({'items': [{
+                    'id': 'item-id',
+                    'content': {'number': 891, 'repository': 'Daeguk-Sun/dcNess'},
+                    'status': 'Todo',
+                    'issueType': 'feature',
+                    'priority': 'major',
+                }]}))
+                sys.exit(0)
+            print('unexpected gh call: ' + ' '.join(args), file=sys.stderr)
+            sys.exit(2)
+            """,
+        )
+
+        self.assertEqual(1, completed.returncode)
+        self.assertIn("expected exactly one IssueType label", completed.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #891
Part of #887

## 배경 및 문제

#887 결정에 따라 lifecycle 상태의 SSOT 는 issue open/closed + label 이고, GitHub Projects 보드는 optional best-effort mirror 로 유지하기로 했다. 하지만 기존 `start-work`, `pr-merged`, `validate-issue` 경로는 Project 조회/쓰기 실패를 명령 실패로 취급할 수 있어 label 전이와 보드 미러가 아직 강하게 결합되어 있었다.

## 원인 (해당 시)

Project 좌표가 설정된 경우 공통 context 로더가 label 전이보다 먼저 Project view/field-list 를 읽고, Project item 누락이나 Status drift 를 실패 조건에 포함했다. 그 결과 권한 부족, item 부재, field mismatch 같은 보드 측 문제가 issue/label lifecycle 의 성공 여부를 바꿨다.

## 작업내용

- `scripts/github_project_lifecycle.mjs` 에 Project 미러 전용 helper 를 추가해 Project 조회/쓰기 실패를 warning-only 로 분리했다.
- `start-work --apply` 는 `in-progress` label 부착을 먼저 수행하고, 이후 Project `Status=In progress` 를 best-effort 로 1회 미러한다.
- `pr-merged --apply` 는 `in-progress` label 제거를 먼저 수행하고, 이후 Project `Status=Done` 을 best-effort 로 1회 미러한다.
- `validate-issue` 는 issue/label 계약 위반만 실패로 유지하고, Project drift 는 warning 으로만 보고한다.
- fake `gh` 기반 CLI 회귀 테스트를 추가해 Project 권한 실패, item 부재, Project drift warning, label 계약 실패를 검증했다.
- 사용자용 SSOT 문서와 action/skill 문구를 `best-effort Project mirror` 계약으로 갱신했다.

## 결정 근거

보드 자동 이동은 유지하되 lifecycle 원본과 실패 조건에서는 분리해야 한다. 따라서 Project 접점을 제거하지 않고, 좌표가 있을 때만 미러를 시도하며 보드 실패가 label 전이를 막지 않는 구조로 정리했다. `/next-work` 와 drift 실패 판정은 보드를 원본으로 읽지 않고, 선택적 drift 리포트만 보드를 warning source 로 읽을 수 있게 문서화했다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체: `scripts/github_project_lifecycle.mjs`, `skills/impl/SKILL.md`, `skills/to-issue/issue-fields.md`, `docs/plugin/**` 변경은 plug-in 업데이트 시 사용자 환경에 도달한다.
- GitHub Action 경로: `.github/actions/github-project-lifecycle/action.yml` 과 repo-local script 변경은 사용자 repo 의 `github-project-lifecycle.yml` 이 `alruminum/dcNess/.github/actions/github-project-lifecycle@main` 을 호출하므로 main 머지 후 기존 설치 workflow에도 도달한다.
- init-dcness deploy: 새 workflow template 파일 추가/복사는 없고, 기존 `templates/github-workflows/github-project-lifecycle.yml` 은 action `@main` 호출 구조라 변경 불필요하다. 문서 reference(`docs/plugin/init-dcness.md`)는 best-effort mirror 계약으로 갱신했다.
- 사용자용 SSOT 문서: `docs/plugin/github-project.md`, `docs/plugin/issue-lifecycle.md`, `docs/plugin/hooks.md`, `docs/plugin/init-dcness.md` 에 label SSOT / optional Project mirror / warning-only drift 계약을 반영했다.
- 기존 사용자 고지: Project 좌표가 없는 repo 는 정상 skip, Project 좌표가 있는 repo 는 보드 미러 실패가 warning 으로만 출력되고 lifecycle label 전이는 계속 성공한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. 기존 lifecycle script/action/문서 계약만 수정.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `python3.11 -m unittest tests.test_github_project_lifecycle tests.test_github_project_lifecycle_docs -v`
- [x] `node --check scripts/github_project_lifecycle.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] commit pre-commit hook: `python3.11 -m unittest discover -s tests` 1539 tests PASS after review-round amend

## 참고

- Static quality dependencies were installed in a temporary `/tmp/dcness-quality-venv` because the host Python is externally managed; the venv was removed after the gate completed.

