### PR TITLE
[docs] 자기개선 루프 SSOT 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@
 | 각 skill 의 `<skill>-routing.md` ([`impl`](skills/impl/impl-routing.md) / [`design`](skills/design/design-routing.md) / [`impl-loop`](skills/impl-loop/impl-loop-routing.md) 등) | 분기 규칙 진본 (mermaid + enum 표) + retry 한도 + escalate — agent 결론 → 다음 호출 매핑 수정 시 |
 | [`scripts/check_public_surface.mjs`](scripts/check_public_surface.mjs) | 공개 workflow 진입점 gate 기대값 수정 시 |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md) | Step 0~8 mechanics (begin-run → begin-step → Agent → end-step → finalize-run) 수정 시 |
-| [`docs/plugin/hooks.md`](docs/plugin/hooks.md) | hook 시스템 (SessionStart / PreToolUse / PostToolUse / SubagentStop / Stop = 8 hook) 수정 시 SSOT. dcness self 작업용 `scripts/hooks/cc-pre-commit.sh` 는 별 항목 |
+| [`docs/plugin/hooks.md`](docs/plugin/hooks.md) | hook 시스템 (SessionStart / PreToolUse / PostToolUse / SubagentStop) 수정 시 SSOT. dcness self 작업용 `scripts/hooks/cc-pre-commit.sh` 는 별 항목 |
 | [`docs/plugin/issue-lifecycle.md`](docs/plugin/issue-lifecycle.md) | 외부 활성 프로젝트의 epic / story / impl 흐름 변경 시 SSOT (본 저장소 자체엔 미적용 — [dcness 자체는 init-dcness 미적용](#dcness-자체는-init-dcness-미적용-자기-규격-미얽매임) 참조) |
 | [`docs/plugin/deliverables-map.md`](docs/plugin/deliverables-map.md) | 외부 활성 프로젝트의 docs 산출물 위치·양식·계층 (`docs/index.md`, 전역 anchors, epic 산출물, `docs/decisions/`, `.dcness-work/`, 시드=산출 양식) SSOT — 산출물 경로/템플릿 수정 시 |
 | [`docs/plugin/parallel-policy.md`](docs/plugin/parallel-policy.md) | 병렬 peer 세션·claim board·merge lock 정책 수정 시 |
@@ -128,6 +128,7 @@
 | [`scripts/hooks/pre-commit`](scripts/hooks/pre-commit) | git pre-commit hook 수정 시 |
 | [`scripts/hooks/cc-pre-commit.sh`](scripts/hooks/cc-pre-commit.sh) | Claude Code PreToolUse hook 수정 시 |
 | [`docs/internal/doc-conventions.md`](docs/internal/doc-conventions.md) | 문서 섹션 참조·anchor 링크 표기 수정/리뷰 시 (cross-ref 게이트가 강제하는 규약 SSOT) |
+| [`docs/internal/self-improvement-loop.md`](docs/internal/self-improvement-loop.md) | 측정 신호를 하네스 개선으로 닫는 Sense→Diagnose→Decide→Act→Verify 자기개선 루프 수정 시 |
 | [`docs/internal/plugin-release.md`](docs/internal/plugin-release.md) | 플러그인 릴리즈·버전 배포 요청 시 — 순서·태그·주의사항 |
 | [`docs/internal/release-notes.md`](docs/internal/release-notes.md) | 릴리즈 노트 기록 — 버전별 커밋 범위·변경 요약 |
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ claude plugin install dcness@dcness
 | 유틸 | `/smart-compact` | 컨텍스트 압축 + 다음 세션 resume prompt 생성 |
 | 유틸 | `/efficiency` | 세션 토큰·비용 분석 + HTML 대시보드 |
 
-12개 sub-agent(`agents/`, architect / validator / engineer / reviewer / acceptance 계열)는 사용자가 직접 부르는 게 아니라 workflow 안에서 gate·worker·reviewer 로 호출된다.
+Sub-agent(`agents/`, architect / validator / engineer / reviewer / acceptance 계열)는 사용자가 직접 부르는 게 아니라 workflow 안에서 gate·worker·reviewer 로 호출된다.
 
 ## 거버넌스 (dcNess 저장소 자체 작업 기준)
 
@@ -191,7 +191,7 @@ bash scripts/check_static_quality.sh          # ruff + mypy + bandit
 | [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md) | 자유 형식 요청을 어떤 workflow 로 보낼지 판정 |
 | [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현 가이드 + 표본 한계 |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md#진입-모델) | loop 실행 절차 (Step 0~8) |
-| [`docs/plugin/hooks.md`](docs/plugin/hooks.md#catastrophic-gatesh) | 순서 차단 훅 + 8 hook SSOT |
+| [`docs/plugin/hooks.md`](docs/plugin/hooks.md#catastrophic-gatesh) | 순서 차단 훅 + hook SSOT |
 | [`PROGRESS.md`](PROGRESS.md) | 현재 상태 / TODO / Blockers |
 | [`AGENTS.md`](AGENTS.md) | 외부 에이전트(Codex 등) 지침 |
 

--- a/commands/smart-compact.md
+++ b/commands/smart-compact.md
@@ -175,7 +175,7 @@ EOF
 # 컨텍스트
 - 핵심: harness/session_state.py, harness/hooks.py, hooks/*.sh, commands/*.md
 - spec: docs/plugin/loop-procedure.md (Task/Agent/helper/hook loop mechanics)
-- agents/*.md 12개 모두 자유서술 방식 (DCN-CHG-27)
+- agents/*.md 전체 자유서술 방식 (DCN-CHG-27)
 - 기준: CLAUDE.md 강제 원칙 + docs/plugin/workflow-router.md
 
 다음 세션은 worktree 도입 의논 이어서 + manual smoke 또는 /init-dcness 진행.

--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -21,6 +21,15 @@ GitHub object 형식(`{"source": "github", "repo": "...", "ref": "release"}`)은
 
 ## 3. 릴리즈 순서
 
+릴리즈 전 자기개선 점검은 [`self-improvement-loop.md`](self-improvement-loop.md)의
+Sense→Diagnose→Decide→Act→Verify 루프를 따른다. 새 CI 게이트가 아니라 사람이 도는
+권고 절차다.
+
+- Sense: `python3 evals/guard_efficacy.py`와 `EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh`를 실행한다. 행동 eval 산출물은 `.metrics/evals/` 또는 `EVAL_OUTPUT_DIR`에 남긴다.
+- Diagnose: 가드 발화 텔레메트리([#875](https://github.com/alruminum/dcNess/issues/875))가 준비되어 있으면 집계를 보고, 없으면 최근 CI·hook 실패 이력을 수동 확인한다. 재발·낭비 신호([#876](https://github.com/alruminum/dcNess/issues/876))도 같은 자리에서 본다.
+- Decide: 추가 전 제거 검토를 먼저 한다. 소멸 후보나 follow-up이 있으면 릴리즈 노트 `Unreleased` 또는 별도 GitHub issue에 기록한다.
+- Verify: 핵심 행동 eval(`shorts-real-spec`, `headless-prose-quality`)은 릴리즈 체크 모드에서 N/N 통과해야 한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 [#894](https://github.com/alruminum/dcNess/issues/894) 보정 입력으로 남긴다.
+
 ```sh
 # 1. 브랜치 생성
 git checkout -b docs/release_{버전}_{설명} main

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -6,7 +6,8 @@
 
 ## Unreleased
 
-- (없음)
+- 자기개선 루프 SSOT 추가 — 측정 신호를 Sense→Diagnose→Decide→Act→Verify로 닫는 내부 절차를 [`docs/internal/self-improvement-loop.md`](self-improvement-loop.md)에 정의하고, 릴리즈 점검·eval 산출물 보존·핵심 행동 eval N/N 기준을 연결했다. [#893](https://github.com/alruminum/dcNess/issues/893)
+- 문서 개수 하드코딩 제거 — README/CLAUDE/loop-procedure/smart-compact의 구성 요소 count prose와 cross-ref count deny-list를 제거해 stale 방지 룰을 소멸시켰다. [#877](https://github.com/alruminum/dcNess/issues/877)
 
 ---
 

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -1,0 +1,76 @@
+# 자기개선 루프
+
+> dcNess self 운영용 SSOT. 이 문서는 측정 신호를 하네스 개선으로 닫는 절차를 정의한다.
+> 외부 활성 프로젝트용 규격이 아니므로 `docs/plugin/`으로 배포하지 않는다.
+
+## 원칙
+
+자기개선 루프는 코드 강제 게이트가 아니다. dcNess가 측정 도구를 늘릴수록 그 측정을
+소비하는 사람이 한 바퀴를 돌 수 있도록, 문서 SSOT와 릴리즈 리듬만 제공한다.
+
+루프는 항상 사람 판단을 통과한다. 측정값은 후보를 표면화하고, 룰·skill·hook·CI의 추가,
+제거, 축약, 보류 결정은 사람이 한다. 자동 룰 박제와 자동 제거는 범위 밖이다.
+
+## 루프 슬롯
+
+| 슬롯 | 질문 | 현재 담당 |
+|---|---|---|
+| Sense | 어떤 신호를 보나 | `/run-review`, benchmark/fleet 집계, `evals/guard_efficacy.py`, `evals/run.sh`, 가드 발화 텔레메트리 후보 [#875](https://github.com/alruminum/dcNess/issues/875), 재발·낭비 집계 후보 [#876](https://github.com/alruminum/dcNess/issues/876), judge 보정 후보 [#894](https://github.com/alruminum/dcNess/issues/894) |
+| Diagnose | 여러 신호를 어떻게 우선순위화하나 | 릴리즈 점검 [#878](https://github.com/alruminum/dcNess/issues/878)이 겸한다. 릴리즈 후보에서 Sense 신호를 한 자리에서 모아 blocker, release-note follow-up, 별도 issue로 나눈다. |
+| Decide | 무엇을 바꾸나 | 추가 전 제거 검토를 먼저 한다. 새 룰·hook·CI를 추가하기 전에 기존 룰 삭제, 문구 축약, SSOT 파생 생성으로 같은 효과를 낼 수 있는지 확인한다. 첫 사례는 개수 하드코딩 제거 [#877](https://github.com/alruminum/dcNess/issues/877)이다. |
+| Act | 실제 변경은 어디서 하나 | 일반 dcNess 변경 절차대로 branch → PR → merge를 탄다. PR 본문에 Sense 근거, Diagnose 판단, Decide 이유, Verify 계획을 짧게 적는다. |
+| Verify | 개선이 먹혔는지 어떻게 보나 | 변경 성격별로 결정적 eval, 행동 eval, 다음 Sense 주기 재측정을 분리한다. |
+
+## 트리거 리듬
+
+릴리즈마다 한 번 돈다. [`plugin-release.md`](plugin-release.md)의 릴리즈 전 점검에서
+Sense 산출물을 모으고, Diagnose/Decide 결과를 릴리즈 노트 또는 후속 이슈에 남긴다.
+
+평소 run 중 발견한 단발 신호는 바로 룰로 박지 않는다. 같은 신호가 반복되거나 릴리즈
+점검에서 비용·위험이 충분히 커졌을 때 Decide 슬롯으로 올린다.
+
+## 결정 규칙
+
+Decide 슬롯은 아래 순서로 판단한다.
+
+1. 기존 강제 장치를 제거하거나 축약할 수 있는가.
+2. 문서 본문 하드코딩을 없애고 SSOT 파생 생성이나 링크로 대체할 수 있는가.
+3. 권고 문구만으로 충분한가.
+4. 그래도 되돌릴 수 없는 경계를 막아야 할 때만 hook·CI 같은 강제를 추가한다.
+
+이 순서는 [`CLAUDE.md`의 안티패턴](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)
+중 "룰이 룰을 부르는 reactive cycle"을 피하기 위한 기본값이다.
+
+## 검증 기준
+
+Verify는 하나의 PASS로 뭉개지 않는다.
+
+| 변경 종류 | Verify 도구 | 한계 |
+|---|---|---|
+| hook/function/order/TDD guard 변경 | `python3 evals/guard_efficacy.py` | fixture 계약의 재현만 본다. 실제 agent 행동은 보지 않는다. |
+| agent·skill 행동 판단 변경 | `bash evals/run.sh` | LLM 실행이라 흔들림이 있다. judge 신뢰성은 [#894](https://github.com/alruminum/dcNess/issues/894) 보정 대상이다. |
+| 릴리즈 전 핵심 실사고 회귀 | `EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh` | `shorts-real-spec`, `headless-prose-quality`는 N/N 통과가 기준이다. |
+| 재발·낭비·비용 신호 | 다음 Sense 주기 재측정 | evals 밖 운영 신호라 즉시 증명할 수 없다. |
+
+`evals/run.sh`는 블라인드 검수 보고와 judge 채점 결과를 `.metrics/evals/` 아래 또는
+`EVAL_OUTPUT_DIR`로 지정한 위치에 저장한다. MISS가 났을 때 사람은 해당 파일을 직접 읽어
+agent 결함인지 judge 결함인지 구분한다.
+
+## 첫 실증
+
+첫 루프 실증은 [#877](https://github.com/alruminum/dcNess/issues/877)로 기록한다.
+
+| 슬롯 | 기록 |
+|---|---|
+| Sense | 하네스 엔지니어링 리뷰에서 구성 요소 개수 하드코딩과 그 stale 방지 deny-list가 reactive cycle 사례로 식별됐다. |
+| Diagnose | [#893](https://github.com/alruminum/dcNess/issues/893)의 자기개선 루프 epic에서 Decide 슬롯 첫 사례로 배치했다. |
+| Decide | 개수 변경마다 문서 본문과 deny-list를 같이 고치는 방식 대신, 본문 개수 표기를 제거하고 SSOT 링크·파생 검증으로 대체한다. |
+| Act | [#893](https://github.com/alruminum/dcNess/issues/893) 구현 PR에서 README/CLAUDE/loop-procedure/smart-compact의 count prose와 cross-ref count deny-list를 제거한다. |
+| Verify | `python3.11 -m unittest tests.test_surface_docs_sync tests.test_evals_harness -v`와 `node scripts/check_cross_refs.mjs`로 확인한다. |
+
+## 이슈 연결
+
+- Epic: [#893](https://github.com/alruminum/dcNess/issues/893)
+- Sense: [#875](https://github.com/alruminum/dcNess/issues/875), [#876](https://github.com/alruminum/dcNess/issues/876), [#894](https://github.com/alruminum/dcNess/issues/894)
+- Decide: [#877](https://github.com/alruminum/dcNess/issues/877)
+- Trigger/Diagnose: [#878](https://github.com/alruminum/dcNess/issues/878)

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -453,14 +453,14 @@ dcNess run 밖에서 호출되면 ledger 기록은 경고만 내고 PR 작업 �
 
 ## 순서 차단 훅 정합
 
-각 loop 의 entry_point / task_list / advance / expected_steps 진본 = 해당 skill 의 `## Loop` contract. 그 시퀀스가 중대 차단 룰을 자연 충족한다 — 순서 차단 훅 진본 = [`hooks.md`](hooks.md#catastrophic-gatesh) (`hooks/catastrophic-gate.sh` 강제): code-validator → pr-reviewer 직전 PASS / engineer·build-worker 직전 module-architect `PASS` enum 또는 동등 설계 산출물 / `/design` 첫 module-architect 단위 진입 직전 architecture-validator 1차 PASS. (tech-review 진입 gate = PRD 변경 후 사용자 2 차 OK · `/design` 진입 후 tech-reviewer 재호출 비권장 = 코드 강제 아닌 자연어 관례.) 8 hook 전체 시점·차단·우회 = [`hooks.md`](hooks.md).
+각 loop 의 entry_point / task_list / advance / expected_steps 진본 = 해당 skill 의 `## Loop` contract. 그 시퀀스가 중대 차단 룰을 자연 충족한다 — 순서 차단 훅 진본 = [`hooks.md`](hooks.md#catastrophic-gatesh) (`hooks/catastrophic-gate.sh` 강제): code-validator → pr-reviewer 직전 PASS / engineer·build-worker 직전 module-architect `PASS` enum 또는 동등 설계 산출물 / `/design` 첫 module-architect 단위 진입 직전 architecture-validator 1차 PASS. (tech-review 진입 gate = PRD 변경 후 사용자 2 차 OK · `/design` 진입 후 tech-reviewer 재호출 비권장 = 코드 강제 아닌 자연어 관례.) hook 전체 시점·차단·우회 = [`hooks.md`](hooks.md).
 
 ---
 
 ## 참조
 
 - 각 loop skill 의 `<skill>-routing.md` — 분기 규칙 / retry / escalate ([`impl-routing.md`](../../skills/impl/impl-routing.md) / [`design-routing.md`](../../skills/design/design-routing.md) / [`impl-loop-routing.md`](../../skills/impl-loop/impl-loop-routing.md) / [`ux-routing.md`](../../skills/ux/ux-routing.md) / [`tech-review-routing.md`](../../skills/tech-review/tech-review-routing.md)) · loop 진입 spec = 각 skill 의 `## Loop` contract
-- [`hooks.md`](hooks.md) — 8 hook (catastrophic-gate / file-guard / tdd-guard / stop-end-run / session-start / post-agent-clear / post-file-op-trace / subagent-stop-clear) 시점·차단·우회 SSOT
+- [`hooks.md`](hooks.md) — hook 시점·차단·우회 SSOT
 - 본 문서 [표준 1 step 시퀀스](#표준-1-step-시퀀스-per-agent-의무) + [Step 8 — review 결과 인지](#step-8-review-결과-인지) — echo / 자가점검 / REDO 분류 / 개선점 코멘트 (옛 dcness-rules §3/§4 흡수)
 - `harness/session_state.py` — helper CLI (`begin-run` / `end-run` / `begin-step` / `end-step` / `finalize-run` / `run-dir` / `auto-resolve`)
 - `harness/run_review.py` — review 엔진 (`--auto-review` 호출 대상)

--- a/evals/README.md
+++ b/evals/README.md
@@ -33,7 +33,9 @@ python3 evals/guard_efficacy.py --json # 범주별 pass/fail JSON
 
 bash evals/run.sh                    # 전 케이스 1회씩
 EVAL_RUNS=3 bash evals/run.sh        # 케이스당 3회 반복 (릴리즈 전 권장)
+EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh  # 핵심 실사고 케이스 N/N 확인
 EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonnet)
+EVAL_OUTPUT_DIR=/tmp/dcness-evals bash evals/run.sh # 산출물 저장 위치 지정
 ```
 
 `guard_efficacy.py` 는 범주별 pass/fail count 를 출력한다. `provider-agnostic-order-gate`
@@ -42,6 +44,16 @@ EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonne
 아니라 문서화된 한계가 실제로 한계로 남아 있음을 드러내는 항목이다.
 
 케이스마다 `정답 k/N` 표가 출력된다. 어떤 케이스든 정답 0회면 exit 1 — 방금 바꾼 지침이 보호를 깨먹었는지 확인한다.
+릴리즈 점검에서는 `EVAL_RELEASE_CHECK=1`을 함께 켜고 `shorts-real-spec`, `headless-prose-quality`
+같은 핵심 실사고 케이스가 N/N으로 통과해야 한다. 이 기준은 새 CI 게이트가 아니라
+[`docs/internal/self-improvement-loop.md`](../docs/internal/self-improvement-loop.md)의
+Verify 슬롯을 사람이 도는 릴리즈 전 권고다.
+
+실행 산출물은 기본적으로 `.metrics/evals/run-<timestamp>-<pid>/`에 저장된다. 각 케이스
+디렉터리 아래 `run-<N>-report.md`는 블라인드 검수 보고, `run-<N>-judge.md`는 judge 채점
+출력이다. MISS가 나면 두 파일을 대조해 agent 결함인지 judge 결함인지 분리한다. 이 파일은
+[#875](https://github.com/alruminum/dcNess/issues/875)의 추세 집계와
+[#894](https://github.com/alruminum/dcNess/issues/894)의 judge 보정 입력으로 소비된다.
 
 ## 채점 원리 — 정답표는 계약 수준으로만 쓴다
 

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -10,14 +10,30 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RUNS="${EVAL_RUNS:-1}"
 MODEL="${EVAL_MODEL:-sonnet}"
+OUTPUT_DIR="${EVAL_OUTPUT_DIR:-$ROOT/.metrics/evals/run-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RELEASE_CHECK="${EVAL_RELEASE_CHECK:-0}"
+STRICT_CASES="${EVAL_STRICT_CASES:-shorts-real-spec headless-prose-quality}"
 
 command -v claude >/dev/null 2>&1 || { echo "[eval] claude CLI 가 필요하다"; exit 2; }
 
 overall_fail=0
+mkdir -p "$OUTPUT_DIR"
+echo "[eval] output: $OUTPUT_DIR"
+
+is_strict_case() {
+  local needle="$1"
+  local item
+  for item in $STRICT_CASES; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
 
 for case_dir in "$ROOT"/evals/cases/*/; do
   case_name="$(basename "$case_dir")"
   case_path="${case_dir%/}"
+  case_output="$OUTPUT_DIR/$case_name"
+  mkdir -p "$case_output"
 
   for f in prompt.md expected.md; do
     [ -f "$case_path/$f" ] || { echo "[eval] $case_name: $f 없음 — skip"; overall_fail=1; continue 2; }
@@ -37,10 +53,14 @@ for case_dir in "$ROOT"/evals/cases/*/; do
   pass=0
 
   for ((i = 1; i <= RUNS; i++)); do
+    report_file="$case_output/run-$i-report.md"
+    judge_file="$case_output/run-$i-judge.md"
+
     if ! report="$(claude -p "$prompt" --model "$MODEL" --allowedTools "Read" --add-dir "$sandbox" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 검수 실행 실패"
       continue
     fi
+    printf '%s\n' "$report" > "$report_file"
 
     judge_prompt="너는 채점자다. 아래 [검수 보고]가 [정답표]의 각 기대를 충족하는지만 판정한다.
 - MUST 기대: 그 취지의 결함이 보고 어딘가에서 지적되면 충족.
@@ -57,6 +77,7 @@ $report"
       echo "[eval] $case_name run $i: 채점 실행 실패"
       continue
     fi
+    printf '%s\n' "$grade" > "$judge_file"
 
     verdict="$(printf '%s\n' "$grade" | grep -E '^RESULT: (PASS|FAIL)$' | tail -1 || true)"
     if [ "$verdict" = "RESULT: PASS" ]; then
@@ -71,6 +92,10 @@ $report"
   rm -rf "$sandbox"
   echo "[eval] $case_name — 정답 $pass/$RUNS"
   [ "$pass" -gt 0 ] || overall_fail=1
+  if [ "$RELEASE_CHECK" = "1" ] && is_strict_case "$case_name" && [ "$pass" -ne "$RUNS" ]; then
+    echo "[eval] $case_name — 릴리즈 체크 실패: 핵심 실사고 케이스는 $RUNS/$RUNS 필요"
+    overall_fail=1
+  fi
 done
 
 if [ "$overall_fail" -ne 0 ]; then

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -81,22 +81,6 @@ const DENY_LIST = [
     label: '옛 step 로그 `.steps.jsonl` — `ledger.jsonl` 의 step_completed event 로 흡수 (이슈 #587). legacy/폴백 맥락(옛·legacy 키워드 동반)만 허용.',
   },
   {
-    pattern: /agent\s+1[013]\s*종/,
-    label: '옛 agent 카운트 (10, 11, 13 종) — 현재 12 종 (product-acceptance / designer / build-worker 포함)',
-  },
-  {
-    pattern: /\b1[013]\s*개\s+(?:sub-)?agent\b/,
-    label: '옛 agent 카운트 (10, 11, 13개 agent/sub-agent) — 현재 12개',
-  },
-  {
-    pattern: /\b1[013]\s+agents?\b/,
-    label: '옛 agent 카운트 (10, 11, 13 agent/agents) — 현재 12 agents',
-  },
-  {
-    pattern: /\b[79]\s*hook\s+(상세|전체|공유|충족|시점)/,
-    label: '옛 hook 카운트 (7 또는 9) — 현재 8 hook (hooks.md §3 sub-section 정합, issue #598 SubagentStop 추가)',
-  },
-  {
     pattern: /\b8\s+loop\s+(행별|풀스펙)/,
     label: '옛 loop 카운트 — 현재 loop 진본은 각 `skills/<skill>/SKILL.md` 의 `## Loop` contract',
   },

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -6,9 +6,12 @@ evals/ 의 러너·케이스·정답표가 구조 계약(계약 수준 정답표
 """
 from __future__ import annotations
 
+import os
+import stat
 import subprocess
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -93,6 +96,60 @@ class EvalsHarnessContractTests(unittest.TestCase):
         claude_md = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
         self.assertIn("bash evals/run.sh", claude_md)
         self.assertIn("행동 eval (권고 — CI 차단 아님)", claude_md)
+
+    def test_runner_persists_blind_report_and_judge_output(self) -> None:
+        """#893 — run.sh must leave artifacts for missed-case and judge calibration review."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            out_dir = tmp / "eval-output"
+            bin_dir.mkdir()
+            fake_claude = bin_dir / "claude"
+            fake_claude.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        "prompt=''",
+                        "while [ \"$#\" -gt 0 ]; do",
+                        "  case \"$1\" in",
+                        "    -p) shift; prompt=\"$1\" ;;",
+                        "  esac",
+                        "  shift || true",
+                        "done",
+                        "if printf '%s' \"$prompt\" | grep -q '\\[정답표\\]'; then",
+                        "  printf 'OK FAKE\\nRESULT: PASS\\n'",
+                        "else",
+                        "  printf 'blind report with concrete evidence\\n'",
+                        "fi",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            env["EVAL_OUTPUT_DIR"] = str(out_dir)
+            env["EVAL_RUNS"] = "1"
+            env["EVAL_RELEASE_CHECK"] = "1"
+            result = subprocess.run(
+                ["bash", str(EVALS / "run.sh")],
+                cwd=str(ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn(str(out_dir), result.stdout)
+            report_files = sorted(out_dir.glob("*/run-1-report.md"))
+            judge_files = sorted(out_dir.glob("*/run-1-judge.md"))
+            self.assertGreaterEqual(len(report_files), 1)
+            self.assertEqual(len(report_files), len(judge_files))
+            self.assertIn("blind report", report_files[0].read_text(encoding="utf-8"))
+            self.assertIn("RESULT: PASS", judge_files[0].read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -254,7 +254,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         for name in REMOVED_WORKFLOW + SUPPORT:
             self.assertNotIn(f"| `{name}` |", basic_table)
 
-        public_surface = self._section(self.readme, r"## 공개 진입점", r"\n12개 sub-agent")
+        public_surface = self._section(self.readme, r"## 공개 진입점", r"\n## 거버넌스")
         for name in LIFECYCLE:
             self.assertIn(f"| 기본 workflow | `{name}` |", public_surface)
         for name in REMOVED_WORKFLOW:
@@ -316,14 +316,12 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             self.assertIn("/spec", text)
             self.assertNotIn("/product-plan", text)
 
-    def test_cross_ref_gate_agent_count_label_matches_public_surface(self) -> None:
-        self.assertIn("현재 12 종", self.cross_ref_script)
-        self.assertIn(r"agent\s+1[013]\s*종", self.cross_ref_script)
-        self.assertIn(r"1[013]\s*개\s+(?:sub-)?agent", self.cross_ref_script)
-        self.assertIn(r"1[013]\s+agents?", self.cross_ref_script)
-        self.assertIn("13개 agent/sub-agent", self.cross_ref_script)
-        self.assertNotIn(r"agent\s+1[0-2]\s*종", self.cross_ref_script)
-        self.assertNotIn("현재 13 종", self.cross_ref_script)
+    def test_cross_ref_gate_does_not_freeze_component_counts(self) -> None:
+        """#877 — component count drift should be avoided at the source, not patched by deny-list."""
+        self.assertNotIn("옛 agent 카운트", self.cross_ref_script)
+        self.assertNotIn("옛 hook 카운트", self.cross_ref_script)
+        self.assertNotIn("현재 12 종", self.cross_ref_script)
+        self.assertNotIn("현재 8 hook", self.cross_ref_script)
 
     def test_strict_conveyor_docs_use_current_entrypoints(self) -> None:
         expected = "entry_point=design|impl|ux"
@@ -347,7 +345,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
                     self.assertIsNotNone(match, command)
                     runtime_hooks.add(match.group(1))
 
-        self.assertEqual(8, len(runtime_hooks))
+        self.assertGreater(len(runtime_hooks), 0)
         for hook_name in sorted(runtime_hooks):
             self.assertIn(f"### {hook_name}", self.hooks_doc)
             self.assertRegex(


### PR DESCRIPTION
## 관련 이슈 번호
Part of #893
Closes #877

## 배경 및 문제
- dcNess에는 `/run-review`, benchmark, guard-efficacy, 행동 eval 같은 측정 도구가 있지만 Sense→Diagnose→Decide→Act→Verify로 개선을 닫는 내부 SSOT가 없었다.
- 행동 eval MISS 분석과 judge 보정을 위해 블라인드 검수 보고와 judge 채점 결과를 파일로 남길 필요가 있었다.
- 구성 요소 개수 stale을 막기 위해 문서 count를 또 다른 deny-list로 막는 구조가 reactive cycle 사례로 남아 있었다.

## 원인 (해당 시)
- 측정 도구는 늘었지만 릴리즈 시점에 사람이 신호를 종합하고 개선/제거/보류를 판단하는 절차가 문서화되지 않았다.
- `evals/run.sh`는 stdout 요약만 남기고 per-run 검수 보고와 judge 출력을 보존하지 않았다.
- 일부 문서가 agent/hook 개수를 본문에 고정 표기했고, cross-ref가 stale count를 별도 deny-list로 막고 있었다.

## 작업내용
- `docs/internal/self-improvement-loop.md` 신규 추가: Sense/Diagnose/Decide/Act/Verify 5슬롯, 이슈 매핑, 릴리즈 리듬, 추가 전 제거 검토 규칙, Verify 기준 정의.
- `evals/run.sh`에 `.metrics/evals/` 산출물 저장과 `EVAL_RELEASE_CHECK=1` 핵심 실사고 케이스 N/N 기준을 추가.
- `evals/README.md`, `docs/internal/plugin-release.md`, `CLAUDE.md`, `docs/internal/release-notes.md`를 새 SSOT와 연결.
- README/CLAUDE/loop-procedure/smart-compact의 구성 요소 count prose와 `scripts/check_cross_refs.mjs`의 count deny-list를 제거.
- GitHub #893에 #875/#876/#877/#878/#894를 sub-issue로 연결.

## 결정 근거
- 자기개선 루프는 새 CI 강제가 아니라 문서 SSOT + 릴리즈 사람이 도는 절차로 두었다. #392의 자동 누적/자동 박제 실패 교훈과 CLAUDE.md의 “추가 전 제거 검토” 원칙을 따른다.
- #877은 새 deny-list를 유지하는 대신 count prose를 제거해 stale 원인을 없애는 방향으로 처리했다.

## 배포 경로 검증 (plug-in 영향 시)
- `docs/internal/**`, `evals/**`, `tests/**`, `scripts/check_cross_refs.mjs`: dcness self QA/운영 경로. release 브랜치 배포 대상 아님.
- `commands/smart-compact.md`, `docs/plugin/loop-procedure.md`: plug-in 본체 경로. 사용자 환경에는 plugin update 후 반영된다.
- `/init-dcness` 복사/배포 파일 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public skill/command/agent/gate 없음. 기존 내부 문서와 eval runner만 갱신.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `PYTHON_BIN=tmp/quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `python3.11 evals/guard_efficacy.py`
- [x] git pre-commit hook PASS (1540 unittest 재실행)

## 참고
- 실제 `bash evals/run.sh`는 LLM 비용/변동성이 있는 릴리즈 권고 eval이므로 이번 PR에서는 fake `claude` CLI 계약 테스트로 산출물 저장과 release-check branch를 검증했다.
