### PR TITLE
[docs] restore Stop hook in CLAUDE map

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@
 | 각 skill 의 `<skill>-routing.md` ([`impl`](skills/impl/impl-routing.md) / [`design`](skills/design/design-routing.md) / [`impl-loop`](skills/impl-loop/impl-loop-routing.md) 등) | 분기 규칙 진본 (mermaid + enum 표) + retry 한도 + escalate — agent 결론 → 다음 호출 매핑 수정 시 |
 | [`scripts/check_public_surface.mjs`](scripts/check_public_surface.mjs) | 공개 workflow 진입점 gate 기대값 수정 시 |
 | [`docs/plugin/loop-procedure.md`](docs/plugin/loop-procedure.md) | Step 0~8 mechanics (begin-run → begin-step → Agent → end-step → finalize-run) 수정 시 |
-| [`docs/plugin/hooks.md`](docs/plugin/hooks.md) | hook 시스템 (SessionStart / PreToolUse / PostToolUse / SubagentStop) 수정 시 SSOT. dcness self 작업용 `scripts/hooks/cc-pre-commit.sh` 는 별 항목 |
+| [`docs/plugin/hooks.md`](docs/plugin/hooks.md) | hook 시스템 (SessionStart / PreToolUse / PostToolUse / SubagentStop / Stop) 수정 시 SSOT. dcness self 작업용 `scripts/hooks/cc-pre-commit.sh` 는 별 항목 |
 | [`docs/plugin/issue-lifecycle.md`](docs/plugin/issue-lifecycle.md) | 외부 활성 프로젝트의 epic / story / impl 흐름 변경 시 SSOT (본 저장소 자체엔 미적용 — [dcness 자체는 init-dcness 미적용](#dcness-자체는-init-dcness-미적용-자기-규격-미얽매임) 참조) |
 | [`docs/plugin/deliverables-map.md`](docs/plugin/deliverables-map.md) | 외부 활성 프로젝트의 docs 산출물 위치·양식·계층 (`docs/index.md`, 전역 anchors, epic 산출물, `docs/decisions/`, `.dcness-work/`, 시드=산출 양식) SSOT — 산출물 경로/템플릿 수정 시 |
 | [`docs/plugin/parallel-policy.md`](docs/plugin/parallel-policy.md) | 병렬 peer 세션·claim board·merge lock 정책 수정 시 |


### PR DESCRIPTION
## 관련 이슈 번호

Part of #893

## 배경 및 문제

- PR #895에서 hook count 하드코딩을 제거하는 과정에서 CLAUDE.md 문서 지도에서 실제 hook 이벤트명인 Stop까지 누락됐다.
- hooks/hooks.json과 docs/plugin/hooks.md에는 Stop hook이 계속 등록·문서화되어 있어 CLAUDE.md의 hook 시스템 요약이 사실과 어긋났다.

## 원인 (해당 시)

- count 표기 제거와 이벤트명 열거 유지가 분리되지 않았다.

## 작업내용

- CLAUDE.md의 docs/plugin/hooks.md 행에 Stop 이벤트명을 복원했다.
- = 8 hook 같은 count 표기는 되살리지 않았다.

## 결정 근거

- Stop은 hook 개수가 아니라 hooks/hooks.json에 등록된 실제 Claude Code hook 이벤트명이다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — CLAUDE.md 문서 지도 한 줄 수정이며 plugin 배포 surface 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 surface 없음.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증

검증 명령:

```sh
python3.11 -m unittest tests.test_evals_harness tests.test_surface_docs_sync
```

결과: 46 tests OK.

## 참고

- Review follow-up from PR #895.
