### PR TITLE
[issue-877] count deny-list 후속 보정

### DIFF
--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -65,8 +65,8 @@ agent 결함인지 judge 결함인지 구분한다.
 | Sense | 하네스 엔지니어링 리뷰에서 구성 요소 개수 하드코딩과 그 stale 방지 deny-list가 reactive cycle 사례로 식별됐다. |
 | Diagnose | [#893](https://github.com/alruminum/dcNess/issues/893)의 자기개선 루프 epic에서 Decide 슬롯 첫 사례로 배치했다. |
 | Decide | 개수 변경마다 문서 본문과 deny-list를 같이 고치는 방식 대신, 본문 개수 표기를 제거하고 SSOT 링크·파생 검증으로 대체한다. |
-| Act | [#893](https://github.com/alruminum/dcNess/issues/893) 구현 PR에서 README/CLAUDE/loop-procedure/smart-compact의 count prose와 cross-ref count deny-list를 제거한다. |
-| Verify | `python3.11 -m unittest tests.test_surface_docs_sync tests.test_evals_harness -v`와 `node scripts/check_cross_refs.mjs`로 확인한다. |
+| Act | [#893](https://github.com/alruminum/dcNess/issues/893) 구현 PR에서 README/CLAUDE/loop-procedure/smart-compact의 count prose와 cross-ref count deny-list를 제거하고, `evals/run.sh` report/judge artifact 저장 계약을 보존한다. |
+| Verify | `python3.11 -m unittest tests.test_surface_docs_sync tests.test_evals_harness -v`와 `node scripts/check_cross_refs.mjs`로 count deny-list 제거와 eval artifact 저장을 확인한다. |
 
 ## 이슈 연결
 

--- a/scripts/check_cross_refs.mjs
+++ b/scripts/check_cross_refs.mjs
@@ -81,10 +81,6 @@ const DENY_LIST = [
     label: '옛 step 로그 `.steps.jsonl` — `ledger.jsonl` 의 step_completed event 로 흡수 (이슈 #587). legacy/폴백 맥락(옛·legacy 키워드 동반)만 허용.',
   },
   {
-    pattern: /\b8\s+loop\s+(행별|풀스펙)/,
-    label: '옛 loop 카운트 — 현재 loop 진본은 각 `skills/<skill>/SKILL.md` 의 `## Loop` contract',
-  },
-  {
     // `design-routing.md` 등 skill 분기 파일은 앞에 `-`/단어문자가 붙어 제외.
     pattern: /(?<![\w-])routing\.md/,
     label: '폐기 SSOT `docs/plugin/routing.md` — Phase 3 (#564) 폐기, 분기 규칙은 각 skill `<skill>-routing.md` 로 분산',

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -151,6 +151,58 @@ class EvalsHarnessContractTests(unittest.TestCase):
             self.assertIn("blind report", report_files[0].read_text(encoding="utf-8"))
             self.assertIn("RESULT: PASS", judge_files[0].read_text(encoding="utf-8"))
 
+    def test_runner_persists_miss_report_and_judge_output_before_failing(self) -> None:
+        """#893 — MISS runs must leave files for human/judge comparison."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            out_dir = tmp / "eval-output"
+            bin_dir.mkdir()
+            fake_claude = bin_dir / "claude"
+            fake_claude.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        "prompt=''",
+                        "while [ \"$#\" -gt 0 ]; do",
+                        "  case \"$1\" in",
+                        "    -p) shift; prompt=\"$1\" ;;",
+                        "  esac",
+                        "  shift || true",
+                        "done",
+                        "if printf '%s' \"$prompt\" | grep -q '\\[정답표\\]'; then",
+                        "  printf 'MISS FAKE\\nRESULT: FAIL\\n'",
+                        "else",
+                        "  printf 'blind miss report with concrete evidence\\n'",
+                        "fi",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            env["EVAL_OUTPUT_DIR"] = str(out_dir)
+            env["EVAL_RUNS"] = "1"
+            result = subprocess.run(
+                ["bash", str(EVALS / "run.sh")],
+                cwd=str(ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            report_files = sorted(out_dir.glob("*/run-1-report.md"))
+            judge_files = sorted(out_dir.glob("*/run-1-judge.md"))
+            self.assertGreaterEqual(len(report_files), 1)
+            self.assertEqual(len(report_files), len(judge_files))
+            self.assertIn("blind miss report", report_files[0].read_text(encoding="utf-8"))
+            self.assertIn("RESULT: FAIL", judge_files[0].read_text(encoding="utf-8"))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -320,6 +320,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         """#877 — component count drift should be avoided at the source, not patched by deny-list."""
         self.assertNotIn("옛 agent 카운트", self.cross_ref_script)
         self.assertNotIn("옛 hook 카운트", self.cross_ref_script)
+        self.assertNotIn("옛 loop 카운트", self.cross_ref_script)
         self.assertNotIn("현재 12 종", self.cross_ref_script)
         self.assertNotIn("현재 8 hook", self.cross_ref_script)
 


### PR DESCRIPTION
## 관련 이슈 번호

Part of #893
Refs #877

## 배경 및 문제

#895가 #877을 닫았지만 `scripts/check_cross_refs.mjs`에 `8 loop ...` 기반 개수 deny-list가 한 건 남아 있었다. 이 상태에서는 구성요소 개수가 바뀔 때마다 옛 개수를 deny-list에 추가하는 reactive cycle이 완전히 사라지지 않는다.

#893의 eval raw artifact AC는 `evals/run.sh`의 블라인드 검수 보고와 judge 채점 결과를 파일로 남겨 #875 추세 집계와 #894 judge 보정 입력으로 쓸 수 있어야 한다.

## 원인 (해당 시)

#895 범위에서 agent/hook count deny-list와 문서 count prose는 제거됐지만 loop count deny-list가 누락됐다. eval artifact 저장 동작은 구현돼 있었지만 MISS 결과에서 파일이 남는지 직접 고정하는 회귀 테스트가 부족했다.

## 작업내용

- `scripts/check_cross_refs.mjs`의 남은 loop 개수 deny-list 제거
- `tests/test_surface_docs_sync.py`에 loop count deny-list 부재 assertion 추가
- `tests/test_evals_harness.py`에 MISS 결과에서도 `run-<N>-report.md`와 `run-<N>-judge.md`가 남는 회귀 테스트 추가
- `docs/internal/self-improvement-loop.md`의 첫 실증 기록을 count deny-list 제거 + eval artifact 저장 검증으로 보강

## 결정 근거

구성요소 개수 stale은 옛 개수 정규식으로 막을 대상이 아니라, 문서 본문에서 개수 표기를 제거하거나 SSOT 링크·파생 검증으로 다뤄야 한다. eval artifact는 실제 LLM 호출 없이 fake `claude`로 report/judge 파일 계약만 테스트하는 편이 안정적이다.

## 배포 경로 검증 (plug-in 영향 시)

`scripts/check_cross_refs.mjs`는 repo/plug-in root script 변경이며 plug-in 업데이트로 반영된다. 사용자 프로젝트로 복사되는 신규 파일은 없어서 `commands/init-dcness.md` deploy inventory 변경은 없다.

`docs/internal/self-improvement-loop.md`와 `tests/**` 변경은 dcness self 운영/검증 전용이다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음.

## Test Plan

- [x] python3.11 -m unittest tests.test_surface_docs_sync tests.test_evals_harness -v
- [x] node scripts/check_cross_refs.mjs
- [x] PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh
- [x] bash scripts/check_python_tests.sh
- [x] git commit hook: pre-commit pytest 1541 tests PASS + commit-msg git-naming PASS

## 참고

#877은 이미 #895에서 close된 상태라 이 PR은 #893의 첫 한 바퀴 실증 후속 보정으로 둔다.
