### PR TITLE
[feature] 가드 발화 텔레메트리 추가

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -50,6 +50,8 @@ PreToolUse 차단 hook 은 정책 위반만 `exit 2` 로 내보낸다. Claude Co
 
 Fail-open 관측성: 미활성 프로젝트 no-op, main Claude turn, active run 밖 Agent 호출처럼 예상된 benign skip 은 조용히 통과한다. 반대로 활성 프로젝트에서 enforcement hook 이 payload 파싱 실패, session id 부재, state read/write 오류, handler 비정상 종료 때문에 검사를 평가하지 못하고 allow 한 경우는 `<project>/.claude/harness-state/fail-open-events.jsonl` 에 structured event 로 남긴다. `dcness-helper status` 의 `hook fail-open 진단` 항목은 최근 24시간 count 와 reason category 를 WARN 으로 보여준다.
 
+Guard hit 관측성: 정책 위반을 실제로 차단한 경우는 `<project>/.claude/harness-state/guard-telemetry.jsonl` 또는 active run 의 `guard-telemetry.jsonl` 에 `guard_hit` 이벤트로 append 된다. 기록 필드는 guard 이름, category, source, 시각, detail 이며 기록 실패는 원래 차단/허용 판정을 바꾸지 않는다. `dcness-helper guard-telemetry` 는 guard 별 hit 수와 최근 hit 시각을 집계하고, 기본 30일 동안 hit 가 없는 guard 를 **재평가 후보**로 표시한다. 이 표시는 정보 제공 전용이며 guard 를 자동으로 비활성화하지 않는다.
+
 Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision: "block"` JSON 을 stdout 으로 내보내 메인 turn 을 재발화시킨다.
 
 ### session-start.sh
@@ -93,6 +95,7 @@ PASS prose 판정은 `end-step` 저장 규칙과 같은 파일명을 본다. 즉
 **tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. /design 도중 미검증 새 외부 의존이 발견되면 design 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 
 **차단**: Claude Code PreToolUse 에서는 위반 시 `exit 2` + stderr, helper `begin-step` 에서는 비-0 종료 + stderr. engineer / pr-reviewer / module-architect 게이트 위반은 `[순서 차단 훅: <gate>]`, 진행 순서 검사 위반은 `[진행 순서 검사]` 접두사를 포함한다. 게이트 자체 예외는 fail-open 계측으로 남기고 과차단하지 않는다.
+차단이 발생하면 `guard-telemetry.jsonl` 에 `guard=catastrophic-gate` 로 기록된다.
 
 ### file-guard.sh
 
@@ -110,6 +113,8 @@ PASS prose 판정은 `end-step` 저장 규칙과 같은 파일명을 본다. 즉
 | 외부 변경 차단 목록 | sub-agent 의 `git push`, Bash `gh pr create/merge/review`, Bash `gh issue create/edit/close/comment`, 상태 변경 `gh api`, GitHub MCP PR/repo 외부 상태 변경 차단 |
 
 메인 Claude turn 은 file boundary 를 통과한다.
+
+차단이 발생하면 `guard-telemetry.jsonl` 에 `guard=file-guard` 로 기록된다.
 
 #### 프로젝트별 write 경계 override — `.dcness/boundary.json`
 
@@ -230,6 +235,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
 
 활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
+git hook 차단도 같은 telemetry 체계를 쓴다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 `guard-telemetry.jsonl` 에 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록한다.
 
 ### .git/hooks/commit-msg
 
@@ -240,6 +246,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 **역할**: commit title 을 읽고 `check_git_naming.mjs --title` 로 git-spec 제목 규칙을 검증한다. merge commit 제목은 면제한다.
 
 **차단**: 제목 위반 시 commit 실패.
+차단 시 `guard-telemetry.jsonl` 에 `category=git_naming` hit 가 남는다.
 
 ### .git/hooks/post-checkout
 
@@ -263,6 +270,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 - push 대상 브랜치명이 git-spec 을 어기면 차단
 
 **차단**: main push 또는 브랜치명 위반 시 push 실패.
+차단 시 `guard-telemetry.jsonl` 에 `category=main_push_block` 또는 `category=branch_naming` hit 가 남는다.
 
 ## Layer 3 — CI/CD workflows
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -54,6 +54,11 @@ Verify 슬롯을 사람이 도는 릴리즈 전 권고다.
 출력이다. MISS가 나면 두 파일을 대조해 agent 결함인지 judge 결함인지 분리한다. 이 파일은
 [#875](https://github.com/alruminum/dcNess/issues/875)의 추세 집계와
 [#894](https://github.com/alruminum/dcNess/issues/894)의 judge 보정 입력으로 소비된다.
+동시에 `guard-telemetry.jsonl` 에 케이스별 `eval_case_result` 이벤트를 append 한다.
+`dcness-helper guard-telemetry` 는 이 이벤트를 읽어 최근 window 에서 장기간 만점인
+케이스를 **노후 후보**로 표시한다. 이 표시는 케이스 삭제나 비활성화를 자동 실행하지 않는다.
+기본 산출 위치인 `.metrics/evals/**` 는 자동 집계 대상이다. `EVAL_OUTPUT_DIR` 를 repo 밖으로
+지정한 경우에는 `dcness-helper guard-telemetry --base-dir <EVAL_OUTPUT_DIR>` 로 그 산출물을 직접 본다.
 
 ## 채점 원리 — 정답표는 계약 수준으로만 쓴다
 

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -83,9 +83,27 @@ $report"
     if [ "$verdict" = "RESULT: PASS" ]; then
       pass=$((pass + 1))
       echo "[eval] $case_name run $i: 정답"
+      PYTHONPATH="$ROOT:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-eval \
+        --case "$case_name" \
+        --passed \
+        --run-index "$i" \
+        --total-runs "$RUNS" \
+        --report-file "$report_file" \
+        --judge-file "$judge_file" \
+        --model "$MODEL" \
+        --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
     else
       echo "[eval] $case_name run $i: 오답"
       printf '%s\n' "$grade" | grep -E "^(OK|MISS) " || true
+      PYTHONPATH="$ROOT:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-eval \
+        --case "$case_name" \
+        --failed \
+        --run-index "$i" \
+        --total-runs "$RUNS" \
+        --report-file "$report_file" \
+        --judge-file "$judge_file" \
+        --model "$MODEL" \
+        --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
     fi
   done
 

--- a/harness/guard_telemetry.py
+++ b/harness/guard_telemetry.py
@@ -1,0 +1,497 @@
+"""Guard/eval telemetry append log (#875).
+
+The log is append-only JSONL. Guard hits are written next to run artifacts when
+session/run context is known, and to the project state root as a fallback. Eval
+case results use the same event schema and aggregation helpers.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from harness.session_state import RUN_ID_RE, run_dir, valid_session_id
+
+
+TELEMETRY_NAME = "guard-telemetry.jsonl"
+DEFAULT_IDLE_DAYS = 30
+DEFAULT_SATURATION_DAYS = 30
+DEFAULT_SATURATION_MIN_RUNS = 3
+
+KNOWN_GUARDS: tuple[str, ...] = (
+    "catastrophic-gate",
+    "file-guard",
+    "tdd-guard",
+    "git-pre-commit",
+    "git-commit-msg",
+    "git-pre-push",
+)
+
+_DETAIL_MAX = 500
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _resolve_project_root(cwd: Optional[Path] = None) -> Path:
+    probe = Path(cwd or Path.cwd()).resolve()
+    try:
+        import subprocess  # nosec B404
+
+        result = subprocess.run(  # nosec B603, B607
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(probe),
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=2.0,
+        )
+        root = result.stdout.strip()
+        if root:
+            return Path(root).resolve()
+    except Exception:  # noqa: BLE001 # nosec B110
+        pass
+    return probe
+
+
+def _project_log_path(cwd: Optional[Path] = None, *, base_dir: Optional[Path] = None) -> Path:
+    if base_dir is not None:
+        return Path(base_dir).resolve() / TELEMETRY_NAME
+    return _resolve_project_root(cwd) / ".claude" / "harness-state" / TELEMETRY_NAME
+
+
+def _event_path(
+    *,
+    session_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    cwd: Optional[Path] = None,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    if (
+        isinstance(session_id, str)
+        and valid_session_id(session_id)
+        and isinstance(run_id, str)
+        and RUN_ID_RE.match(run_id)
+    ):
+        try:
+            return run_dir(session_id, run_id, base_dir=base_dir, create=True) / TELEMETRY_NAME
+        except Exception:  # noqa: BLE001 # nosec B110
+            pass
+    return _project_log_path(cwd, base_dir=base_dir)
+
+
+def append_event(
+    event: Dict[str, Any],
+    *,
+    session_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    cwd: Optional[Path] = None,
+    base_dir: Optional[Path] = None,
+) -> None:
+    """Append one telemetry event.
+
+    Raises TypeError for caller bugs. I/O failures stay silent because hook
+    telemetry must never change the original guard decision.
+    """
+    if not isinstance(event, dict):
+        raise TypeError(f"event must be dict, got {type(event).__name__}")
+    try:
+        payload = dict(event)
+        payload.setdefault("ts", _now_iso())
+        if session_id and valid_session_id(session_id):
+            payload.setdefault("session_id", session_id)
+        if run_id and isinstance(run_id, str) and RUN_ID_RE.match(run_id):
+            payload.setdefault("run_id", run_id)
+        target = _event_path(
+            session_id=session_id,
+            run_id=run_id,
+            cwd=cwd,
+            base_dir=base_dir,
+        )
+        target.parent.mkdir(parents=True, exist_ok=True)
+        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+        fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+        try:
+            os.write(fd, line.encode("utf-8"))
+        finally:
+            os.close(fd)
+    except Exception:  # noqa: BLE001 # nosec B110
+        pass
+
+
+def record_guard_hit(
+    guard: str,
+    *,
+    category: str = "block",
+    detail: str = "",
+    source: str = "git_hook",
+    session_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    cwd: Optional[Path] = None,
+    base_dir: Optional[Path] = None,
+) -> None:
+    guard_s = str(guard or "unknown")[:120]
+    category_s = str(category or "block")[:120]
+    detail_s = str(detail or "").replace("\n", " ")[:_DETAIL_MAX]
+    source_s = str(source or "unknown")[:80]
+    append_event(
+        {
+            "kind": "guard_hit",
+            "guard": guard_s,
+            "category": category_s,
+            "source": source_s,
+            "detail": detail_s,
+        },
+        session_id=session_id,
+        run_id=run_id,
+        cwd=cwd,
+        base_dir=base_dir,
+    )
+
+
+def record_eval_case_result(
+    case: str,
+    *,
+    passed: bool,
+    run_index: Optional[int] = None,
+    total_runs: Optional[int] = None,
+    report_file: str = "",
+    judge_file: str = "",
+    model: str = "",
+    cwd: Optional[Path] = None,
+    base_dir: Optional[Path] = None,
+) -> None:
+    event: Dict[str, Any] = {
+        "kind": "eval_case_result",
+        "case": str(case or "unknown")[:160],
+        "passed": bool(passed),
+    }
+    if run_index is not None:
+        event["run_index"] = int(run_index)
+    if total_runs is not None:
+        event["total_runs"] = int(total_runs)
+    if report_file:
+        event["report_file"] = str(report_file)
+    if judge_file:
+        event["judge_file"] = str(judge_file)
+    if model:
+        event["model"] = str(model)
+    append_event(event, cwd=cwd, base_dir=base_dir)
+
+
+def _candidate_log_paths(cwd: Optional[Path] = None, *, base_dir: Optional[Path] = None) -> list[Path]:
+    project_root = _resolve_project_root(cwd)
+    root = (
+        Path(base_dir).resolve()
+        if base_dir is not None
+        else project_root / ".claude" / "harness-state"
+    )
+    paths: list[Path] = [root / TELEMETRY_NAME]
+    sessions = root / ".sessions"
+    if sessions.is_dir():
+        try:
+            for path in sessions.glob("*/runs/*/" + TELEMETRY_NAME):
+                paths.append(path)
+        except OSError:
+            pass
+    if base_dir is None:
+        evals_root = project_root / ".metrics" / "evals"
+        if evals_root.is_dir():
+            try:
+                for path in evals_root.glob("*/" + TELEMETRY_NAME):
+                    paths.append(path)
+            except OSError:
+                pass
+    # Preserve deterministic order while avoiding duplicate paths.
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for path in paths:
+        resolved = path.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        unique.append(path)
+    return unique
+
+
+def read_events(
+    cwd: Optional[Path] = None,
+    *,
+    base_dir: Optional[Path] = None,
+    since_days: Optional[int] = None,
+    limit: Optional[int] = None,
+) -> list[Dict[str, Any]]:
+    cutoff = None
+    if since_days is not None:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=since_days)
+
+    events: list[Dict[str, Any]] = []
+    for path in _candidate_log_paths(cwd, base_dir=base_dir):
+        try:
+            if not path.exists():
+                continue
+            with open(path, "r", encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        row = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(row, dict):
+                        continue
+                    if cutoff is not None:
+                        parsed = _parse_ts(row.get("ts"))
+                        if parsed is None or parsed < cutoff:
+                            continue
+                    events.append(row)
+        except OSError:
+            continue
+    events.sort(key=lambda row: str(row.get("ts") or ""))
+    if limit == 0:
+        return []
+    if limit is not None and limit > 0:
+        return events[-limit:]
+    return events
+
+
+def collect_guard_summary(
+    cwd: Optional[Path] = None,
+    *,
+    base_dir: Optional[Path] = None,
+    known_guards: Iterable[str] = KNOWN_GUARDS,
+    idle_days: int = DEFAULT_IDLE_DAYS,
+) -> Dict[str, Any]:
+    events = [
+        event for event in read_events(cwd, base_dir=base_dir)
+        if event.get("kind") == "guard_hit"
+    ]
+    rows: dict[str, Dict[str, Any]] = {}
+    for guard in known_guards:
+        rows[str(guard)] = {
+            "count": 0,
+            "last_ts": None,
+            "categories": {},
+            "sources": [],
+            "reassessment_candidate": True,
+        }
+    for event in events:
+        guard = str(event.get("guard") or "unknown")
+        row = rows.setdefault(
+            guard,
+            {
+                "count": 0,
+                "last_ts": None,
+                "categories": {},
+                "sources": [],
+                "reassessment_candidate": True,
+            },
+        )
+        row["count"] += 1
+        ts = str(event.get("ts") or "")
+        if ts and (row["last_ts"] is None or ts > row["last_ts"]):
+            row["last_ts"] = ts
+        category = str(event.get("category") or "unknown")
+        row["categories"][category] = row["categories"].get(category, 0) + 1
+        source = str(event.get("source") or "unknown")
+        if source not in row["sources"]:
+            row["sources"].append(source)
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max(int(idle_days), 0))
+    for row in rows.values():
+        parsed = _parse_ts(row.get("last_ts"))
+        row["reassessment_candidate"] = parsed is None or parsed < cutoff
+        row["sources"] = sorted(row["sources"])
+    return {"idle_days": idle_days, "guards": rows}
+
+
+def collect_eval_summary(
+    cwd: Optional[Path] = None,
+    *,
+    base_dir: Optional[Path] = None,
+    saturation_days: int = DEFAULT_SATURATION_DAYS,
+    saturation_min_runs: int = DEFAULT_SATURATION_MIN_RUNS,
+) -> Dict[str, Any]:
+    events = [
+        event for event in read_events(cwd, base_dir=base_dir, since_days=saturation_days)
+        if event.get("kind") == "eval_case_result"
+    ]
+    rows: dict[str, Dict[str, Any]] = {}
+    for event in events:
+        case = str(event.get("case") or "unknown")
+        row = rows.setdefault(
+            case,
+            {
+                "attempts": 0,
+                "passes": 0,
+                "accuracy": 0.0,
+                "last_ts": None,
+                "saturation_candidate": False,
+            },
+        )
+        row["attempts"] += 1
+        if event.get("passed") is True:
+            row["passes"] += 1
+        ts = str(event.get("ts") or "")
+        if ts and (row["last_ts"] is None or ts > row["last_ts"]):
+            row["last_ts"] = ts
+
+    min_runs = max(int(saturation_min_runs), 1)
+    for row in rows.values():
+        attempts = int(row["attempts"])
+        passes = int(row["passes"])
+        row["accuracy"] = (passes / attempts) if attempts else 0.0
+        row["saturation_candidate"] = attempts >= min_runs and attempts == passes
+    return {
+        "saturation_days": saturation_days,
+        "saturation_min_runs": saturation_min_runs,
+        "cases": rows,
+    }
+
+
+def format_telemetry_report(
+    guard_summary: Dict[str, Any],
+    eval_summary: Optional[Dict[str, Any]] = None,
+) -> str:
+    lines: list[str] = []
+    idle_days = int(guard_summary.get("idle_days") or DEFAULT_IDLE_DAYS)
+    lines.append(f"[guard telemetry] guard hits — idle threshold: {idle_days}d")
+    guards = guard_summary.get("guards") if isinstance(guard_summary, dict) else {}
+    if isinstance(guards, dict) and guards:
+        for guard, row_any in sorted(guards.items()):
+            row = row_any if isinstance(row_any, dict) else {}
+            marker = "재평가 후보" if row.get("reassessment_candidate") else "active"
+            last = row.get("last_ts") or "-"
+            count = int(row.get("count") or 0)
+            lines.append(f"- {guard}: {count} hit(s), last={last}, {marker}")
+    else:
+        lines.append("- no guard telemetry events")
+
+    if eval_summary is not None:
+        saturation_days = int(eval_summary.get("saturation_days") or DEFAULT_SATURATION_DAYS)
+        min_runs = int(eval_summary.get("saturation_min_runs") or DEFAULT_SATURATION_MIN_RUNS)
+        lines.append(
+            f"[guard telemetry] eval saturation — window: {saturation_days}d, min_runs={min_runs}"
+        )
+        cases = eval_summary.get("cases") if isinstance(eval_summary, dict) else {}
+        if isinstance(cases, dict) and cases:
+            for case, row_any in sorted(cases.items()):
+                row = row_any if isinstance(row_any, dict) else {}
+                marker = "노후 후보" if row.get("saturation_candidate") else "active"
+                attempts = int(row.get("attempts") or 0)
+                passes = int(row.get("passes") or 0)
+                accuracy = float(row.get("accuracy") or 0.0)
+                last = row.get("last_ts") or "-"
+                lines.append(
+                    f"- {case}: {passes}/{attempts} ({accuracy:.0%}), last={last}, {marker}"
+                )
+        else:
+            lines.append("- no eval case telemetry events")
+    lines.append("자동 비활성화 없음 — 판단과 제거는 사람이 한다.")
+    return "\n".join(lines)
+
+
+def _cli_record_hit(args: argparse.Namespace) -> int:
+    record_guard_hit(
+        args.guard,
+        category=args.category,
+        detail=args.detail,
+        source=args.source,
+        cwd=Path(args.cwd) if args.cwd else None,
+        base_dir=Path(args.base_dir) if args.base_dir else None,
+    )
+    return 0
+
+
+def _cli_record_eval(args: argparse.Namespace) -> int:
+    record_eval_case_result(
+        args.case,
+        passed=args.passed,
+        run_index=args.run_index,
+        total_runs=args.total_runs,
+        report_file=args.report_file or "",
+        judge_file=args.judge_file or "",
+        model=args.model or "",
+        cwd=Path(args.cwd) if args.cwd else None,
+        base_dir=Path(args.base_dir) if args.base_dir else None,
+    )
+    return 0
+
+
+def _cli_report(args: argparse.Namespace) -> int:
+    cwd = Path(args.cwd) if args.cwd else None
+    base_dir = Path(args.base_dir) if args.base_dir else None
+    guard_summary = collect_guard_summary(cwd, base_dir=base_dir, idle_days=args.idle_days)
+    eval_summary = collect_eval_summary(
+        cwd,
+        base_dir=base_dir,
+        saturation_days=args.saturation_days,
+        saturation_min_runs=args.saturation_min_runs,
+    )
+    if args.json:
+        print(json.dumps({"guards": guard_summary, "evals": eval_summary}, ensure_ascii=False))
+    else:
+        print(format_telemetry_report(guard_summary, eval_summary))
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python3 -m harness.guard_telemetry")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_hit = sub.add_parser("record-hit", help="internal: append guard hit event")
+    p_hit.add_argument("--guard", required=True)
+    p_hit.add_argument("--category", default="block")
+    p_hit.add_argument("--detail", default="")
+    p_hit.add_argument("--source", default="git_hook")
+    p_hit.add_argument("--cwd", default="")
+    p_hit.add_argument("--base-dir", default="")
+    p_hit.set_defaults(func=_cli_record_hit)
+
+    p_eval = sub.add_parser("record-eval", help="internal: append eval case result")
+    p_eval.add_argument("--case", required=True)
+    p_eval.add_argument("--passed", action="store_true")
+    p_eval.add_argument("--failed", dest="passed", action="store_false")
+    p_eval.set_defaults(passed=False)
+    p_eval.add_argument("--run-index", type=int, default=None)
+    p_eval.add_argument("--total-runs", type=int, default=None)
+    p_eval.add_argument("--report-file", default="")
+    p_eval.add_argument("--judge-file", default="")
+    p_eval.add_argument("--model", default="")
+    p_eval.add_argument("--cwd", default="")
+    p_eval.add_argument("--base-dir", default="")
+    p_eval.set_defaults(func=_cli_record_eval)
+
+    p_report = sub.add_parser("report", help="summarize guard hits and eval saturation")
+    p_report.add_argument("--idle-days", type=int, default=DEFAULT_IDLE_DAYS)
+    p_report.add_argument("--saturation-days", type=int, default=DEFAULT_SATURATION_DAYS)
+    p_report.add_argument("--saturation-min-runs", type=int, default=DEFAULT_SATURATION_MIN_RUNS)
+    p_report.add_argument("--cwd", default="")
+    p_report.add_argument("--base-dir", default="")
+    p_report.add_argument("--json", action="store_true")
+    p_report.set_defaults(func=_cli_report)
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = _build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -138,6 +138,32 @@ def _append_trace_safe(
         pass
 
 
+def _record_guard_hit_safe(
+    guard: str,
+    category: str,
+    detail: str,
+    *,
+    sid: str = "",
+    rid: str = "",
+    base_dir: Optional[Path] = None,
+) -> None:
+    """Best-effort guard-hit telemetry. Never changes hook allow/block result."""
+    try:
+        from harness.guard_telemetry import record_guard_hit
+
+        record_guard_hit(
+            guard,
+            category=category,
+            detail=detail,
+            source="plugin_hook",
+            session_id=sid,
+            run_id=rid,
+            base_dir=base_dir,
+        )
+    except Exception:  # noqa: BLE001 # nosec B110
+        pass
+
+
 # #272 W2 — prose robust extraction (어떤 nested 형식이든 first non-empty text)
 # CC PostToolUse Agent 의 tool_response 형식 이력:
 #   - 2026-05-01 도입 시 dict {"text": ...} 가정 (실측 X — 항상 fail)
@@ -508,6 +534,14 @@ def handle_pretooluse_agent(
                 mode=_mode_or_none(mode),
             )
             if strict_msg:
+                _record_guard_hit_safe(
+                    "catastrophic-gate",
+                    "strict_conveyor",
+                    strict_msg,
+                    sid=sid,
+                    rid=rid,
+                    base_dir=base_dir,
+                )
                 print(strict_msg, file=sys.stderr)
                 return 1
     except (OSError, ValueError) as exc:
@@ -538,6 +572,14 @@ def handle_pretooluse_agent(
         )
         order_gate_msg = None
     if order_gate_msg:
+        _record_guard_hit_safe(
+            "catastrophic-gate",
+            "order_gate",
+            order_gate_msg,
+            sid=sid,
+            rid=rid,
+            base_dir=base_dir,
+        )
         print(order_gate_msg, file=sys.stderr)
         return 1
 
@@ -726,6 +768,14 @@ def handle_pretooluse_file_op(
         if fp:
             reason = check_read_allowed(acting_agent, fp, cwd=cwd)
             if reason:
+                _record_guard_hit_safe(
+                    "file-guard",
+                    "read_boundary",
+                    reason,
+                    sid=sid,
+                    rid=_resolve_rid(sid, cc_pid, base_dir=base_dir),
+                    base_dir=base_dir,
+                )
                 print(f"[agent-boundary] {reason}", file=sys.stderr)
                 return 1
     elif tool_name in ("Edit", "Write", "NotebookEdit"):
@@ -733,6 +783,14 @@ def handle_pretooluse_file_op(
         if fp:
             reason = check_write_allowed(acting_agent, fp, cwd=cwd)
             if reason:
+                _record_guard_hit_safe(
+                    "file-guard",
+                    "write_boundary",
+                    reason,
+                    sid=sid,
+                    rid=_resolve_rid(sid, cc_pid, base_dir=base_dir),
+                    base_dir=base_dir,
+                )
                 print(f"[agent-boundary] {reason}", file=sys.stderr)
                 return 1
     elif tool_name == "Bash":
@@ -742,6 +800,14 @@ def handle_pretooluse_file_op(
         if not mutation_guard_off:
             reason = check_bash_mutation(cmd)
             if reason:
+                _record_guard_hit_safe(
+                    "file-guard",
+                    "bash_mutation",
+                    reason,
+                    sid=sid,
+                    rid=_resolve_rid(sid, cc_pid, base_dir=base_dir),
+                    base_dir=base_dir,
+                )
                 print(f"[agent-boundary][Bash] {reason}", file=sys.stderr)
                 return 1
         for fp in extract_bash_paths(cmd):
@@ -749,6 +815,14 @@ def handle_pretooluse_file_op(
             # (#694 codex P2). Edit/Write 의 literal 경로 검사(위)는 기본 False 라 영향 없음.
             reason = check_write_allowed(acting_agent, fp, cwd=cwd, shell_context=True)
             if reason:
+                _record_guard_hit_safe(
+                    "file-guard",
+                    "bash_write_boundary",
+                    reason,
+                    sid=sid,
+                    rid=_resolve_rid(sid, cc_pid, base_dir=base_dir),
+                    base_dir=base_dir,
+                )
                 print(f"[agent-boundary][Bash] {reason}", file=sys.stderr)
                 return 1
     elif tool_name.startswith("mcp__github__"):
@@ -756,6 +830,14 @@ def handle_pretooluse_file_op(
         # opt-out/infra 면 우회.
         reason = None if mutation_guard_off else check_github_mcp_mutation(tool_name)
         if reason:
+            _record_guard_hit_safe(
+                "file-guard",
+                "mcp_mutation",
+                reason,
+                sid=sid,
+                rid=_resolve_rid(sid, cc_pid, base_dir=base_dir),
+                base_dir=base_dir,
+            )
             print(f"[agent-boundary][MCP] {reason}", file=sys.stderr)
             return 1
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3859,6 +3859,32 @@ def _cli_status(args: Any) -> int:
     return 0
 
 
+def _cli_guard_telemetry(args: Any) -> int:
+    """Guard hit / eval saturation summary (#875)."""
+    from harness.guard_telemetry import (
+        collect_eval_summary,
+        collect_guard_summary,
+        format_telemetry_report,
+    )
+
+    guard_summary = collect_guard_summary(
+        cwd=Path(args.cwd) if args.cwd else None,
+        base_dir=Path(args.base_dir) if args.base_dir else None,
+        idle_days=args.idle_days,
+    )
+    eval_summary = collect_eval_summary(
+        cwd=Path(args.cwd) if args.cwd else None,
+        base_dir=Path(args.base_dir) if args.base_dir else None,
+        saturation_days=args.saturation_days,
+        saturation_min_runs=args.saturation_min_runs,
+    )
+    if args.json:
+        print(json.dumps({"guards": guard_summary, "evals": eval_summary}, ensure_ascii=False))
+    else:
+        print(format_telemetry_report(guard_summary, eval_summary))
+    return 0
+
+
 def _cli_routing(args: Any) -> int:
     """Local provider 분기 CLI.
 
@@ -4249,6 +4275,18 @@ def _build_arg_parser() -> Any:
 
     p_st = sub.add_parser("status", help="whitelist + 현재 cwd 상태")
     p_st.set_defaults(func=_cli_status)
+
+    p_gt = sub.add_parser(
+        "guard-telemetry",
+        help="#875 guard hit / eval saturation telemetry summary",
+    )
+    p_gt.add_argument("--idle-days", type=int, default=30)
+    p_gt.add_argument("--saturation-days", type=int, default=30)
+    p_gt.add_argument("--saturation-min-runs", type=int, default=3)
+    p_gt.add_argument("--cwd", default="")
+    p_gt.add_argument("--base-dir", default="")
+    p_gt.add_argument("--json", action="store_true")
+    p_gt.set_defaults(func=_cli_guard_telemetry)
 
     p_rt = sub.add_parser(
         "routing",

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -30,6 +30,14 @@ record_fail_open() {
     --detail "$2" >/dev/null 2>&1 || true
 }
 
+record_guard_hit() {
+  python3 -m harness.guard_telemetry record-hit \
+    --guard tdd-guard \
+    --category "$1" \
+    --detail "$2" \
+    --source plugin_hook >/dev/null 2>&1 || true
+}
+
 # 활성화 게이트 (#597 커밋3) — 미활성 프로젝트는 즉시 allow (no-op).
 # 나머지 6 wrapper 는 이미 보유. tdd-guard 만 누락이라 비활성 프로젝트서도 deny 발동하던 결함 수정.
 python3 -m harness.session_state is-active >/dev/null 2>&1 || allow
@@ -98,6 +106,7 @@ PY
     TARGET_ERR=$(printf '%s' "$TARGET_PAYLOAD" | bash "$0" 2>&1 >/dev/null)
     _tdd_target_rc=$?
     if [ "$_tdd_target_rc" -eq 2 ]; then
+      record_guard_hit "bash_missing_test" "Bash write target ${BASH_TARGET} missing matching test"
       deny "TDD GUARD[Bash]: Bash write target '${BASH_TARGET}' failed matching-test enforcement.
 
 ${TARGET_ERR}"
@@ -254,6 +263,7 @@ if ! has_test_for "$FILE_PATH"; then
     */src/*) SRC_ROOT="${FILE_PATH%%/src/*}/src" ;;
     *) SRC_ROOT="${PROJECT_ROOT}/src" ;;
   esac
+  record_guard_hit "missing_test" "$FILE_PATH"
   deny "TDD GUARD: '${BASE}' 에 대한 테스트 파일이 존재하지 않습니다. 구현 코드를 작성하기 *전*에 테스트를 먼저 작성하세요.
 
 권장 위치 (먼저 시도):

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -50,5 +50,16 @@ if [ -z "$PLUGIN_ROOT" ]; then
   exit 0
 fi
 
+record_guard_hit() {
+  PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
+    --guard git-commit-msg \
+    --category "$1" \
+    --detail "$2" \
+    --source git_hook >/dev/null 2>&1 || true
+}
+
 # 1. git-naming 검증 — TDD chain 폐기 (v0.2.16 — PreToolUse hook 으로 이전)
-node "$PLUGIN_ROOT/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE" || exit 1
+if ! node "$PLUGIN_ROOT/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE"; then
+  record_guard_hit "git_naming" "commit title rejected: $COMMIT_TITLE"
+  exit 1
+fi

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -10,12 +10,51 @@
 
 set -e
 
-current_branch=$(git rev-parse --abbrev-ref HEAD)
+resolve_dcness_root() {
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$legacy" ] && [ -f "$legacy/harness/guard_telemetry.py" ]; then
+    echo "$legacy"
+    return 0
+  fi
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/harness/guard_telemetry.py" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}"
+    return 0
+  fi
+  cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/harness/guard_telemetry.py" ]; then
+      echo "$cache_dir/$latest"
+      return 0
+    fi
+  fi
+  return 1
+}
+
+record_guard_hit() {
+  root="$(resolve_dcness_root 2>/dev/null || true)"
+  [ -n "$root" ] || return 0
+  PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
+    --guard git-pre-commit \
+    --category "$1" \
+    --detail "$2" \
+    --source git_hook >/dev/null 2>&1 || true
+}
+
+current_branch=$(
+  git symbolic-ref --quiet --short HEAD 2>/dev/null \
+    || git rev-parse --abbrev-ref HEAD 2>/dev/null \
+    || echo ""
+)
 if [ "$current_branch" = "main" ]; then
+  record_guard_hit "main_block" "main branch commit blocked"
   echo "ERROR: main 직접 commit 금지. branch 만든 후 commit + PR." >&2
   echo "  git checkout -b feature/<name>" >&2
   echo "  git commit ..." >&2
   exit 1
 fi
 
-sh scripts/check_python_tests.sh
+if ! sh scripts/check_python_tests.sh; then
+  record_guard_hit "python_tests" "pre-commit python test gate failed"
+  exit 1
+fi

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -28,11 +28,43 @@ resolve_plugin_script() {
   return 1
 }
 
+resolve_dcness_root() {
+  if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -f "${CLAUDE_PLUGIN_ROOT}/harness/guard_telemetry.py" ]; then
+    echo "${CLAUDE_PLUGIN_ROOT}"
+    return 0
+  fi
+  cache_dir="${HOME}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/harness/guard_telemetry.py" ]; then
+      echo "$cache_dir/$latest"
+      return 0
+    fi
+  fi
+  legacy="$(git rev-parse --show-toplevel 2>/dev/null)"
+  if [ -n "$legacy" ] && [ -f "$legacy/harness/guard_telemetry.py" ]; then
+    echo "$legacy"
+    return 0
+  fi
+  return 1
+}
+
+record_guard_hit() {
+  root="$(resolve_dcness_root 2>/dev/null || true)"
+  [ -n "$root" ] || return 0
+  PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
+    --guard git-pre-push \
+    --category "$1" \
+    --detail "$2" \
+    --source git_hook >/dev/null 2>&1 || true
+}
+
 SCRIPT_PATH=$(resolve_plugin_script)
 
 while read local_ref local_sha remote_ref remote_sha; do
   # 1. main 직접 push 차단
   if [ "$remote_ref" = "refs/heads/main" ]; then
+    record_guard_hit "main_push_block" "push to refs/heads/main blocked"
     echo "ERROR: main 직접 push 금지. branch → PR → merge 절차를 따르세요." >&2
     echo "  gh pr create --title '...' --body '...'" >&2
     exit 1
@@ -47,6 +79,7 @@ while read local_ref local_sha remote_ref remote_sha; do
 
       if [ -n "$SCRIPT_PATH" ]; then
         if ! node "$SCRIPT_PATH" --branch "$BRANCH" >&2; then
+          record_guard_hit "branch_naming" "branch rejected: $BRANCH"
           echo "ERROR: 브랜치명 형식 위반 — push 차단 (#255 W4 정합)." >&2
           echo "  로컬에서 수정: git branch -m <올바른-브랜치명>" >&2
           echo "  허용 패턴 = docs/plugin/git-spec.md §1" >&2

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -150,6 +150,12 @@ class EvalsHarnessContractTests(unittest.TestCase):
             self.assertEqual(len(report_files), len(judge_files))
             self.assertIn("blind report", report_files[0].read_text(encoding="utf-8"))
             self.assertIn("RESULT: PASS", judge_files[0].read_text(encoding="utf-8"))
+            telemetry = sorted(out_dir.glob("guard-telemetry.jsonl"))
+            self.assertEqual(len(telemetry), 1)
+            self.assertIn(
+                '"kind":"eval_case_result"',
+                telemetry[0].read_text(encoding="utf-8"),
+            )
 
     def test_runner_persists_miss_report_and_judge_output_before_failing(self) -> None:
         """#893 — MISS runs must leave files for human/judge comparison."""
@@ -202,6 +208,11 @@ class EvalsHarnessContractTests(unittest.TestCase):
             self.assertEqual(len(report_files), len(judge_files))
             self.assertIn("blind miss report", report_files[0].read_text(encoding="utf-8"))
             self.assertIn("RESULT: FAIL", judge_files[0].read_text(encoding="utf-8"))
+            telemetry = sorted(out_dir.glob("guard-telemetry.jsonl"))
+            self.assertEqual(len(telemetry), 1)
+            text = telemetry[0].read_text(encoding="utf-8")
+            self.assertIn('"kind":"eval_case_result"', text)
+            self.assertIn('"passed":false', text)
 
 
 if __name__ == "__main__":

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -1,0 +1,90 @@
+"""git hook guard telemetry contracts (#875)."""
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.guard_telemetry import read_events
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", "-C", str(root), *args],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=True,
+    )
+
+
+def _env() -> dict[str, str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(ROOT)
+    env["CLAUDE_PLUGIN_ROOT"] = str(ROOT)
+    return env
+
+
+class GitHookGuardTelemetryTests(unittest.TestCase):
+    def test_pre_commit_main_block_records_guard_hit(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _git(root, "init")
+            _git(root, "checkout", "-b", "main")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-commit")],
+                cwd=str(root),
+                env=_env(),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            events = read_events(cwd=root)
+            self.assertTrue(
+                any(
+                    e.get("kind") == "guard_hit"
+                    and e.get("guard") == "git-pre-commit"
+                    and e.get("category") == "main_block"
+                    for e in events
+                ),
+                events,
+            )
+
+    def test_commit_msg_naming_block_records_guard_hit(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _git(root, "init")
+            msg = root / "COMMIT_EDITMSG"
+            msg.write_text("bad subject\n", encoding="utf-8")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "commit-msg"), str(msg)],
+                cwd=str(root),
+                env=_env(),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            events = read_events(cwd=root)
+            self.assertTrue(
+                any(
+                    e.get("kind") == "guard_hit"
+                    and e.get("guard") == "git-commit-msg"
+                    and e.get("category") == "git_naming"
+                    for e in events
+                ),
+                events,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_guard_telemetry.py
+++ b/tests/test_guard_telemetry.py
@@ -1,0 +1,205 @@
+"""guard telemetry append/read/summary contracts (#875)."""
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness.guard_telemetry import (
+    TELEMETRY_NAME,
+    collect_eval_summary,
+    collect_guard_summary,
+    format_telemetry_report,
+    read_events,
+    record_eval_case_result,
+    record_guard_hit,
+)
+from harness.session_state import generate_run_id, run_dir
+
+
+SID = "guard-telemetry-sid"
+
+
+class GuardTelemetryAppendTests(unittest.TestCase):
+    def test_guard_hit_roundtrip_in_run_dir(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            rid = generate_run_id()
+            record_guard_hit(
+                "catastrophic-gate",
+                category="order_gate",
+                detail="engineer before design",
+                session_id=SID,
+                run_id=rid,
+                base_dir=base,
+            )
+
+            target = run_dir(SID, rid, base_dir=base) / TELEMETRY_NAME
+            self.assertTrue(target.is_file())
+            self.assertEqual(target.stat().st_mode & 0o777, 0o600)
+            events = read_events(base_dir=base)
+            self.assertEqual(len(events), 1)
+            self.assertEqual(events[0]["kind"], "guard_hit")
+            self.assertEqual(events[0]["guard"], "catastrophic-gate")
+            self.assertEqual(events[0]["category"], "order_gate")
+
+    def test_guard_hit_without_run_falls_back_to_project_log(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_guard_hit(
+                "git-pre-commit",
+                category="main_block",
+                detail="main commit blocked",
+                cwd=root,
+            )
+
+            target = root / ".claude" / "harness-state" / TELEMETRY_NAME
+            self.assertTrue(target.is_file())
+            events = read_events(cwd=root)
+            self.assertEqual(events[0]["guard"], "git-pre-commit")
+            self.assertEqual(events[0]["source"], "git_hook")
+
+
+class GuardSummaryTests(unittest.TestCase):
+    def test_summary_includes_known_zero_hit_guards_as_candidates(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            summary = collect_guard_summary(
+                cwd=root,
+                known_guards=("catastrophic-gate",),
+                idle_days=30,
+            )
+
+            self.assertEqual(summary["guards"]["catastrophic-gate"]["count"], 0)
+            self.assertTrue(
+                summary["guards"]["catastrophic-gate"]["reassessment_candidate"]
+            )
+
+    def test_recent_hit_is_not_reassessment_candidate(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_guard_hit("file-guard", category="write_boundary", cwd=root)
+
+            summary = collect_guard_summary(
+                cwd=root,
+                known_guards=("file-guard",),
+                idle_days=30,
+            )
+
+            row = summary["guards"]["file-guard"]
+            self.assertEqual(row["count"], 1)
+            self.assertFalse(row["reassessment_candidate"])
+
+
+class EvalSummaryTests(unittest.TestCase):
+    def test_eval_case_results_share_the_same_event_log(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_eval_case_result(
+                "headless-prose-quality",
+                passed=True,
+                run_index=1,
+                total_runs=2,
+                cwd=root,
+                report_file="/tmp/report.md",
+                judge_file="/tmp/judge.md",
+            )
+
+            events = read_events(cwd=root)
+            self.assertEqual(events[0]["kind"], "eval_case_result")
+            self.assertEqual(events[0]["case"], "headless-prose-quality")
+            self.assertTrue(events[0]["passed"])
+
+    def test_all_pass_eval_case_is_saturation_candidate(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            for run_index in (1, 2):
+                record_eval_case_result(
+                    "shorts-real-spec",
+                    passed=True,
+                    run_index=run_index,
+                    total_runs=2,
+                    cwd=root,
+                )
+
+            summary = collect_eval_summary(
+                cwd=root,
+                saturation_days=30,
+                saturation_min_runs=2,
+            )
+
+            row = summary["cases"]["shorts-real-spec"]
+            self.assertEqual(row["attempts"], 2)
+            self.assertEqual(row["passes"], 2)
+            self.assertEqual(row["accuracy"], 1.0)
+            self.assertTrue(row["saturation_candidate"])
+
+    def test_any_recent_fail_prevents_saturation_candidate(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_eval_case_result("flow-ownership-owner-good", passed=True, cwd=root)
+            record_eval_case_result("flow-ownership-owner-good", passed=False, cwd=root)
+
+            summary = collect_eval_summary(
+                cwd=root,
+                saturation_days=30,
+                saturation_min_runs=2,
+            )
+
+            row = summary["cases"]["flow-ownership-owner-good"]
+            self.assertEqual(row["accuracy"], 0.5)
+            self.assertFalse(row["saturation_candidate"])
+
+    def test_project_summary_reads_default_metrics_eval_output_logs(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_eval_case_result(
+                "headless-prose-quality",
+                passed=True,
+                base_dir=root / ".metrics" / "evals" / "run-1",
+            )
+
+            summary = collect_eval_summary(
+                cwd=root,
+                saturation_days=30,
+                saturation_min_runs=1,
+            )
+
+            self.assertIn("headless-prose-quality", summary["cases"])
+
+
+class ReportFormatTests(unittest.TestCase):
+    def test_report_marks_guard_and_eval_candidates(self) -> None:
+        guard_summary = {
+            "idle_days": 30,
+            "guards": {
+                "catastrophic-gate": {
+                    "count": 0,
+                    "last_ts": None,
+                    "categories": {},
+                    "sources": [],
+                    "reassessment_candidate": True,
+                }
+            },
+        }
+        eval_summary = {
+            "saturation_days": 30,
+            "saturation_min_runs": 2,
+            "cases": {
+                "shorts-real-spec": {
+                    "attempts": 2,
+                    "passes": 2,
+                    "accuracy": 1.0,
+                    "last_ts": "2026-07-04T00:00:00Z",
+                    "saturation_candidate": True,
+                }
+            },
+        }
+
+        report = format_telemetry_report(guard_summary, eval_summary)
+        self.assertIn("재평가 후보", report)
+        self.assertIn("노후 후보", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hook_wrapper_exit.py
+++ b/tests/test_hook_wrapper_exit.py
@@ -19,6 +19,8 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from harness.guard_telemetry import read_events
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -87,6 +89,16 @@ class CatastrophicGateWrapperExitTests(unittest.TestCase):
             f"위반은 exit 2 여야 차단됨. stdout={result.stdout!r} stderr={result.stderr!r}",
         )
         self.assertIn("순서 차단 훅: engineer", result.stderr)
+        events = read_events(base_dir=self.base)
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "catastrophic-gate"
+                and e.get("category") == "order_gate"
+                for e in events
+            ),
+            events,
+        )
 
     def test_allow_exits_0(self) -> None:
         from harness.session_state import run_dir
@@ -145,6 +157,16 @@ class FileGuardWrapperExitTests(unittest.TestCase):
             f"인프라 write 는 exit 2 여야 차단됨. stdout={result.stdout!r} stderr={result.stderr!r}",
         )
         self.assertIn("agent-boundary", result.stderr)
+        events = read_events(base_dir=self.base)
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "file-guard"
+                and e.get("category") == "write_boundary"
+                for e in events
+            ),
+            events,
+        )
 
     def test_src_write_exits_0(self) -> None:
         # engineer 의 src/ Write 는 허용 → exit 0.

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -25,6 +25,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from harness.guard_telemetry import read_events
 from harness.session_state import read_fail_open_events
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -671,6 +672,16 @@ class TestBlockingSemantics(unittest.TestCase):
         self.assertIn("TDD GUARD", result.stderr)
         # 차단 reason 은 stderr 로 — stdout 에 deny JSON 을 더는 쓰지 않는다.
         self.assertNotIn("permissionDecision", result.stdout)
+        events = read_events(cwd=Path(self._tmp))
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "tdd-guard"
+                and e.get("category") == "missing_test"
+                for e in events
+            ),
+            events,
+        )
 
     def test_allow_exits_0(self):
         """매칭 테스트 존재 → exit 0 (allow)."""


### PR DESCRIPTION
## 관련 이슈 번호
Closes #875
Part of #893

## 배경 및 문제
- dcNess 강제 가드가 실제로 정책 위반을 얼마나 차단하는지 남는 기록이 없어, 장기 무발화 가드를 재평가할 근거가 부족했다.
- #893 자기개선 Sense 슬롯에서 eval 케이스 포화 여부도 같은 방식으로 추세화할 필요가 있다.

## 원인 (해당 시)
- 기존 관측 로그는 hook fail-open과 agent trace 중심이라, 정책 위반을 정상적으로 차단한 guard hit 이벤트는 별도로 기록하지 않았다.

## 작업내용
- `harness/guard_telemetry.py` append-only JSONL 기록/집계 모듈과 `dcness-helper guard-telemetry` 집계 명령 추가.
- `catastrophic-gate`, `file-guard`, `tdd-guard`, git hook 차단을 `guard_hit` 이벤트로 기록.
- `evals/run.sh` judge 결과를 `eval_case_result` 이벤트로 남기고, 장기간 만점 케이스를 노후 후보로 집계.
- `docs/plugin/hooks.md`, `evals/README.md`에 로그 위치, 집계 명령, 자동 비활성화 없음 원칙 문서화.
- plugin hook/git hook/eval telemetry 회귀 테스트 추가.

## 결정 근거
- 기존 `agent-trace`처럼 append-only JSONL을 사용해 hook 본동작과 관측 실패를 분리했다.
- telemetry 기록은 best-effort로 두어 기록 실패가 원래 차단/허용 판정을 바꾸지 않게 했다.
- 새 slash command 대신 기존 helper CLI에 집계 subcommand를 추가해 공개 surface를 작게 유지했다.

## 배포 경로 검증 (plug-in 영향 시)
- Runtime hook/helper 경로: `harness/guard_telemetry.py`, `harness/hooks.py`, `hooks/tdd-guard.sh`, `harness/session_state.py`는 plug-in 업데이트로 활성 프로젝트에 도달한다.
- Git hook 경로: `scripts/hooks/{commit-msg,pre-commit,pre-push}`는 기존 hook 사본을 갱신해야 하므로, 기존 활성 프로젝트는 `/init-dcness` 재실행 또는 hook 재설치가 필요하다. 신규 활성 프로젝트는 갱신된 script를 받는다.
- 사용자용 SSOT: `docs/plugin/hooks.md` 갱신으로 guard telemetry 동작과 자동 비활성화 없음 원칙을 문서화했다.
- Eval 경로: `evals/run.sh`와 `evals/README.md`는 dcness self QA 산출물이며, 기본 `.metrics/evals/**/guard-telemetry.jsonl`과 `--base-dir` 집계를 검증했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
- 새 slash command/skill/agent/gate는 추가하지 않았다.
- 집계는 기존 helper 진단 surface의 subcommand로 충분하다. workflow router나 validator/reviewer는 runtime telemetry를 집계하는 역할이 아니므로 별도 구현 경로로 흡수하기 어렵다.
- helper subcommand는 정보 조회 전용이며 guard 제거/비활성화를 자동 수행하지 않는다.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `PYTHON_BIN=.venv-quality/bin/python bash scripts/check_static_quality.sh`
- [x] `python3.11 evals/guard_efficacy.py`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `bash -n hooks/tdd-guard.sh scripts/hooks/pre-commit scripts/hooks/commit-msg scripts/hooks/pre-push evals/run.sh`

## 참고
- `dcness-helper guard-telemetry` 출력은 guard별 hit 수/최근 hit 시각과 eval 노후 후보를 보여주며, 어떤 guard도 자동으로 끄지 않는다.
