### PR TITLE
[feature] 재발 신호 개선 후보 표면화

### DIFF
--- a/commands/run-review.md
+++ b/commands/run-review.md
@@ -1,6 +1,6 @@
 ---
 name: run-review
-description: dcness loop run (begin-run / end-run 사이클) 사후 분석 스킬. 각 step 의 잘한 점·잘못한 점·비용을 추출해서 메타-하네스 self-improvement 루프 시작점 제공. 사용자가 "/run-review", "리뷰", "이번 run 어땠어", "낭비 분석", "잘못한 점 찾아", "사후 분석" 등을 말할 때 사용한다.
+description: dcness loop run (begin-run / end-run 사이클) 사후 분석 스킬. 각 step 의 비용·낭비 finding·재발 개선 후보를 추출해서 메타-하네스 self-improvement 루프 시작점 제공. 사용자가 "/run-review", "리뷰", "이번 run 어땠어", "낭비 분석", "잘못한 점 찾아", "사후 분석" 등을 말할 때 사용한다.
 ---
 
 # Run Review Skill — 사후 분석 + 메타-하네스 self-improvement
@@ -12,7 +12,7 @@ description: dcness loop run (begin-run / end-run 사이클) 사후 분석 스�
 - 사용자 발화: "/run-review", "리뷰", "이번 run 어땠어", "낭비 분석", "잘못한 점 찾아", "사후 분석", "복기"
 - impl-loop / spec 등 큰 사이클 종료 후 자동 회고
 - 대표 workflow 종료 시 CLAUDE.md/AGENTS.md 현행화 후보를 read-only 로 확인
-- 30일 누적 위반 사례 수집 (별도 후속 — 본 skill 은 단일 run)
+- 현재 run 의 waste pattern 이 같은 sessions root 에서 몇 번째 반복인지 확인
 
 ## 언제 사용하지 않음
 
@@ -25,8 +25,8 @@ description: dcness loop run (begin-run / end-run 사이클) 사후 분석 스�
 `.sessions/{sid}/runs/{rid}/ledger.jsonl` (step_completed event) + 단계별 prose + CC session JSONL 을 cross-correlation 해서:
 
 1. **단계별 비용** — run 시작/종료 timestamp 내 assistant turn cost 합산 (price_for util 재사용)
-2. **잘한 점** (GOOD findings) — ENUM_CLEAN / PROSE_ECHO_OK / DDD_PHASE_A / DEPENDENCY_CAUSAL / EXTERNAL_VERIFIED_PRESENT
-3. **잘못한 점** (WASTE findings) — RETRY_SAME_FAIL / ECHO_VIOLATION / PLACEHOLDER_LEAK / MUST_FIX_GHOST / SPEC_GAP_LOOP / INFRA_READ / READONLY_BASH / EXTERNAL_VERIFIED_MISSING
+2. **잘못한 점** (WASTE findings) — `run_review.py` 의 현재 waste detector 결과
+3. **재발 기반 개선 후보** — 현재 run 의 waste pattern 이 같은 sessions root 에서 임계(기본 3회) 이상 반복되면 표면화. 룰 추가, skill 박제, 기존 룰 제거 중 무엇을 할지는 사용자가 결정한다.
 4. **CLAUDE.md/AGENTS.md 현행화 후보** — context 문서 존재, AGENTS.md 의 CLAUDE.md SSOT 참조, CLAUDE.md 공식 구조·6축 rubric·dcNess cold-start 앵커, run-review finding 기반 세션 학습 환류 후보. 자동 수정하지 않고 제안만 출력한다.
 
 ## 절차
@@ -63,20 +63,13 @@ Bash stdout 의 마크다운 리포트를 **한 글자도 바꾸지 않고 그�
 
 리포트 출력 *후* 메인 Claude 가 추가 1~3 줄로 후속 액션 권고 가능 (별도 줄 — 리포트 본문에 삽입 X):
 - HIGH waste 1+ → 해당 agent prompt 고치는 PR 권유
-- HIGH waste 0 + GOOD 다수 → "이번 run clean 정합. 다음 task 진행 가능"
+- HIGH waste 0 + 재발 후보 없음 → "이번 run clean 정합. 다음 task 진행 가능"
 - MUST_FIX_GHOST 발견 → 주의사항 멈춤 룰 강화 검토
 - context audit 후보 있음 → 사용자 승인 후 CLAUDE.md/AGENTS.md docs PR 또는 loop insight / agent prompt 수정으로 분리
 
-## 잘한 점 / 잘못한 점 패턴 매트릭스
+## 잘못한 점 패턴 매트릭스
 
-### 잘한 점 (GOOD)
-
-| 패턴 | 검출 조건 | 정합 룰 |
-|---|---|---|
-| `ENUM_CLEAN` | step enum 이 해당 skill `## Loop` advance/expected_steps 정합 + must_fix=False | 각 skill `## Loop` + [loop-procedure Step mechanics](../docs/plugin/loop-procedure.md#진입-모델) |
-| `PROSE_ECHO_OK` | prose_excerpt 5~12줄 | DCN-30-15 |
-| `DDD_PHASE_A` | architect SD prose 안 Domain Model / Phase A 섹션 | DCN-30-16 |
-| `DEPENDENCY_CAUSAL` | architect SD prose 의존성 화살표에 인과관계 표기 | DCN-30-16 |
+GOOD 자동 finding 은 폐기됐다. 잘한 사례 누적은 baseline noise 가 커서 학습 신호로 쓰지 않는다.
 
 ### 잘못한 점 (WASTE)
 
@@ -107,7 +100,7 @@ Bash stdout 의 마크다운 리포트를 **한 글자도 바꾸지 않고 그�
 
 - **per-Agent 정확 cost X (Phase 1)** — 현재는 run timeframe 합산 (coarse). Phase 2 = `toolUseResult.totalCost` 매칭 (Agent tool call 별).
 - **prose 텍스트 분석 한계** — 한국어/영어 mixed regex 기반. semantic 분석 안 함.
-- **한 run 만** — 30일 누적 / 다른 run 비교는 별도 skill 후속.
+- **단일 run 중심** — `/run-review` 의 재발 후보는 현재 run 의 waste pattern 만 같은 sessions root 에서 카운트한다. 전체 fleet 후보는 `harness/benchmark_aggregate.py` 를 사용한다.
 - **자동 트리거 범위 제한** — helper 기반 `/design`·`/impl` run 은 `end-run` 의 review.md 안에 context audit 섹션이 자동 포함된다. helper run 이 없는 `/spec`·standalone `/acceptance` 는 skill 종료 절차에서 `dcness-review --context-audit` 를 명시 호출한다.
 
 ## 참조

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -54,7 +54,9 @@ Verify는 하나의 PASS로 뭉개지 않는다.
 
 `evals/run.sh`는 블라인드 검수 보고와 judge 채점 결과를 `.metrics/evals/` 아래 또는
 `EVAL_OUTPUT_DIR`로 지정한 위치에 저장한다. MISS가 났을 때 사람은 해당 파일을 직접 읽어
-agent 결함인지 judge 결함인지 구분한다.
+agent 결함인지 judge 결함인지 구분한다. 동시에 `guard-telemetry.jsonl`의
+`eval_case_result` 이벤트에 pass/fail, LLM 호출 수, 추정 출력 token 을 남겨 정답률은
+같지만 비용이 커진 회귀도 Sense 단계에서 볼 수 있게 한다.
 
 ## 첫 실증
 

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -13,7 +13,7 @@ dcNess 는 측정 인프라를 plug-in 본체에 같이 배포한다.
 |---|---|---|
 | [`scripts/measure_main_turns.py`](../../scripts/measure_main_turns.py) | Claude Code 세션의 메인 assistant turn 분포 (tool / text-only / thinking-only) + tool histogram + sub-agent 호출 분포 | 직접 실행 |
 | [`harness/run_review.py`](../../harness/run_review.py) | run 1개의 step별 비용·토큰 + 낭비(waste) finding | `/run-review` skill |
-| [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py) | 여러 run 가로질러 fleet 집계 (PR 머지 성공률 / review rejection / escalate / blocked / waste top-N) | 직접 실행 |
+| [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py) | 여러 run 가로질러 fleet 집계 (PR 머지 성공률 / review rejection / escalate / blocked / waste top-N / 재발 개선 후보) | 직접 실행 |
 
 guard 효능 재현은 별도다. dcNess 소스 checkout 에서만 제공되는
 `evals/guard_efficacy.py` 는 LLM 없이 hook/function 진입점을 직접 호출해 file boundary,
@@ -112,7 +112,9 @@ dcNess loop(`begin-run` ~ `end-run` 사이클)을 한 번이라도 돌린 run �
 ```
 
 `/run-review` 는 step별 비용, 낭비(WASTE — 같은 실패 재시도 / read-only Bash 낭비 /
-placeholder 누수 등) finding, 수정 제안을 리포트로 출력한다. 실 구현은
+placeholder 누수 등) finding, 수정 제안을 리포트로 출력한다. 현재 run 의 waste pattern
+이 같은 sessions root 의 과거 run 에서도 임계(기본 3회) 이상 반복됐으면 재발 기반 개선
+후보로 같이 표면화한다. 실 구현은
 [`harness/run_review.py`](../../harness/run_review.py) 다.
 
 ## 실측 샘플 (turn 절감)
@@ -149,8 +151,8 @@ notes 기록). 측정 스크립트의 재현 정확성은 알려진 두 세션(t
 
 위 두 도구가 run 1개를 보는 반면, [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py)
 는 한 프로젝트의 **모든 run 의 `ledger.jsonl` 을 가로질러** 집계한다 — PR 머지 성공률,
-review rejection, escalate 수, blocked 수, waste top-N. `run_review.py` 의 검증된
-파서를 재사용한다.
+review rejection, escalate 수, blocked 수, waste top-N, 재발 기반 개선 후보.
+`run_review.py` 의 검증된 waste 분류를 재사용한다.
 
 ```sh
 # 활성 프로젝트 안에서 (sessions-root 자동 탐색) — $DCN 은 위 "스크립트 위치" 참조
@@ -159,7 +161,14 @@ python3 "$DCN"/harness/benchmark_aggregate.py
 # 경로 명시 + impl run 만 + JSON
 python3 "$DCN"/harness/benchmark_aggregate.py <repo>/.claude/harness-state/.sessions --entry-point impl
 python3 "$DCN"/harness/benchmark_aggregate.py <sessions-root> --json
+
+# 동일 waste pattern 이 2회 이상 반복되면 개선 후보로 표면화
+python3 "$DCN"/harness/benchmark_aggregate.py --recurrence-threshold 2
 ```
+
+재발 개선 후보의 기본 임계값은 3회다. 후보는 룰 추가, skill 박제, 기존 룰 제거 검토
+중 하나를 사람이 결정하기 위한 표면화일 뿐이며, `CLAUDE.md`·룰·skill·문서를 자동
+수정하지 않는다. GOOD 사례는 집계 대상이 아니다.
 
 ### multi-run 측정 recipe
 
@@ -193,7 +202,8 @@ done
 
 4. publish 가능한 표는 다음 항목을 같이 적는다: `run_count`, `pr_created_count`,
    `pr_merge_success_ratio`, `pr_reviewer_rejection_count/review_count`,
-   `blocked_event_count`, `escalate_count`, `waste_top`, source count, 한계.
+   `blocked_event_count`, `escalate_count`, `waste_top`, `improvement_candidates`,
+   source count, 한계.
 
 ### fleet 실측 (외부 활성 프로젝트 1곳)
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -55,8 +55,11 @@ Verify 슬롯을 사람이 도는 릴리즈 전 권고다.
 [#875](https://github.com/alruminum/dcNess/issues/875)의 추세 집계와
 [#894](https://github.com/alruminum/dcNess/issues/894)의 judge 보정 입력으로 소비된다.
 동시에 `guard-telemetry.jsonl` 에 케이스별 `eval_case_result` 이벤트를 append 한다.
+이 이벤트에는 pass/fail 뿐 아니라 블라인드 검수와 judge 호출 2회를 기준으로 한
+`llm_turns`, 보고서/judge 출력 길이, 추정 출력 token 이 함께 기록된다.
 `dcness-helper guard-telemetry` 는 이 이벤트를 읽어 최근 window 에서 장기간 만점인
-케이스를 **노후 후보**로 표시한다. 이 표시는 케이스 삭제나 비활성화를 자동 실행하지 않는다.
+케이스를 **노후 후보**로 표시하고 평균 turn/token effort 를 함께 보여준다. 이 표시는
+케이스 삭제나 비활성화를 자동 실행하지 않는다.
 기본 산출 위치인 `.metrics/evals/**` 는 자동 집계 대상이다. `EVAL_OUTPUT_DIR` 를 repo 밖으로
 지정한 경우에는 `dcness-helper guard-telemetry --base-dir <EVAL_OUTPUT_DIR>` 로 그 산출물을 직접 본다.
 

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -79,6 +79,11 @@ $report"
     fi
     printf '%s\n' "$grade" > "$judge_file"
 
+    report_chars="${#report}"
+    judge_chars="${#grade}"
+    estimated_output_tokens=$(((report_chars + judge_chars + 3) / 4))
+    llm_turns=2
+
     verdict="$(printf '%s\n' "$grade" | grep -E '^RESULT: (PASS|FAIL)$' | tail -1 || true)"
     if [ "$verdict" = "RESULT: PASS" ]; then
       pass=$((pass + 1))
@@ -91,6 +96,10 @@ $report"
         --report-file "$report_file" \
         --judge-file "$judge_file" \
         --model "$MODEL" \
+        --llm-turns "$llm_turns" \
+        --report-chars "$report_chars" \
+        --judge-chars "$judge_chars" \
+        --estimated-output-tokens "$estimated_output_tokens" \
         --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
     else
       echo "[eval] $case_name run $i: 오답"
@@ -103,6 +112,10 @@ $report"
         --report-file "$report_file" \
         --judge-file "$judge_file" \
         --model "$MODEL" \
+        --llm-turns "$llm_turns" \
+        --report-chars "$report_chars" \
+        --judge-chars "$judge_chars" \
+        --estimated-output-tokens "$estimated_output_tokens" \
         --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
     fi
   done

--- a/harness/benchmark_aggregate.py
+++ b/harness/benchmark_aggregate.py
@@ -15,6 +15,7 @@ N run 을 한 번에 집계한다 — public benchmark (성공률/FAIL/escalate/
 - `blocked` 이벤트 수
 - PR 머지 성공률 (= pr_created 중 pr_merged 로 확인된 PR 비율, 이벤트 있을 때만)
 - waste finding top-N (detect_wastes 합산)
+- 재발 기반 개선 후보 (동일 waste pattern 이 임계 이상 반복될 때만 표면화)
 
 사용
 ----
@@ -22,6 +23,7 @@ N run 을 한 번에 집계한다 — public benchmark (성공률/FAIL/escalate/
     python3 harness/benchmark_aggregate.py [sessions-root] --entry-point impl
     python3 harness/benchmark_aggregate.py [sessions-root] --json
     python3 harness/benchmark_aggregate.py --top 8
+    python3 harness/benchmark_aggregate.py --recurrence-threshold 2
 
 sessions-root 미지정 시 cwd 기준 `.claude/harness-state/.sessions` 자동 탐색.
 """
@@ -56,6 +58,13 @@ _PR_REVIEWER_VERDICTS = {"PASS", "LGTM"} | _PR_REVIEWER_FAIL
 # 폴백하되 이 값들은 verdict 가 아니므로 제외한다.
 _NON_VERDICT_ENUMS = {"PROSE_LOGGED", "AMBIGUOUS", ""}
 
+DEFAULT_RECURRENCE_THRESHOLD = 3
+
+_IMPROVEMENT_SUGGESTION = (
+    "자동 박제 없음. 재발 원인을 확인한 뒤 룰 추가, skill 박제, 또는 기존 룰 제거 "
+    "중 하나를 사용자 결정으로 분리합니다."
+)
+
 
 def _step_verdict(step) -> str:
     """step 의 진짜 verdict — stored enum 이 실제 결론이면 그것을 우선한다.
@@ -82,6 +91,15 @@ def _repo_path_for_run(run_dir: Path) -> Optional[Path]:
 
 
 @dataclass
+class ImprovementCandidate:
+    pattern: str
+    count: int
+    threshold: int
+    source: str
+    suggestion: str
+
+
+@dataclass
 class FleetReport:
     run_count: int
     by_entry_point: dict
@@ -98,7 +116,34 @@ class FleetReport:
     pr_merge_success_ratio: Optional[float]
     waste_top: list  # [(pattern, count), ...] count desc
     success_measurable: bool
+    recurrence_threshold: int
+    improvement_candidates: list[ImprovementCandidate]
     waste_limit: int = 10
+
+
+def _build_improvement_candidates(
+    waste_counter: Counter,
+    *,
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+) -> list[ImprovementCandidate]:
+    """Return recurrent waste candidates only.
+
+    GOOD 사례나 raw note 는 입력 자체가 아니므로 집계되지 않는다. 후보는 제안일 뿐이며
+    CLAUDE.md·룰·스킬·문서를 자동 수정하지 않는다.
+    """
+    threshold = max(int(threshold), 1)
+    candidates: list[ImprovementCandidate] = []
+    for pattern, count in sorted(waste_counter.items(), key=lambda kv: (-kv[1], kv[0])):
+        if count < threshold:
+            continue
+        candidates.append(ImprovementCandidate(
+            pattern=pattern,
+            count=count,
+            threshold=threshold,
+            source="run_review.waste",
+            suggestion=_IMPROVEMENT_SUGGESTION,
+        ))
+    return candidates
 
 
 def _run_entry_point(run_dir: Path) -> Optional[str]:
@@ -150,7 +195,13 @@ def _run_event_counts(run_dir: Path) -> tuple[int, set[str], set[str]]:
     return blocked, pr_created, pr_merged
 
 
-def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> FleetReport:
+def aggregate_runs(
+    run_dirs: list,
+    *,
+    top: int = 10,
+    recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+    repo_override=None,
+) -> FleetReport:
     """run_dir 목록을 fleet 집계한다.
 
     repo_override: build_report 의 invocation/cost 산출 기준 repo. 지정 시 모든 run 에
@@ -217,6 +268,7 @@ def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> Flee
     pr_merge_success_ratio = (
         pr_merge_success_count / pr_created_count if pr_created_count else None
     )
+    recurrence_threshold = max(int(recurrence_threshold), 1)
 
     return FleetReport(
         run_count=run_count,
@@ -234,18 +286,30 @@ def aggregate_runs(run_dirs: list, *, top: int = 10, repo_override=None) -> Flee
         pr_merge_success_ratio=pr_merge_success_ratio,
         waste_top=waste_counter.most_common(top),
         success_measurable=pr_merge_success_ratio is not None,
+        recurrence_threshold=recurrence_threshold,
+        improvement_candidates=_build_improvement_candidates(
+            waste_counter,
+            threshold=recurrence_threshold,
+        ),
         waste_limit=top,
     )
 
 
 def aggregate_sessions(sessions_root, *, entry_point: Optional[str] = None,
-                       top: int = 10, repo_override=None) -> FleetReport:
+                       top: int = 10,
+                       recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+                       repo_override=None) -> FleetReport:
     """sessions-root 아래 모든 run 을 집계한다. entry_point 지정 시 그 진입점만."""
     sessions_root = Path(sessions_root)
     run_dirs = run_review.list_runs(sessions_root)
     if entry_point:
         run_dirs = [r for r in run_dirs if _run_entry_point(r) == entry_point]
-    return aggregate_runs(run_dirs, top=top, repo_override=repo_override)
+    return aggregate_runs(
+        run_dirs,
+        top=top,
+        recurrence_threshold=recurrence_threshold,
+        repo_override=repo_override,
+    )
 
 
 def _fmt_ratio(r: Optional[float]) -> str:
@@ -309,6 +373,21 @@ def render_markdown(report: FleetReport) -> str:
     else:
         lines.append("(검출된 waste 없음)")
     lines.append("")
+
+    lines.append(f"## 재발 기반 개선 후보 (threshold {report.recurrence_threshold})")
+    lines.append("")
+    if report.improvement_candidates:
+        lines.append("| pattern | count | suggestion |")
+        lines.append("|---|---:|---|")
+        for candidate in report.improvement_candidates:
+            lines.append(
+                f"| {candidate.pattern} | {candidate.count} | {candidate.suggestion} |"
+            )
+    else:
+        lines.append("(임계 도달 후보 없음 — GOOD 사례는 집계 대상이 아닙니다.)")
+    lines.append("")
+    lines.append("자동 수정 없음 — 후보 표면화까지만 수행하고 박제 여부는 사용자가 결정합니다.")
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -321,6 +400,12 @@ def main(argv: Optional[list] = None) -> int:
     ap.add_argument("--entry-point", default=None,
                     help="impl / design 등 특정 진입점만 집계")
     ap.add_argument("--top", type=int, default=10, help="waste top-N (기본 10)")
+    ap.add_argument(
+        "--recurrence-threshold",
+        type=int,
+        default=DEFAULT_RECURRENCE_THRESHOLD,
+        help="개선 후보로 표면화할 동일 waste pattern 반복 임계값 (기본 3)",
+    )
     ap.add_argument("--repo", default=None,
                     help="cost/invocation 산출 기준 repo (세션 JSONL 위치). "
                          "worktree run 의 정확한 cost/END_STEP_SKIP 가 필요할 때 "
@@ -342,7 +427,9 @@ def main(argv: Optional[list] = None) -> int:
     # 절대 cwd 기준으로 인코딩하므로 `--repo .` 같은 상대경로는 키가 어긋난다.
     repo_override = Path(args.repo).resolve() if args.repo else None
     report = aggregate_sessions(sessions_root, entry_point=args.entry_point,
-                                top=args.top, repo_override=repo_override)
+                                top=args.top,
+                                recurrence_threshold=args.recurrence_threshold,
+                                repo_override=repo_override)
 
     if args.json:
         print(json.dumps({
@@ -361,6 +448,17 @@ def main(argv: Optional[list] = None) -> int:
             "pr_merge_success_ratio": report.pr_merge_success_ratio,
             "waste_top": report.waste_top,
             "success_measurable": report.success_measurable,
+            "recurrence_threshold": report.recurrence_threshold,
+            "improvement_candidates": [
+                {
+                    "pattern": candidate.pattern,
+                    "count": candidate.count,
+                    "threshold": candidate.threshold,
+                    "source": candidate.source,
+                    "suggestion": candidate.suggestion,
+                }
+                for candidate in report.improvement_candidates
+            ],
         }, ensure_ascii=False, indent=2))
     else:
         print(render_markdown(report))

--- a/harness/guard_telemetry.py
+++ b/harness/guard_telemetry.py
@@ -175,6 +175,10 @@ def record_eval_case_result(
     report_file: str = "",
     judge_file: str = "",
     model: str = "",
+    llm_turns: Optional[int] = None,
+    report_chars: Optional[int] = None,
+    judge_chars: Optional[int] = None,
+    estimated_output_tokens: Optional[int] = None,
     cwd: Optional[Path] = None,
     base_dir: Optional[Path] = None,
 ) -> None:
@@ -193,6 +197,14 @@ def record_eval_case_result(
         event["judge_file"] = str(judge_file)
     if model:
         event["model"] = str(model)
+    for key, value in (
+        ("llm_turns", llm_turns),
+        ("report_chars", report_chars),
+        ("judge_chars", judge_chars),
+        ("estimated_output_tokens", estimated_output_tokens),
+    ):
+        if value is not None:
+            event[key] = max(int(value), 0)
     append_event(event, cwd=cwd, base_dir=base_dir)
 
 
@@ -340,6 +352,12 @@ def collect_eval_summary(
                 "attempts": 0,
                 "passes": 0,
                 "accuracy": 0.0,
+                "llm_turns": 0,
+                "estimated_output_tokens": 0,
+                "report_chars": 0,
+                "judge_chars": 0,
+                "avg_llm_turns": 0.0,
+                "avg_estimated_output_tokens": 0.0,
                 "last_ts": None,
                 "saturation_candidate": False,
             },
@@ -347,6 +365,12 @@ def collect_eval_summary(
         row["attempts"] += 1
         if event.get("passed") is True:
             row["passes"] += 1
+        row["llm_turns"] += max(int(event.get("llm_turns") or 0), 0)
+        row["estimated_output_tokens"] += max(
+            int(event.get("estimated_output_tokens") or 0), 0
+        )
+        row["report_chars"] += max(int(event.get("report_chars") or 0), 0)
+        row["judge_chars"] += max(int(event.get("judge_chars") or 0), 0)
         ts = str(event.get("ts") or "")
         if ts and (row["last_ts"] is None or ts > row["last_ts"]):
             row["last_ts"] = ts
@@ -356,6 +380,12 @@ def collect_eval_summary(
         attempts = int(row["attempts"])
         passes = int(row["passes"])
         row["accuracy"] = (passes / attempts) if attempts else 0.0
+        row["avg_llm_turns"] = (
+            row["llm_turns"] / attempts if attempts else 0.0
+        )
+        row["avg_estimated_output_tokens"] = (
+            row["estimated_output_tokens"] / attempts if attempts else 0.0
+        )
         row["saturation_candidate"] = attempts >= min_runs and attempts == passes
     return {
         "saturation_days": saturation_days,
@@ -396,9 +426,13 @@ def format_telemetry_report(
                 attempts = int(row.get("attempts") or 0)
                 passes = int(row.get("passes") or 0)
                 accuracy = float(row.get("accuracy") or 0.0)
+                avg_turns = float(row.get("avg_llm_turns") or 0.0)
+                avg_tokens = float(row.get("avg_estimated_output_tokens") or 0.0)
                 last = row.get("last_ts") or "-"
                 lines.append(
-                    f"- {case}: {passes}/{attempts} ({accuracy:.0%}), last={last}, {marker}"
+                    f"- {case}: {passes}/{attempts} ({accuracy:.0%}), "
+                    f"avg_turns={avg_turns:.1f}, avg_tokens≈{avg_tokens:.0f}, "
+                    f"last={last}, {marker}"
                 )
         else:
             lines.append("- no eval case telemetry events")
@@ -427,6 +461,10 @@ def _cli_record_eval(args: argparse.Namespace) -> int:
         report_file=args.report_file or "",
         judge_file=args.judge_file or "",
         model=args.model or "",
+        llm_turns=args.llm_turns,
+        report_chars=args.report_chars,
+        judge_chars=args.judge_chars,
+        estimated_output_tokens=args.estimated_output_tokens,
         cwd=Path(args.cwd) if args.cwd else None,
         base_dir=Path(args.base_dir) if args.base_dir else None,
     )
@@ -473,6 +511,10 @@ def _build_parser() -> argparse.ArgumentParser:
     p_eval.add_argument("--report-file", default="")
     p_eval.add_argument("--judge-file", default="")
     p_eval.add_argument("--model", default="")
+    p_eval.add_argument("--llm-turns", type=int, default=None)
+    p_eval.add_argument("--report-chars", type=int, default=None)
+    p_eval.add_argument("--judge-chars", type=int, default=None)
+    p_eval.add_argument("--estimated-output-tokens", type=int, default=None)
     p_eval.add_argument("--cwd", default="")
     p_eval.add_argument("--base-dir", default="")
     p_eval.set_defaults(func=_cli_record_eval)

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -23,6 +23,7 @@ import argparse
 import json
 import re
 import sys
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -259,6 +260,22 @@ class ContextAuditFinding:
 
 # issue #392 — `GoodFinding` dataclass 폐기. `detect_goods` 폐기와 정합.
 
+DEFAULT_RECURRENCE_THRESHOLD = 3
+
+_RECURRENCE_SUGGESTION = (
+    "자동 박제 없음. 재발 원인을 확인한 뒤 룰 추가, skill 박제, 또는 기존 룰 제거 "
+    "중 하나를 사용자 결정으로 분리합니다."
+)
+
+
+@dataclass
+class RecurrenceCandidate:
+    pattern: str
+    count: int
+    threshold: int
+    source: str
+    suggestion: str
+
 
 @dataclass
 class RunReport:
@@ -277,6 +294,9 @@ class RunReport:
     elapsed_s: int = 0
     final_enum: str = ""
     final_clean: bool = False
+    recurrence_checked: bool = False
+    recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD
+    recurrence_candidates: list[RecurrenceCandidate] = field(default_factory=list)
 
 
 def _read_context_doc(repo_path: Path, name: str) -> tuple[Path, str, bool]:
@@ -513,6 +533,49 @@ def find_run_dir(sessions_root: Path, run_id: Optional[str], use_latest: bool) -
         runs = list_runs(sessions_root)
         return runs[0] if runs else None
     return None
+
+
+def _sessions_root_for_run(run_dir: Path) -> Optional[Path]:
+    for parent in Path(run_dir).resolve().parents:
+        if parent.name == ".sessions":
+            return parent
+    return None
+
+
+def _build_recurrence_candidates(
+    current_wastes: list[WasteFinding],
+    run_dir: Path,
+    *,
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+) -> list[RecurrenceCandidate]:
+    """Count current run waste patterns across finished runs in the same sessions root."""
+    threshold = max(int(threshold), 1)
+    target_patterns = {w.pattern for w in current_wastes}
+    if not target_patterns:
+        return []
+    sessions_root = _sessions_root_for_run(run_dir)
+    if sessions_root is None:
+        return []
+
+    counter: Counter = Counter()
+    for candidate_run_dir in list_runs(sessions_root):
+        steps = parse_steps(candidate_run_dir)
+        for waste in detect_wastes(steps, run_dir=candidate_run_dir):
+            if waste.pattern in target_patterns:
+                counter[waste.pattern] += 1
+
+    candidates: list[RecurrenceCandidate] = []
+    for pattern, count in sorted(counter.items(), key=lambda kv: (-kv[1], kv[0])):
+        if count < threshold:
+            continue
+        candidates.append(RecurrenceCandidate(
+            pattern=pattern,
+            count=count,
+            threshold=threshold,
+            source="run_review.waste",
+            suggestion=_RECURRENCE_SUGGESTION,
+        ))
+    return candidates
 
 
 # ── Step 파싱 ─────────────────────────────────────────────────────────
@@ -1530,6 +1593,22 @@ def render_report(report: RunReport) -> str:
         lines.append("## 잘못한 점 — 없음 ✅")
         lines.append("")
 
+    if report.recurrence_checked:
+        lines.append(f"## 재발 기반 개선 후보 (threshold {report.recurrence_threshold})")
+        lines.append("")
+        if report.recurrence_candidates:
+            lines.append("| pattern | count | suggestion |")
+            lines.append("|---|---:|---|")
+            for candidate in report.recurrence_candidates:
+                lines.append(
+                    f"| {candidate.pattern} | {candidate.count} | {candidate.suggestion} |"
+                )
+        else:
+            lines.append("(임계 도달 후보 없음 — GOOD 사례는 집계 대상이 아닙니다.)")
+        lines.append("")
+        lines.append("자동 수정 없음 — 후보 표면화까지만 수행하고 박제 여부는 사용자가 결정합니다.")
+        lines.append("")
+
     lines.append(render_context_audit_section(report.repo_path, report=report))
 
     # issue #396 — 메인 인사이트 prompt (review.md 끝 임베드)
@@ -1554,7 +1633,13 @@ def render_report(report: RunReport) -> str:
 
 # ── 실행 ──────────────────────────────────────────────────────────────
 
-def build_report(run_dir: Path, repo_path: Path) -> RunReport:
+def build_report(
+    run_dir: Path,
+    repo_path: Path,
+    *,
+    include_recurrence: bool = False,
+    recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+) -> RunReport:
     steps = parse_steps(run_dir)
 
     # DCN-CHG-20260430-20: per-Agent invocation 매칭 — wastes 탐지 *전*에 enrichment.
@@ -1602,6 +1687,16 @@ def build_report(run_dir: Path, repo_path: Path) -> RunReport:
         final_enum and not has_must_fix and not has_ambiguous
         and len([w for w in wastes if w.severity == "HIGH"]) == 0
     )
+    recurrence_threshold = max(int(recurrence_threshold), 1)
+    recurrence_candidates = (
+        _build_recurrence_candidates(
+            wastes,
+            run_dir,
+            threshold=recurrence_threshold,
+        )
+        if include_recurrence
+        else []
+    )
 
     sid = run_dir.parent.parent.name
     return RunReport(
@@ -1618,6 +1713,9 @@ def build_report(run_dir: Path, repo_path: Path) -> RunReport:
         elapsed_s=elapsed,
         final_enum=final_enum,
         final_clean=final_clean,
+        recurrence_checked=include_recurrence,
+        recurrence_threshold=recurrence_threshold,
+        recurrence_candidates=recurrence_candidates,
     )
 
 
@@ -1654,6 +1752,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     p.add_argument("--repo", default=".", help="저장소 cwd (default: cwd)")
     p.add_argument("--limit", type=int, default=10, help="--list 시 최대 개수")
     p.add_argument(
+        "--recurrence-threshold",
+        type=int,
+        default=DEFAULT_RECURRENCE_THRESHOLD,
+        help="재발 개선 후보로 표면화할 동일 waste pattern 반복 임계값 (기본 3)",
+    )
+    p.add_argument(
         "--context-audit",
         action="store_true",
         help="run 없이 CLAUDE.md/AGENTS.md 현행화 후보만 read-only 출력",
@@ -1685,7 +1789,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         print(f"[run-review] run_dir 미탐지 (run_id={args.run_id})", file=sys.stderr)
         return 2
 
-    report = build_report(run_dir, repo_path)
+    report = build_report(
+        run_dir,
+        repo_path,
+        include_recurrence=True,
+        recurrence_threshold=args.recurrence_threshold,
+    )
     print(render_report(report))
     return 0
 

--- a/tests/test_benchmark_aggregate.py
+++ b/tests/test_benchmark_aggregate.py
@@ -357,6 +357,76 @@ class TestWasteTop(unittest.TestCase):
             self.assertIsInstance(rep.waste_top, list)
 
 
+class TestImprovementCandidates(unittest.TestCase):
+    def _run_with_retry_waste(self, tmp: Path, rid: str) -> Path:
+        same = "동일 실패 반복\nFAIL\n"
+        return _make_run_dir_ledger(
+            tmp, "s1", rid,
+            _run_events("impl", [
+                _step("code-validator", "v.md", enum="FAIL",
+                      ts="2026-06-01T00:01:00Z"),
+                _step("code-validator", "v.md", enum="FAIL",
+                      ts="2026-06-01T00:02:00Z"),
+            ]),
+            {"v.md": same},
+        )
+
+    def test_default_threshold_surfaces_recurrent_waste_candidate(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            runs = [
+                self._run_with_retry_waste(tmp, f"run-rc{i:06d}")
+                for i in range(3)
+            ]
+
+            rep = aggregate_runs(runs)
+
+            self.assertEqual(rep.recurrence_threshold, 3)
+            self.assertEqual(len(rep.improvement_candidates), 1)
+            candidate = rep.improvement_candidates[0]
+            self.assertEqual(candidate.pattern, "RETRY_SAME_FAIL")
+            self.assertEqual(candidate.count, 3)
+            self.assertEqual(candidate.threshold, 3)
+            self.assertIn("기존 룰 제거", candidate.suggestion)
+
+            md = render_markdown(rep)
+            self.assertIn("## 재발 기반 개선 후보", md)
+            self.assertIn("RETRY_SAME_FAIL", md)
+            self.assertIn("기존 룰 제거", md)
+
+    def test_recurrence_threshold_is_adjustable(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            runs = [
+                self._run_with_retry_waste(tmp, f"run-th{i:06d}")
+                for i in range(2)
+            ]
+
+            default_rep = aggregate_runs(runs)
+            lowered_rep = aggregate_runs(runs, recurrence_threshold=2)
+
+            self.assertEqual(default_rep.improvement_candidates, [])
+            self.assertEqual(len(lowered_rep.improvement_candidates), 1)
+            self.assertEqual(lowered_rep.improvement_candidates[0].threshold, 2)
+
+    def test_good_text_is_not_counted_as_recurrence_signal(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            runs = [
+                _make_run_dir_ledger(
+                    tmp, "s1", f"run-good{i:04d}",
+                    _run_events("impl", [_step("engineer", "e.md")]),
+                    {"e.md": "좋았던 점 GOOD\nIMPL_DONE\n"},
+                )
+                for i in range(3)
+            ]
+
+            rep = aggregate_runs(runs)
+
+            self.assertEqual(rep.waste_top, [])
+            self.assertEqual(rep.improvement_candidates, [])
+
+
 class TestEntryPointFilter(unittest.TestCase):
     def test_aggregate_sessions_filters_entry_point(self):
         with tempfile.TemporaryDirectory() as d:

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -156,6 +156,9 @@ class EvalsHarnessContractTests(unittest.TestCase):
                 '"kind":"eval_case_result"',
                 telemetry[0].read_text(encoding="utf-8"),
             )
+            telemetry_text = telemetry[0].read_text(encoding="utf-8")
+            self.assertIn('"llm_turns":2', telemetry_text)
+            self.assertIn('"estimated_output_tokens"', telemetry_text)
 
     def test_runner_persists_miss_report_and_judge_output_before_failing(self) -> None:
         """#893 — MISS runs must leave files for human/judge comparison."""
@@ -213,6 +216,8 @@ class EvalsHarnessContractTests(unittest.TestCase):
             text = telemetry[0].read_text(encoding="utf-8")
             self.assertIn('"kind":"eval_case_result"', text)
             self.assertIn('"passed":false', text)
+            self.assertIn('"llm_turns":2', text)
+            self.assertIn('"estimated_output_tokens"', text)
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_telemetry.py
+++ b/tests/test_guard_telemetry.py
@@ -103,12 +103,18 @@ class EvalSummaryTests(unittest.TestCase):
                 cwd=root,
                 report_file="/tmp/report.md",
                 judge_file="/tmp/judge.md",
+                llm_turns=2,
+                report_chars=120,
+                judge_chars=80,
+                estimated_output_tokens=50,
             )
 
             events = read_events(cwd=root)
             self.assertEqual(events[0]["kind"], "eval_case_result")
             self.assertEqual(events[0]["case"], "headless-prose-quality")
             self.assertTrue(events[0]["passed"])
+            self.assertEqual(events[0]["llm_turns"], 2)
+            self.assertEqual(events[0]["estimated_output_tokens"], 50)
 
     def test_all_pass_eval_case_is_saturation_candidate(self) -> None:
         with TemporaryDirectory() as td:
@@ -138,7 +144,13 @@ class EvalSummaryTests(unittest.TestCase):
         with TemporaryDirectory() as td:
             root = Path(td)
             record_eval_case_result("flow-ownership-owner-good", passed=True, cwd=root)
-            record_eval_case_result("flow-ownership-owner-good", passed=False, cwd=root)
+            record_eval_case_result(
+                "flow-ownership-owner-good",
+                passed=False,
+                cwd=root,
+                llm_turns=2,
+                estimated_output_tokens=40,
+            )
 
             summary = collect_eval_summary(
                 cwd=root,
@@ -148,6 +160,10 @@ class EvalSummaryTests(unittest.TestCase):
 
             row = summary["cases"]["flow-ownership-owner-good"]
             self.assertEqual(row["accuracy"], 0.5)
+            self.assertEqual(row["llm_turns"], 2)
+            self.assertEqual(row["estimated_output_tokens"], 40)
+            self.assertEqual(row["avg_llm_turns"], 1.0)
+            self.assertEqual(row["avg_estimated_output_tokens"], 20.0)
             self.assertFalse(row["saturation_candidate"])
 
     def test_project_summary_reads_default_metrics_eval_output_logs(self) -> None:
@@ -190,6 +206,10 @@ class ReportFormatTests(unittest.TestCase):
                     "attempts": 2,
                     "passes": 2,
                     "accuracy": 1.0,
+                    "llm_turns": 4,
+                    "estimated_output_tokens": 120,
+                    "avg_llm_turns": 2.0,
+                    "avg_estimated_output_tokens": 60.0,
                     "last_ts": "2026-07-04T00:00:00Z",
                     "saturation_candidate": True,
                 }
@@ -199,6 +219,8 @@ class ReportFormatTests(unittest.TestCase):
         report = format_telemetry_report(guard_summary, eval_summary)
         self.assertIn("재평가 후보", report)
         self.assertIn("노후 후보", report)
+        self.assertIn("avg_turns=2.0", report)
+        self.assertIn("avg_tokens≈60", report)
 
 
 if __name__ == "__main__":

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -708,6 +708,47 @@ class ReportRenderTests(unittest.TestCase):
             self.assertIn("| clean 판정 | ✅ |", text)
 
 
+class RecurrenceReportTests(unittest.TestCase):
+    def _retry_run(self, tmp: Path, rid: str) -> Path:
+        return _make_run_dir(tmp, "sid1", rid, [
+            {"ts": "2026-04-30T10:00:00", "agent": "code-validator", "mode": None,
+             "enum": "FAIL", "must_fix": False, "prose_excerpt": "same fail\nFAIL"},
+            {"ts": "2026-04-30T10:01:00", "agent": "code-validator", "mode": None,
+             "enum": "FAIL", "must_fix": False, "prose_excerpt": "same fail\nFAIL"},
+        ])
+
+    def test_build_report_can_include_cross_run_recurrence_candidates(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            runs = [self._retry_run(tmp, f"run-rec{i:04d}") for i in range(3)]
+
+            report = build_report(
+                runs[-1],
+                repo_path=tmp,
+                include_recurrence=True,
+                recurrence_threshold=3,
+            )
+            text = render_report(report)
+
+            self.assertTrue(report.recurrence_checked)
+            self.assertEqual(len(report.recurrence_candidates), 1)
+            candidate = report.recurrence_candidates[0]
+            self.assertEqual(candidate.pattern, "RETRY_SAME_FAIL")
+            self.assertEqual(candidate.count, 3)
+            self.assertIn("## 재발 기반 개선 후보", text)
+            self.assertIn("기존 룰 제거", text)
+
+    def test_build_report_skips_recurrence_scan_by_default(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = self._retry_run(tmp, "run-rec-default")
+
+            report = build_report(rd, repo_path=tmp)
+
+            self.assertFalse(report.recurrence_checked)
+            self.assertEqual(report.recurrence_candidates, [])
+
+
 class ContextAuditTests(unittest.TestCase):
     def test_render_report_includes_context_audit_section(self):
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
> 룰 SSOT: [`docs/plugin/git-spec.md` PR 본문](../docs/plugin/git-spec.md#pr-본문) (외부 활성 프로젝트 공통).
> 본 template = dcness self 전용 — `## 배포 경로 검증` 섹션이 dcness self 작업용으로 추가됨 ([`CLAUDE.md` 추가한 기능은 반드시 배포 경로에도 포함](../CLAUDE.md#추가한-기능은-반드시-배포-경로에도-포함)).

## 관련 이슈 번호

Closes #876

## 배경 및 문제

- `/run-review` 와 benchmark aggregate 는 run/fleet 단위 waste 를 보여줄 수 있었지만, 같은 실수가 여러 run 을 가로질러 임계 이상 재발했는지 개선 후보로 표면화하지 못했다.
- eval 결과는 pass/fail 중심이라 동일 정답률에서 LLM 호출 수나 추정 token 비용이 늘어나는 효율 회귀를 Sense 단계에서 보기 어려웠다.

## 원인 (해당 시)

- 재발 판단용 cross-run waste pattern 집계가 없었다.
- `eval_case_result` telemetry 가 artifact pointer 와 pass/fail 만 기록하고 turn/token effort 축을 기록하지 않았다.

## 작업내용

- `harness/run_review.py` 에 현재 run 의 waste pattern 을 같은 sessions root 에서 카운트하는 재발 개선 후보 섹션을 추가했다.
- `harness/benchmark_aggregate.py` 에 fleet-wide 재발 개선 후보와 `--recurrence-threshold` 옵션, JSON 필드를 추가했다.
- `evals/run.sh` 와 `harness/guard_telemetry.py` 에 eval LLM turn, report/judge 출력 길이, 추정 출력 token 기록 및 평균 표시를 추가했다.
- `commands/run-review.md`, `docs/plugin/benchmark.md`, `evals/README.md`, `docs/internal/self-improvement-loop.md` 를 갱신했다.
- run-review, benchmark aggregate, guard telemetry, eval harness 회귀 테스트를 추가/갱신했다.

## 결정 근거

- waste 분류는 기존 `run_review.detect_wastes` 를 재사용해 재발 후보 집계의 SSOT 를 늘리지 않았다.
- `/run-review` 는 현재 run 에서 실제로 발생한 waste pattern 만 재발 카운트해 단일 run 리뷰가 fleet 전체 후보로 과하게 noisy 해지지 않게 했다.
- 전체 fleet 후보는 `benchmark_aggregate.py` 에서 별도로 제공한다.
- 후보는 룰 추가, skill 박제, 기존 룰 제거 중 사람이 판단할 입력으로만 표면화하고 `CLAUDE.md`·룰·skill·문서를 자동 수정하지 않는다.
- GOOD 사례는 재발 후보 입력으로 사용하지 않는다.

## 배포 경로 검증 (plug-in 영향 시)

- 영향 파일은 plug-in 본체/배포 문서 경로인 `harness/**`, `evals/**`, `commands/run-review.md`, `docs/plugin/benchmark.md` 및 dcness self 문서 `docs/internal/self-improvement-loop.md` 이다.
- init-dcness 로 복사되는 사용자 프로젝트 파일은 변경하지 않았다.
- 신규 동작은 기존 plug-in 배포 경로로 전달된다. 기존 사용자 프로젝트에 별도 재복사할 파일은 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 는 추가하지 않았고, 기존 CLI 옵션과 기존 리포트 섹션만 확장했다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `PYTHON_BIN=/private/tmp/dcness-876-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `python3.11 evals/guard_efficacy.py`
- [x] `bash -n evals/run.sh`
- [x] git pre-commit hook PASS during commit
- [ ] `bash evals/run.sh` 전체 LLM eval 은 비용이 있어 미실행. 이 PR 은 agent/skill prompt 변경이 아니라 harness/eval runner telemetry 변경이며, 구조 검증은 `tests/test_evals_harness.py` 와 `bash -n evals/run.sh` 로 확인했다.

## 참고

- #893 의 self-improvement Sense slot 후속 작업 중 #876 범위다.
