### PR TITLE
[feature] judge calibration 리포트 추가

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -36,6 +36,10 @@ EVAL_RUNS=3 bash evals/run.sh        # 케이스당 3회 반복 (릴리즈 전 �
 EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh  # 핵심 실사고 케이스 N/N 확인
 EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonnet)
 EVAL_OUTPUT_DIR=/tmp/dcness-evals bash evals/run.sh # 산출물 저장 위치 지정
+
+# judge 보정 — 먼저 run 출력 디렉터리에 사람이 judge-golden.json 을 작성한다
+python3 evals/calibrate_judge.py .metrics/evals/run-YYYYMMDDTHHMMSSZ-PID
+python3 evals/calibrate_judge.py /tmp/dcness-evals --golden /tmp/dcness-evals/judge-golden.json --min-agreement 0.9 --report-file /tmp/dcness-evals/judge-calibration.md
 ```
 
 `guard_efficacy.py` 는 범주별 pass/fail count 를 출력한다. `provider-agnostic-order-gate`
@@ -62,6 +66,43 @@ Verify 슬롯을 사람이 도는 릴리즈 전 권고다.
 케이스 삭제나 비활성화를 자동 실행하지 않는다.
 기본 산출 위치인 `.metrics/evals/**` 는 자동 집계 대상이다. `EVAL_OUTPUT_DIR` 를 repo 밖으로
 지정한 경우에는 `dcness-helper guard-telemetry --base-dir <EVAL_OUTPUT_DIR>` 로 그 산출물을 직접 본다.
+
+## judge 보정 — 사람 golden 과 채점 모델 대조
+
+`run-N-judge.md` 자체가 맞는지도 소수 케이스에서 따로 확인한다. 절차는 표면화까지만 한다.
+`calibrate_judge.py` 는 judge 모델, prompt, eval 설정을 수정하지 않는다.
+
+1. `bash evals/run.sh` 를 실행해 `.metrics/evals/run-.../<case>/run-N-report.md` 와
+   `run-N-judge.md` 를 남긴다.
+2. `evals/judge-golden.example.json` 을 해당 run 디렉터리의 `judge-golden.json` 으로 복사한 뒤,
+   사람이 `run-N-report.md` 를 읽고 각 기대 ID 의 정답 라벨을 `OK` / `MISS` 로 채운다.
+   `result` 는 생략 가능하다. 생략하면 모든 기대가 `OK` 일 때 `PASS`, 하나라도 `MISS` 면
+   `FAIL` 로 파생한다.
+3. `python3 evals/calibrate_judge.py <run-dir>` 를 실행한다. 기본 임계는 `--min-agreement 1.0`
+   이며, 일치도가 임계 미만이면 `judge_review_candidate: YES` 로 표시하고 exit 1 을 반환한다.
+   임계는 `--min-agreement 0.9` 처럼 조정할 수 있다.
+
+golden 파일 형식:
+
+```json
+{
+  "labels": [
+    {
+      "case": "shorts-real-spec",
+      "run": 1,
+      "expectations": {
+        "E1": "OK",
+        "E2": "OK"
+      }
+    }
+  ]
+}
+```
+
+`case` + `run` 은 `<run-dir>/<case>/run-<run>-judge.md` 를 가리킨다. 특수 경로를 비교할 때는
+`judge_file` 에 run 디렉터리 기준 상대 경로나 절대 경로를 넣을 수 있다. 리포트는 stdout 으로
+나오며, `--report-file <path>` 를 주면 같은 내용을 파일로도 남긴다. JSON 소비가 필요하면
+`--json` 을 사용한다.
 
 ## 채점 원리 — 정답표는 계약 수준으로만 쓴다
 

--- a/evals/calibrate_judge.py
+++ b/evals/calibrate_judge.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Compare saved eval judge output with human golden labels (#894)."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MIN_AGREEMENT = 1.0
+LABEL_RE = re.compile(r"^\s*(?:[-*]\s*)?(OK|MISS)\s+(\S+)(?:\s.*)?$")
+RESULT_RE = re.compile(r"^\s*RESULT:\s*(PASS|FAIL)\s*$")
+VALID_EXPECTATION_LABELS = {"OK", "MISS"}
+VALID_RESULTS = {"PASS", "FAIL"}
+
+
+@dataclass(frozen=True)
+class GoldenLabel:
+    case: str
+    run: int | None
+    judge_file: str | None
+    expectations: dict[str, str]
+    result: str | None
+
+
+@dataclass(frozen=True)
+class JudgeOutput:
+    expectations: dict[str, str]
+    result: str | None
+
+
+def _clean_expectation_id(raw: str) -> str:
+    return raw.strip().strip("`").strip().strip("[]").strip(",:;.").strip()
+
+
+def _normalize_expectation_label(raw: Any, *, field: str) -> str:
+    value = str(raw or "").strip().upper()
+    if value not in VALID_EXPECTATION_LABELS:
+        raise ValueError(f"{field}: label must be OK or MISS")
+    return value
+
+
+def _normalize_result(raw: Any, *, field: str) -> str:
+    value = str(raw or "").strip().upper()
+    if value not in VALID_RESULTS:
+        raise ValueError(f"{field}: result must be PASS or FAIL")
+    return value
+
+
+def parse_judge_output(text: str) -> JudgeOutput:
+    expectations: dict[str, str] = {}
+    result: str | None = None
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        result_match = RESULT_RE.match(line)
+        if result_match:
+            result = result_match.group(1)
+            continue
+        label_match = LABEL_RE.match(line)
+        if not label_match:
+            continue
+        label = label_match.group(1)
+        expectation_id = _clean_expectation_id(label_match.group(2))
+        if not expectation_id:
+            continue
+        expectations[expectation_id] = label
+    return JudgeOutput(expectations=expectations, result=result)
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"cannot read golden labels: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON in golden labels: {path}: {exc}") from exc
+
+
+def load_golden_labels(path: Path) -> list[GoldenLabel]:
+    payload = _load_json(path)
+    if isinstance(payload, list):
+        raw_labels = payload
+    elif isinstance(payload, dict):
+        raw_labels = payload.get("labels")
+    else:
+        raw_labels = None
+    if not isinstance(raw_labels, list):
+        raise ValueError("golden labels must be a JSON object with a labels array")
+
+    labels: list[GoldenLabel] = []
+    for idx, raw_item in enumerate(raw_labels, start=1):
+        field = f"labels[{idx}]"
+        if not isinstance(raw_item, dict):
+            raise ValueError(f"{field}: must be an object")
+        case = str(raw_item.get("case") or "").strip()
+        if not case:
+            raise ValueError(f"{field}.case is required")
+
+        judge_file_raw = raw_item.get("judge_file")
+        judge_file = str(judge_file_raw).strip() if judge_file_raw else None
+
+        run: int | None = None
+        if raw_item.get("run") is not None:
+            try:
+                run = int(raw_item["run"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError(f"{field}.run must be a positive integer") from exc
+            if run <= 0:
+                raise ValueError(f"{field}.run must be a positive integer")
+        if not judge_file and run is None:
+            raise ValueError(f"{field}: either run or judge_file is required")
+
+        raw_expectations = raw_item.get("expectations")
+        if not isinstance(raw_expectations, dict) or not raw_expectations:
+            raise ValueError(f"{field}.expectations must be a non-empty object")
+        expectations = {
+            _clean_expectation_id(str(expectation_id)): _normalize_expectation_label(
+                label,
+                field=f"{field}.expectations.{expectation_id}",
+            )
+            for expectation_id, label in raw_expectations.items()
+        }
+        if any(not expectation_id for expectation_id in expectations):
+            raise ValueError(f"{field}.expectations contains an empty expectation id")
+
+        result = None
+        if raw_item.get("result") is not None:
+            result = _normalize_result(raw_item["result"], field=f"{field}.result")
+
+        labels.append(
+            GoldenLabel(
+                case=case,
+                run=run,
+                judge_file=judge_file,
+                expectations=expectations,
+                result=result,
+            )
+        )
+    return labels
+
+
+def _judge_path(run_dir: Path, label: GoldenLabel) -> Path:
+    if label.judge_file:
+        path = Path(label.judge_file)
+        return path if path.is_absolute() else run_dir / path
+    assert label.run is not None
+    return run_dir / label.case / f"run-{label.run}-judge.md"
+
+
+def _label_name(label: GoldenLabel) -> str:
+    if label.run is not None:
+        return f"{label.case} run {label.run}"
+    return f"{label.case} {label.judge_file}"
+
+
+def _derived_result(expectations: dict[str, str]) -> str:
+    return "PASS" if all(label == "OK" for label in expectations.values()) else "FAIL"
+
+
+def calibrate(
+    run_dir: Path,
+    golden_labels: list[GoldenLabel],
+    *,
+    min_agreement: float,
+) -> dict[str, Any]:
+    matches = 0
+    comparisons = 0
+    mismatches: list[dict[str, Any]] = []
+    missing_artifacts: list[str] = []
+    artifacts: list[dict[str, Any]] = []
+
+    for label in golden_labels:
+        path = _judge_path(run_dir, label)
+        name = _label_name(label)
+        if not path.is_file():
+            missing_artifacts.append(str(path))
+            continue
+        actual = parse_judge_output(path.read_text(encoding="utf-8"))
+        artifact_matches = 0
+        artifact_comparisons = 0
+
+        for expectation_id, human_label in sorted(label.expectations.items()):
+            comparisons += 1
+            artifact_comparisons += 1
+            judge_label = actual.expectations.get(expectation_id, "MISSING")
+            if judge_label == human_label:
+                matches += 1
+                artifact_matches += 1
+                continue
+            mismatches.append(
+                {
+                    "artifact": name,
+                    "expectation": expectation_id,
+                    "human": human_label,
+                    "judge": judge_label,
+                    "judge_file": str(path),
+                }
+            )
+
+        expected_result = label.result or _derived_result(label.expectations)
+        comparisons += 1
+        artifact_comparisons += 1
+        judge_result = actual.result or "MISSING"
+        if judge_result == expected_result:
+            matches += 1
+            artifact_matches += 1
+        else:
+            mismatches.append(
+                {
+                    "artifact": name,
+                    "expectation": "RESULT",
+                    "human": expected_result,
+                    "judge": judge_result,
+                    "judge_file": str(path),
+                }
+            )
+
+        artifacts.append(
+            {
+                "artifact": name,
+                "judge_file": str(path),
+                "matches": artifact_matches,
+                "comparisons": artifact_comparisons,
+            }
+        )
+
+    agreement = (matches / comparisons) if comparisons else 0.0
+    return {
+        "run_dir": str(run_dir),
+        "threshold": min_agreement,
+        "agreement": agreement,
+        "totals": {"matches": matches, "comparisons": comparisons},
+        "judge_review_candidate": agreement < min_agreement,
+        "mismatches": mismatches,
+        "missing_artifacts": missing_artifacts,
+        "artifacts": artifacts,
+        "note": "No judge settings were changed.",
+    }
+
+
+def format_report(report: dict[str, Any]) -> str:
+    totals = report["totals"]
+    matches = int(totals["matches"])
+    comparisons = int(totals["comparisons"])
+    agreement = float(report["agreement"])
+    threshold = float(report["threshold"])
+    lines = [
+        "[judge calibration]",
+        f"run_dir: {report['run_dir']}",
+        f"agreement: {matches}/{comparisons} ({agreement:.1%})",
+        f"threshold: {threshold:.1%}",
+        f"judge_review_candidate: {'YES' if report['judge_review_candidate'] else 'no'}",
+    ]
+    artifacts = report.get("artifacts")
+    if isinstance(artifacts, list) and artifacts:
+        lines.append("artifacts:")
+        for artifact in artifacts:
+            lines.append(
+                f"- {artifact['artifact']}: "
+                f"{artifact['matches']}/{artifact['comparisons']} "
+                f"({artifact['judge_file']})"
+            )
+    missing = report.get("missing_artifacts")
+    if isinstance(missing, list) and missing:
+        lines.append("missing_artifacts:")
+        for path in missing:
+            lines.append(f"- {path}")
+    mismatches = report.get("mismatches")
+    if isinstance(mismatches, list) and mismatches:
+        lines.append("mismatches:")
+        for mismatch in mismatches:
+            lines.append(
+                f"- {mismatch['artifact']} {mismatch['expectation']}: "
+                f"human={mismatch['human']} judge={mismatch['judge']} "
+                f"({mismatch['judge_file']})"
+            )
+    else:
+        lines.append("mismatches: none")
+    lines.append(str(report["note"]))
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Compare saved eval run-N-judge.md files with human golden labels."
+    )
+    parser.add_argument("run_dir", help="eval output directory, e.g. .metrics/evals/run-...")
+    parser.add_argument(
+        "--golden",
+        default="",
+        help="golden JSON path; defaults to <run_dir>/judge-golden.json",
+    )
+    parser.add_argument(
+        "--min-agreement",
+        type=float,
+        default=DEFAULT_MIN_AGREEMENT,
+        help="minimum acceptable agreement ratio, 0.0-1.0 (default: 1.0)",
+    )
+    parser.add_argument("--json", action="store_true", help="print machine-readable JSON")
+    parser.add_argument("--report-file", default="", help="also write a markdown report")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    run_dir = Path(args.run_dir).resolve()
+    golden_path = Path(args.golden).resolve() if args.golden else run_dir / "judge-golden.json"
+    if args.min_agreement < 0.0 or args.min_agreement > 1.0:
+        parser.error("--min-agreement must be between 0.0 and 1.0")
+
+    try:
+        labels = load_golden_labels(golden_path)
+        report = calibrate(run_dir, labels, min_agreement=float(args.min_agreement))
+    except ValueError as exc:
+        print(f"[judge calibration] ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if int(report["totals"]["comparisons"]) == 0:
+        print("[judge calibration] ERROR: no comparison labels found", file=sys.stderr)
+        return 2
+    if report["missing_artifacts"]:
+        output = json.dumps(report, ensure_ascii=False, indent=2) if args.json else format_report(report)
+        print(output)
+        return 2
+
+    text_report = format_report(report)
+    if args.report_file:
+        report_path = Path(args.report_file)
+        report_path.parent.mkdir(parents=True, exist_ok=True)
+        report_path.write_text(text_report + "\n", encoding="utf-8")
+
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2))
+    else:
+        print(text_report)
+    return 1 if report["judge_review_candidate"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/judge-golden.example.json
+++ b/evals/judge-golden.example.json
@@ -1,0 +1,24 @@
+{
+  "_comment": "Copy this file to <eval-run-dir>/judge-golden.json after running bash evals/run.sh. Fill labels by reading the matching run-N-report.md and deciding what the judge output should have said. If result is omitted, PASS is derived when every expectation is OK; otherwise FAIL is derived.",
+  "labels": [
+    {
+      "case": "shorts-real-spec",
+      "run": 1,
+      "expectations": {
+        "E1": "OK",
+        "E2": "OK"
+      }
+    },
+    {
+      "case": "headless-prose-quality",
+      "run": 1,
+      "expectations": {
+        "HPQ-1": "OK",
+        "HPQ-2": "OK",
+        "HPQ-3": "OK",
+        "HPQ-4": "OK",
+        "HPQ-5": "OK"
+      }
+    }
+  ]
+}

--- a/tests/test_eval_judge_calibration.py
+++ b/tests/test_eval_judge_calibration.py
@@ -1,0 +1,108 @@
+"""Judge calibration report contracts (#894)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "evals" / "calibrate_judge.py"
+
+
+class JudgeCalibrationTests(unittest.TestCase):
+    def test_reports_review_candidate_when_agreement_is_below_threshold(self) -> None:
+        with TemporaryDirectory() as td:
+            run_dir = Path(td)
+            case_dir = run_dir / "shorts-real-spec"
+            case_dir.mkdir()
+            (case_dir / "run-1-judge.md").write_text(
+                "OK E1\nMISS E2\nRESULT: FAIL\n",
+                encoding="utf-8",
+            )
+            golden = run_dir / "judge-golden.json"
+            golden.write_text(
+                json.dumps(
+                    {
+                        "labels": [
+                            {
+                                "case": "shorts-real-spec",
+                                "run": 1,
+                                "expectations": {"E1": "OK", "E2": "OK"},
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(run_dir),
+                    "--min-agreement",
+                    "1.0",
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            self.assertIn("agreement: 1/3 (33.3%)", result.stdout)
+            self.assertIn("judge_review_candidate: YES", result.stdout)
+            self.assertIn("shorts-real-spec run 1 E2", result.stdout)
+            self.assertIn("No judge settings were changed.", result.stdout)
+
+    def test_json_report_passes_when_threshold_is_met(self) -> None:
+        with TemporaryDirectory() as td:
+            run_dir = Path(td)
+            case_dir = run_dir / "flow-ownership-owner-good"
+            case_dir.mkdir()
+            (case_dir / "run-2-judge.md").write_text(
+                "OK E1 - accepted by the report\nOK `E2`\nRESULT: PASS\n",
+                encoding="utf-8",
+            )
+            golden = run_dir / "judge-golden.json"
+            golden.write_text(
+                json.dumps(
+                    {
+                        "labels": [
+                            {
+                                "case": "flow-ownership-owner-good",
+                                "run": 2,
+                                "expectations": {"E1": "OK", "E2": "OK"},
+                            }
+                        ]
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(run_dir),
+                    "--json",
+                    "--min-agreement",
+                    "1.0",
+                ],
+                cwd=str(ROOT),
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["agreement"], 1.0)
+            self.assertFalse(payload["judge_review_candidate"])
+            self.assertEqual(payload["totals"], {"matches": 3, "comparisons": 3})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -27,6 +27,29 @@ class EvalsHarnessContractTests(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0, result.stderr)
 
+    def test_judge_calibration_tool_is_documented(self) -> None:
+        calibrate = EVALS / "calibrate_judge.py"
+        self.assertTrue(calibrate.is_file())
+        result = subprocess.run(
+            ["python3.11", "-m", "py_compile", str(calibrate)],
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        example = EVALS / "judge-golden.example.json"
+        self.assertTrue(example.is_file())
+        self.assertIn('"labels"', example.read_text(encoding="utf-8"))
+
+        readme = (EVALS / "README.md").read_text(encoding="utf-8")
+        for needle in (
+            "python3 evals/calibrate_judge.py",
+            "judge-golden.json",
+            "judge_review_candidate",
+            "--min-agreement",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, readme)
+
     def test_every_case_has_required_files(self) -> None:
         case_dirs = sorted((EVALS / "cases").iterdir())
         self.assertGreaterEqual(len(case_dirs), 2)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #894
Part of #893

## 배경 및 문제

LLM 행동 eval 은 `run-N-report.md` 를 judge 모델이 `OK` / `MISS` 로 채점하지만, 그 judge 출력이 사람 판정과 일치하는지 대조하는 보정 경로가 없었습니다. #893/#875에서 raw judge artifact 와 eval telemetry 는 남게 되었으므로, #894에서는 저장된 `run-N-judge.md`를 인간 golden 라벨과 비교하는 표면화 절차를 추가합니다.

## 원인 (해당 시)

자동 eval 결과는 agent 품질과 judge 품질이 섞여 있습니다. judge 출력 파일을 사람이 확인한 golden 과 비교하지 않으면, 모델 grader 자체가 후하거나 놓치는 결함 유형을 별도로 감지할 수 없습니다.

## 작업내용

- `evals/calibrate_judge.py` 추가: eval run 디렉터리의 `run-N-judge.md`를 `judge-golden.json`과 비교하고 일치율, mismatch, `judge_review_candidate`를 출력합니다.
- `evals/judge-golden.example.json` 추가: 사람이 소수 케이스에 golden 라벨을 붙이는 JSON 예시를 제공합니다.
- `evals/README.md` 갱신: 보정 실행 명령, golden 작성 방식, threshold 조정, report 파일 저장 방식을 문서화했습니다.
- calibration CLI와 문서 surface를 unittest로 고정했습니다.

## 결정 근거

- 기존 #893 산출물인 `run-N-judge.md`를 재사용해 LLM 재실행 없이 calibration을 수행합니다.
- 기본 `--min-agreement 1.0`으로 소수 케이스에서는 mismatch를 보수적으로 표면화하고, 필요 시 `--min-agreement 0.9`처럼 완화할 수 있게 했습니다.
- 보정 결과는 `judge_review_candidate` 표시와 exit code까지만 제공하며, judge 모델/prompt/config는 자동 변경하지 않습니다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — `evals/`는 dcness self QA 도구이며 plug-in 배포물/활성 프로젝트 복사 경로를 변경하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public skill/command/agent/gate 추가 없음. `evals/calibrate_judge.py`는 dcness self QA 스크립트입니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_eval_judge_calibration -v`
- [x] `python3.11 -m unittest tests.test_evals_harness -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `PYTHON_BIN=tmp/quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`

## 참고

- 정적 게이트용 quality dependency는 PEP 668 보호 때문에 전역 설치하지 않고 ignored 경로인 `tmp/quality-venv`에 설치해 실행했습니다.
