### PR TITLE
[docs] 릴리즈 가드 재평가 절차 기록

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -26,8 +26,16 @@ Sense→Diagnose→Decide→Act→Verify 루프를 따른다. 새 CI 게이트�
 권고 절차다.
 
 - Sense: `python3 evals/guard_efficacy.py`와 `EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh`를 실행한다. 행동 eval 산출물은 `.metrics/evals/` 또는 `EVAL_OUTPUT_DIR`에 남긴다.
-- Diagnose: 가드 발화 텔레메트리([#875](https://github.com/alruminum/dcNess/issues/875))가 준비되어 있으면 집계를 보고, 없으면 최근 CI·hook 실패 이력을 수동 확인한다. 재발·낭비 신호([#876](https://github.com/alruminum/dcNess/issues/876))도 같은 자리에서 본다.
-- Decide: 추가 전 제거 검토를 먼저 한다. 소멸 후보나 follow-up이 있으면 릴리즈 노트 `Unreleased` 또는 별도 GitHub issue에 기록한다.
+- Diagnose: 가드 발화 이력을 재확인하고, 재발·낭비 신호([#876](https://github.com/alruminum/dcNess/issues/876))와 함께 본다. 새 CI 게이트가 아니라 릴리즈 전 사람이 읽는 점검이다.
+
+  ```sh
+  python3.11 -m harness.guard_telemetry report --idle-days 30 --saturation-days 30 --saturation-min-runs 3
+  ```
+
+  - 가드 발화 텔레메트리([#875](https://github.com/alruminum/dcNess/issues/875))가 있으면 `재평가 후보` guard를 검토한다.
+  - 텔레메트리가 아직 없거나 관측 기간이 부족하면 최근 릴리즈 이후 CI 실패, 로컬 hook 차단, PR 수정 이력을 수동 확인한다.
+  - 장기 무발화 guard는 바로 제거하지 않고 **소멸 후보**로만 기록한다. 실제 제거는 별도 issue/PR에서 Decide→Act→Verify를 탄다.
+- Decide: 추가 전 제거 검토를 먼저 한다. 소멸 후보나 follow-up이 있으면 릴리즈 노트 `Unreleased`의 자기개선 점검 기록에 적고, 후보가 없으면 `소멸 후보 없음`이라고 적는다. 추적이 길어질 항목은 별도 GitHub issue로 분리한다.
 - Verify: 핵심 행동 eval(`shorts-real-spec`, `headless-prose-quality`)은 릴리즈 체크 모드에서 N/N 통과해야 한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 [#894](https://github.com/alruminum/dcNess/issues/894) 보정 입력으로 남긴다.
 
 ```sh

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -8,6 +8,13 @@
 
 - 자기개선 루프 SSOT 추가 — 측정 신호를 Sense→Diagnose→Decide→Act→Verify로 닫는 내부 절차를 [`docs/internal/self-improvement-loop.md`](self-improvement-loop.md)에 정의하고, 릴리즈 점검·eval 산출물 보존·핵심 행동 eval N/N 기준을 연결했다. [#893](https://github.com/alruminum/dcNess/issues/893)
 - 문서 개수 하드코딩 제거 — README/CLAUDE/loop-procedure/smart-compact의 구성 요소 count prose와 cross-ref count deny-list를 제거해 stale 방지 룰을 소멸시켰다. [#877](https://github.com/alruminum/dcNess/issues/877)
+- 릴리즈 전 가드 재평가 점검 명문화 — 릴리즈 절차가 `guard-telemetry` 집계 또는 수동 CI·hook 이력 확인으로 장기 무발화 guard를 소멸 후보로 판정하고, 결과를 아래 자기개선 점검 기록에 남기도록 했다. 새 CI 강제 게이트는 추가하지 않았다. [#878](https://github.com/alruminum/dcNess/issues/878)
+
+### 자기개선 점검 기록
+
+| 날짜 | 입력 | 판정 |
+|---|---|---|
+| 2026-07-04 | `python3.11 -m harness.guard_telemetry report` | 첫 Diagnose 수행. 프로젝트 `guard-telemetry.jsonl` 없음, `.metrics/evals/**/guard-telemetry.jsonl` 0개라 30일 관측 근거가 아직 없다. known guard는 원시 출력상 `재평가 후보`로 표시되지만, 장기 무발화가 아니라 신규 텔레메트리 관측 기간 부족으로 해석한다. 이번 릴리즈의 즉시 소멸 후보 없음. 다음 릴리즈에서 재확인한다. |
 
 ---
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #878

## 배경 및 문제

#893 자기개선 루프에서 #878은 릴리즈마다 Sense 신호를 모아 Diagnose까지 수행하는 트리거 역할이다. 기존 릴리즈 절차에는 자기개선 점검 골격은 있었지만, 장기 무발화 guard를 어떻게 소멸 후보로 판정하고 어디에 기록하는지가 충분히 명시되지 않았다.

## 원인 (해당 시)

릴리즈 절차가 `guard-telemetry` 집계, 관측 기간 부족 시 수동 확인, 후보 없음 기록까지 하나의 체크 항목으로 닫지 못했다.

## 작업내용

- `docs/internal/plugin-release.md`에 릴리즈 전 `guard-telemetry` 재확인 명령, 수동 CI·hook 이력 확인 fallback, 소멸 후보 기록 규칙을 명시했다.
- `docs/internal/release-notes.md` Unreleased에 #878 변경 요약과 2026-07-04 첫 Diagnose 수행 결과를 기록했다.
- 첫 수행 결과는 텔레메트리 로그 부재/0개를 관측 기간 부족으로 해석해, 이번 릴리즈의 즉시 소멸 후보 없음으로 남겼다.

## 결정 근거

#878은 새 강제 게이트가 아니라 릴리즈 전 권고 절차가 요구사항이다. 따라서 CI나 hook을 추가하지 않고, 기존 `harness.guard_telemetry` 요약과 릴리즈 노트 기록으로 사람 판단 지점을 고정했다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — `docs/internal/**` dcness self 운영 문서 변경이다. 외부 활성 프로젝트로 배포되는 `agents/**`, `commands/**`, `hooks/**`, `docs/plugin/**`, `/init-dcness` 복사 파일은 변경하지 않았다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public skill/command/agent/gate 없음.

## Test Plan

- [x] `python3.11 -m harness.guard_telemetry report`
- [x] `python3.11 -m unittest tests.test_guard_telemetry tests.test_evals_harness -v`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `python3.11 -m unittest discover -s tests -v` (1560 tests)

## 참고

- 전역 `python3.11`은 PEP 668 externally managed 환경이라 quality dependency 설치가 막혀, `/tmp/dcness-quality-venv` 임시 venv로 static-quality를 실행했다.
