### PR TITLE
[feature] 자기개선 Diagnose 도구 추가

### DIFF
--- a/.claude/commands/loop-diagnose.md
+++ b/.claude/commands/loop-diagnose.md
@@ -1,0 +1,46 @@
+# /loop-diagnose
+
+dcNess self 전용 Diagnose 도구를 실행한다. 이 command 는 외부 활성 프로젝트로 배포하지
+않는다.
+
+## 절차
+
+1. dcNess repo root 에서 도구를 실행한다.
+
+   ```sh
+   python3.11 scripts/loop_diagnose.py
+   ```
+
+   필요 시 JSON 으로 확인한다.
+
+   ```sh
+   python3.11 scripts/loop_diagnose.py --json
+   ```
+
+2. stdout 리포트를 그대로 echo 한다. `/run-review` 와 같은 원칙으로 섹션 생략, 표 재배치,
+   자체 요약 삽입을 하지 않는다.
+
+3. 통합 후보 표를 보고 후보를 분류한다.
+   - blocker: 릴리즈 전에 별도 issue/PR 로 Decide→Act→Verify 를 탄다.
+   - release-note follow-up: `docs/internal/release-notes.md` 의 자기개선 점검 기록에 적는다.
+   - 기각 또는 이미 처리: 결정 원장에 소비 표식을 남긴다.
+
+4. 후보별 결정을 기록한다.
+
+   ```sh
+   python3.11 scripts/loop_diagnose.py record-decision \
+     --key "guard:file-guard@project" \
+     --decision hold \
+     --ref "#NNN"
+   ```
+
+   `--decision` 은 `fixed`, `hold`, `rejected` 중 하나다. `fixed`/`rejected` 후보는 다음
+   리포트에서 `--hide-decided` 로 숨길 수 있고, `hold` 는 계속 표시된다.
+
+5. 릴리즈 점검 중이면 release notes 의 "자기개선 점검 기록" 표에 결론을 남긴다.
+
+## 참조
+
+- `scripts/loop_diagnose.py`
+- `docs/internal/self-improvement-loop.md`
+- `docs/internal/plugin-release.md`

--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -26,14 +26,15 @@ Sense→Diagnose→Decide→Act→Verify 루프를 따른다. 새 CI 게이트�
 권고 절차다.
 
 - Sense: `python3 evals/guard_efficacy.py`와 `EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh`를 실행한다. 행동 eval 산출물은 `.metrics/evals/` 또는 `EVAL_OUTPUT_DIR`에 남긴다.
-- Diagnose: 가드 발화 이력을 재확인하고, 재발·낭비 신호([#876](https://github.com/alruminum/dcNess/issues/876))와 함께 본다. 새 CI 게이트가 아니라 릴리즈 전 사람이 읽는 점검이다.
+- Diagnose: 전용 도구로 활성 프로젝트의 가드 발화 이력과 재발·낭비 신호([#876](https://github.com/alruminum/dcNess/issues/876)), dcNess self eval 포화 후보를 함께 본다. 새 CI 게이트가 아니라 릴리즈 전 사람이 읽는 점검이다.
 
   ```sh
-  python3.11 -m harness.guard_telemetry report --idle-days 30 --saturation-days 30 --saturation-min-runs 3
+  python3.11 scripts/loop_diagnose.py --idle-days 30 --saturation-days 30 --saturation-min-runs 3
   ```
 
-  - 가드 발화 텔레메트리([#875](https://github.com/alruminum/dcNess/issues/875))가 있으면 `재평가 후보` guard를 검토한다.
-  - 텔레메트리가 아직 없거나 관측 기간이 부족하면 최근 릴리즈 이후 CI 실패, 로컬 hook 차단, PR 수정 이력을 수동 확인한다.
+  - 가드 발화 텔레메트리([#875](https://github.com/alruminum/dcNess/issues/875))가 있으면 통합 후보 표의 `guard:*` 후보를 검토한다.
+  - 텔레메트리가 아직 없거나 관측 기간이 부족하면 리포트의 `관측 이력 없음(미배포 또는 무발화)` 프로젝트를 확인하고, 최근 릴리즈 이후 CI 실패, 로컬 hook 차단, PR 수정 이력을 수동 확인한다.
+  - 이미 판단한 후보는 `record-decision` 으로 `docs/internal/loop-decisions.jsonl` 에 남긴다. 다음 리포트에서 `fixed`/`rejected` 는 `--hide-decided` 로 숨길 수 있고, `hold` 는 계속 표시된다.
   - 장기 무발화 guard는 바로 제거하지 않고 **소멸 후보**로만 기록한다. 실제 제거는 별도 issue/PR에서 Decide→Act→Verify를 탄다.
 - Decide: 추가 전 제거 검토를 먼저 한다. 소멸 후보나 follow-up이 있으면 릴리즈 노트 `Unreleased`의 자기개선 점검 기록에 적고, 후보가 없으면 `소멸 후보 없음`이라고 적는다. 추적이 길어질 항목은 별도 GitHub issue로 분리한다.
 - Verify: 핵심 행동 eval(`shorts-real-spec`, `headless-prose-quality`)은 릴리즈 체크 모드에서 N/N 통과해야 한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 [#894](https://github.com/alruminum/dcNess/issues/894) 보정 입력으로 남긴다.

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -16,7 +16,7 @@
 | 슬롯 | 질문 | 현재 담당 |
 |---|---|---|
 | Sense | 어떤 신호를 보나 | `/run-review`, benchmark/fleet 집계, `evals/guard_efficacy.py`, `evals/run.sh`, 가드 발화 텔레메트리 후보 [#875](https://github.com/alruminum/dcNess/issues/875), 재발·낭비 집계 후보 [#876](https://github.com/alruminum/dcNess/issues/876), judge 보정 후보 [#894](https://github.com/alruminum/dcNess/issues/894) |
-| Diagnose | 여러 신호를 어떻게 우선순위화하나 | 릴리즈 점검 [#878](https://github.com/alruminum/dcNess/issues/878)이 겸한다. 릴리즈 후보에서 Sense 신호를 한 자리에서 모아 blocker, release-note follow-up, 별도 issue로 나눈다. |
+| Diagnose | 여러 신호를 어떻게 우선순위화하나 | `scripts/loop_diagnose.py`와 repo-local `/loop-diagnose` command가 전담한다. 활성 프로젝트 whitelist 를 읽어 cross-project 신호를 당겨오고, 수시 점검과 릴리즈 점검 양쪽에서 후보를 blocker, release-note follow-up, 별도 issue로 나눈다. |
 | Decide | 무엇을 바꾸나 | 추가 전 제거 검토를 먼저 한다. 새 룰·hook·CI를 추가하기 전에 기존 룰 삭제, 문구 축약, SSOT 파생 생성으로 같은 효과를 낼 수 있는지 확인한다. 첫 사례는 개수 하드코딩 제거 [#877](https://github.com/alruminum/dcNess/issues/877)이다. |
 | Act | 실제 변경은 어디서 하나 | 일반 dcNess 변경 절차대로 branch → PR → merge를 탄다. PR 본문에 Sense 근거, Diagnose 판단, Decide 이유, Verify 계획을 짧게 적는다. |
 | Verify | 개선이 먹혔는지 어떻게 보나 | 변경 성격별로 결정적 eval, 행동 eval, 다음 Sense 주기 재측정을 분리한다. |
@@ -28,6 +28,20 @@ Sense 산출물을 모으고, Diagnose/Decide 결과를 릴리즈 노트 또는 
 
 평소 run 중 발견한 단발 신호는 바로 룰로 박지 않는다. 같은 신호가 반복되거나 릴리즈
 점검에서 비용·위험이 충분히 커졌을 때 Decide 슬롯으로 올린다.
+
+## 소비 표식
+
+Diagnose 후보는 같은 항목이 매번 다시 떠도 맥락을 잃지 않도록 3층으로 소비 상태를
+남긴다.
+
+| 층 | 위치 | 역할 |
+|---|---|---|
+| 워터마크 | `.metrics/loop-diagnose/sweeps.jsonl` | sweep 마다 프로젝트별 마지막 관측 시각과 후보 key 를 남긴다. 다음 sweep 은 이를 기준으로 `신규 발생 since ...` / `기왕` 을 구분한다. 로컬 runtime 상태라 git 추적하지 않는다. |
+| 결정 원장 | `docs/internal/loop-decisions.jsonl` | `record-decision` 이 후보별 최신 결정(`fixed` / `hold` / `rejected`)을 append 한다. git 추적 대상이며 리포트는 후보 옆에 이전 결정을 주석으로 표시한다. |
+| 릴리즈 노트 | `docs/internal/release-notes.md` | 릴리즈 시 사람이 읽는 최종 점검 기록이다. blocker, follow-up, 소멸 후보 없음 같은 릴리즈 판단을 수동으로 남긴다. |
+
+`fixed`와 `rejected` 는 `--hide-decided` 로 숨길 수 있다. `hold` 는 의도적으로 계속
+표시해 보류 사유가 stale 해졌는지 다음 Diagnose 때 다시 보게 한다.
 
 ## 결정 규칙
 
@@ -75,4 +89,4 @@ agent 결함인지 judge 결함인지 구분한다. 동시에 `guard-telemetry.j
 - Epic: [#893](https://github.com/alruminum/dcNess/issues/893)
 - Sense: [#875](https://github.com/alruminum/dcNess/issues/875), [#876](https://github.com/alruminum/dcNess/issues/876), [#894](https://github.com/alruminum/dcNess/issues/894)
 - Decide: [#877](https://github.com/alruminum/dcNess/issues/877)
-- Trigger/Diagnose: [#878](https://github.com/alruminum/dcNess/issues/878)
+- Trigger/Diagnose: [#878](https://github.com/alruminum/dcNess/issues/878), [#902](https://github.com/alruminum/dcNess/issues/902)

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+"""Cross-project Diagnose sweep for the dcNess self-improvement loop (#902)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from harness import ledger  # noqa: E402
+from harness import run_review  # noqa: E402
+from harness.benchmark_aggregate import aggregate_sessions  # noqa: E402
+from harness.guard_telemetry import (  # noqa: E402
+    collect_eval_summary,
+    collect_guard_summary,
+    read_events,
+)
+
+
+DEFAULT_PROJECTS_FILE = (
+    Path.home() / ".claude" / "plugins" / "data" / "dcness-dcness" / "projects.json"
+)
+SWEEP_PATH = Path(".metrics") / "loop-diagnose" / "sweeps.jsonl"
+DECISIONS_PATH = Path("docs") / "internal" / "loop-decisions.jsonl"
+VALID_DECISIONS = {"fixed", "hold", "rejected"}
+DECISION_LABELS = {
+    "fixed": "고침",
+    "hold": "보류",
+    "rejected": "기각",
+}
+NO_OBSERVATION = "관측 이력 없음(미배포 또는 무발화)"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_ts(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _max_ts(values: list[Any]) -> Optional[str]:
+    best_value: Optional[str] = None
+    best_dt: Optional[datetime] = None
+    for value in values:
+        parsed = _parse_ts(value)
+        if parsed is None:
+            continue
+        if best_dt is None or parsed > best_dt:
+            best_dt = parsed
+            best_value = str(value)
+    return best_value
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(row, dict):
+                    rows.append(row)
+    except OSError:
+        return []
+    return rows
+
+
+def _append_jsonl(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(payload, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def _project_name(path: Path) -> str:
+    name = path.name.strip()
+    return name if name else str(path)
+
+
+def _load_projects(path: Path) -> list[Path]:
+    try:
+        data = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, dict) or not isinstance(data.get("projects"), list):
+        return []
+    projects: list[Path] = []
+    seen: set[str] = set()
+    for item in data["projects"]:
+        if not isinstance(item, str) or not item.strip():
+            continue
+        try:
+            resolved = Path(item).expanduser().resolve()
+        except (OSError, ValueError):
+            continue
+        key = str(resolved)
+        if key in seen:
+            continue
+        seen.add(key)
+        projects.append(resolved)
+    return projects
+
+
+def _latest_run_event_ts(sessions_root: Path) -> Optional[str]:
+    values: list[Any] = []
+    for run_dir in run_review.list_runs(sessions_root):
+        for event in ledger.read_events_at(run_dir):
+            values.append(event.get("ts"))
+    return _max_ts(values)
+
+
+def _latest_project_ts(events: list[dict[str, Any]], sessions_root: Path) -> Optional[str]:
+    values = [event.get("ts") for event in events]
+    run_ts = _latest_run_event_ts(sessions_root)
+    if run_ts:
+        values.append(run_ts)
+    return _max_ts(values)
+
+
+def _candidate(
+    *,
+    key: str,
+    kind: str,
+    project: str,
+    scope_path: Path,
+    detail: str,
+    last_ts: Optional[str],
+) -> dict[str, Any]:
+    return {
+        "key": key,
+        "kind": kind,
+        "project": project,
+        "scope_path": str(scope_path),
+        "detail": detail,
+        "last_ts": last_ts,
+    }
+
+
+def _guard_candidates(
+    project_name: str,
+    project_path: Path,
+    guard_summary: dict[str, Any],
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    guards = guard_summary.get("guards")
+    if not isinstance(guards, dict):
+        return candidates
+    for guard, raw in sorted(guards.items()):
+        row = raw if isinstance(raw, dict) else {}
+        count = int(row.get("count") or 0)
+        if count <= 0 or not row.get("reassessment_candidate"):
+            continue
+        last = row.get("last_ts") if isinstance(row.get("last_ts"), str) else None
+        detail = f"{count} hit(s), last={last or '-'}"
+        candidates.append(
+            _candidate(
+                key=f"guard:{guard}@{project_name}",
+                kind="guard",
+                project=project_name,
+                scope_path=project_path,
+                detail=detail,
+                last_ts=last,
+            )
+        )
+    return candidates
+
+
+def _fleet_to_json(report: Any) -> dict[str, Any]:
+    return {
+        "run_count": report.run_count,
+        "by_entry_point": report.by_entry_point,
+        "pr_reviewer_fail_ratio": report.pr_reviewer_fail_ratio,
+        "escalate_count": report.escalate_count,
+        "blocked_event_count": report.blocked_event_count,
+        "waste_top": report.waste_top,
+        "recurrence_threshold": report.recurrence_threshold,
+        "improvement_candidates": [
+            {
+                "pattern": candidate.pattern,
+                "count": candidate.count,
+                "threshold": candidate.threshold,
+                "source": candidate.source,
+                "suggestion": candidate.suggestion,
+            }
+            for candidate in report.improvement_candidates
+        ],
+    }
+
+
+def _waste_candidates(
+    project_name: str,
+    project_path: Path,
+    fleet: dict[str, Any],
+    last_event_ts: Optional[str],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for candidate in fleet["improvement_candidates"]:
+        pattern = str(candidate["pattern"])
+        detail = f"{candidate['count']} occurrence(s), threshold={candidate['threshold']}"
+        out.append(
+            _candidate(
+                key=f"waste:{pattern}@{project_name}",
+                kind="waste",
+                project=project_name,
+                scope_path=project_path,
+                detail=detail,
+                last_ts=last_event_ts,
+            )
+        )
+    return out
+
+
+def _collect_project(path: Path, args: argparse.Namespace) -> dict[str, Any]:
+    name = _project_name(path)
+    events = read_events(cwd=path)
+    sessions_root = path / ".claude" / "harness-state" / ".sessions"
+    last_event_ts = _latest_project_ts(events, sessions_root)
+    guard_summary = collect_guard_summary(cwd=path, idle_days=args.idle_days)
+    fleet_report = aggregate_sessions(
+        sessions_root,
+        top=args.waste_top,
+        recurrence_threshold=args.recurrence_threshold,
+        repo_override=path,
+    )
+    fleet = _fleet_to_json(fleet_report)
+    candidates = _guard_candidates(name, path, guard_summary)
+    candidates.extend(_waste_candidates(name, path, fleet, last_event_ts))
+    return {
+        "name": name,
+        "path": str(path),
+        "telemetry_event_count": len(events),
+        "last_event_ts": last_event_ts,
+        "observation": "observed" if events else NO_OBSERVATION,
+        "guard_summary": guard_summary,
+        "fleet": fleet,
+        "candidates": candidates,
+    }
+
+
+def _collect_self_evals(repo_root: Path, args: argparse.Namespace) -> dict[str, Any]:
+    summary = collect_eval_summary(
+        cwd=repo_root,
+        saturation_days=args.saturation_days,
+        saturation_min_runs=args.saturation_min_runs,
+    )
+    candidates: list[dict[str, Any]] = []
+    cases = summary.get("cases")
+    if isinstance(cases, dict):
+        for case, raw in sorted(cases.items()):
+            row = raw if isinstance(raw, dict) else {}
+            if not row.get("saturation_candidate"):
+                continue
+            attempts = int(row.get("attempts") or 0)
+            passes = int(row.get("passes") or 0)
+            accuracy = float(row.get("accuracy") or 0.0)
+            detail = f"{passes}/{attempts} pass, accuracy={accuracy:.0%}"
+            last = row.get("last_ts") if isinstance(row.get("last_ts"), str) else None
+            candidates.append(
+                _candidate(
+                    key=f"eval:{case}",
+                    kind="eval",
+                    project="dcness-self",
+                    scope_path=repo_root,
+                    detail=detail,
+                    last_ts=last,
+                )
+            )
+    return {
+        "repo_root": str(repo_root),
+        "summary": summary,
+        "candidates": candidates,
+        "last_event_ts": _max_ts([c.get("last_ts") for c in candidates]),
+    }
+
+
+def _latest_sweep(repo_root: Path) -> Optional[dict[str, Any]]:
+    rows = _read_jsonl(repo_root / SWEEP_PATH)
+    return rows[-1] if rows else None
+
+
+def _previous_records(previous: Optional[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    if not isinstance(previous, dict) or not isinstance(previous.get("projects"), list):
+        return {}
+    records: dict[str, dict[str, Any]] = {}
+    for raw in previous["projects"]:
+        if not isinstance(raw, dict) or not isinstance(raw.get("path"), str):
+            continue
+        records[raw["path"]] = raw
+    return records
+
+
+def _freshness(candidate: dict[str, Any], previous: Optional[dict[str, Any]]) -> str:
+    records = _previous_records(previous)
+    record = records.get(str(candidate.get("scope_path") or ""))
+    if record is None:
+        return "신규"
+    previous_ts = record.get("last_event_ts") if isinstance(record.get("last_event_ts"), str) else None
+    previous_keys = record.get("candidates") if isinstance(record.get("candidates"), list) else []
+    key = str(candidate.get("key") or "")
+    if key not in previous_keys:
+        return f"신규 발생 since {previous_ts}" if previous_ts else "신규"
+    current_dt = _parse_ts(candidate.get("last_ts"))
+    previous_dt = _parse_ts(previous_ts)
+    if current_dt is not None and previous_dt is not None and current_dt > previous_dt:
+        return f"신규 발생 since {previous_ts}"
+    return "기왕"
+
+
+def _load_decisions(repo_root: Path) -> dict[str, dict[str, Any]]:
+    decisions: dict[str, dict[str, Any]] = {}
+    for row in _read_jsonl(repo_root / DECISIONS_PATH):
+        key = row.get("key")
+        decision = row.get("decision")
+        ref = row.get("ref")
+        if not isinstance(key, str) or decision not in VALID_DECISIONS:
+            continue
+        if not isinstance(ref, str) or not ref.strip():
+            continue
+        decisions[key] = row
+    return decisions
+
+
+def _decision_annotation(decision: Optional[dict[str, Any]]) -> str:
+    if not decision:
+        return "-"
+    label = DECISION_LABELS.get(str(decision.get("decision")), str(decision.get("decision")))
+    decided_at = str(decision.get("decided_at") or "")
+    date = decided_at[:10] if decided_at else "-"
+    ref = str(decision.get("ref") or "-")
+    return f"이전 결정: {label} {date} {ref}"
+
+
+def _attach_status(
+    candidates: list[dict[str, Any]],
+    *,
+    previous: Optional[dict[str, Any]],
+    decisions: dict[str, dict[str, Any]],
+) -> None:
+    for candidate in candidates:
+        candidate["freshness"] = _freshness(candidate, previous)
+        decision = decisions.get(str(candidate.get("key") or ""))
+        candidate["decision"] = decision
+        candidate["decision_annotation"] = _decision_annotation(decision)
+
+
+def _visible_candidates(candidates: list[dict[str, Any]], hide_decided: bool) -> list[dict[str, Any]]:
+    if not hide_decided:
+        return candidates
+    visible: list[dict[str, Any]] = []
+    for candidate in candidates:
+        decision = candidate.get("decision")
+        if isinstance(decision, dict) and decision.get("decision") in {"fixed", "rejected"}:
+            continue
+        visible.append(candidate)
+    return visible
+
+
+def _sweep_project_records(
+    projects: list[dict[str, Any]],
+    evals: dict[str, Any],
+    candidates: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    by_path: dict[str, dict[str, Any]] = {}
+    for project in projects:
+        by_path[str(project["path"])] = {
+            "path": project["path"],
+            "last_event_ts": project.get("last_event_ts"),
+            "candidates": [],
+        }
+    eval_path = str(evals["repo_root"])
+    by_path.setdefault(
+        eval_path,
+        {
+            "path": eval_path,
+            "last_event_ts": evals.get("last_event_ts"),
+            "candidates": [],
+        },
+    )
+    grouped: dict[str, list[str]] = defaultdict(list)
+    for candidate in candidates:
+        grouped[str(candidate["scope_path"])].append(str(candidate["key"]))
+    for path, keys in grouped.items():
+        by_path.setdefault(path, {"path": path, "last_event_ts": None, "candidates": []})
+        by_path[path]["candidates"] = sorted(set(keys))
+    return [by_path[path] for path in sorted(by_path)]
+
+
+def _append_sweep(
+    repo_root: Path,
+    *,
+    swept_at: str,
+    projects: list[dict[str, Any]],
+    evals: dict[str, Any],
+    candidates: list[dict[str, Any]],
+) -> None:
+    payload = {
+        "swept_at": swept_at,
+        "projects": _sweep_project_records(projects, evals, candidates),
+    }
+    _append_jsonl(repo_root / SWEEP_PATH, payload)
+
+
+def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    projects_file = Path(args.projects_file).expanduser().resolve()
+    swept_at = _now_iso()
+    previous = _latest_sweep(repo_root)
+    decisions = _load_decisions(repo_root)
+    projects = [_collect_project(path, args) for path in _load_projects(projects_file)]
+    evals = _collect_self_evals(repo_root, args)
+
+    candidates: list[dict[str, Any]] = []
+    for project in projects:
+        candidates.extend(project["candidates"])
+    candidates.extend(evals["candidates"])
+    _attach_status(candidates, previous=previous, decisions=decisions)
+    _append_sweep(
+        repo_root,
+        swept_at=swept_at,
+        projects=projects,
+        evals=evals,
+        candidates=candidates,
+    )
+
+    return {
+        "swept_at": swept_at,
+        "projects_file": str(projects_file),
+        "state_file": str(repo_root / SWEEP_PATH),
+        "decisions_file": str(repo_root / DECISIONS_PATH),
+        "projects": projects,
+        "evals": evals,
+        "candidates": _visible_candidates(candidates, bool(args.hide_decided)),
+    }
+
+
+def _md_cell(value: Any) -> str:
+    text = str(value if value is not None else "-")
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def _render_project(project: dict[str, Any]) -> list[str]:
+    lines: list[str] = []
+    lines.append(f"## 프로젝트: {project['name']}")
+    lines.append("")
+    lines.append(f"- path: `{project['path']}`")
+    if project["observation"] == NO_OBSERVATION:
+        lines.append(f"- telemetry: {NO_OBSERVATION}")
+    else:
+        lines.append(
+            f"- telemetry: {project['telemetry_event_count']} event(s), "
+            f"last={project.get('last_event_ts') or '-'}"
+        )
+    fleet = project["fleet"]
+    lines.append(
+        f"- fleet runs: {fleet['run_count']}, "
+        f"recurrent waste candidates: {len(fleet['improvement_candidates'])}"
+    )
+    lines.append("")
+    lines.append("| guard | count | last | status |")
+    lines.append("|---|---:|---|---|")
+    guards = project["guard_summary"].get("guards", {})
+    if isinstance(guards, dict):
+        for guard, raw in sorted(guards.items()):
+            row = raw if isinstance(raw, dict) else {}
+            status = "재평가 후보" if row.get("reassessment_candidate") else "active"
+            lines.append(
+                f"| {_md_cell(guard)} | {int(row.get('count') or 0)} | "
+                f"{_md_cell(row.get('last_ts') or '-')} | {status} |"
+            )
+    lines.append("")
+    return lines
+
+
+def render_markdown(payload: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("# loop-diagnose report")
+    lines.append("")
+    lines.append(f"- swept_at: `{payload['swept_at']}`")
+    lines.append(f"- projects_file: `{payload['projects_file']}`")
+    lines.append(f"- state_file: `{payload['state_file']}`")
+    lines.append(f"- decisions_file: `{payload['decisions_file']}`")
+    lines.append("")
+    for project in payload["projects"]:
+        lines.extend(_render_project(project))
+
+    lines.append("## 통합 후보")
+    lines.append("")
+    candidates = payload["candidates"]
+    if candidates:
+        lines.append("| key | kind | project | detail | last | 상태 | 결정 |")
+        lines.append("|---|---|---|---|---|---|---|")
+        for candidate in candidates:
+            lines.append(
+                f"| `{_md_cell(candidate['key'])}` | {_md_cell(candidate['kind'])} | "
+                f"{_md_cell(candidate['project'])} | {_md_cell(candidate['detail'])} | "
+                f"{_md_cell(candidate.get('last_ts') or '-')} | "
+                f"{_md_cell(candidate.get('freshness') or '-')} | "
+                f"{_md_cell(candidate.get('decision_annotation') or '-')} |"
+            )
+    else:
+        lines.append("(후보 없음)")
+    lines.append("")
+    lines.append("## 수동 절차")
+    lines.append("")
+    lines.append(
+        "- judge 보정은 자동 수집하지 않습니다. 필요 시 `evals/calibrate_judge.py`를 "
+        "수동 실행하고 결과를 별도 Decide 입력으로 남깁니다."
+    )
+    lines.append(
+        "- 자동 수정과 자동 이슈 생성은 하지 않습니다. 후보 검토 뒤 "
+        "`record-decision`으로 소비 표식을 남깁니다."
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def record_decision(args: argparse.Namespace) -> int:
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    key = str(args.key or "").strip()
+    ref = str(args.ref or "").strip()
+    if not key:
+        print("record-decision: --key is required", file=sys.stderr)
+        return 2
+    if args.decision not in VALID_DECISIONS:
+        print("record-decision: invalid --decision", file=sys.stderr)
+        return 2
+    if not ref:
+        print("record-decision: --ref is required", file=sys.stderr)
+        return 2
+    payload = {
+        "key": key,
+        "decision": args.decision,
+        "ref": ref,
+        "decided_at": args.decided_at or _now_iso(),
+    }
+    note = str(args.note or "").strip()
+    if note:
+        payload["note"] = note
+    _append_jsonl(repo_root / DECISIONS_PATH, payload)
+    print(f"recorded decision: {key} -> {args.decision} {ref}")
+    return 0
+
+
+def _projects_file_default() -> str:
+    return os.environ.get("DCNESS_PROJECTS_FILE") or str(DEFAULT_PROJECTS_FILE)
+
+
+def _add_common_report_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo-root", default=str(Path.cwd()))
+    parser.add_argument("--projects-file", default=_projects_file_default())
+    parser.add_argument("--idle-days", type=int, default=30)
+    parser.add_argument("--saturation-days", type=int, default=30)
+    parser.add_argument("--saturation-min-runs", type=int, default=3)
+    parser.add_argument("--waste-top", type=int, default=10)
+    parser.add_argument("--recurrence-threshold", type=int, default=3)
+    parser.add_argument("--hide-decided", action="store_true")
+    parser.add_argument("--json", action="store_true")
+
+
+def _build_report_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loop_diagnose.py",
+        description="Sweep active dcNess projects and surface Diagnose candidates.",
+    )
+    _add_common_report_args(parser)
+    return parser
+
+
+def _build_decision_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="loop_diagnose.py record-decision")
+    parser.add_argument("--repo-root", default=str(Path.cwd()))
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--decision", required=True, choices=sorted(VALID_DECISIONS))
+    parser.add_argument("--ref", required=True)
+    parser.add_argument("--note", default="")
+    parser.add_argument("--decided-at", default="")
+    return parser
+
+
+def _run_report(argv: list[str]) -> int:
+    args = _build_report_parser().parse_args(argv)
+    payload = build_payload(args)
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(render_markdown(payload))
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] == "record-decision":
+        args = _build_decision_parser().parse_args(argv[1:])
+        return record_decision(args)
+    if argv and argv[0] == "report":
+        argv = argv[1:]
+    return _run_report(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -16,6 +16,7 @@ EXCLUDE_PATHS=(
     "PROGRESS.md"
     "CLAUDE.md"
     "scripts/sync_release.sh"
+    "scripts/loop_diagnose.py"
     ".claude-plugin/marketplace.json"
     ".github/workflows/python-tests.yml"
     ".github/workflows/release-sync.yml"

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -1,0 +1,282 @@
+"""loop_diagnose self-improvement sweep tool tests (#902)."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / "scripts" / "loop_diagnose.py"
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _write_guard_hit(project: Path, guard: str = "file-guard") -> None:
+    _write_jsonl(
+        project / ".claude" / "harness-state" / "guard-telemetry.jsonl",
+        [
+            {
+                "kind": "guard_hit",
+                "guard": guard,
+                "category": "write_boundary",
+                "source": "test",
+                "ts": "2026-01-01T00:00:00Z",
+            }
+        ],
+    )
+
+
+def _write_recurrent_waste_run(project: Path) -> None:
+    run_dir = (
+        project
+        / ".claude"
+        / "harness-state"
+        / ".sessions"
+        / "sid-loop-diagnose"
+        / "runs"
+        / "run-loop902a"
+    )
+    _write_jsonl(
+        run_dir / ".steps.jsonl",
+        [
+            {
+                "ts": "2026-01-01T00:00:01Z",
+                "agent": "engineer",
+                "mode": "IMPL",
+                "enum": "TESTS_FAIL",
+                "must_fix": False,
+                "prose_excerpt": "same failure\nline2\nline3\nline4\nline5",
+            },
+            {
+                "ts": "2026-01-01T00:01:01Z",
+                "agent": "engineer",
+                "mode": "IMPL",
+                "enum": "TESTS_FAIL",
+                "must_fix": False,
+                "prose_excerpt": "same failure\nline2\nline3\nline4\nline5",
+            },
+        ],
+    )
+
+
+def _write_eval_events(repo_root: Path) -> None:
+    _write_jsonl(
+        repo_root / ".metrics" / "evals" / "run-1" / "guard-telemetry.jsonl",
+        [
+            {
+                "kind": "eval_case_result",
+                "case": "headless-prose-quality",
+                "passed": True,
+                "ts": "2026-07-01T00:00:00Z",
+            },
+            {
+                "kind": "eval_case_result",
+                "case": "headless-prose-quality",
+                "passed": True,
+                "ts": "2026-07-02T00:00:00Z",
+            },
+        ],
+    )
+
+
+def _snapshot_tree(root: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for path in sorted(p for p in root.rglob("*") if p.is_file()):
+        out[str(path.relative_to(root))] = path.read_text(encoding="utf-8")
+    return out
+
+
+class LoopDiagnoseTests(unittest.TestCase):
+    def _run(
+        self,
+        repo_root: Path,
+        projects_file: Path,
+        *extra: str,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["DCNESS_PROJECTS_FILE"] = str(projects_file)
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--repo-root",
+                str(repo_root),
+                "--recurrence-threshold",
+                "1",
+                "--saturation-min-runs",
+                "2",
+                *extra,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_report_aggregates_projects_watermark_json_and_readonly(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            beta = tmp / "beta"
+            alpha.mkdir()
+            beta.mkdir()
+            _write_guard_hit(alpha)
+            _write_recurrent_waste_run(alpha)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha), str(beta)]}),
+                encoding="utf-8",
+            )
+            before_alpha = _snapshot_tree(alpha)
+            before_beta = _snapshot_tree(beta)
+
+            first = self._run(repo_root, projects_file)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            self.assertIn("guard:file-guard@alpha", first.stdout)
+            self.assertIn("waste:RETRY_SAME_FAIL@alpha", first.stdout)
+            self.assertIn("프로젝트: beta", first.stdout)
+            self.assertIn("관측 이력 없음(미배포 또는 무발화)", first.stdout)
+            self.assertIn("신규", first.stdout)
+            self.assertTrue((repo_root / ".metrics" / "loop-diagnose" / "sweeps.jsonl").is_file())
+            self.assertEqual(_snapshot_tree(alpha), before_alpha)
+            self.assertEqual(_snapshot_tree(beta), before_beta)
+
+            second = self._run(repo_root, projects_file)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("기왕", second.stdout)
+
+            as_json = self._run(repo_root, projects_file, "--json")
+            self.assertEqual(as_json.returncode, 0, as_json.stderr)
+            payload = json.loads(as_json.stdout)
+            self.assertEqual([p["name"] for p in payload["projects"]], ["alpha", "beta"])
+            self.assertIn("swept_at", payload)
+            self.assertIn("candidates", payload)
+            keys = {candidate["key"] for candidate in payload["candidates"]}
+            self.assertIn("guard:file-guard@alpha", keys)
+            self.assertIn("waste:RETRY_SAME_FAIL@alpha", keys)
+
+    def test_decision_record_annotation_and_hide_decided(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            alpha.mkdir()
+            _write_guard_hit(alpha)
+            _write_recurrent_waste_run(alpha)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha)]}),
+                encoding="utf-8",
+            )
+
+            invalid = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "record-decision",
+                    "--repo-root",
+                    str(repo_root),
+                    "--key",
+                    "guard:file-guard@alpha",
+                    "--decision",
+                    "maybe",
+                    "--ref",
+                    "#902",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(invalid.returncode, 0)
+            self.assertFalse((repo_root / "docs" / "internal" / "loop-decisions.jsonl").exists())
+
+            fixed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "record-decision",
+                    "--repo-root",
+                    str(repo_root),
+                    "--key",
+                    "guard:file-guard@alpha",
+                    "--decision",
+                    "fixed",
+                    "--ref",
+                    "#902",
+                    "--decided-at",
+                    "2026-07-04T00:00:00Z",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(fixed.returncode, 0, fixed.stderr)
+            hold = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "record-decision",
+                    "--repo-root",
+                    str(repo_root),
+                    "--key",
+                    "waste:RETRY_SAME_FAIL@alpha",
+                    "--decision",
+                    "hold",
+                    "--ref",
+                    "#903",
+                    "--decided-at",
+                    "2026-07-04T00:00:01Z",
+                ],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(hold.returncode, 0, hold.stderr)
+
+            report = self._run(repo_root, projects_file)
+            self.assertIn("이전 결정: 고침 2026-07-04 #902", report.stdout)
+            self.assertIn("이전 결정: 보류 2026-07-04 #903", report.stdout)
+
+            hidden = self._run(repo_root, projects_file, "--hide-decided")
+            self.assertNotIn("guard:file-guard@alpha", hidden.stdout)
+            self.assertIn("waste:RETRY_SAME_FAIL@alpha", hidden.stdout)
+
+    def test_eval_saturation_candidate_from_self_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": []}),
+                encoding="utf-8",
+            )
+            _write_eval_events(repo_root)
+
+            result = self._run(repo_root, projects_file)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("eval:headless-prose-quality", result.stdout)
+            self.assertIn("judge 보정은 자동 수집하지 않습니다", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호
Closes #902

## 배경 및 문제
가드 텔레메트리와 재발 후보가 활성 프로젝트별 `.claude/harness-state/`에 흩어져 있어 dcNess self 릴리즈 점검에서 cross-project 신호를 한 번에 보지 못했다. 또한 같은 후보가 반복 표면화되어 이미 판단한 항목을 기계적으로 구분할 소비 표식이 없었다.

## 원인 (해당 시)
기존 `harness.guard_telemetry report`와 `harness.benchmark_aggregate`는 단일 cwd/sessions-root 기준 도구였고, whitelist 순회·워터마크·결정 원장을 묶는 Diagnose 슬롯 전용 상위 루프가 없었다.

## 작업내용
- `scripts/loop_diagnose.py` 추가: whitelist 순회, 프로젝트별 guard/fleet 집계, dcNess self eval 포화 후보, 통합 후보 표, `--json`, sweep 워터마크, `record-decision` 지원
- `.claude/commands/loop-diagnose.md` 추가: repo-local 실행 절차와 stdout verbatim echo 원칙 문서화
- `docs/internal/self-improvement-loop.md` / `docs/internal/plugin-release.md` 갱신: Diagnose 전용 도구와 소비 표식 3층 관계 반영
- `scripts/sync_release.sh` EXCLUDE_PATHS에 self 전용 스크립트 추가
- `tests/test_loop_diagnose.py` 추가: 다중 프로젝트 합산, 워터마크 신규/기왕, decision 주석/hide, record validation, read-only, no telemetry, JSON, self eval 후보 검증

## 결정 근거
기존 집계 로직을 재구현하지 않고 `harness.guard_telemetry`의 `collect_guard_summary`/`collect_eval_summary`/`read_events`와 `harness.benchmark_aggregate.aggregate_sessions`를 직접 재사용했다. 활성 프로젝트는 read-only로 순회하고, 상태 파일은 dcNess self repo의 `.metrics/loop-diagnose/`와 `docs/internal/loop-decisions.jsonl`에만 쓰도록 분리했다.

## 배포 경로 검증 (plug-in 영향 시)
- `scripts/loop_diagnose.py`는 dcNess self 전용이며 `scripts/sync_release.sh` EXCLUDE_PATHS에 추가해 release 브랜치 배포물에서 제거된다.
- `.claude/commands/loop-diagnose.md`, `docs/internal/**`, `tests/**`는 기존 release sync 제외 경로라 외부 활성 프로젝트로 배포되지 않는다.
- 활성 프로젝트 디렉토리에는 쓰지 않는다. `tests/test_loop_diagnose.py`의 read-only snapshot 테스트와 실제 whitelist sweep으로 확인했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 외부 public skill/command/agent/gate 추가 없음. 새 command는 dcNess self repo-local `.claude/commands/loop-diagnose.md`이고 release 배포 대상이 아니다.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_loop_diagnose -v`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `PYTHON_BIN=.venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `python3.11 scripts/loop_diagnose.py`
- [x] `python3.11 scripts/loop_diagnose.py --json >/tmp/loop-diagnose.json 2>/tmp/loop-diagnose.err` + `python3.11 -m json.tool /tmp/loop-diagnose.json`
- [x] `bash -n scripts/sync_release.sh`
- [x] commit pre-commit hook 전체 unittest PASS

## 참고
- 실제 whitelist sweep에서 telemetry 미배포/무발화 프로젝트는 `관측 이력 없음(미배포 또는 무발화)`로 구분되고, youTubeGenerator 재발 후보와 dcNess self eval 포화 후보가 통합 표에 표시됨.
