### PR TITLE
[issue-903] telemetry 위생 개선

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -28,6 +28,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - whitelist 활성화: 중복 제거.
 - `~/.claude/settings.json` Read 권한: 없을 때만 추가.
 - `.git/hooks/*`: thin shim always-overwrite.
+- `.gitignore`: `.claude/harness-state/` 는 core 에서 없을 때만 추가. `.dcness-work/` 는 선택형 docs seed 에서 없을 때만 추가.
 - `.github/workflows/*.yml`: 사용자가 선택한 경우 always-overwrite.
 - `docs/*`, `docs/design-variants/*`: 부재 시만 seed. 단 기존 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 섹션은 없을 때만 append.
 - Codex validator skills: `$CODEX_HOME/skills/dcness-*` always-overwrite.
@@ -53,6 +54,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 - whitelist 활성화
 - `~/.claude/settings.json` Read 권한
 - git hook shim 3종 설치
+- runtime state `.gitignore` 보장
 - Codex validator skill 배포
 - `CLAUDE.md` seed/migration 감사
 - Provider routing 상태 확인
@@ -115,19 +117,15 @@ fi
 
 ```bash
 mkdir -p "$PROJECT_ROOT/.git/hooks"
-
 cp "$PLUGIN_ROOT/scripts/hooks/commit-msg" "$PROJECT_ROOT/.git/hooks/commit-msg"
 chmod +x "$PROJECT_ROOT/.git/hooks/commit-msg"
 echo "[dcness] .git/hooks/commit-msg 갱신 (thin shim -> plugin SSOT 호출)"
-
 cp "$PLUGIN_ROOT/scripts/hooks/post-checkout" "$PROJECT_ROOT/.git/hooks/post-checkout"
 chmod +x "$PROJECT_ROOT/.git/hooks/post-checkout"
 echo "[dcness] .git/hooks/post-checkout 갱신 (thin shim -> plugin SSOT 호출)"
-
 cp "$PLUGIN_ROOT/scripts/hooks/pre-push" "$PROJECT_ROOT/.git/hooks/pre-push"
 chmod +x "$PROJECT_ROOT/.git/hooks/pre-push"
 echo "[dcness] .git/hooks/pre-push 갱신 (thin shim -> plugin SSOT 호출)"
-
 if [ -f "$PROJECT_ROOT/scripts/check_git_naming.mjs" ]; then
   echo "[dcness] NOTE - scripts/check_git_naming.mjs 가 사용자 repo 에 잔존. 이제 plugin SSOT 에서 호출하므로 제거 권장:"
   echo "         git rm scripts/check_git_naming.mjs"
@@ -136,6 +134,8 @@ if [ -f "$PROJECT_ROOT/docs/plugin/skill-guidelines.md" ]; then
   echo "[dcness] NOTE - docs/plugin/skill-guidelines.md 가 사용자 repo 에 잔존. session-start.sh 가 이제 plugin SSOT 에서 read. 제거 권장:"
   echo "         git rm docs/plugin/skill-guidelines.md"
 fi
+touch "$PROJECT_ROOT/.gitignore"
+grep -qxF '.claude/harness-state/' "$PROJECT_ROOT/.gitignore" || { printf '%s\n' '.claude/harness-state/' >> "$PROJECT_ROOT/.gitignore"; echo "[dcness] .gitignore 에 .claude/harness-state/ 추가"; }
 ```
 
 ### Core Step 5 - Codex skill 배포와 routing 상태 확인
@@ -225,7 +225,7 @@ core activation 완료 뒤에만 진행한다. 기본 경로에서 선택형 항
 - 루트 `architecture.md` 가 있고 `docs/architecture.md` 가 없으면 `docs/architecture.md` 는 추천 OFF. 메시지에 `root architecture.md 감지로 docs/architecture.md skip` 을 남긴다.
 - `docs/index.md`, `docs/prd.md`, `docs/conventions.md`, `docs/decisions/` 는 부재 시 추천 ON. 기존 `docs/index.md` 에 진행 상태 섹션이 없으면 보강 ON.
 - 루트 `architecture.md` 가 없고 `docs/architecture.md` 도 없으면 `docs/architecture.md` 추천 ON.
-- `.gitignore` 에 `.dcness-work/` 가 없으면 추천 ON.
+- `.gitignore` 에 `.dcness-work/` 가 없으면 추천 ON. `.claude/harness-state/` 는 core activation 에서 이미 보장한다.
 - UI 흔적이 있어도 `docs/design-variants/` 는 기본 skip. 특히 단일 `app/page.tsx` 정도만으로 design kit 를 설치하지 않는다.
 - GitHub Project lifecycle 은 기본 skip. `gh` 인증, Project number, PAT/secrets, field/label 복구가 얽히므로 custom 에서만 진행한다.
 - Codex validation routing 이 이미 enabled 면 skip. disabled/미설정이면 추천 bundle 에서 enable 대상으로 표시하고, custom 에서는 명시 선택으로 다룬다.
@@ -301,10 +301,9 @@ if [ ! -f "$PROJECT_ROOT/docs/decisions/README.md" ]; then
   echo "[dcness] docs/decisions/README.md 시드 완료"
 fi
 touch "$PROJECT_ROOT/.gitignore"
-if ! grep -qxF '.dcness-work/' "$PROJECT_ROOT/.gitignore"; then
-  printf '%s\n' '.dcness-work/' >> "$PROJECT_ROOT/.gitignore"
-  echo "[dcness] .gitignore 에 .dcness-work/ 추가"
-fi
+for IGNORE in '.dcness-work/' '.claude/harness-state/'; do
+  grep -qxF "$IGNORE" "$PROJECT_ROOT/.gitignore" || { printf '%s\n' "$IGNORE" >> "$PROJECT_ROOT/.gitignore"; echo "[dcness] .gitignore 에 $IGNORE 추가"; }
+done
 ```
 
 #### Provider routing

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -235,7 +235,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
 
 활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
-git hook 차단도 같은 telemetry 체계를 쓴다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 `guard-telemetry.jsonl` 에 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록한다.
+git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 통과 뒤에만 수행한다. 비활성 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
 
 ### .git/hooks/commit-msg
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -19,6 +19,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 | local git hook | `.git/hooks/commit-msg` | `scripts/hooks/commit-msg` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/post-checkout` | `scripts/hooks/post-checkout` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | 항상 | always-overwrite | X |
+| runtime state ignore | `.gitignore` 의 `.claude/harness-state/` | `/init-dcness` append | 항상 | 없을 때만 추가 | X |
 | project context seed/migration | `CLAUDE.md` | `scripts/dcness-context-docs` / `harness/context_docs.py` | 항상 | 부재 시 생성. 기존 파일은 cold-start 앵커만 없을 때 append | X |
 | Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite | X |
 | Codex provider routing 상태 확인 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing status` | 항상 확인 | read-only | X |
@@ -36,7 +37,7 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 | doc sync workflow | `.github/workflows/doc-sync.yml` | [`templates/github-workflows/doc-sync.yml`](../../templates/github-workflows/doc-sync.yml) | GitHub remote 감지 시 추천 ON | always-overwrite | O |
 | Project lifecycle workflow | `.github/workflows/github-project-lifecycle.yml` | [`templates/github-workflows/github-project-lifecycle.yml`](../../templates/github-workflows/github-project-lifecycle.yml) | custom 선택 | always-overwrite | O |
 | project docs seed | `docs/index.md`, `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/` | authoring 템플릿 (`skills/spec/templates/index.md`, `skills/spec/templates/prd.md`, `agents/system-architect/templates/root-architecture.md`, `agents/system-architect/templates/conventions.md`) + `scripts/ensure_docs_index_next_section.mjs` — 시드와 산출 양식 단일 원본. 위치 SSOT [`deliverables-map.md`](deliverables-map.md) | 추천 bundle 또는 custom | 부재 시 생성. 기존 `docs/index.md` 는 진행 상태 섹션만 없을 때 append | X |
-| volatile workdir ignore | `.gitignore` 의 `.dcness-work/` | `/init-dcness` append | 추천 bundle 또는 custom | 없을 때만 추가 | X |
+| volatile workdir ignore | `.gitignore` 의 `.dcness-work/` + `.claude/harness-state/` 재확인 | `/init-dcness` append | 추천 bundle 또는 custom | 없을 때만 추가 | X |
 | design seed | `docs/design.md` | `docs/plugin/design.md` minimal 예시 | custom 선택 | 부재 시만 생성 | X |
 | design preview seed | `docs/design-variants/**` | `templates/design-variants/**` | custom 선택 | 부재 시만 생성 | X |
 | Codex validation routing 변경 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-codex-validation` / `disable-codex-validation` | disabled/미설정일 때 추천 bundle 또는 custom | opt-in 값으로 갱신 | X |
@@ -71,7 +72,7 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 - 루트 `architecture.md` 가 있고 `docs/architecture.md` 가 없으면 `docs/architecture.md` 는 추천 OFF. 메시지에 `root architecture.md 감지로 docs/architecture.md skip` 을 남긴다.
 - `docs/index.md`, `docs/prd.md`, `docs/conventions.md`, `docs/decisions/` 는 부재 시 추천 ON. 기존 `docs/index.md` 에 진행 상태 섹션이 없으면 보강 ON.
 - 루트 `architecture.md` 가 없고 `docs/architecture.md` 도 없으면 `docs/architecture.md` 추천 ON.
-- `.gitignore` 에 `.dcness-work/` 가 없으면 추천 ON.
+- `.gitignore` 에 `.dcness-work/` 가 없으면 추천 ON. `.claude/harness-state/` 는 core activation 에서 항상 보장한다.
 - `docs/design-variants/` 는 기본 skip. 단일 `app/page.tsx` 정도의 UI 흔적만으로 design kit 를 설치하지 않는다.
 - GitHub Project lifecycle 은 기본 skip. `gh` 인증, Project number, PAT/secrets, field/label 복구가 얽히므로 custom 에서만 진행한다.
 - Codex validation routing 이 이미 enabled 면 skip. disabled/미설정이면 추천 bundle 또는 custom 에서 명시적으로 다룬다.
@@ -163,6 +164,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | plugin 본체 문서/skill/hook 만 갱신 | 아니오 | `claude plugin update dcness@dcness` 로 plug-in cache 가 갱신된다. |
 | plugin uninstall/reinstall | 예 | plugin data 디렉토리가 정리되어 whitelist 가 사라진다. |
 | `.git/hooks/*` thin shim 갱신 | 예 | 사용자 repo `.git/hooks/` 파일은 plugin update 만으로 바뀌지 않는다. |
+| `.claude/harness-state/` gitignore 보강 | 예 | runtime state ignore 는 사용자 repo `.gitignore` append 라서 `/init-dcness` 재실행 때 적용된다. |
 | `CLAUDE.md` seed/migration 로직 갱신 | 예 | 기존 활성 프로젝트의 root `CLAUDE.md` 생성·cold-start 앵커 append 는 `/init-dcness` 재실행 때 적용된다. |
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 또는 module docs 가 있는 프로젝트는 doc-sync 채택 직후 index/architecture 집계기를 1회 실행해야 한다. |
 | Codex validation routing opt-in 변경 | 예 | local plugin data 와 `$CODEX_HOME/skills` 를 갱신해야 한다. |
@@ -176,7 +178,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 `/init-dcness` 의 자동 commit + PR 단계는 `.github/workflows/*.yml` 만 대상으로 한다.
 
 - 포함: `git-naming-validation.yml`, `pr-body-validation.yml`, `doc-path-integrity.yml`, `doc-sync.yml`, `github-project-lifecycle.yml`
-- 제외: `.git/hooks/*` (git 내부 파일), `~/.claude/**`, `$CODEX_HOME/**`, `docs/*` seed, `docs/design-variants/*` seed, 자동 CC hook 설명
+- 제외: `.git/hooks/*` (git 내부 파일), `~/.claude/**`, `$CODEX_HOME/**`, `.gitignore` runtime/volatile ignore, `docs/*` seed, `docs/design-variants/*` seed, 자동 CC hook 설명
 - 선행 조건: GitHub remote 존재, 현재 branch `main`, `gh auth status` 통과. 조건이 안 맞으면 branch/commit/push 를 시작하지 않고 skip 안내만 출력한다.
 
 seed 문서는 사용자 프로젝트 내용물이므로 사용자가 별도 작업 PR 에 포함할지 직접 판단한다.

--- a/harness/guard_telemetry.py
+++ b/harness/guard_telemetry.py
@@ -22,14 +22,17 @@ DEFAULT_IDLE_DAYS = 30
 DEFAULT_SATURATION_DAYS = 30
 DEFAULT_SATURATION_MIN_RUNS = 3
 
-KNOWN_GUARDS: tuple[str, ...] = (
+DISTRIBUTED_KNOWN_GUARDS: tuple[str, ...] = (
     "catastrophic-gate",
     "file-guard",
     "tdd-guard",
-    "git-pre-commit",
     "git-commit-msg",
     "git-pre-push",
 )
+SELF_ONLY_KNOWN_GUARDS: tuple[str, ...] = (
+    "git-pre-commit",
+)
+KNOWN_GUARDS: tuple[str, ...] = DISTRIBUTED_KNOWN_GUARDS
 
 _DETAIL_MAX = 500
 

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -51,6 +51,8 @@ if [ -z "$PLUGIN_ROOT" ]; then
 fi
 
 record_guard_hit() {
+  PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.session_state is-active \
+    >/dev/null 2>&1 || return 0
   PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
     --guard git-commit-msg \
     --category "$1" \

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -52,6 +52,8 @@ resolve_dcness_root() {
 record_guard_hit() {
   root="$(resolve_dcness_root 2>/dev/null || true)"
   [ -n "$root" ] || return 0
+  PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.session_state is-active \
+    >/dev/null 2>&1 || return 0
   PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
     --guard git-pre-push \
     --category "$1" \

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from harness.guard_telemetry import read_events
+from harness.guard_telemetry import TELEMETRY_NAME
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -22,10 +23,16 @@ def _git(root: Path, *args: str) -> None:
     )
 
 
-def _env() -> dict[str, str]:
+def _env(*, active: bool = False, whitelist_path: Path | None = None) -> dict[str, str]:
     env = os.environ.copy()
     env["PYTHONPATH"] = str(ROOT)
     env["CLAUDE_PLUGIN_ROOT"] = str(ROOT)
+    if whitelist_path is not None:
+        env["DCNESS_WHITELIST_PATH"] = str(whitelist_path)
+    if active:
+        env["DCNESS_FORCE_ENABLE"] = "1"
+    else:
+        env.pop("DCNESS_FORCE_ENABLE", None)
     return env
 
 
@@ -39,7 +46,7 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
             result = subprocess.run(
                 ["sh", str(ROOT / "scripts" / "hooks" / "pre-commit")],
                 cwd=str(root),
-                env=_env(),
+                env=_env(active=True),
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -67,7 +74,7 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
             result = subprocess.run(
                 ["sh", str(ROOT / "scripts" / "hooks" / "commit-msg"), str(msg)],
                 cwd=str(root),
-                env=_env(),
+                env=_env(active=True),
                 capture_output=True,
                 text=True,
                 timeout=10,
@@ -84,6 +91,80 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
                 ),
                 events,
             )
+
+    def test_inactive_commit_msg_block_does_not_create_telemetry(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "repo"
+            root.mkdir()
+            _git(root, "init")
+            msg = root / "COMMIT_EDITMSG"
+            msg.write_text("bad subject\n", encoding="utf-8")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "commit-msg"), str(msg)],
+                cwd=str(root),
+                env=_env(whitelist_path=base / "projects.json"),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            self.assertFalse(
+                (root / ".claude" / "harness-state" / TELEMETRY_NAME).exists()
+            )
+            self.assertEqual(read_events(cwd=root), [])
+
+    def test_pre_push_main_block_records_guard_hit_when_active(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _git(root, "init")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-push")],
+                input="refs/heads/main abc refs/heads/main def\n",
+                cwd=str(root),
+                env=_env(active=True),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            events = read_events(cwd=root)
+            self.assertTrue(
+                any(
+                    e.get("kind") == "guard_hit"
+                    and e.get("guard") == "git-pre-push"
+                    and e.get("category") == "main_push_block"
+                    for e in events
+                ),
+                events,
+            )
+
+    def test_inactive_pre_push_block_does_not_create_telemetry(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "repo"
+            root.mkdir()
+            _git(root, "init")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-push")],
+                input="refs/heads/main abc refs/heads/main def\n",
+                cwd=str(root),
+                env=_env(whitelist_path=base / "projects.json"),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            self.assertFalse(
+                (root / ".claude" / "harness-state" / TELEMETRY_NAME).exists()
+            )
+            self.assertEqual(read_events(cwd=root), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_guard_telemetry.py
+++ b/tests/test_guard_telemetry.py
@@ -90,6 +90,15 @@ class GuardSummaryTests(unittest.TestCase):
             self.assertEqual(row["count"], 1)
             self.assertFalse(row["reassessment_candidate"])
 
+    def test_default_report_known_guards_exclude_self_only_pre_commit(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            summary = collect_guard_summary(cwd=root, idle_days=30)
+
+            self.assertIn("git-commit-msg", summary["guards"])
+            self.assertIn("git-pre-push", summary["guards"])
+            self.assertNotIn("git-pre-commit", summary["guards"])
+
 
 class EvalSummaryTests(unittest.TestCase):
     def test_eval_case_results_share_the_same_event_log(self) -> None:

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -730,6 +730,14 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("진행 상태 섹션", self.init_doc)
         self.assertIn("진행 상태 섹션", self.init_reference)
 
+    def test_issue_903_init_dcness_ignores_runtime_harness_state(self) -> None:
+        """#903 — /init-dcness keeps runtime telemetry/state out of git status."""
+        for text in (self.init_doc, self.init_reference):
+            with self.subTest(source=text[:30]):
+                self.assertIn(".dcness-work/", text)
+                self.assertIn(".claude/harness-state/", text)
+                self.assertIn(".gitignore", text)
+
     def test_issue_885_claude_md_seed_and_audit_stays_inside_existing_surfaces(self) -> None:
         """#885 — CLAUDE.md seed/migration and audit wire into init/run-review only."""
         helper = "scripts/dcness-context-docs"


### PR DESCRIPTION
## 관련 이슈 번호
Closes #903

## 배경 및 문제
PR #898 이후 guard telemetry가 git hook 차단까지 기록하게 됐지만, 배포되는 git hook shim은 dcness 활성 여부를 확인하지 않고 사용자 repo의 `.claude/harness-state/guard-telemetry.jsonl`에 append 할 수 있었다. 또한 `/init-dcness`는 `.dcness-work/`만 gitignore에 보장해 runtime telemetry/state 디렉터리의 git status 노출 가능성이 남아 있었다.

## 원인 (해당 시)
- `scripts/hooks/commit-msg`와 `scripts/hooks/pre-push`의 telemetry 기록 함수가 `harness.session_state is-active` 게이트를 거치지 않았다.
- `harness/guard_telemetry.py`의 default known guard 목록에 dcness self 전용 `git-pre-commit`이 포함되어 외부 활성 프로젝트 report에서 영구 0-hit 재평가 후보가 될 수 있었다.
- `/init-dcness` runbook/reference가 `.claude/harness-state/` gitignore 보장을 소유하지 않았다.

## 작업내용
- `commit-msg` / `pre-push` git hook telemetry append 전에 `is-active` 게이트를 추가했다.
- 외부 report 기본 known guard를 배포 공통 guard로 제한하고, `git-pre-commit`은 self-only guard로 분리했다.
- `/init-dcness` core activation에서 `.claude/harness-state/` gitignore를 보장하고, optional docs seed에서도 `.dcness-work/`와 함께 재확인하도록 문서화했다.
- 비활성 repo hook 차단 시 telemetry 파일이 생기지 않는 회귀 테스트, pre-push 기록 테스트, init-dcness 문서 계약 테스트를 추가했다.

## 결정 근거
활성 프로젝트 판정은 이미 `harness.session_state is-active`가 hook 계층의 SSOT이므로 git hook shim에서도 같은 게이트를 재사용했다. 기록 위치를 바꾸는 대신 기록 조건을 제한해 기존 활성 프로젝트의 telemetry schema와 report aggregation은 유지했다.

## 배포 경로 검증 (plug-in 영향 시)
- 경로 1 plug-in 본체: `harness/guard_telemetry.py`, `scripts/hooks/commit-msg`, `scripts/hooks/pre-push`, `commands/init-dcness.md`, `docs/plugin/hooks.md`, `docs/plugin/init-dcness.md`는 plug-in update로 사용자 환경에 도달한다.
- 경로 2 init-dcness 복사/배포물: 기존 활성 프로젝트의 `.git/hooks/commit-msg`와 `.git/hooks/pre-push`는 `/init-dcness` 재실행 시 always-overwrite로 갱신된다. 같은 재실행에서 `.gitignore`에 `.claude/harness-state/`가 없으면 append된다.
- 기존 활성 프로젝트 안내: plug-in update 후 `/init-dcness`를 재실행하면 hook shim과 gitignore 보강을 받는다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public surface 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_git_hook_guard_telemetry tests.test_guard_telemetry tests.test_surface_docs_sync -v`
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `sh -n scripts/hooks/commit-msg scripts/hooks/pre-push`

## 참고
- static-quality 도구는 시스템 Python의 PEP 668 정책 때문에 `/tmp/dcness-quality-venv` 임시 venv에 `requirements-quality.txt`를 설치해 실행했다.