### PR TITLE
[issue-904] guard telemetry 품질 개선

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -50,7 +50,7 @@ PreToolUse 차단 hook 은 정책 위반만 `exit 2` 로 내보낸다. Claude Co
 
 Fail-open 관측성: 미활성 프로젝트 no-op, main Claude turn, active run 밖 Agent 호출처럼 예상된 benign skip 은 조용히 통과한다. 반대로 활성 프로젝트에서 enforcement hook 이 payload 파싱 실패, session id 부재, state read/write 오류, handler 비정상 종료 때문에 검사를 평가하지 못하고 allow 한 경우는 `<project>/.claude/harness-state/fail-open-events.jsonl` 에 structured event 로 남긴다. `dcness-helper status` 의 `hook fail-open 진단` 항목은 최근 24시간 count 와 reason category 를 WARN 으로 보여준다.
 
-Guard hit 관측성: 정책 위반을 실제로 차단한 경우는 `<project>/.claude/harness-state/guard-telemetry.jsonl` 또는 active run 의 `guard-telemetry.jsonl` 에 `guard_hit` 이벤트로 append 된다. 기록 필드는 guard 이름, category, source, 시각, detail 이며 기록 실패는 원래 차단/허용 판정을 바꾸지 않는다. `dcness-helper guard-telemetry` 는 guard 별 hit 수와 최근 hit 시각을 집계하고, 기본 30일 동안 hit 가 없는 guard 를 **재평가 후보**로 표시한다. 이 표시는 정보 제공 전용이며 guard 를 자동으로 비활성화하지 않는다.
+Guard hit 관측성: 정책 위반을 실제로 차단한 경우는 `<project>/.claude/harness-state/guard-telemetry.jsonl` 또는 active run 의 `guard-telemetry.jsonl` 에 `guard_hit` 이벤트로 append 된다. 기록 필드는 guard 이름, category, source, 시각, detail 이며 기록 실패는 원래 차단/허용 판정을 바꾸지 않는다. 첫 기록 시 `telemetry_epoch` 를 함께 남겨 "도입 직후 무발화" 와 "충분히 관측한 장기 무발화" 를 구분한다. `dcness-helper guard-telemetry` 는 기본 `--since-days 90` 기간 한정 스캔으로 guard 별 hit 수와 최근 hit 시각을 집계하고, 관측 기간이 idle threshold 보다 짧으면 **관측 부족**, 충분히 관측했는데 기본 30일 동안 hit 가 없으면 **재평가 후보**로 표시한다. 이 표시는 정보 제공 전용이며 guard 를 자동으로 비활성화하지 않는다.
 
 Stop hook 은 tool 호출을 막는 hook 이 아니다. 필요할 때 `decision: "block"` JSON 을 stdout 으로 내보내 메인 turn 을 재발화시킨다.
 
@@ -235,7 +235,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
 
 활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
-git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 통과 뒤에만 수행한다. 비활성 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
+git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 통과 뒤에만 수행한다. 비활성 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
 
 ### .git/hooks/commit-msg
 

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -29,6 +29,58 @@ is_strict_case() {
   return 1
 }
 
+byte_len() {
+  LC_ALL=C printf '%s' "$1" | wc -c | tr -d ' '
+}
+
+record_eval_result() {
+  local passed_flag="$1"
+  local failure_stage="$2"
+  local report_path="$3"
+  local judge_path="$4"
+  local turns="$5"
+  local report_len="$6"
+  local judge_len="$7"
+  local token_estimate="$8"
+  local status_arg="--failed"
+  if [ "$passed_flag" = "passed" ]; then
+    status_arg="--passed"
+  fi
+  if [ -n "$failure_stage" ]; then
+    PYTHONPATH="$ROOT:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-eval \
+      --case "$case_name" \
+      "$status_arg" \
+      --run-index "$i" \
+      --total-runs "$RUNS" \
+      --report-file "$report_path" \
+      --judge-file "$judge_path" \
+      --model "$MODEL" \
+      --llm-turns "$turns" \
+      --report-chars "$report_len" \
+      --judge-chars "$judge_len" \
+      --estimated-output-tokens "$token_estimate" \
+      --token-estimate-basis "utf8_bytes/4_lower_bound" \
+      --failure-stage "$failure_stage" \
+      --failure-detail "claude invocation failed" \
+      --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
+    return 0
+  fi
+  PYTHONPATH="$ROOT:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-eval \
+    --case "$case_name" \
+    "$status_arg" \
+    --run-index "$i" \
+    --total-runs "$RUNS" \
+    --report-file "$report_path" \
+    --judge-file "$judge_path" \
+    --model "$MODEL" \
+    --llm-turns "$turns" \
+    --report-chars "$report_len" \
+    --judge-chars "$judge_len" \
+    --estimated-output-tokens "$token_estimate" \
+    --token-estimate-basis "utf8_bytes/4_lower_bound" \
+    --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
+}
+
 for case_dir in "$ROOT"/evals/cases/*/; do
   case_name="$(basename "$case_dir")"
   case_path="${case_dir%/}"
@@ -58,6 +110,7 @@ for case_dir in "$ROOT"/evals/cases/*/; do
 
     if ! report="$(claude -p "$prompt" --model "$MODEL" --allowedTools "Read" --add-dir "$sandbox" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 검수 실행 실패"
+      record_eval_result "failed" "report" "" "" 1 0 0 0
       continue
     fi
     printf '%s\n' "$report" > "$report_file"
@@ -75,48 +128,30 @@ $report"
 
     if ! grade="$(claude -p "$judge_prompt" --model "$MODEL" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 채점 실행 실패"
+      report_chars="${#report}"
+      report_bytes="$(byte_len "$report")"
+      estimated_output_tokens=$(((report_bytes + 3) / 4))
+      record_eval_result "failed" "judge" "$report_file" "" 2 "$report_chars" 0 "$estimated_output_tokens"
       continue
     fi
     printf '%s\n' "$grade" > "$judge_file"
 
     report_chars="${#report}"
     judge_chars="${#grade}"
-    estimated_output_tokens=$(((report_chars + judge_chars + 3) / 4))
+    report_bytes="$(byte_len "$report")"
+    judge_bytes="$(byte_len "$grade")"
+    estimated_output_tokens=$(((report_bytes + judge_bytes + 3) / 4))
     llm_turns=2
 
     verdict="$(printf '%s\n' "$grade" | grep -E '^RESULT: (PASS|FAIL)$' | tail -1 || true)"
     if [ "$verdict" = "RESULT: PASS" ]; then
       pass=$((pass + 1))
       echo "[eval] $case_name run $i: 정답"
-      PYTHONPATH="$ROOT:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-eval \
-        --case "$case_name" \
-        --passed \
-        --run-index "$i" \
-        --total-runs "$RUNS" \
-        --report-file "$report_file" \
-        --judge-file "$judge_file" \
-        --model "$MODEL" \
-        --llm-turns "$llm_turns" \
-        --report-chars "$report_chars" \
-        --judge-chars "$judge_chars" \
-        --estimated-output-tokens "$estimated_output_tokens" \
-        --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
+      record_eval_result "passed" "" "$report_file" "$judge_file" "$llm_turns" "$report_chars" "$judge_chars" "$estimated_output_tokens"
     else
       echo "[eval] $case_name run $i: 오답"
       printf '%s\n' "$grade" | grep -E "^(OK|MISS) " || true
-      PYTHONPATH="$ROOT:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-eval \
-        --case "$case_name" \
-        --failed \
-        --run-index "$i" \
-        --total-runs "$RUNS" \
-        --report-file "$report_file" \
-        --judge-file "$judge_file" \
-        --model "$MODEL" \
-        --llm-turns "$llm_turns" \
-        --report-chars "$report_chars" \
-        --judge-chars "$judge_chars" \
-        --estimated-output-tokens "$estimated_output_tokens" \
-        --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
+      record_eval_result "failed" "" "$report_file" "$judge_file" "$llm_turns" "$report_chars" "$judge_chars" "$estimated_output_tokens"
     fi
   done
 

--- a/harness/guard_telemetry.py
+++ b/harness/guard_telemetry.py
@@ -19,8 +19,10 @@ from harness.session_state import RUN_ID_RE, run_dir, valid_session_id
 
 TELEMETRY_NAME = "guard-telemetry.jsonl"
 DEFAULT_IDLE_DAYS = 30
+DEFAULT_REPORT_SINCE_DAYS = 90
 DEFAULT_SATURATION_DAYS = 30
 DEFAULT_SATURATION_MIN_RUNS = 3
+OUTPUT_ESTIMATE_BASIS = "utf8_bytes/4_lower_bound"
 
 DISTRIBUTED_KNOWN_GUARDS: tuple[str, ...] = (
     "catastrophic-gate",
@@ -129,10 +131,19 @@ def append_event(
             base_dir=base_dir,
         )
         target.parent.mkdir(parents=True, exist_ok=True)
-        line = json.dumps(payload, ensure_ascii=False, separators=(",", ":")) + "\n"
+        needs_epoch = (
+            payload.get("kind") != "telemetry_epoch"
+            and (not target.exists() or target.stat().st_size == 0)
+        )
+        lines: list[Dict[str, Any]] = []
+        if needs_epoch:
+            lines.append({"kind": "telemetry_epoch", "ts": payload["ts"]})
+        lines.append(payload)
         fd = os.open(str(target), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
         try:
-            os.write(fd, line.encode("utf-8"))
+            for item in lines:
+                line = json.dumps(item, ensure_ascii=False, separators=(",", ":")) + "\n"
+                os.write(fd, line.encode("utf-8"))
         finally:
             os.close(fd)
     except Exception:  # noqa: BLE001 # nosec B110
@@ -182,6 +193,9 @@ def record_eval_case_result(
     report_chars: Optional[int] = None,
     judge_chars: Optional[int] = None,
     estimated_output_tokens: Optional[int] = None,
+    failure_stage: str = "",
+    failure_detail: str = "",
+    token_estimate_basis: str = "",
     cwd: Optional[Path] = None,
     base_dir: Optional[Path] = None,
 ) -> None:
@@ -200,6 +214,12 @@ def record_eval_case_result(
         event["judge_file"] = str(judge_file)
     if model:
         event["model"] = str(model)
+    if failure_stage:
+        event["failure_stage"] = str(failure_stage)[:80]
+    if failure_detail:
+        event["failure_detail"] = str(failure_detail).replace("\n", " ")[:_DETAIL_MAX]
+    if token_estimate_basis:
+        event["token_estimate_basis"] = str(token_estimate_basis)[:120]
     for key, value in (
         ("llm_turns", llm_turns),
         ("report_chars", report_chars),
@@ -244,6 +264,18 @@ def _candidate_log_paths(cwd: Optional[Path] = None, *, base_dir: Optional[Path]
         seen.add(resolved)
         unique.append(path)
     return unique
+
+
+def _has_nonempty_log_path(
+    cwd: Optional[Path] = None, *, base_dir: Optional[Path] = None
+) -> bool:
+    for path in _candidate_log_paths(cwd, base_dir=base_dir):
+        try:
+            if path.is_file() and path.stat().st_size > 0:
+                return True
+        except OSError:
+            continue
+    return False
 
 
 def read_events(
@@ -291,9 +323,11 @@ def collect_guard_summary(
     base_dir: Optional[Path] = None,
     known_guards: Iterable[str] = KNOWN_GUARDS,
     idle_days: int = DEFAULT_IDLE_DAYS,
+    since_days: Optional[int] = None,
 ) -> Dict[str, Any]:
+    all_events = read_events(cwd, base_dir=base_dir, since_days=since_days)
     events = [
-        event for event in read_events(cwd, base_dir=base_dir)
+        event for event in all_events
         if event.get("kind") == "guard_hit"
     ]
     rows: dict[str, Dict[str, Any]] = {}
@@ -304,6 +338,9 @@ def collect_guard_summary(
             "categories": {},
             "sources": [],
             "reassessment_candidate": True,
+            "observation_since": None,
+            "observation_days": None,
+            "observation_status": "no_observation",
         }
     for event in events:
         guard = str(event.get("guard") or "unknown")
@@ -315,6 +352,9 @@ def collect_guard_summary(
                 "categories": {},
                 "sources": [],
                 "reassessment_candidate": True,
+                "observation_since": None,
+                "observation_days": None,
+                "observation_status": "no_observation",
             },
         )
         row["count"] += 1
@@ -327,12 +367,46 @@ def collect_guard_summary(
         if source not in row["sources"]:
             row["sources"].append(source)
 
-    cutoff = datetime.now(timezone.utc) - timedelta(days=max(int(idle_days), 0))
+    now = datetime.now(timezone.utc)
+    idle_days_i = max(int(idle_days), 0)
+    cutoff = now - timedelta(days=idle_days_i)
+    epoch_candidates = [
+        _parse_ts(event.get("ts"))
+        for event in all_events
+        if event.get("kind") == "telemetry_epoch"
+    ]
+    epoch = min((ts for ts in epoch_candidates if ts is not None), default=None)
+    if epoch is None:
+        event_candidates = [_parse_ts(event.get("ts")) for event in all_events]
+        epoch = min((ts for ts in event_candidates if ts is not None), default=None)
+    if epoch is None and since_days is not None and _has_nonempty_log_path(cwd, base_dir=base_dir):
+        epoch = now - timedelta(days=max(int(since_days), 0))
+
+    observation_days: Optional[int] = None
+    observation_since: Optional[str] = None
+    if epoch is not None:
+        observation_days = max((now - epoch).days, 0)
+        observation_since = epoch.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
     for row in rows.values():
         parsed = _parse_ts(row.get("last_ts"))
-        row["reassessment_candidate"] = parsed is None or parsed < cutoff
+        if epoch is None:
+            status = "no_observation"
+        elif int(row.get("count") or 0) == 0 and (observation_days or 0) < idle_days_i:
+            status = "insufficient_observation"
+        else:
+            status = "observed"
+        row["observation_since"] = observation_since
+        row["observation_days"] = observation_days
+        row["observation_status"] = status
+        if parsed is not None:
+            row["reassessment_candidate"] = parsed < cutoff
+        else:
+            row["reassessment_candidate"] = (
+                status == "observed" and (observation_days or 0) >= idle_days_i
+            )
         row["sources"] = sorted(row["sources"])
-    return {"idle_days": idle_days, "guards": rows}
+    return {"idle_days": idle_days, "since_days": since_days, "guards": rows}
 
 
 def collect_eval_summary(
@@ -361,6 +435,7 @@ def collect_eval_summary(
                 "judge_chars": 0,
                 "avg_llm_turns": 0.0,
                 "avg_estimated_output_tokens": 0.0,
+                "failure_stages": {},
                 "last_ts": None,
                 "saturation_candidate": False,
             },
@@ -374,6 +449,11 @@ def collect_eval_summary(
         )
         row["report_chars"] += max(int(event.get("report_chars") or 0), 0)
         row["judge_chars"] += max(int(event.get("judge_chars") or 0), 0)
+        failure_stage = str(event.get("failure_stage") or "")
+        if failure_stage:
+            row["failure_stages"][failure_stage] = (
+                row["failure_stages"].get(failure_stage, 0) + 1
+            )
         ts = str(event.get("ts") or "")
         if ts and (row["last_ts"] is None or ts > row["last_ts"]):
             row["last_ts"] = ts
@@ -393,6 +473,7 @@ def collect_eval_summary(
     return {
         "saturation_days": saturation_days,
         "saturation_min_runs": saturation_min_runs,
+        "token_estimate_basis": OUTPUT_ESTIMATE_BASIS,
         "cases": rows,
     }
 
@@ -403,12 +484,22 @@ def format_telemetry_report(
 ) -> str:
     lines: list[str] = []
     idle_days = int(guard_summary.get("idle_days") or DEFAULT_IDLE_DAYS)
-    lines.append(f"[guard telemetry] guard hits — idle threshold: {idle_days}d")
+    guard_header = f"[guard telemetry] guard hits — idle threshold: {idle_days}d"
+    since_days = guard_summary.get("since_days")
+    if since_days is not None:
+        guard_header += f", scan window: {int(since_days)}d"
+    lines.append(guard_header)
     guards = guard_summary.get("guards") if isinstance(guard_summary, dict) else {}
     if isinstance(guards, dict) and guards:
         for guard, row_any in sorted(guards.items()):
             row = row_any if isinstance(row_any, dict) else {}
-            marker = "재평가 후보" if row.get("reassessment_candidate") else "active"
+            status = row.get("observation_status")
+            if status == "no_observation":
+                marker = "관측 없음"
+            elif status == "insufficient_observation":
+                marker = "관측 부족"
+            else:
+                marker = "재평가 후보" if row.get("reassessment_candidate") else "active"
             last = row.get("last_ts") or "-"
             count = int(row.get("count") or 0)
             lines.append(f"- {guard}: {count} hit(s), last={last}, {marker}")
@@ -421,6 +512,8 @@ def format_telemetry_report(
         lines.append(
             f"[guard telemetry] eval saturation — window: {saturation_days}d, min_runs={min_runs}"
         )
+        if eval_summary.get("token_estimate_basis"):
+            lines.append("[guard telemetry] 토큰 추정 하한 — UTF-8 bytes/4 기준")
         cases = eval_summary.get("cases") if isinstance(eval_summary, dict) else {}
         if isinstance(cases, dict) and cases:
             for case, row_any in sorted(cases.items()):
@@ -432,10 +525,16 @@ def format_telemetry_report(
                 avg_turns = float(row.get("avg_llm_turns") or 0.0)
                 avg_tokens = float(row.get("avg_estimated_output_tokens") or 0.0)
                 last = row.get("last_ts") or "-"
+                failures = row.get("failure_stages") if isinstance(row, dict) else {}
+                failure_note = ""
+                if isinstance(failures, dict) and failures:
+                    failure_note = ", failures=" + ",".join(
+                        f"{stage}:{count}" for stage, count in sorted(failures.items())
+                    )
                 lines.append(
                     f"- {case}: {passes}/{attempts} ({accuracy:.0%}), "
                     f"avg_turns={avg_turns:.1f}, avg_tokens≈{avg_tokens:.0f}, "
-                    f"last={last}, {marker}"
+                    f"last={last}, {marker}{failure_note}"
                 )
         else:
             lines.append("- no eval case telemetry events")
@@ -449,6 +548,8 @@ def _cli_record_hit(args: argparse.Namespace) -> int:
         category=args.category,
         detail=args.detail,
         source=args.source,
+        session_id=args.session_id,
+        run_id=args.run_id,
         cwd=Path(args.cwd) if args.cwd else None,
         base_dir=Path(args.base_dir) if args.base_dir else None,
     )
@@ -468,6 +569,9 @@ def _cli_record_eval(args: argparse.Namespace) -> int:
         report_chars=args.report_chars,
         judge_chars=args.judge_chars,
         estimated_output_tokens=args.estimated_output_tokens,
+        failure_stage=args.failure_stage or "",
+        failure_detail=args.failure_detail or "",
+        token_estimate_basis=args.token_estimate_basis or "",
         cwd=Path(args.cwd) if args.cwd else None,
         base_dir=Path(args.base_dir) if args.base_dir else None,
     )
@@ -477,7 +581,13 @@ def _cli_record_eval(args: argparse.Namespace) -> int:
 def _cli_report(args: argparse.Namespace) -> int:
     cwd = Path(args.cwd) if args.cwd else None
     base_dir = Path(args.base_dir) if args.base_dir else None
-    guard_summary = collect_guard_summary(cwd, base_dir=base_dir, idle_days=args.idle_days)
+    since_days = args.since_days if args.since_days and args.since_days > 0 else None
+    guard_summary = collect_guard_summary(
+        cwd,
+        base_dir=base_dir,
+        idle_days=args.idle_days,
+        since_days=since_days,
+    )
     eval_summary = collect_eval_summary(
         cwd,
         base_dir=base_dir,
@@ -500,6 +610,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_hit.add_argument("--category", default="block")
     p_hit.add_argument("--detail", default="")
     p_hit.add_argument("--source", default="git_hook")
+    p_hit.add_argument("--session-id", default="")
+    p_hit.add_argument("--run-id", default="")
     p_hit.add_argument("--cwd", default="")
     p_hit.add_argument("--base-dir", default="")
     p_hit.set_defaults(func=_cli_record_hit)
@@ -518,12 +630,16 @@ def _build_parser() -> argparse.ArgumentParser:
     p_eval.add_argument("--report-chars", type=int, default=None)
     p_eval.add_argument("--judge-chars", type=int, default=None)
     p_eval.add_argument("--estimated-output-tokens", type=int, default=None)
+    p_eval.add_argument("--failure-stage", default="")
+    p_eval.add_argument("--failure-detail", default="")
+    p_eval.add_argument("--token-estimate-basis", default="")
     p_eval.add_argument("--cwd", default="")
     p_eval.add_argument("--base-dir", default="")
     p_eval.set_defaults(func=_cli_record_eval)
 
     p_report = sub.add_parser("report", help="summarize guard hits and eval saturation")
     p_report.add_argument("--idle-days", type=int, default=DEFAULT_IDLE_DAYS)
+    p_report.add_argument("--since-days", type=int, default=DEFAULT_REPORT_SINCE_DAYS)
     p_report.add_argument("--saturation-days", type=int, default=DEFAULT_SATURATION_DAYS)
     p_report.add_argument("--saturation-min-runs", type=int, default=DEFAULT_SATURATION_MIN_RUNS)
     p_report.add_argument("--cwd", default="")

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3867,10 +3867,12 @@ def _cli_guard_telemetry(args: Any) -> int:
         format_telemetry_report,
     )
 
+    since_days = args.since_days if args.since_days and args.since_days > 0 else None
     guard_summary = collect_guard_summary(
         cwd=Path(args.cwd) if args.cwd else None,
         base_dir=Path(args.base_dir) if args.base_dir else None,
         idle_days=args.idle_days,
+        since_days=since_days,
     )
     eval_summary = collect_eval_summary(
         cwd=Path(args.cwd) if args.cwd else None,
@@ -4281,6 +4283,7 @@ def _build_arg_parser() -> Any:
         help="#875 guard hit / eval saturation telemetry summary",
     )
     p_gt.add_argument("--idle-days", type=int, default=30)
+    p_gt.add_argument("--since-days", type=int, default=90)
     p_gt.add_argument("--saturation-days", type=int, default=30)
     p_gt.add_argument("--saturation-min-runs", type=int, default=3)
     p_gt.add_argument("--cwd", default="")

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -22,6 +22,8 @@ allow() {
 
 # plugin root 를 PYTHONPATH 에 prepend — cross-project 시나리오 대응 (다른 wrapper 정합).
 export PYTHONPATH="${CLAUDE_PLUGIN_ROOT:-.}:${PYTHONPATH:-}"
+SESSION_ID="${DCNESS_SESSION_ID:-}"
+RUN_ID="${DCNESS_RUN_ID:-}"
 
 record_fail_open() {
   python3 -m harness.session_state hook-fail-open \
@@ -35,7 +37,9 @@ record_guard_hit() {
     --guard tdd-guard \
     --category "$1" \
     --detail "$2" \
-    --source plugin_hook >/dev/null 2>&1 || true
+    --source plugin_hook \
+    --session-id "$SESSION_ID" \
+    --run-id "$RUN_ID" >/dev/null 2>&1 || true
 }
 
 # 활성화 게이트 (#597 커밋3) — 미활성 프로젝트는 즉시 allow (no-op).
@@ -47,6 +51,18 @@ if [ -z "$INPUT" ]; then
   record_fail_open "payload_empty" "empty stdin; TDD enforcement skipped"
   allow
 fi
+PAYLOAD_SESSION_ID=$(python3 - "$INPUT" <<'PY'
+import json, sys
+try:
+    payload = json.loads(sys.argv[1])
+except Exception:
+    sys.exit(0)
+sid = payload.get("sessionId") or payload.get("session_id") or payload.get("sessionid")
+if isinstance(sid, str):
+    print(sid)
+PY
+)
+[ -n "$SESSION_ID" ] || SESSION_ID="$PAYLOAD_SESSION_ID"
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -57,7 +57,9 @@ record_guard_hit() {
     --guard git-commit-msg \
     --category "$1" \
     --detail "$2" \
-    --source git_hook >/dev/null 2>&1 || true
+    --source git_hook \
+    --session-id "${DCNESS_SESSION_ID:-}" \
+    --run-id "${DCNESS_RUN_ID:-}" >/dev/null 2>&1 || true
 }
 
 # 1. git-naming 검증 — TDD chain 폐기 (v0.2.16 — PreToolUse hook 으로 이전)

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -38,7 +38,9 @@ record_guard_hit() {
     --guard git-pre-commit \
     --category "$1" \
     --detail "$2" \
-    --source git_hook >/dev/null 2>&1 || true
+    --source git_hook \
+    --session-id "${DCNESS_SESSION_ID:-}" \
+    --run-id "${DCNESS_RUN_ID:-}" >/dev/null 2>&1 || true
 }
 
 current_branch=$(

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -58,7 +58,9 @@ record_guard_hit() {
     --guard git-pre-push \
     --category "$1" \
     --detail "$2" \
-    --source git_hook >/dev/null 2>&1 || true
+    --source git_hook \
+    --session-id "${DCNESS_SESSION_ID:-}" \
+    --run-id "${DCNESS_RUN_ID:-}" >/dev/null 2>&1 || true
 }
 
 SCRIPT_PATH=$(resolve_plugin_script)

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -242,6 +242,101 @@ class EvalsHarnessContractTests(unittest.TestCase):
             self.assertIn('"llm_turns":2', text)
             self.assertIn('"estimated_output_tokens"', text)
 
+    def test_runner_records_report_execution_failure(self) -> None:
+        """#904 — failed report LLM calls still count in eval telemetry."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            out_dir = tmp / "eval-output"
+            bin_dir.mkdir()
+            fake_claude = bin_dir / "claude"
+            fake_claude.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        "exit 42",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            env["EVAL_OUTPUT_DIR"] = str(out_dir)
+            env["EVAL_RUNS"] = "1"
+            result = subprocess.run(
+                ["bash", str(EVALS / "run.sh")],
+                cwd=str(ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            telemetry = sorted(out_dir.glob("guard-telemetry.jsonl"))
+            self.assertEqual(len(telemetry), 1)
+            text = telemetry[0].read_text(encoding="utf-8")
+            self.assertIn('"kind":"eval_case_result"', text)
+            self.assertIn('"passed":false', text)
+            self.assertIn('"failure_stage":"report"', text)
+            self.assertIn('"llm_turns":1', text)
+
+    def test_runner_records_judge_execution_failure(self) -> None:
+        """#904 — failed judge LLM calls leave report artifact and failed attempt."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            out_dir = tmp / "eval-output"
+            bin_dir.mkdir()
+            fake_claude = bin_dir / "claude"
+            fake_claude.write_text(
+                "\n".join(
+                    [
+                        "#!/usr/bin/env bash",
+                        "set -euo pipefail",
+                        "prompt=''",
+                        "while [ \"$#\" -gt 0 ]; do",
+                        "  case \"$1\" in",
+                        "    -p) shift; prompt=\"$1\" ;;",
+                        "  esac",
+                        "  shift || true",
+                        "done",
+                        "if printf '%s' \"$prompt\" | grep -q '\\[정답표\\]'; then",
+                        "  exit 43",
+                        "else",
+                        "  printf '한글 검수 보고\\n'",
+                        "fi",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+
+            env = os.environ.copy()
+            env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+            env["EVAL_OUTPUT_DIR"] = str(out_dir)
+            env["EVAL_RUNS"] = "1"
+            result = subprocess.run(
+                ["bash", str(EVALS / "run.sh")],
+                cwd=str(ROOT),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            self.assertGreaterEqual(len(sorted(out_dir.glob("*/run-1-report.md"))), 1)
+            telemetry = sorted(out_dir.glob("guard-telemetry.jsonl"))
+            self.assertEqual(len(telemetry), 1)
+            text = telemetry[0].read_text(encoding="utf-8")
+            self.assertIn('"failure_stage":"judge"', text)
+            self.assertIn('"llm_turns":2', text)
+            self.assertIn('"token_estimate_basis":"utf8_bytes/4_lower_bound"', text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -9,6 +9,7 @@ from tempfile import TemporaryDirectory
 
 from harness.guard_telemetry import read_events
 from harness.guard_telemetry import TELEMETRY_NAME
+from harness.session_state import generate_run_id, run_dir
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -141,6 +142,45 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
                     for e in events
                 ),
                 events,
+            )
+
+    def test_pre_push_branch_naming_records_run_context_when_available(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _git(root, "init")
+            run_id = generate_run_id()
+            env = _env(active=True)
+            env["DCNESS_SESSION_ID"] = "git-hook-telemetry-sid"
+            env["DCNESS_RUN_ID"] = run_id
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-push")],
+                input="refs/heads/BadBranch abc refs/heads/BadBranch def\n",
+                cwd=str(root),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            events = read_events(cwd=root)
+            self.assertTrue(
+                any(
+                    e.get("kind") == "guard_hit"
+                    and e.get("guard") == "git-pre-push"
+                    and e.get("category") == "branch_naming"
+                    and e.get("session_id") == "git-hook-telemetry-sid"
+                    and e.get("run_id") == run_id
+                    for e in events
+                ),
+                events,
+            )
+            self.assertTrue(
+                (
+                    run_dir("git-hook-telemetry-sid", run_id, base_dir=root / ".claude" / "harness-state")
+                    / TELEMETRY_NAME
+                ).is_file()
             )
 
     def test_inactive_pre_push_block_does_not_create_telemetry(self) -> None:

--- a/tests/test_guard_telemetry.py
+++ b/tests/test_guard_telemetry.py
@@ -1,12 +1,15 @@
 """guard telemetry append/read/summary contracts (#875)."""
 from __future__ import annotations
 
-import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import subprocess
 from tempfile import TemporaryDirectory
+import unittest
 
 from harness.guard_telemetry import (
     TELEMETRY_NAME,
+    append_event,
     collect_eval_summary,
     collect_guard_summary,
     format_telemetry_report,
@@ -38,10 +41,11 @@ class GuardTelemetryAppendTests(unittest.TestCase):
             self.assertTrue(target.is_file())
             self.assertEqual(target.stat().st_mode & 0o777, 0o600)
             events = read_events(base_dir=base)
-            self.assertEqual(len(events), 1)
-            self.assertEqual(events[0]["kind"], "guard_hit")
-            self.assertEqual(events[0]["guard"], "catastrophic-gate")
-            self.assertEqual(events[0]["category"], "order_gate")
+            self.assertEqual(len(events), 2)
+            self.assertEqual(events[0]["kind"], "telemetry_epoch")
+            self.assertEqual(events[1]["kind"], "guard_hit")
+            self.assertEqual(events[1]["guard"], "catastrophic-gate")
+            self.assertEqual(events[1]["category"], "order_gate")
 
     def test_guard_hit_without_run_falls_back_to_project_log(self) -> None:
         with TemporaryDirectory() as td:
@@ -56,12 +60,47 @@ class GuardTelemetryAppendTests(unittest.TestCase):
             target = root / ".claude" / "harness-state" / TELEMETRY_NAME
             self.assertTrue(target.is_file())
             events = read_events(cwd=root)
-            self.assertEqual(events[0]["guard"], "git-pre-commit")
-            self.assertEqual(events[0]["source"], "git_hook")
+            self.assertEqual(events[0]["kind"], "telemetry_epoch")
+            self.assertEqual(events[1]["guard"], "git-pre-commit")
+            self.assertEqual(events[1]["source"], "git_hook")
+
+    def test_cli_record_hit_accepts_run_context(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            rid = generate_run_id()
+
+            result = subprocess.run(
+                [
+                    "python3.11",
+                    "-m",
+                    "harness.guard_telemetry",
+                    "record-hit",
+                    "--guard",
+                    "tdd-guard",
+                    "--category",
+                    "bash_missing_test",
+                    "--session-id",
+                    SID,
+                    "--run-id",
+                    rid,
+                    "--base-dir",
+                    str(base),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            events = read_events(base_dir=base)
+            hit = [event for event in events if event.get("kind") == "guard_hit"][0]
+            self.assertEqual(hit["session_id"], SID)
+            self.assertEqual(hit["run_id"], rid)
+            self.assertTrue((run_dir(SID, rid, base_dir=base) / TELEMETRY_NAME).is_file())
 
 
 class GuardSummaryTests(unittest.TestCase):
-    def test_summary_includes_known_zero_hit_guards_as_candidates(self) -> None:
+    def test_summary_marks_no_log_as_observation_insufficient(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)
             summary = collect_guard_summary(
@@ -71,9 +110,57 @@ class GuardSummaryTests(unittest.TestCase):
             )
 
             self.assertEqual(summary["guards"]["catastrophic-gate"]["count"], 0)
-            self.assertTrue(
-                summary["guards"]["catastrophic-gate"]["reassessment_candidate"]
+            self.assertFalse(summary["guards"]["catastrophic-gate"]["reassessment_candidate"])
+            self.assertEqual(
+                summary["guards"]["catastrophic-gate"]["observation_status"],
+                "no_observation",
             )
+
+    def test_zero_hit_guard_needs_full_idle_window_before_reassessment(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            epoch = datetime.now(timezone.utc) - timedelta(days=10)
+            append_event(
+                {
+                    "kind": "telemetry_epoch",
+                    "ts": epoch.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                },
+                cwd=root,
+            )
+
+            summary = collect_guard_summary(
+                cwd=root,
+                known_guards=("catastrophic-gate",),
+                idle_days=30,
+            )
+
+            row = summary["guards"]["catastrophic-gate"]
+            self.assertEqual(row["count"], 0)
+            self.assertFalse(row["reassessment_candidate"])
+            self.assertEqual(row["observation_status"], "insufficient_observation")
+
+    def test_zero_hit_guard_after_idle_window_is_reassessment_candidate(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            epoch = datetime.now(timezone.utc) - timedelta(days=45)
+            append_event(
+                {
+                    "kind": "telemetry_epoch",
+                    "ts": epoch.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                },
+                cwd=root,
+            )
+
+            summary = collect_guard_summary(
+                cwd=root,
+                known_guards=("catastrophic-gate",),
+                idle_days=30,
+            )
+
+            row = summary["guards"]["catastrophic-gate"]
+            self.assertEqual(row["count"], 0)
+            self.assertTrue(row["reassessment_candidate"])
+            self.assertEqual(row["observation_status"], "observed")
 
     def test_recent_hit_is_not_reassessment_candidate(self) -> None:
         with TemporaryDirectory() as td:
@@ -89,6 +176,36 @@ class GuardSummaryTests(unittest.TestCase):
             row = summary["guards"]["file-guard"]
             self.assertEqual(row["count"], 1)
             self.assertFalse(row["reassessment_candidate"])
+            self.assertEqual(row["observation_status"], "observed")
+
+    def test_since_days_limits_guard_summary_window(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            old = datetime.now(timezone.utc) - timedelta(days=20)
+            append_event(
+                {
+                    "kind": "guard_hit",
+                    "guard": "file-guard",
+                    "category": "write_boundary",
+                    "source": "plugin_hook",
+                    "ts": old.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+                },
+                cwd=root,
+            )
+
+            summary = collect_guard_summary(
+                cwd=root,
+                known_guards=("file-guard",),
+                idle_days=30,
+                since_days=7,
+            )
+
+            self.assertEqual(summary["since_days"], 7)
+            self.assertEqual(summary["guards"]["file-guard"]["count"], 0)
+            self.assertEqual(
+                summary["guards"]["file-guard"]["observation_status"],
+                "insufficient_observation",
+            )
 
     def test_default_report_known_guards_exclude_self_only_pre_commit(self) -> None:
         with TemporaryDirectory() as td:
@@ -119,11 +236,31 @@ class EvalSummaryTests(unittest.TestCase):
             )
 
             events = read_events(cwd=root)
-            self.assertEqual(events[0]["kind"], "eval_case_result")
-            self.assertEqual(events[0]["case"], "headless-prose-quality")
-            self.assertTrue(events[0]["passed"])
-            self.assertEqual(events[0]["llm_turns"], 2)
-            self.assertEqual(events[0]["estimated_output_tokens"], 50)
+            event = [row for row in events if row.get("kind") == "eval_case_result"][0]
+            self.assertEqual(event["case"], "headless-prose-quality")
+            self.assertTrue(event["passed"])
+            self.assertEqual(event["llm_turns"], 2)
+            self.assertEqual(event["estimated_output_tokens"], 50)
+
+    def test_eval_case_failure_stage_counts_as_attempt(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            record_eval_case_result(
+                "headless-prose-quality",
+                passed=False,
+                cwd=root,
+                failure_stage="report",
+                failure_detail="claude exited 1",
+                llm_turns=1,
+            )
+
+            summary = collect_eval_summary(cwd=root, saturation_min_runs=1)
+
+            row = summary["cases"]["headless-prose-quality"]
+            self.assertEqual(row["attempts"], 1)
+            self.assertEqual(row["passes"], 0)
+            self.assertEqual(row["failure_stages"]["report"], 1)
+            self.assertFalse(row["saturation_candidate"])
 
     def test_all_pass_eval_case_is_saturation_candidate(self) -> None:
         with TemporaryDirectory() as td:
@@ -204,6 +341,7 @@ class ReportFormatTests(unittest.TestCase):
                     "categories": {},
                     "sources": [],
                     "reassessment_candidate": True,
+                    "observation_status": "observed",
                 }
             },
         }
@@ -221,8 +359,10 @@ class ReportFormatTests(unittest.TestCase):
                     "avg_estimated_output_tokens": 60.0,
                     "last_ts": "2026-07-04T00:00:00Z",
                     "saturation_candidate": True,
+                    "failure_stages": {},
                 }
             },
+            "token_estimate_basis": "utf8_bytes/4_lower_bound",
         }
 
         report = format_telemetry_report(guard_summary, eval_summary)
@@ -230,6 +370,28 @@ class ReportFormatTests(unittest.TestCase):
         self.assertIn("노후 후보", report)
         self.assertIn("avg_turns=2.0", report)
         self.assertIn("avg_tokens≈60", report)
+        self.assertIn("토큰 추정 하한", report)
+
+    def test_report_marks_observation_insufficient(self) -> None:
+        guard_summary = {
+            "idle_days": 30,
+            "since_days": 7,
+            "guards": {
+                "catastrophic-gate": {
+                    "count": 0,
+                    "last_ts": None,
+                    "categories": {},
+                    "sources": [],
+                    "reassessment_candidate": False,
+                    "observation_status": "insufficient_observation",
+                }
+            },
+        }
+
+        report = format_telemetry_report(guard_summary)
+
+        self.assertIn("scan window: 7d", report)
+        self.assertIn("관측 부족", report)
 
 
 if __name__ == "__main__":

--- a/tests/test_hook_wrapper_exit.py
+++ b/tests/test_hook_wrapper_exit.py
@@ -168,6 +168,82 @@ class FileGuardWrapperExitTests(unittest.TestCase):
             events,
         )
 
+    def test_infra_read_records_read_boundary(self) -> None:
+        result = _run_wrapper(
+            "file-guard.sh",
+            self._file_payload("Read", file_path="hooks/secret.sh"),
+            cwd=self.cwd,
+        )
+
+        self.assertEqual(result.returncode, 2, result.stderr + result.stdout)
+        events = read_events(base_dir=self.base)
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "file-guard"
+                and e.get("category") == "read_boundary"
+                for e in events
+            ),
+            events,
+        )
+
+    def test_bash_external_mutation_records_bash_mutation(self) -> None:
+        result = _run_wrapper(
+            "file-guard.sh",
+            self._file_payload("Bash", command="git push origin main"),
+            cwd=self.cwd,
+        )
+
+        self.assertEqual(result.returncode, 2, result.stderr + result.stdout)
+        events = read_events(base_dir=self.base)
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "file-guard"
+                and e.get("category") == "bash_mutation"
+                for e in events
+            ),
+            events,
+        )
+
+    def test_bash_write_target_records_bash_write_boundary(self) -> None:
+        result = _run_wrapper(
+            "file-guard.sh",
+            self._file_payload("Bash", command="printf x > hooks/evil.sh"),
+            cwd=self.cwd,
+        )
+
+        self.assertEqual(result.returncode, 2, result.stderr + result.stdout)
+        events = read_events(base_dir=self.base)
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "file-guard"
+                and e.get("category") == "bash_write_boundary"
+                for e in events
+            ),
+            events,
+        )
+
+    def test_github_mcp_mutation_records_mcp_mutation(self) -> None:
+        result = _run_wrapper(
+            "file-guard.sh",
+            self._file_payload("mcp__github__merge_pull_request"),
+            cwd=self.cwd,
+        )
+
+        self.assertEqual(result.returncode, 2, result.stderr + result.stdout)
+        events = read_events(base_dir=self.base)
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "file-guard"
+                and e.get("category") == "mcp_mutation"
+                for e in events
+            ),
+            events,
+        )
+
     def test_src_write_exits_0(self) -> None:
         # engineer 의 src/ Write 는 허용 → exit 0.
         result = _run_wrapper(

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -683,6 +683,25 @@ class TestBlockingSemantics(unittest.TestCase):
             events,
         )
 
+    def test_bash_missing_test_records_guard_hit(self):
+        """#904 — Bash write target 재귀 차단도 telemetry category 로 남긴다."""
+        command = "cat > src/biz_from_bash.ts <<'EOF'\nexport const x = 1;\nEOF\n"
+
+        result = run_bash_hook(command, self._tmp)
+
+        self.assertEqual(result.returncode, 2, result.stderr + result.stdout)
+        self.assertIn("TDD GUARD[Bash]", result.stderr)
+        events = read_events(cwd=Path(self._tmp))
+        self.assertTrue(
+            any(
+                e.get("kind") == "guard_hit"
+                and e.get("guard") == "tdd-guard"
+                and e.get("category") == "bash_missing_test"
+                for e in events
+            ),
+            events,
+        )
+
     def test_allow_exits_0(self):
         """매칭 테스트 존재 → exit 0 (allow)."""
         self._touch("src/biz.ts", "export const x = 1;\n")


### PR DESCRIPTION
## 관련 이슈 번호
Closes #904

## 배경 및 문제
- guard telemetry 후속 리뷰에서 도입 직후 무발화와 장기 무발화를 구분하지 못해 zero-hit guard가 즉시 재평가 후보로 보이는 문제가 있었다.
- report 집계는 기간 한정 스캔 옵션이 없었고, eval runner는 report/judge LLM 호출 실패를 telemetry 분모에 남기지 않았다.
- shell guard telemetry가 active run에 귀속될 수 있는 경로와 관련 테스트 coverage가 부족했다.

## 원인 (해당 시)
- telemetry log에 관측 시작 epoch가 없어 `last_ts=None`인 guard를 관측 부족이 아니라 idle 후보로만 해석했다.
- `record-hit` CLI가 `session_id`/`run_id`를 받지 않아 shell hook이 worker run context를 전달할 수 없었다.
- `evals/run.sh`가 LLM 호출 실패 시 `continue`만 수행해 실패 시도가 `eval_case_result`로 기록되지 않았다.

## 작업내용
- `guard_telemetry`에 `telemetry_epoch`, `--since-days` report window, `관측 없음`/`관측 부족`/`재평가 후보` 구분을 추가했다.
- `record-hit` CLI와 git/tdd shell hook 호출부에 `--session-id`/`--run-id` 전달을 추가해 가능한 경우 active run 로그에 귀속되게 했다.
- eval 실패 단계(`report`/`judge`)를 실패 이벤트로 기록하고 토큰 추정은 UTF-8 byte/4 하한 기준으로 바꿨다.
- pre-push, tdd Bash write target, file-guard read/bash/mcp category coverage와 관련 문서를 보강했다.

## 결정 근거
- 로그 로테이션 대신 report 기본 `--since-days 90` 기간 한정 스캔을 채택했다. 기존 JSONL과 하위 호환을 유지하면서 읽기 범위를 줄이고, 필요 시 `--since-days 0`으로 전체 이력을 볼 수 있다.
- 자동 비활성화 계약은 유지하고 report 표기만 바꿨다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in 본체 경로: `harness/guard_telemetry.py`, `harness/session_state.py`, `hooks/tdd-guard.sh`는 plug-in 업데이트로 사용자 환경에 도달한다.
- `/init-dcness` 복사 경로: `scripts/hooks/commit-msg`, `scripts/hooks/pre-push`는 기존 `commands/init-dcness.md` 복사 목록에 이미 포함되어 있어 deploy 스텝 추가는 필요 없다. 기존 활성 프로젝트는 `/init-dcness` 재실행 시 로컬 `.git/hooks/` shim이 갱신된다.
- dcness self 전용: `scripts/hooks/pre-commit`은 본 저장소 hook 체인용 변경이다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public surface 없음. 기존 `guard-telemetry` CLI 옵션과 telemetry event 필드 확장만 수행.

## Test Plan
- [x] `python3.11 -m unittest discover -s tests -v`
- [x] `sh scripts/check_python_tests.sh`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `python3.11 -m unittest tests.test_surface_docs_sync -v`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`

## 참고
- `bash evals/run.sh` 실제 LLM 행동 eval은 실행하지 않았다. 이번 변경은 runner 구조/기록 계약을 fake `claude` 기반 unit test로 검증했다.