### PR TITLE
[issue-902] 통합 drift 수정

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -29,7 +29,7 @@ Sense→Diagnose→Decide→Act→Verify 루프를 따른다. 새 CI 게이트�
 - Diagnose: 전용 도구로 활성 프로젝트의 가드 발화 이력과 재발·낭비 신호([#876](https://github.com/alruminum/dcNess/issues/876)), dcNess self eval 포화 후보를 함께 본다. 새 CI 게이트가 아니라 릴리즈 전 사람이 읽는 점검이다.
 
   ```sh
-  python3.11 scripts/loop_diagnose.py --idle-days 30 --saturation-days 30 --saturation-min-runs 3
+  python3.11 scripts/loop_diagnose.py --idle-days 30 --since-days 90 --saturation-days 30 --saturation-min-runs 3
   ```
 
   - 가드 발화 텔레메트리([#875](https://github.com/alruminum/dcNess/issues/875))가 있으면 통합 후보 표의 `guard:*` 후보를 검토한다.

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -16,7 +16,7 @@
 | 슬롯 | 질문 | 현재 담당 |
 |---|---|---|
 | Sense | 어떤 신호를 보나 | `/run-review`, benchmark/fleet 집계, `evals/guard_efficacy.py`, `evals/run.sh`, 가드 발화 텔레메트리 후보 [#875](https://github.com/alruminum/dcNess/issues/875), 재발·낭비 집계 후보 [#876](https://github.com/alruminum/dcNess/issues/876), judge 보정 후보 [#894](https://github.com/alruminum/dcNess/issues/894) |
-| Diagnose | 여러 신호를 어떻게 우선순위화하나 | `scripts/loop_diagnose.py`와 repo-local `/loop-diagnose` command가 전담한다. 활성 프로젝트 whitelist 를 읽어 cross-project 신호를 당겨오고, 수시 점검과 릴리즈 점검 양쪽에서 후보를 blocker, release-note follow-up, 별도 issue로 나눈다. |
+| Diagnose | 여러 신호를 어떻게 우선순위화하나 | `scripts/loop_diagnose.py`와 repo-local `/loop-diagnose` command가 전담한다. 활성 프로젝트 whitelist 를 읽어 cross-project 신호를 당겨오고, guard telemetry 는 `dcness-helper guard-telemetry` 와 같은 기본 90일 스캔창(`--since-days`)으로 본다. 수시 점검과 릴리즈 점검 양쪽에서 후보를 blocker, release-note follow-up, 별도 issue로 나눈다. |
 | Decide | 무엇을 바꾸나 | 추가 전 제거 검토를 먼저 한다. 새 룰·hook·CI를 추가하기 전에 기존 룰 삭제, 문구 축약, SSOT 파생 생성으로 같은 효과를 낼 수 있는지 확인한다. 첫 사례는 개수 하드코딩 제거 [#877](https://github.com/alruminum/dcNess/issues/877)이다. |
 | Act | 실제 변경은 어디서 하나 | 일반 dcNess 변경 절차대로 branch → PR → merge를 탄다. PR 본문에 Sense 근거, Diagnose 판단, Decide 이유, Verify 계획을 짧게 적는다. |
 | Verify | 개선이 먹혔는지 어떻게 보나 | 변경 성격별로 결정적 eval, 행동 eval, 다음 Sense 주기 재측정을 분리한다. |

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -235,7 +235,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
 
 활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
-git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 통과 뒤에만 수행한다. 비활성 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. dcness self repo 는 whitelist 없이 active 로 판정해 self 작업 중 발생한 `commit-msg` / `pre-push` 차단 신호를 보존한다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
+git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또는 dcness self repo 판정 통과 뒤에만 수행한다. 비활성 외부 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. dcness self repo 는 plugin hook 전체를 active 로 만들지 않고, self 작업 중 발생한 `commit-msg` / `pre-push` 차단 신호만 git hook shim 기록 지점에서 보존한다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
 
 ### .git/hooks/commit-msg
 

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -235,7 +235,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
 
 활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
-git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 통과 뒤에만 수행한다. 비활성 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
+git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 통과 뒤에만 수행한다. 비활성 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. dcness self repo 는 whitelist 없이 active 로 판정해 self 작업 중 발생한 `commit-msg` / `pre-push` 차단 신호를 보존한다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
 
 ### .git/hooks/commit-msg
 

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1738,7 +1738,6 @@ def is_project_active(cwd: Optional[Path] = None) -> bool:
 
     - 기본 disabled — whitelist 없거나 cwd 가 목록 밖이면 False
     - whitelist 경로의 서브디렉토리 (worktree 포함) 도 True (γ resolution 으로 main repo 추출)
-    - dcNess plugin 본체 repo 는 self git hook telemetry 보존을 위해 whitelist 없이 True
     - `DCNESS_FORCE_ENABLE=1` env 로 임시 활성 (디버깅)
     """
     if os.environ.get("DCNESS_FORCE_ENABLE") == "1":
@@ -1747,8 +1746,6 @@ def is_project_active(cwd: Optional[Path] = None) -> bool:
         project_root = _resolve_project_root(cwd).resolve()
     except OSError:
         return False
-    if _is_self_repo(project_root):
-        return True
     project_root_str = str(project_root)
     for entry in _load_whitelist():
         if project_root_str == entry or project_root_str.startswith(entry + os.sep):
@@ -3417,6 +3414,15 @@ def _cli_is_active(args: Any) -> int:
     return 0 if is_project_active() else 1
 
 
+def _cli_is_self(args: Any) -> int:
+    """현재 cwd 가 dcNess plugin 본체 repo 인지 여부 — self=exit 0, 아니면 1."""
+    try:
+        project_root = _resolve_project_root().resolve()
+    except OSError:
+        return 1
+    return 0 if _is_self_repo(project_root) else 1
+
+
 def _cli_hook_fail_open(args: Any) -> int:
     """hook wrapper 내부용 fail-open 이벤트 기록."""
     record_fail_open_event(
@@ -4267,6 +4273,9 @@ def _build_arg_parser() -> Any:
 
     p_ia = sub.add_parser("is-active", help="활성 여부 (silent, exit 0/1) — hook 게이트용")
     p_ia.set_defaults(func=_cli_is_active)
+
+    p_is = sub.add_parser("is-self", help="dcNess self repo 여부 (silent, exit 0/1)")
+    p_is.set_defaults(func=_cli_is_self)
 
     p_hfo = sub.add_parser(
         "hook-fail-open",

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1738,6 +1738,7 @@ def is_project_active(cwd: Optional[Path] = None) -> bool:
 
     - 기본 disabled — whitelist 없거나 cwd 가 목록 밖이면 False
     - whitelist 경로의 서브디렉토리 (worktree 포함) 도 True (γ resolution 으로 main repo 추출)
+    - dcNess plugin 본체 repo 는 self git hook telemetry 보존을 위해 whitelist 없이 True
     - `DCNESS_FORCE_ENABLE=1` env 로 임시 활성 (디버깅)
     """
     if os.environ.get("DCNESS_FORCE_ENABLE") == "1":
@@ -1746,6 +1747,8 @@ def is_project_active(cwd: Optional[Path] = None) -> bool:
         project_root = _resolve_project_root(cwd).resolve()
     except OSError:
         return False
+    if _is_self_repo(project_root):
+        return True
     project_root_str = str(project_root)
     for entry in _load_whitelist():
         if project_root_str == entry or project_root_str.startswith(entry + os.sep):

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -51,8 +51,13 @@ if [ -z "$PLUGIN_ROOT" ]; then
 fi
 
 record_guard_hit() {
-  PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.session_state is-active \
-    >/dev/null 2>&1 || return 0
+  if PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.session_state is-active >/dev/null 2>&1; then
+    :
+  elif PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.session_state is-self >/dev/null 2>&1; then
+    :
+  else
+    return 0
+  fi
   PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
     --guard git-commit-msg \
     --category "$1" \

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -52,8 +52,13 @@ resolve_dcness_root() {
 record_guard_hit() {
   root="$(resolve_dcness_root 2>/dev/null || true)"
   [ -n "$root" ] || return 0
-  PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.session_state is-active \
-    >/dev/null 2>&1 || return 0
+  if PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.session_state is-active >/dev/null 2>&1; then
+    :
+  elif PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.session_state is-self >/dev/null 2>&1; then
+    :
+  else
+    return 0
+  fi
   PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
     --guard git-pre-push \
     --category "$1" \

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -20,6 +20,7 @@ from harness import ledger  # noqa: E402
 from harness import run_review  # noqa: E402
 from harness.benchmark_aggregate import aggregate_sessions  # noqa: E402
 from harness.guard_telemetry import (  # noqa: E402
+    DEFAULT_REPORT_SINCE_DAYS,
     collect_eval_summary,
     collect_guard_summary,
     read_events,
@@ -167,10 +168,13 @@ def _guard_candidates(
     for guard, raw in sorted(guards.items()):
         row = raw if isinstance(raw, dict) else {}
         count = int(row.get("count") or 0)
-        if count <= 0 or not row.get("reassessment_candidate"):
+        if not row.get("reassessment_candidate"):
             continue
         last = row.get("last_ts") if isinstance(row.get("last_ts"), str) else None
         detail = f"{count} hit(s), last={last or '-'}"
+        observation_since = row.get("observation_since")
+        if count == 0 and isinstance(observation_since, str) and observation_since:
+            detail += f", observed_since={observation_since}"
         candidates.append(
             _candidate(
                 key=f"guard:{guard}@{project_name}",
@@ -231,10 +235,14 @@ def _waste_candidates(
 
 def _collect_project(path: Path, args: argparse.Namespace) -> dict[str, Any]:
     name = _project_name(path)
-    events = read_events(cwd=path)
+    events = read_events(cwd=path, since_days=args.since_days)
     sessions_root = path / ".claude" / "harness-state" / ".sessions"
     last_event_ts = _latest_project_ts(events, sessions_root)
-    guard_summary = collect_guard_summary(cwd=path, idle_days=args.idle_days)
+    guard_summary = collect_guard_summary(
+        cwd=path,
+        idle_days=args.idle_days,
+        since_days=args.since_days,
+    )
     fleet_report = aggregate_sessions(
         sessions_root,
         top=args.waste_top,
@@ -481,13 +489,22 @@ def _render_project(project: dict[str, Any]) -> list[str]:
     if isinstance(guards, dict):
         for guard, raw in sorted(guards.items()):
             row = raw if isinstance(raw, dict) else {}
-            status = "재평가 후보" if row.get("reassessment_candidate") else "active"
+            status = _guard_status_label(row)
             lines.append(
                 f"| {_md_cell(guard)} | {int(row.get('count') or 0)} | "
                 f"{_md_cell(row.get('last_ts') or '-')} | {status} |"
             )
     lines.append("")
     return lines
+
+
+def _guard_status_label(row: dict[str, Any]) -> str:
+    status = row.get("observation_status")
+    if status == "no_observation":
+        return "관측 없음"
+    if status == "insufficient_observation":
+        return "관측 부족"
+    return "재평가 후보" if row.get("reassessment_candidate") else "active"
 
 
 def render_markdown(payload: dict[str, Any]) -> str:
@@ -568,6 +585,7 @@ def _add_common_report_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--repo-root", default=str(Path.cwd()))
     parser.add_argument("--projects-file", default=_projects_file_default())
     parser.add_argument("--idle-days", type=int, default=30)
+    parser.add_argument("--since-days", type=int, default=DEFAULT_REPORT_SINCE_DAYS)
     parser.add_argument("--saturation-days", type=int, default=30)
     parser.add_argument("--saturation-min-runs", type=int, default=3)
     parser.add_argument("--waste-top", type=int, default=10)

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -1,6 +1,7 @@
 """git hook guard telemetry contracts (#875)."""
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import unittest
@@ -116,6 +117,39 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
                 (root / ".claude" / "harness-state" / TELEMETRY_NAME).exists()
             )
             self.assertEqual(read_events(cwd=root), [])
+
+    def test_self_repo_commit_msg_block_records_without_whitelist(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "dcness"
+            root.mkdir()
+            _git(root, "init")
+            manifest = root / ".claude-plugin" / "plugin.json"
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_text(json.dumps({"name": "dcness"}), encoding="utf-8")
+            msg = root / "COMMIT_EDITMSG"
+            msg.write_text("bad subject\n", encoding="utf-8")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "commit-msg"), str(msg)],
+                cwd=str(root),
+                env=_env(whitelist_path=base / "projects.json"),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            events = read_events(cwd=root)
+            self.assertTrue(
+                any(
+                    e.get("kind") == "guard_hit"
+                    and e.get("guard") == "git-commit-msg"
+                    and e.get("category") == "git_naming"
+                    for e in events
+                ),
+                events,
+            )
 
     def test_pre_push_main_block_records_guard_hit_when_active(self) -> None:
         with TemporaryDirectory() as td:

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -178,6 +178,38 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
                 events,
             )
 
+    def test_self_repo_pre_push_block_records_without_whitelist(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "dcness"
+            root.mkdir()
+            _git(root, "init")
+            manifest = root / ".claude-plugin" / "plugin.json"
+            manifest.parent.mkdir(parents=True, exist_ok=True)
+            manifest.write_text(json.dumps({"name": "dcness"}), encoding="utf-8")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-push")],
+                input="refs/heads/main abc refs/heads/main def\n",
+                cwd=str(root),
+                env=_env(whitelist_path=base / "projects.json"),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            events = read_events(cwd=root)
+            self.assertTrue(
+                any(
+                    e.get("kind") == "guard_hit"
+                    and e.get("guard") == "git-pre-push"
+                    and e.get("category") == "main_push_block"
+                    for e in events
+                ),
+                events,
+            )
+
     def test_pre_push_branch_naming_records_run_context_when_available(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,13 @@ def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
             f.write(json.dumps(row, ensure_ascii=False) + "\n")
 
 
+def _iso_days_ago(days: int) -> str:
+    return (
+        datetime.now(timezone.utc)
+        - timedelta(days=days)
+    ).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
 def _write_guard_hit(project: Path, guard: str = "file-guard") -> None:
     _write_jsonl(
         project / ".claude" / "harness-state" / "guard-telemetry.jsonl",
@@ -31,7 +39,20 @@ def _write_guard_hit(project: Path, guard: str = "file-guard") -> None:
                 "guard": guard,
                 "category": "write_boundary",
                 "source": "test",
-                "ts": "2026-01-01T00:00:00Z",
+                "ts": _iso_days_ago(45),
+            }
+        ],
+    )
+
+
+def _write_telemetry_epoch(project: Path, *, days_ago: int) -> None:
+    _write_jsonl(
+        project / ".claude" / "harness-state" / "guard-telemetry.jsonl",
+        [
+            {
+                "kind": "telemetry_epoch",
+                "source": "test",
+                "ts": _iso_days_ago(days_ago),
             }
         ],
     )
@@ -168,6 +189,86 @@ class LoopDiagnoseTests(unittest.TestCase):
             keys = {candidate["key"] for candidate in payload["candidates"]}
             self.assertIn("guard:file-guard@alpha", keys)
             self.assertIn("waste:RETRY_SAME_FAIL@alpha", keys)
+            self.assertEqual(payload["projects"][0]["guard_summary"]["since_days"], 90)
+
+    def test_zero_hit_guard_after_observation_window_is_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            old_observed = tmp / "old-observed"
+            new_observed = tmp / "new-observed"
+            old_observed.mkdir()
+            new_observed.mkdir()
+            _write_telemetry_epoch(old_observed, days_ago=45)
+            _write_telemetry_epoch(new_observed, days_ago=5)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps(
+                    {"version": 1, "projects": [str(old_observed), str(new_observed)]}
+                ),
+                encoding="utf-8",
+            )
+
+            result = self._run(repo_root, projects_file, "--json")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            keys = {candidate["key"] for candidate in payload["candidates"]}
+            self.assertIn("guard:file-guard@old-observed", keys)
+            self.assertNotIn("guard:file-guard@new-observed", keys)
+            old_summary = payload["projects"][0]["guard_summary"]["guards"]["file-guard"]
+            new_summary = payload["projects"][1]["guard_summary"]["guards"]["file-guard"]
+            self.assertEqual(old_summary["count"], 0)
+            self.assertEqual(old_summary["observation_status"], "observed")
+            self.assertTrue(old_summary["reassessment_candidate"])
+            self.assertEqual(
+                new_summary["observation_status"],
+                "insufficient_observation",
+            )
+            self.assertFalse(new_summary["reassessment_candidate"])
+
+            rendered = self._run(repo_root, projects_file)
+            self.assertEqual(rendered.returncode, 0, rendered.stderr)
+            self.assertIn("| file-guard | 0 | - | 재평가 후보 |", rendered.stdout)
+            self.assertIn("| file-guard | 0 | - | 관측 부족 |", rendered.stdout)
+
+    def test_since_days_limits_guard_summary_scan_window(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            alpha.mkdir()
+            _write_jsonl(
+                alpha / ".claude" / "harness-state" / "guard-telemetry.jsonl",
+                [
+                    {
+                        "kind": "guard_hit",
+                        "guard": "file-guard",
+                        "category": "write_boundary",
+                        "source": "test",
+                        "ts": _iso_days_ago(45),
+                    }
+                ],
+            )
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha)]}),
+                encoding="utf-8",
+            )
+
+            result = self._run(repo_root, projects_file, "--since-days", "7", "--json")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            summary = payload["projects"][0]["guard_summary"]
+            self.assertEqual(summary["since_days"], 7)
+            row = summary["guards"]["file-guard"]
+            self.assertEqual(row["count"], 0)
+            self.assertEqual(row["observation_status"], "insufficient_observation")
+            keys = {candidate["key"] for candidate in payload["candidates"]}
+            self.assertNotIn("guard:file-guard@alpha", keys)
 
     def test_decision_record_annotation_and_hide_decided(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -2016,9 +2016,10 @@ class ProjectActivationTests(unittest.TestCase):
         os.chdir(repo_b)
         self.assertFalse(is_project_active())
 
-    def test_dcness_self_repo_active_without_whitelist(self) -> None:
-        """dcNess plugin 본체 repo 는 self hook telemetry 보존을 위해 active 로 판정."""
-        from harness.session_state import is_project_active
+    def test_dcness_self_repo_is_not_globally_active_but_is_self(self) -> None:
+        """self repo 는 plugin hook 전체 active 가 아니며 is-self 로만 구분한다."""
+        from harness.session_state import _cli_is_self, is_project_active
+        from types import SimpleNamespace
         repo = Path(self._tmp.name) / "dcness"
         self._init_git_repo(repo)
         manifest = repo / ".claude-plugin" / "plugin.json"
@@ -2026,7 +2027,8 @@ class ProjectActivationTests(unittest.TestCase):
         manifest.write_text(json.dumps({"name": "dcness"}), encoding="utf-8")
         os.chdir(repo)
 
-        self.assertTrue(is_project_active())
+        self.assertFalse(is_project_active())
+        self.assertEqual(_cli_is_self(SimpleNamespace()), 0)
         self.assertFalse(self._whitelist_file.exists())
 
     def test_whitelist_corrupt_returns_empty(self) -> None:

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -2016,6 +2016,19 @@ class ProjectActivationTests(unittest.TestCase):
         os.chdir(repo_b)
         self.assertFalse(is_project_active())
 
+    def test_dcness_self_repo_active_without_whitelist(self) -> None:
+        """dcNess plugin 본체 repo 는 self hook telemetry 보존을 위해 active 로 판정."""
+        from harness.session_state import is_project_active
+        repo = Path(self._tmp.name) / "dcness"
+        self._init_git_repo(repo)
+        manifest = repo / ".claude-plugin" / "plugin.json"
+        manifest.parent.mkdir(parents=True, exist_ok=True)
+        manifest.write_text(json.dumps({"name": "dcness"}), encoding="utf-8")
+        os.chdir(repo)
+
+        self.assertTrue(is_project_active())
+        self.assertFalse(self._whitelist_file.exists())
+
     def test_whitelist_corrupt_returns_empty(self) -> None:
         """projects.json 파일 깨졌을 때 빈 리스트 반환 (silent)."""
         from harness.session_state import list_active_projects


### PR DESCRIPTION
## 관련 이슈 번호

Part of #902
Part of #903
Part of #904

## 배경 및 문제

PR #905 / #907 / #911이 순차 머지되며 통합 drift가 생겼습니다. Diagnose 도구가 #911의 관측 의미론과 기본 scan window를 반영하지 못했고, #907의 active gate 보완 과정에서 dcNess self git hook telemetry 범위를 좁혀 보존해야 했습니다.

## 원인 (해당 시)

- `scripts/loop_diagnose.py`가 `collect_guard_summary()`를 `since_days` 없이 호출하고, `count <= 0` guard 후보를 버려 충분히 관측한 0-hit 재평가 후보를 숨겼습니다.
- Diagnose markdown 렌더러가 `observation_status`를 보지 않고 `reassessment_candidate`만 이분법으로 표시했습니다.
- self git hook telemetry 보존을 `is_project_active()` 전역 확장으로 풀면 plugin hook 전체가 self repo에서 발화할 수 있으므로, 기록 지점에만 self 예외를 둬야 합니다.

## 작업내용

- Diagnose guard telemetry 기본 scan window를 `DEFAULT_REPORT_SINCE_DAYS`와 같은 90일로 맞추고 `--since-days` CLI를 추가했습니다.
- 충분히 관측한 0-hit guard도 `guard:*` 통합 후보로 올리고, `관측 없음` / `관측 부족` / `재평가 후보` 상태를 markdown guard 표에 반영했습니다.
- `is_project_active()`는 self repo를 계속 비활성으로 유지하고, `dcness-helper is-self` CLI를 추가했습니다.
- `scripts/hooks/commit-msg`와 `scripts/hooks/pre-push`의 telemetry 기록 게이트만 `is-active` 또는 `is-self` 통과로 좁혔습니다.
- 관련 회귀 테스트와 운영 문서를 갱신했습니다.

## 결정 근거

외부 비활성 프로젝트에서는 기존처럼 hook telemetry를 만들지 않고, dcNess self repo에서도 SessionStart / catastrophic-gate / file-guard / tdd-guard 등 plugin hook 전체를 active로 만들지 않습니다. self 신호 보존이 필요한 `commit-msg` / `pre-push` 기록 지점에만 `is-self` fallback을 둬 CLAUDE.md의 self repo 비활성 원칙과 git hook telemetry 목적을 분리했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in runtime: `harness/session_state.py`, `scripts/loop_diagnose.py`, `scripts/hooks/commit-msg`, `scripts/hooks/pre-push` 변경은 plugin update로 배포됩니다.
- git hook shim: 기존 활성 프로젝트는 `/init-dcness` 재실행 또는 hook 재설치 시 갱신된 shim을 받습니다. `harness.session_state is-self`는 plugin runtime 경로로 제공됩니다.
- docs/plugin SSOT: `docs/plugin/hooks.md`에 self repo 예외가 git hook telemetry 기록 지점에만 적용됨을 문서화했습니다.
- `/init-dcness` 복사 inventory 변경은 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate는 없습니다. `is-self`는 기존 `dcness-helper` 내부 hook 게이트용 silent subcommand입니다.

## Test Plan

- [x] python3.11 -m unittest discover -s tests -v
- [x] sh scripts/check_python_tests.sh
- [x] PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] node scripts/aggregate_index_map.mjs --check
- [x] node scripts/aggregate_architecture_map.mjs --check
- [x] python3.11 -m unittest tests.test_surface_docs_sync -v
- [x] sh -n scripts/hooks/commit-msg
- [x] sh -n scripts/hooks/pre-push
- [x] git diff --check

## 참고

통합 리뷰 지적 3건 대응. 결함 2는 추가 리뷰 반려 의견에 따라 전역 active 확장이 아니라 git hook telemetry 기록 지점 예외로 재작업했습니다. 머지는 하지 않고 PR 상태에서 대기합니다.
