### PR TITLE
[feature] 파일 경계 override 제안 트리거

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -58,6 +58,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 - Codex validator skill 배포
 - `CLAUDE.md` seed/migration 감사
 - Provider routing 상태 확인
+- 파일 경계 override 후보 확인
 - `dcness-helper status` 기준 FAIL 0
 선택형 확장은 core activation 성공 조건이 아니다. CI workflow, project docs seed, design seed, GitHub Project lifecycle, workflow 변경 PR 은 INFO/WARN 으로 남아도 core 성공 메시지를 흐리지 않는다.
 
@@ -126,14 +127,6 @@ echo "[dcness] .git/hooks/post-checkout 갱신 (thin shim -> plugin SSOT 호출)
 cp "$PLUGIN_ROOT/scripts/hooks/pre-push" "$PROJECT_ROOT/.git/hooks/pre-push"
 chmod +x "$PROJECT_ROOT/.git/hooks/pre-push"
 echo "[dcness] .git/hooks/pre-push 갱신 (thin shim -> plugin SSOT 호출)"
-if [ -f "$PROJECT_ROOT/scripts/check_git_naming.mjs" ]; then
-  echo "[dcness] NOTE - scripts/check_git_naming.mjs 가 사용자 repo 에 잔존. 이제 plugin SSOT 에서 호출하므로 제거 권장:"
-  echo "         git rm scripts/check_git_naming.mjs"
-fi
-if [ -f "$PROJECT_ROOT/docs/plugin/skill-guidelines.md" ]; then
-  echo "[dcness] NOTE - docs/plugin/skill-guidelines.md 가 사용자 repo 에 잔존. session-start.sh 가 이제 plugin SSOT 에서 read. 제거 권장:"
-  echo "         git rm docs/plugin/skill-guidelines.md"
-fi
 touch "$PROJECT_ROOT/.gitignore"
 grep -qxF '.claude/harness-state/' "$PROJECT_ROOT/.gitignore" || { printf '%s\n' '.claude/harness-state/' >> "$PROJECT_ROOT/.gitignore"; echo "[dcness] .gitignore 에 .claude/harness-state/ 추가"; }
 ```
@@ -166,7 +159,15 @@ done
 "$CONTEXT_DOCS" --ensure --repo "$PROJECT_ROOT"
 ```
 
-### Core Step 7 - 완료 선언
+### Core Step 7 - 파일 경계 override 후보 확인
+
+```bash
+"$HELPER" boundary-suggestions
+```
+
+비표준 소스 디렉터리 후보가 출력되면 사용자에게 보여주고 사람 승인 뒤에만 `.dcness/boundary.json` 을 작성한다. 표준 레이아웃 또는 빈 프로젝트는 no-op 이며, 이 step 은 파일을 쓰지 않는다.
+
+### Core Step 8 - 완료 선언
 
 core 작업 뒤 `status` 를 재실행한다. FAIL 이 0 이면 INFO·NA 행과 선택 WARN 이 남아도 즉시 완료를 먼저 출력한다.
 

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -131,6 +131,7 @@ PASS prose 판정은 `end-step` 저장 규칙과 같은 파일명을 본다. 즉
 - **`add`**: 코어 `ALLOW_MATRIX` 에 없는 경로를 그 agent 에 허용 (비표준 레이아웃 / 의도적 기본 제외 완화).
 - **`remove`**: 코어 기본 허용 경로를 이 프로젝트에서 제거 (ALLOW 보다 우선하는 DENY 오버레이).
 - **탐색**: `harness/agent_boundary.py` 가 cwd 에서 **working tree top-level(`git rev-parse --show-toplevel`)까지만** 조상을 거슬러 이 파일을 찾는다. nested·linked worktree 와 하위 디렉토리에서도 worktree 루트 설정이 적용되지만, 그 *위* 상위 워크스페이스·home 디렉토리의 `.dcness/boundary.json` 은 무시된다 (무관한 상위 설정이 경계를 약화하지 못하도록).
+- **제안 트리거**: `/init-dcness` 와 `/impl` 시작 시 `dcness-helper boundary-suggestions` 가 비표준 소스 디렉터리의 `engineer.add` 후보를 read-only 로 출력한다. 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이며, 실제 파일 작성은 사람 승인 뒤 메인이 수행한다.
 - **build-worker 전파**: 코어 `ALLOW_MATRIX["build-worker"]` 가 `engineer ∪ test-engineer` 합집합이듯, `engineer` / `test-engineer` 의 `add`·`remove` 는 `build-worker`(`/impl-loop` 의 실제 mutation agent)에도 합쳐 전파된다. 즉 `"engineer": {"remove": ["^app/"]}` 만 선언해도 build-worker 의 `app/` write 가 함께 막힌다 (별도 `build-worker` 키 불필요).
 - **안전 degrade**: 파일 부재·깨진 JSON·형식 위반·컴파일 불가 정규식은 조용히 무시하고 코어 기본값을 유지한다 (잘못된 설정이 경계를 깨뜨리지 않는다).
 - **배포**: 읽는 로직은 plugin 본체(`harness/`)라 plugin 버전업으로 자동 적용 (cp 0). 설정 파일은 프로젝트가 직접 작성한다.

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -21,6 +21,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 | local git hook | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | 항상 | always-overwrite | X |
 | runtime state ignore | `.gitignore` 의 `.claude/harness-state/` | `/init-dcness` append | 항상 | 없을 때만 추가 | X |
 | project context seed/migration | `CLAUDE.md` | `scripts/dcness-context-docs` / `harness/context_docs.py` | 항상 | 부재 시 생성. 기존 파일은 cold-start 앵커만 없을 때 append | X |
+| file boundary override suggestion | `.dcness/boundary.json` 후보만 | `dcness-helper boundary-suggestions` / `harness/boundary_suggestions.py` | 항상 | read-only. 사람 승인 전 작성 없음 | X |
 | Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite | X |
 | Codex provider routing 상태 확인 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing status` | 항상 확인 | read-only | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
@@ -49,6 +50,8 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 `dcness-helper status` 는 설치 상태뿐 아니라 최근 hook fail-open 활동도 `hook fail-open 진단` 항목으로 보여준다. 정상 inactive no-op 은 기록하지 않고, 활성 프로젝트에서 enforcement hook 이 검사를 평가하지 못하고 allow 한 경우만 최근 reason category 를 WARN 으로 노출한다. 자세한 정책은 [`hooks.md`](hooks.md) 가 SSOT 다.
 
 `CLAUDE.md` seed/migration 은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-context-docs`) 로 처리한다. 부재 시 Anthropic 공식 구조 기반 템플릿을 만들고, 기존 파일은 cold-start 앵커만 additive append 한다. 6축 quality audit 결과는 출력하지만 구조 개선·삭제·재배치는 후보만 제안한다.
+
+파일 경계 override 제안은 `dcness-helper boundary-suggestions` 로 처리한다. 코어 `ALLOW_MATRIX` 가 커버하지 않는 비표준 소스 디렉터리가 있을 때만 `.dcness/boundary.json` 의 `engineer.add` 후보를 출력하며, 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다. 이 helper 는 read-only 이므로 실제 boundary 파일 작성은 사람 승인 뒤 메인이 수행한다.
 
 `docs/index.md` 의 epic/module 표, 전역 `docs/architecture.md` 의 집계 섹션, 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
@@ -164,6 +167,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | plugin 본체 문서/skill/hook 만 갱신 | 아니오 | `claude plugin update dcness@dcness` 로 plug-in cache 가 갱신된다. |
 | plugin uninstall/reinstall | 예 | plugin data 디렉토리가 정리되어 whitelist 가 사라진다. |
 | `.git/hooks/*` thin shim 갱신 | 예 | 사용자 repo `.git/hooks/` 파일은 plugin update 만으로 바뀌지 않는다. |
+| 파일 경계 override 후보 재확인 | 아니오 | `/init-dcness` 와 `/impl` 시작 시 `dcness-helper boundary-suggestions` 가 read-only 로 다시 감지한다. |
 | `.claude/harness-state/` gitignore 보강 | 예 | runtime state ignore 는 사용자 repo `.gitignore` append 라서 `/init-dcness` 재실행 때 적용된다. |
 | `CLAUDE.md` seed/migration 로직 갱신 | 예 | 기존 활성 프로젝트의 root `CLAUDE.md` 생성·cold-start 앵커 append 는 `/init-dcness` 재실행 때 적용된다. |
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 또는 module docs 가 있는 프로젝트는 doc-sync 채택 직후 index/architecture 집계기를 1회 실행해야 한다. |

--- a/harness/boundary_suggestions.py
+++ b/harness/boundary_suggestions.py
@@ -1,0 +1,296 @@
+"""Suggest project boundary overrides for nonstandard source layouts.
+
+The suggestion path is deliberately read-only. `.dcness/boundary.json` changes
+must still be made by the main agent or a human after explicit approval.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess  # nosec B404
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+from harness.agent_boundary import check_write_allowed
+
+
+SOURCE_EXTENSIONS: frozenset[str] = frozenset(
+    {
+        ".c",
+        ".astro",
+        ".cc",
+        ".cjs",
+        ".clj",
+        ".cljs",
+        ".cpp",
+        ".cs",
+        ".dart",
+        ".erl",
+        ".ex",
+        ".exs",
+        ".fs",
+        ".fsx",
+        ".go",
+        ".h",
+        ".hpp",
+        ".hrl",
+        ".java",
+        ".js",
+        ".jsx",
+        ".kt",
+        ".kts",
+        ".lua",
+        ".m",
+        ".mm",
+        ".mjs",
+        ".php",
+        ".py",
+        ".pyi",
+        ".r",
+        ".rb",
+        ".rs",
+        ".scala",
+        ".svelte",
+        ".swift",
+        ".ts",
+        ".tsx",
+        ".vue",
+    }
+)
+
+IGNORED_DIR_PARTS: frozenset[str] = frozenset(
+    {
+        ".claude",
+        ".dcness",
+        ".git",
+        ".github",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "__tests__",
+        "build",
+        "coverage",
+        "dist",
+        "docs",
+        "node_modules",
+        "out",
+        "spec",
+        "target",
+        "test",
+        "tests",
+        "third_party",
+        "tmp",
+        "vendor",
+        "venv",
+    }
+)
+
+PARTIAL_STANDARD_TOP_LEVELS: frozenset[str] = frozenset({"apps", "packages"})
+MAX_EXAMPLES = 3
+
+
+@dataclass
+class BoundarySuggestion:
+    directory: str
+    pattern: str
+    file_count: int
+    examples: list[str]
+
+
+@dataclass
+class BoundarySuggestionReport:
+    project_root: str
+    scanned_files: int
+    uncovered_files: int
+    suggestions: list[BoundarySuggestion]
+    reason: str
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def _git_toplevel(cwd: Path) -> Optional[Path]:
+    try:
+        proc = subprocess.run(  # nosec B603, B607
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=str(cwd),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    out = proc.stdout.strip()
+    return Path(out).resolve() if out else None
+
+
+def _project_root(cwd: Optional[Path]) -> Path:
+    root = (cwd or Path.cwd()).resolve()
+    return _git_toplevel(root) or root
+
+
+def _is_dcness_self_repo(root: Path) -> bool:
+    manifest = root / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(data, dict) and data.get("name") == "dcness"
+
+
+def _ignored_by_directory(rel: Path) -> bool:
+    for part in rel.parts[:-1]:
+        if _should_skip_dir_name(part):
+            return True
+    return False
+
+
+def _should_skip_dir_name(name: str) -> bool:
+    return name in IGNORED_DIR_PARTS or name.startswith(".")
+
+
+def _is_test_like_file(path: Path) -> bool:
+    name = path.name.lower()
+    return bool(
+        name.startswith("test_")
+        or re.search(r"(^|[_\-.])test\.", name)
+        or re.search(r"(^|[_\-.])spec\.", name)
+        or name.endswith("_test.py")
+        or name.endswith("_test.go")
+        or name.endswith("_test.rb")
+        or name.endswith("_spec.rb")
+    )
+
+
+def _is_source_candidate(rel: Path) -> bool:
+    if rel.suffix.lower() not in SOURCE_EXTENSIONS:
+        return False
+    if len(rel.parts) < 2:
+        return False
+    if _ignored_by_directory(rel):
+        return False
+    return not _is_test_like_file(rel)
+
+
+def _iter_source_candidates(root: Path) -> Iterable[Path]:
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [name for name in dirnames if not _should_skip_dir_name(name)]
+        base = Path(dirpath)
+        for filename in filenames:
+            path = base / filename
+            try:
+                rel = path.relative_to(root)
+            except ValueError:
+                continue
+            if _is_source_candidate(rel):
+                yield rel
+
+
+def _pattern_for_directory(directory: str) -> str:
+    return "^" + "/".join(re.escape(part) for part in directory.rstrip("/").split("/")) + "/"
+
+
+def _group_uncovered(uncovered: list[Path]) -> list[BoundarySuggestion]:
+    grouped: dict[str, list[Path]] = {}
+    for rel in uncovered:
+        if len(rel.parts) < 2:
+            continue
+        directory = _suggestion_directory(rel)
+        grouped.setdefault(directory, []).append(rel)
+
+    suggestions: list[BoundarySuggestion] = []
+    for directory, paths in grouped.items():
+        examples = sorted(p.as_posix() for p in paths)[:MAX_EXAMPLES]
+        suggestions.append(
+            BoundarySuggestion(
+                directory=directory,
+                pattern=_pattern_for_directory(directory),
+                file_count=len(paths),
+                examples=examples,
+            )
+        )
+    return sorted(suggestions, key=lambda item: item.directory)
+
+
+def _suggestion_directory(rel: Path) -> str:
+    if rel.parts[0] in PARTIAL_STANDARD_TOP_LEVELS:
+        max_parts = 3 if len(rel.parts) >= 4 else 2
+        return "/".join(rel.parts[:max_parts]) + "/"
+    parent = rel.parent.as_posix()
+    return parent.rstrip("/") + "/"
+
+
+def collect_boundary_suggestions(cwd: Optional[Path] = None) -> BoundarySuggestionReport:
+    """Detect source directories not covered by the effective engineer boundary."""
+    root = _project_root(cwd)
+    if _is_dcness_self_repo(root):
+        return BoundarySuggestionReport(
+            project_root=str(root),
+            scanned_files=0,
+            uncovered_files=0,
+            suggestions=[],
+            reason="self_repo",
+        )
+
+    source_files = sorted(_iter_source_candidates(root), key=lambda p: p.as_posix())
+    uncovered: list[Path] = []
+    for rel in source_files:
+        reason = check_write_allowed("engineer", rel.as_posix(), cwd=root)
+        if reason is not None and "ALLOW_MATRIX" in reason:
+            uncovered.append(rel)
+
+    suggestions = _group_uncovered(uncovered)
+    if not source_files:
+        report_reason = "empty"
+    elif suggestions:
+        report_reason = "uncovered"
+    else:
+        report_reason = "covered"
+    return BoundarySuggestionReport(
+        project_root=str(root),
+        scanned_files=len(source_files),
+        uncovered_files=len(uncovered),
+        suggestions=suggestions,
+        reason=report_reason,
+    )
+
+
+def format_boundary_suggestions(report: BoundarySuggestionReport) -> str:
+    """Human-readable read-only suggestion output."""
+    if report.reason == "self_repo":
+        return "[dcness boundary] no-op - dcNess self repo 는 boundary override 제안 대상이 아닙니다."
+    if not report.suggestions:
+        detail = (
+            "소스 파일 없음"
+            if report.reason == "empty"
+            else "코어 ALLOW_MATRIX 또는 기존 .dcness/boundary.json 으로 모두 커버됨"
+        )
+        return f"[dcness boundary] no-op - {detail}."
+
+    add_patterns = [item.pattern for item in report.suggestions]
+    sample = {"engineer": {"add": add_patterns}}
+    lines = [
+        "[dcness boundary] 코어 ALLOW_MATRIX 미커버 소스 디렉터리 후보:",
+    ]
+    for item in report.suggestions:
+        examples = ", ".join(f"`{example}`" for example in item.examples)
+        lines.append(
+            f"- `{item.directory}` ({item.file_count} files) -> "
+            f"`{item.pattern}`; examples: {examples}"
+        )
+    lines.extend(
+        [
+            "",
+            "사람 승인 후에만 `.dcness/boundary.json` 에 add override 를 작성하세요.",
+            "build-worker 는 engineer add override 를 자동 상속합니다.",
+            "",
+            json.dumps(sample, ensure_ascii=False, indent=2),
+        ]
+    )
+    return "\n".join(lines)

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3868,6 +3868,21 @@ def _cli_status(args: Any) -> int:
     return 0
 
 
+def _cli_boundary_suggestions(args: Any) -> int:
+    """Read-only `.dcness/boundary.json` add override suggestion (#910)."""
+    from harness.boundary_suggestions import (
+        collect_boundary_suggestions,
+        format_boundary_suggestions,
+    )
+
+    report = collect_boundary_suggestions(Path(args.cwd) if args.cwd else None)
+    if args.json:
+        print(json.dumps(report.to_dict(), ensure_ascii=False))
+    else:
+        print(format_boundary_suggestions(report))
+    return 0
+
+
 def _cli_guard_telemetry(args: Any) -> int:
     """Guard hit / eval saturation summary (#875)."""
     from harness.guard_telemetry import (
@@ -4289,6 +4304,14 @@ def _build_arg_parser() -> Any:
 
     p_st = sub.add_parser("status", help="whitelist + 현재 cwd 상태")
     p_st.set_defaults(func=_cli_status)
+
+    p_bsug = sub.add_parser(
+        "boundary-suggestions",
+        help="#910 read-only: 비표준 소스 디렉터리 boundary override 후보 출력",
+    )
+    p_bsug.add_argument("--cwd", default="", help="검사할 프로젝트 cwd (기본 현재 cwd)")
+    p_bsug.add_argument("--json", action="store_true")
+    p_bsug.set_defaults(func=_cli_boundary_suggestions)
 
     p_gt = sub.add_parser(
         "guard-telemetry",

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -77,6 +77,16 @@ GitHub issue 등록이 목표인 요청이면 `/to-issue` 로 보내고, 수정/
 
 GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#issuelabel-status-lifecycle)에 따라 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 Project `Status=In progress` 도 best-effort 로 함께 미러된다.
 
+## Step 0.2 — 파일 경계 override 후보 확인
+
+구현 경로 판정 전에 한 번 실행한다.
+
+```bash
+"$HELPER" boundary-suggestions
+```
+
+코어 `ALLOW_MATRIX` 로 커버되지 않는 비표준 소스 디렉터리가 있으면 `.dcness/boundary.json` 의 `engineer.add` 후보만 출력한다. 후보가 있으면 사람 승인 후에만 메인이 boundary 파일을 작성한다. 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다.
+
 ## Step 0.4 — UI 기준 확보 분기
 
 UI 작업이면 구현 경로(Lite/Standard) 판정과 별도로 **UI 기준 확보 분기**를 먼저 판정한다. 목업은 무조건 만들지 않는다. 강제되는 불변식은 "신규 시각 구조 작업은 기대 고정 기준을 확보하고, 기준이 존재하면 구현까지 배선된다" 이다.

--- a/tests/test_boundary_suggestions.py
+++ b/tests/test_boundary_suggestions.py
@@ -1,0 +1,156 @@
+"""Boundary override suggestion tests for issue #910."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+from harness.boundary_suggestions import (  # noqa: E402
+    collect_boundary_suggestions,
+    format_boundary_suggestions,
+)
+
+
+class BoundarySuggestionsTests(unittest.TestCase):
+    @staticmethod
+    def _write(path: Path, text: str = "") -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    @staticmethod
+    def _write_boundary(root: Path, mapping: dict) -> None:
+        cfg = root / ".dcness" / "boundary.json"
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text(json.dumps(mapping), encoding="utf-8")
+
+    def test_empty_project_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            report = collect_boundary_suggestions(Path(td))
+            self.assertEqual([], report.suggestions)
+            self.assertEqual("empty", report.reason)
+
+    def test_standard_layout_is_noop(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(root / "src" / "app.ts", "export const x = 1\n")
+            self._write(root / "lib" / "core.py", "x = 1\n")
+            self._write(root / "apps" / "web" / "src" / "App.tsx", "export {}\n")
+
+            report = collect_boundary_suggestions(root)
+
+            self.assertEqual([], report.suggestions)
+            self.assertEqual("covered", report.reason)
+
+    def test_nonstandard_source_directory_suggests_engineer_add(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(root / "remotion" / "shorts-types.ts", "export {}\n")
+            self._write(root / "remotion" / "scene.tsx", "export {}\n")
+
+            report = collect_boundary_suggestions(root)
+
+            self.assertEqual(1, len(report.suggestions))
+            suggestion = report.suggestions[0]
+            self.assertEqual("remotion/", suggestion.directory)
+            self.assertEqual(r"^remotion/", suggestion.pattern)
+            self.assertEqual(2, suggestion.file_count)
+            self.assertEqual(
+                ["remotion/scene.tsx", "remotion/shorts-types.ts"],
+                suggestion.examples,
+            )
+
+            formatted = format_boundary_suggestions(report)
+            self.assertIn(".dcness/boundary.json", formatted)
+            self.assertIn("사람 승인", formatted)
+            self.assertIn('"engineer"', formatted)
+            self.assertIn(r'"^remotion/"', formatted)
+            self.assertFalse((root / ".dcness" / "boundary.json").exists())
+
+    def test_nonstandard_frontend_extension_is_detected(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(root / "components" / "Button.vue", "<template />\n")
+
+            report = collect_boundary_suggestions(root)
+
+            self.assertEqual(1, len(report.suggestions))
+            self.assertEqual("components/", report.suggestions[0].directory)
+            self.assertEqual(r"^components/", report.suggestions[0].pattern)
+
+    def test_partial_standard_top_level_keeps_suggestions_narrow(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(root / "apps" / "web" / "components" / "Button.tsx", "export {}\n")
+            self._write(root / "apps" / "api" / "server" / "main.go", "package main\n")
+
+            report = collect_boundary_suggestions(root)
+
+            self.assertEqual(
+                [r"^apps/api/server/", r"^apps/web/components/"],
+                [item.pattern for item in report.suggestions],
+            )
+            self.assertNotIn(r"^apps/", [item.pattern for item in report.suggestions])
+
+    def test_existing_boundary_override_suppresses_suggestion(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(root / "remotion" / "scene.tsx", "export {}\n")
+            self._write_boundary(root, {"engineer": {"add": [r"^remotion/"]}})
+
+            report = collect_boundary_suggestions(root)
+
+            self.assertEqual([], report.suggestions)
+            self.assertEqual("covered", report.reason)
+
+    def test_ignores_tests_docs_dependencies_and_build_outputs(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            for rel in (
+                "tests/test_app.py",
+                "docs/snippet.ts",
+                "node_modules/pkg/src/index.ts",
+                "dist/generated.js",
+                ".venv/lib/python/site-packages/pkg.py",
+            ):
+                self._write(root / rel, "x = 1\n")
+
+            report = collect_boundary_suggestions(root)
+
+            self.assertEqual([], report.suggestions)
+            self.assertEqual("empty", report.reason)
+
+    def test_helper_cli_outputs_json(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._write(root / "remotion" / "scene.tsx", "export {}\n")
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "harness.session_state",
+                    "boundary-suggestions",
+                    "--cwd",
+                    str(root),
+                    "--json",
+                ],
+                cwd=str(REPO_ROOT),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(proc.stdout)
+
+            self.assertEqual("uncovered", payload["reason"])
+            self.assertEqual(r"^remotion/", payload["suggestions"][0]["pattern"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -738,6 +738,16 @@ class SurfaceDocsSyncTests(unittest.TestCase):
                 self.assertIn(".claude/harness-state/", text)
                 self.assertIn(".gitignore", text)
 
+    def test_issue_910_boundary_suggestion_trigger_is_documented(self) -> None:
+        """#910 — init/impl start suggests boundary override without writing it."""
+        for text in (self.init_doc, self.impl_skill, self.init_reference, self.hooks_doc):
+            with self.subTest(source=text[:30]):
+                self.assertIn("boundary-suggestions", text)
+                self.assertIn(".dcness/boundary.json", text)
+                self.assertIn("사람 승인", text)
+        self.assertIn("read-only", self.init_reference)
+        self.assertIn("표준 레이아웃·빈 프로젝트", self.impl_skill)
+
     def test_issue_885_claude_md_seed_and_audit_stays_inside_existing_surfaces(self) -> None:
         """#885 — CLAUDE.md seed/migration and audit wire into init/run-review only."""
         helper = "scripts/dcness-context-docs"


### PR DESCRIPTION
## 관련 이슈 번호

Closes #910

## 배경 및 문제

- `/init-dcness` 와 `/impl` 시작 시 표준 레이아웃 밖의 소스 디렉터리를 발견해도 `.dcness/boundary.json` override 후보를 안내하는 read-only 트리거가 없었습니다.
- 이로 인해 Remotion, Electron, SvelteKit 같은 비표준 레이아웃 프로젝트에서 engineer write boundary가 막힌 뒤에야 수동 진단해야 했습니다.

## 원인 (해당 시)

-

## 작업내용

- `harness/boundary_suggestions.py` 를 추가해 프로젝트 소스 파일을 스캔하고 core `ALLOW_MATRIX` 와 기존 `.dcness/boundary.json` 으로 이미 허용되지 않은 top-level 소스 디렉터리만 후보로 출력합니다.
- `dcness-helper boundary-suggestions` CLI를 추가하고 `/init-dcness`, `/impl` 시작 절차에 연결했습니다.
- 후보 출력은 `.dcness/boundary.json` 예시만 제시하며 실제 파일 생성/수정은 사람 승인 후에만 수행하도록 문서화했습니다.
- 표준/빈 프로젝트, dcNess self repo, 이미 override가 있는 프로젝트, tests/docs/dependencies/build output은 no-op 또는 제외되도록 회귀 테스트를 추가했습니다.

## 결정 근거

- core `ALLOW_MATRIX` 를 넓히지 않고 프로젝트별 `.dcness/boundary.json` override만 제안해야 한다는 #910 범위를 따랐습니다.
- runtime enforcement 변경 없이 시작 절차의 read-only 안내 단계로만 두어 기존 boundary 판정 경로를 건드리지 않았습니다.

## 배포 경로 검증 (plug-in 영향 시)

- plugin body 영향: `harness/**`, `commands/init-dcness.md`, `skills/impl/SKILL.md`, `docs/plugin/**`.
- `/init-dcness` 와 `/impl` 본문은 plugin update 후 활성 프로젝트에서 새 시작 단계로 배포됩니다.
- `.dcness/boundary.json` 은 활성 프로젝트 로컬 파일이며, helper는 후보만 출력하고 사람 승인 전에는 생성/수정하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 사용자-facing skill/command/agent/gate는 추가하지 않았습니다. 내부 helper subcommand만 추가했습니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv-910/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `python3 evals/guard_efficacy.py`
- [x] pre-commit hook pytest gate during `git commit`

## 참고

- `scripts/dcness-helper boundary-suggestions` on dcNess self repo: no-op 확인