### PR TITLE
[feature] 생성형 TDD hook 계약 추가

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -33,7 +33,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - `docs/*`, `docs/design-variants/*`: 부재 시만 seed. 단 기존 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 섹션은 없을 때만 append.
 - Codex validator skills: `$CODEX_HOME/skills/dcness-*` always-overwrite.
 - Codex provider routing: core 에서는 상태만 확인하고, 선택형 확장에서 validation opt-in 과 implementation 기본값을 갱신.
-- CC hook / TDD Guard: 사용자 repo 파일 설치 없음. 활성화 후 plug-in hook 으로 자동 발화.
+- TDD Guard: dcNess 가 **TDD 계약 + self-test** 를 소유한다. 프로젝트가 비어 있지 않으면 플랫폼 감지 후 project-local CC/Codex hook 생성을 제안하고, 생성 후보는 self-test 통과 전에는 등록하지 않는다. 생성 훅이 없으면 중앙 plug-in hook 이 안전 fallback 으로 동작한다.
 
 ## 공통 변수
 이후 절차에서 반복 사용한다.
@@ -49,18 +49,7 @@ CONTEXT_DOCS="$PLUGIN_ROOT/scripts/dcness-context-docs"
 
 ## Core Activation
 
-core activation 의 성공 기준은 다음 항목까지다.
-
-- whitelist 활성화
-- `~/.claude/settings.json` Read 권한
-- git hook shim 3종 설치
-- runtime state `.gitignore` 보장
-- Codex validator skill 배포
-- `CLAUDE.md` seed/migration 감사
-- Provider routing 상태 확인
-- 파일 경계 override 후보 확인
-- `dcness-helper status` 기준 FAIL 0
-선택형 확장은 core activation 성공 조건이 아니다. CI workflow, project docs seed, design seed, GitHub Project lifecycle, workflow 변경 PR 은 INFO/WARN 으로 남아도 core 성공 메시지를 흐리지 않는다.
+core activation 의 성공 기준은 whitelist, Read 권한, git hook shim, runtime ignore, Codex validator skills, `CLAUDE.md` 감사, provider routing, 파일 경계 후보, Generated TDD hook 상태, `dcness-helper status` FAIL 0 까지다. 선택형 확장은 core activation 성공 조건이 아니다. CI workflow, project docs seed, design seed, GitHub Project lifecycle, workflow 변경 PR 은 INFO/WARN 으로 남아도 core 성공 메시지를 흐리지 않는다.
 
 ### Core Step 1 - 상태 진단
 
@@ -78,6 +67,7 @@ core activation 의 성공 기준은 다음 항목까지다.
 - `Codex validator skills` FAIL → Core Step 5 재실행.
 - `CLAUDE.md` 부재 또는 cold-start 앵커 부재 → Core Step 6.
 - `Provider routing` 은 INFO 로 상태만 확인한다. validation 이 이미 enabled 면 다시 쓰지 않고, implementation 은 custom 선택 때만 명시 변경한다.
+- `Generated TDD hooks` 는 INFO/WARN 이다. 빈 프로젝트는 skip 하고, 미생성 non-empty 프로젝트는 아래 Core Step 7.5 의 역제안으로 처리한다.
 - `선택형 CI workflow` 는 INFO 다. core activation 성공/실패 판정에 넣지 않는다.
 
 ### Core Step 2 - 활성화
@@ -167,6 +157,12 @@ done
 
 비표준 소스 디렉터리 후보가 출력되면 사용자에게 보여주고 사람 승인 뒤에만 `.dcness/boundary.json` 을 작성한다. 표준 레이아웃 또는 빈 프로젝트는 no-op 이며, 이 step 은 파일을 쓰지 않는다.
 
+### Core Step 7.5 - generated TDD hook 역제안
+
+`"$PLUGIN_ROOT/scripts/dcness-tdd-hooks" status --project-root "$PROJECT_ROOT"` 로 상태를 본다. 지원 플랫폼에서 hook 이 없으면 사용자 승인 뒤 `ensure --targets cc,codex` 를 실행한다.
+
+순서는 고정: **TDD 계약 + self-test** → **CC hook self-test/등록** → **Codex hook self-test/등록**. 빈 프로젝트/미지원/실패는 no-op 이며 상세는 [`docs/plugin/init-dcness.md`](../docs/plugin/init-dcness.md) 와 [`hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh) 를 따른다.
+
 ### Core Step 8 - 완료 선언
 
 core 작업 뒤 `status` 를 재실행한다. FAIL 이 0 이면 INFO·NA 행과 선택 WARN 이 남아도 즉시 완료를 먼저 출력한다.
@@ -182,7 +178,7 @@ core 작업 뒤 `status` 를 재실행한다. FAIL 이 0 이면 INFO·NA 행과 
 
 다음 세션부터 자동 적용:
 - SessionStart / PreToolUse / PostToolUse / SubagentStop / Stop hook
-- TDD Guard 는 사용자 설정 없이 plug-in hook 으로 자동 발화
+- TDD Guard 는 생성된 project-local hook 이 있으면 그 계약으로, 없으면 중앙 fallback 으로 동작
 
 기본 workflow:
 - /spec — PRD / Epic / Story / AC 정의
@@ -320,7 +316,7 @@ done
 
 #### workflow 변경 PR
 
-자동 PR 대상은 `/init-dcness` 가 배포한 `.github/workflows/*.yml` 변경만이다. TDD Guard 는 자동 hook 이라 사용자 repo 파일 변경이 없고, docs/design seed 는 사용자 콘텐츠라 자동 infra PR 에 섞지 않는다.
+자동 PR 대상은 `/init-dcness` 가 배포한 `.github/workflows/*.yml` 변경만이다. Generated TDD hook 은 사용자 repo 의 `.dcness/`, `.claude/`, `.codex/` 에 project-local 파일을 쓸 수 있지만 activation bootstrap 산출물이라 자동 workflow PR 대상은 아니다. docs/design seed 는 사용자 콘텐츠라 자동 infra PR 에 섞지 않는다.
 
 ```bash
 cd "$PROJECT_ROOT"

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -30,7 +30,7 @@ dcNess 의 강제 영역은 두 가지뿐이다.
 | `session-start.sh` | `SessionStart` | 새 세션, resume, `/clear` 직후 | sid/live state 초기화 + 활성 안내 inject | X |
 | `catastrophic-gate.sh` | `PreToolUse / Agent` | sub-agent 호출 직전 | 작업 순서 보호 + 진행 순서 검사 | O |
 | `file-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit|Read|Bash|mcp__.*` | file/bash/MCP tool 호출 직전 | agent 별 파일 경계 + 외부 변경 차단 목록 검사 | O |
-| `tdd-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit|Bash` | 파일 수정 직전 | TS/JS 구현 파일에 매칭 test 존재 확인 | O |
+| `tdd-guard.sh` | `PreToolUse / Edit|Write|NotebookEdit|Bash` | 파일 수정 직전 | project-local generated TDD hook 우선 실행, 없으면 TS/JS fallback 으로 매칭 test 존재 확인 | O |
 | `post-agent-clear.sh` | `PostToolUse / Agent` | sub-agent 호출 직후 | active agent clear, prose 자동 staging, histogram inject | X |
 | `post-file-op-trace.sh` | `PostToolUse / Edit|Write|NotebookEdit|Read|Bash|mcp__.*` | file/bash/MCP tool 호출 직후 | agent trace append | X |
 | `subagent-stop-clear.sh` | `SubagentStop` | sub-agent 컨텍스트 종료 직후 | active agent clear 보강 | X |
@@ -159,9 +159,17 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. `Bash` 는 명시적 write target 추출 직후, 각 target 에 같은 검사를 적용한다. Codex/headless 구현 worker 는 Codex 성공 종료 후 `end-step` 저장 전에 변경 파일 목록에 같은 검사를 적용한다.
 
-**지원 언어**: TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`). 그 외 확장자는 silent skip — Python·Rust·Go 등 다른 ecosystem 의 TDD 강제는 현재 범위 밖이다.
+**우선순위**: 프로젝트에 generated TDD hook 이 있으면 중앙 plug-in `tdd-guard.sh` 는 먼저 `.claude/hooks/dcness-tdd-guard.sh` 를 실행한다. 이 generated hook 은 `/init-dcness` 가 플랫폼 감지 후 만든 project-local 파일이며, 등록 전에 dcNess 소유 **TDD 계약**과 **self-test** 를 통과해야 한다. generated hook 이 없을 때만 중앙 TS/JS fallback 이 돈다.
 
-**역할**: 위 TS/JS 구현 파일에 대응하는 test/spec 파일이 *존재하는지* 확인한다. 없으면 구현 파일 작성을 막는다. **test 의 존재만 검사하고, test 를 실행하지는 않는다** — green/red 판정이 아니라 "작성 전 test 가 먼저 있는가" 강제다.
+**TDD 계약 + self-test**: 계약은 생성물과 독립이다. `scripts/dcness-tdd-hooks self-test` 는 fixture 로 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 재현한다. `/init-dcness` 의 `scripts/dcness-tdd-hooks ensure --targets cc,codex` 는 이 계약 self-test 를 먼저 실행하고, 통과한 후보만 hook 으로 등록한다.
+
+**지원 플랫폼**: generated hook 은 프로젝트 감지 결과(android/iOS/web/backend 등)를 기준으로 project-local config(`.dcness/tdd-hooks.json`)를 만든다. 빈 프로젝트 또는 미지원 플랫폼은 생성 skip 이며 안전 no-op 이다. 중앙 fallback 은 기존 호환을 위해 TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 검사한다. 그 외 확장자는 generated hook 이 없으면 silent skip 이다.
+
+**생성/등록 순서**: CC hook 이 먼저다. `.claude/hooks/dcness-tdd-guard.sh` 후보가 self-test 를 통과해야 `.claude/settings.json` PreToolUse(`Edit|Write|NotebookEdit|Bash`) 에 등록된다. Codex hook 은 그 다음 같은 패턴으로 `.codex/hooks/dcness-tdd-guard.sh` 와 `.codex/hooks.json` PreToolUse(`Edit|Write|apply_patch`) 에 등록된다. Codex 쪽은 CLI 의 사용자 신뢰 승인(`~/.codex/config.toml` trusted hash 흐름)이 추가로 필요할 수 있다.
+
+**공존 규칙**: generated hook 이 있으면 중앙 hook 은 위임 후 종료한다. 따라서 TS/JS 프로젝트에서도 중앙 fallback 과 project-local hook 이 같은 파일을 이중 deny 하지 않는다. generated hook 이 실패하거나 self-test 를 통과하지 못한 후보는 등록되지 않으며, 미설정·생성 실패 시 no-op 으로 안전 통과한다.
+
+**중앙 fallback 역할**: generated hook 이 없는 프로젝트에서는 TS/JS 구현 파일에 대응하는 test/spec 파일이 *존재하는지* 확인한다. 없으면 구현 파일 작성을 막는다. **test 의 존재만 검사하고, test 를 실행하지는 않는다** — green/red 판정이 아니라 "작성 전 test 가 먼저 있는가" 강제다.
 
 **skip 대상**:
 
@@ -179,7 +187,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **Bash write target 정책**: `Bash` payload 는 [`harness.agent_boundary.extract_bash_paths`](../../harness/agent_boundary.py) 가 추출하는 명시적 write target 에 한해 검사한다. 예: redirect(`>`, `>>`), `tee`, in-place edit(`sed/perl/awk -i`), `cp`/`mv`/`rm` target. 추출된 target 이 TS/JS 구현 파일이면 직접 `Edit`/`Write`/`NotebookEdit` 와 동일한 skip 규칙 및 6-tier matching-test 존재 검사를 탄다. write target 이 없거나 TS/JS 구현 파일이 아니면 silent skip 한다.
 
-**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 와 [`scripts/dcness-claude-worker`](../../scripts/dcness-claude-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
+**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 와 [`scripts/dcness-claude-worker`](../../scripts/dcness-claude-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. 중앙 `tdd-guard.sh` 가 generated hook 을 위임하므로 headless lane 도 non-TS/JS 플랫폼에서 같은 project-local **TDD 계약**을 재사용한다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
 
 **차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다. Headless worker 차단 메시지는 `[dcness-codex-worker] BLOCKED: TDD GUARD ...` 또는 `[dcness-claude-worker] BLOCKED: TDD GUARD ...` 로 시작하고 위반 파일 목록을 포함한다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -22,6 +22,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 | runtime state ignore | `.gitignore` 의 `.claude/harness-state/` | `/init-dcness` append | 항상 | 없을 때만 추가 | X |
 | project context seed/migration | `CLAUDE.md` | `scripts/dcness-context-docs` / `harness/context_docs.py` | 항상 | 부재 시 생성. 기존 파일은 cold-start 앵커만 없을 때 append | X |
 | file boundary override suggestion | `.dcness/boundary.json` 후보만 | `dcness-helper boundary-suggestions` / `harness/boundary_suggestions.py` | 항상 | read-only. 사람 승인 전 작성 없음 | X |
+| generated TDD hook 제안/생성 | `.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh` | `scripts/dcness-tdd-hooks` | 플랫폼 감지 + 사용자 승인 시 | self-test 통과 후보만 등록. CC 검증 후 Codex 생성 | X |
 | Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite | X |
 | Codex provider routing 상태 확인 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing status` | 항상 확인 | read-only | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
@@ -52,6 +53,8 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 `CLAUDE.md` seed/migration 은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-context-docs`) 로 처리한다. 부재 시 Anthropic 공식 구조 기반 템플릿을 만들고, 기존 파일은 cold-start 앵커만 additive append 한다. 6축 quality audit 결과는 출력하지만 구조 개선·삭제·재배치는 후보만 제안한다.
 
 파일 경계 override 제안은 `dcness-helper boundary-suggestions` 로 처리한다. 코어 `ALLOW_MATRIX` 가 커버하지 않는 비표준 소스 디렉터리가 있을 때만 `.dcness/boundary.json` 의 `engineer.add` 후보를 출력하며, 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다. 이 helper 는 read-only 이므로 실제 boundary 파일 작성은 사람 승인 뒤 메인이 수행한다.
+
+Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소유 영역은 **TDD 계약**과 **self-test** 이며, self-test fixture 는 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 검증한다. `/init-dcness` 에서 생성할 때는 CC hook 후보를 먼저 self-test 하고 통과해야 `.claude/settings.json` 에 등록한다. 그 다음 Codex hook 후보를 같은 계약으로 self-test 하고 `.codex/hooks.json` 에 등록한다. 빈 프로젝트·미지원 플랫폼·생성 실패는 no-op 으로 안전 통과한다.
 
 `docs/index.md` 의 epic/module 표, 전역 `docs/architecture.md` 의 집계 섹션, 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
@@ -89,10 +92,10 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 - `session-start.sh`: 세션 상태 초기화와 활성 안내.
 - `catastrophic-gate.sh`: Agent 호출 전 작업 순서 보호.
 - `file-guard.sh`: file/bash/MCP 경계와 외부 상태 변경 차단.
-- `tdd-guard.sh`: TS/JS 구현 파일 및 Bash write target 수정 직전 매칭 test 존재 확인. 상세 범위와 한계는 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 가 SSOT.
+- `tdd-guard.sh`: generated project-local hook 이 있으면 그 hook 을 먼저 실행하고, 없으면 TS/JS 구현 파일 및 Bash write target 수정 직전 매칭 test 존재를 중앙 fallback 으로 확인한다. 상세 범위와 한계는 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 가 SSOT.
 - `post-agent-clear.sh`, `post-file-op-trace.sh`, `subagent-stop-clear.sh`, `stop-end-run.sh`: run state 보존과 종료 처리.
 
-과거 TDD 관련 CI/commit-msg 방식의 폐기 이력은 release note 기록이며, `/init-dcness` 실행 절차가 아니다. 현행 TDD Guard 계약은 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 만 따른다.
+과거 TDD 관련 CI/commit-msg 방식의 폐기 이력은 release note 기록이며, `/init-dcness` 실행 절차가 아니다. 현행 TDD Guard 계약은 [`hooks.md#tdd-guardsh`](hooks.md#tdd-guardsh) 와 `scripts/dcness-tdd-hooks` self-test 만 따른다.
 
 ## CI Workflow Snippets
 
@@ -175,14 +178,14 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | Implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |
 | Project lifecycle 좌표 저장/변경 | 예 | repo variables 와 선택형 workflow 를 갱신해야 한다. |
 | docs/design + docs/design-variants seed 추가 | 예 | 부재 파일 seed 는 사용자 repo 에 직접 생성된다. draft 는 `docs/design-variants/drafts/` 에 두고 `.gitignore` 로 무시하되 `drafts/.gitkeep` 으로 디렉터리를 보존한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 `/init-dcness` custom design seed 를 재실행하거나 `templates/design-variants/{.gitignore,canvas.html,_lib/*,drafts/.gitkeep}` 를 `docs/design-variants/` 로 복사한다. |
-| TDD Guard 정책 갱신 | 아니오 | 사용자 repo 파일이 아니라 plug-in hook 본체가 갱신된다. |
+| TDD Guard 정책 갱신 | 아니오 | 중앙 fallback 과 self-test 본체는 plug-in update 로 갱신된다. project-local generated hook 이 없는 기존 프로젝트는 `/init-dcness` 또는 `/impl` 진입 시 생성 제안을 다시 받을 수 있다. |
 
 ## Auto PR Scope
 
 `/init-dcness` 의 자동 commit + PR 단계는 `.github/workflows/*.yml` 만 대상으로 한다.
 
 - 포함: `git-naming-validation.yml`, `pr-body-validation.yml`, `doc-path-integrity.yml`, `doc-sync.yml`, `github-project-lifecycle.yml`
-- 제외: `.git/hooks/*` (git 내부 파일), `~/.claude/**`, `$CODEX_HOME/**`, `.gitignore` runtime/volatile ignore, `docs/*` seed, `docs/design-variants/*` seed, 자동 CC hook 설명
+- 제외: `.git/hooks/*` (git 내부 파일), generated TDD hook bootstrap(`.dcness/tdd-hooks.json`, `.claude/**`, `.codex/**`), `~/.claude/**`, `$CODEX_HOME/**`, `.gitignore` runtime/volatile ignore, `docs/*` seed, `docs/design-variants/*` seed, 자동 CC hook 설명
 - 선행 조건: GitHub remote 존재, 현재 branch `main`, `gh auth status` 통과. 조건이 안 맞으면 branch/commit/push 를 시작하지 않고 skip 안내만 출력한다.
 
 seed 문서는 사용자 프로젝트 내용물이므로 사용자가 별도 작업 PR 에 포함할지 직접 판단한다.

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3663,6 +3663,7 @@ def collect_status_diagnostics(
             ("git_hooks", "git hook shim 3종"),
             ("claude_context", "CLAUDE.md context"),
             ("codex_skills", "Codex validator skills"),
+            ("generated_tdd_hooks", "Generated TDD hooks"),
             ("ci_workflows", "선택형 CI workflow"),
         ):
             add(key, label, "NA", na_detail)
@@ -3780,6 +3781,53 @@ def collect_status_diagnostics(
             "INFO",
             f"설치됨: {', '.join(installed)}" if installed else "없음 (선택 사항)",
         )
+        try:
+            from harness.tdd_hooks import inspect_installation
+
+            generated_tdd = inspect_installation(project_root)
+            platform = generated_tdd.get("platform")
+            if not platform:
+                add(
+                    "generated_tdd_hooks",
+                    "Generated TDD hooks",
+                    "INFO",
+                    "빈 프로젝트 또는 미지원 플랫폼 — 생성 skip",
+                )
+            elif generated_tdd.get("cc_registered") and generated_tdd.get("codex_registered"):
+                add(
+                    "generated_tdd_hooks",
+                    "Generated TDD hooks",
+                    "PASS",
+                    f"platform={platform}, CC+Codex 등록됨",
+                )
+            elif generated_tdd.get("cc_registered") or generated_tdd.get("codex_registered"):
+                add(
+                    "generated_tdd_hooks",
+                    "Generated TDD hooks",
+                    "WARN",
+                    (
+                        f"platform={platform}, partial "
+                        f"cc={generated_tdd.get('cc_registered')} "
+                        f"codex={generated_tdd.get('codex_registered')}"
+                    ),
+                    "scripts/dcness-tdd-hooks ensure --targets cc,codex 재실행",
+                )
+            else:
+                add(
+                    "generated_tdd_hooks",
+                    "Generated TDD hooks",
+                    "WARN",
+                    f"platform={platform}, 프로젝트 로컬 TDD hook 미생성",
+                    "init-dcness 의 generated TDD hook 단계 실행",
+                )
+        except Exception as exc:
+            add(
+                "generated_tdd_hooks",
+                "Generated TDD hooks",
+                "WARN",
+                f"진단 실패: {exc}",
+                "dcness 업데이트 또는 scripts/dcness-tdd-hooks status 확인",
+            )
 
     # Provider routing (self / 외부 공통 — INFO)
     if check_routing:

--- a/harness/tdd_hooks.py
+++ b/harness/tdd_hooks.py
@@ -1,0 +1,879 @@
+"""Project-local generated TDD hook contract and self-test support (#909)."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shlex
+import shutil
+import subprocess  # nosec B404
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+
+CONFIG_REL = Path(".dcness/tdd-hooks.json")
+CC_HOOK_REL = Path(".claude/hooks/dcness-tdd-guard.sh")
+CODEX_HOOK_REL = Path(".codex/hooks/dcness-tdd-guard.sh")
+CC_SETTINGS_REL = Path(".claude/settings.json")
+CODEX_HOOKS_REL = Path(".codex/hooks.json")
+CONFIG_VERSION = 1
+HOOK_TIMEOUT_SEC = 10
+EXCLUDED_SCAN_DIRS = {
+    ".git",
+    ".claude",
+    ".codex",
+    ".dcness",
+    "node_modules",
+    ".venv",
+    "venv",
+    "dist",
+    "build",
+}
+TEST_DIR_SEGMENTS = {
+    "__tests__",
+    "__test__",
+    "__mocks__",
+    "test",
+    "tests",
+    "spec",
+    "specs",
+    "e2e",
+}
+
+
+@dataclass(frozen=True)
+class SelfTestCase:
+    name: str
+    path: Path
+    expected: str
+
+
+@dataclass(frozen=True)
+class SelfTestFailure:
+    name: str
+    expected: str
+    actual: str
+    stderr: str
+
+
+class SelfTestError(RuntimeError):
+    def __init__(self, failures: list[SelfTestFailure]) -> None:
+        self.failures = failures
+        lines = ["TDD hook self-test failed:"]
+        for failure in failures:
+            lines.append(
+                f"- {failure.name}: expected {failure.expected}, got {failure.actual}"
+            )
+            if failure.stderr:
+                lines.append(f"  stderr: {failure.stderr.strip()}")
+        super().__init__("\n".join(lines))
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _iter_project_files(root: Path, suffixes: tuple[str, ...]) -> Iterable[Path]:
+    for path in root.rglob("*"):
+        rel_parts = path.relative_to(root).parts
+        if any(part in EXCLUDED_SCAN_DIRS for part in rel_parts):
+            continue
+        if path.is_file() and path.suffix in suffixes:
+            yield path
+
+
+def _existing_source_roots(root: Path, candidates: tuple[str, ...]) -> list[str]:
+    found = [candidate for candidate in candidates if (root / candidate).is_dir()]
+    return found or ["."]
+
+
+def _has_files(root: Path, suffixes: tuple[str, ...]) -> bool:
+    return next(iter(_iter_project_files(root, suffixes)), None) is not None
+
+
+def detect_platform(project_root: Path) -> Optional[str]:
+    """Return a broad platform bucket or None for empty/unknown projects."""
+    root = project_root.resolve()
+    if (root / "pyproject.toml").exists() or (root / "requirements.txt").exists():
+        return "python"
+    if _has_files(root, (".py",)):
+        return "python"
+    if (root / "package.json").exists() or _has_files(root, (".ts", ".tsx", ".js", ".jsx")):
+        return "web"
+    if (root / "go.mod").exists() or _has_files(root, (".go",)):
+        return "go"
+    if (
+        (root / "settings.gradle").exists()
+        or (root / "settings.gradle.kts").exists()
+        or (root / "build.gradle").exists()
+        or (root / "build.gradle.kts").exists()
+        or _has_files(root, (".kt", ".java"))
+    ):
+        return "android"
+    if (root / "Package.swift").exists() or _has_files(root, (".swift",)):
+        return "ios"
+    return None
+
+
+def build_contract_config(project_root: Path, platform: Optional[str] = None) -> Optional[dict[str, Any]]:
+    """Build the project-local TDD contract config used by generated hooks."""
+    root = project_root.resolve()
+    detected = platform or detect_platform(root)
+    if detected is None:
+        return None
+
+    if detected == "python":
+        source_roots = _existing_source_roots(root, ("src", "app", "apps", "packages"))
+        impl_exts = [".py"]
+    elif detected == "web":
+        source_roots = _existing_source_roots(root, ("src", "app", "apps", "packages"))
+        impl_exts = [".ts", ".tsx", ".js", ".jsx"]
+    elif detected == "go":
+        source_roots = _existing_source_roots(root, (".", "cmd", "pkg", "internal"))
+        impl_exts = [".go"]
+    elif detected == "android":
+        source_roots = _existing_source_roots(
+            root,
+            ("app/src/main", "src/main", "app", "src"),
+        )
+        impl_exts = [".kt", ".java"]
+    elif detected == "ios":
+        source_roots = _existing_source_roots(root, ("Sources", "App", "src"))
+        impl_exts = [".swift"]
+    else:
+        return None
+
+    return {
+        "version": CONFIG_VERSION,
+        "platform": detected,
+        "source_roots": source_roots,
+        "impl_exts": impl_exts,
+        "registered": {"cc": False, "codex": False},
+    }
+
+
+def _rel_path(path: Path, project_root: Path) -> Optional[Path]:
+    candidate = path
+    if not candidate.is_absolute():
+        candidate = project_root / candidate
+    try:
+        return candidate.resolve().relative_to(project_root.resolve())
+    except (OSError, ValueError):
+        return None
+
+
+def _is_under_source_root(rel: Path, config: dict[str, Any]) -> bool:
+    source_roots = config.get("source_roots")
+    if not isinstance(source_roots, list):
+        return True
+    rel_text = rel.as_posix()
+    for source_root in source_roots:
+        if not isinstance(source_root, str):
+            continue
+        normalized = source_root.strip("/")
+        if normalized in ("", "."):
+            return True
+        if rel_text == normalized or rel_text.startswith(f"{normalized}/"):
+            return True
+    return False
+
+
+def _is_test_file(rel: Path, platform: str) -> bool:
+    parts = set(rel.parts[:-1])
+    if parts & TEST_DIR_SEGMENTS:
+        return True
+    name = rel.name
+    if ".test." in name or ".spec." in name:
+        return True
+    if platform == "python":
+        return name.startswith("test_") or name.endswith("_test.py")
+    if platform == "go":
+        return name.endswith("_test.go")
+    if platform == "android":
+        return name.endswith("Test.kt") or name.endswith("Test.java")
+    if platform == "ios":
+        return name.endswith("Test.swift") or name.endswith("Tests.swift") or "Tests" in parts
+    return False
+
+
+def _strip_known_suffix(path: Path) -> str:
+    return path.name[: -len(path.suffix)] if path.suffix else path.name
+
+
+def matching_test_candidates(source_rel: Path, config: dict[str, Any]) -> list[Path]:
+    platform = str(config.get("platform") or "")
+    ext = source_rel.suffix
+    base = _strip_known_suffix(source_rel)
+    parent = source_rel.parent
+    candidates: list[Path] = []
+
+    if platform == "python":
+        candidates.extend(
+            [
+                parent / f"test_{base}.py",
+                parent / f"{base}_test.py",
+                parent / "tests" / f"test_{base}.py",
+                Path("tests") / f"test_{base}.py",
+                Path("tests") / f"{base}_test.py",
+            ]
+        )
+    elif platform == "web":
+        for test_ext in (".ts", ".tsx", ".js", ".jsx"):
+            candidates.extend(
+                [
+                    parent / f"{base}.test{test_ext}",
+                    parent / f"{base}.spec{test_ext}",
+                    parent / "__tests__" / f"{base}.test{test_ext}",
+                    Path("src") / "__tests__" / f"{base}.test{test_ext}",
+                ]
+            )
+    elif platform == "go":
+        candidates.append(parent / f"{base}_test.go")
+    elif platform == "android":
+        mirrored = _android_test_path(source_rel, base, ext)
+        candidates.append(mirrored)
+        candidates.append(parent / f"{base}Test{ext}")
+    elif platform == "ios":
+        candidates.append(Path("Tests") / f"{base}Tests.swift")
+        candidates.append(parent / f"{base}Tests.swift")
+    else:
+        candidates.append(parent / f"{base}.test{ext}")
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = candidate.as_posix()
+        if key not in seen:
+            unique.append(candidate)
+            seen.add(key)
+    return unique
+
+
+def _android_test_path(source_rel: Path, base: str, ext: str) -> Path:
+    parts = list(source_rel.parts)
+    try:
+        main_index = parts.index("main")
+    except ValueError:
+        return Path("app/src/test/java") / f"{base}Test{ext}"
+    test_parts = parts[:main_index] + ["test"] + parts[main_index + 1 :]
+    test_parts[-1] = f"{base}Test{ext}"
+    return Path(*test_parts)
+
+
+def should_enforce(path: Path, project_root: Path, config: dict[str, Any]) -> bool:
+    rel = _rel_path(path, project_root)
+    if rel is None:
+        return False
+    platform = str(config.get("platform") or "")
+    impl_exts = config.get("impl_exts")
+    if not isinstance(impl_exts, list) or rel.suffix not in impl_exts:
+        return False
+    if _is_test_file(rel, platform):
+        return False
+    return _is_under_source_root(rel, config)
+
+
+def has_matching_test(path: Path, project_root: Path, config: dict[str, Any]) -> bool:
+    rel = _rel_path(path, project_root)
+    if rel is None:
+        return True
+    for candidate in matching_test_candidates(rel, config):
+        if (project_root / candidate).is_file():
+            return True
+    return False
+
+
+def extract_payload_paths(payload: dict[str, Any]) -> list[Path]:
+    tool_name = payload.get("tool_name")
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return []
+    if tool_name == "Bash":
+        command = tool_input.get("command")
+        if not isinstance(command, str):
+            return []
+        try:
+            from harness.agent_boundary import extract_bash_paths
+
+            return [Path(path) for path in extract_bash_paths(command)]
+        except Exception:
+            return []
+    if tool_name == "apply_patch":
+        return _extract_apply_patch_paths(tool_input)
+    for key in ("file_path", "path", "filename", "notebook_path"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value:
+            return [Path(value)]
+    return []
+
+
+def _extract_apply_patch_paths(tool_input: dict[str, Any]) -> list[Path]:
+    text_parts: list[str] = []
+    for key in ("patch", "input", "command"):
+        value = tool_input.get(key)
+        if isinstance(value, str):
+            text_parts.append(value)
+    text = "\n".join(text_parts)
+    paths: list[Path] = []
+    for line in text.splitlines():
+        for prefix in ("*** Add File: ", "*** Update File: "):
+            if line.startswith(prefix):
+                paths.append(Path(line[len(prefix) :].strip()))
+        if line.startswith("+++ b/"):
+            paths.append(Path(line[len("+++ b/") :].strip()))
+    return paths
+
+
+def evaluate_payload(
+    payload: dict[str, Any],
+    project_root: Path,
+    config: dict[str, Any],
+) -> tuple[str, str]:
+    """Return (allow|deny, reason). Missing config/path is intentionally allow."""
+    paths = extract_payload_paths(payload)
+    for path in paths:
+        if not should_enforce(path, project_root, config):
+            continue
+        if has_matching_test(path, project_root, config):
+            continue
+        rel = _rel_path(path, project_root) or path
+        candidates = matching_test_candidates(rel, config)
+        suggested = "\n".join(f"  - {candidate.as_posix()}" for candidate in candidates[:5])
+        return (
+            "deny",
+            "TDD GUARD[generated]: "
+            f"'{rel.as_posix()}' 에 대한 매칭 테스트가 없습니다.\n"
+            "구현 파일을 쓰기 전에 테스트를 먼저 작성하세요.\n"
+            f"권장 위치:\n{suggested}",
+        )
+    return "allow", ""
+
+
+def _allow_json() -> str:
+    return (
+        '{"suppressOutput": true, "hookSpecificOutput": '
+        '{"hookEventName": "PreToolUse", "permissionDecision": "allow"}}'
+    )
+
+
+def run_generated_hook(
+    *,
+    project_root: Path,
+    config_path: Path,
+    stdin_text: str,
+) -> int:
+    config = _read_json(config_path)
+    if not config:
+        print(_allow_json())
+        return 0
+    try:
+        payload = json.loads(stdin_text or "{}")
+    except json.JSONDecodeError:
+        print(_allow_json())
+        return 0
+    if not isinstance(payload, dict):
+        print(_allow_json())
+        return 0
+    decision, reason = evaluate_payload(payload, project_root.resolve(), config)
+    if decision == "deny":
+        print(reason, file=sys.stderr)
+        return 2
+    print(_allow_json())
+    return 0
+
+
+def _primary_source_root(config: dict[str, Any]) -> str:
+    roots = config.get("source_roots")
+    if isinstance(roots, list):
+        for root in roots:
+            if isinstance(root, str) and root not in ("", "."):
+                return root
+    platform = str(config.get("platform") or "")
+    if platform == "ios":
+        return "Sources"
+    return "src"
+
+
+def _first_impl_ext(config: dict[str, Any]) -> str:
+    exts = config.get("impl_exts")
+    if isinstance(exts, list) and exts and isinstance(exts[0], str):
+        return exts[0]
+    return ".txt"
+
+
+def _self_test_paths(config: dict[str, Any], token: str) -> tuple[Path, Path, Path]:
+    source_root = Path(_primary_source_root(config))
+    ext = _first_impl_ext(config)
+    no_test = source_root / f"dcness_tdd_contract_no_test_{token}{ext}"
+    with_test = source_root / f"dcness_tdd_contract_with_test_{token}{ext}"
+    test_file = matching_test_candidates(with_test, config)[0]
+    test_self = test_file.parent / f"test_dcness_tdd_contract_self_{token}.py"
+    platform = str(config.get("platform") or "")
+    if platform == "web":
+        test_self = test_file.parent / f"dcness_tdd_contract_self_{token}.test.ts"
+    elif platform == "go":
+        test_self = test_file.parent / f"dcness_tdd_contract_self_{token}_test.go"
+    elif platform == "android":
+        test_self = test_file.parent / f"DcnessTddContractSelf{token}Test{ext}"
+    elif platform == "ios":
+        test_self = test_file.parent / f"DcnessTddContractSelf{token}Tests.swift"
+    return no_test, with_test, test_self
+
+
+def _fixture_content(path: Path) -> str:
+    if path.suffix == ".py":
+        return "def dcness_contract_subject():\n    return 1\n"
+    if path.suffix in {".ts", ".tsx", ".js", ".jsx"}:
+        return "export function dcnessContractSubject() { return 1; }\n"
+    if path.suffix == ".go":
+        return "package dcness\n\nfunc DcnessContractSubject() int { return 1 }\n"
+    if path.suffix in {".kt", ".java", ".swift"}:
+        return "// dcness contract subject\n"
+    return "dcness contract subject\n"
+
+
+def _write_fixture_file(project_root: Path, rel: Path) -> Path:
+    path = project_root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_fixture_content(rel), encoding="utf-8")
+    return path
+
+
+def _cleanup_created(paths: list[Path], project_root: Path) -> None:
+    dirs: set[Path] = set()
+    for path in paths:
+        if path.exists():
+            path.unlink()
+        parent = path.parent
+        while parent != project_root and project_root in parent.parents:
+            dirs.add(parent)
+            parent = parent.parent
+    for directory in sorted(dirs, key=lambda item: len(item.parts), reverse=True):
+        try:
+            directory.rmdir()
+        except OSError:
+            pass
+
+
+def _run_hook_command(
+    hook_command: str,
+    project_root: Path,
+    payload_path: Path,
+    *,
+    config_path: Path,
+    plugin_root: Optional[Path],
+) -> tuple[str, str]:
+    payload = {"tool_name": "Edit", "tool_input": {"file_path": str(payload_path)}}
+    env = os.environ.copy()
+    env["DCNESS_TDD_CONFIG"] = str(config_path)
+    env["DCNESS_TDD_PROJECT_ROOT"] = str(project_root)
+    if plugin_root is not None:
+        env["DCNESS_TDD_PLUGIN_ROOT"] = str(plugin_root)
+        env["CLAUDE_PLUGIN_ROOT"] = str(plugin_root)
+        env["PYTHONPATH"] = f"{plugin_root}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    try:
+        proc = subprocess.run(  # nosec B603
+            shlex.split(hook_command),
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            cwd=project_root,
+            timeout=HOOK_TIMEOUT_SEC,
+            env=env,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return "error", str(exc)
+    if proc.returncode == 0:
+        return "allow", proc.stderr
+    if proc.returncode == 2:
+        return "deny", proc.stderr
+    return "error", proc.stderr or proc.stdout
+
+
+def run_self_test(
+    *,
+    project_root: Path,
+    config: dict[str, Any],
+    hook_command: str,
+    config_path: Path,
+    plugin_root: Optional[Path] = None,
+) -> None:
+    token = uuid.uuid4().hex[:8]
+    no_test_rel, with_test_rel, test_self_rel = _self_test_paths(config, token)
+    created = [
+        _write_fixture_file(project_root, no_test_rel),
+        _write_fixture_file(project_root, with_test_rel),
+        _write_fixture_file(project_root, matching_test_candidates(with_test_rel, config)[0]),
+        _write_fixture_file(project_root, test_self_rel),
+    ]
+    cases = [
+        SelfTestCase("without_test", created[0], "deny"),
+        SelfTestCase("with_test", created[1], "allow"),
+        SelfTestCase("test_file_self", created[3], "allow"),
+    ]
+    failures: list[SelfTestFailure] = []
+    try:
+        for case in cases:
+            actual, stderr = _run_hook_command(
+                hook_command,
+                project_root,
+                case.path,
+                config_path=config_path,
+                plugin_root=plugin_root,
+            )
+            if actual != case.expected:
+                failures.append(SelfTestFailure(case.name, case.expected, actual, stderr))
+    finally:
+        _cleanup_created(created, project_root)
+    if failures:
+        raise SelfTestError(failures)
+
+
+def _generated_hook_text(target: str) -> str:
+    return f"""#!/usr/bin/env bash
+# Generated by dcNess for this project. Do not edit by hand.
+set -u
+
+allow() {{
+  cat >/dev/null || true
+  echo '{{"suppressOutput": true, "hookSpecificOutput": {{"hookEventName": "PreToolUse", "permissionDecision": "allow"}}}}'
+  exit 0
+}}
+
+resolve_plugin_root() {{
+  if [ -n "${{DCNESS_TDD_PLUGIN_ROOT:-}}" ] && [ -f "${{DCNESS_TDD_PLUGIN_ROOT}}/scripts/dcness-tdd-hooks" ]; then
+    echo "${{DCNESS_TDD_PLUGIN_ROOT}}"; return 0
+  fi
+  if [ -n "${{CLAUDE_PLUGIN_ROOT:-}}" ] && [ -f "${{CLAUDE_PLUGIN_ROOT}}/scripts/dcness-tdd-hooks" ]; then
+    echo "${{CLAUDE_PLUGIN_ROOT}}"; return 0
+  fi
+  cache_dir="${{HOME}}/.claude/plugins/cache/dcness/dcness"
+  if [ -d "$cache_dir" ]; then
+    latest=$(ls -1 "$cache_dir" 2>/dev/null | sort -V | tail -1)
+    if [ -n "$latest" ] && [ -f "$cache_dir/$latest/scripts/dcness-tdd-hooks" ]; then
+      echo "$cache_dir/$latest"; return 0
+    fi
+  fi
+  return 1
+}}
+
+PLUGIN_ROOT="$(resolve_plugin_root 2>/dev/null || true)"
+[ -n "$PLUGIN_ROOT" ] || allow
+
+PROJECT_ROOT="${{DCNESS_TDD_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+CONFIG_PATH="${{DCNESS_TDD_CONFIG:-$PROJECT_ROOT/.dcness/tdd-hooks.json}}"
+
+exec bash "$PLUGIN_ROOT/scripts/dcness-tdd-hooks" run \\
+  --project-root "$PROJECT_ROOT" \\
+  --config "$CONFIG_PATH" \\
+  --target "{target}"
+"""
+
+
+def _install_hook_script(project_root: Path, target: str, source: Path) -> Path:
+    rel = CC_HOOK_REL if target == "cc" else CODEX_HOOK_REL
+    final_path = project_root / rel
+    final_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source, final_path)
+    final_path.chmod(0o755)
+    return final_path
+
+
+def _strip_existing_dcness_tdd_hooks(entries: list[Any]) -> list[Any]:
+    kept: list[Any] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            kept.append(entry)
+            continue
+        hooks = entry.get("hooks")
+        if not isinstance(hooks, list):
+            kept.append(entry)
+            continue
+        new_hooks = []
+        for hook in hooks:
+            if not isinstance(hook, dict):
+                new_hooks.append(hook)
+                continue
+            command = hook.get("command")
+            if isinstance(command, str) and "dcness-tdd-guard.sh" in command:
+                continue
+            new_hooks.append(hook)
+        if new_hooks:
+            cloned = dict(entry)
+            cloned["hooks"] = new_hooks
+            kept.append(cloned)
+    return kept
+
+
+def _register_hook_json(path: Path, matcher: str, command: str) -> None:
+    data = _read_json(path)
+    hooks = data.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        hooks = {}
+        data["hooks"] = hooks
+    pre = hooks.setdefault("PreToolUse", [])
+    if not isinstance(pre, list):
+        pre = []
+        hooks["PreToolUse"] = pre
+    pre = _strip_existing_dcness_tdd_hooks(pre)
+    pre.append(
+        {
+            "matcher": matcher,
+            "hooks": [{"type": "command", "command": command, "timeout": 10}],
+        }
+    )
+    hooks["PreToolUse"] = pre
+    _write_json(path, data)
+
+
+def _register_cc(project_root: Path) -> None:
+    command = (
+        'bash "$(git rev-parse --show-toplevel 2>/dev/null || pwd)'
+        '/.claude/hooks/dcness-tdd-guard.sh"'
+    )
+    _register_hook_json(
+        project_root / CC_SETTINGS_REL,
+        "Edit|Write|NotebookEdit|Bash",
+        command,
+    )
+
+
+def _register_codex(project_root: Path) -> None:
+    command = (
+        'bash "$(git rev-parse --show-toplevel 2>/dev/null || pwd)'
+        '/.codex/hooks/dcness-tdd-guard.sh"'
+    )
+    _register_hook_json(
+        project_root / CODEX_HOOKS_REL,
+        "Edit|Write|apply_patch",
+        command,
+    )
+
+
+def ensure_generated_hooks(
+    *,
+    project_root: Path,
+    targets: tuple[str, ...],
+    plugin_root: Path,
+) -> list[str]:
+    root = project_root.resolve()
+    config = build_contract_config(root)
+    if config is None:
+        return ["skip: empty_or_unknown_project"]
+
+    normalized = list(dict.fromkeys(targets))
+    if "codex" in normalized and "cc" not in normalized:
+        normalized.insert(0, "cc")
+    if "cc" in normalized and "codex" in normalized:
+        normalized = ["cc"] + [target for target in normalized if target != "cc"]
+
+    config_path = root / CONFIG_REL
+    current = _read_json(config_path)
+    registered_data = current.get("registered")
+    registered: dict[str, Any] = registered_data if isinstance(registered_data, dict) else {}
+    registered_config: dict[str, bool] = {
+        "cc": bool(registered.get("cc")),
+        "codex": bool(registered.get("codex")),
+    }
+    config["registered"] = registered_config
+
+    tmp_dir = root / ".dcness" / ".tmp"
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    messages: list[str] = []
+    try:
+        for target in normalized:
+            if target not in {"cc", "codex"}:
+                raise ValueError(f"unknown target: {target}")
+            if target == "codex" and not registered_config.get("cc"):
+                raise SelfTestError(
+                    [SelfTestFailure("cc_before_codex", "cc registered", "missing", "")]
+                )
+            candidate = tmp_dir / f"dcness-tdd-guard-{target}.sh"
+            candidate.write_text(_generated_hook_text(target), encoding="utf-8")
+            candidate.chmod(0o755)
+            candidate_config = tmp_dir / f"tdd-hooks-{target}.json"
+            _write_json(candidate_config, config)
+            run_self_test(
+                project_root=root,
+                config=config,
+                hook_command=f"bash {shlex.quote(str(candidate))}",
+                config_path=candidate_config,
+                plugin_root=plugin_root,
+            )
+            _install_hook_script(root, target, candidate)
+            if target == "cc":
+                _register_cc(root)
+            else:
+                _register_codex(root)
+            registered_config[target] = True
+            config["registered"] = registered_config
+            _write_json(config_path, config)
+            messages.append(f"{target}: registered")
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+    return messages
+
+
+def inspect_installation(project_root: Path) -> dict[str, Any]:
+    root = project_root.resolve()
+    platform = detect_platform(root)
+    config = _read_json(root / CONFIG_REL)
+    registered_data = config.get("registered")
+    registered: dict[str, Any] = registered_data if isinstance(registered_data, dict) else {}
+    cc_hook = (root / CC_HOOK_REL).is_file()
+    codex_hook = (root / CODEX_HOOK_REL).is_file()
+    cc_configured = _hook_json_references(root / CC_SETTINGS_REL, "dcness-tdd-guard.sh")
+    codex_configured = _hook_json_references(root / CODEX_HOOKS_REL, "dcness-tdd-guard.sh")
+    return {
+        "platform": platform,
+        "config": bool(config),
+        "cc_hook": cc_hook,
+        "codex_hook": codex_hook,
+        "cc_registered": bool(registered.get("cc")) and cc_hook and cc_configured,
+        "codex_registered": bool(registered.get("codex")) and codex_hook and codex_configured,
+    }
+
+
+def _hook_json_references(path: Path, needle: str) -> bool:
+    data = _read_json(path)
+    hooks = data.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    pre = hooks.get("PreToolUse")
+    if not isinstance(pre, list):
+        return False
+    return any(needle in json.dumps(entry) for entry in pre)
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    project_root = Path(args.project_root).resolve()
+    config_path = Path(args.config).resolve()
+    stdin_text = sys.stdin.read()
+    return run_generated_hook(
+        project_root=project_root,
+        config_path=config_path,
+        stdin_text=stdin_text,
+    )
+
+
+def _cmd_self_test(args: argparse.Namespace) -> int:
+    project_root = Path(args.project_root).resolve()
+    config: Optional[dict[str, Any]]
+    if args.config:
+        config_path = Path(args.config).resolve()
+        config = _read_json(config_path)
+    else:
+        config = build_contract_config(project_root, args.platform)
+        config_path = project_root / ".dcness" / ".tmp-self-test-config.json"
+        if config is not None:
+            _write_json(config_path, config)
+    if config is None or not config:
+        print("skip: empty_or_unknown_project")
+        return 0
+    try:
+        run_self_test(
+            project_root=project_root,
+            config=config,
+            hook_command=args.hook_command,
+            config_path=config_path,
+            plugin_root=Path(args.plugin_root).resolve() if args.plugin_root else None,
+        )
+    except SelfTestError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    finally:
+        if not args.config:
+            config_path.unlink(missing_ok=True)
+    print("self-test: PASS")
+    return 0
+
+
+def _cmd_ensure(args: argparse.Namespace) -> int:
+    try:
+        messages = ensure_generated_hooks(
+            project_root=Path(args.project_root),
+            targets=tuple(part for part in args.targets.split(",") if part),
+            plugin_root=Path(args.plugin_root).resolve(),
+        )
+    except (SelfTestError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    for message in messages:
+        print(message)
+    return 0
+
+
+def _cmd_status(args: argparse.Namespace) -> int:
+    report = inspect_installation(Path(args.project_root))
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+        return 0
+    platform = report.get("platform") or "empty_or_unknown_project"
+    print(
+        "generated TDD hooks: "
+        f"platform={platform}, "
+        f"cc={report['cc_registered']}, "
+        f"codex={report['codex_registered']}"
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="dcness-tdd-hooks",
+        description="dcNess generated project-local TDD hook contract helper",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_run = sub.add_parser("run", help="internal generated hook entrypoint")
+    p_run.add_argument("--project-root", required=True)
+    p_run.add_argument("--config", required=True)
+    p_run.add_argument("--target", choices=("cc", "codex"), default="cc")
+    p_run.set_defaults(func=_cmd_run)
+
+    p_self = sub.add_parser("self-test", help="run TDD contract self-test for a hook")
+    p_self.add_argument("--project-root", required=True)
+    p_self.add_argument("--hook-command", required=True)
+    p_self.add_argument("--platform", default=None)
+    p_self.add_argument("--config", default="")
+    p_self.add_argument("--plugin-root", default="")
+    p_self.set_defaults(func=_cmd_self_test)
+
+    p_ensure = sub.add_parser("ensure", help="generate and register CC/Codex hooks")
+    p_ensure.add_argument("--project-root", required=True)
+    p_ensure.add_argument("--targets", default="cc,codex")
+    p_ensure.add_argument("--plugin-root", required=True)
+    p_ensure.set_defaults(func=_cmd_ensure)
+
+    p_status = sub.add_parser("status", help="inspect generated hook installation")
+    p_status.add_argument("--project-root", default=".")
+    p_status.add_argument("--json", action="store_true")
+    p_status.set_defaults(func=_cmd_status)
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -66,6 +66,39 @@ PY
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
+delegate_generated_project_hook() {
+  # #909 — project-local generated hook wins over the legacy central TS/JS guard.
+  # The generated hook has already passed dcNess-owned contract self-test before
+  # registration. Central hook delegates here so interactive CC and headless
+  # wrappers both use the same project-specific contract.
+  [ "${DCNESS_TDD_DELEGATED:-}" = "1" ] && return 0
+  local generated_hook="$PROJECT_ROOT/.claude/hooks/dcness-tdd-guard.sh"
+  local generated_config="$PROJECT_ROOT/.dcness/tdd-hooks.json"
+  [ -x "$generated_hook" ] && [ -f "$generated_config" ] || return 0
+
+  local generated_err generated_rc
+  generated_err=$(
+    printf '%s' "$INPUT" \
+      | DCNESS_TDD_DELEGATED=1 \
+        DCNESS_TDD_PROJECT_ROOT="$PROJECT_ROOT" \
+        DCNESS_TDD_PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-}" \
+        bash "$generated_hook" 2>&1 >/dev/null
+  )
+  generated_rc=$?
+  if [ "$generated_rc" -eq 0 ]; then
+    allow
+  fi
+  if [ "$generated_rc" -eq 2 ]; then
+    record_guard_hit "generated_missing_test" "$generated_err"
+    printf '%s\n' "$generated_err" >&2
+    exit 2
+  fi
+  record_fail_open "generated_hook_error" "generated hook exited ${generated_rc}; central fallback skipped"
+  allow
+}
+
+delegate_generated_project_hook
+
 deny() {
   # reason 을 stderr 로 — exit 2 (호출부) 와 짝지어 CC 가 Claude 에 피드백.
   printf '%s\n' "$1" >&2

--- a/scripts/dcness-tdd-hooks
+++ b/scripts/dcness-tdd-hooks
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# dcNess generated TDD hook helper wrapper.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+export PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}"
+
+exec python3 -m harness.tdd_hooks "$@"

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -87,6 +87,22 @@ GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecy
 
 코어 `ALLOW_MATRIX` 로 커버되지 않는 비표준 소스 디렉터리가 있으면 `.dcness/boundary.json` 의 `engineer.add` 후보만 출력한다. 후보가 있으면 사람 승인 후에만 메인이 boundary 파일을 작성한다. 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다.
 
+## Step 0.3 — generated TDD hook 부재 확인
+
+구현 진입 전에 project-local TDD hook 상태를 한 번 확인한다. dcNess 는 **TDD 계약**과 생성 직후 **self-test** 를 소유하고, hook 본문은 프로젝트 플랫폼에 맞게 생성된다.
+
+```bash
+"$PLUGIN_ROOT/scripts/dcness-tdd-hooks" status --project-root "$PROJECT_ROOT"
+```
+
+플랫폼이 감지됐는데 generated hook 이 없으면 사용자에게 생성 제안을 보여준다. 승인 시 `/init-dcness` 와 같은 순서로 진행한다: TDD 계약 self-test fixture 확인 → CC hook 후보 생성/self-test/등록 → Codex hook 후보 생성/self-test/등록.
+
+```bash
+"$PLUGIN_ROOT/scripts/dcness-tdd-hooks" ensure --project-root "$PROJECT_ROOT" --targets cc,codex --plugin-root "$PLUGIN_ROOT"
+```
+
+빈 프로젝트, 미지원 플랫폼, 생성 실패, self-test 실패는 no-op 으로 안전 통과한다. 생성 훅이 있으면 중앙 `tdd-guard.sh` 와 headless worker 사후 검사는 그 generated hook 을 먼저 실행한다.
+
 ## Step 0.4 — UI 기준 확보 분기
 
 UI 작업이면 구현 경로(Lite/Standard) 판정과 별도로 **UI 기준 확보 분기**를 먼저 판정한다. 목업은 무조건 만들지 않는다. 강제되는 불변식은 "신규 시각 구조 작업은 기대 고정 기준을 확보하고, 기준이 존재하면 구현까지 배선된다" 이다.

--- a/tests/test_generated_tdd_hooks.py
+++ b/tests/test_generated_tdd_hooks.py
@@ -1,0 +1,335 @@
+"""Generated project-local TDD hook contract tests (#909)."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from harness.tdd_hooks import inspect_installation
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TDD_HOOKS = ROOT / "scripts" / "dcness-tdd-hooks"
+CENTRAL_TDD_GUARD = ROOT / "hooks" / "tdd-guard.sh"
+
+
+def _run_hook(hook: Path, project: Path, file_path: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(file_path)},
+    }
+    return subprocess.run(
+        ["bash", str(hook)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=project,
+        timeout=10,
+        env={
+            **os.environ,
+            "CLAUDE_PLUGIN_ROOT": str(ROOT),
+            "DCNESS_TDD_PLUGIN_ROOT": str(ROOT),
+            "PYTHONPATH": str(ROOT),
+        },
+    )
+
+
+def _run_central_guard(project: Path, file_path: Path) -> subprocess.CompletedProcess[str]:
+    payload = {
+        "tool_name": "Edit",
+        "tool_input": {"file_path": str(file_path)},
+    }
+    return subprocess.run(
+        ["bash", str(CENTRAL_TDD_GUARD)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=project,
+        timeout=10,
+        env={
+            **os.environ,
+            "CLAUDE_PLUGIN_ROOT": str(ROOT),
+            "DCNESS_FORCE_ENABLE": "1",
+            "PYTHONPATH": str(ROOT),
+        },
+    )
+
+
+class GeneratedTddHookContractTests(unittest.TestCase):
+    def test_self_test_rejects_allow_all_hook_before_generation(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            bad_hook = Path(td) / "allow-all.sh"
+            bad_hook.write_text("#!/bin/sh\ncat >/dev/null\nexit 0\n", encoding="utf-8")
+            bad_hook.chmod(0o755)
+
+            result = subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "self-test",
+                    "--project-root",
+                    str(project),
+                    "--platform",
+                    "python",
+                    "--hook-command",
+                    f"bash {bad_hook}",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("without_test", result.stderr)
+
+    def test_ensure_generates_cc_then_codex_hooks_after_self_test(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project with space"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            result = subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc,codex",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("cc: registered", result.stdout)
+            self.assertIn("codex: registered", result.stdout)
+
+            config = json.loads(
+                (project / ".dcness" / "tdd-hooks.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(config["platform"], "python")
+            self.assertTrue(config["registered"]["cc"])
+            self.assertTrue(config["registered"]["codex"])
+
+            cc_settings = json.loads(
+                (project / ".claude" / "settings.json").read_text(encoding="utf-8")
+            )
+            cc_hooks = cc_settings["hooks"]["PreToolUse"]
+            self.assertTrue(any("dcness-tdd-guard.sh" in json.dumps(e) for e in cc_hooks))
+
+            codex_hooks = json.loads(
+                (project / ".codex" / "hooks.json").read_text(encoding="utf-8")
+            )
+            codex_pre = codex_hooks["hooks"]["PreToolUse"]
+            self.assertTrue(
+                any("apply_patch" in e.get("matcher", "") for e in codex_pre),
+                codex_hooks,
+            )
+
+    def test_generated_python_hook_enforces_flat_project_without_source_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            no_test = project / "price.py"
+            no_test.write_text("def price():\n    return 1\n", encoding="utf-8")
+            denied = _run_hook(hook, project, no_test)
+            self.assertEqual(denied.returncode, 2, denied.stderr)
+            self.assertIn("price.py", denied.stderr)
+
+    def test_status_does_not_trust_stale_registered_flags_without_hook_files(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / ".dcness").mkdir()
+            (project / ".dcness" / "tdd-hooks.json").write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "platform": "python",
+                        "source_roots": ["."],
+                        "impl_exts": [".py"],
+                        "registered": {"cc": True, "codex": True},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            report = inspect_installation(project)
+            self.assertFalse(report["cc_registered"])
+            self.assertFalse(report["codex_registered"])
+
+    def test_generated_python_hook_enforces_contract_cases(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            no_test = project / "src" / "price.py"
+            no_test.write_text("def price():\n    return 1\n", encoding="utf-8")
+            denied = _run_hook(hook, project, no_test)
+            self.assertEqual(denied.returncode, 2, denied.stderr)
+            self.assertIn("TDD GUARD", denied.stderr)
+
+            (project / "tests").mkdir()
+            (project / "tests" / "test_price.py").write_text(
+                "from src.price import price\n\n\ndef test_price():\n    assert price() == 1\n",
+                encoding="utf-8",
+            )
+            allowed = _run_hook(hook, project, no_test)
+            self.assertEqual(allowed.returncode, 0, allowed.stderr)
+
+            test_file = project / "tests" / "test_new_contract.py"
+            test_file.write_text("def test_new_contract():\n    assert True\n", encoding="utf-8")
+            test_allowed = _run_hook(hook, project, test_file)
+            self.assertEqual(test_allowed.returncode, 0, test_allowed.stderr)
+
+    def test_central_tdd_guard_delegates_to_generated_hook_for_headless_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            target = project / "src" / "headless_contract.py"
+            target.write_text("def headless_contract():\n    return 1\n", encoding="utf-8")
+
+            result = _run_central_guard(project, target)
+            self.assertEqual(result.returncode, 2, result.stderr)
+            self.assertIn("headless_contract", result.stderr)
+
+    def test_ensure_skips_empty_project_without_registering_hooks(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            result = subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc,codex",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("skip: empty_or_unknown_project", result.stdout)
+            self.assertFalse((project / ".claude" / "settings.json").exists())
+            self.assertFalse((project / ".codex" / "hooks.json").exists())
+
+
+class GeneratedTddHookDocsTests(unittest.TestCase):
+    def test_public_docs_keep_contract_before_generation_order(self) -> None:
+        init_skill = (ROOT / "commands" / "init-dcness.md").read_text(encoding="utf-8")
+        hooks_doc = (ROOT / "docs" / "plugin" / "hooks.md").read_text(encoding="utf-8")
+        impl_skill = (ROOT / "skills" / "impl" / "SKILL.md").read_text(encoding="utf-8")
+
+        for text in (init_skill, hooks_doc, impl_skill):
+            with self.subTest(text=text[:20]):
+                self.assertIn("TDD 계약", text)
+                self.assertIn("self-test", text)
+
+        ordered = [
+            "TDD 계약",
+            "CC",
+            "Codex",
+        ]
+        cursor = -1
+        for needle in ordered:
+            next_pos = init_skill.find(needle, cursor + 1)
+            self.assertGreater(next_pos, cursor, textwrap.shorten(init_skill, width=200))
+            cursor = next_pos


### PR DESCRIPTION
## 관련 이슈 번호

Closes #909
Part of #908

## 배경 및 문제

현재 중앙 TDD guard 는 TS/JS 중심이고, non-TS/JS 프로젝트와 interactive Codex 경로는 프로젝트별 TDD 계약을 강제하지 못한다. #909 요구처럼 dcNess 는 hook 본문 자체보다 계약과 self-test 를 소유해야 한다.

## 원인 (해당 시)

중앙 `hooks/tdd-guard.sh` 가 TS/JS 규칙을 직접 보유했고, 생성된 project-local hook 이 계약을 지키는지 등록 전에 검증하는 self-test 경로가 없었다.

## 작업내용

- `harness/tdd_hooks.py`, `scripts/dcness-tdd-hooks` 로 플랫폼 감지, TDD 계약 평가, self-test fixture, CC/Codex hook 생성·등록 helper 를 추가했다.
- 생성 순서를 TDD 계약/self-test → CC hook self-test/등록 → Codex hook self-test/등록으로 고정했다.
- `hooks/tdd-guard.sh` 가 project-local generated hook 을 먼저 위임해 interactive/headless 경로가 같은 계약을 쓰게 했다.
- `dcness-helper status`, `/init-dcness`, `/impl`, `docs/plugin/hooks.md`, `docs/plugin/init-dcness.md` 에 생성/상태/배포 경로를 연결했다.
- `tests/test_generated_tdd_hooks.py` 로 allow-all hook 거부, CC→Codex 순서, flat Python, stale registration, 중앙 위임을 회귀 테스트했다.

## 결정 근거

생성부터 만들면 "생성됐지만 TDD를 조용히 뚫는 hook"을 검증할 방법이 없다. 그래서 생성물과 독립인 계약 self-test를 먼저 두고, 그 self-test를 통과한 후보만 실제 `.claude/settings.json` / `.codex/hooks.json` 에 등록하게 했다. 중앙 fallback 은 유지하되 generated hook 이 있으면 위임 후 종료해 TS/JS 이중 deny 를 피한다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체: `harness/tdd_hooks.py`, `scripts/dcness-tdd-hooks`, `hooks/tdd-guard.sh`.
- `/init-dcness` 경로: `commands/init-dcness.md` 와 `docs/plugin/init-dcness.md` 에 generated TDD hook 제안/생성 순서와 자동 PR 제외 범위를 반영했다.
- `/impl` 경로: `skills/impl/SKILL.md` Step 0.3 에 hook 부재 확인과 생성 제안을 추가했다.
- hook 정책 SSOT: `docs/plugin/hooks.md` 에 계약/self-test, CC→Codex 순서, 중앙 fallback, headless 재사용, Codex trusted hash 안내를 반영했다.
- 기존 활성 프로젝트는 plug-in update 후 `/init-dcness` 또는 `/impl` 진입 시 project-local hook 생성을 제안받는다. 생성 파일(`.dcness/**`, `.claude/**`, `.codex/**`)은 사용자 승인 bootstrap 산출물이며 `/init-dcness` 자동 workflow PR에는 포함하지 않는다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public slash command/skill/agent/gate 는 없다. `scripts/dcness-tdd-hooks` 는 기존 `/init-dcness` 와 `/impl` 내부에서 호출되는 helper surface 다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -p 'test_generated_tdd_hooks.py' -v < /dev/null`
- [x] `python3.11 -m unittest tests.test_status_diagnostics tests.test_tdd_guard -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] pre-commit pytest gate: `Ran 1606 tests ... OK`
- [x] `PYTHON_BIN=/tmp/dcness-quality-909/bin/python bash scripts/check_static_quality.sh`
- [x] `python3.11 evals/guard_efficacy.py`
- [x] `node scripts/check_cross_refs.mjs && node scripts/check_public_surface.mjs && node scripts/check_plugin_manifest.mjs && node scripts/aggregate_index_map.mjs --check && node scripts/aggregate_architecture_map.mjs --check && node scripts/check_design_artifact_structure.mjs`

## 참고

- `bash evals/run.sh` 는 LLM behavior eval 이라 로컬 자동 검증에는 포함하지 않았다. 이번 변경의 강제 계약은 deterministic unit/guard-efficacy 경로로 검증했다.