### PR TITLE
[issue-908] 생성형 TDD hook 후속 보강

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -163,6 +163,8 @@ done
 
 순서는 고정: **TDD 계약 + self-test** → **CC hook self-test/등록** → **Codex hook self-test/등록**. 빈 프로젝트/미지원/실패는 no-op 이며 상세는 [`docs/plugin/init-dcness.md`](../docs/plugin/init-dcness.md) 와 [`hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh) 를 따른다.
 
+`status` 또는 `ensure` 가 `commit-required` 를 출력하면 생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)을 activation bootstrap commit 에 포함하도록 사용자에게 안내한다. 이 파일들은 자동 workflow PR 대상은 아니지만, 커밋되지 않으면 새 worktree/headless worker 가 project-local 계약을 재사용하지 못한다.
+
 ### Core Step 8 - 완료 선언
 
 core 작업 뒤 `status` 를 재실행한다. FAIL 이 0 이면 INFO·NA 행과 선택 WARN 이 남아도 즉시 완료를 먼저 출력한다.
@@ -316,7 +318,7 @@ done
 
 #### workflow 변경 PR
 
-자동 PR 대상은 `/init-dcness` 가 배포한 `.github/workflows/*.yml` 변경만이다. Generated TDD hook 은 사용자 repo 의 `.dcness/`, `.claude/`, `.codex/` 에 project-local 파일을 쓸 수 있지만 activation bootstrap 산출물이라 자동 workflow PR 대상은 아니다. docs/design seed 는 사용자 콘텐츠라 자동 infra PR 에 섞지 않는다.
+자동 PR 대상은 `/init-dcness` 가 배포한 `.github/workflows/*.yml` 변경만이다. Generated TDD hook 은 사용자 repo 의 `.dcness/`, `.claude/`, `.codex/` 에 project-local 파일을 쓸 수 있지만 activation bootstrap 산출물이라 자동 workflow PR 대상은 아니다. 단, 새 worktree/headless worker 도 같은 TDD 계약을 쓰려면 이 생성 파일들은 별도 bootstrap commit 에 포함돼야 한다. docs/design seed 는 사용자 콘텐츠라 자동 infra PR 에 섞지 않는다.
 
 ```bash
 cd "$PROJECT_ROOT"

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -159,15 +159,17 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **시점**: `Edit`, `Write`, `NotebookEdit` 로 파일을 수정하기 직전. `Bash` 는 명시적 write target 추출 직후, 각 target 에 같은 검사를 적용한다. Codex/headless 구현 worker 는 Codex 성공 종료 후 `end-step` 저장 전에 변경 파일 목록에 같은 검사를 적용한다.
 
-**우선순위**: 프로젝트에 generated TDD hook 이 있으면 중앙 plug-in `tdd-guard.sh` 는 먼저 `.claude/hooks/dcness-tdd-guard.sh` 를 실행한다. 이 generated hook 은 `/init-dcness` 가 플랫폼 감지 후 만든 project-local 파일이며, 등록 전에 dcNess 소유 **TDD 계약**과 **self-test** 를 통과해야 한다. generated hook 이 없을 때만 중앙 TS/JS fallback 이 돈다.
+**우선순위**: 프로젝트에 generated TDD hook 이 있으면 project-local hook 이 TDD 판단을 소유한다. Interactive Claude Code 경로에서 `.claude/settings.json` 이 generated hook 을 등록한 상태라면 중앙 plug-in `tdd-guard.sh` 는 중복 판단을 피하고 즉시 allow 한다. Headless worker 와 synthetic 검사 경로는 `DCNESS_HEADLESS_TDD_CHECK=1` 로 중앙 hook 을 호출해 `.claude/hooks/dcness-tdd-guard.sh` 에 위임한다. generated hook 이 없을 때만 중앙 TS/JS fallback 이 돈다.
 
 **TDD 계약 + self-test**: 계약은 생성물과 독립이다. `scripts/dcness-tdd-hooks self-test` 는 fixture 로 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 재현한다. `/init-dcness` 의 `scripts/dcness-tdd-hooks ensure --targets cc,codex` 는 이 계약 self-test 를 먼저 실행하고, 통과한 후보만 hook 으로 등록한다.
 
-**지원 플랫폼**: generated hook 은 프로젝트 감지 결과(android/iOS/web/backend 등)를 기준으로 project-local config(`.dcness/tdd-hooks.json`)를 만든다. 빈 프로젝트 또는 미지원 플랫폼은 생성 skip 이며 안전 no-op 이다. 중앙 fallback 은 기존 호환을 위해 TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 검사한다. 그 외 확장자는 generated hook 이 없으면 silent skip 이다.
+**지원 플랫폼**: 현재 generated hook helper 는 `python`, `web`, `go`, `android`, `ios` 프리셋을 기준으로 project-local config(`.dcness/tdd-hooks.json`)를 만든다. 빈 프로젝트 또는 미지원 플랫폼은 생성 skip 이며 안전 no-op 이다. 새 플랫폼은 이 프리셋을 확장해야 하므로, 프로젝트 에이전트가 플랫폼별 규칙을 더 직접 소유하는 후속 위임 작업 대상이다. 중앙 fallback 은 기존 호환을 위해 TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 검사한다. 그 외 확장자는 generated hook 이 없으면 silent skip 이다.
 
-**생성/등록 순서**: CC hook 이 먼저다. `.claude/hooks/dcness-tdd-guard.sh` 후보가 self-test 를 통과해야 `.claude/settings.json` PreToolUse(`Edit|Write|NotebookEdit|Bash`) 에 등록된다. Codex hook 은 그 다음 같은 패턴으로 `.codex/hooks/dcness-tdd-guard.sh` 와 `.codex/hooks.json` PreToolUse(`Edit|Write|apply_patch`) 에 등록된다. Codex 쪽은 CLI 의 사용자 신뢰 승인(`~/.codex/config.toml` trusted hash 흐름)이 추가로 필요할 수 있다.
+**생성/등록 순서**: CC hook 이 먼저다. `.claude/hooks/dcness-tdd-guard.sh` 후보가 self-test 를 통과해야 `.claude/settings.json` PreToolUse(`Edit|Write|NotebookEdit|Bash`) 에 등록된다. Codex hook 은 그 다음 같은 패턴으로 `.codex/hooks/dcness-tdd-guard.sh` 와 `.codex/hooks.json` PreToolUse(`Edit|Write|apply_patch`) 에 등록된다. 기존 `.claude/settings.json` 또는 `.codex/hooks.json` 이 깨진 JSON 이면 등록을 거부하고 파일을 덮어쓰지 않는다. Codex 쪽은 CLI 의 사용자 신뢰 승인(`~/.codex/config.toml` trusted hash 흐름)이 추가로 필요할 수 있으므로, `registered` 는 project-local 파일 등록 상태이지 사용자 trust 승인 완료를 뜻하지 않는다.
 
-**공존 규칙**: generated hook 이 있으면 중앙 hook 은 위임 후 종료한다. 따라서 TS/JS 프로젝트에서도 중앙 fallback 과 project-local hook 이 같은 파일을 이중 deny 하지 않는다. generated hook 이 실패하거나 self-test 를 통과하지 못한 후보는 등록되지 않으며, 미설정·생성 실패 시 no-op 으로 안전 통과한다.
+**Git 도달성**: 생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)은 Git 에 커밋되어야 새 worktree 와 headless worker 체크아웃에서 같은 계약을 재사용한다. 자동 workflow PR 대상은 아니지만 activation bootstrap commit 대상이다. `scripts/dcness-tdd-hooks status` 는 HEAD 에 깨끗하게 반영되지 않은 생성 파일을 `commit-required` 로 표시하고, `dcness-helper status` 는 같은 상태를 WARN 으로 표시한다.
+
+**공존 규칙**: generated hook 이 interactive CC project hook 으로 등록되어 있으면 중앙 hook 은 중복 실행하지 않는다. Headless/synthetic 경로는 중앙 hook 이 generated hook 에 위임한 뒤 종료한다. 따라서 TS/JS 프로젝트에서도 중앙 fallback 과 project-local hook 이 같은 파일을 이중 deny 하지 않는다. generated hook 이 실패하거나 self-test 를 통과하지 못한 후보는 등록되지 않으며, 미설정·생성 실패 시 no-op 으로 안전 통과한다.
 
 **중앙 fallback 역할**: generated hook 이 없는 프로젝트에서는 TS/JS 구현 파일에 대응하는 test/spec 파일이 *존재하는지* 확인한다. 없으면 구현 파일 작성을 막는다. **test 의 존재만 검사하고, test 를 실행하지는 않는다** — green/red 판정이 아니라 "작성 전 test 가 먼저 있는가" 강제다.
 
@@ -187,7 +189,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **Bash write target 정책**: `Bash` payload 는 [`harness.agent_boundary.extract_bash_paths`](../../harness/agent_boundary.py) 가 추출하는 명시적 write target 에 한해 검사한다. 예: redirect(`>`, `>>`), `tee`, in-place edit(`sed/perl/awk -i`), `cp`/`mv`/`rm` target. 추출된 target 이 TS/JS 구현 파일이면 직접 `Edit`/`Write`/`NotebookEdit` 와 동일한 skip 규칙 및 6-tier matching-test 존재 검사를 탄다. write target 이 없거나 TS/JS 구현 파일이 아니면 silent skip 한다.
 
-**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 와 [`scripts/dcness-claude-worker`](../../scripts/dcness-claude-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. 중앙 `tdd-guard.sh` 가 generated hook 을 위임하므로 headless lane 도 non-TS/JS 플랫폼에서 같은 project-local **TDD 계약**을 재사용한다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
+**Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 와 [`scripts/dcness-claude-worker`](../../scripts/dcness-claude-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. 중앙 `tdd-guard.sh` 가 generated hook 을 위임하므로 headless lane 도 non-TS/JS 플랫폼에서 같은 project-local **TDD 계약**을 재사용한다. 단, 이 재사용은 generated hook 파일들이 Git 에 커밋되어 해당 worktree 에 존재할 때만 성립한다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
 
 **차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다. Headless worker 차단 메시지는 `[dcness-codex-worker] BLOCKED: TDD GUARD ...` 또는 `[dcness-claude-worker] BLOCKED: TDD GUARD ...` 로 시작하고 위반 파일 목록을 포함한다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -54,7 +54,9 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 
 파일 경계 override 제안은 `dcness-helper boundary-suggestions` 로 처리한다. 코어 `ALLOW_MATRIX` 가 커버하지 않는 비표준 소스 디렉터리가 있을 때만 `.dcness/boundary.json` 의 `engineer.add` 후보를 출력하며, 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다. 이 helper 는 read-only 이므로 실제 boundary 파일 작성은 사람 승인 뒤 메인이 수행한다.
 
-Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소유 영역은 **TDD 계약**과 **self-test** 이며, self-test fixture 는 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 검증한다. `/init-dcness` 에서 생성할 때는 CC hook 후보를 먼저 self-test 하고 통과해야 `.claude/settings.json` 에 등록한다. 그 다음 Codex hook 후보를 같은 계약으로 self-test 하고 `.codex/hooks.json` 에 등록한다. 빈 프로젝트·미지원 플랫폼·생성 실패는 no-op 으로 안전 통과한다.
+Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소유 영역은 **TDD 계약**과 **self-test** 이며, self-test fixture 는 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 검증한다. 현재 helper 는 `python`, `web`, `go`, `android`, `ios` 프리셋으로 project-local config 를 만들며, 새 플랫폼은 후속 위임 작업 전까지 프리셋 확장이 필요하다. `/init-dcness` 에서 생성할 때는 CC hook 후보를 먼저 self-test 하고 통과해야 `.claude/settings.json` 에 등록한다. 그 다음 Codex hook 후보를 같은 계약으로 self-test 하고 `.codex/hooks.json` 에 등록한다. 빈 프로젝트·미지원 플랫폼·생성 실패는 no-op 으로 안전 통과한다.
+
+생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)은 자동 workflow PR 에 섞지 않지만 Git 커밋 대상이다. 커밋되지 않으면 새 worktree 나 headless worker 체크아웃에서 project-local hook 을 볼 수 없어 중앙 fallback 으로 내려간다. `scripts/dcness-tdd-hooks status` 와 `ensure` 는 이 파일들이 HEAD 에 깨끗하게 반영되기 전까지 `commit-required` 를 출력한다.
 
 `docs/index.md` 의 epic/module 표, 전역 `docs/architecture.md` 의 집계 섹션, 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
@@ -185,7 +187,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 `/init-dcness` 의 자동 commit + PR 단계는 `.github/workflows/*.yml` 만 대상으로 한다.
 
 - 포함: `git-naming-validation.yml`, `pr-body-validation.yml`, `doc-path-integrity.yml`, `doc-sync.yml`, `github-project-lifecycle.yml`
-- 제외: `.git/hooks/*` (git 내부 파일), generated TDD hook bootstrap(`.dcness/tdd-hooks.json`, `.claude/**`, `.codex/**`), `~/.claude/**`, `$CODEX_HOME/**`, `.gitignore` runtime/volatile ignore, `docs/*` seed, `docs/design-variants/*` seed, 자동 CC hook 설명
+- 제외: `.git/hooks/*` (git 내부 파일), generated TDD hook bootstrap(`.dcness/tdd-hooks.json`, `.claude/**`, `.codex/**` — 자동 workflow PR 제외일 뿐 Git 커밋 대상), `~/.claude/**`, `$CODEX_HOME/**`, `.gitignore` runtime/volatile ignore, `docs/*` seed, `docs/design-variants/*` seed, 자동 CC hook 설명
 - 선행 조건: GitHub remote 존재, 현재 branch `main`, `gh auth status` 통과. 조건이 안 맞으면 branch/commit/push 를 시작하지 않고 skip 안내만 출력한다.
 
 seed 문서는 사용자 프로젝트 내용물이므로 사용자가 별도 작업 PR 에 포함할지 직접 판단한다.

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -3793,12 +3793,26 @@ def collect_status_diagnostics(
                     "INFO",
                     "빈 프로젝트 또는 미지원 플랫폼 — 생성 skip",
                 )
+            elif (
+                generated_tdd.get("cc_registered")
+                and generated_tdd.get("codex_registered")
+                and not generated_tdd.get("generated_files_committed")
+            ):
+                uncommitted = generated_tdd.get("uncommitted_generated_files") or []
+                detail = ", ".join(str(item) for item in uncommitted[:5])
+                add(
+                    "generated_tdd_hooks",
+                    "Generated TDD hooks",
+                    "WARN",
+                    f"platform={platform}, CC+Codex 등록됨, 미커밋 생성 파일: {detail}",
+                    "generated TDD hook 파일을 bootstrap commit 에 포함",
+                )
             elif generated_tdd.get("cc_registered") and generated_tdd.get("codex_registered"):
                 add(
                     "generated_tdd_hooks",
                     "Generated TDD hooks",
                     "PASS",
-                    f"platform={platform}, CC+Codex 등록됨",
+                    f"platform={platform}, CC+Codex 로컬 등록됨 (Codex trust 승인은 별도 확인)",
                 )
             elif generated_tdd.get("cc_registered") or generated_tdd.get("codex_registered"):
                 add(

--- a/harness/tdd_hooks.py
+++ b/harness/tdd_hooks.py
@@ -72,13 +72,27 @@ class SelfTestError(RuntimeError):
         super().__init__("\n".join(lines))
 
 
-def _read_json(path: Path) -> dict[str, Any]:
+class JsonConfigError(RuntimeError):
+    """Raised when an existing user-owned JSON file would be overwritten."""
+
+
+def _read_json(path: Path, *, strict: bool = False) -> dict[str, Any]:
     if not path.is_file():
         return {}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-    except (json.JSONDecodeError, OSError):
+    except json.JSONDecodeError as exc:
+        if strict:
+            raise JsonConfigError(
+                f"{path}: invalid JSON; refusing to overwrite existing file"
+            ) from exc
         return {}
+    except OSError as exc:
+        if strict:
+            raise JsonConfigError(f"{path}: cannot read JSON file: {exc}") from exc
+        return {}
+    if strict and not isinstance(data, dict):
+        raise JsonConfigError(f"{path}: JSON root must be an object")
     return data if isinstance(data, dict) else {}
 
 
@@ -623,7 +637,7 @@ def _strip_existing_dcness_tdd_hooks(entries: list[Any]) -> list[Any]:
 
 
 def _register_hook_json(path: Path, matcher: str, command: str) -> None:
-    data = _read_json(path)
+    data = _read_json(path, strict=True)
     hooks = data.setdefault("hooks", {})
     if not isinstance(hooks, dict):
         hooks = {}
@@ -667,6 +681,82 @@ def _register_codex(project_root: Path) -> None:
     )
 
 
+def _preflight_registration_json(project_root: Path, targets: Iterable[str]) -> None:
+    _read_json(project_root / CONFIG_REL, strict=True)
+    target_set = set(targets)
+    if "cc" in target_set:
+        _read_json(project_root / CC_SETTINGS_REL, strict=True)
+    if "codex" in target_set:
+        _read_json(project_root / CODEX_HOOKS_REL, strict=True)
+
+
+def _run_git(project_root: Path, args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # nosec B603, B607
+        ["git", "-C", str(project_root), *args],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+
+
+def _is_git_work_tree(project_root: Path) -> bool:
+    try:
+        proc = _run_git(project_root, ["rev-parse", "--is-inside-work-tree"])
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0 and proc.stdout.strip() == "true"
+
+
+def _is_committed_clean(project_root: Path, rel: Path) -> bool:
+    rel_text = rel.as_posix()
+    try:
+        status = _run_git(project_root, ["status", "--porcelain", "--", rel_text])
+        tracked = _run_git(project_root, ["ls-files", "--error-unmatch", "--", rel_text])
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return status.returncode == 0 and not status.stdout.strip() and tracked.returncode == 0
+
+
+def generated_files_git_state(project_root: Path) -> dict[str, Any]:
+    root = project_root.resolve()
+    existing = _existing_generated_file_rels(root)
+    if not existing:
+        return {
+            "generated_files": [],
+            "generated_files_committed": True,
+            "uncommitted_generated_files": [],
+        }
+    if not _is_git_work_tree(root):
+        return {
+            "generated_files": existing,
+            "generated_files_committed": False,
+            "uncommitted_generated_files": existing,
+        }
+    uncommitted = [
+        rel for rel in existing if not _is_committed_clean(root, Path(rel))
+    ]
+    return {
+        "generated_files": existing,
+        "generated_files_committed": not uncommitted,
+        "uncommitted_generated_files": uncommitted,
+    }
+
+
+def _existing_generated_file_rels(root: Path) -> list[str]:
+    existing: list[str] = []
+    if (root / CONFIG_REL).exists():
+        existing.append(CONFIG_REL.as_posix())
+    if _hook_json_references(root / CC_SETTINGS_REL, "dcness-tdd-guard.sh"):
+        existing.append(CC_SETTINGS_REL.as_posix())
+    if (root / CC_HOOK_REL).exists():
+        existing.append(CC_HOOK_REL.as_posix())
+    if _hook_json_references(root / CODEX_HOOKS_REL, "dcness-tdd-guard.sh"):
+        existing.append(CODEX_HOOKS_REL.as_posix())
+    if (root / CODEX_HOOK_REL).exists():
+        existing.append(CODEX_HOOK_REL.as_posix())
+    return existing
+
+
 def ensure_generated_hooks(
     *,
     project_root: Path,
@@ -685,7 +775,8 @@ def ensure_generated_hooks(
         normalized = ["cc"] + [target for target in normalized if target != "cc"]
 
     config_path = root / CONFIG_REL
-    current = _read_json(config_path)
+    _preflight_registration_json(root, normalized)
+    current = _read_json(config_path, strict=True)
     registered_data = current.get("registered")
     registered: dict[str, Any] = registered_data if isinstance(registered_data, dict) else {}
     registered_config: dict[str, bool] = {
@@ -725,9 +816,20 @@ def ensure_generated_hooks(
             registered_config[target] = True
             config["registered"] = registered_config
             _write_json(config_path, config)
-            messages.append(f"{target}: registered")
+            if target == "codex":
+                messages.append("codex: registered (Codex trust approval may still be required)")
+            else:
+                messages.append(f"{target}: registered")
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)
+    git_state = generated_files_git_state(root)
+    uncommitted = git_state["uncommitted_generated_files"]
+    if uncommitted:
+        joined = ", ".join(uncommitted)
+        messages.append(
+            "commit-required: generated TDD hook files must be committed for "
+            f"worktree/headless reuse: {joined}"
+        )
     return messages
 
 
@@ -741,7 +843,7 @@ def inspect_installation(project_root: Path) -> dict[str, Any]:
     codex_hook = (root / CODEX_HOOK_REL).is_file()
     cc_configured = _hook_json_references(root / CC_SETTINGS_REL, "dcness-tdd-guard.sh")
     codex_configured = _hook_json_references(root / CODEX_HOOKS_REL, "dcness-tdd-guard.sh")
-    return {
+    report = {
         "platform": platform,
         "config": bool(config),
         "cc_hook": cc_hook,
@@ -749,6 +851,8 @@ def inspect_installation(project_root: Path) -> dict[str, Any]:
         "cc_registered": bool(registered.get("cc")) and cc_hook and cc_configured,
         "codex_registered": bool(registered.get("codex")) and codex_hook and codex_configured,
     }
+    report.update(generated_files_git_state(root))
+    return report
 
 
 def _hook_json_references(path: Path, needle: str) -> bool:
@@ -778,7 +882,11 @@ def _cmd_self_test(args: argparse.Namespace) -> int:
     config: Optional[dict[str, Any]]
     if args.config:
         config_path = Path(args.config).resolve()
-        config = _read_json(config_path)
+        try:
+            config = _read_json(config_path, strict=True)
+        except JsonConfigError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
     else:
         config = build_contract_config(project_root, args.platform)
         config_path = project_root / ".dcness" / ".tmp-self-test-config.json"
@@ -812,7 +920,7 @@ def _cmd_ensure(args: argparse.Namespace) -> int:
             targets=tuple(part for part in args.targets.split(",") if part),
             plugin_root=Path(args.plugin_root).resolve(),
         )
-    except (SelfTestError, ValueError) as exc:
+    except (JsonConfigError, SelfTestError, ValueError) as exc:
         print(str(exc), file=sys.stderr)
         return 1
     for message in messages:
@@ -830,8 +938,13 @@ def _cmd_status(args: argparse.Namespace) -> int:
         "generated TDD hooks: "
         f"platform={platform}, "
         f"cc={report['cc_registered']}, "
-        f"codex={report['codex_registered']}"
+        f"codex={report['codex_registered']}, "
+        f"generated_files_committed={report['generated_files_committed']}"
     )
+    uncommitted = report.get("uncommitted_generated_files")
+    if isinstance(uncommitted, list) and uncommitted:
+        joined = ", ".join(str(item) for item in uncommitted)
+        print(f"commit-required: {joined}")
     return 0
 
 

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -66,6 +66,26 @@ PY
 
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
+cc_generated_project_hook_registered() {
+  local settings="$PROJECT_ROOT/.claude/settings.json"
+  [ -f "$settings" ] || return 1
+  python3 - "$settings" >/dev/null 2>&1 <<'PY'
+import json
+import sys
+
+try:
+    data = json.loads(open(sys.argv[1], encoding="utf-8").read())
+except Exception:
+    sys.exit(1)
+hooks = data.get("hooks") if isinstance(data, dict) else None
+pre = hooks.get("PreToolUse") if isinstance(hooks, dict) else None
+if not isinstance(pre, list):
+    sys.exit(1)
+needle = "dcness-tdd-guard.sh"
+sys.exit(0 if any(needle in json.dumps(entry) for entry in pre) else 1)
+PY
+}
+
 delegate_generated_project_hook() {
   # #909 — project-local generated hook wins over the legacy central TS/JS guard.
   # The generated hook has already passed dcNess-owned contract self-test before
@@ -75,6 +95,13 @@ delegate_generated_project_hook() {
   local generated_hook="$PROJECT_ROOT/.claude/hooks/dcness-tdd-guard.sh"
   local generated_config="$PROJECT_ROOT/.dcness/tdd-hooks.json"
   [ -x "$generated_hook" ] && [ -f "$generated_config" ] || return 0
+
+  # Interactive Claude Code can run both the plug-in hook and the project-local
+  # hook for the same event. If the project hook is registered, let it own the
+  # decision and keep the central hook for headless/synthetic checks only.
+  if [ "${DCNESS_HEADLESS_TDD_CHECK:-}" != "1" ] && cc_generated_project_hook_registered; then
+    allow
+  fi
 
   local generated_err generated_rc
   generated_err=$(

--- a/scripts/dcness-claude-worker
+++ b/scripts/dcness-claude-worker
@@ -419,6 +419,7 @@ PY
         | CLAUDE_PLUGIN_ROOT="$SCRIPT_DIR/.." \
           PYTHONPATH="$SCRIPT_DIR/..:${PYTHONPATH:-}" \
           DCNESS_FORCE_ENABLE=1 \
+          DCNESS_HEADLESS_TDD_CHECK=1 \
           bash "$SCRIPT_DIR/../hooks/tdd-guard.sh" 2>&1 >/dev/null
     )"
     _tdd_rc=$?

--- a/scripts/dcness-codex-worker
+++ b/scripts/dcness-codex-worker
@@ -378,6 +378,7 @@ PY
         | CLAUDE_PLUGIN_ROOT="$SCRIPT_DIR/.." \
           PYTHONPATH="$SCRIPT_DIR/..:${PYTHONPATH:-}" \
           DCNESS_FORCE_ENABLE=1 \
+          DCNESS_HEADLESS_TDD_CHECK=1 \
           bash "$SCRIPT_DIR/../hooks/tdd-guard.sh" 2>&1 >/dev/null
     )"
     _tdd_rc=$?

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -89,7 +89,7 @@ GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecy
 
 ## Step 0.3 — generated TDD hook 부재 확인
 
-구현 진입 전에 project-local TDD hook 상태를 한 번 확인한다. dcNess 는 **TDD 계약**과 생성 직후 **self-test** 를 소유하고, hook 본문은 프로젝트 플랫폼에 맞게 생성된다.
+구현 진입 전에 project-local TDD hook 상태를 한 번 확인한다. dcNess 는 **TDD 계약**과 생성 직후 **self-test** 를 소유하고, hook 본문은 현재 helper 의 플랫폼 프리셋(`python`, `web`, `go`, `android`, `ios`)에 맞게 생성된다.
 
 ```bash
 "$PLUGIN_ROOT/scripts/dcness-tdd-hooks" status --project-root "$PROJECT_ROOT"
@@ -102,6 +102,8 @@ GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecy
 ```
 
 빈 프로젝트, 미지원 플랫폼, 생성 실패, self-test 실패는 no-op 으로 안전 통과한다. 생성 훅이 있으면 중앙 `tdd-guard.sh` 와 headless worker 사후 검사는 그 generated hook 을 먼저 실행한다.
+
+`status` 또는 `ensure` 가 `commit-required` 를 출력하면 생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)을 bootstrap commit 에 포함해야 한다. 커밋되지 않은 생성 파일은 새 worktree/headless worker 체크아웃에 없으므로 project-local TDD 계약이 재사용되지 않는다.
 
 ## Step 0.4 — UI 기준 확보 분기
 

--- a/tests/test_generated_tdd_hooks.py
+++ b/tests/test_generated_tdd_hooks.py
@@ -38,11 +38,24 @@ def _run_hook(hook: Path, project: Path, file_path: Path) -> subprocess.Complete
     )
 
 
-def _run_central_guard(project: Path, file_path: Path) -> subprocess.CompletedProcess[str]:
+def _run_central_guard(
+    project: Path,
+    file_path: Path,
+    *,
+    headless: bool = False,
+) -> subprocess.CompletedProcess[str]:
     payload = {
         "tool_name": "Edit",
         "tool_input": {"file_path": str(file_path)},
     }
+    env = {
+        **os.environ,
+        "CLAUDE_PLUGIN_ROOT": str(ROOT),
+        "DCNESS_FORCE_ENABLE": "1",
+        "PYTHONPATH": str(ROOT),
+    }
+    if headless:
+        env["DCNESS_HEADLESS_TDD_CHECK"] = "1"
     return subprocess.run(
         ["bash", str(CENTRAL_TDD_GUARD)],
         input=json.dumps(payload),
@@ -50,12 +63,7 @@ def _run_central_guard(project: Path, file_path: Path) -> subprocess.CompletedPr
         text=True,
         cwd=project,
         timeout=10,
-        env={
-            **os.environ,
-            "CLAUDE_PLUGIN_ROOT": str(ROOT),
-            "DCNESS_FORCE_ENABLE": "1",
-            "PYTHONPATH": str(ROOT),
-        },
+        env=env,
     )
 
 
@@ -122,6 +130,7 @@ class GeneratedTddHookContractTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("cc: registered", result.stdout)
             self.assertIn("codex: registered", result.stdout)
+            self.assertIn("commit-required:", result.stdout)
 
             config = json.loads(
                 (project / ".dcness" / "tdd-hooks.json").read_text(encoding="utf-8")
@@ -144,6 +153,118 @@ class GeneratedTddHookContractTests(unittest.TestCase):
                 any("apply_patch" in e.get("matcher", "") for e in codex_pre),
                 codex_hooks,
             )
+
+    def test_status_reports_generated_files_until_committed_to_git(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc,codex",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            report = inspect_installation(project)
+            self.assertFalse(report["generated_files_committed"])
+            self.assertIn(".dcness/tdd-hooks.json", report["uncommitted_generated_files"])
+            self.assertIn(".claude/settings.json", report["uncommitted_generated_files"])
+            self.assertIn(".codex/hooks.json", report["uncommitted_generated_files"])
+
+            subprocess.run(["git", "add", "."], cwd=project, check=True)
+            subprocess.run(
+                [
+                    "git",
+                    "-c",
+                    "user.name=dcness-test",
+                    "-c",
+                    "user.email=dcness@example.invalid",
+                    "commit",
+                    "-q",
+                    "-m",
+                    "bootstrap generated hooks",
+                ],
+                cwd=project,
+                check=True,
+            )
+
+            committed_report = inspect_installation(project)
+            self.assertTrue(committed_report["generated_files_committed"])
+            self.assertEqual(committed_report["uncommitted_generated_files"], [])
+
+    def test_status_ignores_unrelated_user_settings_without_tdd_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            settings = project / ".claude" / "settings.json"
+            settings.parent.mkdir()
+            settings.write_text(
+                json.dumps({"permissions": {"allow": ["Read(docs/**)"]}}),
+                encoding="utf-8",
+            )
+            codex_hooks = project / ".codex" / "hooks.json"
+            codex_hooks.parent.mkdir()
+            codex_hooks.write_text(json.dumps({"hooks": {}}), encoding="utf-8")
+
+            report = inspect_installation(project)
+
+            self.assertEqual(report["generated_files"], [])
+            self.assertTrue(report["generated_files_committed"])
+            self.assertEqual(report["uncommitted_generated_files"], [])
+
+    def test_ensure_refuses_malformed_cc_settings_without_overwriting(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+            settings = project / ".claude" / "settings.json"
+            settings.parent.mkdir()
+            original = '{"permissions": '
+            settings.write_text(original, encoding="utf-8")
+
+            result = subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("invalid JSON", result.stderr)
+            self.assertEqual(settings.read_text(encoding="utf-8"), original)
+            self.assertFalse((project / ".claude" / "hooks" / "dcness-tdd-guard.sh").exists())
+            self.assertFalse((project / ".dcness" / "tdd-hooks.json").exists())
 
     def test_generated_python_hook_enforces_flat_project_without_source_dir(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -279,9 +400,48 @@ class GeneratedTddHookContractTests(unittest.TestCase):
             target = project / "src" / "headless_contract.py"
             target.write_text("def headless_contract():\n    return 1\n", encoding="utf-8")
 
-            result = _run_central_guard(project, target)
+            result = _run_central_guard(project, target, headless=True)
             self.assertEqual(result.returncode, 2, result.stderr)
             self.assertIn("headless_contract", result.stderr)
+
+    def test_central_tdd_guard_skips_project_hook_during_interactive_cc_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            target = project / "src" / "interactive_contract.py"
+            target.write_text("def interactive_contract():\n    return 1\n", encoding="utf-8")
+
+            central = _run_central_guard(project, target)
+            self.assertEqual(central.returncode, 0, central.stderr)
+            self.assertNotIn("TDD GUARD", central.stderr)
+
+            project_hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            generated = _run_hook(project_hook, project, target)
+            self.assertEqual(generated.returncode, 2, generated.stderr)
+            self.assertIn("interactive_contract", generated.stderr)
 
     def test_ensure_skips_empty_project_without_registering_hooks(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## 관련 이슈 번호

Part of #908

## 배경 및 문제

#916 머지 후 리뷰에서 generated TDD hook 의 worktree/headless 도달성, interactive 중복 발화, settings JSON 파손 시 보존, 플랫폼 프리셋 MVP 한계가 남은 소견으로 확인됐다. 핵심 계약은 유지하되 운영상 조용히 빠지는 경로를 막고, 즉시 구현 범위를 넘는 플랫폼 위임 확장은 별도 follow-up 으로 추적한다.

## 원인 (해당 시)

- generated hook 파일이 자동 workflow PR 에서 제외되지만 별도 커밋 필요성이 status/문서에 충분히 드러나지 않아 새 worktree/headless 체크아웃에서 project-local hook 이 사라질 수 있었다.
- 중앙 plug-in hook 과 project-local CC hook 이 같은 interactive 이벤트에서 모두 판단할 수 있었다.
- 기존 JSON reader 가 파싱 실패를 빈 dict 로 취급하면 사용자 `.claude/settings.json` 또는 `.codex/hooks.json` 을 덮어쓸 위험이 있었다.
- 현재 구현은 실용적 프리셋 MVP 이므로 #909/#908 의 장기 철학과 남은 간극을 후속 이슈로 명시해야 했다.

## 작업내용

- `scripts/dcness-tdd-hooks ensure/status` 와 `inspect_installation` 이 generated 파일의 git 도달성을 검사하고 `commit-required` / `generated_files_committed` 를 노출하게 했다.
- `dcness-helper status` 의 Generated TDD hooks 진단이 미커밋 생성 파일을 WARN 으로 표시하고, Codex trust 승인은 별도임을 과대 표시하지 않게 했다.
- 기존 `.claude/settings.json` / `.codex/hooks.json` / `.dcness/tdd-hooks.json` 이 깨진 JSON 이면 등록을 거부하고 기존 파일을 보존하게 했다.
- interactive CC 에서는 project-local hook 이 등록된 경우 중앙 `tdd-guard.sh` 가 중복 판단하지 않고, headless worker 는 `DCNESS_HEADLESS_TDD_CHECK=1` 로 중앙 위임 경로를 유지하게 했다.
- `/init-dcness`, `/impl`, hook 문서에 생성 파일 커밋 정책, 현재 지원 프리셋, headless 재사용 조건, Codex trust 한계를 반영했다.
- 플랫폼 프리셋의 장기 위임 확장은 #918 로 분리했다.

## 결정 근거

리뷰 소견 1/3/4 는 동일 PR 안에서 회귀 테스트와 코드 보강으로 닫을 수 있는 운영 결함이다. 소견 2는 현재 MVP 를 당장 뒤집으면 #909 의 안정화 범위를 크게 넘기므로, 현 상태를 문서에 정확히 표시하고 #918 로 제품/아키텍처 후속을 분리했다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체: `harness/tdd_hooks.py`, `hooks/tdd-guard.sh`, headless worker 스크립트가 plugin update 로 배포된다.
- `/init-dcness` 경로: `commands/init-dcness.md`, `docs/plugin/init-dcness.md` 가 generated hook 생성 파일의 별도 bootstrap commit 필요성을 안내한다.
- `/impl` 경로: `skills/impl/SKILL.md` 가 구현 진입 시 `commit-required` 대응을 안내한다.
- hook 정책 SSOT: `docs/plugin/hooks.md` 가 interactive/headless 공존 규칙, Git 도달성, 프리셋 한계, Codex trust 한계를 설명한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. #918 은 후속 추적용 이슈다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -p 'test_generated_tdd_hooks.py' -v < /dev/null`\n- [x] `python3.11 -m unittest tests.test_status_diagnostics tests.test_tdd_guard -v < /dev/null`\n- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1610 tests OK via pre-commit\n- [x] `node scripts/check_cross_refs.mjs`\n- [x] `node scripts/check_public_surface.mjs`\n- [x] `node scripts/check_plugin_manifest.mjs`\n- [x] `node scripts/aggregate_index_map.mjs --check`\n- [x] `node scripts/aggregate_architecture_map.mjs --check`\n- [x] `node scripts/check_design_artifact_structure.mjs`\n- [x] `git diff --check origin/main...HEAD`\n- [x] `PYTHON_BIN=/tmp/dcness-quality-issue908/bin/python bash scripts/check_static_quality.sh`\n\n## 참고\n\n- Follow-up: #918 — generated TDD hook 플랫폼 프리셋 위임 확장