### PR TITLE
[feature] 프로젝트 로컬 lesson 층 추가

### DIFF
--- a/commands/run-review.md
+++ b/commands/run-review.md
@@ -28,6 +28,7 @@ description: dcness loop run (begin-run / end-run 사이클) 사후 분석 스�
 2. **잘못한 점** (WASTE findings) — `run_review.py` 의 현재 waste detector 결과
 3. **재발 기반 개선 후보** — 현재 run 의 waste pattern 이 같은 sessions root 에서 임계(기본 3회) 이상 반복되면 표면화. 룰 추가, skill 박제, 기존 룰 제거 중 무엇을 할지는 사용자가 결정한다.
 4. **CLAUDE.md/AGENTS.md 현행화 후보** — context 문서 존재, AGENTS.md 의 CLAUDE.md SSOT 참조, CLAUDE.md 공식 구조·6축 rubric·dcNess cold-start 앵커, run-review finding 기반 세션 학습 환류 후보. 자동 수정하지 않고 제안만 출력한다.
+5. **프로젝트-로컬 lesson 생성 입력** — helper `end-run` 시점에 같은 sessions root 의 recurrent WasteFinding 을 `.claude/loop-lessons/<agent>[-<mode>].md` 로 자동 축적한다. NoteFinding 은 lesson 입력이 아니다.
 
 ## 절차
 
@@ -73,16 +74,13 @@ GOOD 자동 finding 은 폐기됐다. 잘한 사례 누적은 baseline noise 가
 
 ### 잘못한 점 (WASTE)
 
-| 패턴 | 심각도 | 검출 조건 | 정합 룰 |
-|---|---|---|---|
-| `RETRY_SAME_FAIL` | MEDIUM | 연속 동일 FAIL enum | 각 skill `<skill>-routing.md` 의 retry 한도 |
-| `ECHO_VIOLATION` | MEDIUM | prose_excerpt < 3줄 | DCN-30-15 |
-| `PLACEHOLDER_LEAK` | HIGH (system-architect) / MEDIUM | prose 안 `[미기록]` / `M0 이후` / `NotImplementedError` | DCN-30-18 |
-| `MUST_FIX_GHOST` | HIGH | must_fix=true 이후 다음 step 진행 | loop 실행 절차 주의사항 룰 |
-| `SPEC_GAP_LOOP` | MEDIUM | module-architect 보강 cycle > 2회 | 각 skill `<skill>-routing.md` 의 retry 한도 |
-| `INFRA_READ` | HIGH | prose 안 인프라 경로 흔적 | 중대 차단 권한 경계 |
-| `READONLY_BASH` | HIGH | read-only agent 가 Bash 호출 | 중대 차단 권한 경계 |
-| `THINKING_LOOP` (DCN-30-20) | HIGH | duration > budget × 1.5 + output_tokens < budget × 0.3 (또는 duration > 5분 + output < 1k) | old planning run 6분 stall 실측 사례 |
+패턴 목록의 SSOT 는 `harness/run_review.py` 의 `ACTIVE_WASTE_PATTERNS` 와
+`detect_wastes()` 구현이다. 이 문서는 목록 사본을 박제하지 않는다. detector 추가·삭제
+시 lesson archive 여부도 이 코드 SSOT 를 따른다.
+
+`THINKING_LOOP` / `TOOL_USE_OVERFLOW` 같은 `detect_notes()` 결과는 severity 없는
+raw 알림이다. run-review 리포트에는 "측정 noted" 로 표시되지만, 재발 lesson 입력에는
+포함하지 않는다.
 
 ### Per-Agent 비용 / 토큰 (DCN-30-20, Phase 2)
 
@@ -102,11 +100,11 @@ GOOD 자동 finding 은 폐기됐다. 잘한 사례 누적은 baseline noise 가
 - **prose 텍스트 분석 한계** — 한국어/영어 mixed regex 기반. semantic 분석 안 함.
 - **단일 run 중심** — `/run-review` 의 재발 후보는 현재 run 의 waste pattern 만 같은 sessions root 에서 카운트한다. 전체 fleet 후보는 `harness/benchmark_aggregate.py` 를 사용한다.
 - **자동 트리거 범위 제한** — helper 기반 `/design`·`/impl` run 은 `end-run` 의 review.md 안에 context audit 섹션이 자동 포함된다. helper run 이 없는 `/spec`·standalone `/acceptance` 는 skill 종료 절차에서 `dcness-review --context-audit` 를 명시 호출한다.
+- **lesson 생성 시점** — helper `end-run` 이 `run_finished` 를 기록한 직후 recurrent WasteFinding 을 동기화한다. 따라서 review.md 에 표시되는 후보와 별개로, 다음 `begin-step` 의 `[LESSONS]` 주입은 finished run 기준으로 계산된다.
 
 ## 참조
 
 - `harness/run_review.py` — 본 skill 의 실 구현
+- `harness/loop_lessons.py` — recurrent WasteFinding 기반 프로젝트-로컬 lesson 저장·주입
 - `commands/efficiency.md` — 세션 단위 토큰/캐시 효율 (보완 관계)
-- [`system-architect-agent.md` 판단 축](../agents/system-architect/system-architect-agent.md#판단-축) — PLACEHOLDER_LEAK 룰 출처 (옛 Spike Gate 차단 패턴)
-- loop skill 가시성 룰 (DCN-30-15) — ECHO_VIOLATION 룰 출처
 - 선행 하네스 review skill 패턴 — 본 skill 출처

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -6,6 +6,7 @@
 
 ## Unreleased
 
+- 프로젝트-로컬 lesson 층 추가 — recurrent WasteFinding 을 `.claude/loop-lessons/<agent>[-<mode>].md` 로 자동 축적하고 다음 `begin-step` 에 `[LESSONS]` 로 주입한다. NoteFinding 은 제외하며, `loop-diagnose` 가 활성 lesson 과 복수 프로젝트 동일 패턴을 Sense 후보로 읽는다. [#917](https://github.com/alruminum/dcNess/issues/917)
 - 자기개선 루프 SSOT 추가 — 측정 신호를 Sense→Diagnose→Decide→Act→Verify로 닫는 내부 절차를 [`docs/internal/self-improvement-loop.md`](self-improvement-loop.md)에 정의하고, 릴리즈 점검·eval 산출물 보존·핵심 행동 eval N/N 기준을 연결했다. [#893](https://github.com/alruminum/dcNess/issues/893)
 - 문서 개수 하드코딩 제거 — README/CLAUDE/loop-procedure/smart-compact의 구성 요소 count prose와 cross-ref count deny-list를 제거해 stale 방지 룰을 소멸시켰다. [#877](https://github.com/alruminum/dcNess/issues/877)
 - 릴리즈 전 가드 재평가 점검 명문화 — 릴리즈 절차가 `guard-telemetry` 집계 또는 수동 CI·hook 이력 확인으로 장기 무발화 guard를 소멸 후보로 판정하고, 결과를 아래 자기개선 점검 기록에 남기도록 했다. 새 CI 강제 게이트는 추가하지 않았다. [#878](https://github.com/alruminum/dcNess/issues/878)

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -15,8 +15,8 @@
 
 | 슬롯 | 질문 | 현재 담당 |
 |---|---|---|
-| Sense | 어떤 신호를 보나 | `/run-review`, benchmark/fleet 집계, `evals/guard_efficacy.py`, `evals/run.sh`, 가드 발화 텔레메트리 후보 [#875](https://github.com/alruminum/dcNess/issues/875), 재발·낭비 집계 후보 [#876](https://github.com/alruminum/dcNess/issues/876), judge 보정 후보 [#894](https://github.com/alruminum/dcNess/issues/894) |
-| Diagnose | 여러 신호를 어떻게 우선순위화하나 | `scripts/loop_diagnose.py`와 repo-local `/loop-diagnose` command가 전담한다. 활성 프로젝트 whitelist 를 읽어 cross-project 신호를 당겨오고, guard telemetry 는 `dcness-helper guard-telemetry` 와 같은 기본 90일 스캔창(`--since-days`)으로 본다. 수시 점검과 릴리즈 점검 양쪽에서 후보를 blocker, release-note follow-up, 별도 issue로 나눈다. |
+| Sense | 어떤 신호를 보나 | `/run-review`, benchmark/fleet 집계, 프로젝트-로컬 `.claude/loop-lessons/` 활성 lesson, `evals/guard_efficacy.py`, `evals/run.sh`, 가드 발화 텔레메트리 후보 [#875](https://github.com/alruminum/dcNess/issues/875), 재발·낭비 집계 후보 [#876](https://github.com/alruminum/dcNess/issues/876), judge 보정 후보 [#894](https://github.com/alruminum/dcNess/issues/894) |
+| Diagnose | 여러 신호를 어떻게 우선순위화하나 | `scripts/loop_diagnose.py`와 repo-local `/loop-diagnose` command가 전담한다. 활성 프로젝트 whitelist 를 읽어 cross-project 신호를 당겨오고, guard telemetry 는 `dcness-helper guard-telemetry` 와 같은 기본 90일 스캔창(`--since-days`)으로 본다. 활성 lesson 은 프로젝트별 Sense 항목으로 표시하고, 같은 lesson 패턴이 복수 프로젝트에서 활성화되면 중앙 RULE 후보로 올린다. 수시 점검과 릴리즈 점검 양쪽에서 후보를 blocker, release-note follow-up, 별도 issue로 나눈다. |
 | Decide | 무엇을 바꾸나 | 추가 전 제거 검토를 먼저 한다. 새 룰·hook·CI를 추가하기 전에 기존 룰 삭제, 문구 축약, SSOT 파생 생성으로 같은 효과를 낼 수 있는지 확인한다. 첫 사례는 개수 하드코딩 제거 [#877](https://github.com/alruminum/dcNess/issues/877)이다. |
 | Act | 실제 변경은 어디서 하나 | 일반 dcNess 변경 절차대로 branch → PR → merge를 탄다. PR 본문에 Sense 근거, Diagnose 판단, Decide 이유, Verify 계획을 짧게 적는다. |
 | Verify | 개선이 먹혔는지 어떻게 보나 | 변경 성격별로 결정적 eval, 행동 eval, 다음 Sense 주기 재측정을 분리한다. |

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -61,7 +61,7 @@ hook/function 의 결정적 allow/block 성능을 대신하지 않는다.
 | review rejection | `pr-reviewer` 가 실제로 반려한 비율 | `pr-reviewer` verdict: `FAIL / (PASS + LGTM + FAIL)` |
 | blocked events | run 이 안전하게 멈춘 횟수 | `ledger.jsonl` 의 `blocked` event |
 | escalate | agent 가 자동 진행을 거부하고 사용자/상위 설계로 올린 횟수 | step verdict 에 `ESCALATE` 포함 |
-| waste | 반복 실패, 도구 반복, placeholder 누수 등 비용 낭비 finding | `run_review.py` 의 waste detector |
+| waste | 반복 실패, 도구 반복, gate 모순 등 비용 낭비 finding | `run_review.py` 의 waste detector |
 | PR merge success | 생성된 PR 중 실제 merge 완료로 확인된 비율 | `pr_created` denominator 중 matching `pr_merged` event |
 
 `pr_merged` 만 있고 matching `pr_created` 가 없으면 성공률을 만들지 않는다. 이 경우
@@ -112,7 +112,7 @@ dcNess loop(`begin-run` ~ `end-run` 사이클)을 한 번이라도 돌린 run �
 ```
 
 `/run-review` 는 step별 비용, 낭비(WASTE — 같은 실패 재시도 / read-only Bash 낭비 /
-placeholder 누수 등) finding, 수정 제안을 리포트로 출력한다. 현재 run 의 waste pattern
+도구 반복, gate 모순 등) finding, 수정 제안을 리포트로 출력한다. 현재 run 의 waste pattern
 이 같은 sessions root 의 과거 run 에서도 임계(기본 3회) 이상 반복됐으면 재발 기반 개선
 후보로 같이 표면화한다. 실 구현은
 [`harness/run_review.py`](../../harness/run_review.py) 다.
@@ -152,7 +152,9 @@ notes 기록). 측정 스크립트의 재현 정확성은 알려진 두 세션(t
 위 두 도구가 run 1개를 보는 반면, [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py)
 는 한 프로젝트의 **모든 run 의 `ledger.jsonl` 을 가로질러** 집계한다 — PR 머지 성공률,
 review rejection, escalate 수, blocked 수, waste top-N, 재발 기반 개선 후보.
-`run_review.py` 의 검증된 waste 분류를 재사용한다.
+`run_review.py` 의 검증된 waste 분류를 재사용한다. helper 기반 run 은 `end-run`
+직후 recurrent WasteFinding 을 프로젝트-로컬 `.claude/loop-lessons/` 에도 반영하므로,
+다음 같은 agent/mode `begin-step` 에서는 `[LESSONS]` 로 최근 lesson 이 주입된다.
 
 ```sh
 # 활성 프로젝트 안에서 (sessions-root 자동 탐색) — $DCN 은 위 "스크립트 위치" 참조

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -80,9 +80,10 @@ Agent(subagent_type="<agent>", mode="<MODE>", description="...")  # 또는 provi
 TaskUpdate("<task>", completed)
 ```
 
-begin-step stdout 에 `[PROMPT_SLOT_CHECK]` 가 있으면 **Agent prompt 작성 전 먼저 읽고 self-check** 한다. 이 섹션은 메인 Claude 용 호출 직전 reminder 다. `[INSIGHTS: <agent>/<mode>]` 또는 `[PREVIOUS_TASKS]` 섹션이 있으면 Agent prompt 끝에 그대로 포함시킨다.
+begin-step stdout 에 `[PROMPT_SLOT_CHECK]` 가 있으면 **Agent prompt 작성 전 먼저 읽고 self-check** 한다. 이 섹션은 메인 Claude 용 호출 직전 reminder 다. `[INSIGHTS: <agent>/<mode>]`, `[LESSONS: <agent>/<mode>]`, 또는 `[PREVIOUS_TASKS]` 섹션이 있으면 Agent prompt 끝에 그대로 포함시킨다.
 - `[PROMPT_SLOT_CHECK]` — `/impl`·`/impl-loop`·`/design`·`/ux` action loop 에서 3슬롯 self-check 를 호출 순간에 노출한다. worktree 활성 시 worktree 절대경로를 prompt 에 넣고, 슬롯3에는 미기록 제약·신호만 두며 agent 본업의 방법(정규식·구현 단계·알고리즘·테스트 assert 방식)을 처방하지 않는다. 권고 신호이며 hook block 이 아니다. 출력의 `template` 경로는 [`agent-prompt-slots.md`](templates/agent-prompt-slots.md) 를 가리킨다.
 - `[INSIGHTS]` — 해당 agent 의 과거 루프 학습 ("하지 말 것" / "잘 됐던 것"), 프로젝트 레벨 누적.
+- `[LESSONS]` — 같은 sessions root 안에서 임계 이상 재발한 `run_review.py` WasteFinding 기반 자동 lesson. 패턴별 고정 문장 + hits + 최근 evidence 만 주입한다. NoteFinding 은 대상이 아니며, detector 목록에서 제거된 패턴은 archive 되어 주입에서 제외된다.
 - `[PREVIOUS_TASKS]` — `/impl-loop` chain 의 직전 task 산출 요약 list (build-worker 진입 시만, #525). 인접 task 인터페이스 정합 참고용 — build-worker 가 phase 3 통과 시 `prev-tasks-append` 로 자기 산출을 누적한 것.
 
 active run(`entry_point=design|impl|ux`) 안에서 `begin-step` 없이 `Agent` 를 직접 호출하거나, `begin-step` 의 agent/mode 와 다른 `Agent` 를 호출하면 PreToolUse hook 의 진행 순서 검사가 호출 전 차단한다. 정상 `/design` 은 `begin-run design` 로 시작하며 같은 gate 를 탄다. Agent 결과가 hook 에 의해 staged 된 뒤에는 반드시 `end-step` 으로 기록하고 다음 `begin-step` 으로 넘어간다.

--- a/harness/loop_lessons.py
+++ b/harness/loop_lessons.py
@@ -1,0 +1,387 @@
+"""Project-local recurrent waste lessons (#917).
+
+Lessons are deterministic, project-local memory entries created from recurrent
+``run_review`` WasteFinding signals. They intentionally do not consume
+NoteFinding rows.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from harness.session_state import _resolve_project_root
+
+
+LESSONS_DIR = Path(".claude") / "loop-lessons"
+LESSON_FILE_MARKER = "<!-- dcness-loop-lessons:v1 -->"
+
+LESSON_TEMPLATES: dict[str, str] = {
+    "RETRY_SAME_FAIL": (
+        "같은 실패 결론을 반복했다. 다음 호출은 같은 접근 재시도가 아니라 실패 원인 "
+        "확인과 다른 해결 전략부터 시작한다."
+    ),
+    "MISSING_CONCLUSION_ENUM": (
+        "engineer prose 마지막 단락에 요구된 결론 enum 을 명시한다. 메인은 enum 부재를 "
+        "routing 신호로 쓰지 않는다."
+    ),
+    "STRAY_DIR_LEAK": (
+        "인프라 디렉터리명 typo 또는 유사 경로를 추측하지 않는다. 실제 경로를 확인한 뒤 "
+        "한 번만 접근한다."
+    ),
+    "MUST_FIX_GHOST": (
+        "게이트 agent 가 미해결 MUST FIX 를 남겼으면 PASS/LGTM 으로 진행하지 않는다. "
+        "메인은 blocker 를 해결하거나 FAIL 흐름으로 되돌린다."
+    ),
+    "MUST_FIX_LEAK": (
+        "마지막 step 에 positive MUST FIX 가 남으면 종료하지 않고 caveat 를 사용자에게 "
+        "드러낸 뒤 다음 행동을 분리한다."
+    ),
+    "SPEC_GAP_LOOP": (
+        "SPEC_GAP 보강이 반복되면 같은 보강 호출을 계속하지 말고 설계 입력 자체를 "
+        "재정리하거나 상위 설계로 되돌린다."
+    ),
+    "INFRA_READ": (
+        "agent 는 harness-state, harness log, plugin infra 경로를 읽지 않는다. 필요한 "
+        "상태는 메인이 요약해서 전달한다."
+    ),
+    "READONLY_BASH": (
+        "read-only agent 는 Bash 를 쓰지 않는다. 필요한 실측 명령은 메인 또는 write 권한 "
+        "agent 에게 넘긴다."
+    ),
+    "END_STEP_SKIP": (
+        "Agent 호출 직후 같은 흐름에서 end-step 을 닫는다. 메인은 PR/검증 작업으로 "
+        "분기하기 전에 ledger 기록을 먼저 완료한다."
+    ),
+    "TOOL_REPEAT_HIGH": (
+        "같은 tool/input 반복 호출을 멈추고 첫 결과를 재사용한다. 재확인은 grep, offset, "
+        "더 좁은 입력으로 수행한다."
+    ),
+}
+
+
+@dataclass
+class LessonEntry:
+    pattern: str
+    status: str = "active"
+    hits: int = 0
+    last: str = ""
+    lesson: str = ""
+    evidence: list[str] = field(default_factory=list)
+
+
+def _normalize_cwd(cwd: Path) -> Path:
+    try:
+        return _resolve_project_root(Path(cwd).resolve()).resolve()
+    except OSError:
+        return Path(cwd).resolve()
+
+
+def lessons_path(agent: str, mode: Optional[str] = None, cwd: Path = Path(".")) -> Path:
+    name = agent if not mode else f"{agent}-{mode}"
+    return _normalize_cwd(cwd) / LESSONS_DIR / f"{name}.md"
+
+
+def _header(agent: str, mode: Optional[str]) -> str:
+    return f"# Loop Lessons: {agent}" + (f" / {mode}" if mode else "")
+
+
+def _template(pattern: str) -> str:
+    return LESSON_TEMPLATES.get(
+        pattern,
+        f"{pattern} 재발이 확인됐다. 같은 패턴을 반복하지 않도록 직전 evidence 를 먼저 확인한다.",
+    )
+
+
+def _parse_entries(text: str) -> dict[str, LessonEntry]:
+    entries: dict[str, LessonEntry] = {}
+    current: Optional[LessonEntry] = None
+    for line in text.splitlines():
+        if line.startswith("### "):
+            pattern = line[4:].strip()
+            current = LessonEntry(pattern=pattern, lesson=_template(pattern))
+            entries[pattern] = current
+            continue
+        if current is None:
+            continue
+        if line.startswith("- status:"):
+            current.status = line.split(":", 1)[1].strip() or "active"
+        elif line.startswith("- hits:"):
+            raw = line.split(":", 1)[1].strip()
+            try:
+                current.hits = int(raw)
+            except ValueError:
+                current.hits = 0
+        elif line.startswith("- last:"):
+            current.last = line.split(":", 1)[1].strip()
+        elif line.startswith("- lesson:"):
+            current.lesson = line.split(":", 1)[1].strip() or _template(current.pattern)
+        elif line.startswith("  - "):
+            evidence = line[4:].strip()
+            if evidence and evidence not in current.evidence:
+                current.evidence.append(evidence)
+    return entries
+
+
+def _render_entries(agent: str, mode: Optional[str], entries: dict[str, LessonEntry]) -> str:
+    lines: list[str] = [
+        _header(agent, mode),
+        "",
+        LESSON_FILE_MARKER,
+        "",
+        "## Active",
+        "",
+    ]
+
+    def emit(entry: LessonEntry) -> None:
+        lines.append(f"### {entry.pattern}")
+        lines.append(f"- status: {entry.status}")
+        lines.append(f"- hits: {entry.hits}")
+        lines.append(f"- last: {entry.last}")
+        lines.append(f"- lesson: {entry.lesson or _template(entry.pattern)}")
+        lines.append("- evidence:")
+        for evidence in entry.evidence:
+            lines.append(f"  - {evidence}")
+        lines.append("")
+
+    active = [e for e in entries.values() if e.status == "active"]
+    archived = [e for e in entries.values() if e.status == "archived"]
+    for entry in sorted(active, key=lambda e: e.pattern):
+        emit(entry)
+
+    lines.append("## Archived")
+    lines.append("")
+    for entry in sorted(archived, key=lambda e: e.pattern):
+        emit(entry)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _read_entries(path: Path) -> dict[str, LessonEntry]:
+    if not path.exists():
+        return {}
+    try:
+        return _parse_entries(path.read_text(encoding="utf-8"))
+    except OSError:
+        return {}
+
+
+def _infer_agent_mode(path: Path) -> tuple[str, Optional[str]]:
+    stem = path.stem
+    if "-" not in stem:
+        return stem, None
+    agent, mode = stem.rsplit("-", 1)
+    # Modes are conventionally uppercase labels such as IMPL, POLISH, or
+    # CODE_VALIDATION. Lowercase suffixes are part of hyphenated agent names.
+    if mode and mode == mode.upper() and any(ch.isalpha() for ch in mode):
+        return agent, mode
+    return stem, None
+
+
+def _write_entries(path: Path, entries: dict[str, LessonEntry]) -> None:
+    agent, mode = _infer_agent_mode(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_render_entries(agent, mode, entries), encoding="utf-8")
+
+
+def upsert_entry(
+    agent: str,
+    mode: Optional[str],
+    pattern: str,
+    *,
+    hits: int,
+    last: str,
+    evidence: list[str],
+    cwd: Path = Path("."),
+) -> Path:
+    path = lessons_path(agent, mode, cwd)
+    entries = _read_entries(path)
+    entry = entries.get(pattern) or LessonEntry(pattern=pattern, lesson=_template(pattern))
+    entry.status = "active"
+    entry.hits = max(int(hits), entry.hits)
+    entry.last = last or entry.last
+    entry.lesson = entry.lesson or _template(pattern)
+    for item in evidence:
+        if item and item not in entry.evidence:
+            entry.evidence.append(item)
+    entries[pattern] = entry
+    _write_entries(path, entries)
+    return path
+
+
+def archive_removed_patterns(path: Path, *, active_patterns: set[str]) -> bool:
+    entries = _read_entries(path)
+    changed = False
+    for entry in entries.values():
+        if entry.status == "active" and entry.pattern not in active_patterns:
+            entry.status = "archived"
+            changed = True
+    if changed:
+        _write_entries(path, entries)
+    return changed
+
+
+def _active_patterns_default() -> set[str]:
+    try:
+        from harness.run_review import ACTIVE_WASTE_PATTERNS
+
+        return set(ACTIVE_WASTE_PATTERNS)
+    except Exception:
+        return set(LESSON_TEMPLATES)
+
+
+def read(
+    agent: str,
+    mode: Optional[str] = None,
+    cwd: Path = Path("."),
+    *,
+    active_patterns: Optional[set[str]] = None,
+) -> str:
+    path = lessons_path(agent, mode, cwd)
+    if not path.exists():
+        return ""
+    active = active_patterns if active_patterns is not None else _active_patterns_default()
+    archive_removed_patterns(path, active_patterns=active)
+    entries = _read_entries(path)
+    lines: list[str] = []
+    for entry in sorted(entries.values(), key=lambda e: e.pattern):
+        if entry.status != "active" or entry.pattern not in active:
+            continue
+        evidence = entry.evidence[-1] if entry.evidence else "-"
+        lines.append(
+            f"- `{entry.pattern}`: {entry.lesson or _template(entry.pattern)} "
+            f"(hits={entry.hits}, last={entry.last or '-'}, evidence={evidence})"
+        )
+    return "\n".join(lines)
+
+
+def list_active_lessons(
+    cwd: Path = Path("."),
+    *,
+    active_patterns: Optional[set[str]] = None,
+) -> list[dict[str, object]]:
+    root = _normalize_cwd(cwd)
+    base = root / LESSONS_DIR
+    if not base.exists():
+        return []
+    active = active_patterns if active_patterns is not None else _active_patterns_default()
+    rows: list[dict[str, object]] = []
+    for path in sorted(base.glob("*.md")):
+        archive_removed_patterns(path, active_patterns=active)
+        agent, mode = _infer_agent_mode(path)
+        for entry in _read_entries(path).values():
+            if entry.status != "active" or entry.pattern not in active:
+                continue
+            rows.append({
+                "agent": agent,
+                "mode": mode,
+                "pattern": entry.pattern,
+                "hits": entry.hits,
+                "last": entry.last,
+                "path": str(path),
+            })
+    return rows
+
+
+def _sessions_root_for_run(run_dir: Path) -> Optional[Path]:
+    for parent in Path(run_dir).resolve().parents:
+        if parent.name == ".sessions":
+            return parent
+    return None
+
+
+def _key_for_waste(report: object, waste: object) -> tuple[str, Optional[str], str]:
+    agent = getattr(waste, "agent", "?")
+    mode: Optional[str] = None
+    step_idx = getattr(waste, "step_idx", -1)
+    steps = getattr(report, "steps", [])
+    if isinstance(step_idx, int) and 0 <= step_idx < len(steps):
+        mode = getattr(steps[step_idx], "mode", None)
+    return agent, mode, getattr(waste, "pattern", "")
+
+
+def _evidence_for_waste(report: object, waste: object) -> str:
+    run_id = getattr(report, "run_id", "")
+    run_dir = getattr(report, "run_dir", Path("."))
+    path = ""
+    step_idx = getattr(waste, "step_idx", -1)
+    steps = getattr(report, "steps", [])
+    if isinstance(step_idx, int) and 0 <= step_idx < len(steps):
+        path = getattr(steps[step_idx], "prose_file", "") or ""
+    if not path:
+        agent, mode, _pattern = _key_for_waste(report, waste)
+        filename = f"{agent}-{mode}.md" if mode else f"{agent}.md"
+        path = str(Path(run_dir) / filename)
+    return f"run_id={run_id} path={path}"
+
+
+def sync_from_run(
+    run_dir: Path,
+    *,
+    repo_path: Path,
+    recurrence_threshold: int = 3,
+    active_patterns: Optional[set[str]] = None,
+) -> list[Path]:
+    """Create/update lessons for recurrent WasteFinding rows in ``run_dir``.
+
+    Counts are scoped by ``(agent, mode, pattern)`` inside the same sessions root.
+    Only keys present in the current run can create/update lessons.
+    """
+    from collections import Counter, defaultdict
+
+    from harness import run_review
+
+    active = active_patterns if active_patterns is not None else set(run_review.ACTIVE_WASTE_PATTERNS)
+    current = run_review.build_report(Path(run_dir), Path(repo_path))
+    current_keys = {
+        _key_for_waste(current, waste)
+        for waste in current.wastes
+        if getattr(waste, "pattern", "") in active
+    }
+    if not current_keys:
+        return []
+
+    sessions_root = _sessions_root_for_run(Path(run_dir))
+    if sessions_root is None:
+        return []
+
+    counts: Counter = Counter()
+    evidence: dict[tuple[str, Optional[str], str], list[str]] = defaultdict(list)
+    last: dict[tuple[str, Optional[str], str], str] = {}
+    for candidate_run in run_review.list_runs(sessions_root):
+        report = run_review.build_report(candidate_run, Path(repo_path))
+        for waste in report.wastes:
+            pattern = getattr(waste, "pattern", "")
+            if pattern not in active:
+                continue
+            key = _key_for_waste(report, waste)
+            counts[key] += 1
+            ev = _evidence_for_waste(report, waste)
+            if ev not in evidence[key]:
+                evidence[key].append(ev)
+            step_idx = getattr(waste, "step_idx", -1)
+            steps = getattr(report, "steps", [])
+            if isinstance(step_idx, int) and 0 <= step_idx < len(steps):
+                ts = getattr(steps[step_idx], "ts", "")
+            else:
+                ts = ""
+            if ts and ts > last.get(key, ""):
+                last[key] = ts
+
+    changed: set[Path] = set()
+    threshold = max(int(recurrence_threshold), 1)
+    for agent, mode, pattern in sorted(current_keys):
+        key = (agent, mode, pattern)
+        if counts[key] < threshold:
+            continue
+        changed.add(
+            upsert_entry(
+                agent,
+                mode,
+                pattern,
+                hits=counts[key],
+                last=last.get(key, ""),
+                evidence=evidence.get(key, []),
+                cwd=Path(repo_path),
+            )
+        )
+    return sorted(changed)

--- a/harness/loop_lessons.py
+++ b/harness/loop_lessons.py
@@ -15,6 +15,7 @@ from harness.session_state import _resolve_project_root
 
 LESSONS_DIR = Path(".claude") / "loop-lessons"
 LESSON_FILE_MARKER = "<!-- dcness-loop-lessons:v1 -->"
+MAX_EVIDENCE_ITEMS = 10
 
 LESSON_TEMPLATES: dict[str, str] = {
     "RETRY_SAME_FAIL": (
@@ -203,6 +204,7 @@ def upsert_entry(
     for item in evidence:
         if item and item not in entry.evidence:
             entry.evidence.append(item)
+    entry.evidence = entry.evidence[-MAX_EVIDENCE_ITEMS:]
     entries[pattern] = entry
     _write_entries(path, entries)
     return path

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -81,6 +81,21 @@ INFRA_PATH_PATTERNS = [
 READONLY_AGENTS = {"code-validator", "architecture-validator", "pr-reviewer",
                     "plan-reviewer", "product-acceptance"}
 
+# #917 — lesson 대상 WasteFinding 패턴의 코드 SSOT.
+# NoteFinding(THINKING_LOOP / TOOL_USE_OVERFLOW)은 의도적으로 제외한다.
+ACTIVE_WASTE_PATTERNS = frozenset({
+    "RETRY_SAME_FAIL",
+    "MISSING_CONCLUSION_ENUM",
+    "STRAY_DIR_LEAK",
+    "MUST_FIX_GHOST",
+    "MUST_FIX_LEAK",
+    "SPEC_GAP_LOOP",
+    "INFRA_READ",
+    "READONLY_BASH",
+    "END_STEP_SKIP",
+    "TOOL_REPEAT_HIGH",
+})
+
 # DCN-CHG-20260430-20: Phase 2 — per-Agent budget for THINKING_LOOP detection.
 # elapsed_s: 정상 sub-agent 한 번 호출 한도 (초).
 # min_output_tokens: 정상 sub-agent 가 emit 할 최소 output token (이하 = stall 의심).
@@ -226,6 +241,8 @@ class StepRecord:
     # 마지막 단락 결론 (agents/code-validator.md 의 결론 + 권장 다음 단계 "PASS / FAIL / ESCALATE")
     # 을 표시 단계에서 추출. 부재 시 빈 문자열 (= sentinel 그대로 표시 fallback).
     conclusion_enum: str = ""
+    # #917 — recurrent lesson evidence. ledger 의 prose_file 절대경로를 보존한다.
+    prose_file: str = ""
 
 
 @dataclass
@@ -760,6 +777,7 @@ def parse_steps(run_dir: Path) -> list[StepRecord]:
             prose_excerpt=rec.get("prose_excerpt", ""),
             prose_full=prose_full,
             conclusion_enum=_extract_conclusion_enum(prose_full),
+            prose_file=str(prose_file or ""),
         ))
 
     # elapsed 계산 — 다음 step ts 와의 차이

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -2030,6 +2030,19 @@ def _cli_end_run(args: Any) -> int:
         ledger.append_event(sid, rid, "run_finished")
     except Exception:  # nosec B110
         pass
+    try:
+        from harness.loop_lessons import sync_from_run
+
+        changed = sync_from_run(run_dir(sid, rid), repo_path=Path.cwd())
+        if changed:
+            changed_list = ", ".join(str(path) for path in changed)
+            print(f"[lessons] updated: {changed_list}", file=sys.stderr)
+    except Exception as exc:  # nosec B110
+        print(
+            f"[lessons] WARN — recurrent lesson sync skipped: "
+            f"{type(exc).__name__}: {exc}",
+            file=sys.stderr,
+        )
     _record_design_run_if_applicable(sid, rid)
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
@@ -2383,6 +2396,18 @@ def _cli_begin_step(args: Any) -> int:
             print(f"\n[INSIGHTS: {label}]\n{_insights}")
     except Exception:  # nosec B110
         pass  # insights 주입 실패는 silent — 본 step 차단 X
+
+    # #917: recurrent waste lessons. loop-insights 와 동렬의 advisory 주입이며,
+    # 실패해도 begin-step 자체를 차단하지 않는다.
+    try:
+        from harness.loop_lessons import read as _ll_read
+
+        _lessons = _ll_read(agent, mode or None)
+        if _lessons:
+            label = f"{agent}/{mode}" if mode else agent
+            print(f"\n[LESSONS: {label}]\n{_lessons}")
+    except Exception:  # nosec B110
+        pass
 
     # #525: build-worker 진입 시 직전 task 산출 요약 stdout 주입. 메인 Claude 가
     # Bash 결과로 읽고 build-worker prompt 에 포함시킨다 (loop_insights 와 동일

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -19,6 +19,7 @@ if str(_REPO_ROOT) not in sys.path:
 from harness import ledger  # noqa: E402
 from harness import run_review  # noqa: E402
 from harness.benchmark_aggregate import aggregate_sessions  # noqa: E402
+from harness.loop_lessons import list_active_lessons  # noqa: E402
 from harness.guard_telemetry import (  # noqa: E402
     DEFAULT_REPORT_SINCE_DAYS,
     collect_eval_summary,
@@ -233,6 +234,32 @@ def _waste_candidates(
     return out
 
 
+def _lesson_candidates(
+    project_name: str,
+    project_path: Path,
+    lessons: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for lesson in lessons:
+        pattern = str(lesson.get("pattern") or "")
+        agent = str(lesson.get("agent") or "")
+        mode = lesson.get("mode")
+        label = agent + (f"-{mode}" if mode else "")
+        hits = int(lesson.get("hits") or 0)
+        last = lesson.get("last") if isinstance(lesson.get("last"), str) else None
+        out.append(
+            _candidate(
+                key=f"lesson:{pattern}@{project_name}/{label}",
+                kind="lesson",
+                project=project_name,
+                scope_path=project_path,
+                detail=f"{pattern} active for {label}, hits={hits}",
+                last_ts=last,
+            )
+        )
+    return out
+
+
 def _collect_project(path: Path, args: argparse.Namespace) -> dict[str, Any]:
     name = _project_name(path)
     events = read_events(cwd=path, since_days=args.since_days)
@@ -252,6 +279,8 @@ def _collect_project(path: Path, args: argparse.Namespace) -> dict[str, Any]:
     fleet = _fleet_to_json(fleet_report)
     candidates = _guard_candidates(name, path, guard_summary)
     candidates.extend(_waste_candidates(name, path, fleet, last_event_ts))
+    lessons = list_active_lessons(path)
+    candidates.extend(_lesson_candidates(name, path, lessons))
     return {
         "name": name,
         "path": str(path),
@@ -260,8 +289,47 @@ def _collect_project(path: Path, args: argparse.Namespace) -> dict[str, Any]:
         "observation": "observed" if events else NO_OBSERVATION,
         "guard_summary": guard_summary,
         "fleet": fleet,
+        "lessons": lessons,
         "candidates": candidates,
     }
+
+
+def _cross_project_lesson_candidates(
+    repo_root: Path,
+    projects: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    by_pattern: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for project in projects:
+        for lesson in project.get("lessons", []):
+            if not isinstance(lesson, dict):
+                continue
+            pattern = str(lesson.get("pattern") or "")
+            if pattern:
+                row = dict(lesson)
+                row["project_name"] = project["name"]
+                by_pattern[pattern].append(row)
+
+    out: list[dict[str, Any]] = []
+    for pattern, rows in sorted(by_pattern.items()):
+        projects_with_pattern = sorted({str(row["project_name"]) for row in rows})
+        if len(projects_with_pattern) < 2:
+            continue
+        last = _max_ts([row.get("last") for row in rows])
+        detail = (
+            f"active in {len(projects_with_pattern)} project(s): "
+            + ", ".join(projects_with_pattern)
+        )
+        out.append(
+            _candidate(
+                key=f"lesson-rule:{pattern}",
+                kind="lesson-rule",
+                project="cross-project",
+                scope_path=repo_root,
+                detail=detail,
+                last_ts=last,
+            )
+        )
+    return out
 
 
 def _collect_self_evals(repo_root: Path, args: argparse.Namespace) -> dict[str, Any]:
@@ -439,6 +507,7 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     candidates: list[dict[str, Any]] = []
     for project in projects:
         candidates.extend(project["candidates"])
+    candidates.extend(_cross_project_lesson_candidates(repo_root, projects))
     candidates.extend(evals["candidates"])
     _attach_status(candidates, previous=previous, decisions=decisions)
     _append_sweep(
@@ -482,6 +551,8 @@ def _render_project(project: dict[str, Any]) -> list[str]:
         f"- fleet runs: {fleet['run_count']}, "
         f"recurrent waste candidates: {len(fleet['improvement_candidates'])}"
     )
+    lessons = project.get("lessons") if isinstance(project.get("lessons"), list) else []
+    lines.append(f"- active lessons: {len(lessons)}")
     lines.append("")
     lines.append("| guard | count | last | status |")
     lines.append("|---|---:|---|---|")
@@ -495,6 +566,18 @@ def _render_project(project: dict[str, Any]) -> list[str]:
                 f"{_md_cell(row.get('last_ts') or '-')} | {status} |"
             )
     lines.append("")
+    if lessons:
+        lines.append("| lesson pattern | agent/mode | hits | last |")
+        lines.append("|---|---|---:|---|")
+        for lesson in lessons:
+            agent = str(lesson.get("agent") or "")
+            mode = lesson.get("mode")
+            label = agent + (f"/{mode}" if mode else "")
+            lines.append(
+                f"| `{_md_cell(lesson.get('pattern'))}` | {_md_cell(label)} | "
+                f"{int(lesson.get('hits') or 0)} | {_md_cell(lesson.get('last') or '-')} |"
+            )
+        lines.append("")
     return lines
 
 

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -111,6 +111,26 @@ def _write_eval_events(repo_root: Path) -> None:
     )
 
 
+def _write_lesson(project: Path, pattern: str, *, hits: int = 3) -> None:
+    path = project / ".claude" / "loop-lessons" / "engineer-IMPL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "# Loop Lessons: engineer / IMPL\n\n"
+        "<!-- dcness-loop-lessons:v1 -->\n\n"
+        "## Active\n\n"
+        f"### {pattern}\n"
+        "- status: active\n"
+        f"- hits: {hits}\n"
+        "- last: 2026-07-05T00:03:00Z\n"
+        "- lesson: Engineer must change approach before retrying this recurrent waste.\n"
+        "- evidence:\n"
+        "  - run_id=run-lesson path=.claude/harness-state/.sessions/s/runs/run-lesson/engineer-IMPL.md\n"
+        "\n"
+        "## Archived\n",
+        encoding="utf-8",
+    )
+
+
 def _snapshot_tree(root: Path) -> dict[str, str]:
     out: dict[str, str] = {}
     for path in sorted(p for p in root.rglob("*") if p.is_file()):
@@ -377,6 +397,33 @@ class LoopDiagnoseTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertIn("eval:headless-prose-quality", result.stdout)
             self.assertIn("judge 보정은 자동 수집하지 않습니다", result.stdout)
+
+    def test_active_lessons_are_sense_candidates_and_cross_project_rule_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            beta = tmp / "beta"
+            alpha.mkdir()
+            beta.mkdir()
+            _write_lesson(alpha, "MUST_FIX_GHOST", hits=3)
+            _write_lesson(beta, "MUST_FIX_GHOST", hits=4)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha), str(beta)]}),
+                encoding="utf-8",
+            )
+
+            result = self._run(repo_root, projects_file, "--json")
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual(payload["projects"][0]["lessons"][0]["pattern"], "MUST_FIX_GHOST")
+            keys = {candidate["key"] for candidate in payload["candidates"]}
+            self.assertIn("lesson:MUST_FIX_GHOST@alpha/engineer-IMPL", keys)
+            self.assertIn("lesson:MUST_FIX_GHOST@beta/engineer-IMPL", keys)
+            self.assertIn("lesson-rule:MUST_FIX_GHOST", keys)
 
 
 if __name__ == "__main__":

--- a/tests/test_loop_lessons.py
+++ b/tests/test_loop_lessons.py
@@ -1,0 +1,202 @@
+"""loop_lessons — recurrent waste lesson storage and injection tests (#917)."""
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from harness import ledger
+from harness.loop_lessons import (
+    archive_removed_patterns,
+    lessons_path,
+    list_active_lessons,
+    read,
+    sync_from_run,
+    upsert_entry,
+)
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _ghost_run(tmp: Path, rid: str) -> Path:
+    run_dir = (
+        tmp
+        / ".claude"
+        / "harness-state"
+        / ".sessions"
+        / "sid-lessons"
+        / "runs"
+        / rid
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    reviewer = run_dir / "pr-reviewer.md"
+    reviewer.write_text("MUST FIX: blocker remains\n\nPASS\n", encoding="utf-8")
+    engineer = run_dir / "engineer-IMPL.md"
+    engineer.write_text("follow-up step\n\nIMPL_DONE\n", encoding="utf-8")
+    _write_jsonl(
+        run_dir / "ledger.jsonl",
+        [
+            {"event": "run_started", "ts": "2026-07-05T00:00:00Z", "entry_point": "impl"},
+            {
+                "event": "step_completed",
+                "ts": "2026-07-05T00:01:00Z",
+                "agent": "pr-reviewer",
+                "mode": None,
+                "enum": "PROSE_LOGGED",
+                "must_fix": True,
+                "prose_excerpt": "MUST FIX: blocker remains\n\nPASS",
+                "prose_file": str(reviewer),
+                "sha256": ledger.sha256_text(reviewer.read_text(encoding="utf-8")),
+            },
+            {
+                "event": "step_completed",
+                "ts": "2026-07-05T00:02:00Z",
+                "agent": "engineer",
+                "mode": "IMPL",
+                "enum": "PROSE_LOGGED",
+                "must_fix": False,
+                "prose_excerpt": "follow-up step\n\nIMPL_DONE",
+                "prose_file": str(engineer),
+                "sha256": ledger.sha256_text(engineer.read_text(encoding="utf-8")),
+            },
+            {"event": "run_finished", "ts": "2026-07-05T00:03:00Z"},
+        ],
+    )
+    return run_dir
+
+
+class LoopLessonsPathTests(unittest.TestCase):
+    def test_path_shape_matches_loop_insights(self) -> None:
+        p = lessons_path("engineer", "IMPL", cwd=Path("/tmp"))
+
+        self.assertEqual(p.name, "engineer-IMPL.md")
+        self.assertIn(".claude/loop-lessons", str(p))
+
+    def test_worktree_cwd_normalizes_to_main_root(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            main = Path(td) / "main"
+            worktree = main / ".claude" / "worktrees" / "wt1"
+            worktree.mkdir(parents=True)
+
+            with patch("harness.loop_lessons._resolve_project_root", return_value=main):
+                p = lessons_path("pr-reviewer", None, cwd=worktree)
+
+            self.assertEqual(
+                p,
+                main.resolve() / ".claude" / "loop-lessons" / "pr-reviewer.md",
+            )
+
+
+class LoopLessonsSyncTests(unittest.TestCase):
+    def test_sync_creates_lesson_when_agent_pattern_reaches_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            runs = [_ghost_run(tmp, f"run-ghost{i}") for i in range(3)]
+
+            changed = sync_from_run(runs[-1], repo_path=tmp, recurrence_threshold=3)
+
+            p = tmp.resolve() / ".claude" / "loop-lessons" / "pr-reviewer.md"
+            self.assertEqual(changed, [p])
+            content = p.read_text(encoding="utf-8")
+            self.assertIn("### MUST_FIX_GHOST", content)
+            self.assertIn("- status: active", content)
+            self.assertIn("- hits: 3", content)
+            self.assertIn("run_id=run-ghost2", content)
+            self.assertIn("pr-reviewer.md", content)
+
+            injected = read("pr-reviewer", cwd=tmp)
+            self.assertIn("MUST_FIX_GHOST", injected)
+            self.assertIn("hits=3", injected)
+
+    def test_sync_skips_below_threshold(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            run = _ghost_run(tmp, "run-ghost0")
+
+            changed = sync_from_run(run, repo_path=tmp, recurrence_threshold=2)
+
+            self.assertEqual(changed, [])
+            self.assertFalse((tmp / ".claude" / "loop-lessons").exists())
+
+    def test_existing_entry_is_updated_not_duplicated(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            p = upsert_entry(
+                "pr-reviewer",
+                None,
+                "MUST_FIX_GHOST",
+                hits=3,
+                last="2026-07-05T00:03:00Z",
+                evidence=["run_id=run-a path=/tmp/a.md"],
+                cwd=tmp,
+            )
+            upsert_entry(
+                "pr-reviewer",
+                None,
+                "MUST_FIX_GHOST",
+                hits=4,
+                last="2026-07-05T00:04:00Z",
+                evidence=["run_id=run-b path=/tmp/b.md"],
+                cwd=tmp,
+            )
+
+            content = p.read_text(encoding="utf-8")
+            self.assertEqual(content.count("### MUST_FIX_GHOST"), 1)
+            self.assertIn("- hits: 4", content)
+            self.assertIn("run_id=run-a", content)
+            self.assertIn("run_id=run-b", content)
+            self.assertIn("# Loop Lessons: pr-reviewer", content)
+            self.assertNotIn("# Loop Lessons: pr / reviewer", content)
+
+            active = list_active_lessons(tmp)
+            self.assertEqual(active[0]["agent"], "pr-reviewer")
+            self.assertIsNone(active[0]["mode"])
+
+    def test_archive_removed_patterns_excludes_from_read(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            p = upsert_entry(
+                "engineer",
+                "IMPL",
+                "OLD_REMOVED_PATTERN",
+                hits=3,
+                last="2026-07-05T00:03:00Z",
+                evidence=["run_id=run-old path=/tmp/old.md"],
+                cwd=tmp,
+            )
+
+            archive_removed_patterns(p, active_patterns={"MUST_FIX_GHOST"})
+
+            content = p.read_text(encoding="utf-8")
+            self.assertIn("### OLD_REMOVED_PATTERN", content)
+            self.assertIn("- status: archived", content)
+            self.assertEqual(read("engineer", "IMPL", cwd=tmp, active_patterns={"MUST_FIX_GHOST"}), "")
+
+    def test_explicit_empty_active_patterns_archives_without_fallback(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            p = upsert_entry(
+                "pr-reviewer",
+                None,
+                "MUST_FIX_GHOST",
+                hits=3,
+                last="2026-07-05T00:03:00Z",
+                evidence=["run_id=run-a path=/tmp/a.md"],
+                cwd=tmp,
+            )
+
+            self.assertEqual(read("pr-reviewer", cwd=tmp, active_patterns=set()), "")
+            content = p.read_text(encoding="utf-8")
+            self.assertIn("- status: archived", content)
+            self.assertEqual(list_active_lessons(tmp, active_patterns=set()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_loop_lessons.py
+++ b/tests/test_loop_lessons.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 
 from harness import ledger
 from harness.loop_lessons import (
+    MAX_EVIDENCE_ITEMS,
     archive_removed_patterns,
     lessons_path,
     list_active_lessons,
@@ -158,6 +159,26 @@ class LoopLessonsSyncTests(unittest.TestCase):
             active = list_active_lessons(tmp)
             self.assertEqual(active[0]["agent"], "pr-reviewer")
             self.assertIsNone(active[0]["mode"])
+
+    def test_evidence_is_capped_to_recent_items(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            p = upsert_entry(
+                "engineer",
+                "IMPL",
+                "TOOL_REPEAT_HIGH",
+                hits=12,
+                last="2026-07-05T00:12:00Z",
+                evidence=[f"run_id=run-{i:02d} path=/tmp/{i:02d}.md" for i in range(12)],
+                cwd=tmp,
+            )
+
+            content = p.read_text(encoding="utf-8")
+            self.assertEqual(content.count("run_id=run-"), MAX_EVIDENCE_ITEMS)
+            self.assertNotIn("run_id=run-00", content)
+            self.assertNotIn("run_id=run-01", content)
+            self.assertIn("run_id=run-02", content)
+            self.assertIn("run_id=run-11", content)
 
     def test_archive_removed_patterns_excludes_from_read(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -1,5 +1,7 @@
 """tests/test_run_review.py — DCN-CHG-20260430-19 run_review 단위 테스트."""
 
+import ast
+import inspect
 import json
 import sys
 import tempfile
@@ -11,16 +13,43 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
 from harness import ledger  # noqa: E402
+from harness import run_review as run_review_module  # noqa: E402
 from harness.run_review import (  # noqa: E402
     RunReport, StepRecord, WasteFinding, build_report, detect_wastes, detect_notes,
     parse_steps, render_report, list_runs, find_run_dir,
     _normalize_agent_type, assign_invocations_to_steps,
     DCNESS_AGENT_NAMES, LEGACY_AGENT_ALIASES,
     WINDOW_TS_PADDING, _extract_conclusion_enum,
-    audit_context_docs,
+    audit_context_docs, ACTIVE_WASTE_PATTERNS,
 )
 # issue #392 — detect_goods 폐기
 # issue #394 — detect_notes 신규 (TOOL_USE_OVERFLOW / THINKING_LOOP)
+
+
+class ActiveWastePatternSsotTests(unittest.TestCase):
+    def test_active_waste_patterns_match_wastefinding_emit_literals(self) -> None:
+        """#917 — lesson 대상 SSOT가 WasteFinding detector emit 목록과 drift 나지 않는다."""
+        tree = ast.parse(inspect.getsource(run_review_module))
+        emitted: set[str] = set()
+        dynamic_pattern_lines: list[int] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            if not isinstance(func, ast.Name) or func.id != "WasteFinding":
+                continue
+            pattern_kw = next((kw for kw in node.keywords if kw.arg == "pattern"), None)
+            if not isinstance(pattern_kw, ast.keyword):
+                dynamic_pattern_lines.append(node.lineno)
+                continue
+            value = pattern_kw.value
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                emitted.add(value.value)
+            else:
+                dynamic_pattern_lines.append(value.lineno)
+
+        self.assertEqual(dynamic_pattern_lines, [])
+        self.assertEqual(ACTIVE_WASTE_PATTERNS, frozenset(emitted))
 
 
 def _make_run_dir(tmp: Path, sid: str, rid: str, step_records: list[dict],

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1111,6 +1111,24 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertNotIn("[PROMPT_SLOT_CHECK]", out.getvalue())
 
+    def test_begin_step_emits_loop_lessons_when_present(self) -> None:
+        """#917 — lessons are injected next to insights without blocking the step."""
+        from harness.session_state import _cli_begin_step
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout
+        from unittest.mock import patch
+
+        out = StringIO()
+        with patch("harness.loop_lessons.read", return_value="- `MUST_FIX_GHOST`: stop on blockers"):
+            with redirect_stdout(out):
+                rc = _cli_begin_step(SimpleNamespace(agent="pr-reviewer", mode=None))
+
+        self.assertEqual(rc, 0)
+        stdout = out.getvalue()
+        self.assertIn("[LESSONS: pr-reviewer]", stdout)
+        self.assertIn("MUST_FIX_GHOST", stdout)
+
     def test_run_dir_cli_outputs_absolute_path(self) -> None:
         # DCN-30-21: run-dir subcommand for prose-staging path 격리.
         from harness.session_state import _cli_run_dir, run_dir


### PR DESCRIPTION
## 관련 이슈 번호

Closes #917

## 배경 및 문제

- `/run-review`는 recurrent WasteFinding을 후보로 표면화했지만, 같은 프로젝트의 다음 agent 호출에 자동으로 반영되는 프로젝트-로컬 lesson 층은 없었습니다.
- 이슈 #917의 수정된 요구사항에 따라 NoteFinding은 제외하고, recurrent WasteFinding만 임계 도달 시 `.claude/loop-lessons/`에 저장해 다음 `begin-step`에 주입해야 합니다.

## 원인 (해당 시)

- N/A — 신규 feature 추가입니다.

## 작업내용

- `harness/loop_lessons.py`를 추가해 `.claude/loop-lessons/<agent>[-<mode>].md` 저장, active/archive 관리, recurrent WasteFinding sync, begin-step 주입용 read를 구현했습니다.
- `harness/run_review.py`에 lesson 대상 WasteFinding SSOT(`ACTIVE_WASTE_PATTERNS`)와 `prose_file` evidence 보존을 추가했습니다.
- `harness/session_state.py`에서 `end-run` 직후 lesson sync, `begin-step`에서 `[LESSONS]` 출력을 연결했습니다.
- `scripts/loop_diagnose.py`가 활성 lesson과 복수 프로젝트 동일 pattern의 `lesson-rule` 후보를 Sense/Diagnose payload에 포함하도록 확장했습니다.
- `commands/run-review.md`, `docs/plugin/loop-procedure.md`, `docs/plugin/benchmark.md`, `docs/internal/self-improvement-loop.md`, `docs/internal/release-notes.md`를 현행 동작에 맞게 갱신했습니다.
- loop-lessons 저장/주입/파일명 파싱/archive, loop-diagnose lesson 후보, begin-step 출력 회귀 테스트를 추가했습니다.

## 결정 근거

- lesson 입력은 `run_review.py`의 WasteFinding에 한정했습니다. `detect_notes()`의 raw note는 severity/행동 규칙이 약하므로 자동 학습 입력에서 제외했습니다.
- detector 삭제/이름 변경 시 오래된 lesson을 즉시 삭제하지 않고 archive하여 이력은 보존하되 prompt 주입에서는 제외했습니다.
- `pr-reviewer.md`처럼 하이픈이 포함된 agent 이름은 mode로 오인하지 않도록 mode suffix는 `IMPL`, `CODE_VALIDATION` 같은 uppercase label만 분리합니다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/loop_lessons.py`, `harness/session_state.py`, `harness/run_review.py`, `scripts/loop_diagnose.py`는 dcNess plugin/runtime 코드 경로입니다. plugin update 시 helper runtime에 함께 배포됩니다.
- `docs/plugin/loop-procedure.md`, `docs/plugin/benchmark.md`, `commands/run-review.md`는 plugin 문서/command 표면 설명이며 cross-ref 검증을 통과했습니다.
- 신규 init-dcness 복사 파일은 없습니다. `.claude/loop-lessons/`는 활성 프로젝트에서 helper가 런타임에 생성하는 프로젝트-로컬 상태 디렉터리입니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate를 추가하지 않았습니다. 기존 helper lifecycle, `/run-review`, repo-local `loop-diagnose` 동작 확장입니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_loop_lessons -v`
- [x] `python3.11 -m unittest tests.test_loop_lessons tests.test_loop_diagnose tests.test_run_review tests.test_session_state -v`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1619 tests PASS
- [x] `PYTHON_BIN=python3.11 sh scripts/check_python_tests.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `node scripts/check_git_naming.mjs --branch feature/issue917_loop_lessons`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `git diff --check`
- [x] git pre-commit hook — 1619 tests PASS

## 참고

- push 인증은 현재 `gh` keyring의 `alruminum` HTTPS token으로 정상 동작함을 재확인했습니다.
