### PR TITLE
[feature] TDD hook 플랫폼 규칙 위임

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -33,7 +33,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - `docs/*`, `docs/design-variants/*`: 부재 시만 seed. 단 기존 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 섹션은 없을 때만 append.
 - Codex validator skills: `$CODEX_HOME/skills/dcness-*` always-overwrite.
 - Codex provider routing: core 에서는 상태만 확인하고, 선택형 확장에서 validation opt-in 과 implementation 기본값을 갱신.
-- TDD Guard: dcNess 가 **TDD 계약 + self-test** 를 소유한다. 프로젝트가 비어 있지 않으면 플랫폼 감지 후 project-local CC/Codex hook 생성을 제안하고, 생성 후보는 self-test 통과 전에는 등록하지 않는다. 생성 훅이 없으면 중앙 plug-in hook 이 안전 fallback 으로 동작한다.
+- TDD Guard: dcNess 가 **TDD 계약 + self-test** 를 소유한다. 프로젝트가 비어 있지 않으면 플랫폼 감지 또는 사람 승인된 `.dcness/tdd-hooks.json` 계약(`source_roots`, `impl_exts`, custom 플랫폼의 `test_candidate_templates`, 선택 `test_file_globs`)을 기준으로 project-local CC/Codex hook 생성을 제안하고, 생성 후보는 self-test 통과 전에는 등록하지 않는다. 생성 훅이 없으면 중앙 plug-in hook 이 안전 fallback 으로 동작한다.
 
 ## 공통 변수
 이후 절차에서 반복 사용한다.
@@ -159,9 +159,9 @@ done
 
 ### Core Step 7.5 - generated TDD hook 역제안
 
-`"$PLUGIN_ROOT/scripts/dcness-tdd-hooks" status --project-root "$PROJECT_ROOT"` 로 상태를 본다. 지원 플랫폼에서 hook 이 없으면 사용자 승인 뒤 `ensure --targets cc,codex` 를 실행한다.
+`"$PLUGIN_ROOT/scripts/dcness-tdd-hooks" status --project-root "$PROJECT_ROOT"` 로 상태를 본다. 지원 플랫폼이거나 사람 승인된 `.dcness/tdd-hooks.json` 계약(`test_candidate_templates` 포함)이 있는데 hook 이 없으면 사용자 승인 뒤 `ensure --targets cc,codex` 를 실행한다. 미지원 플랫폼이고 project-local 계약도 없으면 no-op 으로 skip 한다.
 
-순서는 고정: **TDD 계약 + self-test** → **CC hook self-test/등록** → **Codex hook self-test/등록**. 빈 프로젝트/미지원/실패는 no-op 이며 상세는 [`docs/plugin/init-dcness.md`](../docs/plugin/init-dcness.md) 와 [`hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh) 를 따른다.
+순서는 고정: **TDD 계약 + self-test** → **CC hook self-test/등록** → **Codex hook self-test/등록**. 빈 프로젝트/미지원/설정 생성 실패는 no-op 이며, 기존 config 가 깨졌거나 필수 필드가 없으면 덮어쓰지 않는다. 상세는 [`docs/plugin/init-dcness.md`](../docs/plugin/init-dcness.md) 와 [`hooks.md#tdd-guardsh`](../docs/plugin/hooks.md#tdd-guardsh) 를 따른다.
 
 `status` 또는 `ensure` 가 `commit-required` 를 출력하면 생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)을 activation bootstrap commit 에 포함하도록 사용자에게 안내한다. 이 파일들은 자동 workflow PR 대상은 아니지만, 커밋되지 않으면 새 worktree/headless worker 가 project-local 계약을 재사용하지 못한다.
 

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -163,7 +163,9 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **TDD 계약 + self-test**: 계약은 생성물과 독립이다. `scripts/dcness-tdd-hooks self-test` 는 fixture 로 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 재현한다. `/init-dcness` 의 `scripts/dcness-tdd-hooks ensure --targets cc,codex` 는 이 계약 self-test 를 먼저 실행하고, 통과한 후보만 hook 으로 등록한다.
 
-**지원 플랫폼**: 현재 generated hook helper 는 `python`, `web`, `go`, `android`, `ios` 프리셋을 기준으로 project-local config(`.dcness/tdd-hooks.json`)를 만든다. 빈 프로젝트 또는 미지원 플랫폼은 생성 skip 이며 안전 no-op 이다. 새 플랫폼은 이 프리셋을 확장해야 하므로, 프로젝트 에이전트가 플랫폼별 규칙을 더 직접 소유하는 후속 위임 작업 대상이다. 중앙 fallback 은 기존 호환을 위해 TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 검사한다. 그 외 확장자는 generated hook 이 없으면 silent skip 이다.
+**프로젝트 로컬 계약**: `.dcness/tdd-hooks.json` 이 있으면 helper 는 코어 프리셋보다 이 파일을 우선한다. 모든 계약은 `source_roots`, `impl_exts` 가 필요하고, custom 플랫폼은 `test_candidate_templates` 도 필요하다. `test_file_globs` 는 test 파일 자체를 구현 파일로 오인하지 않게 하는 선택 필드다. template placeholder 는 `{parent}`, `{stem}`, `{base}`, `{ext}`, `{path}`, `{path_no_ext}`, `{filename}` 을 지원한다. 기존 파일이 깨진 JSON 이거나 필수 필드가 없으면 덮어쓰지 않고 등록을 중단한다.
+
+**지원 플랫폼**: helper 는 `python`, `web`, `go`, `android`, `ios` 프리셋으로 기본 project-local config 를 만들 수 있다. 새 플랫폼은 코어 프리셋을 추가하지 않아도 프로젝트 에이전트나 사람이 위 형식의 `.dcness/tdd-hooks.json` 을 승인·커밋하면 같은 self-test/등록 경로를 쓴다. 빈 프로젝트 또는 project-local 계약이 없는 미지원 플랫폼은 생성 skip 이며 안전 no-op 이다. 중앙 fallback 은 기존 호환을 위해 TS/JS 만 (`*.ts`, `*.tsx`, `*.js`, `*.jsx`) 검사한다. 그 외 확장자는 generated hook 이 없으면 silent skip 이다.
 
 **생성/등록 순서**: CC hook 이 먼저다. `.claude/hooks/dcness-tdd-guard.sh` 후보가 self-test 를 통과해야 `.claude/settings.json` PreToolUse(`Edit|Write|NotebookEdit|Bash`) 에 등록된다. Codex hook 은 그 다음 같은 패턴으로 `.codex/hooks/dcness-tdd-guard.sh` 와 `.codex/hooks.json` PreToolUse(`Edit|Write|apply_patch`) 에 등록된다. 기존 `.claude/settings.json` 또는 `.codex/hooks.json` 이 깨진 JSON 이면 등록을 거부하고 파일을 덮어쓰지 않는다. Codex 쪽은 CLI 의 사용자 신뢰 승인(`~/.codex/config.toml` trusted hash 흐름)이 추가로 필요할 수 있으므로, `registered` 는 project-local 파일 등록 상태이지 사용자 trust 승인 완료를 뜻하지 않는다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -22,7 +22,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 | runtime state ignore | `.gitignore` 의 `.claude/harness-state/` | `/init-dcness` append | 항상 | 없을 때만 추가 | X |
 | project context seed/migration | `CLAUDE.md` | `scripts/dcness-context-docs` / `harness/context_docs.py` | 항상 | 부재 시 생성. 기존 파일은 cold-start 앵커만 없을 때 append | X |
 | file boundary override suggestion | `.dcness/boundary.json` 후보만 | `dcness-helper boundary-suggestions` / `harness/boundary_suggestions.py` | 항상 | read-only. 사람 승인 전 작성 없음 | X |
-| generated TDD hook 제안/생성 | `.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh` | `scripts/dcness-tdd-hooks` | 플랫폼 감지 + 사용자 승인 시 | self-test 통과 후보만 등록. CC 검증 후 Codex 생성 | X |
+| generated TDD hook 제안/생성 | `.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh` | `scripts/dcness-tdd-hooks` | 플랫폼 감지 또는 사람 승인된 project-local 계약 + 사용자 승인 시 | self-test 통과 후보만 등록. CC 검증 후 Codex 생성 | X |
 | Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite | X |
 | Codex provider routing 상태 확인 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing status` | 항상 확인 | read-only | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
@@ -54,7 +54,7 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 
 파일 경계 override 제안은 `dcness-helper boundary-suggestions` 로 처리한다. 코어 `ALLOW_MATRIX` 가 커버하지 않는 비표준 소스 디렉터리가 있을 때만 `.dcness/boundary.json` 의 `engineer.add` 후보를 출력하며, 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다. 이 helper 는 read-only 이므로 실제 boundary 파일 작성은 사람 승인 뒤 메인이 수행한다.
 
-Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소유 영역은 **TDD 계약**과 **self-test** 이며, self-test fixture 는 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 검증한다. 현재 helper 는 `python`, `web`, `go`, `android`, `ios` 프리셋으로 project-local config 를 만들며, 새 플랫폼은 후속 위임 작업 전까지 프리셋 확장이 필요하다. `/init-dcness` 에서 생성할 때는 CC hook 후보를 먼저 self-test 하고 통과해야 `.claude/settings.json` 에 등록한다. 그 다음 Codex hook 후보를 같은 계약으로 self-test 하고 `.codex/hooks.json` 에 등록한다. 빈 프로젝트·미지원 플랫폼·생성 실패는 no-op 으로 안전 통과한다.
+Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소유 영역은 **TDD 계약**과 **self-test** 이며, self-test fixture 는 `무-test 구현 파일 → deny`, `매칭 test 있음 → allow`, `test 파일 자체 → allow` 를 검증한다. helper 는 `python`, `web`, `go`, `android`, `ios` 프리셋으로 기본 project-local config 를 만들 수 있고, 프리셋 미지원 플랫폼은 사람 승인된 `.dcness/tdd-hooks.json` 계약을 우선 사용한다. 모든 계약은 `source_roots`, `impl_exts` 가 필요하고, custom 플랫폼은 `test_candidate_templates` 도 필요하다. 선택 `test_file_globs` 로 test 파일 자체 allow 규칙을 보강한다. `/init-dcness` 에서 생성할 때는 CC hook 후보를 먼저 self-test 하고 통과해야 `.claude/settings.json` 에 등록한다. 그 다음 Codex hook 후보를 같은 계약으로 self-test 하고 `.codex/hooks.json` 에 등록한다. 빈 프로젝트·project-local 계약 없는 미지원 플랫폼·생성 실패는 no-op 으로 안전 통과한다.
 
 생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)은 자동 workflow PR 에 섞지 않지만 Git 커밋 대상이다. 커밋되지 않으면 새 worktree 나 headless worker 체크아웃에서 project-local hook 을 볼 수 없어 중앙 fallback 으로 내려간다. `scripts/dcness-tdd-hooks status` 와 `ensure` 는 이 파일들이 HEAD 에 깨끗하게 반영되기 전까지 `commit-required` 를 출력한다.
 

--- a/harness/tdd_hooks.py
+++ b/harness/tdd_hooks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 import os
 import shlex
@@ -42,6 +43,9 @@ TEST_DIR_SEGMENTS = {
     "specs",
     "e2e",
 }
+TEST_CANDIDATE_TEMPLATES_KEY = "test_candidate_templates"
+TEST_FILE_GLOBS_KEY = "test_file_globs"
+PRESET_PLATFORMS = {"python", "web", "go", "android", "ios"}
 
 
 @dataclass(frozen=True)
@@ -104,6 +108,51 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
     )
 
 
+def _string_list(config: dict[str, Any], key: str) -> list[str]:
+    value = config.get(key)
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]
+
+
+def _normalize_contract_config(config: dict[str, Any]) -> dict[str, Any]:
+    source_roots = _string_list(config, "source_roots")
+    impl_exts = _string_list(config, "impl_exts")
+    platform = str(config.get("platform") or "custom")
+    test_candidate_templates = _string_list(config, TEST_CANDIDATE_TEMPLATES_KEY)
+    if not source_roots or not impl_exts:
+        raise JsonConfigError(
+            f"{CONFIG_REL}: TDD config must include non-empty source_roots and impl_exts"
+        )
+    if platform not in PRESET_PLATFORMS and not test_candidate_templates:
+        raise JsonConfigError(
+            f"{CONFIG_REL}: custom TDD config must include non-empty "
+            f"{TEST_CANDIDATE_TEMPLATES_KEY}"
+        )
+    normalized = dict(config)
+    normalized["version"] = config.get("version", CONFIG_VERSION)
+    normalized["platform"] = platform
+    normalized["source_roots"] = source_roots
+    normalized["impl_exts"] = impl_exts
+    normalized[TEST_CANDIDATE_TEMPLATES_KEY] = test_candidate_templates
+    normalized[TEST_FILE_GLOBS_KEY] = _string_list(config, TEST_FILE_GLOBS_KEY)
+    registered = config.get("registered")
+    normalized["registered"] = registered if isinstance(registered, dict) else {}
+    return normalized
+
+
+def _load_project_contract_config(project_root: Path) -> Optional[dict[str, Any]]:
+    config_path = project_root / CONFIG_REL
+    if not config_path.is_file():
+        return None
+    config = _read_json(config_path, strict=True)
+    if not config:
+        raise JsonConfigError(
+            f"{config_path}: empty TDD config; refusing to overwrite existing file"
+        )
+    return _normalize_contract_config(config)
+
+
 def _iter_project_files(root: Path, suffixes: tuple[str, ...]) -> Iterable[Path]:
     for path in root.rglob("*"):
         rel_parts = path.relative_to(root).parts
@@ -146,9 +195,32 @@ def detect_platform(project_root: Path) -> Optional[str]:
     return None
 
 
+def _base_contract_config(
+    *,
+    platform: str,
+    source_roots: list[str],
+    impl_exts: list[str],
+    test_candidate_templates: list[str],
+    test_file_globs: list[str],
+) -> dict[str, Any]:
+    return {
+        "version": CONFIG_VERSION,
+        "platform": platform,
+        "source_roots": source_roots,
+        "impl_exts": impl_exts,
+        TEST_CANDIDATE_TEMPLATES_KEY: test_candidate_templates,
+        TEST_FILE_GLOBS_KEY: test_file_globs,
+        "registered": {"cc": False, "codex": False},
+    }
+
+
 def build_contract_config(project_root: Path, platform: Optional[str] = None) -> Optional[dict[str, Any]]:
     """Build the project-local TDD contract config used by generated hooks."""
     root = project_root.resolve()
+    if platform is None:
+        existing = _load_project_contract_config(root)
+        if existing is not None:
+            return existing
     detected = platform or detect_platform(root)
     if detected is None:
         return None
@@ -156,31 +228,72 @@ def build_contract_config(project_root: Path, platform: Optional[str] = None) ->
     if detected == "python":
         source_roots = _existing_source_roots(root, ("src", "app", "apps", "packages"))
         impl_exts = [".py"]
+        test_candidate_templates = [
+            "{parent}/test_{stem}.py",
+            "{parent}/{stem}_test.py",
+            "{parent}/tests/test_{stem}.py",
+            "tests/test_{stem}.py",
+            "tests/{stem}_test.py",
+        ]
+        test_file_globs = ["test_*.py", "*_test.py", "tests/**/*.py"]
     elif detected == "web":
         source_roots = _existing_source_roots(root, ("src", "app", "apps", "packages"))
         impl_exts = [".ts", ".tsx", ".js", ".jsx"]
+        test_candidate_templates = []
+        for test_ext in (".ts", ".tsx", ".js", ".jsx"):
+            test_candidate_templates.extend(
+                [
+                    f"{{parent}}/{{stem}}.test{test_ext}",
+                    f"{{parent}}/{{stem}}.spec{test_ext}",
+                    f"{{parent}}/__tests__/{{stem}}.test{test_ext}",
+                    f"src/__tests__/{{stem}}.test{test_ext}",
+                ]
+            )
+        test_file_globs = [
+            "**/*.test.ts",
+            "**/*.test.tsx",
+            "**/*.test.js",
+            "**/*.test.jsx",
+            "**/*.spec.ts",
+            "**/*.spec.tsx",
+            "**/*.spec.js",
+            "**/*.spec.jsx",
+            "**/__tests__/**",
+        ]
     elif detected == "go":
         source_roots = _existing_source_roots(root, (".", "cmd", "pkg", "internal"))
         impl_exts = [".go"]
+        test_candidate_templates = ["{parent}/{stem}_test.go"]
+        test_file_globs = ["**/*_test.go"]
     elif detected == "android":
         source_roots = _existing_source_roots(
             root,
             ("app/src/main", "src/main", "app", "src"),
         )
         impl_exts = [".kt", ".java"]
+        test_candidate_templates = [
+            "app/src/test/java/{stem}Test{ext}",
+            "{parent}/{stem}Test{ext}",
+        ]
+        test_file_globs = ["**/*Test.kt", "**/*Test.java"]
     elif detected == "ios":
         source_roots = _existing_source_roots(root, ("Sources", "App", "src"))
         impl_exts = [".swift"]
+        test_candidate_templates = [
+            "Tests/{stem}Tests.swift",
+            "{parent}/{stem}Tests.swift",
+        ]
+        test_file_globs = ["Tests/**/*.swift", "**/*Test.swift", "**/*Tests.swift"]
     else:
         return None
 
-    return {
-        "version": CONFIG_VERSION,
-        "platform": detected,
-        "source_roots": source_roots,
-        "impl_exts": impl_exts,
-        "registered": {"cc": False, "codex": False},
-    }
+    return _base_contract_config(
+        platform=detected,
+        source_roots=source_roots,
+        impl_exts=impl_exts,
+        test_candidate_templates=test_candidate_templates,
+        test_file_globs=test_file_globs,
+    )
 
 
 def _rel_path(path: Path, project_root: Path) -> Optional[Path]:
@@ -209,7 +322,76 @@ def _is_under_source_root(rel: Path, config: dict[str, Any]) -> bool:
     return False
 
 
-def _is_test_file(rel: Path, platform: str) -> bool:
+def _template_context(source_rel: Path) -> dict[str, str]:
+    parent = source_rel.parent.as_posix()
+    if parent in ("", "."):
+        parent = "."
+    stem = _strip_known_suffix(source_rel)
+    path_no_ext = (source_rel.parent / stem).as_posix()
+    return {
+        "path": source_rel.as_posix(),
+        "path_no_ext": path_no_ext,
+        "parent": parent,
+        "filename": source_rel.name,
+        "stem": stem,
+        "base": stem,
+        "ext": source_rel.suffix,
+    }
+
+
+def _render_template(template: str, source_rel: Path) -> Optional[str]:
+    try:
+        rendered = template.format(**_template_context(source_rel)).strip()
+    except (KeyError, ValueError):
+        return None
+    return rendered or None
+
+
+def _candidate_from_template(template: str, source_rel: Path) -> Optional[Path]:
+    rendered = _render_template(template, source_rel)
+    if rendered is None:
+        return None
+    candidate = Path(rendered)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+    return candidate
+
+
+def _configured_test_candidates(source_rel: Path, config: dict[str, Any]) -> list[Path]:
+    candidates: list[Path] = []
+    for template in _string_list(config, TEST_CANDIDATE_TEMPLATES_KEY):
+        candidate = _candidate_from_template(template, source_rel)
+        if candidate is not None:
+            candidates.append(candidate)
+    return candidates
+
+
+def _unique_candidate_paths(candidates: list[Path]) -> list[Path]:
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        key = candidate.as_posix()
+        if key not in seen:
+            unique.append(candidate)
+            seen.add(key)
+    return unique
+
+
+def _matches_configured_test_file_glob(rel: Path, config: dict[str, Any]) -> bool:
+    rel_text = rel.as_posix()
+    for template in _string_list(config, TEST_FILE_GLOBS_KEY):
+        pattern = _render_template(template, rel)
+        if pattern is None:
+            continue
+        patterns = [pattern]
+        if pattern.startswith("./"):
+            patterns.append(pattern[2:])
+        if any(fnmatch.fnmatchcase(rel_text, item) for item in patterns):
+            return True
+    return False
+
+
+def _is_platform_test_file(rel: Path, platform: str) -> bool:
     parts = set(rel.parts[:-1])
     if parts & TEST_DIR_SEGMENTS:
         return True
@@ -227,6 +409,13 @@ def _is_test_file(rel: Path, platform: str) -> bool:
     return False
 
 
+def _is_test_file(rel: Path, config: dict[str, Any]) -> bool:
+    if _matches_configured_test_file_glob(rel, config):
+        return True
+    platform = str(config.get("platform") or "")
+    return _is_platform_test_file(rel, platform)
+
+
 def _strip_known_suffix(path: Path) -> str:
     return path.name[: -len(path.suffix)] if path.suffix else path.name
 
@@ -236,7 +425,9 @@ def matching_test_candidates(source_rel: Path, config: dict[str, Any]) -> list[P
     ext = source_rel.suffix
     base = _strip_known_suffix(source_rel)
     parent = source_rel.parent
-    candidates: list[Path] = []
+    candidates: list[Path] = _configured_test_candidates(source_rel, config)
+    if candidates and platform not in PRESET_PLATFORMS:
+        return _unique_candidate_paths(candidates)
 
     if platform == "python":
         candidates.extend(
@@ -270,14 +461,7 @@ def matching_test_candidates(source_rel: Path, config: dict[str, Any]) -> list[P
     else:
         candidates.append(parent / f"{base}.test{ext}")
 
-    unique: list[Path] = []
-    seen: set[str] = set()
-    for candidate in candidates:
-        key = candidate.as_posix()
-        if key not in seen:
-            unique.append(candidate)
-            seen.add(key)
-    return unique
+    return _unique_candidate_paths(candidates)
 
 
 def _android_test_path(source_rel: Path, base: str, ext: str) -> Path:
@@ -295,11 +479,10 @@ def should_enforce(path: Path, project_root: Path, config: dict[str, Any]) -> bo
     rel = _rel_path(path, project_root)
     if rel is None:
         return False
-    platform = str(config.get("platform") or "")
     impl_exts = config.get("impl_exts")
     if not isinstance(impl_exts, list) or rel.suffix not in impl_exts:
         return False
-    if _is_test_file(rel, platform):
+    if _is_test_file(rel, config):
         return False
     return _is_under_source_root(rel, config)
 
@@ -438,17 +621,7 @@ def _self_test_paths(config: dict[str, Any], token: str) -> tuple[Path, Path, Pa
     no_test = source_root / f"dcness_tdd_contract_no_test_{token}{ext}"
     with_test = source_root / f"dcness_tdd_contract_with_test_{token}{ext}"
     test_file = matching_test_candidates(with_test, config)[0]
-    test_self = test_file.parent / f"test_dcness_tdd_contract_self_{token}.py"
-    platform = str(config.get("platform") or "")
-    if platform == "web":
-        test_self = test_file.parent / f"dcness_tdd_contract_self_{token}.test.ts"
-    elif platform == "go":
-        test_self = test_file.parent / f"dcness_tdd_contract_self_{token}_test.go"
-    elif platform == "android":
-        test_self = test_file.parent / f"DcnessTddContractSelf{token}Test{ext}"
-    elif platform == "ios":
-        test_self = test_file.parent / f"DcnessTddContractSelf{token}Tests.swift"
-    return no_test, with_test, test_self
+    return no_test, with_test, test_file
 
 
 def _fixture_content(path: Path) -> str:
@@ -458,6 +631,8 @@ def _fixture_content(path: Path) -> str:
         return "export function dcnessContractSubject() { return 1; }\n"
     if path.suffix == ".go":
         return "package dcness\n\nfunc DcnessContractSubject() int { return 1 }\n"
+    if path.suffix == ".rs":
+        return "pub fn dcness_contract_subject() -> i32 { 1 }\n"
     if path.suffix in {".kt", ".java", ".swift"}:
         return "// dcness contract subject\n"
     return "dcness contract subject\n"
@@ -530,17 +705,16 @@ def run_self_test(
     plugin_root: Optional[Path] = None,
 ) -> None:
     token = uuid.uuid4().hex[:8]
-    no_test_rel, with_test_rel, test_self_rel = _self_test_paths(config, token)
+    no_test_rel, with_test_rel, test_file_rel = _self_test_paths(config, token)
     created = [
         _write_fixture_file(project_root, no_test_rel),
         _write_fixture_file(project_root, with_test_rel),
-        _write_fixture_file(project_root, matching_test_candidates(with_test_rel, config)[0]),
-        _write_fixture_file(project_root, test_self_rel),
+        _write_fixture_file(project_root, test_file_rel),
     ]
     cases = [
         SelfTestCase("without_test", created[0], "deny"),
         SelfTestCase("with_test", created[1], "allow"),
-        SelfTestCase("test_file_self", created[3], "allow"),
+        SelfTestCase("test_file_self", created[2], "allow"),
     ]
     failures: list[SelfTestFailure] = []
     try:
@@ -835,8 +1009,9 @@ def ensure_generated_hooks(
 
 def inspect_installation(project_root: Path) -> dict[str, Any]:
     root = project_root.resolve()
-    platform = detect_platform(root)
     config = _read_json(root / CONFIG_REL)
+    config_platform = config.get("platform") if isinstance(config.get("platform"), str) else None
+    platform = config_platform or detect_platform(root)
     registered_data = config.get("registered")
     registered: dict[str, Any] = registered_data if isinstance(registered_data, dict) else {}
     cc_hook = (root / CC_HOOK_REL).is_file()

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -89,13 +89,13 @@ GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecy
 
 ## Step 0.3 — generated TDD hook 부재 확인
 
-구현 진입 전에 project-local TDD hook 상태를 한 번 확인한다. dcNess 는 **TDD 계약**과 생성 직후 **self-test** 를 소유하고, hook 본문은 현재 helper 의 플랫폼 프리셋(`python`, `web`, `go`, `android`, `ios`)에 맞게 생성된다.
+구현 진입 전에 project-local TDD hook 상태를 한 번 확인한다. dcNess 는 **TDD 계약**과 생성 직후 **self-test** 를 소유하고, hook 본문은 현재 helper 의 플랫폼 프리셋(`python`, `web`, `go`, `android`, `ios`) 또는 사람 승인된 `.dcness/tdd-hooks.json` 계약(`source_roots`, `impl_exts`, custom 플랫폼의 `test_candidate_templates`, 선택 `test_file_globs`)에 맞게 생성된다.
 
 ```bash
 "$PLUGIN_ROOT/scripts/dcness-tdd-hooks" status --project-root "$PROJECT_ROOT"
 ```
 
-플랫폼이 감지됐는데 generated hook 이 없으면 사용자에게 생성 제안을 보여준다. 승인 시 `/init-dcness` 와 같은 순서로 진행한다: TDD 계약 self-test fixture 확인 → CC hook 후보 생성/self-test/등록 → Codex hook 후보 생성/self-test/등록.
+플랫폼이 감지됐거나 project-local 계약이 있는데 generated hook 이 없으면 사용자에게 생성 제안을 보여준다. 미지원 플랫폼에서 새 규칙이 필요하면 구현 에이전트가 `.dcness/tdd-hooks.json` 초안을 만들 수 있지만, 사람 승인 뒤에만 `ensure` 를 실행한다. 승인 시 `/init-dcness` 와 같은 순서로 진행한다: TDD 계약 self-test fixture 확인 → CC hook 후보 생성/self-test/등록 → Codex hook 후보 생성/self-test/등록.
 
 ```bash
 "$PLUGIN_ROOT/scripts/dcness-tdd-hooks" ensure --project-root "$PROJECT_ROOT" --targets cc,codex --plugin-root "$PLUGIN_ROOT"

--- a/tests/test_generated_tdd_hooks.py
+++ b/tests/test_generated_tdd_hooks.py
@@ -136,6 +136,7 @@ class GeneratedTddHookContractTests(unittest.TestCase):
                 (project / ".dcness" / "tdd-hooks.json").read_text(encoding="utf-8")
             )
             self.assertEqual(config["platform"], "python")
+            self.assertIn("test_candidate_templates", config)
             self.assertTrue(config["registered"]["cc"])
             self.assertTrue(config["registered"]["codex"])
 
@@ -298,6 +299,83 @@ class GeneratedTddHookContractTests(unittest.TestCase):
             denied = _run_hook(hook, project, no_test)
             self.assertEqual(denied.returncode, 2, denied.stderr)
             self.assertIn("price.py", denied.stderr)
+
+    def test_ensure_uses_project_owned_config_for_unknown_platform(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "Cargo.toml").write_text("[package]\nname='demo'\nversion='0.1.0'\n")
+            (project / "src").mkdir()
+            (project / "src" / "lib.rs").write_text("pub fn existing() -> i32 { 1 }\n")
+            (project / ".dcness").mkdir()
+            (project / ".dcness" / "tdd-hooks.json").write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "platform": "rust",
+                        "source_roots": ["src"],
+                        "impl_exts": [".rs"],
+                        "test_candidate_templates": [
+                            "tests/{stem}_test{ext}",
+                            "{parent}/{stem}_test{ext}",
+                        ],
+                        "test_file_globs": [
+                            "tests/**/*{ext}",
+                            "**/*_test{ext}",
+                        ],
+                        "registered": {"cc": False, "codex": False},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("cc: registered", result.stdout)
+
+            report = inspect_installation(project)
+            self.assertEqual(report["platform"], "rust")
+            self.assertTrue(report["cc_registered"])
+
+            hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            no_test = project / "src" / "price.rs"
+            no_test.write_text("pub fn price() -> i32 { 1 }\n", encoding="utf-8")
+            denied = _run_hook(hook, project, no_test)
+            self.assertEqual(denied.returncode, 2, denied.stderr)
+            self.assertIn("price.rs", denied.stderr)
+            self.assertIn("tests/price_test.rs", denied.stderr)
+
+            (project / "src" / "price.test.rs").write_text(
+                "#[test]\nfn generic_name_only() { assert_eq!(1, 1); }\n",
+                encoding="utf-8",
+            )
+            still_denied = _run_hook(hook, project, no_test)
+            self.assertEqual(still_denied.returncode, 2, still_denied.stderr)
+
+            (project / "tests").mkdir()
+            (project / "tests" / "price_test.rs").write_text(
+                "#[test]\nfn price_contract() { assert_eq!(1, 1); }\n",
+                encoding="utf-8",
+            )
+            allowed = _run_hook(hook, project, no_test)
+            self.assertEqual(allowed.returncode, 0, allowed.stderr)
 
     def test_status_does_not_trust_stale_registered_flags_without_hook_files(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -482,6 +560,7 @@ class GeneratedTddHookDocsTests(unittest.TestCase):
             with self.subTest(text=text[:20]):
                 self.assertIn("TDD 계약", text)
                 self.assertIn("self-test", text)
+                self.assertIn("test_candidate_templates", text)
 
         ordered = [
             "TDD 계약",


### PR DESCRIPTION
## 관련 이슈 번호

Closes #918
Part of #908

## 배경 및 문제

#909/#916 의 generated TDD hook MVP 는 TDD 계약과 self-test 는 확보했지만, 플랫폼별 source roots / impl extensions / matching test candidates 를 `harness/tdd_hooks.py` 프리셋이 계속 소유했다. 그 결과 Rust/Ruby 같은 새 플랫폼은 프로젝트가 규칙을 알고 있어도 dcNess 코어 수정이 기본 경로가 됐다.

## 원인 (해당 시)

`ensure_generated_hooks` 가 기존 `.dcness/tdd-hooks.json` 계약을 hook 생성 입력으로 우선 사용하지 않았고, matching test 후보 생성도 플랫폼 분기 안에 고정돼 있었다.

## 작업내용

- `harness/tdd_hooks.py` 가 사람 승인된 `.dcness/tdd-hooks.json` 계약을 프리셋보다 우선 사용하게 했다.
- project-local 계약에 `test_candidate_templates` / `test_file_globs` 를 추가하고, generated 기본 프리셋 config 에도 matching 후보 템플릿을 기록하게 했다.
- custom 플랫폼은 명시된 `test_candidate_templates` 만 matching 후보로 사용해 코어 generic fallback 이 승인되지 않은 테스트 위치를 allow 하지 않게 했다.
- Rust custom config fixture 로 self-test, hook 등록, no-test deny, 승인되지 않은 generic 위치 deny, matching test allow 를 회귀 테스트했다.
- `/init-dcness`, `/impl`, hook/init reference 문서에 사람 승인·커밋 정책과 위임 경로를 반영했다.

## 결정 근거

dcNess 가 계속 보유해야 하는 것은 `무-test 구현 deny / 매칭 test allow / test 파일 allow` 계약과 생성 전 self-test 다. 플랫폼별 후보 규칙은 프로젝트 로컬 JSON으로 옮기면 새 플랫폼 추가가 코어 프리셋 수정이 아니라 프로젝트 승인 config 작성으로 닫힌다. 다만 기존 `python`, `web`, `go`, `android`, `ios` 프리셋은 bootstrap 편의를 위해 유지했다.

## 배포 경로 검증 (plug-in 영향 시)

- plug-in 본체: `harness/tdd_hooks.py` 변경은 `scripts/dcness-tdd-hooks` wrapper 를 통해 plugin update 로 배포된다.
- `/init-dcness` 경로: `commands/init-dcness.md` 와 `docs/plugin/init-dcness.md` 에 project-local 계약 승인/생성 정책을 반영했다.
- `/impl` 경로: `skills/impl/SKILL.md` 에 구현 진입 시 custom TDD 계약 확인/승인 흐름을 반영했다.
- hook 정책 SSOT: `docs/plugin/hooks.md` 에 `test_candidate_templates`, `test_file_globs`, placeholder, custom 플랫폼 안전 no-op 정책을 반영했다.
- 기존 활성 프로젝트는 plugin update 후 기존 프리셋 config 를 계속 쓸 수 있고, 미지원 플랫폼은 사람 승인된 `.dcness/tdd-hooks.json` bootstrap commit 으로 새 계약을 공유한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public command/skill/agent/gate 없음. 기존 `scripts/dcness-tdd-hooks` helper 의 project-local config 계약만 확장했다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -p 'test_generated_tdd_hooks.py' -v < /dev/null`
- [x] `python3.11 -m unittest tests.test_status_diagnostics tests.test_tdd_guard -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1622 tests OK
- [x] pre-commit pytest gate — 1622 tests OK
- [x] `PYTHON_BIN=/tmp/dcness-quality-issue908/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs && node scripts/check_public_surface.mjs && node scripts/check_plugin_manifest.mjs && node scripts/aggregate_index_map.mjs --check && node scripts/aggregate_architecture_map.mjs --check && node scripts/check_design_artifact_structure.mjs`
- [x] `python3.11 evals/guard_efficacy.py` — 33/33 passed
- [x] `git diff --check`

## 참고

- Local review round 1/3: custom 플랫폼에 generic fallback 이 섞이는 결함을 발견해 회귀 테스트 추가 후 수정. 최종 local review PASS.