### PR TITLE
[feature] 모듈별 CLAUDE.md 분할 권고 기준 추가

### DIFF
--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -134,6 +134,23 @@ scope: module:<module-id>/epic-NN
 
 기존 `global` 과 `epic-NN` 값은 그대로 유효하다. 결정이 여러 모듈을 동시에 바꾸면 module scope 를 여러 개 나열하지 말고 `epic-NN` 또는 `global` 로 올린 뒤 본문 링크에서 영향 모듈을 적는다. `module:<module-id>/epic-NN` 은 특정 epic 안에서 특정 모듈에만 닫히는 결정에 사용한다.
 
+## 모듈 CLAUDE.md (권고)
+
+Claude Code 는 프로젝트 루트뿐 아니라 하위 폴더의 `CLAUDE.md` 도 인식한다. 루트 계층(user `~/.claude/CLAUDE.md` → 상위 디렉토리 → 작업 디렉토리)은 세션 시작 시 로드되고, 하위 폴더 `CLAUDE.md` 는 그 아래 파일을 다룰 때 로드된다. 여러 파일은 상위 → 하위 순으로 이어붙어 더 가까운 파일의 규칙이 나중에 놓여 우선한다. 아래는 활성 프로젝트가 이 계층을 언제·무엇으로 나눌지에 대한 권고다. `CLAUDE.md` 는 사용자 소유물이라 dcNess 는 게이트·hook·CI 로 강제하지 않고 기준만 제시한다.
+
+**분할 시점** — 모듈이 독자 스택·빌드/테스트 명령·컨벤션을 갖게 되어 루트 규칙만으로는 그 폴더의 작업 지침이 부정확해질 때 하위 `CLAUDE.md` 를 만든다. 이는 위 [모듈 산출물](#모듈-산출물)에서 `docs/modules/<module-id>/` 를 만드는 신호(독자 스택·빌드 명령·규약·runtime boundary)와 같다. 단순 디렉토리, 작은 library, 전역 규약으로 충분한 내부 package 는 하위 `CLAUDE.md` 를 만들지 않는다.
+
+**분할 내용** — 모듈 특수 규칙만 하위로 내린다: 그 폴더에서만 다른 빌드/테스트/실행 명령, local convention, 모듈 한정 주의사항. 전역 규칙(공통 formatter, branch/commit 규약, repo 전역 style, dcNess workflow)은 루트 `CLAUDE.md` 에 유지하고 하위에 복제하지 않는다. 가까운 파일이 우선하므로 전역 규칙을 하위에 다시 쓰면 두 사본이 drift 되는 원천이 된다. [모듈 산출물](#모듈-산출물)의 "전역은 루트, 모듈은 delta 만" 원칙을 `CLAUDE.md` 계층에도 그대로 적용한다.
+
+**크기 압력** — 루트 `CLAUDE.md` 가 특정 모듈 세부로 비대해지면, 그 세부를 해당 폴더 `CLAUDE.md` 로 내려 루트를 전역 규칙만으로 얇게 유지하는 것을 우선 검토한다. 하위 `CLAUDE.md` 는 그 폴더 작업 시에만 로드되므로, 세부를 내릴수록 무관한 모듈에서 작업하는 cold session 이 읽는 입력이 줄어든다. 이는 위 [문서 총량 예산](#문서-총량-예산)의 module scoped pack 상한과 같은 철학이다. `CLAUDE.md` 는 자동 상속이라 예산 표에는 넣지 않지만 "전역은 한 곳, 모듈 delta 만 하위" 라는 같은 입력 경계를 따른다.
+
+`docs/modules/<module-id>/` 와 하위 폴더 `CLAUDE.md` 는 같은 모듈 경계에서 갈라지지만 다른 산출물이다. 전자는 dcNess workflow agent 가 읽는 git-tracked 설계 입력이고, 후자는 그 폴더에서 동작하는 모든 Claude Code 세션에 자동 적용되는 사용자 소유 지침이다. 서로를 대체하지 않는다.
+
+시나리오:
+
+- **모노레포 — 독자 스택 모듈 추가**: TypeScript 웹 서비스 repo 에 React Native 모바일 앱을 `apps/mobile/` 로 추가하면, 모바일 빌드/테스트/실행 명령과 플랫폼 특수 convention 을 `apps/mobile/CLAUDE.md` 에 둔다. 루트 `CLAUDE.md` 에는 공통 규칙(커밋·branch·리뷰 규약, 공용 lint)만 남기고 모바일 세부를 루트로 끌어올리지 않는다. 같은 경계에서 `docs/modules/mobile/` 설계 문서도 만든다.
+- **단일 서비스 내 모듈화**: 단일 스택 repo 라도 특정 하위 패키지가 독자 도메인 규칙·엄격한 테스트 게이트를 가지면(예: `packages/payment/` 가 결제 도메인 불변식과 추가 검증 명령을 요구), 그 규칙만 `packages/payment/CLAUDE.md` 에 둔다. 공통 스택·도구 규칙은 여전히 루트 하나에만 둔다.
+
 ## 교차 모듈 epic
 
 epic 은 제품 단위라 여러 모듈을 가로지를 수 있다. 교차 모듈 epic 도 `docs/epics/epic-NN-<slug>/` 하나만 가진다. backend 와 mobile app 을 동시에 바꾸는 기능이라도 모듈별 `stories.md` 사본을 만들지 않는다.


### PR DESCRIPTION
## 관련 이슈 번호

Closes #882

## 배경 및 문제

Claude Code 는 폴더별 CLAUDE.md 상속(루트 → 하위, 가까운 파일 우선)을 내장 지원하지만, dcNess 산출물 지도 체계에는 CLAUDE.md 분할 기준이 0건이었다. 활성 프로젝트가 모노레포가 되거나(예: 웹 서비스에 모바일 앱 추가) 서비스 내부가 모듈화될 때, 무엇을 하위 CLAUDE.md 로 내리고 무엇을 루트에 남길지 참고할 규칙이 없었다. 기존 분할 계층은 `docs/` 산출물(전역 → epic → impl task)만 다루고 CLAUDE.md 계층은 다루지 않았다.

## 원인 (해당 시)

-

## 작업내용

- `docs/plugin/deliverables-map.md` 에 "모듈 CLAUDE.md (권고)" 섹션 추가.
  - **분할 시점**: 모듈이 독자 스택·빌드/테스트 명령·컨벤션을 갖게 될 때. `docs/modules/<module-id>/` 를 만드는 신호와 동일하게 묶음.
  - **분할 내용**: 모듈 특수 규칙만 하위로, 전역 규칙은 루트 유지·복제 금지(가까운 파일 우선 → 하위 복제는 drift 원천).
  - **크기 압력**: 루트 CLAUDE.md 비대 시 세부를 폴더 CLAUDE.md 로 내려 루트를 얇게 유지 우선 검토. 하위 CLAUDE.md 는 on-demand 로드라 무관 모듈 cold session 입력이 줄어 기존 `문서 총량 예산` 철학과 정합.
  - `docs/modules/<module-id>/`(agent 입력, git-tracked) 와 폴더 CLAUDE.md(사용자 소유, 모든 세션 자동 적용)의 차이 명시 — 같은 경계에서 갈라지되 서로 대체 안 함.
  - 시나리오 2건: 모노레포(독자 스택 모듈 추가, `apps/mobile/CLAUDE.md`) / 단일 서비스 내 모듈화(`packages/payment/CLAUDE.md`).
- 게이트·hook·CI 추가 없음. 순수 권고 — CLAUDE.md 는 사용자 소유물.

## 결정 근거

- 위치: `deliverables-map.md` 는 활성 프로젝트 산출물 지도의 SSOT 이며 이미 `docs/modules/` 모듈 축(모노레포·모듈화)을 다룬다. CLAUDE.md 분할은 같은 모듈 트리거를 공유하므로 `모듈 산출물` 섹션 바로 뒤에 배치해 트리거·"전역은 루트, 모듈 delta 만" 원칙을 재사용.
- Claude Code 로딩 메커니즘(루트 계층 세션 시작 로드, 하위 폴더 CLAUDE.md on-demand 로드, 가까운 파일 나중에 붙어 우선)은 claude-code-guide 로 실측 검증 후 반영.
- 새 게이트/hook 미추가: 이슈 요구대로 CLAUDE.md 사용자 소유물 원칙 유지 → 권고 문서 성격.

## 배포 경로 검증 (plug-in 영향 시)

- **배포 경로 1 (plug-in 본체)**. `docs/plugin/deliverables-map.md` 는 plug-in 에 번들되어 배포됨 — marketplace(`~/.claude/plugins/marketplaces/dcness/docs/plugin/deliverables-map.md`) 와 cache 최신 버전(`0.11.0/docs/plugin/deliverables-map.md`) 모두에 실존 확인.
- 활성 프로젝트의 workflow agents/skills(`ux-architect`, `module-architect`, `/design` SKILL, `commands/init-dcness.md`)가 `$PLUGIN_ROOT/docs/plugin/deliverables-map.md` 상대 경로로 참조 → 사용자가 plugin 버전 업 시 자동 도달. 사용자 repo 로 복사되는 파일이 아니므로 init-dcness deploy 스텝 변경 불요.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음. 기존 SSOT 문서에 권고 섹션만 추가.

## Test Plan

- [x] `node scripts/check_cross_refs.mjs` — PASS (dead link / dead anchor / 옛 명칭 / 고아 0건, 동일 파일 앵커 `#모듈-산출물`·`#문서-총량-예산` 해소)
- [x] `node scripts/check_doc_path_integrity.mjs` — PASS
- [x] 회귀 검증 — 문서 추가만, 코드/게이트 변경 없음

## 참고

- 대상 문서: [`docs/plugin/deliverables-map.md`](../blob/main/docs/plugin/deliverables-map.md) `모듈 CLAUDE.md (권고)` 섹션