### PR TITLE
[feature] 시간 기반 loop-diagnose sweep 스케줄 자동화

### DIFF
--- a/.claude/commands/loop-diagnose.md
+++ b/.claude/commands/loop-diagnose.md
@@ -39,8 +39,13 @@ dcNess self 전용 Diagnose 도구를 실행한다. 이 command 는 외부 활�
 
 5. 릴리즈 점검 중이면 release notes 의 "자기개선 점검 기록" 표에 결론을 남긴다.
 
+> 사람 세션 없이 주기 실행되는 시간 기반 sweep 은 `scripts/loop_diagnose.py sweep` 이
+> 담당한다. 최신 digest 는 `.metrics/loop-diagnose/digest-latest.md` 에 남는다. 설치·주기는
+> `docs/internal/self-improvement-loop.md` 의 스케줄 sweep 절을 본다.
+
 ## 참조
 
 - `scripts/loop_diagnose.py`
+- `scripts/launchd/install-loop-sweep.sh`
 - `docs/internal/self-improvement-loop.md`
 - `docs/internal/plugin-release.md`

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -26,6 +26,12 @@
 릴리즈마다 한 번 돈다. [`plugin-release.md`](plugin-release.md)의 릴리즈 전 점검에서
 Sense 산출물을 모으고, Diagnose/Decide 결과를 릴리즈 노트 또는 후속 이슈에 남긴다.
 
+릴리즈 리듬과 별개로 시간 기반 sweep 이 사람 세션 없이 주기 실행된다. 로컬 스케줄러가
+`scripts/loop_diagnose.py sweep` 을 정해진 주기(기본 하루 1회)로 돌려 활성 프로젝트
+전반의 Diagnose 후보를 워터마크 기준 digest 로 남긴다. 릴리즈 사이에 신호가 stale 하게
+쌓이지 않게 하는 Sense 자동화이며, Decide 는 그대로 사람 몫이다 — sweep 은 read-only 라
+repo·이슈·설정을 바꾸지 않는다. 설치·주기·teardown 은 [스케줄 sweep](#스케줄-sweep) 참조.
+
 평소 run 중 발견한 단발 신호는 바로 룰로 박지 않는다. 같은 신호가 반복되거나 릴리즈
 점검에서 비용·위험이 충분히 커졌을 때 Decide 슬롯으로 올린다.
 
@@ -42,6 +48,51 @@ Diagnose 후보는 같은 항목이 매번 다시 떠도 맥락을 잃지 않도
 
 `fixed`와 `rejected` 는 `--hide-decided` 로 숨길 수 있다. `hold` 는 의도적으로 계속
 표시해 보류 사유가 stale 해졌는지 다음 Diagnose 때 다시 보게 한다.
+
+## 스케줄 sweep
+
+시간 기반 Sense 자동화다. 로컬 스케줄러가 사람 세션 없이 sweep 을 주기 실행해, 릴리즈
+리듬 사이에 신호가 stale 하게 쌓이지 않게 한다. dcNess self 운영 도구이며 plugin
+배포물이 아니다(활성 프로젝트로 배포하지 않는다).
+
+### 실행 주체와 주기
+
+macOS launchd LaunchAgent(`com.dcness.loop-sweep`)가
+`python3.11 scripts/loop_diagnose.py sweep --repo-root <repo>` 를 `StartInterval` 마다
+실행한다. GitHub Actions 는 loop_diagnose 가 로컬 whitelist·telemetry·세션 상태를 읽어야
+하므로 쓸 수 없다.
+
+```sh
+# 설치 (기본 주기 = 하루 1회, 86400초)
+bash scripts/launchd/install-loop-sweep.sh
+
+# 주기 파라미터화 (예: 6시간마다)
+bash scripts/launchd/install-loop-sweep.sh --interval 21600
+
+# 제거
+bash scripts/launchd/install-loop-sweep.sh --uninstall
+```
+
+기본 주기는 86400초(하루 1회)이며 `--interval SECONDS` 로 바꾼다. 즉시 1회 실행으로
+확인하려면 `launchctl kickstart -k gui/$(id -u)/com.dcness.loop-sweep` 를 쓴다.
+
+### 산출물
+
+| 경로 | 역할 |
+|---|---|
+| `.metrics/loop-diagnose/digest-latest.md` | 최신 sweep 의 사람이 읽는 digest. `report` 와 같은 통합 후보 표에 `신규` / `신규 발생 since` / `기왕` 을 표시한다. 다음 세션이나 릴리즈 점검에서 소비한다. |
+| `.metrics/loop-diagnose/sweep-log.jsonl` | sweep 실행 원장. 성공은 `status: ok`(후보 수·digest 경로), 실패는 `status: error`(사유)를 append 한다. |
+| `.metrics/loop-diagnose/launchd.{out,err}.log` | launchd 가 잡은 stdout/stderr. sweep-log 를 못 남길 만큼 이른 실패의 최후 흔적. |
+
+모두 `.metrics/` 아래 로컬 untracked 런타임 상태라 git 추적하지 않는다. 워터마크
+(`sweeps.jsonl`)와 같은 층이다.
+
+### 계약
+
+- read-only. sweep 은 관측·기록만 하고 repo·이슈·설정을 바꾸지 않는다. Decide/Act
+  자동화(룰 자동 추가·제거, 이슈 자동 생성)는 범위 밖이다.
+- 실패는 조용히 사라지지 않는다. build 실패 시 `sweep-log.jsonl` 에 `status: error` 를
+  남기고 non-zero 로 종료하며, launchd 가 `launchd.err.log` 에 stderr 를 잡는다.
 
 ## 결정 규칙
 

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -76,6 +76,11 @@ bash scripts/launchd/install-loop-sweep.sh --uninstall
 기본 주기는 86400초(하루 1회)이며 `--interval SECONDS` 로 바꾼다. 즉시 1회 실행으로
 확인하려면 `launchctl kickstart -k gui/$(id -u)/com.dcness.loop-sweep` 를 쓴다.
 
+설치는 **persistent main checkout 에서 실행한다**. LaunchAgent 는 오래 사는 스케줄이라
+transient worktree(`.claude/worktrees/<branch>`) 경로가 박히면 `ExitWorktree` 로 worktree
+가 제거된 뒤 sweep 이 죽는다. installer 는 worktree 에서의 설치를 거부하고 main 경로를
+안내한다(제거는 경로 무관하게 동작).
+
 ### 산출물
 
 | 경로 | 역할 |

--- a/harness/loop_lessons.py
+++ b/harness/loop_lessons.py
@@ -260,6 +260,7 @@ def list_active_lessons(
     cwd: Path = Path("."),
     *,
     active_patterns: Optional[set[str]] = None,
+    archive: bool = True,
 ) -> list[dict[str, object]]:
     root = _normalize_cwd(cwd)
     base = root / LESSONS_DIR
@@ -268,7 +269,8 @@ def list_active_lessons(
     active = active_patterns if active_patterns is not None else _active_patterns_default()
     rows: list[dict[str, object]] = []
     for path in sorted(base.glob("*.md")):
-        archive_removed_patterns(path, active_patterns=active)
+        if archive:
+            archive_removed_patterns(path, active_patterns=active)
         agent, mode = _infer_agent_mode(path)
         for entry in _read_entries(path).values():
             if entry.status != "active" or entry.pattern not in active:

--- a/scripts/launchd/com.dcness.loop-sweep.plist.template
+++ b/scripts/launchd/com.dcness.loop-sweep.plist.template
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Placeholders (__PYTHON_BIN__ / __REPO_ROOT__ / __INTERVAL_SECONDS__) are filled
+     by scripts/launchd/install-loop-sweep.sh. Do not load this template directly. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.dcness.loop-sweep</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PYTHON_BIN__</string>
+        <string>__REPO_ROOT__/scripts/loop_diagnose.py</string>
+        <string>sweep</string>
+        <string>--repo-root</string>
+        <string>__REPO_ROOT__</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__REPO_ROOT__</string>
+    <key>StartInterval</key>
+    <integer>__INTERVAL_SECONDS__</integer>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StandardOutPath</key>
+    <string>__REPO_ROOT__/.metrics/loop-diagnose/launchd.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>__REPO_ROOT__/.metrics/loop-diagnose/launchd.err.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/launchd/install-loop-sweep.sh
+++ b/scripts/launchd/install-loop-sweep.sh
@@ -79,6 +79,18 @@ PYTHON_BIN="$(command -v python3.11 || true)"
 TEMPLATE="${SCRIPT_DIR}/${LABEL}.plist.template"
 [ -f "${TEMPLATE}" ] || { echo "template not found: ${TEMPLATE}" >&2; exit 1; }
 
+# The plist is rendered by textual substitution; a path with XML- or sed-hostile
+# characters (& < > " |) would corrupt it and make launchctl bootstrap fail. These never
+# occur in a normal checkout, so refuse clearly instead of emitting a broken plist.
+case "${REPO_ROOT}${PYTHON_BIN}" in
+  *[\&\<\>\"\|]*)
+    echo "refusing: repo root or python path contains an unsupported character (& < > \" |)" >&2
+    echo "  repo:   ${REPO_ROOT}" >&2
+    echo "  python: ${PYTHON_BIN}" >&2
+    exit 1
+    ;;
+esac
+
 mkdir -p "${AGENTS_DIR}" "${REPO_ROOT}/.metrics/loop-diagnose"
 
 sed -e "s|__PYTHON_BIN__|${PYTHON_BIN}|g" \

--- a/scripts/launchd/install-loop-sweep.sh
+++ b/scripts/launchd/install-loop-sweep.sh
@@ -42,6 +42,29 @@ if [ "${UNINSTALL}" -eq 1 ]; then
   exit 0
 fi
 
+# A LaunchAgent is a persistent schedule that must point at the stable main checkout.
+# A linked git worktree carries a .git *file* (gitlink) rather than a directory; if we
+# installed from one, its .claude/worktrees/<branch> path would get baked into the plist
+# and the sweep would die once ExitWorktree removes that worktree. Refuse and point the
+# user at the main repo instead of silently installing a self-destructing schedule.
+if [ -f "${REPO_ROOT}/.git" ]; then
+  COMMON_DIR="$(cd "${REPO_ROOT}" && git rev-parse --git-common-dir 2>/dev/null || true)"
+  MAIN_ROOT=""
+  if [ -n "${COMMON_DIR}" ]; then
+    case "${COMMON_DIR}" in
+      /*) ABS_COMMON="${COMMON_DIR}" ;;
+      *) ABS_COMMON="$(cd "${REPO_ROOT}/${COMMON_DIR}" && pwd)" ;;
+    esac
+    MAIN_ROOT="$(dirname "${ABS_COMMON}")"
+  fi
+  echo "refusing to install from a transient worktree: ${REPO_ROOT}" >&2
+  echo "a LaunchAgent must point at the persistent main checkout, not a worktree that ExitWorktree can remove." >&2
+  if [ -n "${MAIN_ROOT}" ]; then
+    echo "re-run from the main repo: bash ${MAIN_ROOT}/scripts/launchd/install-loop-sweep.sh" >&2
+  fi
+  exit 1
+fi
+
 case "${INTERVAL}" in
   ''|*[!0-9]*)
     echo "interval must be a positive integer number of seconds" >&2

--- a/scripts/launchd/install-loop-sweep.sh
+++ b/scripts/launchd/install-loop-sweep.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Install (or remove) the launchd LaunchAgent that runs the dcNess loop-diagnose
+# sweep on a timer without a human session. dcNess self only — not a plugin
+# deploy-path artifact. See docs/internal/self-improvement-loop.md.
+set -euo pipefail
+
+LABEL="com.dcness.loop-sweep"
+INTERVAL="86400"   # default period: once per day (seconds). Override with --interval.
+UNINSTALL=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --interval)
+      INTERVAL="${2:-}"
+      shift 2
+      ;;
+    --uninstall)
+      UNINSTALL=1
+      shift
+      ;;
+    -h|--help)
+      echo "usage: install-loop-sweep.sh [--interval SECONDS] [--uninstall]"
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+AGENTS_DIR="${HOME}/Library/LaunchAgents"
+PLIST_DEST="${AGENTS_DIR}/${LABEL}.plist"
+DOMAIN="gui/$(id -u)"
+
+if [ "${UNINSTALL}" -eq 1 ]; then
+  launchctl bootout "${DOMAIN}/${LABEL}" 2>/dev/null || true
+  rm -f "${PLIST_DEST}"
+  echo "uninstalled ${LABEL}"
+  exit 0
+fi
+
+case "${INTERVAL}" in
+  ''|*[!0-9]*)
+    echo "interval must be a positive integer number of seconds" >&2
+    exit 2
+    ;;
+esac
+[ "${INTERVAL}" -ge 1 ] || { echo "interval must be >= 1" >&2; exit 2; }
+
+PYTHON_BIN="$(command -v python3.11 || true)"
+[ -n "${PYTHON_BIN}" ] || { echo "python3.11 not found on PATH" >&2; exit 1; }
+
+TEMPLATE="${SCRIPT_DIR}/${LABEL}.plist.template"
+[ -f "${TEMPLATE}" ] || { echo "template not found: ${TEMPLATE}" >&2; exit 1; }
+
+mkdir -p "${AGENTS_DIR}" "${REPO_ROOT}/.metrics/loop-diagnose"
+
+sed -e "s|__PYTHON_BIN__|${PYTHON_BIN}|g" \
+    -e "s|__REPO_ROOT__|${REPO_ROOT}|g" \
+    -e "s|__INTERVAL_SECONDS__|${INTERVAL}|g" \
+    "${TEMPLATE}" > "${PLIST_DEST}"
+
+launchctl bootout "${DOMAIN}/${LABEL}" 2>/dev/null || true
+launchctl bootstrap "${DOMAIN}" "${PLIST_DEST}"
+
+echo "installed ${LABEL} (interval=${INTERVAL}s) -> ${PLIST_DEST}"
+echo "trigger a test run:  launchctl kickstart -k ${DOMAIN}/${LABEL}"
+echo "check status:        launchctl print ${DOMAIN}/${LABEL} | grep -i state"
+echo "digest:              ${REPO_ROOT}/.metrics/loop-diagnose/digest-latest.md"
+echo "failure trace:       ${REPO_ROOT}/.metrics/loop-diagnose/sweep-log.jsonl (+ launchd.err.log)"

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -32,6 +32,12 @@ DEFAULT_PROJECTS_FILE = (
     Path.home() / ".claude" / "plugins" / "data" / "dcness-dcness" / "projects.json"
 )
 SWEEP_PATH = Path(".metrics") / "loop-diagnose" / "sweeps.jsonl"
+DIGEST_FILENAME = "digest-latest.md"
+SWEEP_LOG_FILENAME = "sweep-log.jsonl"
+DIGEST_NOTE = (
+    "> 스케줄 sweep 이 남긴 최신 digest. sweep 은 read-only 관측만 하며 Decide 는 사람 몫이다.\n"
+    "> 후보 소비는 `record-decision` 으로 남긴다.\n\n"
+)
 DECISIONS_PATH = Path("docs") / "internal" / "loop-decisions.jsonl"
 VALID_DECISIONS = {"fixed", "hold", "rejected"}
 DECISION_LABELS = {
@@ -495,6 +501,26 @@ def _append_sweep(
     _append_jsonl(repo_root / SWEEP_PATH, payload)
 
 
+def _digest_dir(args: argparse.Namespace) -> Path:
+    if getattr(args, "digest_dir", ""):
+        return Path(args.digest_dir).expanduser()
+    repo_root = Path(args.repo_root).expanduser().resolve()
+    return repo_root / SWEEP_PATH.parent
+
+
+def _write_digest(digest_dir: Path, markdown: str) -> Path:
+    digest_dir.mkdir(parents=True, exist_ok=True)
+    target = digest_dir / DIGEST_FILENAME
+    tmp = digest_dir / (DIGEST_FILENAME + ".tmp")
+    tmp.write_text(markdown, encoding="utf-8")
+    os.replace(tmp, target)
+    return target
+
+
+def _append_sweep_log(digest_dir: Path, entry: dict[str, Any]) -> None:
+    _append_jsonl(digest_dir / SWEEP_LOG_FILENAME, entry)
+
+
 def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     repo_root = Path(args.repo_root).expanduser().resolve()
     projects_file = Path(args.projects_file).expanduser().resolve()
@@ -686,6 +712,16 @@ def _build_report_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _build_sweep_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="loop_diagnose.py sweep",
+        description="Run an unattended sweep and persist a digest for later human review.",
+    )
+    _add_common_report_args(parser)
+    parser.add_argument("--digest-dir", default="")
+    return parser
+
+
 def _build_decision_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="loop_diagnose.py record-decision")
     parser.add_argument("--repo-root", default=str(Path.cwd()))
@@ -707,11 +743,41 @@ def _run_report(argv: list[str]) -> int:
     return 0
 
 
+def _run_sweep(args: argparse.Namespace) -> int:
+    """Unattended sweep: persist a digest and always leave a trace, never vanish."""
+    digest_dir = _digest_dir(args)
+    swept_at = _now_iso()
+    try:
+        payload = build_payload(args)
+    except Exception as exc:  # noqa: BLE001 - a failed scheduled sweep must leave a trace
+        print(f"loop sweep failed: {exc!r}", file=sys.stderr)
+        try:
+            _append_sweep_log(digest_dir, {"swept_at": swept_at, "status": "error", "error": repr(exc)})
+        except OSError as log_exc:
+            print(f"loop sweep: could not write failure log: {log_exc!r}", file=sys.stderr)
+        return 1
+    target = _write_digest(digest_dir, DIGEST_NOTE + render_markdown(payload))
+    _append_sweep_log(
+        digest_dir,
+        {
+            "swept_at": payload["swept_at"],
+            "status": "ok",
+            "candidate_count": len(payload["candidates"]),
+            "digest_path": str(target),
+        },
+    )
+    print(f"loop sweep ok: digest -> {target}")
+    return 0
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     argv = list(sys.argv[1:] if argv is None else argv)
     if argv and argv[0] == "record-decision":
         args = _build_decision_parser().parse_args(argv[1:])
         return record_decision(args)
+    if argv and argv[0] == "sweep":
+        args = _build_sweep_parser().parse_args(argv[1:])
+        return _run_sweep(args)
     if argv and argv[0] == "report":
         argv = argv[1:]
     return _run_report(argv)

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -285,7 +285,9 @@ def _collect_project(path: Path, args: argparse.Namespace) -> dict[str, Any]:
     fleet = _fleet_to_json(fleet_report)
     candidates = _guard_candidates(name, path, guard_summary)
     candidates.extend(_waste_candidates(name, path, fleet, last_event_ts))
-    lessons = list_active_lessons(path)
+    # loop_diagnose only observes swept projects — never mutate their lesson files
+    # (archiving is left to each project's own write path).
+    lessons = list_active_lessons(path, archive=False)
     candidates.extend(_lesson_candidates(name, path, lessons))
     return {
         "name": name,

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -523,7 +523,7 @@ def _append_sweep_log(digest_dir: Path, entry: dict[str, Any]) -> None:
     _append_jsonl(digest_dir / SWEEP_LOG_FILENAME, entry)
 
 
-def build_payload(args: argparse.Namespace) -> dict[str, Any]:
+def build_payload(args: argparse.Namespace, *, write_watermark: bool = True) -> dict[str, Any]:
     repo_root = Path(args.repo_root).expanduser().resolve()
     projects_file = Path(args.projects_file).expanduser().resolve()
     swept_at = _now_iso()
@@ -538,15 +538,16 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
     candidates.extend(_cross_project_lesson_candidates(repo_root, projects))
     candidates.extend(evals["candidates"])
     _attach_status(candidates, previous=previous, decisions=decisions)
-    _append_sweep(
-        repo_root,
-        swept_at=swept_at,
-        projects=projects,
-        evals=evals,
-        candidates=candidates,
-    )
+    if write_watermark:
+        _append_sweep(
+            repo_root,
+            swept_at=swept_at,
+            projects=projects,
+            evals=evals,
+            candidates=candidates,
+        )
 
-    return {
+    payload = {
         "swept_at": swept_at,
         "projects_file": str(projects_file),
         "state_file": str(repo_root / SWEEP_PATH),
@@ -555,6 +556,19 @@ def build_payload(args: argparse.Namespace) -> dict[str, Any]:
         "evals": evals,
         "candidates": _visible_candidates(candidates, bool(args.hide_decided)),
     }
+    if not write_watermark:
+        # The caller advances the watermark itself, after the digest is durable, so a
+        # persistence failure never marks these candidates as seen (freshness would drop
+        # to 기왕 and the signal would be lost). Full candidate list — not the visibility
+        # filtered view — so the watermark records every key observed this sweep.
+        payload["_pending_watermark"] = {
+            "repo_root": repo_root,
+            "swept_at": swept_at,
+            "projects": projects,
+            "evals": evals,
+            "candidates": candidates,
+        }
+    return payload
 
 
 def _md_cell(value: Any) -> str:
@@ -746,11 +760,31 @@ def _run_report(argv: list[str]) -> int:
 
 
 def _run_sweep(args: argparse.Namespace) -> int:
-    """Unattended sweep: persist a digest and always leave a trace, never vanish."""
+    """Unattended sweep: persist a digest, then advance the watermark, always leaving a
+    trace. The watermark is written only after the digest is durable so a persistence
+    failure neither hides fresh signal nor vanishes without a status:error entry."""
     digest_dir = _digest_dir(args)
     swept_at = _now_iso()
     try:
-        payload = build_payload(args)
+        payload = build_payload(args, write_watermark=False)
+        pending = payload.pop("_pending_watermark")
+        target = _write_digest(digest_dir, DIGEST_NOTE + render_markdown(payload))
+        _append_sweep(
+            pending["repo_root"],
+            swept_at=pending["swept_at"],
+            projects=pending["projects"],
+            evals=pending["evals"],
+            candidates=pending["candidates"],
+        )
+        _append_sweep_log(
+            digest_dir,
+            {
+                "swept_at": payload["swept_at"],
+                "status": "ok",
+                "candidate_count": len(payload["candidates"]),
+                "digest_path": str(target),
+            },
+        )
     except Exception as exc:  # noqa: BLE001 - a failed scheduled sweep must leave a trace
         print(f"loop sweep failed: {exc!r}", file=sys.stderr)
         try:
@@ -758,16 +792,6 @@ def _run_sweep(args: argparse.Namespace) -> int:
         except OSError as log_exc:
             print(f"loop sweep: could not write failure log: {log_exc!r}", file=sys.stderr)
         return 1
-    target = _write_digest(digest_dir, DIGEST_NOTE + render_markdown(payload))
-    _append_sweep_log(
-        digest_dir,
-        {
-            "swept_at": payload["swept_at"],
-            "status": "ok",
-            "candidate_count": len(payload["candidates"]),
-            "digest_path": str(target),
-        },
-    )
     print(f"loop sweep ok: digest -> {target}")
     return 0
 

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -539,6 +539,38 @@ class LoopSweepTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(_snapshot_tree(alpha), before_alpha)
 
+    def test_sweep_digest_failure_leaves_error_and_does_not_advance_watermark(self) -> None:
+        # If the digest cannot be persisted, the watermark must NOT advance — otherwise the
+        # candidates would be recorded as seen and resurface as 기왕 (signal lost) — and the
+        # failure must still leave a status:error trace.
+        module = _load_loop_diagnose()
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            alpha.mkdir()
+            _write_guard_hit(alpha)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha)]}),
+                encoding="utf-8",
+            )
+            digest_dir = repo_root / ".metrics" / "loop-diagnose"
+            # digest-latest.md as a directory makes _write_digest's os.replace fail
+            (digest_dir / "digest-latest.md").mkdir(parents=True)
+            args = module._build_sweep_parser().parse_args(
+                ["--repo-root", str(repo_root), "--projects-file", str(projects_file),
+                 "--recurrence-threshold", "1"]
+            )
+
+            rc = module._run_sweep(args)
+
+            self.assertEqual(rc, 1)
+            last = json.loads((digest_dir / "sweep-log.jsonl").read_text(encoding="utf-8").splitlines()[-1])
+            self.assertEqual(last["status"], "error")
+            self.assertFalse((digest_dir / "sweeps.jsonl").exists())
+
     def test_sweep_failure_leaves_trace_and_nonzero_exit(self) -> None:
         module = _load_loop_diagnose()
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -516,6 +516,29 @@ class LoopSweepTests(unittest.TestCase):
             self.assertEqual(len(entries), 2)
             self.assertTrue(all(entry["status"] == "ok" for entry in entries))
 
+    def test_sweep_does_not_archive_stale_lessons_in_swept_projects(self) -> None:
+        # A lesson pattern no longer in the active set would be flipped to archived
+        # (file rewrite) by the default lesson listing. The read-only sweep must not
+        # mutate a swept project's files for that.
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            alpha.mkdir()
+            _write_lesson(alpha, "OLD_REMOVED_PATTERN", hits=3)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha)]}),
+                encoding="utf-8",
+            )
+            before_alpha = _snapshot_tree(alpha)
+
+            result = self._run_sweep(repo_root, projects_file)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(_snapshot_tree(alpha), before_alpha)
+
     def test_sweep_failure_leaves_trace_and_nonzero_exit(self) -> None:
         module = _load_loop_diagnose()
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -1,6 +1,7 @@
 """loop_diagnose self-improvement sweep tool tests (#902)."""
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 import subprocess
@@ -10,10 +11,19 @@ import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
+from unittest import mock
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "scripts" / "loop_diagnose.py"
+
+
+def _load_loop_diagnose() -> Any:
+    spec = importlib.util.spec_from_file_location("loop_diagnose", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
@@ -424,6 +434,106 @@ class LoopDiagnoseTests(unittest.TestCase):
             self.assertIn("lesson:MUST_FIX_GHOST@alpha/engineer-IMPL", keys)
             self.assertIn("lesson:MUST_FIX_GHOST@beta/engineer-IMPL", keys)
             self.assertIn("lesson-rule:MUST_FIX_GHOST", keys)
+
+
+class LoopSweepTests(unittest.TestCase):
+    def _run_sweep(
+        self,
+        repo_root: Path,
+        projects_file: Path,
+        *extra: str,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env["DCNESS_PROJECTS_FILE"] = str(projects_file)
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "sweep",
+                "--repo-root",
+                str(repo_root),
+                "--recurrence-threshold",
+                "1",
+                "--saturation-min-runs",
+                "2",
+                *extra,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_sweep_persists_digest_and_log_and_is_readonly(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            alpha = tmp / "alpha"
+            beta = tmp / "beta"
+            alpha.mkdir()
+            beta.mkdir()
+            _write_guard_hit(alpha)
+            _write_recurrent_waste_run(alpha)
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(alpha), str(beta)]}),
+                encoding="utf-8",
+            )
+            before_alpha = _snapshot_tree(alpha)
+            before_beta = _snapshot_tree(beta)
+
+            first = self._run_sweep(repo_root, projects_file)
+            self.assertEqual(first.returncode, 0, first.stderr)
+
+            digest_dir = repo_root / ".metrics" / "loop-diagnose"
+            digest = digest_dir / "digest-latest.md"
+            sweep_log = digest_dir / "sweep-log.jsonl"
+            watermark = digest_dir / "sweeps.jsonl"
+
+            self.assertTrue(digest.is_file())
+            self.assertTrue(watermark.is_file())
+            digest_text = digest.read_text(encoding="utf-8")
+            self.assertIn("통합 후보", digest_text)
+            self.assertIn("guard:file-guard@alpha", digest_text)
+            self.assertIn("신규", digest_text)
+
+            self.assertTrue(sweep_log.is_file())
+            entries = [json.loads(line) for line in sweep_log.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual(entries[-1]["status"], "ok")
+            self.assertGreaterEqual(entries[-1]["candidate_count"], 1)
+            self.assertEqual(Path(entries[-1]["digest_path"]).resolve(), digest.resolve())
+
+            # read-only: swept projects are untouched
+            self.assertEqual(_snapshot_tree(alpha), before_alpha)
+            self.assertEqual(_snapshot_tree(beta), before_beta)
+
+            second = self._run_sweep(repo_root, projects_file)
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("기왕", digest.read_text(encoding="utf-8"))
+            entries = [json.loads(line) for line in sweep_log.read_text(encoding="utf-8").splitlines()]
+            self.assertEqual(len(entries), 2)
+            self.assertTrue(all(entry["status"] == "ok" for entry in entries))
+
+    def test_sweep_failure_leaves_trace_and_nonzero_exit(self) -> None:
+        module = _load_loop_diagnose()
+        with tempfile.TemporaryDirectory() as td:
+            digest_dir = Path(td) / "digest"
+            args = module._build_sweep_parser().parse_args(
+                ["--repo-root", td, "--digest-dir", str(digest_dir)]
+            )
+            with mock.patch.object(module, "build_payload", side_effect=RuntimeError("boom")):
+                rc = module._run_sweep(args)
+
+            self.assertEqual(rc, 1)
+            sweep_log = digest_dir / "sweep-log.jsonl"
+            self.assertTrue(sweep_log.is_file())
+            last = json.loads(sweep_log.read_text(encoding="utf-8").splitlines()[-1])
+            self.assertEqual(last["status"], "error")
+            self.assertIn("boom", last["error"])
+            # a failed build must not leave a stale/partial digest
+            self.assertFalse((digest_dir / "digest-latest.md").exists())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 배경 · 문제
자기개선 루프의 Sense/Diagnose 트리거가 이벤트/수동(run 종료 auto-review, 릴리즈 리듬 수동 `/loop-diagnose`)뿐이라 **시간 기반 트리거가 부재**했다. `sweeps.jsonl` 워터마크 층은 주기 실행을 전제한 설계인데 주기 실행 장치만 없어, 릴리즈 사이에 자기개선 신호가 stale 하게 쌓였다.

## 근본원인
`scripts/loop_diagnose.py` 는 이미 워터마크 갱신·`신규`/`기왕` freshness 판정을 하지만 (1) digest 를 stdout 으로만 뱉어 파일로 남기지 않았고, (2) 이를 사람 세션 없이 주기 실행할 로컬 스케줄러가 없었다. loop_diagnose 는 로컬 whitelist·telemetry·세션 상태를 읽어 GitHub Actions 로는 실행 불가 → OS 레벨 로컬 스케줄러가 필요.

## 작업내용
- **`sweep` 서브커맨드** (`scripts/loop_diagnose.py`): `build_payload` 재사용으로 워터마크·freshness 를 `report` 와 동일 유지. digest 를 `.metrics/loop-diagnose/digest-latest.md` 로 **원자적 기록**, `sweep-log.jsonl` 에 `ok`(후보 수·digest 경로)/`error`(사유) 원장 append. build 실패 시 error 원장 + non-zero exit → **조용한 소멸 방지**.
- **launchd 스케줄러** (`scripts/launchd/`): LaunchAgent 템플릿 + `install-loop-sweep.sh [--interval N] [--uninstall]`. 기본 주기 **86400초(하루 1회)**, `StandardErrorPath` 로 이른 실패의 최후 흔적 확보.
- **문서** (`docs/internal/self-improvement-loop.md`): 트리거 리듬에 시간 기반 sweep 추가, 스케줄 sweep 절(실행 주체/주기/산출물/read-only 계약) 신설. `/loop-diagnose` 커맨드에 sweep·digest 참조.

## 결정근거
- **launchd 채택**: 플랫폼 macOS + "세션 없이 실행" 요구. 재부팅 생존, `StartInterval` 로 sleep 내성, `StandardErrorPath` 실패 흔적 내장. cron 은 macOS legacy 라 배제. GitHub Actions 는 로컬 상태 의존으로 배제.
- **digest 위치**: `.metrics/loop-diagnose/` — 기존 워터마크와 같은 로컬 untracked 런타임 층. git 추적 안 함(노이즈·충돌 방지).
- **read-only 계약 유지**: sweep 은 관측·기록만. Decide/Act 자동화(룰 자동 박제·제거, 이슈 자동 생성) 범위 밖 — 이슈 out-of-scope 준수.

## 배포 경로 검증
해당 없음 — **dcNess self 운영 도구**(repo-local loop-diagnose 계열). plugin 배포물(`agents/**`·`commands/**`·`hooks/**`) 아니고 `/init-dcness` 복사 대상도 아님. 이슈에서 "배포 경로 검증 대상 아님" 명시.

## Test Plan
- [x] `sweep` TDD: digest·sweep-log 기록 + read-only + 실패 흔적/non-zero 2건 (`tests.test_loop_diagnose` 8건)
- [x] 전체 회귀: `python3.11 -m unittest discover -s tests` 1624건 OK
- [x] 게이트: cross-ref PASS, static-quality(ruff/mypy/bandit) PASS
- [x] launchd 실측: install → `launchctl kickstart` → digest·sweep-log(ok) 생성 → uninstall 클린 확인

Closes #921