### PR TITLE
[feature] init 직후 온보딩 안내 추가

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -178,9 +178,11 @@ core 작업 뒤 `status` 를 재실행한다. FAIL 이 0 이면 INFO·NA 행과 
 - 프로젝트: <main repo root>
 - whitelist: ~/.claude/plugins/data/dcness-dcness/projects.json
 
-다음 세션부터 자동 적용:
-- SessionStart / PreToolUse / PostToolUse / SubagentStop / Stop hook
-- TDD Guard 는 생성된 project-local hook 이 있으면 그 계약으로, 없으면 중앙 fallback 으로 동작
+자동 적용: SessionStart / PreToolUse / PostToolUse / SubagentStop / Stop hook + TDD Guard.
+5분 온보딩 (5분 독해 상한):
+- 강제/자율 경계: 코드로 막는 것은 작업 순서, 접근 영역, git main 직접 commit/push 다. prose/handoff/도구 선택은 agent 자율이다. 포인터: docs/plugin/hooks.md#catastrophic-gatesh
+- 첫 작업 진입점: 구현·수정·버그픽스는 /impl 로 시작한다. 새 제품 합의는 /spec -> /design -> /impl -> /acceptance 흐름이다. 포인터: docs/plugin/workflow-router.md#구현-경로-표
+- 막힐 때 볼 곳: hook-first recovery 원칙으로 hook 차단 메시지와 "$HELPER" status 를 먼저 본다. 재실행·재배포 판단은 docs/plugin/init-dcness.md#re-run-matrix 를 본다.
 
 기본 workflow:
 - /spec — PRD / Epic / Story / AC 정의

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -6,6 +6,14 @@
 
 `/init-dcness` 본문은 실행 런북이고, 이 문서는 상세 reference 다. hook 정책 자체의 SSOT 는 [`hooks.md`](hooks.md) 이며, 본 문서는 hook skip 룰을 재정의하지 않는다.
 
+## Completion Onboarding
+
+Core activation 완료 출력은 한 화면 분량의 **5분 온보딩** 블록을 포함한다. 이 블록은 SSOT 본문을 복제하지 않고 다음 포인터만 제공한다.
+
+- 강제/자율 경계: [`hooks.md#catastrophic-gatesh`](hooks.md#catastrophic-gatesh) 와 [`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)
+- 첫 작업 진입점: [`workflow-router.md#구현-경로-표`](workflow-router.md#구현-경로-표) 와 [`positioning.md`](positioning.md)
+- hook-first recovery / 재실행 판단: hook 차단 메시지, `dcness-helper status`, 본 문서 [Re-run Matrix](#re-run-matrix)
+
 ## Bootstrap Inventory
 
 ### Core

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -796,6 +796,36 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             self.assertNotIn(stale_heading, self.init_doc)
         self.assertNotIn("(Y/n)", self.init_doc)
 
+    def test_issue_920_init_completion_includes_five_minute_onboarding(self) -> None:
+        """#920 — /init-dcness 완료 직후 최소 온보딩 3요소를 한 화면에 제공한다."""
+        onboarding = self._section(
+            self.init_doc,
+            r"5분 온보딩",
+            r"\n\n기본 workflow:",
+        )
+        for needle in (
+            "5분 독해 상한",
+            "강제/자율 경계",
+            "작업 순서",
+            "접근 영역",
+            "첫 작업 진입점",
+            "/impl",
+            "막힐 때 볼 곳",
+            "hook-first recovery",
+            '"$HELPER" status',
+            "docs/plugin/hooks.md#catastrophic-gatesh",
+            "docs/plugin/workflow-router.md#구현-경로-표",
+            "docs/plugin/init-dcness.md#re-run-matrix",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, onboarding)
+
+        self.assertLessEqual(
+            len([line for line in onboarding.splitlines() if line.strip()]),
+            14,
+        )
+        self.assertNotIn("신규 공개 진입점", onboarding)
+
     def test_hooks_doc_distinguishes_issue_mutation_paths(self) -> None:
         """#681 AC#4 — hooks.md 가 Bash `gh issue` 차단 vs GitHub MCP issue 통과를 구별한다."""
         self.assertIn(


### PR DESCRIPTION
## 관련 이슈 번호
Closes #920

## 배경 및 문제
신규 사용자가 `/init-dcness` 완료 직후 무엇이 강제되고 무엇이 자율인지, 첫 작업을 어디서 시작하는지, 막히면 어디를 봐야 하는지 한 화면에서 파악할 수 있는 최소 온보딩 경로가 필요했습니다.

## 원인 (해당 시)
-

## 작업내용
- `/init-dcness` 완료 출력에 5분 독해 상한의 온보딩 블록을 추가했습니다.
- 온보딩은 강제/자율 경계, 첫 작업 진입점, hook-first recovery 포인터만 담고 SSOT 본문 복제를 피했습니다.
- `docs/plugin/init-dcness.md`에 완료 온보딩 계약을 reference로 정리했습니다.
- 완료 출력의 3요소, 포인터, 한 화면 분량을 검증하는 회귀 테스트를 추가했습니다.

## 결정 근거
신규 command/skill을 만들지 않고 기존 `/init-dcness` 완료 출력에 붙이는 방식이 이슈의 public-surface 무변경 요구와 가장 잘 맞습니다. 사용자 repo에 새 파일을 남기지 않으므로 init deploy inventory 변경도 필요 없습니다.

## 배포 경로 검증 (plug-in 영향 시)
경로 1 — plug-in 본체 파일 변경: `commands/init-dcness.md`, `docs/plugin/init-dcness.md`는 plugin update 후 cache에 반영됩니다. 사용자 repo로 복사되는 새 파일은 없으므로 `/init-dcness` deploy inventory와 `dcness-helper status` 진단 항목 추가는 필요 없습니다. 기존 활성 프로젝트는 재배포가 아니라 plugin update 후 `/init-dcness` 재실행 시 새 완료 안내를 볼 수 있습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 신규 public skill/command/agent/gate 없음. 기존 `/init-dcness` 출력만 확장했습니다.

## Test Plan
- [x] `python3.11 -m unittest tests.test_surface_docs_sync.SurfaceDocsSyncTests.test_issue_920_init_completion_includes_five_minute_onboarding tests.test_surface_docs_sync.SurfaceDocsSyncTests.test_init_doc_is_execution_runbook_not_hook_policy_reference -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/aggregate_architecture_map.mjs --check`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] git pre-commit hook 자동 실행: pytest gate PASS

## 참고
-