### PR TITLE
[docs] plugin-release 절차에 release 브랜치 자동 sync 정합 확인 스텝 추가

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -69,7 +69,16 @@ echo ""
 echo "문제 발생 시:"
 echo "  claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness"
 echo "---"
+
+# 7. release 브랜치 배포 정합 확인 (사용자 배포물 — 수동 sync 불필요)
+#    사용자가 받는 배포물은 main/tag 가 아니라 release 브랜치다(dcness self 경로 제외 사본).
+#    release-sync.yml CI 가 main push 마다 sync_release.sh 를 자동 실행해 release 브랜치를 갱신하므로
+#    수동 실행은 불필요하다. 단, 태그만으로는 사용자에게 도달하지 않으니 아래로 정합을 확인한다.
+gh run list --workflow=release-sync.yml --limit 1                   # merge sha 발화 success 확인
+git show origin/release:.claude-plugin/plugin.json | grep version   # release 브랜치 = v{버전} 정합
 ```
+
+> **완료 기준은 3단 정합**: `main` plugin.json · `v{버전}` 태그 · `release` 브랜치 plugin.json 이 모두 같은 버전이어야 사용자에게 도달한 것이다. 태그만 박고 끝내면 배포 미도달을 완료로 착각할 수 있다.
 
 ## 4. 릴리즈 후 사용자 검증 방법
 


### PR DESCRIPTION
Document-Exception-PR-Close: docs-only follow-up — v0.12.0 릴리즈 중 발견한 SSOT 갭 즉시 보정. 신규 issue 없음.

## 배경 및 문제

- v0.12.0 릴리즈 진행 중, `docs/internal/plugin-release.md` 가 버전 bump·PR·merge·tag 만 기술하고 **release 브랜치(실사용자 배포물) 정합 확인 스텝이 누락**돼 있었다. 태그만 박고 끝내면 배포 미도달을 완료로 착각할 위험이 있다. (실제로는 `release-sync.yml` CI 가 자동 sync 하지만 절차 문서에 미기재.)

## 작업내용

- 릴리즈 순서 code block 에 step 7 추가 — release 브랜치가 사용자 배포물이며 `release-sync.yml` CI 가 자동 sync(수동 불필요)함을 명시하고, `gh run list --workflow=release-sync.yml` + `git show origin/release:.claude-plugin/plugin.json` 정합 확인 명령 제공.
- 완료 기준을 **3단 정합(main · tag · release 브랜치)** 으로 명문화.

## 결정 근거

- 새 스텝/게이트가 아니라 기존 자동화(release-sync.yml)를 절차 문서에 노출하는 수술적 보정. 강제 추가 없음.

## 배포 경로 검증 (plug-in 영향 시)

- N/A — `docs/internal/` 은 dcness self 전용(release 브랜치에서 제외). plug-in 본체 영향 없음.

## 신규 surface justification

- N/A — surface 변화 없음.

## Test Plan

- [x] cross-ref / doc-sync CI (문서 링크·파생물 무결성)
- [x] 변경은 절차 문서 1개 prose/주석 추가만