### PR TITLE
[feature] guard eval CI 증거 고정

### DIFF
--- a/.github/workflows/guard-efficacy.yml
+++ b/.github/workflows/guard-efficacy.yml
@@ -1,0 +1,51 @@
+# GitHub Actions — deterministic guard-efficacy eval.
+#
+# Advisory check only: this workflow exposes guard evidence in PR/main CI, but
+# repo policy must not promote it to a required branch-protection check without
+# a separate explicit decision.
+
+name: guard-efficacy
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'evals/**'
+      - 'harness/**'
+      - 'hooks/**'
+      - 'scripts/dcness-*'
+      - 'tests/test_guard_efficacy_eval.py'
+      - '.github/workflows/guard-efficacy.yml'
+      - 'README.md'
+  push:
+    branches: [main]
+    paths:
+      - 'evals/**'
+      - 'harness/**'
+      - 'hooks/**'
+      - 'scripts/dcness-*'
+      - 'tests/test_guard_efficacy_eval.py'
+      - '.github/workflows/guard-efficacy.yml'
+      - 'README.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  guard-efficacy:
+    name: guard-efficacy advisory eval
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.11'
+
+      - name: Run guard-efficacy eval
+        run: python3 evals/guard_efficacy.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@
 - **doc-sync**: `scripts/aggregate_index_map.mjs --check` + `scripts/aggregate_architecture_map.mjs --check` (CI `doc-sync.yml`) — `docs/index.md` epic 표와 전역 architecture map 파생물 drift 차단
 - **cross-ref**: `scripts/check_cross_refs.mjs` (CI `cross-ref-validation.yml`) — markdown link 파일/anchor 실존 + 옛 명칭 deny-list (외부 배포 영역 한정) + 고아 문서 탐지 (docs/plugin·docs/internal 미참조 .md) 회귀 차단
 - **static-quality**: `pyproject.toml` + `requirements-quality.txt` + `scripts/check_static_quality.sh` (CI `static-quality.yml`) — Python 3.11 기준 ruff lint/complexity, mypy, Bandit baseline 회귀 차단
-- **결정적 guard-efficacy eval (권고 — CI 차단 아님)**: `python3 evals/guard_efficacy.py` — guard/hook 변경 PR 머지 전 1회. LLM 없이 file boundary / Bash·MCP mutation / order gate / TDD allow·block fixture 를 범주별 count 로 재현.
+- **결정적 guard-efficacy eval (권고 — required CI 차단 아님)**: `python3 evals/guard_efficacy.py` + advisory workflow `.github/workflows/guard-efficacy.yml` — guard/hook 변경 PR 머지 전 1회. LLM 없이 file boundary / Bash·MCP mutation / order gate / TDD allow·block fixture 를 범주별 count 로 재현.
 - **행동 eval (권고 — CI 차단 아님)**: `bash evals/run.sh` — `agents/**`/`skills/**` 지침 변경 PR 머지 전 + 플러그인 릴리즈 전 1회. agent 가 기준대로 실제 판정하는지 사고 기반 fixture 로 확인. 상세 [`evals/README.md`](evals/README.md)
 
 > ⚠️ **금지**: `--no-verify` 등 hook 우회. main 직접 push.

--- a/README.md
+++ b/README.md
@@ -66,13 +66,15 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 ## Evidence
 
-as of v0.12.0 (2026-07-05), 로컬 실측 기준:
+[![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
+
+as of v0.12.0 + Unreleased (2026-07-05), 로컬 실측 기준:
 
 | 항목 | 결과 | 재현 명령 |
 |---|---:|---|
 | 단위 테스트 | 1627 tests PASS | `python3.11 -m unittest discover -s tests -v < /dev/null` |
 | 결정적 guard eval | 33/33 PASS | `python3 evals/guard_efficacy.py --json` |
-| GitHub Actions gate | 10 workflows | `find .github/workflows -maxdepth 1 -type f -name '*.yml' \| wc -l` |
+| GitHub Actions gate | 11 workflows | `find .github/workflows -maxdepth 1 -type f -name '*.yml' \| wc -l` |
 
 최근 릴리즈별 변경 상세는 [`docs/internal/release-notes.md`](docs/internal/release-notes.md)에 남긴다.
 

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -7,6 +7,7 @@
 ## Unreleased
 
 - README 첫 화면과 plug-in metadata 를 "PR workflow guard" 프레임에서 "agent workflow harness" 프레임으로 개편. README 에 설치 진단표, fail-open 감시, evidence 실측, Safety 범위 요약을 노출하고 최근 정비 상세는 릴리즈 노트 링크로 축소.
+- 결정적 guard-efficacy eval 을 advisory GitHub Actions workflow 로 노출하고 README Evidence 섹션에 상태 badge 를 추가.
 
 ---
 


### PR DESCRIPTION
## 관련 이슈 번호
Part of #928

## 배경 및 문제
- #928 의 PR B slice 입니다.
- 결정적 guard-efficacy eval 은 로컬에서 실행 가능했지만 CI 표면에 고정되어 있지 않아 README Evidence 를 사용자가 즉시 확인하기 어려웠습니다.

## 원인 (해당 시)
- `python3 evals/guard_efficacy.py` 가 로컬/릴리즈 점검 절차에만 있었고 GitHub Actions workflow 로 노출되지 않았습니다.

## 작업내용
- `.github/workflows/guard-efficacy.yml` 를 추가해 guard-efficacy eval 을 pull_request, main push, workflow_dispatch 에서 실행합니다.
- README Evidence 섹션에 guard-efficacy workflow badge 를 추가했습니다.
- README workflow count 를 11개로 갱신했습니다.
- `CLAUDE.md` 게이트 요약에 advisory workflow 를 반영했습니다.
- release notes Unreleased 에 변경을 기록했습니다.

## 결정 근거
- workflow 파일 주석과 `CLAUDE.md` 에 advisory 성격을 명시했습니다. required branch-protection check 로 승격하는 것은 별도 명시 결정 없이는 하지 않는 전제입니다.
- README badge 는 `Daeguk-Sun/dcNess` 의 실제 Actions workflow 경로를 참조합니다.

## 배포 경로 검증 (plug-in 영향 시)
- `.github/workflows/guard-efficacy.yml`: dcness self repo CI 표면입니다. `/init-dcness` 복사 대상이 아니며 외부 활성 프로젝트로 자동 배포하지 않습니다.
- `README.md`: GitHub/marketplace 진입 표면으로 badge 와 evidence count 가 노출됩니다.
- `CLAUDE.md`: dcness self 작업 SSOT 입니다.
- `docs/internal/release-notes.md`: dcness self 릴리즈 노트입니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — public skill/command/agent/gate 추가 없음. CI advisory evidence surface 추가만 해당합니다.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_guard_efficacy_eval tests.test_surface_docs_sync -v < /dev/null` — 43 tests PASS
- [x] `python3 evals/guard_efficacy.py` — 33/33 PASS
- [x] `node scripts/check_cross_refs.mjs` — PASS
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] `node scripts/check_plugin_manifest.mjs` — PASS
- [x] `git diff --check` — PASS
- [x] `find .github/workflows -maxdepth 1 -type f -name '*.yml' | wc -l` — 11

## 참고
- PR B only. PR C(fail-open run 종료·run-review 노출)는 후속 PR 로 진행합니다.
