### PR TITLE
[feature] fail-open 노출 보강

### DIFF
--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -8,6 +8,7 @@
 
 - README 첫 화면과 plug-in metadata 를 "PR workflow guard" 프레임에서 "agent workflow harness" 프레임으로 개편. README 에 설치 진단표, fail-open 감시, evidence 실측, Safety 범위 요약을 노출하고 최근 정비 상세는 릴리즈 노트 링크로 축소.
 - 결정적 guard-efficacy eval 을 advisory GitHub Actions workflow 로 노출하고 README Evidence 섹션에 상태 badge 를 추가.
+- hook fail-open 이벤트를 run 종료 stderr 와 `/run-review` 리포트에 warning 으로 노출해, 기존 fail-open summary API 증거가 작업 마감 표면에서도 보이도록 보강.
 
 ---
 

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -43,10 +43,20 @@ except Exception:
 # 이전 데이터는 단순 단어경계 매칭의 false positive 포함. parser 가 prose_full 보유 시
 # 신규 negation-aware regex 로 재계산. prose_full 부재 시 jsonl fallback.
 try:
-    from harness.session_state import _has_positive_must_fix
+    from harness.session_state import (
+        _has_positive_must_fix,
+        collect_fail_open_summary,
+        format_fail_open_warning,
+    )
 except Exception:
     def _has_positive_must_fix(_prose: str) -> bool:  # type: ignore
         return False
+
+    def collect_fail_open_summary(*_args, **_kwargs) -> dict:  # type: ignore
+        return {"total": 0}
+
+    def format_fail_open_warning(_summary: dict) -> str:  # type: ignore
+        return ""
 
 # ── 상수 ───────────────────────────────────────────────────────────────
 
@@ -1527,6 +1537,13 @@ def render_report(report: RunReport) -> str:
     lines.append(f"| 최종 enum | `{report.final_enum}` |")
     lines.append(f"| clean 판정 | {'✅' if report.final_clean else '❌'} |")
     lines.append("")
+
+    fail_open_warning = format_fail_open_warning(
+        collect_fail_open_summary(cwd=report.repo_path)
+    )
+    if fail_open_warning:
+        lines.append(fail_open_warning)
+        lines.append("")
 
     # 호출 흐름 — issue #383 B4: prose 결론 enum 우선 표시.
     # helper sentinel `PROSE_LOGGED` 는 prose-only mode 신호일 뿐 사용자 가독성 0.

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -91,6 +91,7 @@ __all__ = [
     "record_fail_open_event",
     "read_fail_open_events",
     "collect_fail_open_summary",
+    "format_fail_open_warning",
 ]
 
 # ── 상수 ─────────────────────────────────────────────────────────────
@@ -1947,6 +1948,22 @@ def _format_fail_open_summary(summary: Dict[str, Any]) -> str:
     return f"최근 {since_hours}h {total}건 — {category_text}{latest_text}"
 
 
+def format_fail_open_warning(summary: Dict[str, Any]) -> str:
+    """최근 hook fail-open 을 run 종료/review 표면에 노출하는 공통 문구."""
+    total = int(summary.get("total") or 0) if isinstance(summary, dict) else 0
+    if total <= 0:
+        return ""
+    return "\n".join(
+        [
+            "## ⚠️ hook fail-open warning",
+            "",
+            f"- {_format_fail_open_summary(summary)}",
+            "- enforcement hook 이 정책 판단을 완료하지 못해 allow 한 이벤트입니다.",
+            "- 반복되면 `dcness-helper status` 의 `hook fail-open 진단`과 hook stderr 로그를 확인하세요.",
+        ]
+    )
+
+
 # ── CLI (python3 -m harness.session_state <subcommand>) ─────────────
 
 
@@ -2044,6 +2061,12 @@ def _cli_end_run(args: Any) -> int:
             file=sys.stderr,
         )
     _record_design_run_if_applicable(sid, rid)
+    try:
+        warning = format_fail_open_warning(collect_fail_open_summary(cwd=Path.cwd()))
+        if warning:
+            print(warning, file=sys.stderr)
+    except Exception:  # nosec B110
+        pass
     cc_pid = get_cc_pid_via_ppid_chain()
     if cc_pid is not None:
         clear_pid_current_run(cc_pid)

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from harness import ledger  # noqa: E402
 from harness import run_review as run_review_module  # noqa: E402
+from harness.session_state import record_fail_open_event  # noqa: E402
 from harness.run_review import (  # noqa: E402
     RunReport, StepRecord, WasteFinding, build_report, detect_wastes, detect_notes,
     parse_steps, render_report, list_runs, find_run_dir,
@@ -701,6 +702,28 @@ class ReportRenderTests(unittest.TestCase):
             self.assertIn("## 단계별 상세", text)
             self.assertIn("MODULE_PLAN", text)
             self.assertIn("IMPL_DONE", text)
+
+    def test_render_warns_on_recent_fail_open_event(self):
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            rd = _make_run_dir(tmp, "sid1", "rid1", [
+                {"ts": "2026-04-30T10:00:00", "agent": "engineer", "mode": "IMPL",
+                 "enum": "IMPL_DONE", "must_fix": False,
+                 "prose_excerpt": "line1\nline2\nline3\nline4\nline5\nline6"},
+            ])
+            record_fail_open_event(
+                hook="tdd-guard",
+                category="payload_empty",
+                detail="empty stdin; enforcement skipped",
+                cwd=tmp,
+            )
+
+            report = build_report(rd, repo_path=tmp)
+            text = render_report(report)
+
+            self.assertIn("## ⚠️ hook fail-open warning", text)
+            self.assertIn("payload_empty=1", text)
+            self.assertIn("tdd-guard/payload_empty", text)
 
     def test_verify_only_pass_step_is_clean_without_pr_step(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -81,6 +81,7 @@ from harness.session_state import (
     live_path,
     read_live,
     read_session_pointer,
+    record_fail_open_event,
     run_dir,
     session_dir,
     session_id_from_stdin,
@@ -1482,6 +1483,36 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertFalse(called["hit"])
         self.assertNotIn("/run-review (auto)", out.getvalue())
+
+    def test_end_run_warns_on_recent_fail_open_event(self) -> None:
+        from harness import session_state as ss
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr, redirect_stdout
+
+        live = read_live(self.sid) or {}
+        active = live.get("active_runs", {})
+        slot = dict(active[self.rid])
+        slot["finalized_at"] = "2026-07-05T00:00:00Z"
+        active[self.rid] = slot
+        update_live(self.sid, active_runs=active)
+
+        record_fail_open_event(
+            hook="file-guard",
+            category="payload_missing_session",
+            detail="session id missing; enforcement skipped",
+            cwd=Path.cwd(),
+        )
+
+        err = StringIO()
+        out = StringIO()
+        with redirect_stderr(err), redirect_stdout(out):
+            rc = ss._cli_end_run(SimpleNamespace())
+
+        self.assertEqual(rc, 0)
+        stderr_val = err.getvalue()
+        self.assertIn("hook fail-open warning", stderr_val)
+        self.assertIn("payload_missing_session=1", stderr_val)
 
     # issue #392 — auto accumulate 매커니즘 폐기로 관련 3 tests 삭제:
     #   - test_finalize_run_auto_review_triggers_accumulate


### PR DESCRIPTION
## 관련 이슈 번호

Closes #928

## 배경 및 문제

- issue #928 PR C slice: hook 이 정책 판단을 완료하지 못해 fail-open 한 증거가 status 진단에는 남지만, 작업 마감 표면인 run 종료와 `/run-review` 리포트에서는 바로 드러나지 않았다.
- PR A/B에서 포지셔닝과 guard eval 증거를 먼저 고정했고, 이 PR은 마지막 단계로 fail-open 노출을 보강한다.

## 원인 (해당 시)

-

## 작업내용

- 기존 `collect_fail_open_summary` 기반으로 공통 warning formatter를 추가했다.
- `end-run` 종료 시 최근 hook fail-open summary를 stderr warning으로 출력한다.
- `/run-review` 렌더링 리포트에 동일 warning 섹션을 노출한다.
- run 종료와 review 리포트 각각의 회귀 테스트를 추가했다.
- Unreleased 릴리즈 노트에 사용자-visible 변경을 기록했다.

## 결정 근거

- 새 저장소/계측 경로를 만들지 않고 기존 `fail-open-events.jsonl` 및 summary API를 재사용해 PR C 요구 범위를 좁혔다.
- warning 출력은 진단 실패가 작업 종료 자체를 막지 않도록 best-effort로 유지했다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/**` 변경은 plugin 본체 갱신 경로로 배포된다.
- `/init-dcness` 복사 대상 파일 변경 없음.
- `docs/internal/release-notes.md`는 dcNess self 운영 문서이며 외부 활성 프로젝트 복사 대상이 아니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음. 기존 `end-run` stderr와 `/run-review` report 출력에 warning만 추가.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증

검증:

- `python3.11 -m unittest discover -s tests -v`
- `python3.11 -m unittest tests.test_session_state.CliBeginStepEndStepTests.test_end_run_warns_on_recent_fail_open_event tests.test_run_review.ReportRenderTests.test_render_warns_on_recent_fail_open_event -v`
- `python3 evals/guard_efficacy.py`
- `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- `node scripts/check_cross_refs.mjs`
- `node scripts/check_public_surface.mjs`
- `node scripts/check_plugin_manifest.mjs`
- `node scripts/aggregate_index_map.mjs --check`
- `node scripts/aggregate_architecture_map.mjs --check`
- `git diff --check`

## 참고

- PR A: #933
- PR B: #934
