### PR TITLE
[issue-931] loop Decide 처리 — v0.12.0 후보 7건 hold 기록

### DIFF
--- a/docs/internal/loop-decisions.jsonl
+++ b/docs/internal/loop-decisions.jsonl
@@ -1,0 +1,7 @@
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "waste:TOOL_REPEAT_HIGH@youTubeGenerator", "note": "lesson 층 프로젝트-로컬 소유; 단일 프로젝트라 중앙 RULE 미승격. 복수 프로젝트 확산 시 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "waste:MISSING_CONCLUSION_ENUM@youTubeGenerator", "note": "lesson 층 프로젝트-로컬 소유; 단일 프로젝트라 중앙 RULE 미승격. 복수 프로젝트 확산 시 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "waste:MUST_FIX_GHOST@youTubeGenerator", "note": "lesson 층 프로젝트-로컬 소유; 단일 프로젝트라 중앙 RULE 미승격. 복수 프로젝트 확산 시 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "waste:MUST_FIX_LEAK@youTubeGenerator", "note": "lesson 층 프로젝트-로컬 소유; 단일 프로젝트라 중앙 RULE 미승격. 복수 프로젝트 확산 시 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "eval:flow-ownership-owner-good", "note": "negative-guard 회귀 감시 유지; 포화 지속 시 다음 주기 은퇴 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "eval:story-slice-partfirst", "note": "negative-guard 회귀 감시 유지; 포화 지속 시 다음 주기 은퇴 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "eval:story-slice-skeleton", "note": "negative-guard 회귀 감시 유지; 포화 지속 시 다음 주기 은퇴 재검토.", "ref": "#931"}


### PR DESCRIPTION
## 관련 이슈 번호

Closes #931

## 배경 및 문제

v0.12.0 릴리즈 Diagnose 가 표면화한 self-improvement-loop 후보 7건이 Decide 미처리 상태로 남아 있었다. 릴리즈 blocker 는 아니지만 소비 표식이 없으면 다음 Diagnose 마다 맥락 없이 재등장한다.

## 원인 (해당 시)

-

## 작업내용

- `scripts/loop_diagnose.py record-decision` 로 후보 7건을 `docs/internal/loop-decisions.jsonl` 에 `hold` 기록 (원장 최초 생성):
  - 재발 waste 4 (youTubeGenerator, 기왕): `TOOL_REPEAT_HIGH`(34) / `MISSING_CONCLUSION_ENUM`(7) / `MUST_FIX_GHOST`(4) / `MUST_FIX_LEAK`(4)
  - eval 포화 3 (dcness-self, 10/10 accuracy 100%): `flow-ownership-owner-good` / `story-slice-partfirst` / `story-slice-skeleton`

## 결정 근거

Decide 규칙 = *추가 전 제거 검토 우선*. 7건 모두 중앙 변경(`fixed`) 근거도, 기각(`rejected`) 근거도 아니라 `hold` 로 수렴:
- **waste 4**: 4개 신호 모두 이미 `run_review` 탐지 + `loop_lessons` 템플릿 + `sync_from_run` 자동 박제를 갖췄다. lesson 층이 프로젝트-로컬로 소유 중이고, youTubeGenerator **단일 프로젝트**라 "복수 프로젝트 활성화 시 중앙 RULE 승격" 문턱 미달. 확산 여부를 다음 Sense 에서 재관측하려 `hold`.
- **eval 3**: 모두 negative-guard 케이스(유효 구조를 오지적하면 안 되는 감시). 은퇴 시 회귀 침묵 위험, 유지 비용 저렴 → 포화라도 `hold` 로 회귀 감시 유지.

`rejected` 는 `--hide-decided` 로 숨겨져 확산·회귀 감시를 잃으므로 부적합.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 운영 작업. `docs/internal/loop-decisions.jsonl` 은 self-improvement-loop 원장으로 plugin 배포물이 아니다(외부 활성 프로젝트로 배포 안 함).

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — surface 변화 없음. 기존 `record-decision` CLI 사용.

## Test Plan

- [x] `record-decision` 후 `loop_diagnose.py report` 재실행 시 7개 후보에 `이전 결정: 보류 2026-07-05 #931` 주석 확인
- [x] `loop-decisions.jsonl` 7 라인 JSON 유효성 확인

## 참고

- SSOT: `docs/internal/self-improvement-loop.md` (소비 표식 3층 / 결정 규칙)
