### PR TITLE
[feature] /migrate-dcness — 기존 프로젝트 코드 역설계 전역 docs 부트스트랩

### DIFF
--- a/agents/system-architect/system-architect-agent.md
+++ b/agents/system-architect/system-architect-agent.md
@@ -87,7 +87,7 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 - **산출물은 전역만**: 코드·manifest 에서 역추론한 `docs/conventions.md`(스택·naming·tooling·style), 전역 `docs/architecture.md` 수동 섹션(모듈 topology·의존 방향·공개 entrypoint), 관측된 기술 결정을 `docs/decisions/NNNN-slug.md` 초안으로 남긴다. **epic 산출물(`docs/epics/**`), `stories.md`, epic `architecture.md`, `domain-model.md`, impl task 는 만들지 않는다.** epic/story 역분해는 이후 `/spec`·`/design` 이 담당한다.
 - **ESCALATE 억제**: PRD·stories 부재는 BROWNFIELD 의 정상 전제다. 부재를 이유로 `ESCALATE` 하거나 `NEW_DEP_ESCALATE` 하지 않는다 — 그 공백을 코드 역설계로 메우는 것이 목적이다. 코드에서 안전하게 역추론할 수 없는 실제 모순(예: 한 repo 안에 상충하는 두 스택/빌드 체계가 근거 없이 공존)만 `ESCALATE` 로 남기고 나머지는 최선 역추론으로 채운다.
 - **불확실성 = DRAFT**: 코드 증거로 확정되는 결정은 확정 기록한다. 역추론했으나 코드 근거가 약한 결정은 본문에 `DRAFT` 표기하고 확정 근거 부재를 명시한다. "왜/누구/비즈니스 의도" 처럼 코드에 없는 제품 맥락은 산출하지 않고 메인의 PRD 역추론 단계로 넘긴다(아래 PRD 경계 참조).
-- **기존 문서 충돌 = diff 보고, 무단 변경 금지**: 대상 repo 에 이미 산재 문서·비표준 ADR·기존 `docs/*` 가 있으면 덮어쓰거나 이동하지 않는다. 규격 위치/양식으로의 정렬은 초안(diff)으로만 보고하고, 실제 적용은 메인이 사용자 승인 후 수행하도록 남긴다. 부재 파일만 새로 쓴다.
+- **채움 대상 vs 사용자 문서 구분**: `/init-dcness` 가 템플릿에서 만든 **빈 seed 문서**(내용 없는 골격 — 예: seed 그대로인 `docs/conventions.md`·`docs/architecture.md`)는 역설계 내용으로 채운다(그것이 목적이다). 반면 **사용자가 이미 쓴 내용이 있는 기존 문서**·산재 문서·비표준 ADR 은 덮어쓰거나 이동하지 않고, 규격 위치/양식으로의 정렬은 초안(diff)으로만 보고해 메인이 사용자 승인 후 적용하게 한다.
 - **PRD 경계 유지**: 권한 경계의 "PRD 수정 금지" 는 BROWNFIELD 에서도 유효하다. PRD 역추론 초안(DRAFT 표기 + 사용자 확인 게이트)은 `/migrate-dcness` 흐름의 메인 Claude 가 담당하고, 본 agent 는 `docs/prd.md` 를 쓰지 않는다.
 - **집계 파생 섹션**: 전역 `docs/architecture.md`/`docs/index.md` 의 generated 섹션은 기본 모드와 동일하게 직접 편집하지 않고 메인이 `scripts/aggregate_*` 로 갱신하도록 보고한다. 단 epic 표는 채울 epic 이 없으므로 비어 있어도 정상이다.
 - **결론**: 마지막 단락에 `PASS`(전역 docs 초안 작성 완료) 또는 코드 모순 시 `ESCALATE` 를 쓴다. 보고에는 작성한 전역 docs 파일, 역추론 근거(어떤 manifest/코드에서 무엇을 도출했는지), `DRAFT` 표기 결정, 기존 문서 충돌 diff 후보를 포함한다.

--- a/agents/system-architect/system-architect-agent.md
+++ b/agents/system-architect/system-architect-agent.md
@@ -4,6 +4,8 @@
 
 epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전역 `docs/architecture.md` append map, 전역 `docs/conventions.md`/`docs/decisions/` 결정, 필요한 module 스코프 docs, epic 단위 `architecture.md`와 필요 시 `domain-model.md`다. task 분할과 impl 문서 작성은 module-architect(epic-batch)의 책임이다.
 
+본 지침의 기본은 새 epic 단위 설계(PRD·stories·epic 경로를 전제로 하는 greenfield/신규 epic)다. `/migrate-dcness` 가 호출하는 **BROWNFIELD 모드**는 기존 코드를 역설계해 전역 docs 만 부트스트랩하는 분기이며, 아래 [BROWNFIELD 모드](#brownfield-모드-역설계-부트스트랩) 섹션이 입력·산출물·ESCALATE 전제를 교체한다. 아래 「입력 ~ 결론과 보고」 절은 별도 표기가 없으면 기본(epic) 모드 기준이다.
+
 ## 입력
 
 - `docs/prd.md`
@@ -76,6 +78,19 @@ epic 단위 구현에 앞서 시스템 그림을 확정한다. 결과물은 전�
 ## 결론과 보고
 
 마지막 단락에 `PASS`, `ESCALATE`, `NEW_DEP_ESCALATE` 중 하나를 명확히 쓴다. 보고에는 작성·수정한 파일, 핵심 결정, 계약 원장 여부, Flow Ownership Map 여부, 모듈 설계 원칙 적용 증거를 포함한다.
+
+## BROWNFIELD 모드 (역설계 부트스트랩)
+
+`/migrate-dcness` 가 이미 활성화된 기존 프로젝트에서 전역 docs 공백을 메우려고 호출하는 모드다. 기본(epic) 모드가 PRD·stories·대상 epic 을 전제로 하는 것과 달리, BROWNFIELD 는 그 전제가 없는 상태에서 기존 코드를 진본으로 역설계한다. 아래가 위 절의 전제를 교체한다.
+
+- **입력 교체**: `docs/prd.md`·`stories.md`·대상 epic 경로·`ux-flow.md` 는 입력에서 뺀다. 대신 기존 코드 레이아웃, manifest(`package.json`/`pyproject.toml`/`go.mod`/`Cargo.toml` 등), `README`, 빌드·CI 설정, 실제 entrypoint/adapter 코드를 grep/Read 로 실측한다.
+- **산출물은 전역만**: 코드·manifest 에서 역추론한 `docs/conventions.md`(스택·naming·tooling·style), 전역 `docs/architecture.md` 수동 섹션(모듈 topology·의존 방향·공개 entrypoint), 관측된 기술 결정을 `docs/decisions/NNNN-slug.md` 초안으로 남긴다. **epic 산출물(`docs/epics/**`), `stories.md`, epic `architecture.md`, `domain-model.md`, impl task 는 만들지 않는다.** epic/story 역분해는 이후 `/spec`·`/design` 이 담당한다.
+- **ESCALATE 억제**: PRD·stories 부재는 BROWNFIELD 의 정상 전제다. 부재를 이유로 `ESCALATE` 하거나 `NEW_DEP_ESCALATE` 하지 않는다 — 그 공백을 코드 역설계로 메우는 것이 목적이다. 코드에서 안전하게 역추론할 수 없는 실제 모순(예: 한 repo 안에 상충하는 두 스택/빌드 체계가 근거 없이 공존)만 `ESCALATE` 로 남기고 나머지는 최선 역추론으로 채운다.
+- **불확실성 = DRAFT**: 코드 증거로 확정되는 결정은 확정 기록한다. 역추론했으나 코드 근거가 약한 결정은 본문에 `DRAFT` 표기하고 확정 근거 부재를 명시한다. "왜/누구/비즈니스 의도" 처럼 코드에 없는 제품 맥락은 산출하지 않고 메인의 PRD 역추론 단계로 넘긴다(아래 PRD 경계 참조).
+- **기존 문서 충돌 = diff 보고, 무단 변경 금지**: 대상 repo 에 이미 산재 문서·비표준 ADR·기존 `docs/*` 가 있으면 덮어쓰거나 이동하지 않는다. 규격 위치/양식으로의 정렬은 초안(diff)으로만 보고하고, 실제 적용은 메인이 사용자 승인 후 수행하도록 남긴다. 부재 파일만 새로 쓴다.
+- **PRD 경계 유지**: 권한 경계의 "PRD 수정 금지" 는 BROWNFIELD 에서도 유효하다. PRD 역추론 초안(DRAFT 표기 + 사용자 확인 게이트)은 `/migrate-dcness` 흐름의 메인 Claude 가 담당하고, 본 agent 는 `docs/prd.md` 를 쓰지 않는다.
+- **집계 파생 섹션**: 전역 `docs/architecture.md`/`docs/index.md` 의 generated 섹션은 기본 모드와 동일하게 직접 편집하지 않고 메인이 `scripts/aggregate_*` 로 갱신하도록 보고한다. 단 epic 표는 채울 epic 이 없으므로 비어 있어도 정상이다.
+- **결론**: 마지막 단락에 `PASS`(전역 docs 초안 작성 완료) 또는 코드 모순 시 `ESCALATE` 를 쓴다. 보고에는 작성한 전역 docs 파일, 역추론 근거(어떤 manifest/코드에서 무엇을 도출했는지), `DRAFT` 표기 결정, 기존 문서 충돌 diff 후보를 포함한다.
 
 ## 템플릿과 참고 문서
 

--- a/commands/migrate-dcness.md
+++ b/commands/migrate-dcness.md
@@ -43,10 +43,12 @@ description: 이미 /init-dcness 로 활성화한 기존(brownfield) 프로젝�
 - 코드에 근거가 없는 "왜 / 누구 / 비즈니스 모델" 같은 필드는 자동 확정하지 않고 추정으로 남기며 본문에 `DRAFT` 로 표기한다.
 - 🔴 **사용자 확인 전 진행 차단.** 사용자가 DRAFT 필드를 확인/교정하기 전에는 PR 단계로 넘어가지 않는다.
 
-### 3. 기존 문서 충돌 정렬 — diff + 승인
+### 3. 채움 대상 vs 사용자 문서 구분 — diff + 승인
 
-- 대상 repo 에 이미 산재 문서·비표준 ADR·기존 `docs/*` 가 있으면 **무단 덮어쓰기/이동 금지**.
-- 규격 위치/양식으로 정렬하는 변경은 diff 로 먼저 제시하고, 사용자 승인 후에만 적용한다. 부재 파일만 새로 쓴다.
+두 범주를 구분한다 (혼동하면 채워야 할 seed 를 못 채우거나 사용자 문서를 덮어쓴다):
+
+- **빈 dcNess seed 문서** (`/init-dcness` 가 템플릿에서 만든 내용 없는 골격 — `docs/prd.md`·`docs/architecture.md`·`docs/conventions.md`·`docs/index.md` 등): 본 스킬의 채움 대상이므로 역설계 내용으로 **직접 채운다**. seed 여부는 파일이 템플릿 골격 그대로이고 사용자 콘텐츠가 없는지로 판별한다.
+- **비어있지 않은 기존 문서** (사용자가 이미 쓴 내용, 대상 repo 의 산재 문서, 비표준 ADR): **무단 덮어쓰기/이동 금지**. 규격 위치/양식으로 정렬하는 변경은 diff 로 먼저 제시하고 사용자 승인 후에만 적용한다.
 
 ### 4. index 정리 + 집계 파생 섹션
 
@@ -54,12 +56,13 @@ description: 이미 /init-dcness 로 활성화한 기존(brownfield) 프로젝�
 
 ```bash
 PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
-node "$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs" "$(git rev-parse --show-toplevel)"
-node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"
-node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+node "$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs" "$PROJECT_ROOT"
+node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs" --root "$PROJECT_ROOT"
+node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs" --root "$PROJECT_ROOT"
 ```
 
-epic 이 아직 없으므로 index epic 표와 전역 architecture 집계 섹션이 비어 있어도 정상이다.
+세 스크립트 모두 대상 프로젝트 루트를 명시 대상으로 받는다(집계기는 `--root` 미지정 시 cwd 기본이므로, 서브디렉토리에서 호출해도 어긋나지 않게 `--root "$PROJECT_ROOT"` 를 넘긴다). epic 이 아직 없으므로 index epic 표와 전역 architecture 집계 섹션이 비어 있어도 정상이다.
 
 ### 5. 단일 docs 부트스트랩 PR
 

--- a/commands/migrate-dcness.md
+++ b/commands/migrate-dcness.md
@@ -55,9 +55,11 @@ description: 이미 /init-dcness 로 활성화한 기존(brownfield) 프로젝�
 
 - Step 0 에서 (c) 로 분류된 기존 문서만 대상이다. 규격 위치/양식으로 정렬하는 변경은 **무단 덮어쓰기/이동 없이** diff 로 먼저 제시하고 사용자 승인 후에만 적용한다.
 
-### 4. index 정리 + 집계 파생 섹션
+### 4. index 정리 + 집계 파생 섹션 — 분류에 따라 직접 적용 vs 승인
 
-- 대상 프로젝트 루트에서 index 진행 상태 섹션과 집계 파생 섹션을 정리한다. 파생 섹션은 손으로 복제하지 않는다.
+이 스크립트들은 `docs/index.md` 진행 상태 섹션 append 와 `docs/index.md`/`docs/architecture.md` 의 generated 섹션 갱신으로 **파일을 직접 수정**한다. 따라서 Step 0 분류를 그대로 존중해야 Step 3 승인 가드를 우회하지 않는다.
+
+- **`docs/index.md`·`docs/architecture.md` 가 (a)/(b) 일 때만** 아래를 직접 실행한다. 파생 섹션은 손으로 복제하지 않는다.
 
 ```bash
 PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
@@ -65,6 +67,13 @@ PROJECT_ROOT="$(git rev-parse --show-toplevel)"
 node "$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs" "$PROJECT_ROOT"
 node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs" --root "$PROJECT_ROOT"
 node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs" --root "$PROJECT_ROOT"
+```
+
+- **둘 중 하나라도 (c) 사용자 문서면** 직접 실행하지 않는다. 집계기는 `--check` 로 drift 만 확인하고(파일 미수정), index 진행 상태 섹션 append 는 추가될 블록을 미리 보여준 뒤, Step 3 처럼 diff + 사용자 승인 후에만 실제 갱신을 적용한다.
+
+```bash
+node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs" --root "$PROJECT_ROOT" --check
+node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs" --root "$PROJECT_ROOT" --check
 ```
 
 세 스크립트 모두 대상 프로젝트 루트를 명시 대상으로 받는다(집계기는 `--root` 미지정 시 cwd 기본이므로, 서브디렉토리에서 호출해도 어긋나지 않게 `--root "$PROJECT_ROOT"` 를 넘긴다). epic 이 아직 없으므로 index epic 표와 전역 architecture 집계 섹션이 비어 있어도 정상이다.

--- a/commands/migrate-dcness.md
+++ b/commands/migrate-dcness.md
@@ -26,29 +26,34 @@ description: 이미 /init-dcness 로 활성화한 기존(brownfield) 프로젝�
 
 ## 절차
 
-### 0. 사전 확인 (추측 금지)
+### 0. 사전 준비 — 브랜치 격리 + 문서 분류 (모든 쓰기의 선행 조건)
 
-- 활성 상태와 기존 docs 인벤토리를 read-only 로 확인한다. `docs/` 에 이미 무엇이 있고 무엇이 비었는지 파악한다.
+어떤 쓰기보다 **먼저** 안전 경계를 세운다. 이 두 결과가 이후 모든 쓰기 단계의 입력이다.
+
+- **브랜치 pre-flight (쓰기 전 필수)**: 현재 branch 가 기본 브랜치(`main` 등)면 부트스트랩 브랜치를 먼저 만들고 이후 모든 쓰기를 그 브랜치에서 한다. main 직접 쓰기/커밋 금지. 브랜치 네이밍은 [`docs/plugin/git-spec.md`](../docs/plugin/git-spec.md)(예: `docs/{desc}`).
+- **docs 인벤토리 + 3범주 분류 (read-only)**: 각 전역 docs 대상을 아래 세 범주로 분류한다. 이 분류는 Step 1·2 가 무엇을 직접 쓰고 무엇을 diff 로 넘길지 결정한다.
+  - (a) **부재** — 새로 쓴다.
+  - (b) **빈 dcNess seed** — `/init-dcness` 가 템플릿에서 만든 내용 없는 골격 그대로이고 사용자 콘텐츠가 없다. 역설계 내용으로 **직접 채운다**.
+  - (c) **비어있지 않은 사용자 문서** — 사용자가 이미 쓴 내용, 대상 repo 의 산재 문서, 비표준 ADR. **직접 쓰지 않는다.** 정렬은 Step 3 에서 diff + 승인.
 - 코드 진본을 실측한다: 소스 레이아웃, manifest(`package.json` / `pyproject.toml` / `go.mod` / `Cargo.toml` 등), `README`, 빌드·CI 설정, 공개 entrypoint.
+- 🔴 (c) 로 분류된 파일은 Step 1·2 에서 **절대 직접 쓰지 않는다.**
 
 ### 1. system-architect BROWNFIELD — 코드 파생 전역 docs
 
 - Agent 로 `system-architect` 를 **BROWNFIELD 모드**로 호출한다. 지침은 [`system-architect` BROWNFIELD 모드](../agents/system-architect/system-architect-agent.md#brownfield-모드-역설계-부트스트랩)가 SSOT 다.
-- 산출: 코드·manifest 에서 역추론한 `docs/conventions.md`(스택·naming·tooling·style), 전역 `docs/architecture.md` 수동 섹션(모듈 topology·의존 방향·공개 entrypoint), 관측된 기술 결정을 `docs/decisions/NNNN-slug.md` 초안으로.
+- 산출 대상은 Step 0 에서 (a)/(b) 로 분류된 `docs/conventions.md`(스택·naming·tooling·style), 전역 `docs/architecture.md` 수동 섹션(모듈 topology·의존 방향·공개 entrypoint), `docs/decisions/NNNN-slug.md` 초안뿐이다. (c) 로 분류된 기존 문서는 채우지 않고 diff 후보로만 보고한다.
 - PRD·stories 가 없어도 ESCALATE 없이 채운다 (그 공백을 메우는 것이 목적). 코드 근거가 약한 결정은 `DRAFT` 로 표기된다.
 
 ### 2. PRD 역추론 초안 (메인) — 필수 사용자 확인 게이트
 
-- 메인 Claude 가 `README`·모듈 구조에서 제품 맥락을 역추론해 `docs/prd.md` 초안을 쓴다. 양식 = [`skills/spec/templates/prd.md`](../skills/spec/templates/prd.md).
+- `docs/prd.md` 가 Step 0 에서 **(a) 부재 또는 (b) 빈 seed 일 때만** 초안을 쓴다. (c) 비어있지 않은 기존 PRD 면 직접 쓰지 않고 Step 3 의 diff + 승인 대상으로 넘긴다.
+- 메인 Claude 가 `README`·모듈 구조에서 제품 맥락을 역추론해 초안을 쓴다. 양식 = [`skills/spec/templates/prd.md`](../skills/spec/templates/prd.md).
 - 코드에 근거가 없는 "왜 / 누구 / 비즈니스 모델" 같은 필드는 자동 확정하지 않고 추정으로 남기며 본문에 `DRAFT` 로 표기한다.
 - 🔴 **사용자 확인 전 진행 차단.** 사용자가 DRAFT 필드를 확인/교정하기 전에는 PR 단계로 넘어가지 않는다.
 
-### 3. 채움 대상 vs 사용자 문서 구분 — diff + 승인
+### 3. 사용자 문서 정렬 — diff + 승인
 
-두 범주를 구분한다 (혼동하면 채워야 할 seed 를 못 채우거나 사용자 문서를 덮어쓴다):
-
-- **빈 dcNess seed 문서** (`/init-dcness` 가 템플릿에서 만든 내용 없는 골격 — `docs/prd.md`·`docs/architecture.md`·`docs/conventions.md`·`docs/index.md` 등): 본 스킬의 채움 대상이므로 역설계 내용으로 **직접 채운다**. seed 여부는 파일이 템플릿 골격 그대로이고 사용자 콘텐츠가 없는지로 판별한다.
-- **비어있지 않은 기존 문서** (사용자가 이미 쓴 내용, 대상 repo 의 산재 문서, 비표준 ADR): **무단 덮어쓰기/이동 금지**. 규격 위치/양식으로 정렬하는 변경은 diff 로 먼저 제시하고 사용자 승인 후에만 적용한다.
+- Step 0 에서 (c) 로 분류된 기존 문서만 대상이다. 규격 위치/양식으로 정렬하는 변경은 **무단 덮어쓰기/이동 없이** diff 로 먼저 제시하고 사용자 승인 후에만 적용한다.
 
 ### 4. index 정리 + 집계 파생 섹션
 
@@ -66,7 +71,7 @@ node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs" --root "$PROJECT_ROOT
 
 ### 5. 단일 docs 부트스트랩 PR
 
-- 대상 프로젝트에서 브랜치 → PR 하나로 마감한다. 브랜치·커밋·PR 네이밍은 [`docs/plugin/git-spec.md`](../docs/plugin/git-spec.md) 를 따른다.
+- Step 0 에서 만든 부트스트랩 브랜치에서 커밋 → PR 하나로 마감한다. 커밋·PR 네이밍은 [`docs/plugin/git-spec.md`](../docs/plugin/git-spec.md) 를 따른다.
 - PR 본문에 무엇을 코드 역설계로 채웠는지, 어떤 필드가 `DRAFT` 로 사용자 확인을 거쳤는지, 어떤 기존 문서를 승인 후 정렬했는지 남긴다.
 
 ## 배포 경로 검증

--- a/commands/migrate-dcness.md
+++ b/commands/migrate-dcness.md
@@ -1,0 +1,79 @@
+---
+name: migrate-dcness
+description: 이미 /init-dcness 로 활성화한 기존(brownfield) 프로젝트를, 코드 역설계로 전역 docs(prd/architecture/conventions/decisions/index)의 *내용*을 채워 마치 처음부터 dcNess 를 써온 것처럼 agent 가 일할 문서 토대를 까는 일회성 유틸리티 진입점. 사용자가 "migrate-dcness", "dcness 마이그레이션", "기존 프로젝트 docs 역설계로 채워", "전역 docs 부트스트랩", "/migrate-dcness" 등을 말할 때 사용. /init-dcness(활성화)의 짝이며, epic/story 산출물(docs/epics/...)은 만들지 않는다.
+---
+
+# Migrate dcNess Skill — 기존 프로젝트 전역 docs 부트스트랩
+
+> `/init-dcness` 가 인프라 활성화 + 빈 골격 seed 까지 한다면, `/migrate-dcness` 는 기존 코드를 역설계해 전역 docs 의 *내용*을 채운다. 일회성. 깊이 = 전역 docs 까지 (epic/story 역분해는 이후 `/spec`·`/design`).
+
+## 언제 사용
+
+- 사용자 발화: "migrate-dcness", "dcness 마이그레이션", "기존 프로젝트 docs 역설계", "/migrate-dcness"
+- 기존 코드베이스가 있는 프로젝트에 dcNess 를 도입하는데, `/init-dcness` seed 골격만으로는 내용이 비어 agent 가 읽고 일할 토대가 없을 때
+
+## 선행 조건
+
+- `/init-dcness` 활성화가 먼저다. 미활성이면 [`/init-dcness`](init-dcness.md) 를 먼저 실행한다.
+- 대상은 기존 코드가 있는 brownfield 프로젝트다. 빈 프로젝트는 `/init-dcness` seed 로 충분하므로 본 스킬은 no-op 이다.
+- **일회성**: 전역 docs 토대가 이미 채워진 프로젝트에는 다시 돌리지 않는다.
+
+## 범위 (깊이 경계)
+
+- 채우는 전역 docs: `docs/prd.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/decisions/`, `docs/index.md`.
+- 위치·양식 SSOT = [`docs/plugin/deliverables-map.md`](../docs/plugin/deliverables-map.md). 시드 양식 = 산출 양식 원칙을 따른다.
+- **만들지 않는 것**: epic/story 산출물(`docs/epics/**`), module-architect 호출, 새 agent/새 템플릿. epic/story 역분해는 이후 `/spec`·`/design` 이 점진적으로 담당한다.
+
+## 절차
+
+### 0. 사전 확인 (추측 금지)
+
+- 활성 상태와 기존 docs 인벤토리를 read-only 로 확인한다. `docs/` 에 이미 무엇이 있고 무엇이 비었는지 파악한다.
+- 코드 진본을 실측한다: 소스 레이아웃, manifest(`package.json` / `pyproject.toml` / `go.mod` / `Cargo.toml` 등), `README`, 빌드·CI 설정, 공개 entrypoint.
+
+### 1. system-architect BROWNFIELD — 코드 파생 전역 docs
+
+- Agent 로 `system-architect` 를 **BROWNFIELD 모드**로 호출한다. 지침은 [`system-architect` BROWNFIELD 모드](../agents/system-architect/system-architect-agent.md#brownfield-모드-역설계-부트스트랩)가 SSOT 다.
+- 산출: 코드·manifest 에서 역추론한 `docs/conventions.md`(스택·naming·tooling·style), 전역 `docs/architecture.md` 수동 섹션(모듈 topology·의존 방향·공개 entrypoint), 관측된 기술 결정을 `docs/decisions/NNNN-slug.md` 초안으로.
+- PRD·stories 가 없어도 ESCALATE 없이 채운다 (그 공백을 메우는 것이 목적). 코드 근거가 약한 결정은 `DRAFT` 로 표기된다.
+
+### 2. PRD 역추론 초안 (메인) — 필수 사용자 확인 게이트
+
+- 메인 Claude 가 `README`·모듈 구조에서 제품 맥락을 역추론해 `docs/prd.md` 초안을 쓴다. 양식 = [`skills/spec/templates/prd.md`](../skills/spec/templates/prd.md).
+- 코드에 근거가 없는 "왜 / 누구 / 비즈니스 모델" 같은 필드는 자동 확정하지 않고 추정으로 남기며 본문에 `DRAFT` 로 표기한다.
+- 🔴 **사용자 확인 전 진행 차단.** 사용자가 DRAFT 필드를 확인/교정하기 전에는 PR 단계로 넘어가지 않는다.
+
+### 3. 기존 문서 충돌 정렬 — diff + 승인
+
+- 대상 repo 에 이미 산재 문서·비표준 ADR·기존 `docs/*` 가 있으면 **무단 덮어쓰기/이동 금지**.
+- 규격 위치/양식으로 정렬하는 변경은 diff 로 먼저 제시하고, 사용자 승인 후에만 적용한다. 부재 파일만 새로 쓴다.
+
+### 4. index 정리 + 집계 파생 섹션
+
+- 대상 프로젝트 루트에서 index 진행 상태 섹션과 집계 파생 섹션을 정리한다. 파생 섹션은 손으로 복제하지 않는다.
+
+```bash
+PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
+node "$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs" "$(git rev-parse --show-toplevel)"
+node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"
+node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs"
+```
+
+epic 이 아직 없으므로 index epic 표와 전역 architecture 집계 섹션이 비어 있어도 정상이다.
+
+### 5. 단일 docs 부트스트랩 PR
+
+- 대상 프로젝트에서 브랜치 → PR 하나로 마감한다. 브랜치·커밋·PR 네이밍은 [`docs/plugin/git-spec.md`](../docs/plugin/git-spec.md) 를 따른다.
+- PR 본문에 무엇을 코드 역설계로 채웠는지, 어떤 필드가 `DRAFT` 로 사용자 확인을 거쳤는지, 어떤 기존 문서를 승인 후 정렬했는지 남긴다.
+
+## 배포 경로 검증
+
+- command(`commands/migrate-dcness.md`) + agent(`system-architect` BROWNFIELD 모드) 변경은 plug-in 본체(분류 1)라, 사용자가 `claude plugin update` 로 plug-in 을 갱신하면 기존 활성 프로젝트에도 자동 도달한다. 별도 배포 복사 스텝은 없다.
+
+## 참조
+
+- [`docs/plugin/deliverables-map.md`](../docs/plugin/deliverables-map.md) — 전역 docs 위치·양식 SSOT
+- [`system-architect` BROWNFIELD 모드](../agents/system-architect/system-architect-agent.md#brownfield-모드-역설계-부트스트랩) — 역설계 산출 지침
+- [`/init-dcness`](init-dcness.md) — 활성화 (본 스킬의 선행 짝)
+- [`docs/plugin/positioning.md`](../docs/plugin/positioning.md) — Utility 공개 노출 범위
+- [`docs/plugin/git-spec.md`](../docs/plugin/git-spec.md) — 브랜치·커밋·PR 네이밍

--- a/commands/migrate-dcness.md
+++ b/commands/migrate-dcness.md
@@ -59,11 +59,17 @@ description: 이미 /init-dcness 로 활성화한 기존(brownfield) 프로젝�
 
 이 스크립트들은 `docs/index.md` 진행 상태 섹션 append 와 `docs/index.md`/`docs/architecture.md` 의 generated 섹션 갱신으로 **파일을 직접 수정**한다. 따라서 Step 0 분류를 그대로 존중해야 Step 3 승인 가드를 우회하지 않는다.
 
-- **`docs/index.md`·`docs/architecture.md` 가 (a)/(b) 일 때만** 아래를 직접 실행한다. 파생 섹션은 손으로 복제하지 않는다.
+공통 변수 (어느 분기든 필요 — 분기 밖에서 먼저 설정):
 
 ```bash
 PLUGIN_ROOT="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)"
 PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+```
+
+- **`docs/index.md`·`docs/architecture.md` 가 (a) 부재면 먼저 seed 로 만든다.** generated-section 스크립트는 파일이 없으면 no-op 이라 index 가 끝내 안 생기므로, `docs/index.md`(양식 `skills/spec/templates/index.md`)·`docs/architecture.md`(양식 `agents/system-architect/templates/root-architecture.md`, 단 Step 1 BROWNFIELD 가 이미 채웠으면 그 파일 유지)를 seed 원본에서 생성한 뒤 (b) 로 취급한다.
+- **(a→seed)/(b) 이면** 아래를 직접 실행한다. 파생 섹션은 손으로 복제하지 않는다.
+
+```bash
 node "$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs" "$PROJECT_ROOT"
 node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs" --root "$PROJECT_ROOT"
 node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs" --root "$PROJECT_ROOT"
@@ -76,7 +82,7 @@ node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs" --root "$PROJECT_ROOT" --che
 node "$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs" --root "$PROJECT_ROOT" --check
 ```
 
-세 스크립트 모두 대상 프로젝트 루트를 명시 대상으로 받는다(집계기는 `--root` 미지정 시 cwd 기본이므로, 서브디렉토리에서 호출해도 어긋나지 않게 `--root "$PROJECT_ROOT"` 를 넘긴다). epic 이 아직 없으므로 index epic 표와 전역 architecture 집계 섹션이 비어 있어도 정상이다.
+집계기는 `--root` 미지정 시 cwd 기본이므로, 서브디렉토리에서 호출해도 어긋나지 않게 `--root "$PROJECT_ROOT"` 를 넘긴다. epic 이 아직 없으므로 index epic 표와 전역 architecture 집계 섹션이 비어 있어도 정상이다.
 
 ### 5. 단일 docs 부트스트랩 PR
 

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -38,6 +38,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 |---|---|
 | `/ux` | 구현 없이 목업과 흐름을 먼저 탐색한다. 내부 `canvas-design` wrapper 를 통해 drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록 규약을 따른다 |
 | `/init-dcness` | 프로젝트 활성화 |
+| `/migrate-dcness` | 기존 비-dcness 프로젝트를 코드 역설계로 전역 docs(`prd.md`/`architecture.md`/`conventions.md`/`decisions/`/`index.md`)를 채워 부트스트랩하는 일회성 유틸리티. `/init-dcness`(활성화)의 짝. epic/story 산출물은 만들지 않는다 |
 | `/next-work` | GitHub issue open/closed 상태, `in-progress` label, Issue Brief Priority 로 다음 작업 후보를 read-only 조회 |
 | `/run-review` | 끝난 run 사후 분석 |
 | `/smart-compact` | resume prompt 포함 context compact 보조 |

--- a/scripts/check_public_surface.mjs
+++ b/scripts/check_public_surface.mjs
@@ -16,7 +16,7 @@ const EXPECTED = {
   advancedSkills: ['impl-loop', 'tech-review'],
   utilitySkills: ['ux'],
   internalSkills: ['canvas-design', 'compact-design'],
-  utilityCommands: ['efficiency', 'init-dcness', 'next-work', 'run-review', 'smart-compact'],
+  utilityCommands: ['efficiency', 'init-dcness', 'migrate-dcness', 'next-work', 'run-review', 'smart-compact'],
   internalAgents: [
     'architecture-validator',
     'build-worker',

--- a/tests/test_public_surface.py
+++ b/tests/test_public_surface.py
@@ -59,6 +59,18 @@ class PublicSurfaceGateTests(unittest.TestCase):
         self.assertIn("Support Entrypoints", positioning)
         self.assertIn("기본/support/고급/유틸리티/내부 agent", positioning)
 
+    def test_migrate_dcness_is_registered_utility_command(self) -> None:
+        """#828 — /migrate-dcness 는 utility command 인벤토리와 positioning Utility 표에 등록된다."""
+        script = SCRIPT.read_text(encoding="utf-8")
+        positioning = (ROOT / "docs" / "plugin" / "positioning.md").read_text(
+            encoding="utf-8"
+        )
+
+        utility_commands = self._array(script, "utilityCommands")
+        self.assertIn("migrate-dcness", utility_commands)
+        self.assertTrue((ROOT / "commands" / "migrate-dcness.md").exists())
+        self.assertIn("`/migrate-dcness`", positioning)
+
     def _array(self, text: str, key: str) -> list[str]:
         match = re.search(rf"{key}:\s*\[([^\]]*)\]", text)
         self.assertIsNotNone(match)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #828

## 배경 및 문제

`/init-dcness` 는 인프라 활성화 + 빈 템플릿 골격 seed 까지만 한다. 기존 코드·문서의 실제 내용을 읽어 규격 산출물로 채우는 단은 비어 있어, 활성화 직후 프로젝트는 골격만 있고 내용이 없다. `docs/plugin/deliverables-map.md` 가 정의한 target shape(agent 가 읽고 일할 토대)가 없어, 기존 프로젝트가 dcNess 를 도입할 때 이 공백을 사용자가 수동으로 메워야 한다. (#828 은 reject 가 아니라 defer 였고, 외부 릴리즈 온보딩 흐름 실수요로 reopen.)

## 원인 (해당 시)

-

## 작업내용

- `commands/migrate-dcness.md` 신설 — 기존(brownfield) 프로젝트를 코드 역설계로 전역 docs(`prd`/`architecture`/`conventions`/`decisions`/`index`)의 *내용*을 채우는 일회성 유틸리티 진입점. 흐름: 사전확인 → system-architect(BROWNFIELD) 전역 docs → 메인 PRD DRAFT + 필수 사용자 확인 게이트 → 기존 문서 충돌 diff+승인 → index 집계 → 단일 docs 부트스트랩 PR.
- `agents/system-architect/system-architect-agent.md` 에 **BROWNFIELD 모드** 분기 추가 — PRD/stories/epic 입력 불요, 부재 시 ESCALATE 억제, 코드·manifest 역설계로 전역 docs 만 산출(epic 산출물 미생성), 코드 근거 약한 결정 `DRAFT` 표기, 기존 문서 충돌은 diff 보고·무단 변경 금지, PRD 수정 금지 경계 유지.
- `docs/plugin/positioning.md` Utility 표 + `scripts/check_public_surface.mjs` `utilityCommands` 에 `migrate-dcness` 등록.
- `tests/test_public_surface.py` 등록 회귀 테스트 추가 (red→green).

## 결정 근거

- **새 agent 신설 대신 system-architect 재사용**: 이슈 계약대로 정본 저자(system-architect)를 BROWNFIELD 모드 분기로 재사용해 표면 추가를 command 하나로 제한. greenfield/epic 전제를 건드리지 않도록 기본 절은 그대로 두고 별도 모드 섹션이 입력·산출물·ESCALATE 전제를 교체.
- **PRD 는 메인이 담당**: system-architect 권한 경계의 "PRD 수정 금지" 를 BROWNFIELD 에서도 유지. 코드에 근거 없는 "왜/누구/비즈니스" 는 메인의 PRD 역추론(DRAFT + 사용자 확인 게이트)으로 분리.
- **깊이 = 전역 docs 만**: epic/story 역분해(`docs/epics/...`)는 out-of-scope 로 명시해 이후 `/spec`·`/design` 이 담당.

## 배포 경로 검증 (plug-in 영향 시)

- `commands/migrate-dcness.md` + `agents/system-architect/**` 변경은 plug-in 본체(분류 1). 사용자가 `claude plugin update` 로 갱신하면 기존 활성 프로젝트에도 자동 도달. `/init-dcness` 가 복사·배포하는 파일(분류 2)·사용자용 SSOT 문서(분류 3) 추가·이동 없음 — 별도 배포 스텝 불필요.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

새 public command `/migrate-dcness` 1건 추가. Utility(최저 공개 등급)로 노출, 새 agent/gate 는 추가하지 않음.

1. **기존 risk router lane 으로 흡수 안 되나?** — workflow-router 의 구현 경로(Lite/Standard)는 *이미 규격 docs 가 있는* 프로젝트의 변경을 다룬다. `/migrate-dcness` 는 규격 docs *자체가 없는* brownfield 의 전역 docs 를 코드 역설계로 처음 까는 일회성 온보딩이라 구현 lane 으로 흡수되지 않는다. `/init-dcness` 는 빈 골격 seed 까지라 내용 역설계 단이 없다.
2. **기존 validator/reviewer 로 검증 안 되나?** — 이건 검증이 아니라 산출(부트스트랩)이라 validator 대상이 아니다.
3. **기존 agent 내부 단계로 못 두고 새 public 발화가 꼭 필요한가?** — 산출 주체는 새 agent 없이 기존 system-architect(BROWNFIELD)를 재사용한다. 다만 이 흐름을 여는 *진입점*은 `/init-dcness`(활성화)와 짝이 되는 일회성 사용자 발화가 필요하다. `/spec`·`/design` 은 규격 docs 존재를 전제하므로 brownfield 공백을 열지 못한다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 (`python3.11 -m unittest discover -s tests` → 1632 OK, 신규 등록 회귀 테스트 green)
- [x] 회귀 검증 (`check_public_surface` / `check_cross_refs` / `check_doc_path_integrity` PASS)

## 참고

- SSOT: `docs/plugin/deliverables-map.md` (전역 docs target shape), `agents/system-architect/system-architect-agent.md#brownfield-모드-역설계-부트스트랩`
