### PR TITLE
[feature] 공개 저장소 주소 참조 Daeguk-Sun 으로 통일

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -18,6 +18,6 @@
     "harness",
     "prose-only"
   ],
-  "homepage": "https://github.com/alruminum/dcNess",
-  "repository": "https://github.com/alruminum/dcNess"
+  "homepage": "https://github.com/Daeguk-Sun/dcNess",
+  "repository": "https://github.com/Daeguk-Sun/dcNess"
 }

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ dcNess 는 무거운 절차를 항상 켜 두지 않는다. 문서 수정이나 
 
 ```sh
 # marketplace 등록 + plugin 설치 (Claude Code CLI)
-claude plugin marketplace add alruminum/dcNess
+claude plugin marketplace add Daeguk-Sun/dcNess
 claude plugin install dcness@dcness
 ```
 
@@ -195,7 +195,7 @@ Sub-agent(`agents/`, architect / validator / engineer / reviewer / acceptance �
 검증 기준은 Python 3.11 이다. macOS 기본 `python3` 는 3.9 일 수 있으니 로컬에서는 `python3.11` 을 명시한다.
 
 ```sh
-git clone https://github.com/alruminum/dcNess.git
+git clone https://github.com/Daeguk-Sun/dcNess.git
 cd dcNess
 cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 공개 launch surface 정합 정리 (org 주소 참조 통일) — 별도 이슈 없이 진행하는 self 운영 작업

## 배경 및 문제

설치자·마켓이 보는 저장소 주소가 두 org 로 섞여 있었다. 설치 명령/clone/plugin.json 은 `alruminum`, 상태 뱃지는 `Daeguk-Sun`. 두 org 는 redirect 관계라 링크가 깨지지는 않지만, `alruminum` 으로 설치한 사용자가 뱃지를 누르면 `Daeguk-Sun` 으로 튕겨 첫인상이 지저분하다. 공개 배포(1.0 대비) 전 정리 대상.

## 원인 (해당 시)

-

## 작업내용

실제 현재 저장소인 `Daeguk-Sun` 으로 사용자-facing 주소 4곳을 통일:
- `README.md`: `claude plugin marketplace add` / `git clone` 주소 → Daeguk-Sun
- `.claude-plugin/plugin.json`: `homepage` / `repository` → Daeguk-Sun

## 결정 근거

수술적 범위로 한정 — 사용자가 실제로 보는 주소만 고쳤다. 의도적으로 남긴 것:
- `plugin.json` author `name`/`email` (`alruminum`, `alruminum@gmail.com`) = 작성자 개인 신원이지 org 주소가 아니다.
- `README` Origin 의 `alruminum/realworld-harness` = dcNess 의 실제 fork 원본(다른 저장소)이라 바꾸면 잘못된 출처가 된다.
- 내부 문서·릴리즈노트·test/eval fixture 의 이슈 링크 ~188곳 = redirect 로 작동하며, 과거 기록·fixture 라 일괄 치환은 churn 과 파손 위험만 크다.

## 배포 경로 검증 (plug-in 영향 시)

분류 1 (plugin 본체) — `README.md` + `.claude-plugin/plugin.json` 변경은 `claude plugin update` 로 기존 활성 프로젝트에 자동 도달한다. init-dcness 복사 파일·SSOT 문서 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 surface 변화 없음.

## Test Plan

- [x] 변경이 문서/메타데이터 문자열 4곳 한정 — 코드·테스트 영향 없음
- [x] plugin-manifest / cross-ref CI 게이트로 회귀 검증