### PR TITLE
[feature] README 앞머리 fork Origin 줄 제거

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 > Claude Code와 Codex를 실제 제품 개발 루프에 묶는 agent workflow harness.
 
-> **Origin**: [`alruminum/realworld-harness`](https://github.com/alruminum/realworld-harness) fork-and-refactor
 > **Spec(SSOT)**: [`CLAUDE.md`](CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)
 
 dcNess는 Claude Code와 Codex를 제품 개발 루프로 묶는 agent workflow harness입니다.


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 공개 launch surface 정리 (README fork 출처 줄 제거) — 별도 이슈 없이 진행하는 self 운영 작업

## 배경 및 문제

README 상단에 `> **Origin**: alruminum/realworld-harness fork-and-refactor` 줄이 있었다. 설치·평가하러 온 사용자에게 원본 fork 이력은 잡음이고, 앞면 상단에 다른 저장소 링크를 노출할 이유가 없다. 해당 원본은 작성자 본인의 이전 저장소라 크레딧 의무도 없다.

## 원인 (해당 시)

-

## 작업내용

- `README.md`: fork Origin 줄 1줄 삭제
- 바로 아래 `Spec(SSOT): CLAUDE.md` 줄은 유지

## 결정 근거

앞선 org 통일 PR(#941)에서 이 줄을 "출처라 남긴다"고 판단했으나, 사용자에게는 잡음이라는 지적을 받아 삭제로 정정. 본인 저장소 fork 라 attribution 의무 없음 확인.

## 배포 경로 검증 (plug-in 영향 시)

분류 1 (plugin 본체) — `README.md` 변경은 `claude plugin update` 로 기존 활성 프로젝트에 자동 도달. init-dcness 복사 파일·SSOT 문서 변경 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 surface 변화 없음.

## Test Plan

- [x] README 문서 1줄 삭제 한정 — 코드·테스트 영향 없음
- [x] cross-ref CI 게이트로 링크 회귀 검증