### PR TITLE
[feature] to-issue 선등록 모델 전환 + 발화 트리거·라우팅 강화

### DIFF
--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -47,7 +47,7 @@ node scripts/check_issue_body.mjs \
 gh issue create --title "<title>" --body-file <brief.md> --label "<IssueType>"
 ```
 
-`scripts/check_issue_body.mjs` 가 실패하면 `gh issue create` 를 실행하지 않는다. 실제 issue 생성 preflight 는 `--labels` 를 함께 넘겨 label 계약까지 검증하고, 본문 초안만 점검할 때만 `--body-only` 를 명시한다. `/to-issue` 는 권장 도우미이며, `/to-issue` 외 이미 승인된 대화나 agent workflow 가 issue 를 생성하는 경우에도 같은 pre-create validation 을 통과해야 한다.
+`scripts/check_issue_body.mjs` 가 실패하면 `gh issue create` 를 실행하지 않는다. 실제 issue 생성 preflight 는 `--labels` 를 함께 넘겨 label 계약까지 검증하고, 본문 초안만 점검할 때만 `--body-only` 를 명시한다. GitHub issue 생성·등록은 직접 `gh issue create` 대신 `/to-issue` 를 기본 경로로 사용한다 (작업 흐름 중 자발적으로 남기는 후속 이슈 포함). `/to-issue` 외 대화나 agent workflow 가 issue 를 생성하는 경우에도 같은 pre-create validation 을 통과하고 IssueType 라벨을 붙여야 한다.
 
 ## Issue/label Status lifecycle
 

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -19,7 +19,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 
 | support 진입점 | 역할 |
 |---|---|
-| `/to-issue` | 문제/작업 후보를 메인이 질문해 dcNess 표준 Issue Brief 초안으로 만들고, 사용자 승인 후 GitHub issue 와 Project item 으로 등록 |
+| `/to-issue` | 문제/작업 후보를 메인이 맥락에서 추론해 dcNess 표준 Issue Brief 로 구성하고, 초안 승인 대기 없이 GitHub issue 와 Project item 으로 바로 등록 (사용자는 web 에서 확인·수정) |
 
 ## Advanced Entrypoints
 

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -668,7 +668,8 @@ def render_markdown(payload: dict[str, Any]) -> str:
         "수동 실행하고 결과를 별도 Decide 입력으로 남깁니다."
     )
     lines.append(
-        "- 자동 수정과 자동 이슈 생성은 하지 않습니다. 후보 검토 뒤 "
+        "- 자동 수정과 자동 이슈 생성은 하지 않습니다. 후보를 이슈로 남길 때는 "
+        "직접 gh issue create 대신 /to-issue 를 사용하고, 검토 뒤 "
         "`record-decision`으로 소비 표식을 남깁니다."
     )
     lines.append("")

--- a/skills/to-issue/SKILL.md
+++ b/skills/to-issue/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: to-issue
-description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 만들기 위한 공개 진입점. 사용자가 "/to-issue", "이슈로 만들어줘", "티켓 만들어줘", "GitHub issue 등록", "issue 초안", "작업 후보를 issue 로 쪼개줘"처럼 issue draft/publish 를 원할 때 사용한다. 메인 Claude 가 직접 질문하고 dcNess 표준 Issue Brief 초안을 보여준 뒤 사용자 승인 후에만 GitHub issue 를 만들고 선택적으로 Project backfill 을 수행한다.
+description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 바로 등록하기 위한 공개 진입점. 사용자가 "/to-issue", "이슈 등록해줘", "이슈 만들어줘", "이거 이슈로 남겨줘", "티켓 만들어줘", "GitHub issue 등록", "후속 이슈 등록", "issue 초안", "작업 후보를 issue 로 쪼개줘"처럼 issue 등록을 원하거나, 작업 흐름 중 후속 이슈를 남길 때 사용한다. GitHub issue 생성·등록은 직접 만들지 말고 이 스킬을 기본 경로로 사용한다. 메인 Claude 가 대화 맥락으로 IssueType/Priority 를 추론하고 라벨을 붙여, 초안 승인 대기 없이 바로 GitHub issue 를 등록한 뒤 선택적으로 Project backfill 을 수행한다. 사용자는 등록된 issue 를 GitHub web 에서 확인하고 수정을 요청한다.
 ---
 
 # To Issue Skill
 
-`/to-issue` 는 GitHub issue 작성/등록 흐름이다. 메인 Claude 가 사용자와 직접 대화하며 모호함을 해소하고, 표준 Issue Brief 초안을 만든 뒤, 사용자 승인 후에만 GitHub issue 를 생성한다.
+`/to-issue` 는 GitHub issue 등록 흐름이다. 메인 Claude 가 대화 맥락으로 모호함을 해소하고 표준 Issue Brief 를 구성한 뒤, IssueType/Priority 를 추론하고 라벨을 붙여 초안 승인 대기 없이 바로 GitHub issue 를 등록한다. 사용자는 등록된 issue 를 GitHub web 에서 확인하고 수정 요청으로 교정한다.
 
 ## 범위
 
@@ -13,7 +13,7 @@ description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 
 - 버그를 바로 고칠 요청은 `/impl`, GitHub issue 로 추적할 요청은 `/to-issue` 가 처리한다.
 - `/to-issue` 는 이미 "issue 로 만들겠다"는 의도가 있는 문제/작업 후보를 durable 작업 계약으로 바꾸는 흐름이다.
 - `/spec` 의 epic/story 일괄 생성 흐름은 제품 계획 산출물 전용이다. `/to-issue` 는 단발 issue 또는 승인된 vertical slice 묶음을 다룬다.
-- `/to-issue` 는 권장 도우미다. `/to-issue` 외에 이미 승인된 대화나 다른 agent workflow 가 issue 를 만들 때도 `scripts/check_issue_body.mjs` pre-create validation 을 통과한 뒤 `gh issue create` 를 실행해야 한다.
+- GitHub issue 생성·등록은 `/to-issue` 를 기본 경로로 사용하고 직접 만들지 않는다 (작업 흐름 중 자발적으로 남기는 후속 이슈 포함). `/to-issue` 외 대화나 다른 agent workflow 가 issue 를 만들 때도 `scripts/check_issue_body.mjs` pre-create validation 을 통과하고 IssueType 라벨을 붙인 뒤 `gh issue create` 를 실행해야 한다.
 
 ## 원칙
 
@@ -62,7 +62,7 @@ description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 
 gh issue list --state open --search "<핵심 키워드>" --json number,title,labels,url
 ```
 
-중복 가능성이 있으면 새 issue 를 만들지 말고 사용자에게 기존 issue 를 이어갈지, 새 issue 로 분리할지 확인한다.
+제목이 거의 동일한 open issue 가 있으면 등록하지 말고, 기존 issue 를 이어갈지 새 issue 로 분리할지 먼저 확인한다. 명백한 중복이 아니면 확인 없이 바로 등록으로 진행한다.
 
 ### Step 2 — 명확화
 
@@ -74,34 +74,15 @@ gh issue list --state open --search "<핵심 키워드>" --json number,title,lab
 - IssueType label 값이 맞는가?
 - Priority 는 맥락에서 추론한다 — 매번 되묻지 않는다. 추론 신호가 상충하거나 사용자가 특정 우선순위를 의도한 정황이 있을 때만 확인한다.
 
-여러 issue 로 나눠야 하면 numbered list 로 vertical slice 초안을 먼저 보여주고, 사용자가 breakdown 을 승인한 뒤 각 slice 의 Issue Brief 를 작성한다.
+여러 issue 로 나눠야 하면 end-to-end vertical slice 로 나눠 각 slice 를 바로 등록하고, 분할 기준은 등록 안내에 함께 밝힌다.
 
-### Step 3 — Issue Brief 초안 작성
+### Step 3 — 본문 구성과 바로 등록
 
-issue 생성 전 [`templates/issue-brief.md`](templates/issue-brief.md)를 읽고, [`issue-fields.md`](issue-fields.md)의 선택값으로 `{{IssueType}}`, `{{Priority}}` 를 채운 초안을 보여준다.
+[`templates/issue-brief.md`](templates/issue-brief.md)를 읽고, [`issue-fields.md`](issue-fields.md)의 선택값으로 `{{IssueType}}`, `{{Priority}}` 를 채운다. `{{Priority}}` 는 [`issue-fields.md`](issue-fields.md)의 Priority 추론 가이드로 맥락에서 추론해 채우고, default `major` 로 조용히 수렴시키지 않는다. 템플릿의 섹션 구조를 임의로 축약하지 않는다. 안정적인 계약을 모르면 추측하지 말고 비워두거나 명확화 질문으로 남긴다.
 
-`{{Priority}}` 는 [`issue-fields.md`](issue-fields.md)의 Priority 추론 가이드로 맥락에서 추론해 채우고, default `major` 로 조용히 수렴시키지 않는다. 추론 근거를 초안과 함께 사용자에게 보여준다 (durable 한 Issue Brief 본문이 아니라 확인용). 사용자가 비-`major` 를 의도하거나 초안에서 교정하면 그 값을 그대로 반영한다.
+초안을 미리 보여주거나 승인을 기다리지 않는다. 추론한 IssueType/Priority 와 그에 대응하는 repo label 을 그대로 적용해 바로 등록한다. 사용자는 등록된 issue 를 GitHub web 에서 확인하고 수정 요청으로 교정한다.
 
-템플릿의 섹션 구조를 임의로 축약하지 않는다. 안정적인 계약을 모르면 추측하지 말고 비워두거나 명확화 질문으로 남긴다.
-
-### Step 4 — 승인
-
-초안 아래에 publish plan 을 함께 보여준다.
-
-- title
-- IssueType / Priority (Priority 는 추론값과 추론 근거를 함께 표기. 사용자가 교정하면 그 값을 반영)
-- repo label: IssueType 과 같은 repo label
-- lifecycle state: open issue + `in-progress` label 없음 (`Todo`)
-- optional Project backfill: Project 좌표가 있으면 `Status=Todo`, Project `IssueType`, Project `Priority`
-- parent issue: 있으면 참조만 하고 닫거나 임의 수정하지 않는다
-
-사용자가 명시적으로 승인하기 전에는 GitHub issue 를 만들지 않는다. 승인 전에는 GitHub issue 를 만들지 않는다. 승인을 거절하면 초안을 수정하고 다시 보여준다.
-
-### Step 5 — 등록과 검증
-
-등록 전 preflight 로 Issue Brief 본문과 repo label 이 실제 계약에 맞는지 확인한다. Project field/option 은 선택적 backfill 대상이다. 보드(Project)나 field/option 이 없거나 불완전하면 issue 생성을 멈추지 말고, 사용자가 원할 때만 `node scripts/github_project_lifecycle.mjs bootstrap --apply` (보드 자체가 없으면 `gh project create` + `gh project link` 를 먼저) 로 셋업하고, 좌표를 `gh variable set DCNESS_PROJECT_NUMBER --body <number>` / `gh variable set DCNESS_PROJECT_OWNER --body <owner>` 로 저장한 뒤 Project 등록을 backfill 한다. 거부하면 보드 없이 issue 만 생성한다. 어떤 경우에도 Project 상태는 issue 생성 자체를 막지 않는다.
-
-승인 후에만 생성한다.
+등록 전 preflight 로 Issue Brief 본문과 repo label 이 실제 계약에 맞는지 확인한다. Project field/option 은 선택적 backfill 대상이다. 보드(Project)나 field/option 이 없거나 불완전하면 등록을 멈추지 말고, 사용자가 원할 때만 `node scripts/github_project_lifecycle.mjs bootstrap --apply` (보드 자체가 없으면 `gh project create` + `gh project link` 를 먼저) 로 셋업하고, 좌표를 `gh variable set DCNESS_PROJECT_NUMBER --body <number>` / `gh variable set DCNESS_PROJECT_OWNER --body <owner>` 로 저장한 뒤 Project 등록을 backfill 한다. 거부하면 보드 없이 issue 만 등록한다. 어떤 경우에도 Project 상태는 등록 자체를 막지 않는다.
 
 ```bash
 node scripts/check_issue_body.mjs \
@@ -125,6 +106,17 @@ node scripts/github_project_lifecycle.mjs register-issue \
   --priority "<Priority>" \
   --apply
 ```
+
+### Step 4 — 등록 후 통보와 검증
+
+등록 직후 issue 링크를 사용자에게 통보하고, GitHub web 에서 확인해 수정할 것이 있으면 말해달라고 안내한다. 통보에는 등록된 issue 의 확정 상태를 함께 밝힌다.
+
+- title
+- IssueType / Priority (Priority 는 추론값과 추론 근거를 함께 표기)
+- repo label: IssueType 과 같은 repo label
+- lifecycle state: open issue + `in-progress` label 없음 (`Todo`)
+- optional Project backfill: Project 좌표가 있으면 `Status=Todo`, Project `IssueType`, Project `Priority`
+- parent issue: 있으면 참조만 하고 닫거나 임의 수정하지 않는다
 
 성공 안내 전 등록 상태를 다시 검증한다.
 

--- a/tests/test_to_issue_skill.py
+++ b/tests/test_to_issue_skill.py
@@ -27,8 +27,8 @@ class ToIssueSkillTests(unittest.TestCase):
         self.assertIn("메인 Claude", text)
         self.assertIn("서브에이전트", text)
         self.assertIn("호출하지 않는다", text)
-        self.assertIn("사용자 승인", text)
-        self.assertIn("승인 전에는 GitHub issue 를 만들지 않는다", text)
+        self.assertIn("초안 승인 대기 없이", text)
+        self.assertIn("web 에서 확인", text)
 
     def test_issue_brief_template_has_required_contract_sections(self) -> None:
         skill = self.skill_path.read_text(encoding="utf-8")
@@ -82,7 +82,7 @@ class ToIssueSkillTests(unittest.TestCase):
         for inline_list in forbidden_inline_lists:
             self.assertNotIn(inline_list, skill)
 
-    def test_issue_creation_requires_user_confirmation_and_lifecycle_fields(self) -> None:
+    def test_issue_creation_records_lifecycle_and_label_fields(self) -> None:
         text = self.skill_path.read_text(encoding="utf-8")
 
         for phrase in (


### PR DESCRIPTION
## 관련 이슈 번호
Document-Exception-PR-Close: 근본 예방 성격의 follow-up PR — 대응 이슈 없음. 발현 이슈 #930/#931/#918 IssueType 라벨 누락은 별도 봉합으로 처리.

## 배경 및 문제
`github-project-lifecycle` 워크플로우가 이슈 #930 등에서 `expected exactly one IssueType label, actual=0` 로 반복 실패. 조사 결과 근본 원인은 CI 가 아니라 이슈 생성 관행: 최근 이슈 생성 56건이 거의 전부 직접 `gh issue create` 였고, 작업 흐름 중 자발적으로 남긴 후속 이슈(`[eval]`/`[loop-diagnose]`/`[issue]` 프리픽스)는 `/to-issue` 를 미경유해 IssueType 라벨 부착 스텝을 건너뜀. 사용자 확인 결과 명시적 "이슈 등록해줘" 요청에도 to-issue 가 발화하지 않고 직접 등록되는 경우가 있었음.

## 원인 (해당 시)
- 발화: to-issue description 트리거가 "이슈 등록해줘/만들어줘" 실제 구어를 충분히 커버하지 못함 + 흐름 중 자발 등록은 스킬 트리거가 걸리지 않음.
- 마찰: to-issue 의 초안 미리보기+승인 게이트가 무거워, 메인이 직접 `gh issue create` 로 우회하는 유인이 됨.
- 라벨은 우회 경로에서 메인의 수기 `--label` 에만 의존 → 후속 등록에서 누락.

## 작업내용
- to-issue 선등록 모델 전환: 초안 미리보기+승인 게이트 제거 → 맥락 추론값·IssueType 라벨 자동 부여로 바로 등록, 등록 후 GitHub web 검토·수정. (`SKILL.md` Step 3/4 재편, 등록 결과 통보 요약 유지)
- 발화 트리거 보강: description 에 "이슈 등록해줘/이슈 만들어줘/이거 이슈로 남겨줘/후속 이슈 등록" 추가.
- 라우팅 강화: "GitHub issue 생성·등록은 to-issue 기본 경로 (흐름 중 자발 등록 포함)" 를 `SKILL.md` 범위 · `issue-lifecycle.md` · `loop_diagnose.py` 산출물에 명시.
- 안전장치: 명백한 중복만 등록 전 확인, 그 외 바로 등록.
- 테스트: 승인 게이트 계약 → 선등록 계약으로 갱신, lifecycle/label 필드 계약은 등록 결과 통보로 보존, 오해 소지 테스트명 정정.

## 결정 근거
승인 게이트를 web 검토로 옮기면 (1) 사용자 마찰 감소 (2) 흐름 중 자발 등록도 to-issue 우회 유인 소멸 (3) 그 경로가 라벨을 자동 부착해 CI 실패 근본까지 닫힘 — 세 요구가 한 설계로 수렴. `check_issue_body.mjs` 기본값 변경은 무효(CLI 는 이미 `--body-only` 아니면 라벨 강제, 실제 구멍은 스크립트 미경유)임을 확인해 배제.

## 배포 경로 검증 (plug-in 영향 시)
- `skills/to-issue/SKILL.md` = plug-in 본체 (경로 1) — 사용자 plugin 업데이트 시 자동 적용.
- `docs/plugin/positioning.md`·`issue-lifecycle.md` = 사용자용 SSOT (경로 3) — plug-in 배포물에 포함.
- `scripts/loop_diagnose.py` = plug-in 본체 스크립트 (경로 1) — `/loop-diagnose` 산출물로 사용자 도달.
- Codex 미러 없음 (to-issue 는 Claude 전담, `codex/skills/` 에 validator·reviewer 3종만) → 이중 provider 동기화 불필요.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과 — `tests.test_to_issue_skill` 등 74 관련 · 전체 1632 tests OK
- [x] 회귀 검증 — public-surface PASS · cross-ref PASS (107 파일, dead link/anchor/옛 명칭/고아 0)

## 참고
발현 이슈 #930/#931/#918 IssueType 라벨 봉합은 이 PR 범위 밖(별도 처리).
