### PR TITLE
[feature] fresh 환경 릴리즈 하드닝 4건 (org 참조·node fail-open·seed·label)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "dcness",
-  "description": "Agent workflow harness for Claude Code and Codex that enforces order gates, role boundaries, TDD guard, and verifiable run records inside Git/PR/CI workflows.",
+  "description": "Claude Code와 Codex를 Git/PR/CI 흐름 안에서 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 묶는 agent workflow harness. (한국어 사용자 대상)",
   "owner": {
     "name": "alruminum",
     "email": "alruminum@gmail.com"
@@ -14,7 +14,7 @@
     {
       "name": "dcness",
       "source": "./",
-      "description": "Agent workflow harness for Claude Code and Codex — order gates, role boundaries, TDD guard, and verifiable run records for Git/PR/CI work.",
+      "description": "Claude Code와 Codex를 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 Git/PR/CI 작업에 묶는 agent workflow harness. (한국어 사용자 대상)",
       "category": "development",
       "tags": [
         "claude-code",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "dcness",
   "version": "0.12.0",
-  "description": "Agent workflow harness for Claude Code and Codex that enforces order gates, role boundaries, TDD guard, and verifiable run records inside Git/PR/CI workflows.",
+  "description": "Claude Code와 Codex를 Git/PR/CI 흐름 안에서 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 묶는 agent workflow harness. (한국어 사용자 대상)",
   "author": {
     "name": "alruminum",
     "email": "alruminum@gmail.com"

--- a/.github/workflows/git-naming-validation.yml
+++ b/.github/workflows/git-naming-validation.yml
@@ -4,7 +4,7 @@
 # 규칙 정의: docs/plugin/git-spec.md (SSOT)
 # 본 dcness self repo 는 자기 composite action (.github/actions/git-naming) 을 dogfooding.
 # 외부 활성화 프로젝트는 init-dcness 가 묻고 Y 답변 시 thin yml 을 사용자 repo 에 배포 — 그 yml 은
-# `uses: alruminum/dcNess/.github/actions/git-naming@main` 1줄로 동일 검증.
+# `uses: Daeguk-Sun/dcNess/.github/actions/git-naming@main` 1줄로 동일 검증.
 
 name: git-naming-validation
 

--- a/.github/workflows/github-project-lifecycle.yml
+++ b/.github/workflows/github-project-lifecycle.yml
@@ -3,7 +3,7 @@
 # 모드/룰 정의: docs/plugin/github-project.md + scripts/github_project_lifecycle.mjs (SSOT)
 # 본 dcness self repo 는 자기 composite action (.github/actions/github-project-lifecycle) 을 dogfooding.
 # 외부 활성화 프로젝트는 /init-dcness 선택형 확장 custom 에서 Project lifecycle workflow 를 선택할 때 thin yml 을 사용자 repo 에 배포 — 그 yml 은
-# `uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main` 1줄로 동일 검증.
+# `uses: Daeguk-Sun/dcNess/.github/actions/github-project-lifecycle@main` 1줄로 동일 검증.
 #
 # Project v2 호환 보정에는 classic PAT 의 project + read:org scope 둘 다 필요: secrets.DCNESS_PROJECT_TOKEN
 #   (read:org 없으면 gh project owner 판별이 unknown owner type 으로 실패. 토큰 없거나 권한 부족이면

--- a/.github/workflows/pr-body-validation.yml
+++ b/.github/workflows/pr-body-validation.yml
@@ -3,7 +3,7 @@
 # 규칙 정의: docs/plugin/issue-lifecycle.md §1.4 + §2.3 (SSOT)
 # 본 dcness self repo 는 자기 composite action (.github/actions/pr-body) 을 dogfooding.
 # 외부 활성화 프로젝트는 init-dcness 가 묻고 Y 답변 시 thin yml 을 사용자 repo 에 배포 — 그 yml 은
-# `uses: alruminum/dcNess/.github/actions/pr-body@main` 1줄로 동일 검증.
+# `uses: Daeguk-Sun/dcNess/.github/actions/pr-body@main` 1줄로 동일 검증.
 
 name: pr-body-validation
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Standard 구현 경로의 기본은 `build-worker → pr-reviewer` 이고, 풀 4
 | 기본 workflow | `/design` | 화면·시스템·모듈 설계 |
 | 기본 workflow | `/impl` | 구현 진입 — 경로(Lite/Standard)와 엔진을 내부 판정 |
 | 기본 workflow | `/acceptance` | story/epic 제품 검수 |
-| support | `/to-issue` | 자연어 → Issue Brief 초안 → 승인 후 GitHub 등록 |
+| support | `/to-issue` | 자연어 → Issue Brief → 승인 대기 없이 GitHub 선등록 (web 에서 확인·수정) |
 | 고급 | `/tech-review` | 위험한 설계의 사전 기술 검증 |
 | 고급 | `/impl-loop` | deep impl task 파일 단위 구현 러너 |
 | 유틸 | `/ux` | 구현 없이 목업·흐름 먼저 탐색, PICK 확정본은 canvas 에 등록 |

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -297,7 +297,7 @@ git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또�
 
 ## Layer 3 — CI/CD workflows
 
-설치 경로: 사용자 repo 의 `.github/workflows/`. `/init-dcness` 에서 사용자가 Y 를 선택한 경우 thin workflow 를 생성한다. workflow 본체는 `alruminum/dcNess` 의 composite action 을 호출한다.
+설치 경로: 사용자 repo 의 `.github/workflows/`. `/init-dcness` 에서 사용자가 Y 를 선택한 경우 thin workflow 를 생성한다. workflow 본체는 `Daeguk-Sun/dcNess` 의 composite action 을 호출한다.
 
 | Workflow | Trigger | 언제 | 하는 일 | 성격 |
 |---|---|---|---|---|

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -313,7 +313,7 @@ git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또�
 
 **시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때.
 
-**역할**: `alruminum/dcNess/.github/actions/git-naming@main` 을 호출해 `github.head_ref` 와 PR title 을 검증한다.
+**역할**: `Daeguk-Sun/dcNess/.github/actions/git-naming@main` 을 호출해 `github.head_ref` 와 PR title 을 검증한다.
 
 **차단**: workflow 실패. hard merge gate 여부는 사용자 repo 의 branch protection/ruleset 설정에 달려 있다.
 
@@ -323,7 +323,7 @@ git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또�
 
 **시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때.
 
-**역할**: `alruminum/dcNess/.github/actions/pr-body@main` 을 호출해 PR body 에 issue trailer 가 있는지 확인한다.
+**역할**: `Daeguk-Sun/dcNess/.github/actions/pr-body@main` 을 호출해 PR body 에 issue trailer 가 있는지 확인한다.
 
 허용 패턴:
 
@@ -339,7 +339,7 @@ git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또�
 
 **시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때. 문서가 그대로여도 참조 대상 파일이 삭제·이동되면 stale path 가 생길 수 있으므로 path filter 를 두지 않는다.
 
-**역할**: `alruminum/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`) 안 repo-relative path 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다.
+**역할**: `Daeguk-Sun/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`) 안 repo-relative path 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다.
 
 **차단**: workflow 실패. hard merge gate 여부는 사용자 repo 의 branch protection/ruleset 설정에 달려 있다.
 
@@ -349,7 +349,7 @@ git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또�
 
 **시점**: `main` 대상 PR 이 opened, synchronize, reopened, edited 될 때.
 
-**역할**: `alruminum/dcNess/.github/actions/doc-sync@main` 을 호출해 활성 프로젝트의 `docs/index.md` `## 에픽` / `## 모듈` 생성 표와 `docs/architecture.md` generated architecture map 이 파생 원본과 일치하는지 확인한다. index 표는 `docs/epics/epic-NN-*` 디렉토리, `stories.md` frontmatter, `docs/modules/<module-id>/` 에서, architecture map 은 epic `architecture.md` 의 `## 모듈 목록` / `## Contract Ledger` 표에서 파생된다. 같은 composite action 안에서 `check_design_artifact_structure.mjs` 도 실행해 신규 `/design` 산출물이 canonical Contract Ledger `contract` 열과 level-2 `## Contract References` row-key 포인터 구조를 지키는지 감사한다.
+**역할**: `Daeguk-Sun/dcNess/.github/actions/doc-sync@main` 을 호출해 활성 프로젝트의 `docs/index.md` `## 에픽` / `## 모듈` 생성 표와 `docs/architecture.md` generated architecture map 이 파생 원본과 일치하는지 확인한다. index 표는 `docs/epics/epic-NN-*` 디렉토리, `stories.md` frontmatter, `docs/modules/<module-id>/` 에서, architecture map 은 epic `architecture.md` 의 `## 모듈 목록` / `## Contract Ledger` 표에서 파생된다. 같은 composite action 안에서 `check_design_artifact_structure.mjs` 도 실행해 신규 `/design` 산출물이 canonical Contract Ledger `contract` 열과 level-2 `## Contract References` row-key 포인터 구조를 지키는지 감사한다.
 
 **빈 환경**: `docs/index.md`, `docs/architecture.md`, 또는 유효 epic/module 이 없는 갓 시드된 프로젝트에서는 no-op PASS 한다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -115,31 +115,31 @@ Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소�
 
 - 대상 경로: `.github/workflows/git-naming-validation.yml`
 - 템플릿: [`templates/github-workflows/git-naming-validation.yml`](../../templates/github-workflows/git-naming-validation.yml)
-- 역할: `alruminum/dcNess/.github/actions/git-naming@main` 을 호출해 `github.head_ref` 와 PR title 을 검증한다.
+- 역할: `Daeguk-Sun/dcNess/.github/actions/git-naming@main` 을 호출해 `github.head_ref` 와 PR title 을 검증한다.
 
 ### pr-body-validation.yml
 
 - 대상 경로: `.github/workflows/pr-body-validation.yml`
 - 템플릿: [`templates/github-workflows/pr-body-validation.yml`](../../templates/github-workflows/pr-body-validation.yml)
-- 역할: `alruminum/dcNess/.github/actions/pr-body@main` 을 호출해 PR body 에 issue trailer 가 있는지 확인한다.
+- 역할: `Daeguk-Sun/dcNess/.github/actions/pr-body@main` 을 호출해 PR body 에 issue trailer 가 있는지 확인한다.
 
 ### doc-path-integrity.yml
 
 - 대상 경로: `.github/workflows/doc-path-integrity.yml`
 - 템플릿: [`templates/github-workflows/doc-path-integrity.yml`](../../templates/github-workflows/doc-path-integrity.yml)
-- 역할: `alruminum/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`) 안 repo-relative 경로 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다. 문서가 그대로여도 참조 대상 파일 삭제·이동으로 stale path 가 생길 수 있어 PR마다 실행한다.
+- 역할: `Daeguk-Sun/dcNess/.github/actions/doc-path-integrity@main` 을 호출해 활성 프로젝트의 context/SSOT 문서(`CLAUDE.md`, `AGENTS.md`, root `architecture.md`, `docs/index.md`, `docs/project-context.md`, `docs/architecture.md`, `docs/conventions.md`, `docs/modules/**`, `docs/decisions/**`) 안 repo-relative 경로 참조가 실제 파일 또는 디렉토리를 가리키는지 확인한다. 문서가 그대로여도 참조 대상 파일 삭제·이동으로 stale path 가 생길 수 있어 PR마다 실행한다.
 
 ### doc-sync.yml
 
 - 대상 경로: `.github/workflows/doc-sync.yml`
 - 템플릿: [`templates/github-workflows/doc-sync.yml`](../../templates/github-workflows/doc-sync.yml)
-- 역할: `alruminum/dcNess/.github/actions/doc-sync@main` 을 호출해 `docs/index.md` 의 epic/module 표와 `docs/architecture.md` 의 전역 architecture map 이 파생 원본과 byte-level 로 일치하는지 확인하고, `/design` 산출물의 Contract Ledger row-key 포인터 구조를 감사한다. `docs/index.md`, `docs/architecture.md`, 또는 유효 epic/module 이 없는 빈 환경은 no-op PASS 한다.
+- 역할: `Daeguk-Sun/dcNess/.github/actions/doc-sync@main` 을 호출해 `docs/index.md` 의 epic/module 표와 `docs/architecture.md` 의 전역 architecture map 이 파생 원본과 byte-level 로 일치하는지 확인하고, `/design` 산출물의 Contract Ledger row-key 포인터 구조를 감사한다. `docs/index.md`, `docs/architecture.md`, 또는 유효 epic/module 이 없는 빈 환경은 no-op PASS 한다.
 
 ### github-project-lifecycle.yml
 
 - 대상 경로: `.github/workflows/github-project-lifecycle.yml`
 - 템플릿: [`templates/github-workflows/github-project-lifecycle.yml`](../../templates/github-workflows/github-project-lifecycle.yml)
-- 역할: `alruminum/dcNess/.github/actions/github-project-lifecycle@main` 을 호출해 issue/label drift 를 검출하고 merged PR 의 완료 후보 issue 에서 `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 Project Status `Done` 미러를 best-effort 로 함께 시도한다.
+- 역할: `Daeguk-Sun/dcNess/.github/actions/github-project-lifecycle@main` 을 호출해 issue/label drift 를 검출하고 merged PR 의 완료 후보 issue 에서 `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 Project Status `Done` 미러를 best-effort 로 함께 시도한다.
 
 `in-progress` label 제거에는 `issues: write` 권한이 필요하다. Project v2 미러에는 `secrets.DCNESS_PROJECT_TOKEN` 에 classic PAT `project` + `read:org` scope 가 필요하다. token 이 없거나 Project API 가 실패하면 Project 미러만 warning 으로 skip 되고 issue/label lifecycle 은 GitHub token 권한으로 계속 동작한다.
 

--- a/harness/context_docs.py
+++ b/harness/context_docs.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Optional
 
+from harness.tdd_hooks import detect_platform
+
 
 RECOMMENDED_SECTIONS = (
     "Commands",
@@ -130,17 +132,12 @@ def _detect_package_commands(root: Path) -> list[str]:
     return commands
 
 
-def _has_python_markers(root: Path) -> bool:
-    return any(
-        (root / marker).exists()
-        for marker in ("pyproject.toml", "setup.py", "setup.cfg")
-    )
-
-
 def _detect_python_commands(root: Path) -> list[str]:
-    # Python 마커가 없으면 test 디렉토리만 보고 python 명령을 심지 않는다 — JS 등 비-python
-    # 저장소에도 tests/ 가 흔하고, python3.11 은 일반 기계에 거의 없다. 버전 고정 대신 python3.
-    if not _has_python_markers(root):
+    # "이 저장소가 python 인가" 판정은 tdd_hooks.detect_platform 이 SSOT
+    # (pyproject.toml / requirements.txt / .py 파일). 별도 좁은 기준을 두면 drift 가 난다 —
+    # JS 등 비-python 저장소에도 tests/ 가 흔해 tests/ 존재만으론 python 명령을 심지 않고,
+    # 버전 고정(python3.11) 대신 일반적으로 존재하는 python3 를 쓴다.
+    if detect_platform(root) != "python":
         return []
     commands: list[str] = []
     if (root / "tests").exists():

--- a/harness/context_docs.py
+++ b/harness/context_docs.py
@@ -130,10 +130,21 @@ def _detect_package_commands(root: Path) -> list[str]:
     return commands
 
 
+def _has_python_markers(root: Path) -> bool:
+    return any(
+        (root / marker).exists()
+        for marker in ("pyproject.toml", "setup.py", "setup.cfg")
+    )
+
+
 def _detect_python_commands(root: Path) -> list[str]:
+    # Python 마커가 없으면 test 디렉토리만 보고 python 명령을 심지 않는다 — JS 등 비-python
+    # 저장소에도 tests/ 가 흔하고, python3.11 은 일반 기계에 거의 없다. 버전 고정 대신 python3.
+    if not _has_python_markers(root):
+        return []
     commands: list[str] = []
     if (root / "tests").exists():
-        commands.append("- `python3.11 -m unittest discover -s tests -v`")
+        commands.append("- `python3 -m unittest discover -s tests -v`")
     if (root / "scripts" / "check_static_quality.sh").exists():
         commands.append("- `bash scripts/check_static_quality.sh`")
     return commands

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -44,7 +44,7 @@ if [[ -n "$INSTALLED_VERSION" && "$INSTALLED_VERSION" != "null" ]]; then
 
   # 캐시 stale (24h+) — gh api 로 main 의 plugin.json fetch
   if (( NOW > 0 && NOW - LAST_CHECK > CHECK_INTERVAL )); then
-    FETCHED=$(gh api repos/alruminum/dcNess/contents/.claude-plugin/plugin.json --jq '.content' 2>/dev/null \
+    FETCHED=$(gh api repos/Daeguk-Sun/dcNess/contents/.claude-plugin/plugin.json --jq '.content' 2>/dev/null \
               | base64 -d 2>/dev/null \
               | jq -r '.version' 2>/dev/null \
               || echo "")

--- a/scripts/create_epic_story_issues.sh
+++ b/scripts/create_epic_story_issues.sh
@@ -195,6 +195,18 @@ if [ -z "$VNN" ]; then
   exit 1
 fi
 
+# 신규 저장소에는 vNN / epic-NN-<slug> label 이 없어 gh issue create -l 이 통째로 실패한다
+# (setup_labels.sh 는 IssueType 6종 + in-progress 만 만들고 vNN/epic slug label 은 안 만든다).
+# 이슈 생성 직전, 이 스크립트가 붙이는 label 을 create-if-missing 로 선반영해 첫 등록 실패를 막는다.
+# 이미 있으면 no-op (색/설명은 setup_labels.sh 가 canonical — 여기선 존재만 보장).
+_ensure_issue_label() {
+  gh label create "$1" --color ededed --description "dcNess issue label" >/dev/null 2>&1 || true
+}
+_ensure_issue_label epic
+_ensure_issue_label story
+_ensure_issue_label "$VNN"
+_ensure_issue_label "$EPIC_SLUG"
+
 # epic 이슈 생성
 echo "[issue-create] epic 이슈 생성 — '$EPIC_TITLE'"
 # 헤더 양식 분기 — epic 본문 = epic 헤더 ~ 첫 Story 헤더 사이

--- a/scripts/hooks/commit-msg
+++ b/scripts/hooks/commit-msg
@@ -68,7 +68,14 @@ record_guard_hit() {
 }
 
 # 1. git-naming 검증 — TDD chain 폐기 (v0.2.16 — PreToolUse hook 으로 이전)
-if ! node "$PLUGIN_ROOT/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE"; then
-  record_guard_hit "git_naming" "commit title rejected: $COMMIT_TITLE"
-  exit 1
+# node 부재 시 fail-open — node 미설치(exit 127)를 형식 위반(exit 1)과 구분해 WARN + skip.
+# plugin hook 계열의 fail-open(부재/크래시 시 allow) 설계와 일관 — node 미설치 기계에서
+# 활성화 직후 모든 commit 이 차단되는 것을 막는다.
+if command -v node >/dev/null 2>&1; then
+  if ! node "$PLUGIN_ROOT/scripts/check_git_naming.mjs" --title "$COMMIT_TITLE"; then
+    record_guard_hit "git_naming" "commit title rejected: $COMMIT_TITLE"
+    exit 1
+  fi
+else
+  echo "[commit-msg] WARN — node 미설치. git-naming 검증 skip (fail-open)." >&2
 fi

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -86,14 +86,18 @@ while read local_ref local_sha remote_ref remote_sha; do
       # main / master / HEAD / develop 면 skip (이미 main 차단 별도)
       case "$BRANCH" in main|master|HEAD|develop) continue ;; esac
 
-      if [ -n "$SCRIPT_PATH" ]; then
-        if ! node "$SCRIPT_PATH" --branch "$BRANCH" >&2; then
-          record_guard_hit "branch_naming" "branch rejected: $BRANCH"
-          echo "ERROR: 브랜치명 형식 위반 — push 차단 (#255 W4 정합)." >&2
-          echo "  로컬에서 수정: git branch -m <올바른-브랜치명>" >&2
-          echo "  허용 패턴 = docs/plugin/git-spec.md §1" >&2
-          exit 1
-        fi
+      # node 부재 시 브랜치명 검증만 fail-open (WARN + skip). main-block(위)은 node 미사용이라
+      # 그대로 차단 유지 — node 미설치(exit 127)를 형식 위반과 구분.
+      if [ -z "$SCRIPT_PATH" ]; then
+        : # git-naming 스크립트 미발견 — 기존 동작대로 조용히 skip
+      elif ! command -v node >/dev/null 2>&1; then
+        echo "[pre-push] WARN — node 미설치. 브랜치명 검증 skip (fail-open)." >&2
+      elif ! node "$SCRIPT_PATH" --branch "$BRANCH" >&2; then
+        record_guard_hit "branch_naming" "branch rejected: $BRANCH"
+        echo "ERROR: 브랜치명 형식 위반 — push 차단 (#255 W4 정합)." >&2
+        echo "  로컬에서 수정: git branch -m <올바른-브랜치명>" >&2
+        echo "  허용 패턴 = docs/plugin/git-spec.md §1" >&2
+        exit 1
       fi
       ;;
   esac

--- a/templates/github-workflows/doc-path-integrity.yml
+++ b/templates/github-workflows/doc-path-integrity.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: alruminum/dcNess/.github/actions/doc-path-integrity@main
+      - uses: Daeguk-Sun/dcNess/.github/actions/doc-path-integrity@main

--- a/templates/github-workflows/doc-sync.yml
+++ b/templates/github-workflows/doc-sync.yml
@@ -15,4 +15,4 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: alruminum/dcNess/.github/actions/doc-sync@main
+      - uses: Daeguk-Sun/dcNess/.github/actions/doc-sync@main

--- a/templates/github-workflows/git-naming-validation.yml
+++ b/templates/github-workflows/git-naming-validation.yml
@@ -11,7 +11,7 @@ jobs:
     name: git-naming-spec gate
     runs-on: ubuntu-latest
     steps:
-      - uses: alruminum/dcNess/.github/actions/git-naming@main
+      - uses: Daeguk-Sun/dcNess/.github/actions/git-naming@main
         with:
           branch: ${{ github.head_ref }}
           title: ${{ github.event.pull_request.title }}

--- a/templates/github-workflows/github-project-lifecycle.yml
+++ b/templates/github-workflows/github-project-lifecycle.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event_name == 'issues' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main
+      - uses: Daeguk-Sun/dcNess/.github/actions/github-project-lifecycle@main
         with:
           mode: validate-issue
           repo: ${{ github.repository }}
@@ -25,7 +25,7 @@ jobs:
     if: ${{ github.event_name == 'pull_request' && github.event.pull_request.merged == true }}
     runs-on: ubuntu-latest
     steps:
-      - uses: alruminum/dcNess/.github/actions/github-project-lifecycle@main
+      - uses: Daeguk-Sun/dcNess/.github/actions/github-project-lifecycle@main
         with:
           mode: pr-merged
           repo: ${{ github.repository }}

--- a/templates/github-workflows/pr-body-validation.yml
+++ b/templates/github-workflows/pr-body-validation.yml
@@ -11,6 +11,6 @@ jobs:
     name: PR body close-keyword gate
     runs-on: ubuntu-latest
     steps:
-      - uses: alruminum/dcNess/.github/actions/pr-body@main
+      - uses: Daeguk-Sun/dcNess/.github/actions/pr-body@main
         with:
           body: ${{ github.event.pull_request.body }}

--- a/tests/test_context_docs.py
+++ b/tests/test_context_docs.py
@@ -59,6 +59,37 @@ class ContextDocsTests(unittest.TestCase):
             self.assertIn("appended-cold-start", first.actions)
             self.assertEqual(second.actions, ["noop"])
 
+    def test_seed_skips_python_test_command_without_python_markers(self) -> None:
+        from harness.context_docs import build_claude_seed
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "tests").mkdir()
+            (root / "package.json").write_text(
+                '{"scripts": {"test": "vitest"}}', encoding="utf-8"
+            )
+
+            seed = build_claude_seed(root)
+
+            self.assertNotIn("unittest", seed)
+            self.assertNotIn("python3.11", seed)
+            self.assertIn("npm run test", seed)
+
+    def test_seed_uses_python3_for_python_project_tests(self) -> None:
+        from harness.context_docs import build_claude_seed
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "tests").mkdir()
+            (root / "pyproject.toml").write_text(
+                '[project]\nname = "demo"\n', encoding="utf-8"
+            )
+
+            seed = build_claude_seed(root)
+
+            self.assertIn("- `python3 -m unittest discover -s tests -v`", seed)
+            self.assertNotIn("python3.11", seed)
+
     def test_audit_reports_rubric_gaps_without_mutating_existing_doc(self) -> None:
         from harness.context_docs import audit_claude_md_file
 

--- a/tests/test_context_docs.py
+++ b/tests/test_context_docs.py
@@ -90,6 +90,21 @@ class ContextDocsTests(unittest.TestCase):
             self.assertIn("- `python3 -m unittest discover -s tests -v`", seed)
             self.assertNotIn("python3.11", seed)
 
+    def test_seed_detects_requirements_only_python_project(self) -> None:
+        # requirements.txt 만 있고 pyproject/setup 없는 python 프로젝트도 detect_platform
+        # 이 python 으로 인식 — tests/ 존재 시 python 명령을 심어야 한다 (회귀 가드).
+        from harness.context_docs import build_claude_seed
+
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            (root / "tests").mkdir()
+            (root / "requirements.txt").write_text("pytest\n", encoding="utf-8")
+
+            seed = build_claude_seed(root)
+
+            self.assertIn("- `python3 -m unittest discover -s tests -v`", seed)
+            self.assertNotIn("python3.11", seed)
+
     def test_audit_reports_rubric_gaps_without_mutating_existing_doc(self) -> None:
         from harness.context_docs import audit_claude_md_file
 

--- a/tests/test_create_epic_story_issues.py
+++ b/tests/test_create_epic_story_issues.py
@@ -181,6 +181,16 @@ class CreateEpicStoryBoardTests(unittest.TestCase):
         self.assertEqual(0, node_log.count("register-issue"))
         self.assertIn("보드", result.stdout + result.stderr)
 
+    def test_fresh_run_upserts_labels_before_issue_create(self):
+        # 신규 저장소에는 vNN / epic-NN-<slug> label 이 없어 gh issue create -l 이
+        # 통째로 실패한다 — 생성 직전 label upsert 가 선행돼야 한다.
+        result, gh_log, node_log, _ = self._run(STORIES_NEW, {})
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertEqual(4, gh_log.count("label create"))
+        for lbl in ("epic", "story", "v01", "epic-01-demo"):
+            self.assertIn(f"label create {lbl}", gh_log)
+        self.assertLess(gh_log.index("label create"), gh_log.index("issue create"))
+
     def test_partial_board_failure_reported_issues_still_created(self):
         result, gh_log, node_log, _ = self._run(
             STORIES_NEW, {"VARS_PRESENT": "1", "FAIL_ISSUE": "102"}
@@ -198,6 +208,7 @@ class CreateEpicStoryBoardTests(unittest.TestCase):
         )
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertEqual(0, gh_log.count("issue create"))
+        self.assertEqual(0, gh_log.count("label create"))
         self.assertEqual(3, node_log.count("register-issue"))
         self.assertIn("--issue 100", node_log)
         self.assertIn("--issue 101", node_log)

--- a/tests/test_doc_path_integrity.py
+++ b/tests/test_doc_path_integrity.py
@@ -37,7 +37,7 @@ class DocPathIntegrityTests(unittest.TestCase):
 
         self.assertIn("name: doc-path-integrity", workflow)
         self.assertIn("actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", workflow)
-        self.assertIn("alruminum/dcNess/.github/actions/doc-path-integrity@main", workflow)
+        self.assertIn("Daeguk-Sun/dcNess/.github/actions/doc-path-integrity@main", workflow)
         self.assertNotIn("paths:", workflow)
         self.assertIn("scripts/check_doc_path_integrity.mjs", action)
 

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import unittest
 from pathlib import Path
@@ -271,6 +272,83 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
                 (root / ".claude" / "harness-state" / TELEMETRY_NAME).exists()
             )
             self.assertEqual(read_events(cwd=root), [])
+
+
+class GitHookNodeFailOpenTests(unittest.TestCase):
+    """node 미설치 환경 계약 — naming 검증만 skip (fail-open), main 차단은 유지."""
+
+    def _restricted_path(self, base: Path) -> str:
+        # node 없는 PATH — shim 이 필요로 하는 최소 도구만 symlink.
+        bin_dir = base / "bin"
+        bin_dir.mkdir()
+        for tool in ("head", "grep"):
+            src = shutil.which(tool)
+            self.assertIsNotNone(src, tool)
+            (bin_dir / tool).symlink_to(src)
+        return str(bin_dir)
+
+    def test_commit_msg_skips_naming_when_node_missing(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            repo.mkdir()
+            msg = repo / "COMMIT_EDITMSG"
+            msg.write_text("bad subject\n", encoding="utf-8")
+            env = _env(active=True)
+            env["PATH"] = self._restricted_path(base)
+
+            result = subprocess.run(
+                ["/bin/sh", str(ROOT / "scripts" / "hooks" / "commit-msg"), str(msg)],
+                cwd=str(repo),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn("WARN", result.stderr)
+
+    def test_pre_push_branch_naming_skips_when_node_missing(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            repo.mkdir()
+            env = _env(active=True)
+            env["PATH"] = self._restricted_path(base)
+
+            result = subprocess.run(
+                ["/bin/sh", str(ROOT / "scripts" / "hooks" / "pre-push")],
+                input="refs/heads/BadBranch abc refs/heads/BadBranch def\n",
+                cwd=str(repo),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn("WARN", result.stderr)
+
+    def test_pre_push_main_block_still_blocks_without_node(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            repo = base / "repo"
+            repo.mkdir()
+            env = _env(active=True)
+            env["PATH"] = self._restricted_path(base)
+
+            result = subprocess.run(
+                ["/bin/sh", str(ROOT / "scripts" / "hooks" / "pre-push")],
+                input="refs/heads/main abc refs/heads/main def\n",
+                cwd=str(repo),
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_index_map_aggregate.py
+++ b/tests/test_index_map_aggregate.py
@@ -41,7 +41,7 @@ class IndexMapAggregateTests(unittest.TestCase):
 
         self.assertIn("name: doc-sync", workflow)
         self.assertIn("actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", workflow)
-        self.assertIn("alruminum/dcNess/.github/actions/doc-sync@main", workflow)
+        self.assertIn("Daeguk-Sun/dcNess/.github/actions/doc-sync@main", workflow)
         self.assertNotIn("paths:", workflow)
         self.assertIn("scripts/aggregate_index_map.mjs", action)
         self.assertIn("scripts/aggregate_architecture_map.mjs", action)


### PR DESCRIPTION
## 배경 · 문제

플러그인 marketplace 공개 전, 신규 빈 저장소 관점 감사에서 나온 "출시 전 수정 권장 4건". 넷 다 dcNess 자기 저장소에서는 재현 불가능한 계열(라벨이 이미 있는 저장소 / node 가 이미 있는 기계 / 이미 완성된 CLAUDE.md)이라, 첫 외부 활성화 순간에만 드러난다. 사용자 지시로 추가 2건(README 문구·설명 한국어化)과 codex 리뷰 수정 1건이 뒤따랐다.

## 근본원인 · 작업내용

**항목 1 — stale username (배포 후 되돌릴 수 없는 유일 항목)** `447e30c` + `d0d01a8`
사용자 저장소로 복사되는 CI 템플릿 5종의 composite action `uses:` 참조와 `hooks/session-start.sh` 업데이트 확인이 옛 org `alruminum` 을 가리켰다. redirect 로 동작하나 네임스페이스 재등록 시 외부 CI 에서 남의 코드 실행 위험 + 배포 후 원격 정정 불가. → composite-action org 참조를 **같은 클래스 전수** `Daeguk-Sun` 치환: 배포 템플릿·자체 워크플로 주석·사용자 SSOT 문서(`hooks.md`·`init-dcness.md`)·잠금 테스트 2종. (후속 `d0d01a8`: `/.github/actions` 접미사 없는 산문 참조 `hooks.md:300` 1건 누락분 보정.) 이슈 하이퍼링크와 `docs/archive` 과거 명령 기록은 redirect-safe 역사라 보존.

**항목 2 — git hook fail-closed** `1572f7c`
`commit-msg`·`pre-push` 가 node 실행 실패(exit 127)를 형식 위반과 구분하지 않아 node 미설치 기계에서 활성화 직후 모든 commit/push 차단. → `command -v node` 선확인 후 부재 시 WARN + naming skip. `main` 직접 push 차단은 node 미사용 경로라 그대로 유지(테스트로 고정).

**항목 3 — 언어 불문 python3.11 시드** `f53bcbf` + `2bc72a5`
`build_claude_seed` 가 `tests/` 존재만으로 `python3.11 -m unittest` 를 시드. JS 저장소도 `tests/` 가 흔하고 python3.11 바이너리는 드물다. → **python 판정은 `harness/tdd_hooks.py` 의 `detect_platform` 을 SSOT 로 재사용**(pyproject.toml / requirements.txt / `.py` 파일 존재로 판정) + 버전 고정 대신 `python3`. 별도 좁은 마커 목록을 만들지 않아 drift 를 원천 차단.

**항목 4 — 신규 저장소 첫 이슈 등록 실패** `a1f47dd`
`create_epic_story_issues.sh` 가 `gh issue create -l vNN -l epic-NN-<slug>` 를 요구하나 `setup_labels.sh` 는 그 라벨을 안 만든다. → epic 이슈 생성 직전(VNN 확정 후) 필요한 label(epic·story·vNN·epic slug)을 create-if-missing(`|| true`)로 선반영. backfill·reject 경로는 이 지점 이전 exit → label 생성 0회(테스트로 고정).

**추가 1 — README `/to-issue` 문구** `3315467`
선등록 모델 전환 후에도 README 진입점 표가 구 문구 "승인 후 등록" 으로 남아 `positioning.md` 신 문구와 불일치. → "승인 대기 없이 GitHub 선등록 (web 에서 확인·수정)" 로 정합.

**추가 2 — marketplace·plugin 설명 한국어化** `afe5933`
배포 사용자 대면 텍스트가 사실상 100% 한국어인데 `plugin.json`/`marketplace.json` 의 `description` 만 영어. → 세 description 을 한국어로 통일 + "(한국어 사용자 대상)" 명시(대상 사용자 결정을 문서에 고정). version bump 불요(설명 텍스트만 변경).

## Test Plan

- 신규 TDD 7건 green: node fail-open 3(commit-msg skip · pre-push skip · pre-push main-block 유지) + seed 3(비-python skip · pyproject python3 · requirements.txt-only 회귀) + label 선upsert 1.
- `python3.11 -m unittest discover -s tests` → **1639 tests OK**.
- 게이트: cross-ref · doc-sync · plugin-manifest · public-surface · ruff · mypy · bandit · bash -n 전부 PASS. CI 11/11 PASS.
- codex 리뷰(`--scope branch --base main`) 2 라운드 수렴: 라운드1 P2(requirements.txt 회귀) → 근본 수정, 라운드2 clean PASS.

## 배포 경로 검증

- **경로 1 (plug-in 본체, 자동 적용)**: `hooks/session-start.sh` 업데이트 확인 org.
- **경로 2 (init-dcness 가 복사·배포)**: `templates/github-workflows/*.yml` 5종 — 사용자 CI 로 복사. **기존 활성 프로젝트는 플러그인 업데이트 후 `/init-dcness` 재실행 시 always-overwrite 로 갱신**. `scripts/create_epic_story_issues.sh`·`scripts/hooks/*` 도 배포/설치 경로.
- **경로 3 (사용자 SSOT 문서)**: `docs/plugin/hooks.md`·`init-dcness.md` composite action org.

## 범위 (정정)

- 본 PR 은 감사 4건 + 사용자 지시 추가 2건(README·설명 한국어化)을 **모두 포함**한다.
- 아직 범위 밖: 영어 README 준비(한국어-only 잠정 결정 후 대기), `author.name`="alruminum"(개인 저자 식별자 — `homepage`·`repository` 는 이미 Daeguk-Sun), 잔여 alruminum 이슈 하이퍼링크 일괄 정리(저위험 후보).

Document-Exception-PR-Close: 신규 GitHub 이슈 비연동 — marketplace 릴리즈 전 감사 후속(fresh env hardening), self 저장소 자유 형식 작업.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
