### PR TITLE
[docs] plugin-release 브랜치 예시 버전을 언더스코어 형식으로 정정

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -40,8 +40,9 @@ Sense→Diagnose→Decide→Act→Verify 루프를 따른다. 새 CI 게이트�
 - Verify: 핵심 행동 eval(`shorts-real-spec`, `headless-prose-quality`)은 릴리즈 체크 모드에서 N/N 통과해야 한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 [#894](https://github.com/alruminum/dcNess/issues/894) 보정 입력으로 남긴다.
 
 ```sh
-# 1. 브랜치 생성
-git checkout -b docs/release_{버전}_{설명} main
+# 1. 브랜치 생성 — 브랜치명 버전은 . 대신 _ (0.13.0 → 0_13_0).
+#    docs/{desc} 네이밍 게이트가 . 을 거부한다. (커밋 제목·태그·버전 파일은 . 유지)
+git checkout -b docs/release_0_13_0_{설명} main
 
 # 2. 버전 올리기
 #    .claude-plugin/plugin.json     "version" 필드
@@ -52,7 +53,7 @@ git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
 git commit -m "[docs] release {버전} — {설명}"
 
 # 4. PR 생성 → CI PASS → merge
-git push -u origin docs/release_{버전}_{설명}
+git push -u origin docs/release_0_13_0_{설명}
 gh pr create --title "[docs] release {버전} — {설명}" ...
 gh pr merge {번호} --merge
 


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 문서 papercut 정정 — 이슈 없는 follow-up

## 배경 및 문제

`docs/internal/plugin-release.md` 릴리즈 절차 예시가 브랜치명을 `docs/release_{버전}_{설명}` 으로 안내하는데, `{버전}` 을 `0.13.0` 처럼 그대로 치환하면 점(`.`)이 `docs/{desc}` 네이밍 게이트(`[a-z0-9_-]` 만 허용)에 걸려 브랜치 생성이 거부된다. v0.13.0 릴리즈 시 실제로 막혀 관례대로 `0_13_0` 언더스코어로 우회했다. 다음 릴리즈에서도 반복될 papercut.

## 작업내용

- 브랜치 생성/푸시 예시의 버전을 언더스코어 형식(`0_13_0`)으로 정정 + 이유 주석 추가.
- 커밋 제목·태그·버전 파일은 점(`.`) 유지임을 명시 (게이트 TITLE_RE·태그는 점 허용).

## 결정 근거

기존 릴리즈 브랜치 관례(`docs/release_0_12_0_*`, `docs/release_0_11_0_*`)와 일치시킴. placeholder 대신 concrete `0_13_0` 예시로 치환 모호성 제거.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 운영 문서(`docs/internal/`). 외부 배포물 아님.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A

## Test Plan

- [x] `node scripts/check_git_naming.mjs --branch docs/release_0_13_0_setup_hardening` → PASS (언더스코어 형식 게이트 통과 실증)

## 참고

- v0.13.0 릴리즈 PR: #945