### PR TITLE
[issue-948] 외부 활성 프로젝트 main 브랜치 직접 commit 차단

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -104,19 +104,19 @@ fi
 
 ### Core Step 4 - local git hook 설치
 
-브랜치명, 커밋 제목, main 직접 push 를 로컬에서 조기 차단한다. 본체 검증 로직은 사용자 repo 에 복사하지 않고 plug-in SSOT 를 직접 호출한다.
+브랜치명, 커밋 제목, main 직접 commit, main 직접 push 를 로컬에서 조기 차단한다. 본체 검증 로직은 사용자 repo 에 복사하지 않고 plug-in SSOT 를 직접 호출한다.
 
 ```bash
 mkdir -p "$PROJECT_ROOT/.git/hooks"
+cp "$PLUGIN_ROOT/scripts/hooks/pre-commit" "$PROJECT_ROOT/.git/hooks/pre-commit"
+chmod +x "$PROJECT_ROOT/.git/hooks/pre-commit"
 cp "$PLUGIN_ROOT/scripts/hooks/commit-msg" "$PROJECT_ROOT/.git/hooks/commit-msg"
 chmod +x "$PROJECT_ROOT/.git/hooks/commit-msg"
-echo "[dcness] .git/hooks/commit-msg 갱신 (thin shim -> plugin SSOT 호출)"
 cp "$PLUGIN_ROOT/scripts/hooks/post-checkout" "$PROJECT_ROOT/.git/hooks/post-checkout"
 chmod +x "$PROJECT_ROOT/.git/hooks/post-checkout"
-echo "[dcness] .git/hooks/post-checkout 갱신 (thin shim -> plugin SSOT 호출)"
 cp "$PLUGIN_ROOT/scripts/hooks/pre-push" "$PROJECT_ROOT/.git/hooks/pre-push"
 chmod +x "$PROJECT_ROOT/.git/hooks/pre-push"
-echo "[dcness] .git/hooks/pre-push 갱신 (thin shim -> plugin SSOT 호출)"
+echo "[dcness] .git/hooks/{pre-commit,commit-msg,post-checkout,pre-push} 갱신 (main 직접 commit 차단 + thin shim -> plugin SSOT 호출)"
 touch "$PROJECT_ROOT/.gitignore"
 grep -qxF '.claude/harness-state/' "$PROJECT_ROOT/.gitignore" || { printf '%s\n' '.claude/harness-state/' >> "$PROJECT_ROOT/.gitignore"; echo "[dcness] .gitignore 에 .claude/harness-state/ 추가"; }
 ```

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -253,12 +253,27 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 | Hook | Source | 언제 | 하는 일 | 차단 |
 |---|---|---|---|---|
+| `.git/hooks/pre-commit` | `scripts/hooks/pre-commit` | commit 직전 | main 직접 commit 차단 (+ self 는 python test gate) | O |
 | `.git/hooks/commit-msg` | `scripts/hooks/commit-msg` | commit message 확정 전 | 커밋 제목 git-spec 검증 | O |
 | `.git/hooks/post-checkout` | `scripts/hooks/post-checkout` | branch checkout/switch 직후 | 브랜치명 위반 경고 + rename 안내 | X |
 | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | push 직전 | main 직접 push 차단 + 브랜치명 검증 | O |
 
-활성 프로젝트 기준으로 `pre-commit` 은 기본 설치 대상이 아니다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
-git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또는 dcness self repo 판정 통과 뒤에만 수행한다. 비활성 외부 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. dcness self repo 는 plugin hook 전체를 active 로 만들지 않고, self 작업 중 발생한 `commit-msg` / `pre-push` 차단 신호만 git hook shim 기록 지점에서 보존한다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. dcness self 작업용 `pre-commit` 은 `guard=git-pre-commit` 으로 main 직접 commit 차단과 python test gate 실패를 기록할 수 있지만, 외부 활성 프로젝트의 report 기본 known guard 후보에는 포함하지 않는다.
+`pre-commit` 은 외부 활성 프로젝트에도 배포되지만 그 역할은 main 직접 commit 차단 전용이다. python test gate 단계는 `scripts/check_python_tests.sh` 가 존재할 때만 실행되므로 그 스크립트가 없는 외부 repo 에서는 main-block 만 강제한다. TDD 강제는 git hook 이 아니라 Layer 1 의 `tdd-guard.sh` 가 구현 파일 작성 전에 수행한다.
+git hook 차단도 같은 telemetry 체계를 쓰되, 기록은 `is-active` 또는 dcness self repo 판정 통과 뒤에만 수행한다. 비활성 외부 프로젝트에서 남아 있는 git hook 이 차단하더라도 `guard-telemetry.jsonl` 을 만들지 않는다. dcness self repo 는 plugin hook 전체를 active 로 만들지 않고, self 작업 중 발생한 `pre-commit` / `commit-msg` / `pre-push` 차단 신호만 git hook shim 기록 지점에서 보존한다. `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 가 있는 headless worker 컨텍스트에서는 active run 로그에 귀속하고, 없으면 프로젝트 로그에 fallback 한다. `commit-msg` 차단은 `guard=git-commit-msg`, `pre-push` 차단은 `guard=git-pre-push` 로 기록된다. `pre-commit` 의 main 직접 commit 차단과 python test gate 실패는 `guard=git-pre-commit` 으로 기록되며, 외부 활성 프로젝트에도 배포되므로 report 기본 known guard 후보에 포함한다.
+
+### .git/hooks/pre-commit
+
+**Source**: `scripts/hooks/pre-commit`
+
+**시점**: `git commit` 이 커밋을 만들기 직전.
+
+**역할**:
+
+- 현재 브랜치가 `main` 이면 commit 을 차단한다 (branch → PR → merge 절차 강제). 외부 활성 프로젝트에도 동일 적용된다.
+- `scripts/check_python_tests.sh` 가 존재하는 repo(사실상 dcness self)에서만 python test gate 를 실행한다. 외부 활성 프로젝트에는 이 스크립트가 없어 main-block 만 강제한다.
+
+**차단**: main 브랜치 commit 또는 (self 에서) python test gate 실패 시 commit 실패.
+차단 시 `guard-telemetry.jsonl` 에 `category=main_block` 또는 `category=python_tests` hit 가 남는다.
 
 ### .git/hooks/commit-msg
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -24,6 +24,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 |---|---|---|---|---|---|
 | 활성 whitelist | `~/.claude/plugins/data/dcness-dcness/projects.json` | `harness/session_state.py` | 항상 | 중복 제거 | X |
 | Read 권한 | `~/.claude/settings.json` | `/init-dcness` jq patch | 항상 | 없을 때만 추가 | X |
+| local git hook | `.git/hooks/pre-commit` | `scripts/hooks/pre-commit` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/commit-msg` | `scripts/hooks/commit-msg` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/post-checkout` | `scripts/hooks/post-checkout` | 항상 | always-overwrite | X |
 | local git hook | `.git/hooks/pre-push` | `scripts/hooks/pre-push` | 항상 | always-overwrite | X |

--- a/harness/guard_telemetry.py
+++ b/harness/guard_telemetry.py
@@ -30,10 +30,9 @@ DISTRIBUTED_KNOWN_GUARDS: tuple[str, ...] = (
     "tdd-guard",
     "git-commit-msg",
     "git-pre-push",
-)
-SELF_ONLY_KNOWN_GUARDS: tuple[str, ...] = (
     "git-pre-commit",
 )
+SELF_ONLY_KNOWN_GUARDS: tuple[str, ...] = ()
 KNOWN_GUARDS: tuple[str, ...] = DISTRIBUTED_KNOWN_GUARDS
 
 _DETAIL_MAX = 500

--- a/harness/session_state_status.py
+++ b/harness/session_state_status.py
@@ -11,7 +11,7 @@ from harness.session_state_activation import _resolve_project_root, is_project_a
 from harness.session_state_fail_open import collect_fail_open_summary, _format_fail_open_summary
 
 _READ_PERM = "Read(~/.claude/plugins/cache/dcness/**)"
-_GIT_HOOK_SHIMS = ("commit-msg", "post-checkout", "pre-push")
+_GIT_HOOK_SHIMS = ("commit-msg", "post-checkout", "pre-push", "pre-commit")
 _SHIM_MARKERS = ("plugins/cache/dcness", "CLAUDE_PLUGIN_ROOT")
 _CI_WORKFLOWS = (
     "git-naming-validation.yml",

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -5,8 +5,8 @@
 #   cp scripts/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 #
 # 게이트:
-#   1. main 직접 commit 차단 (모든 commit)
-#   2. python-tests (관련 staged 파일이 있을 때만)
+#   1. main 직접 commit 차단 (모든 commit — 외부 활성 프로젝트 포함, /init-dcness 배포)
+#   2. python-tests (scripts/check_python_tests.sh 존재 시에만 — 사실상 dcness self 전용)
 
 set -e
 
@@ -34,6 +34,13 @@ resolve_dcness_root() {
 record_guard_hit() {
   root="$(resolve_dcness_root 2>/dev/null || true)"
   [ -n "$root" ] || return 0
+  if PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.session_state is-active >/dev/null 2>&1; then
+    :
+  elif PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.session_state is-self >/dev/null 2>&1; then
+    :
+  else
+    return 0
+  fi
   PYTHONPATH="${root}:${PYTHONPATH:-}" python3 -m harness.guard_telemetry record-hit \
     --guard git-pre-commit \
     --category "$1" \
@@ -56,7 +63,9 @@ if [ "$current_branch" = "main" ]; then
   exit 1
 fi
 
-if ! sh scripts/check_python_tests.sh; then
-  record_guard_hit "python_tests" "pre-commit python test gate failed"
-  exit 1
+if [ -f scripts/check_python_tests.sh ]; then
+  if ! sh scripts/check_python_tests.sh; then
+    record_guard_hit "python_tests" "pre-commit python test gate failed"
+    exit 1
+  fi
 fi

--- a/tests/test_git_hook_guard_telemetry.py
+++ b/tests/test_git_hook_guard_telemetry.py
@@ -67,6 +67,47 @@ class GitHookGuardTelemetryTests(unittest.TestCase):
                 events,
             )
 
+    def test_pre_commit_feature_branch_passes_without_python_gate_script(self) -> None:
+        # 외부 활성 프로젝트에는 scripts/check_python_tests.sh 가 없다 — python 게이트는
+        # 스크립트가 있는 repo(사실상 dcness self)에서만 돌고, 부재 시 commit 을 막지 않는다.
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            _git(root, "init")
+            _git(root, "checkout", "-b", "feature/external_work")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-commit")],
+                cwd=str(root),
+                env=_env(active=True),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+
+    def test_inactive_pre_commit_block_does_not_create_telemetry(self) -> None:
+        # 비활성 외부 프로젝트: main-block 차단은 유지하되 telemetry 는 남기지 않는다
+        # (commit-msg / pre-push 와 동일 계약).
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "repo"
+            root.mkdir()
+            _git(root, "init")
+            _git(root, "checkout", "-b", "main")
+
+            result = subprocess.run(
+                ["sh", str(ROOT / "scripts" / "hooks" / "pre-commit")],
+                cwd=str(root),
+                env=_env(whitelist_path=base / "projects.json"),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr + result.stdout)
+            self.assertEqual(read_events(cwd=root), [])
+
     def test_commit_msg_naming_block_records_guard_hit(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_guard_telemetry.py
+++ b/tests/test_guard_telemetry.py
@@ -207,14 +207,14 @@ class GuardSummaryTests(unittest.TestCase):
                 "insufficient_observation",
             )
 
-    def test_default_report_known_guards_exclude_self_only_pre_commit(self) -> None:
+    def test_default_report_known_guards_include_distributed_pre_commit(self) -> None:
         with TemporaryDirectory() as td:
             root = Path(td)
             summary = collect_guard_summary(cwd=root, idle_days=30)
 
             self.assertIn("git-commit-msg", summary["guards"])
             self.assertIn("git-pre-push", summary["guards"])
-            self.assertNotIn("git-pre-commit", summary["guards"])
+            self.assertIn("git-pre-commit", summary["guards"])
 
 
 class EvalSummaryTests(unittest.TestCase):

--- a/tests/test_skill_scenarios.py
+++ b/tests/test_skill_scenarios.py
@@ -219,11 +219,12 @@ class SkillScenarioRegressionTests(unittest.TestCase):
             )
 
     def test_init_dcness_core_hooks_listed(self) -> None:
-        """핵심 thin-shim hook 3개가 deploy 섹션에 명시돼야 한다 (배포 누락 차단)."""
+        """핵심 thin-shim hook 4개가 deploy 섹션에 명시돼야 한다 (배포 누락 차단)."""
         for hook in (
             "scripts/hooks/commit-msg",
             "scripts/hooks/post-checkout",
             "scripts/hooks/pre-push",
+            "scripts/hooks/pre-commit",
         ):
             self.assertIn(hook, self.init_doc)
 

--- a/tests/test_status_diagnostics.py
+++ b/tests/test_status_diagnostics.py
@@ -139,7 +139,7 @@ class GitHooksTests(unittest.TestCase):
     def test_thin_shim_ok(self) -> None:
         with TemporaryDirectory() as td:
             hd = Path(td)
-            for name in ("commit-msg", "post-checkout", "pre-push"):
+            for name in ("commit-msg", "post-checkout", "pre-push", "pre-commit"):
                 self._shim(hd, name)
             result = _check_git_hooks(hd)
             self.assertEqual(set(result.values()), {"ok"})

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -358,7 +358,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         git_hooks = set(
             re.findall(r'scripts/hooks/([A-Za-z0-9_.-]+)"', self.init_doc)
         )
-        self.assertEqual({"commit-msg", "post-checkout", "pre-push"}, git_hooks)
+        self.assertEqual({"commit-msg", "post-checkout", "pre-push", "pre-commit"}, git_hooks)
         for hook_name in sorted(git_hooks):
             self.assertIn(f"### .git/hooks/{hook_name}", self.hooks_doc)
             self.assertIn(f"`scripts/hooks/{hook_name}`", self.hooks_doc)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #948

## 배경 및 문제

외부 활성 프로젝트에서 `main` 브랜치에 직접 `git commit` 이 차단되지 않았다. `/init-dcness` 온보딩 메시지(`commands/init-dcness.md:183`)는 "코드로 막는 것은 … git main 직접 commit/push" 라고 명시하지만, 실제 배포 hook 은 `commit-msg` / `post-checkout` / `pre-push` 만 복사하고 `pre-commit` 은 배포하지 않아 main 직접 commit 이 로컬에 쌓이고 push 시점에만 걸렸다 (주장 vs 배포 불일치). v0.13.0 신선 환경 스모크(#947) Phase 2 에서 발견.

## 원인

- `commands/init-dcness.md` Core Step 4 가 `pre-commit`(main 브랜치 commit 차단)을 배포하지 않았다.
- `scripts/hooks/pre-commit` 은 python test gate 를 무조건 실행해 `scripts/check_python_tests.sh` 가 없는 외부 repo 에 그대로 배포하면 모든 commit 이 차단되는 self 종속이 있었다.
- `record_guard_hit` 이 `is-active`/`is-self` 판정 없이 기록해 "비활성 프로젝트 무기록" 계약(hooks.md Layer 2)과 어긋났다.

## 작업내용

- `scripts/hooks/pre-commit`: (a) python gate 를 `scripts/check_python_tests.sh` 존재 시에만 실행하도록 조건화, (b) telemetry 를 `pre-push` 와 동일한 `is-active → is-self → return 0` 게이트로 미러, (c) 헤더 주석 갱신. 단일 스크립트 유지 — 슬림 사본 분리·PreToolUse 게이트 추가 없음.
- `harness/guard_telemetry.py`: `git-pre-commit` 을 `SELF_ONLY_KNOWN_GUARDS` → `DISTRIBUTED_KNOWN_GUARDS` 로 이동, `SELF_ONLY_KNOWN_GUARDS` 는 빈 튜플(외부 consumer 없음).
- `harness/session_state_status.py`: `_GIT_HOOK_SHIMS` 에 `pre-commit` 추가 (`dcness-helper status` 진단표).
- `commands/init-dcness.md`: Core Step 4 cp 블록에 `pre-commit` 추가 + prose 에 "main 직접 commit" 추가. per-hook echo 4개를 통합 echo 1개로 줄여 라인 순증 0 — `test_init_doc_is_execution_runbook_not_hook_policy_reference` 의 500라인 lean-runbook 게이트(#690) 준수. 온보딩 문구(183행)는 이 구현으로 사실이 되므로 수정하지 않음.
- `docs/plugin/init-dcness.md`, `docs/plugin/hooks.md`: 배포 inventory 표 + Layer 2 표/서술/`### .git/hooks/pre-commit` 서브섹션 갱신.
- tests: `test_git_hook_guard_telemetry.py` 에 신규 2케이스(외부 feature 브랜치 python gate 부재 통과 / 비활성 main-block 무기록) + 기존 5파일 기대값 반전·확장.

## 결정 근거

방법 후보 중 **기존 단일 스크립트 유지 + pytest 게이트 존재-조건화**를 택했다 (이슈 handoff 확정). 슬림 사본 분리는 shim 미러 drift 를 만들고, PreToolUse Bash 게이트는 git hook 계층과 중복 강제라 배제. echo 통합은 500라인 하드 게이트와 필수 hook 추가의 tension 을 lean-runbook 취지(#690) 방향으로 해소한 것으로, 개별 echo 문자열에 의존하는 테스트가 없음을 확인 후 적용.

## 배포 경로 검증 (plug-in 영향 시)

- **경로 1 (plug-in 본체 파일 — plugin 업데이트 시 자동 적용)**: `harness/guard_telemetry.py`, `harness/session_state_status.py`.
- **경로 2 (`/init-dcness` 가 사용자 repo 로 복사·배포)**: `scripts/hooks/pre-commit` + `commands/init-dcness.md` Core Step 4. 기존 활성 프로젝트는 `/init-dcness` 재실행으로 수령(always-overwrite).
- **경로 3 (사용자가 따라야 하는 SSOT 문서)**: `docs/plugin/hooks.md`, `docs/plugin/init-dcness.md`.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public 진입점 없음. 기존 `pre-commit` git hook 을 외부 배포 목록에 추가한 것으로, 새 surface 를 늘리지 않는다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 — `python3.11 -m unittest discover -s tests -v < /dev/null` → 1641 tests OK
- [x] 회귀 검증 — `python3.11 evals/guard_efficacy.py` → 33/33 passed (hook 변경 권고 게이트)

## 참고

- 발견: #947 스모크 Phase 2. main 직접 **push** 차단은 이미 정상 동작이라 out of scope.
