### PR TITLE
[feature] docs/index.md 에픽 표에 파생 다음 액션 컬럼 추가

### DIFF
--- a/.github/workflows/doc-sync.yml
+++ b/.github/workflows/doc-sync.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/**'
       - 'scripts/aggregate_index_map.mjs'
       - 'scripts/aggregate_architecture_map.mjs'
+      - 'scripts/lib/**'
       - '.github/actions/doc-sync/**'
       - '.github/workflows/doc-sync.yml'
 

--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -82,7 +82,7 @@ docs/
 
 `docs/architecture.md` 는 epic 이 늘 때마다 append-growing map 으로 갱신한다. 상세 설계 본문을 전역에 복제하지 않고, 전역 모듈/의존/결정 anchor 와 epic 문서 링크를 추가한다.
 
-`docs/index.md` 는 cold-start agent 의 정적 entrypoint 다. `## 에픽` 표는 `docs/epics/epic-NN-*` 디렉토리와 `stories.md` frontmatter `milestone` 값에서 파생되는 생성 섹션이며 수동 편집하지 않는다. 모듈 축을 쓰는 프로젝트에서는 `## 모듈` 표도 `docs/modules/<module-id>/` 에서 파생된다. live 진행상태를 문서에 복제하지 않고, 수동 섹션 `## 진행 상태 · 다음 작업` 에서 GitHub issue/label 상태, epic/story issue, `/next-work` 를 가리킨다. `/init-dcness` 는 기존 `docs/index.md` 를 overwrite 하지 않지만, 이 섹션이 없으면 `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs` 로 섹션만 append 한다.
+`docs/index.md` 는 cold-start agent 의 정적 entrypoint 다. `## 에픽` 표는 `docs/epics/epic-NN-*` 디렉토리와 `stories.md` frontmatter `milestone` 값에서 파생되는 생성 섹션이며 수동 편집하지 않는다. `다음 액션` 컬럼은 산출물 존재만으로 epic 단위 phase 를 파생한다: `stories.md` 부재면 `/spec`, `stories.md` 는 있으나 설계 미완이면 `/design`, 설계 완료면 `/impl`. 설계 완료 판정은 `architecture.md` 존재 AND `impl/NN-*.md` 1개 이상 존재이며(선택 산출물 `domain-model.md`·`ux-flow.md`·`tech-review.md` 부재는 미완으로 보지 않는다), auto-memory 없이도 콜드스타트 다음 액션을 자족적으로 확정하기 위한 것이다. 모듈 축을 쓰는 프로젝트에서는 `## 모듈` 표도 `docs/modules/<module-id>/` 에서 파생된다. live 진행상태를 문서에 복제하지 않고, 수동 섹션 `## 진행 상태 · 다음 작업` 에서 GitHub issue/label 상태, epic/story issue, `/next-work` 를 가리킨다. `/init-dcness` 는 기존 `docs/index.md` 를 overwrite 하지 않지만, 이 섹션이 없으면 `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs` 로 섹션만 append 한다.
 
 `$PLUGIN_ROOT/scripts/aggregate_index_map.mjs` 는 각 epic 폴더와 opt-in module 폴더를 결정적으로 정렬하고 `docs/index.md` 의 `## 에픽` / `## 모듈` 표를 생성/갱신한다. 파일이 없는 선택 산출물 셀은 링크가 아닌 `—` 로 남긴다. `docs/modules/` 가 없으면 모듈 표는 생성하지 않아 단일 루트 프로젝트의 기존 index 동작을 바꾸지 않는다. 기존 `docs/index.md` 에 수동 `## 모듈` 섹션이 있으면 모듈 축 활성화 시 생성 섹션으로 교체되므로, 수동 설명은 다른 heading 으로 옮긴 뒤 집계기를 실행한다.
 

--- a/scripts/aggregate_index_map.mjs
+++ b/scripts/aggregate_index_map.mjs
@@ -19,6 +19,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { dirname, join, relative, resolve, sep } from 'node:path';
+import { epicPhase } from './lib/epic_phase.mjs';
 
 const SECTION_EPICS = '에픽';
 const SECTION_MODULES = '모듈';
@@ -114,6 +115,7 @@ function collectEpics(root) {
         uxFlowPath: join(epicDir, 'ux-flow.md'),
         techReviewPath: join(epicDir, 'tech-review.md'),
         milestone: parseFrontmatterValue(storiesContent, 'milestone') || PLACEHOLDER,
+        nextAction: epicPhase(epicDir).label,
       };
     });
 }
@@ -161,13 +163,14 @@ function buildEpicTable(indexPath, epics) {
     optionalFileLink('domain-model.md', indexPath, epic.domainModelPath),
     optionalFileLink('ux-flow.md', indexPath, epic.uxFlowPath),
     optionalFileLink('tech-review.md', indexPath, epic.techReviewPath),
+    epic.nextAction,
   ]);
 
   return table(
-    ['에픽', '마일스톤', 'Stories', 'Architecture', 'Domain Model', 'UX Flow', 'Tech Review'],
+    ['에픽', '마일스톤', 'Stories', 'Architecture', 'Domain Model', 'UX Flow', 'Tech Review', '다음 액션'],
     rows.length > 0
       ? rows
-      : [[PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER]]
+      : [[PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER, PLACEHOLDER]]
   );
 }
 

--- a/scripts/check_python_tests.sh
+++ b/scripts/check_python_tests.sh
@@ -4,7 +4,7 @@
 #
 # 동작:
 #   1. staged 파일 목록 추출 (git diff --cached --name-only)
-#   2. harness/ | tests/ | agents/ | skills/ | commands/ | templates/github-workflows/ | audited scripts | doc-path/doc-sync action/script | .github/workflows/python-tests.yml 매칭 시만 실행
+#   2. harness/ | tests/ | agents/ | skills/ | commands/ | templates/github-workflows/ | audited scripts (aggregate_*_map, scripts/lib/ 파생 helper 포함) | doc-path/doc-sync action/script | .github/workflows/python-tests.yml 매칭 시만 실행
 #   3. python3.11/python3 -m unittest discover -s tests
 #
 # 종료 코드:
@@ -26,7 +26,7 @@ if [ -z "$CHANGED" ]; then
   exit 0
 fi
 
-if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|skills/|commands/|templates/github-workflows/|evals/|\.github/actions/(doc-path-integrity|doc-sync)/|scripts/check_git_naming\.mjs$|scripts/check_doc_path_integrity\.mjs$|scripts/check_design_artifact_structure\.mjs$|scripts/aggregate_(index|architecture)_map\.mjs$|docs/plugin/git-spec\.md$|docs/plugin/loop-procedure\.md$|\.github/workflows/python-tests\.yml$)'; then
+if ! printf '%s\n' "$CHANGED" | grep -qE '^(harness/|tests/|agents/|skills/|commands/|templates/github-workflows/|evals/|\.github/actions/(doc-path-integrity|doc-sync)/|scripts/check_git_naming\.mjs$|scripts/check_doc_path_integrity\.mjs$|scripts/check_design_artifact_structure\.mjs$|scripts/aggregate_(index|architecture)_map\.mjs$|scripts/lib/|docs/plugin/git-spec\.md$|docs/plugin/loop-procedure\.md$|\.github/workflows/python-tests\.yml$)'; then
   # 미매칭 — skip
   exit 0
 fi

--- a/scripts/lib/epic_phase.mjs
+++ b/scripts/lib/epic_phase.mjs
@@ -1,0 +1,49 @@
+/**
+ * Epic 의 현재 phase 와 다음 액션을 durable 산출물(파일 존재)만으로 파생하는 SSOT helper.
+ *
+ * 콜드스타트 세션이 auto-memory 없이도 "spec 완료 → design 차례" 같은 다음 액션을
+ * dcNess 산출물만으로 확정하게 하려는 공용 판정. 같은 신호를 두 곳에서 계산하지 않도록
+ * 여기 한 곳에 둔다:
+ *  - scripts/aggregate_index_map.mjs — docs/index.md `## 에픽` 표의 `다음 액션` 파생 컬럼
+ *  - scripts/github_project_lifecycle.mjs next-work — epic별 `/design` vs `/impl` 구분
+ *
+ * 설계 완료 판정 기준 (docs/plugin/deliverables-map.md full design pack):
+ *   architecture.md 존재 AND impl/NN-*.md 1개 이상 존재.
+ *   domain-model.md / ux-flow.md / tech-review.md 는 선택 산출물이라 판정에서 제외한다
+ *   (선택 산출물 부재를 설계 미완으로 오판하지 않는다).
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const IMPL_TASK_RE = /^\d+-.*\.md$/;
+
+export function hasImplTask(epicDir) {
+  const implDir = join(epicDir, 'impl');
+  if (!existsSync(implDir)) return false;
+  try {
+    return readdirSync(implDir, { withFileTypes: true }).some(
+      (entry) => entry.isFile() && IMPL_TASK_RE.test(entry.name)
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isDesignComplete(epicDir) {
+  return existsSync(join(epicDir, 'architecture.md')) && hasImplTask(epicDir);
+}
+
+/**
+ * @param {string} epicDir  docs/epics/epic-NN-<slug> 절대/상대 경로
+ * @returns {{ phase: 'spec'|'design'|'impl', action: '/spec'|'/design'|'/impl', label: string }}
+ *   label = docs/index.md 셀·next-work 출력에 넣는 사람이 읽는 문구.
+ */
+export function epicPhase(epicDir) {
+  if (!existsSync(join(epicDir, 'stories.md'))) {
+    return { phase: 'spec', action: '/spec', label: '`/spec` (스펙 미작성)' };
+  }
+  if (!isDesignComplete(epicDir)) {
+    return { phase: 'design', action: '/design', label: '`/design` (설계 미완)' };
+  }
+  return { phase: 'impl', action: '/impl', label: '`/impl` (설계 완료)' };
+}

--- a/skills/spec/templates/index.md
+++ b/skills/spec/templates/index.md
@@ -18,9 +18,9 @@
 
 <!-- dcness-index-map:generated -->
 <!-- 수정하지 말고 plugin script `aggregate_index_map.mjs` 로 갱신한다. -->
-| 에픽 | 마일스톤 | Stories | Architecture | Domain Model | UX Flow | Tech Review |
-| --- | --- | --- | --- | --- | --- | --- |
-| — | — | — | — | — | — | — |
+| 에픽 | 마일스톤 | Stories | Architecture | Domain Model | UX Flow | Tech Review | 다음 액션 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| — | — | — | — | — | — | — | — |
 
 ## 진행 상태 · 다음 작업
 

--- a/tests/test_index_map_aggregate.py
+++ b/tests/test_index_map_aggregate.py
@@ -94,16 +94,63 @@ class IndexMapAggregateTests(unittest.TestCase):
             self.assertIn("<!-- dcness-index-map:generated -->", index)
             self.assertNotIn("old content", index)
             self.assertIn(
-                "| [epic-01-alpha](epics/epic-01-alpha/) | v01 | [stories.md](epics/epic-01-alpha/stories.md) | [architecture.md](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | — | — |",
+                "| [epic-01-alpha](epics/epic-01-alpha/) | v01 | [stories.md](epics/epic-01-alpha/stories.md) | [architecture.md](epics/epic-01-alpha/architecture.md) | [domain-model.md](epics/epic-01-alpha/domain-model.md) | — | — | `/design` (설계 미완) |",
                 index,
             )
             self.assertIn(
-                "| [epic-02-beta](epics/epic-02-beta/) | — | [stories.md](epics/epic-02-beta/stories.md) | — | — | — | [tech-review.md](epics/epic-02-beta/tech-review.md) |",
+                "| [epic-02-beta](epics/epic-02-beta/) | — | [stories.md](epics/epic-02-beta/stories.md) | — | — | — | [tech-review.md](epics/epic-02-beta/tech-review.md) | `/design` (설계 미완) |",
                 index,
             )
 
             check = _run(project, "--check")
             self.assertEqual(check.returncode, 0, check.stderr)
+
+    def test_epic_table_derives_next_action_column(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(project / "docs/index.md", "# Index\n\n## 에픽\n\n")
+            # 설계 미완: stories 만 존재
+            _write(project / "docs/epics/epic-01-alpha/stories.md", "# Story Backlog\n")
+            # 설계 완료: architecture + impl task 존재
+            _write(project / "docs/epics/epic-02-beta/stories.md", "# Story Backlog\n")
+            _write(project / "docs/epics/epic-02-beta/architecture.md", "# Architecture\n")
+            _write(project / "docs/epics/epic-02-beta/impl/01-foo.md", "# Task\n")
+            # 설계 미완: architecture 는 있으나 impl task 부재 (핵심 엣지)
+            _write(project / "docs/epics/epic-03-gamma/stories.md", "# Story Backlog\n")
+            _write(project / "docs/epics/epic-03-gamma/architecture.md", "# Architecture\n")
+            # 스펙 미작성: stories.md 부재 (에픽 디렉토리만 존재)
+            _write(project / "docs/epics/epic-04-delta/notes.md", "placeholder\n")
+
+            proc = _run(project)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            index = (project / "docs/index.md").read_text(encoding="utf-8")
+            self.assertIn(
+                "| 에픽 | 마일스톤 | Stories | Architecture | Domain Model | UX Flow | Tech Review | 다음 액션 |",
+                index,
+            )
+            self.assertRegex(index, r"epic-01-alpha.*\| `/design` \(설계 미완\) \|")
+            self.assertRegex(index, r"epic-02-beta.*\| `/impl` \(설계 완료\) \|")
+            self.assertRegex(index, r"epic-03-gamma.*\| `/design` \(설계 미완\) \|")
+            self.assertRegex(index, r"epic-04-delta.*\| `/spec` \(스펙 미작성\) \|")
+
+            check = _run(project, "--check")
+            self.assertEqual(check.returncode, 0, check.stderr)
+
+    def test_impl_task_must_match_nn_prefix_for_design_complete(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            _write(project / "docs/index.md", "# Index\n\n## 에픽\n\n")
+            _write(project / "docs/epics/epic-01-alpha/stories.md", "# Story Backlog\n")
+            _write(project / "docs/epics/epic-01-alpha/architecture.md", "# Architecture\n")
+            # impl/ 에 NN- prefix 아닌 파일만 있으면 설계 완료로 보지 않는다
+            _write(project / "docs/epics/epic-01-alpha/impl/README.md", "# Notes\n")
+
+            proc = _run(project)
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+
+            index = (project / "docs/index.md").read_text(encoding="utf-8")
+            self.assertRegex(index, r"epic-01-alpha.*\| `/design` \(설계 미완\) \|")
 
     def test_check_fails_when_index_table_is_stale(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## 배경·문제

콜드스타트 세션이 "spec 완료 → design 차례" 같은 **현재 phase / 다음 액션**을 dcNess durable 산출물만으로 확정하지 못했다. 이 phase 신호가 명시적으로 있던 유일한 곳은 Claude Code auto-memory 였고, `docs/index.md` 에픽 표는 산출물 링크(✓/—)만 보여줘 "빈 컬럼 = 설계 필요 = /design" 은 다단계 추론이라 약했다.

## 근본원인

산출물 존재를 **명시적 다음 액션으로 파생하는 곳이 아예 없었다.** 산출물 링크 컬럼은 "무엇이 있나"만 보여줄 뿐 "그래서 다음에 뭘 하나"를 인코딩하지 않았다. 그래서 phase 판단이 auto-memory(비-durable)로 새어나갔다.

## 작업내용

- `scripts/lib/epic_phase.mjs` (신규): epic 단위 phase / 다음 액션을 산출물 존재만으로 파생하는 **SSOT helper**.
  - `stories.md` 부재 → `/spec`, `stories.md` 있고 설계 미완 → `/design`, 설계 완료 → `/impl`.
  - 설계 완료 판정 = `architecture.md` 존재 **AND** `impl/NN-*.md` 1개 이상 (선택 산출물 `domain-model.md`·`ux-flow.md`·`tech-review.md` 부재는 미완으로 오판 안 함).
- `scripts/aggregate_index_map.mjs`: `## 에픽` 생성 표에 파생 **`다음 액션`** 컬럼 append (rightmost, 기존 컬럼 위치 보존).
- `skills/spec/templates/index.md`: 시드 표를 8컬럼으로 동기화 (템플릿 freshness 유지).
- `docs/plugin/deliverables-map.md`: 파생 규격(SSOT) 명시.

## 결정근거

- **파생 컬럼 방식** (이슈 선행 결정 #2): 에픽 표는 생성 섹션이므로 phase 도 수동이 아닌 파생으로 넣는다.
- **판정 SSOT 단일화** (이슈 선행 결정 #1 + 짝 이슈 #951): 같은 "설계 완료" 신호를 #950(docs/index.md)과 #951(`/next-work`)이 중복 계산하면 drift 난다. 신규 `epic_phase.mjs` 한 곳에 두어 #951(`github_project_lifecycle.mjs`, ESM·상대 import 가능·현재 phase 로직 없음)이 그대로 import 하도록 준비. 본 PR 은 #950 범위(docs/index.md 소비)만 구현하고 `github_project_lifecycle.mjs` 는 건드리지 않음.

## Test Plan

- TDD: 파생 컬럼 부재 상태에서 실패 테스트 선작성 → 구현 → green.
- `tests/test_index_map_aggregate.py`: 설계 미완(stories만)/설계 완료(arch+impl)/arch 있으나 impl 부재/stories 부재 4케이스 + `impl/` 의 non-NN 파일은 완료로 안 보는 회귀 케이스 추가. 기존 2 assertion 8컬럼 갱신.
- `python3.11 -m unittest discover -s tests` → 1643 tests OK.
- `node scripts/check_cross_refs.mjs` PASS, `check_plugin_manifest.mjs` PASS, `check_public_surface.mjs` PASS, self-repo `aggregate_index_map.mjs --check` no-op PASS.

## 배포 경로 검증

- **경로 1 (plugin 본체, 자동 도달)**: `aggregate_index_map.mjs` + 신규 `scripts/lib/epic_phase.mjs` 는 외부 프로젝트에서 `$PLUGIN_ROOT` 로 실행된다. helper 는 aggregate 가 상대 경로(`./lib/epic_phase.mjs`)로 import 하므로 plugin 업데이트만으로 함께 도달 — init-dcness 복사 스텝 불요.
- **경로 2 (init-dcness 복사)**: 해당 없음 (신규 복사 파일 없음).
- **경로 3 (SSOT 문서)**: `docs/plugin/deliverables-map.md` 갱신.
- **마이그레이션 주의** (선행 결정 #3): 에픽 표 컬럼 수가 7→8 로 바뀌므로, `doc-sync.yml` 을 이미 설치한 기존 활성 프로젝트는 plugin 업데이트 후 첫 docs PR 에서 `aggregate_index_map.mjs --check` 가 stale FAIL 한다. 프로젝트 루트에서 `node "$PLUGIN_ROOT/scripts/aggregate_index_map.mjs"` 1회 재생성으로 자가 치유되며(FAIL 메시지가 그대로 안내), 이는 `commands/init-dcness.md` 의 기존 재생성 안내와 동일 경로다. 릴리즈 시 릴리즈 노트에 재생성 1회 안내 명시 예정.

Closes #950