### PR TITLE
[feature] next-work story 나열에 epic 설계 phase(/design vs /impl) 구분 추가

### DIFF
--- a/commands/next-work.md
+++ b/commands/next-work.md
@@ -34,7 +34,7 @@ node "$SCRIPT" next-work --repo OWNER/REPO
 - `subTask` 는 독립 후보에서 제외하고, body 의 `Part of #N` 부모가 L1 에 있을 때만 그 부모 아래에 중첩 표시한다.
 - story 후보는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순으로 표시한다.
 - story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. 설계 미완 epic 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, 설계 완료 epic 만 story 를 impl 후보로 승격한다. 로컬에 해당 epic 산출물이 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 판정을 보류한다.
-- 로컬 산출물은 *현재 checkout* 의 repo 를 서술하므로, `--repo` 로 현재 로컬 checkout 과 다른 repo 를 지정하면 로컬 phase 판정을 쓰지 않고 전부 보류한다(엉뚱한 repo 의 설계 산출물로 `/design`/`/impl` 을 오판하지 않는다).
+- 로컬 산출물은 *현재 git checkout* 의 repo 를 서술하므로, 대상 repo(issue 출처)가 현재 checkout 의 git remote 와 다르면(`--repo`/`GH_REPO` override 등) 로컬 phase 판정을 쓰지 않고 전부 보류한다(엉뚱한 repo 의 설계 산출물로 `/design`/`/impl` 을 오판하지 않는다). 로컬 repo 식별은 `gh` 가 아니라 git remote 에서 뽑아 override 에 영향받지 않는다.
 - Priority 는 Issue Brief 본문의 `Priority` 줄을 파싱한다. 없거나 invalid 면 `priority 미기재` 로 표시하고 그룹 뒤에 둔다.
 - GitHub 조회가 실패하면 실패를 명시하고 로컬 대안 경로를 안내한다.
 

--- a/commands/next-work.md
+++ b/commands/next-work.md
@@ -30,7 +30,7 @@ node "$SCRIPT" next-work --repo OWNER/REPO
 
 - read-only: `--apply` 를 쓰지 않고, issue/label/Project/PR 상태를 변경하지 않는다.
 - Project 좌표나 bootstrap 없이 open issue 목록만으로 동작한다.
-- 출력 계층은 L1 `in-progress` 이어하기 → L2 blocker/critical 긴급 → L3 story/feature/task/bug 후보 순서다.
+- 출력 계층은 L1 `in-progress` 이어하기 → L2 blocker/critical 긴급 → L3 story/feature/task/bug 후보 순서다. L2 긴급 승격은 story 를 제외한다 — story 는 priority 무관하게 소속 epic 설계 phase 로 판정하므로 항상 L3 로 흘려보낸다.
 - `subTask` 는 독립 후보에서 제외하고, body 의 `Part of #N` 부모가 L1 에 있을 때만 그 부모 아래에 중첩 표시한다.
 - story 후보는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순으로 표시한다.
 - story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. 설계 미완 epic 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, 설계 완료 epic 만 story 를 impl 후보로 승격한다. 로컬에 해당 epic 산출물이 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 판정을 보류한다.

--- a/commands/next-work.md
+++ b/commands/next-work.md
@@ -34,6 +34,7 @@ node "$SCRIPT" next-work --repo OWNER/REPO
 - `subTask` 는 독립 후보에서 제외하고, body 의 `Part of #N` 부모가 L1 에 있을 때만 그 부모 아래에 중첩 표시한다.
 - story 후보는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순으로 표시한다.
 - story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. 설계 미완 epic 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, 설계 완료 epic 만 story 를 impl 후보로 승격한다. 로컬에 해당 epic 산출물이 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 판정을 보류한다.
+- 로컬 산출물은 *현재 checkout* 의 repo 를 서술하므로, `--repo` 로 현재 로컬 checkout 과 다른 repo 를 지정하면 로컬 phase 판정을 쓰지 않고 전부 보류한다(엉뚱한 repo 의 설계 산출물로 `/design`/`/impl` 을 오판하지 않는다).
 - Priority 는 Issue Brief 본문의 `Priority` 줄을 파싱한다. 없거나 invalid 면 `priority 미기재` 로 표시하고 그룹 뒤에 둔다.
 - GitHub 조회가 실패하면 실패를 명시하고 로컬 대안 경로를 안내한다.
 

--- a/commands/next-work.md
+++ b/commands/next-work.md
@@ -33,6 +33,7 @@ node "$SCRIPT" next-work --repo OWNER/REPO
 - 출력 계층은 L1 `in-progress` 이어하기 → L2 blocker/critical 긴급 → L3 story/feature/task/bug 후보 순서다.
 - `subTask` 는 독립 후보에서 제외하고, body 의 `Part of #N` 부모가 L1 에 있을 때만 그 부모 아래에 중첩 표시한다.
 - story 후보는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순으로 표시한다.
+- story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. 설계 미완 epic 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, 설계 완료 epic 만 story 를 impl 후보로 승격한다. 로컬에 해당 epic 산출물이 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 판정을 보류한다.
 - Priority 는 Issue Brief 본문의 `Priority` 줄을 파싱한다. 없거나 invalid 면 `priority 미기재` 로 표시하고 그룹 뒤에 둔다.
 - GitHub 조회가 실패하면 실패를 명시하고 로컬 대안 경로를 안내한다.
 

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -76,8 +76,9 @@ node scripts/github_project_lifecycle.mjs next-work --repo OWNER/REPO
 ```
 
 - L1: `in-progress` label 이 붙은 open issue 전부.
-- L2: L1 을 제외한 blocker/critical issue.
+- L2: L1 을 제외한 blocker/critical issue. 단 **story 는 제외** — story 는 priority 와 무관하게 소속 epic 의 설계 phase 로 다음 액션이 결정되므로 항상 L3 로 흘려보낸다(L2 승격 시 phase 판정 우회).
 - L3: story → feature → task → bug 순. story 는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순이다. feature/task/bug 는 Priority rank 후 issue 번호 오름차순이다.
+- L3 story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. **설계 미완 epic** 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, **설계 완료 epic** 만 story 를 impl 후보(L3)로 승격한다. 로컬 산출물은 *현재 git checkout* 의 repo 를 서술하므로 대상 repo 가 현재 checkout(git remote) 과 다르면(`--repo`/`GH_REPO` override) 로컬 phase 판정을 쓰지 않고 보류한다.
 - `subTask` 는 독립 후보에서 제외한다. body 의 `Part of #N` 부모가 L1 에 있으면 해당 부모 아래에 중첩 표시한다.
 
 GitHub 조회가 실패하면 실패를 명시하고 로컬 대안 경로를 안내한다. `docs/index.md` 는 live 상태를 복제하지 않고 issue/label 상태, epic/story issue, `/next-work` 를 가리키는 정적 포인터만 둔다. 기존 `docs/index.md` 에 해당 포인터 섹션이 없으면 `/init-dcness` 가 파일을 덮지 않고 섹션만 append 한다.

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -385,6 +385,13 @@ function detectRepo(repoArg) {
   return repo;
 }
 
+// 현재 checkout 의 canonical repo (gh 가 리다이렉트를 정규화). repo 밖이면 null.
+function detectLocalRepoOrNull() {
+  return gh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
+    allowFailure: true,
+  }) || null;
+}
+
 function repoOwner(repo, ownerArg) {
   return ownerArg || repo.split('/')[0];
 }
@@ -1014,12 +1021,26 @@ function resolveProjectRoot() {
   }
 }
 
+function sameRepo(a, b) {
+  return Boolean(a) && Boolean(b) && String(a).trim().toLowerCase() === String(b).trim().toLowerCase();
+}
+
+// 로컬 `docs/epics/...` 산출물은 *현재 checkout* 의 repo 를 서술한다. 그래서 phase 판정에
+// 로컬 파일을 쓰려면 대상 repo 가 현재 checkout 과 일치해야 한다. `--repo` 로 다른 repo 를
+// 지정하면 (repoArg 존재 && localRepo 불일치) 로컬 산출물이 대상 repo 를 서술하지 않으므로
+// 로컬 phase 판정을 쓰지 않는다. repoArg 미지정 시 resolvedRepo 는 로컬 자동 감지값이라 항상 일치.
+export function shouldUseLocalPhaseRoot(repoArg, resolvedRepo, localRepo) {
+  if (!repoArg) return true;
+  return sameRepo(localRepo, resolvedRepo);
+}
+
 // next-work 는 GitHub issue 로 이미 등록된 story 를 나열하므로, 로컬 산출물이 없어도
-// (repo 밖 실행 / stale checkout) story 자체는 존재한다. 그래서 epic_phase 의 'spec'
-// (stories.md 부재) 은 여기선 "스펙 미작성" 이 아니라 "로컬 산출물 확인 불가 → 판정 보류"
-// 로 해석한다 (오탐으로 /design 을 단정하지 않는다).
+// (repo 밖 실행 / stale checkout / 대상 repo != 로컬 checkout) story 자체는 존재한다.
+// 그래서 로컬 근거가 없을 때(root 부재)와 epic_phase 의 'spec'(stories.md 부재)은 여기선
+// "스펙 미작성" 이 아니라 "로컬 산출물 확인 불가 → 판정 보류" 로 해석한다 (오탐으로 /design 단정 X).
 function epicGroupNextAction(epicSlugLabel, root) {
   if (!epicSlugLabel) return { kind: 'unlabeled' };
+  if (!root) return { kind: 'unresolved' };
   const { phase } = epicPhase(join(root, 'docs', 'epics', epicSlugLabel));
   if (phase === 'impl') return { kind: 'impl' };
   if (phase === 'design') return { kind: 'design' };
@@ -1039,11 +1060,15 @@ function storyGroupHeaderLine(epicSlugLabel, action) {
   }
 }
 
-export function formatStoryGroups(groups, root = resolveProjectRoot()) {
+export function formatStoryGroups(groups, root = null) {
   const lines = ['## L3 Story'];
   if (groups.length === 0) {
     lines.push('- 후보 없음');
     return lines.join('\n');
+  }
+  // root 부재 = 로컬 checkout 이 대상 repo 를 서술하지 않음 (--repo 불일치 / repo 밖). 이유를 밝혀 보류.
+  if (!root && groups.some((group) => group.epicSlugLabel)) {
+    lines.push('- 참고: 대상 repo 가 현재 로컬 checkout 과 달라 설계 phase(`/design` vs `/impl`) 판정을 보류한다.');
   }
   let anyDesignComplete = false;
   for (const group of groups) {
@@ -1061,7 +1086,7 @@ export function formatStoryGroups(groups, root = resolveProjectRoot()) {
   return lines.join('\n');
 }
 
-function formatNextWorkReport({ repo, candidates, limit, root = resolveProjectRoot() }) {
+function formatNextWorkReport({ repo, candidates, limit, root = null }) {
   return [
     `[dcness-next-work] repo=${repo}`,
     '[dcness-next-work] read-only: GitHub issue/label 상태를 변경하지 않았습니다.',
@@ -1120,7 +1145,11 @@ function commandNext(args) {
     ? Number(args.limit)
     : 5;
   const candidates = selectNextCandidates(issues);
-  console.log(formatNextWorkReport({ repo, candidates, limit, root: resolveProjectRoot() }));
+  // 로컬 checkout 이 대상 repo 를 서술할 때만 로컬 산출물로 phase 를 판정한다. `--repo` 로 다른
+  // repo 를 지정하면 로컬 파일이 대상 repo 와 무관하므로 root 를 넘기지 않고 판정을 보류한다.
+  const localRepo = args.repo ? detectLocalRepoOrNull() : repo;
+  const root = shouldUseLocalPhaseRoot(args.repo, repo, localRepo) ? resolveProjectRoot() : null;
+  console.log(formatNextWorkReport({ repo, candidates, limit, root }));
   return 0;
 }
 

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -385,13 +385,6 @@ function detectRepo(repoArg) {
   return repo;
 }
 
-// 현재 checkout 의 canonical repo (gh 가 리다이렉트를 정규화). repo 밖이면 null.
-function detectLocalRepoOrNull() {
-  return gh(['repo', 'view', '--json', 'nameWithOwner', '-q', '.nameWithOwner'], {
-    allowFailure: true,
-  }) || null;
-}
-
 function repoOwner(repo, ownerArg) {
   return ownerArg || repo.split('/')[0];
 }
@@ -1025,13 +1018,29 @@ function sameRepo(a, b) {
   return Boolean(a) && Boolean(b) && String(a).trim().toLowerCase() === String(b).trim().toLowerCase();
 }
 
-// 로컬 `docs/epics/...` 산출물은 *현재 checkout* 의 repo 를 서술한다. 그래서 phase 판정에
-// 로컬 파일을 쓰려면 대상 repo 가 현재 checkout 과 일치해야 한다. `--repo` 로 다른 repo 를
-// 지정하면 (repoArg 존재 && localRepo 불일치) 로컬 산출물이 대상 repo 를 서술하지 않으므로
-// 로컬 phase 판정을 쓰지 않는다. repoArg 미지정 시 resolvedRepo 는 로컬 자동 감지값이라 항상 일치.
-export function shouldUseLocalPhaseRoot(repoArg, resolvedRepo, localRepo) {
-  if (!repoArg) return true;
-  return sameRepo(localRepo, resolvedRepo);
+// git remote URL 에서 OWNER/REPO slug 파싱 (https / ssh / `.git` 접미사 / 후행 슬래시 모두). 없으면 null.
+export function parseRepoSlug(url) {
+  const match = String(url).trim().match(/[:/]([^/:]+)\/([^/]+?)(?:\.git)?\/?$/);
+  return match ? `${match[1]}/${match[2]}` : null;
+}
+
+// 현재 git checkout 의 origin remote slug. git 에서 직접 뽑으므로 `GH_REPO`/`gh` 기본 repo
+// override 에 영향받지 않는다 (로컬 파일이 *어느 repo 것인지*의 진본). 확인 불가면 null.
+function gitRemoteSlugOrNull() {
+  try {
+    const url = execFileSync('git', ['config', '--get', 'remote.origin.url'], { encoding: 'utf8' }).trim();
+    return parseRepoSlug(url);
+  } catch {
+    return null;
+  }
+}
+
+// 로컬 `docs/epics/...` 산출물은 *현재 git checkout* 의 repo 를 서술한다. 그래서 대상 repo
+// (issue 출처)가 현재 checkout 의 git remote 와 일치할 때만 로컬 phase 판정을 쓴다. 로컬 식별을
+// gh 가 아니라 git 에서 뽑는 이유: `gh repo view` 는 `GH_REPO`/기본 repo override 를 따르므로
+// 다른 checkout/repo 밖에서도 대상 repo 를 반환해 가드를 우회시킨다. 불일치/미확인이면 보류.
+export function shouldUseLocalPhaseRoot(targetRepo, localRepoSlug) {
+  return sameRepo(targetRepo, localRepoSlug);
 }
 
 // next-work 는 GitHub issue 로 이미 등록된 story 를 나열하므로, 로컬 산출물이 없어도
@@ -1145,10 +1154,9 @@ function commandNext(args) {
     ? Number(args.limit)
     : 5;
   const candidates = selectNextCandidates(issues);
-  // 로컬 checkout 이 대상 repo 를 서술할 때만 로컬 산출물로 phase 를 판정한다. `--repo` 로 다른
-  // repo 를 지정하면 로컬 파일이 대상 repo 와 무관하므로 root 를 넘기지 않고 판정을 보류한다.
-  const localRepo = args.repo ? detectLocalRepoOrNull() : repo;
-  const root = shouldUseLocalPhaseRoot(args.repo, repo, localRepo) ? resolveProjectRoot() : null;
+  // 로컬 git checkout 이 대상 repo(issue 출처)를 서술할 때만 로컬 산출물로 phase 를 판정한다.
+  // `--repo`/`GH_REPO` 로 다른 repo 를 가리키면 로컬 파일이 무관하므로 root 없이 판정을 보류한다.
+  const root = shouldUseLocalPhaseRoot(repo, gitRemoteSlugOrNull()) ? resolveProjectRoot() : null;
   console.log(formatNextWorkReport({ repo, candidates, limit, root }));
   return 0;
 }

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { parseField } from './check_issue_body.mjs';
+import { epicPhase } from './lib/epic_phase.mjs';
 
 export const GH_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
 
@@ -1004,23 +1006,62 @@ function formatFlatNextSection(title, entries, { emptyText = '없음', limit = n
   return lines.join('\n');
 }
 
-function formatStoryGroups(groups) {
+function resolveProjectRoot() {
+  try {
+    return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+// next-work 는 GitHub issue 로 이미 등록된 story 를 나열하므로, 로컬 산출물이 없어도
+// (repo 밖 실행 / stale checkout) story 자체는 존재한다. 그래서 epic_phase 의 'spec'
+// (stories.md 부재) 은 여기선 "스펙 미작성" 이 아니라 "로컬 산출물 확인 불가 → 판정 보류"
+// 로 해석한다 (오탐으로 /design 을 단정하지 않는다).
+function epicGroupNextAction(epicSlugLabel, root) {
+  if (!epicSlugLabel) return { kind: 'unlabeled' };
+  const { phase } = epicPhase(join(root, 'docs', 'epics', epicSlugLabel));
+  if (phase === 'impl') return { kind: 'impl' };
+  if (phase === 'design') return { kind: 'design' };
+  return { kind: 'unresolved' };
+}
+
+function storyGroupHeaderLine(epicSlugLabel, action) {
+  switch (action.kind) {
+    case 'impl':
+      return `- ${epicSlugLabel} — 설계 완료 → story impl 후보 (\`/impl\`)`;
+    case 'design':
+      return `- ${epicSlugLabel} — 설계 미완 → 다음 액션 \`/design docs/epics/${epicSlugLabel}\` (아래 story 는 아직 impl 후보 아님)`;
+    case 'unlabeled':
+      return '- 미분류 story — epic 라벨 없음 → 판정 보류';
+    default:
+      return `- ${epicSlugLabel} — 설계 산출물 로컬 확인 불가 → 판정 보류 (\`/design\`/\`/impl\` 미결)`;
+  }
+}
+
+export function formatStoryGroups(groups, root = resolveProjectRoot()) {
   const lines = ['## L3 Story'];
   if (groups.length === 0) {
     lines.push('- 후보 없음');
     return lines.join('\n');
   }
+  let anyDesignComplete = false;
   for (const group of groups) {
-    lines.push(`- ${group.epicSlugLabel ?? '미분류 story'}`);
+    const action = epicGroupNextAction(group.epicSlugLabel, root);
+    if (action.kind === 'impl') anyDesignComplete = true;
+    lines.push(storyGroupHeaderLine(group.epicSlugLabel, action));
     for (const item of group.items) {
       lines.push(`  ${formatNextCandidate(item)}`);
     }
   }
-  lines.push('- 참고: story 세부 구현 순서의 진본은 epic 설계 산출물의 구현 순서 섹션이다.');
+  // 각주는 "설계 산출물이 존재한다" 를 전제하므로 설계 완료 epic 이 하나라도 있을 때만 붙인다.
+  if (anyDesignComplete) {
+    lines.push('- 참고: 설계 완료 epic 의 story 구현 순서 진본은 epic 설계 산출물의 구현 순서 섹션이다.');
+  }
   return lines.join('\n');
 }
 
-function formatNextWorkReport({ repo, candidates, limit }) {
+function formatNextWorkReport({ repo, candidates, limit, root = resolveProjectRoot() }) {
   return [
     `[dcness-next-work] repo=${repo}`,
     '[dcness-next-work] read-only: GitHub issue/label 상태를 변경하지 않았습니다.',
@@ -1032,7 +1073,7 @@ function formatNextWorkReport({ repo, candidates, limit }) {
       limit,
     }),
     '',
-    formatStoryGroups(candidates.l3.storyGroups),
+    formatStoryGroups(candidates.l3.storyGroups, root),
     '',
     formatFlatNextSection('L3 Feature', candidates.l3.feature, { emptyText: '후보 없음', limit }),
     '',
@@ -1079,7 +1120,7 @@ function commandNext(args) {
     ? Number(args.limit)
     : 5;
   const candidates = selectNextCandidates(issues);
-  console.log(formatNextWorkReport({ repo, candidates, limit }));
+  console.log(formatNextWorkReport({ repo, candidates, limit, root: resolveProjectRoot() }));
   return 0;
 }
 

--- a/scripts/github_project_lifecycle.mjs
+++ b/scripts/github_project_lifecycle.mjs
@@ -668,7 +668,12 @@ export function selectNextCandidates(issuesInput) {
   const workItems = remaining.filter(
     (issue) => issue.issueType && !['epic', 'subTask'].includes(issue.issueType),
   );
-  const l2 = workItems.filter((issue) => issue.priorityRank <= 1).sort(byPriorityThenNumber);
+  // story 는 priority 와 무관하게 소속 epic 의 설계 phase 로 다음 액션이 결정된다(설계 전이면
+  // impl 후보가 아니라 /design). 그래서 blocker/critical 이어도 L2 긴급으로 승격하지 않고 항상
+  // L3 phase-aware 그룹으로 흘려보낸다 — 승격하면 phase 판정을 우회해 설계 전 story 를 impl 로 오도.
+  const l2 = workItems
+    .filter((issue) => issue.issueType !== 'story' && issue.priorityRank <= 1)
+    .sort(byPriorityThenNumber);
   const l2Numbers = new Set(l2.map((issue) => issue.number));
   const l3Items = workItems.filter((issue) => !l2Numbers.has(issue.number));
 

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -1459,6 +1459,36 @@ class NextWorkStoryGroupPhaseTests(unittest.TestCase):
             expr = f"lifecycle.parseRepoSlug({json.dumps(url)})"
             self.assertEqual(run_node(expr), expected, msg=f"{url=}")
 
+    def test_blocker_story_stays_in_l3_group_not_l2(self) -> None:
+        # blocker/critical story 도 L2 긴급으로 승격되지 않고 L3 phase-aware 그룹으로 간다.
+        # (승격 시 phase 판정을 우회해 설계 전 epic story 를 impl 로 오도하는 것을 차단.)
+        issues = [
+            {
+                "number": 401,
+                "title": "Urgent story in undesigned epic",
+                "body": "**Priority:** blocker\n",
+                "labels": [{"name": "story"}, {"name": "epic-05-urgent"}],
+                "url": "https://github.com/Daeguk-Sun/dcNess/issues/401",
+            },
+            {
+                "number": 402,
+                "title": "Critical bug",
+                "body": "**Priority:** critical\n",
+                "labels": [{"name": "bug"}],
+                "url": "https://github.com/Daeguk-Sun/dcNess/issues/402",
+            },
+        ]
+        result = run_node(f"lifecycle.selectNextCandidates({json.dumps(issues)})")
+        l2_numbers = [item["number"] for item in result["l2"]]
+        self.assertNotIn(401, l2_numbers)
+        self.assertIn(402, l2_numbers)  # bug 는 여전히 L2 긴급
+        story_numbers = [
+            item["number"]
+            for group in result["l3"]["storyGroups"]
+            for item in group["items"]
+        ]
+        self.assertIn(401, story_numbers)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -1275,5 +1275,145 @@ class GithubProjectLifecycleScriptTests(unittest.TestCase):
         self.assertIn("expected exactly one IssueType label", completed.stdout)
 
 
+class NextWorkStoryGroupPhaseTests(unittest.TestCase):
+    """`next-work` L3 Story 나열이 epic 설계 산출물 존재로 `/design` vs `/impl` 을 구분하는지 (#951)."""
+
+    def _epic(
+        self,
+        root: Path,
+        slug: str,
+        *,
+        stories: bool = True,
+        architecture: bool = False,
+        impl_task: bool = False,
+    ) -> None:
+        epic_dir = root / "docs" / "epics" / slug
+        epic_dir.mkdir(parents=True, exist_ok=True)
+        if stories:
+            (epic_dir / "stories.md").write_text("# stories\n", encoding="utf-8")
+        if architecture:
+            (epic_dir / "architecture.md").write_text("# arch\n", encoding="utf-8")
+        if impl_task:
+            impl_dir = epic_dir / "impl"
+            impl_dir.mkdir(exist_ok=True)
+            (impl_dir / "01-foo.md").write_text("# task\n", encoding="utf-8")
+
+    def _format(self, groups: list, root: Path) -> str:
+        return run_node(
+            f"lifecycle.formatStoryGroups({json.dumps(groups)}, {json.dumps(str(root))})"
+        )
+
+    def test_design_incomplete_epic_marks_design_action_without_impl_footnote(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._epic(root, "epic-01-alpha", stories=True)
+            groups = [
+                {
+                    "epicSlugLabel": "epic-01-alpha",
+                    "epicNumber": 1,
+                    "items": [{"number": 201, "title": "Story one"}],
+                }
+            ]
+            out = self._format(groups, root)
+            self.assertIn("설계 미완", out)
+            self.assertIn("/design docs/epics/epic-01-alpha", out)
+            self.assertIn("#201 Story one", out)
+            self.assertNotIn("구현 순서 진본", out)
+
+    def test_design_complete_epic_promotes_impl_with_footnote(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._epic(root, "epic-02-beta", stories=True, architecture=True, impl_task=True)
+            groups = [
+                {
+                    "epicSlugLabel": "epic-02-beta",
+                    "epicNumber": 2,
+                    "items": [{"number": 301, "title": "Beta story"}],
+                }
+            ]
+            out = self._format(groups, root)
+            self.assertRegex(out, r"epic-02-beta.*설계 완료")
+            self.assertIn("/impl", out)
+            self.assertIn("구현 순서 진본", out)
+
+    def test_architecture_without_impl_task_is_still_design_incomplete(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            # architecture.md 는 있으나 impl/NN-*.md 부재 = 설계 미완 (핵심 엣지, #950 SSOT 와 동일)
+            self._epic(root, "epic-03-gamma", stories=True, architecture=True, impl_task=False)
+            groups = [
+                {
+                    "epicSlugLabel": "epic-03-gamma",
+                    "epicNumber": 3,
+                    "items": [{"number": 401, "title": "Gamma story"}],
+                }
+            ]
+            out = self._format(groups, root)
+            self.assertIn("설계 미완", out)
+            self.assertIn("/design docs/epics/epic-03-gamma", out)
+            self.assertNotIn("구현 순서 진본", out)
+
+    def test_mixed_epics_are_labeled_per_epic(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            self._epic(root, "epic-01-alpha", stories=True)
+            self._epic(root, "epic-02-beta", stories=True, architecture=True, impl_task=True)
+            groups = [
+                {
+                    "epicSlugLabel": "epic-01-alpha",
+                    "epicNumber": 1,
+                    "items": [{"number": 201, "title": "A"}],
+                },
+                {
+                    "epicSlugLabel": "epic-02-beta",
+                    "epicNumber": 2,
+                    "items": [{"number": 301, "title": "B"}],
+                },
+            ]
+            out = self._format(groups, root)
+            self.assertRegex(out, r"epic-01-alpha.*설계 미완")
+            self.assertIn("/design docs/epics/epic-01-alpha", out)
+            self.assertRegex(out, r"epic-02-beta.*설계 완료")
+            self.assertIn("구현 순서 진본", out)
+
+    def test_missing_local_epic_dir_holds_judgment(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            # docs/epics 자체가 없음 (repo 밖 실행 / stale checkout) — 오탐으로 /design 단정 금지
+            groups = [
+                {
+                    "epicSlugLabel": "epic-09-late",
+                    "epicNumber": 9,
+                    "items": [{"number": 901, "title": "Late"}],
+                }
+            ]
+            out = self._format(groups, root)
+            self.assertIn("판정 보류", out)
+            self.assertIn("#901 Late", out)
+            self.assertNotIn("/design docs/epics/epic-09-late", out)
+            self.assertNotIn("구현 순서 진본", out)
+
+    def test_unlabeled_story_group_holds_judgment(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            groups = [
+                {
+                    "epicSlugLabel": None,
+                    "epicNumber": None,
+                    "items": [{"number": 250, "title": "Manual"}],
+                }
+            ]
+            out = self._format(groups, root)
+            self.assertIn("미분류 story", out)
+            self.assertIn("판정 보류", out)
+            self.assertIn("#250 Manual", out)
+            self.assertNotIn("구현 순서 진본", out)
+
+    def test_empty_groups_still_report_no_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            out = self._format([], Path(td))
+            self.assertIn("후보 없음", out)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -1414,6 +1414,38 @@ class NextWorkStoryGroupPhaseTests(unittest.TestCase):
             out = self._format([], Path(td))
             self.assertIn("후보 없음", out)
 
+    def test_null_root_holds_all_judgment_with_cross_repo_note(self) -> None:
+        # root 부재(대상 repo != 로컬 checkout) → 로컬 산출물 무시하고 전부 보류, 이유 명시.
+        groups = [
+            {
+                "epicSlugLabel": "epic-01-alpha",
+                "epicNumber": 1,
+                "items": [{"number": 201, "title": "Cross"}],
+            }
+        ]
+        out = run_node(f"lifecycle.formatStoryGroups({json.dumps(groups)}, null)")
+        self.assertIn("현재 로컬 checkout 과 달라", out)
+        self.assertIn("판정 보류", out)
+        self.assertIn("#201 Cross", out)
+        self.assertNotIn("/design docs/epics/epic-01-alpha", out)
+        self.assertNotIn("구현 순서 진본", out)
+
+    def test_should_use_local_phase_root_matrix(self) -> None:
+        cases = [
+            # (repoArg, resolvedRepo, localRepo, expected)
+            (None, "A/B", "A/B", True),          # --repo 미지정 → 자동 감지값이라 항상 로컬 일치
+            ("A/B", "A/B", "A/B", True),         # 명시했지만 로컬과 일치
+            ("a/b", "a/b", "A/B", True),         # 대소문자 무시 일치
+            ("A/B", "A/B", "C/D", False),        # 로컬 checkout 이 다른 repo
+            ("A/B", "A/B", None, False),         # repo 밖 실행 (로컬 감지 실패)
+        ]
+        for repo_arg, resolved, local, expected in cases:
+            expr = (
+                "lifecycle.shouldUseLocalPhaseRoot("
+                f"{json.dumps(repo_arg)}, {json.dumps(resolved)}, {json.dumps(local)})"
+            )
+            self.assertEqual(run_node(expr), expected, msg=f"{repo_arg=} {resolved=} {local=}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_github_project_lifecycle.py
+++ b/tests/test_github_project_lifecycle.py
@@ -1432,19 +1432,32 @@ class NextWorkStoryGroupPhaseTests(unittest.TestCase):
 
     def test_should_use_local_phase_root_matrix(self) -> None:
         cases = [
-            # (repoArg, resolvedRepo, localRepo, expected)
-            (None, "A/B", "A/B", True),          # --repo 미지정 → 자동 감지값이라 항상 로컬 일치
-            ("A/B", "A/B", "A/B", True),         # 명시했지만 로컬과 일치
-            ("a/b", "a/b", "A/B", True),         # 대소문자 무시 일치
-            ("A/B", "A/B", "C/D", False),        # 로컬 checkout 이 다른 repo
-            ("A/B", "A/B", None, False),         # repo 밖 실행 (로컬 감지 실패)
+            # (targetRepo=issue 출처, localRepoSlug=현재 git checkout, expected)
+            ("A/B", "A/B", True),        # 대상 repo == 로컬 checkout
+            ("a/b", "A/B", True),        # 대소문자 무시 일치
+            ("A/B", "C/D", False),       # 로컬 checkout 이 다른 repo (--repo/GH_REPO override)
+            ("A/B", None, False),        # 로컬 git remote 확인 불가 (repo 밖)
         ]
-        for repo_arg, resolved, local, expected in cases:
+        for target, local, expected in cases:
             expr = (
                 "lifecycle.shouldUseLocalPhaseRoot("
-                f"{json.dumps(repo_arg)}, {json.dumps(resolved)}, {json.dumps(local)})"
+                f"{json.dumps(target)}, {json.dumps(local)})"
             )
-            self.assertEqual(run_node(expr), expected, msg=f"{repo_arg=} {resolved=} {local=}")
+            self.assertEqual(run_node(expr), expected, msg=f"{target=} {local=}")
+
+    def test_parse_repo_slug_handles_common_remote_urls(self) -> None:
+        cases = [
+            ("https://github.com/OWNER/REPO.git", "OWNER/REPO"),
+            ("https://github.com/OWNER/REPO", "OWNER/REPO"),
+            ("git@github.com:OWNER/REPO.git", "OWNER/REPO"),
+            ("git@github.com:OWNER/REPO", "OWNER/REPO"),
+            ("ssh://git@github.com/OWNER/REPO.git", "OWNER/REPO"),
+            ("https://github.com/OWNER/REPO/", "OWNER/REPO"),
+            ("not-a-remote-url", None),
+        ]
+        for url, expected in cases:
+            expr = f"lifecycle.parseRepoSlug({json.dumps(url)})"
+            self.assertEqual(run_node(expr), expected, msg=f"{url=}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #951

## 배경 및 문제

`/next-work`(`github_project_lifecycle.mjs next-work`)는 open story 를 L3 impl 후보로 나열하면서 각주로 "구현 순서 진본 = epic 설계 산출물" 을 달았지만, **설계 산출물이 아직 없는 상태(spec 직후)를 감지하지 않았다.** 그래서 story 이슈만 등록되고 설계 전인 epic 에서도 스토리를 구현 대상처럼 제시해, 콜드스타트를 `/impl` 로 오도했다. 실제 다음 액션은 `/design` 이다.

## 원인 (해당 시)

`formatStoryGroups` 가 issue label(`epic-NN-<slug>`)로 story 를 그룹핑만 하고, 그 epic 의 로컬 설계 산출물 존재 여부를 확인하지 않았다. 각주는 "설계 산출물이 있다" 를 무조건 전제했다.

## 작업내용

- `scripts/github_project_lifecycle.mjs`
  - `formatStoryGroups` 를 epic phase 인지형으로 교체. #950 이 만든 SSOT `scripts/lib/epic_phase.mjs` 의 `epicPhase` 를 **재구현 없이 import** 해, epic 단위로 로컬 설계 산출물(`architecture.md` + `impl/NN-*.md`) 존재를 판정한다.
    - 설계 미완 epic → story 를 impl 후보로 내밀지 않고 `- <epic> — 설계 미완 → /design docs/epics/<epic>` 제시.
    - 설계 완료 epic → `- <epic> — 설계 완료 → story impl 후보 (/impl)` 로 승격.
    - epic 산출물이 로컬에 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 **판정 보류**. (next-work 는 이미 등록된 issue 를 나열하므로 `epic_phase` 의 'spec' 은 여기선 "로컬 확인 불가" 로 해석.)
    - `epic` 라벨 없는 미분류 story → 판정 보류.
  - `resolveProjectRoot()` = `git rev-parse --show-toplevel`(`hooks/session-start.sh` 와 동일 패턴, cwd fallback).
  - "구현 순서 진본" 각주는 설계 완료 epic 이 하나라도 있을 때만 부착(전제 정합).
- `commands/next-work.md`: 동작 계약에 epic별 다음 액션 구분 규칙 반영.
- `tests/test_github_project_lifecycle.py`: `NextWorkStoryGroupPhaseTests` 7 케이스 추가.

## 결정 근거

- **SSOT 공유**: epic 설계 완료 판정을 새로 구현하지 않고 #950 의 `scripts/lib/epic_phase.mjs` 를 import — 같은 신호를 두 곳(`aggregate_index_map.mjs` docs/index.md 파생 컬럼 + next-work)에서 계산하지 않는다.
- **오탐 방지**: 로컬 산출물 부재를 `/design` 으로 단정하면 stale checkout/repo 밖 실행에서 오도한다. 그래서 stories.md 조차 없는 경우는 판정 보류로 분리.

## 배포 경로 검증 (plug-in 영향 시)

- 배포 경로 **1 (plug-in 본체)**. `scripts/github_project_lifecycle.mjs` 는 외부 활성 프로젝트에서 `$PLUGIN_ROOT` 로 실행되고, `commands/next-work.md` 도 plug-in 본체 command 다. 둘 다 plugin 업데이트만으로 기존 활성 프로젝트에 도달한다.
- import 대상 `scripts/lib/epic_phase.mjs` 도 plug-in 본체(#950 배포)라 상대 import 가 `$PLUGIN_ROOT/scripts/lib/` 로 정상 해석된다. `docs/epics/...` 는 사용자 프로젝트(`git rev-parse --show-toplevel`)에서 읽는다.
- `/init-dcness` 복사 파일 아님 → **별도 재배포 절차 불요**.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public surface 없음. 기존 next-work 유틸리티의 출력 동작만 변경.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 (`NextWorkStoryGroupPhaseTests` 7/7, `unittest discover` 1650/1650)
- [x] 회귀 검증 (기존 `selectNextCandidates` 포함 lifecycle 58/58, cross-ref / public-surface / static-quality PASS)

## 참고

- 짝 이슈 #950(PR #956) 이 만든 `scripts/lib/epic_phase.mjs` SSOT 재사용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)