### PR TITLE
[feature] handoff: 세션 간 warm 인계 레이어 (/handoff + SessionStart 최우선 주입/archive clear)

### DIFF
--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -25,8 +25,11 @@ description: 세션을 넘기기 전 의도/결정/진행/다음 액션을 `.dcn
 4. **포인터** — 상세를 담은 산출물·파일·이슈 링크 (본문에 덤프하지 않고 링크만).
 
 ```bash
-mkdir -p .dcness-work/handoffs
-cat > .dcness-work/handoffs/next-session.md <<'EOF'
+# repo 루트 기준으로 쓴다 — SessionStart 훅이 소비할 경로와 동일 유도(git top-level).
+# 서브디렉토리에서 /handoff 를 발화해도 훅이 읽는 위치에 정확히 쓰이게 한다.
+PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+mkdir -p "$PROJECT_ROOT/.dcness-work/handoffs"
+cat > "$PROJECT_ROOT/.dcness-work/handoffs/next-session.md" <<'EOF'
 # 다음 세션 핸드오프 — <YYYY-MM-DD>
 
 ## 다음 액션 (필수)
@@ -51,9 +54,9 @@ EOF
 ## 동작 계약
 
 - **단문 원칙** — "다음 액션 1개(필수) + 근거 + 포인터 링크" 중심의 단문으로 제한한다. 세션 전체 요약 덤프 금지. 상세 컨텍스트는 포인터가 가리키는 산출물을 다음 세션이 질의 시점에 lazy 로드한다. SessionStart 주입량이 커지면 slim-inject 원칙이 무너진다.
-- **결정적 단일 경로** — 활성 파일명은 `next-session.md` 로 고정한다. SessionStart 훅이 확인할 결정적 단일 경로가 하나 필요하므로 세션마다 다른 이름을 쓰지 않는다. 이미 파일이 있으면 덮어쓴다(가장 최근 인계만 유효).
-- **소비 = archive 이동** — 다음 세션 SessionStart 훅이 이 파일을 additionalContext 최상단에 주입하고 주입 직후 `.dcness-work/handoffs/archive/<ts>.md` 로 옮긴다(무손실 clear). 다음다음 세션에 stale 재주입되지 않는다.
-- **first-consumer-wins** — 병렬 peer 세션은 각자 SessionStart 를 발화하므로 먼저 시작한 세션이 handoff 를 소비(archive)한다. handoff 는 단일 소비자 인계 문서이고, 병렬 작업 분배는 [claim board](../docs/plugin/parallel-policy.md#4-task-claim-board) 몫이다.
+- **결정적 단일 경로** — 활성 파일은 repo 루트(`git rev-parse --show-toplevel`) 기준 `.dcness-work/handoffs/next-session.md` 로 고정한다. 쓰기(command)와 읽기(SessionStart 훅)가 같은 repo-root 유도를 써 서브디렉토리 실행에도 정합한다. SessionStart 훅이 확인할 결정적 단일 경로가 하나 필요하므로 세션마다 다른 이름을 쓰지 않는다. 이미 파일이 있으면 덮어쓴다(가장 최근 인계만 유효).
+- **소비 = archive claim** — 다음 세션 SessionStart 훅이 이 파일을 `.dcness-work/handoffs/archive/<ts>.md` 로 먼저 옮겨(mv) 원자적으로 소비한 뒤 그 내용을 additionalContext 최상단에 주입한다(무손실 clear). 다음다음 세션에 stale 재주입되지 않는다.
+- **first-consumer-wins** — 병렬 peer 세션은 각자 SessionStart 를 발화하지만, 소비가 read 가 아니라 archive mv(rename)로 먼저 일어나므로 rename 에 성공한 first-consumer 만 handoff 를 얻는다. handoff 는 단일 소비자 인계 문서이고, 병렬 작업 분배는 [claim board](../docs/plugin/parallel-policy.md#4-task-claim-board) 몫이다.
 - **git 제외** — `.dcness-work/` 는 git-excluded 작업 영역이다(활성화 시 `/init-dcness` 가 `.gitignore` 에 추가). handoff 는 커밋 산출물이 아니라 세션 간 scratch 다.
 
 ## 참조

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -28,8 +28,12 @@ description: 세션을 넘기기 전 의도/결정/진행/다음 액션을 `.dcn
 # repo 루트 기준으로 쓴다 — SessionStart 훅이 소비할 경로와 동일 유도(git top-level).
 # 서브디렉토리에서 /handoff 를 발화해도 훅이 읽는 위치에 정확히 쓰이게 한다.
 PROJECT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
-mkdir -p "$PROJECT_ROOT/.dcness-work/handoffs"
-cat > "$PROJECT_ROOT/.dcness-work/handoffs/next-session.md" <<'EOF'
+HANDOFF_DIR="$PROJECT_ROOT/.dcness-work/handoffs"
+mkdir -p "$HANDOFF_DIR"
+# 심링크 타겟 오염 방지 — 임시 파일에 쓴 뒤 rename 으로 교체한다. next-session.md 가
+# 심링크여도 rename 은 링크 자체를 대체(타겟을 따라가 덮어쓰지 않음). 훅의 읽기측
+# 심링크 하드닝과 대칭. `.dcness-work/` 는 writable 이라 이 방어가 필요하다.
+cat > "$HANDOFF_DIR/.next-session.tmp" <<'EOF'
 # 다음 세션 핸드오프 — <YYYY-MM-DD>
 
 ## 다음 액션 (필수)
@@ -47,6 +51,7 @@ cat > "$PROJECT_ROOT/.dcness-work/handoffs/next-session.md" <<'EOF'
 - <핵심 파일 경로>
 - <핵심 문서·이슈 링크>
 EOF
+mv -f "$HANDOFF_DIR/.next-session.tmp" "$HANDOFF_DIR/next-session.md"
 ```
 
 파일을 쓴 뒤 사용자에게 경로와 다음 액션을 보고한다.

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -1,0 +1,63 @@
+---
+name: handoff
+description: 세션을 넘기기 전 의도/결정/진행/다음 액션을 `.dcness-work/handoffs/next-session.md` 에 인계 문서로 기록하는 command. 다음 세션 SessionStart 훅이 이 파일을 additionalContext 최상단에 최우선 주입한 뒤 archive 로 옮겨 clear 한다. CC auto-memory(불투명·모델 임의 저장)에 의존하지 않는 결정적 cross-session 인계다. 사용자가 "/handoff", "핸드오프 만들어줘", "핸드오프 문서 써줘", "인계 문서 작성해줘", "세션 인계", "다음 세션에 넘겨줘" 등을 말할 때 사용한다.
+---
+
+# Handoff — 다음 세션 warm 인계
+
+> 세션을 넘기기 전 *다음 세션이 이것부터 읽고 시작할* 인계 문서를 `.dcness-work/handoffs/next-session.md` 에 쓴다. 다음 세션 SessionStart 훅이 그 내용을 최우선 주입하고 archive 로 옮겨 clear 한다. auto-memory 없이도 다음 세션이 자족적으로 이어가게 하는 결정적 레이어다.
+
+## 언제 사용
+
+- 세션을 마치며 다음 세션(자신이든 다른 세션이든)에 작업을 넘길 때
+- 컨텍스트가 커져 압축·종료 전에 이어갈 지점을 명시적으로 남길 때
+- 사용자가 "핸드오프 만들어줘", "인계 문서 써줘", "다음 세션에 넘겨줘" 등으로 발화할 때
+
+> `/smart-compact` 는 *같은 세션* 안에서 `/compact` 로 컨텍스트를 압축한다. `/handoff` 는 *세션 경계 너머* 로 넘기는 결정적 인계다. 둘은 역할이 다르다.
+
+## 절차
+
+메인이 자체 두뇌로 다음을 수집해 `.dcness-work/handoffs/next-session.md` 에 쓴다.
+
+1. **다음 액션 (필수)** — 다음 세션이 착수할 구체적 작업 1개. 이 항목이 없으면 handoff 를 쓰지 않는다.
+2. **근거** — 왜 이게 다음인지 1~2줄.
+3. **진행 상태** — 현재 branch / 관련 PR·이슈 / 미완료 지점.
+4. **포인터** — 상세를 담은 산출물·파일·이슈 링크 (본문에 덤프하지 않고 링크만).
+
+```bash
+mkdir -p .dcness-work/handoffs
+cat > .dcness-work/handoffs/next-session.md <<'EOF'
+# 다음 세션 핸드오프 — <YYYY-MM-DD>
+
+## 다음 액션 (필수)
+- <다음 세션이 착수할 작업 1개>
+
+## 근거
+- <왜 이게 다음인지 1~2줄>
+
+## 진행 상태
+- branch: <현재 branch>
+- 관련: <PR/이슈 링크>
+- 미완료: <끊긴 지점>
+
+## 포인터 (lazy)
+- <핵심 파일 경로>
+- <핵심 문서·이슈 링크>
+EOF
+```
+
+파일을 쓴 뒤 사용자에게 경로와 다음 액션을 보고한다.
+
+## 동작 계약
+
+- **단문 원칙** — "다음 액션 1개(필수) + 근거 + 포인터 링크" 중심의 단문으로 제한한다. 세션 전체 요약 덤프 금지. 상세 컨텍스트는 포인터가 가리키는 산출물을 다음 세션이 질의 시점에 lazy 로드한다. SessionStart 주입량이 커지면 slim-inject 원칙이 무너진다.
+- **결정적 단일 경로** — 활성 파일명은 `next-session.md` 로 고정한다. SessionStart 훅이 확인할 결정적 단일 경로가 하나 필요하므로 세션마다 다른 이름을 쓰지 않는다. 이미 파일이 있으면 덮어쓴다(가장 최근 인계만 유효).
+- **소비 = archive 이동** — 다음 세션 SessionStart 훅이 이 파일을 additionalContext 최상단에 주입하고 주입 직후 `.dcness-work/handoffs/archive/<ts>.md` 로 옮긴다(무손실 clear). 다음다음 세션에 stale 재주입되지 않는다.
+- **first-consumer-wins** — 병렬 peer 세션은 각자 SessionStart 를 발화하므로 먼저 시작한 세션이 handoff 를 소비(archive)한다. handoff 는 단일 소비자 인계 문서이고, 병렬 작업 분배는 [claim board](../docs/plugin/parallel-policy.md#4-task-claim-board) 몫이다.
+- **git 제외** — `.dcness-work/` 는 git-excluded 작업 영역이다(활성화 시 `/init-dcness` 가 `.gitignore` 에 추가). handoff 는 커밋 산출물이 아니라 세션 간 scratch 다.
+
+## 참조
+
+- [`deliverables-map.md` Volatile 작업 영역](../docs/plugin/deliverables-map.md#volatile-작업-영역)
+- [`hooks.md` session-start.sh](../docs/plugin/hooks.md#session-startsh)
+- [`positioning.md` Utility 공개 노출 범위](../docs/plugin/positioning.md#utility-공개-노출-범위)

--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -197,7 +197,7 @@ compact plan 은 `/impl` Standard 진입 전 경량 설계 산출물이다. 구�
 | `.dcness-work/spikes/` | 짧은 탐색 결과, 버릴 수 있는 실험 |
 | `.dcness-work/research/` | 외부 문서 조사 raw note |
 | `.dcness-work/open-questions/` | 아직 산출물로 확정되지 않은 질문 |
-| `.dcness-work/handoffs/` | run 간 임시 handoff |
+| `.dcness-work/handoffs/` | run 간 임시 handoff + 세션 간 warm 인계 (`/handoff` 가 쓰는 활성 `next-session.md`, SessionStart 소비 후 `archive/<ts>.md`) |
 | `.dcness-work/reviews/` | tech-review evidence, HTML report, logs |
 
 `/init-dcness` 는 사용자 프로젝트 `.gitignore` 에 `.dcness-work/` 를 추가한다.

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -73,7 +73,7 @@ dcNess hook 은 보안 sandbox 가 아니다. file boundary 와 외부 상태 �
 - sid 추출, `.by-pid/<cc_pid>` 작성, `live.json` 초기화
 - 상태 위생 청소 (세션당 1회, fail-open): stale by-pid 파일(24h) + 본 세션의 만료 run 슬롯(24h) + 전 세션의 run 디렉토리(prose/ledger, 7d — `/run-review` 원자료라 슬롯보다 길게 보관). TTL 상수 SSOT = `harness/session_state.py`
 - `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
-- 이전 세션이 `/handoff` 로 남긴 `.dcness-work/handoffs/next-session.md` 가 있으면 그 내용을 `additionalContext` 최상단에 최우선 주입하고, 주입 직후 `.dcness-work/handoffs/archive/<ts>.md` 로 옮겨 무손실 clear 함 — 다음다음 세션 stale 재주입 차단. 파일 부재 시 기존 동작 그대로. 병렬 peer 세션은 first-consumer 가 archive 로 소비
+- 이전 세션이 `/handoff` 로 남긴 `.dcness-work/handoffs/next-session.md` 가 있으면 `.dcness-work/handoffs/archive/<ts>.md` 로 먼저 옮겨(mv) 원자적으로 소비한 뒤 그 내용을 `additionalContext` 최상단에 최우선 주입함(무손실 clear) — 다음다음 세션 stale 재주입 차단. mv(rename)를 read 보다 선행하므로 병렬 peer 세션 중 rename 에 성공한 first-consumer 만 소비(단일 소비자 계약). 파일 부재 시 기존 동작 그대로
 - 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
 - 프로젝트 상태나 다음 작업 질문에는 `docs/index.md` 와 `## 진행 상태 · 다음 작업` 섹션이 실제로 있을 때만 해당 포인터를 안내하고, 파일/섹션이 없으면 `/next-work` issue/label 조회와 `/init-dcness` 보강 경로를 안내함
 - 설치된 plug-in 버전과 `main` 의 최신 버전을 비교(하루 1회 캐시)해 더 높은 버전이 있을 때만 `claude plugin update` 알림을 함께 inject — 외부 활성 프로젝트가 옛 plug-in 버전 운영 룰에 묶이는 drift 회피

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -73,7 +73,7 @@ dcNess hook 은 보안 sandbox 가 아니다. file boundary 와 외부 상태 �
 - sid 추출, `.by-pid/<cc_pid>` 작성, `live.json` 초기화
 - 상태 위생 청소 (세션당 1회, fail-open): stale by-pid 파일(24h) + 본 세션의 만료 run 슬롯(24h) + 전 세션의 run 디렉토리(prose/ledger, 7d — `/run-review` 원자료라 슬롯보다 길게 보관). TTL 상수 SSOT = `harness/session_state.py`
 - `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
-- 이전 세션이 `/handoff` 로 남긴 `.dcness-work/handoffs/next-session.md` 가 있으면 `.dcness-work/handoffs/archive/<ts>.md` 로 먼저 옮겨(mv) 원자적으로 소비한 뒤 그 내용을 `additionalContext` 최상단에 최우선 주입함(무손실 clear) — 다음다음 세션 stale 재주입 차단. mv(rename)를 read 보다 선행하므로 병렬 peer 세션 중 rename 에 성공한 first-consumer 만 소비(단일 소비자 계약). 파일 부재 시 기존 동작 그대로
+- 이전 세션이 `/handoff` 로 남긴 `.dcness-work/handoffs/next-session.md` 가 있으면 `.dcness-work/handoffs/archive/<ts>.md` 로 먼저 옮겨(mv) 원자적으로 소비한 뒤 그 내용을 `additionalContext` 최상단에 최우선 주입함(무손실 clear) — 다음다음 세션 stale 재주입 차단. mv(rename)를 read 보다 선행하므로 병렬 peer 세션 중 rename 에 성공한 first-consumer 만 소비(단일 소비자 계약). `.dcness-work/` 는 writable 이라 심어진 심링크(→ 로컬 시크릿)를 따라가 컨텍스트로 유출하지 않도록 정규 파일(심링크 아님)일 때만 소비. 파일 부재 시 기존 동작 그대로
 - 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
 - 프로젝트 상태나 다음 작업 질문에는 `docs/index.md` 와 `## 진행 상태 · 다음 작업` 섹션이 실제로 있을 때만 해당 포인터를 안내하고, 파일/섹션이 없으면 `/next-work` issue/label 조회와 `/init-dcness` 보강 경로를 안내함
 - 설치된 plug-in 버전과 `main` 의 최신 버전을 비교(하루 1회 캐시)해 더 높은 버전이 있을 때만 `claude plugin update` 알림을 함께 inject — 외부 활성 프로젝트가 옛 plug-in 버전 운영 룰에 묶이는 drift 회피

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -73,6 +73,7 @@ dcNess hook 은 보안 sandbox 가 아니다. file boundary 와 외부 상태 �
 - sid 추출, `.by-pid/<cc_pid>` 작성, `live.json` 초기화
 - 상태 위생 청소 (세션당 1회, fail-open): stale by-pid 파일(24h) + 본 세션의 만료 run 슬롯(24h) + 전 세션의 run 디렉토리(prose/ledger, 7d — `/run-review` 원자료라 슬롯보다 길게 보관). TTL 상수 SSOT = `harness/session_state.py`
 - `hookSpecificOutput.additionalContext` 로 dcNess 활성 사실과 핵심 guard 안내 inject
+- 이전 세션이 `/handoff` 로 남긴 `.dcness-work/handoffs/next-session.md` 가 있으면 그 내용을 `additionalContext` 최상단에 최우선 주입하고, 주입 직후 `.dcness-work/handoffs/archive/<ts>.md` 로 옮겨 무손실 clear 함 — 다음다음 세션 stale 재주입 차단. 파일 부재 시 기존 동작 그대로. 병렬 peer 세션은 first-consumer 가 archive 로 소비
 - 메인 Claude 첫 응답 첫 줄에 `[dcness 활성 확인]` 토큰을 요구해 활성 여부를 사용자가 바로 확인 가능하게 함
 - 프로젝트 상태나 다음 작업 질문에는 `docs/index.md` 와 `## 진행 상태 · 다음 작업` 섹션이 실제로 있을 때만 해당 포인터를 안내하고, 파일/섹션이 없으면 `/next-work` issue/label 조회와 `/init-dcness` 보강 경로를 안내함
 - 설치된 plug-in 버전과 `main` 의 최신 버전을 비교(하루 1회 캐시)해 더 높은 버전이 있을 때만 `claude plugin update` 알림을 함께 inject — 외부 활성 프로젝트가 옛 plug-in 버전 운영 룰에 묶이는 drift 회피

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -41,7 +41,8 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 | `/migrate-dcness` | 기존 비-dcness 프로젝트를 코드 역설계로 전역 docs(`prd.md`/`architecture.md`/`conventions.md`/`decisions/`/`index.md`)를 채워 부트스트랩하는 일회성 유틸리티. `/init-dcness`(활성화)의 짝. epic/story 산출물은 만들지 않는다 |
 | `/next-work` | GitHub issue open/closed 상태, `in-progress` label, Issue Brief Priority 로 다음 작업 후보를 read-only 조회 |
 | `/run-review` | 끝난 run 사후 분석 |
-| `/smart-compact` | resume prompt 포함 context compact 보조 |
+| `/smart-compact` | resume prompt 포함 *같은 세션* context compact 보조 |
+| `/handoff` | 세션을 넘기기 전 의도/결정/진행/다음 액션을 `.dcness-work/handoffs/next-session.md` 에 인계 문서로 기록한다. 다음 세션 SessionStart 훅이 최우선 주입 후 archive 로 clear 하는 결정적 cross-session warm 인계 (auto-memory 비의존) |
 | `/efficiency` | 세션 토큰/비용 분석 |
 
 ## Internal Skills

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -81,14 +81,21 @@ fi
 export DCNESS_NEXT_POINTER_MSG
 
 # === 대기 핸드오프 (warm 레이어) ===
-# 이전 세션이 /handoff 로 남긴 인계 문서가 있으면 내용을 캡처해 additionalContext
-# 최상단에 주입하고, 주입 직후 archive 로 옮겨 무손실 clear 한다. 캡처를 선행하므로
-# 이후 어떤 실패에도 내용은 archive 에 보존된다. 파일 부재 시 아무 동작도 하지 않아
-# 훅은 기존 동작 그대로다.
+# 이전 세션이 /handoff 로 남긴 인계 문서가 있으면 archive 로 먼저 옮겨 원자적으로
+# 소비(claim)한 뒤 그 내용을 additionalContext 최상단에 주입한다. mv(rename)를 read
+# 보다 선행하므로 병렬 peer 세션 중 rename 에 성공한 first-consumer 만 내용을 얻어
+# 단일 소비자 계약을 만족한다. 소비된 파일은 archive 에 보존(무손실)돼 다음다음 세션에
+# stale 재주입되지 않는다. 파일 부재 시 아무 동작도 하지 않아 훅은 기존 동작 그대로다.
+# 쓰기 경로(commands/handoff.md)도 같은 repo 루트를 써 서브디렉토리 실행에도 정합한다.
 DCNESS_HANDOFF_MSG=""
 HANDOFF_ACTIVE="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/next-session.md"
 if [[ -s "$HANDOFF_ACTIVE" ]]; then
-  DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_ACTIVE" 2>/dev/null || echo "")
+  HANDOFF_ARCHIVE_DIR="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/archive"
+  mkdir -p "$HANDOFF_ARCHIVE_DIR" 2>/dev/null
+  HANDOFF_CLAIMED="$HANDOFF_ARCHIVE_DIR/$(date +%Y%m%d-%H%M%S).md"
+  if mv "$HANDOFF_ACTIVE" "$HANDOFF_CLAIMED" 2>/dev/null; then
+    DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_CLAIMED" 2>/dev/null || echo "")
+  fi
 fi
 export DCNESS_HANDOFF_MSG
 
@@ -130,14 +137,6 @@ print(json.dumps({
     }
 }))
 " 2>/dev/null
-
-# 주입 직후 archive 이동 (무손실 clear) — 다음다음 세션 stale 재주입 차단.
-# 병렬 peer 세션은 각자 SessionStart 를 발화하므로 first-consumer 가 이 mv 로 소비한다.
-if [[ -n "$DCNESS_HANDOFF_MSG" && -s "$HANDOFF_ACTIVE" ]]; then
-  HANDOFF_ARCHIVE_DIR="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/archive"
-  mkdir -p "$HANDOFF_ARCHIVE_DIR" 2>/dev/null
-  mv "$HANDOFF_ACTIVE" "$HANDOFF_ARCHIVE_DIR/$(date +%Y%m%d-%H%M%S).md" 2>/dev/null || true
-fi
 
 # 모든 실패는 silent
 exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -87,16 +87,21 @@ export DCNESS_NEXT_POINTER_MSG
 # 단일 소비자 계약을 만족한다. 소비된 파일은 archive 에 보존(무손실)돼 다음다음 세션에
 # stale 재주입되지 않는다. 파일 부재 시 아무 동작도 하지 않아 훅은 기존 동작 그대로다.
 # 쓰기 경로(commands/handoff.md)도 같은 repo 루트를 써 서브디렉토리 실행에도 정합한다.
+# `.dcness-work/` 는 untracked·writable 이므로 심어진 심링크를 따라가 임의 로컬 파일(.env
+# 등)을 컨텍스트로 유출하지 않도록, 심링크가 아닌 정규 파일일 때만 claim/read 한다.
 DCNESS_HANDOFF_MSG=""
 HANDOFF_ACTIVE="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/next-session.md"
-if [[ -s "$HANDOFF_ACTIVE" ]]; then
+if [[ -f "$HANDOFF_ACTIVE" && ! -L "$HANDOFF_ACTIVE" && -s "$HANDOFF_ACTIVE" ]]; then
   HANDOFF_ARCHIVE_DIR="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/archive"
   mkdir -p "$HANDOFF_ARCHIVE_DIR" 2>/dev/null
   # 파일명에 프로세스 PID 를 붙여 같은 초에 소비되는 서로 다른 handoff 끼리 archive
   # 파일명이 충돌해 덮어써지는(무손실 위반) 것을 막는다. 세션마다 별 프로세스라 PID 는
   # 서로 다르고, 동일 src 를 노리는 병렬 mv 는 rename 원자성으로 하나만 성공한다.
   HANDOFF_CLAIMED="$HANDOFF_ARCHIVE_DIR/$(date +%Y%m%d-%H%M%S)-$$.md"
-  if mv "$HANDOFF_ACTIVE" "$HANDOFF_CLAIMED" 2>/dev/null; then
+  # mv(rename)는 심링크를 따라가지 않으므로 check 이후 심링크로 교체되는 TOCTOU 도
+  # archived 사본을 read 전 재확인해 차단한다.
+  if mv "$HANDOFF_ACTIVE" "$HANDOFF_CLAIMED" 2>/dev/null \
+     && [[ -f "$HANDOFF_CLAIMED" && ! -L "$HANDOFF_CLAIMED" ]]; then
     DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_CLAIMED" 2>/dev/null || echo "")
   fi
 fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -80,6 +80,18 @@ else
 fi
 export DCNESS_NEXT_POINTER_MSG
 
+# === 대기 핸드오프 (warm 레이어) ===
+# 이전 세션이 /handoff 로 남긴 인계 문서가 있으면 내용을 캡처해 additionalContext
+# 최상단에 주입하고, 주입 직후 archive 로 옮겨 무손실 clear 한다. 캡처를 선행하므로
+# 이후 어떤 실패에도 내용은 archive 에 보존된다. 파일 부재 시 아무 동작도 하지 않아
+# 훅은 기존 동작 그대로다.
+DCNESS_HANDOFF_MSG=""
+HANDOFF_ACTIVE="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/next-session.md"
+if [[ -s "$HANDOFF_ACTIVE" ]]; then
+  DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_ACTIVE" 2>/dev/null || echo "")
+fi
+export DCNESS_HANDOFF_MSG
+
 # 슬림 inject (#596) — SessionStart 는 *초기화 + 최소 활성 안내* 만 담당.
 # 문서 진입 매트릭스 / 안티패턴 / soft 필수 / cost-aware 항목은 제거: 하네스 모델은
 # "문서 선독 기반 compliance" 가 아니라 "hook 이 차단하고 그 자리에서 복구". 절차·분기는
@@ -88,8 +100,16 @@ python3 -c "
 import json, os
 update_msg = os.environ.get('DCNESS_UPDATE_MSG', '').strip()
 next_pointer_msg = os.environ.get('DCNESS_NEXT_POINTER_MSG', '').strip()
+handoff_msg = os.environ.get('DCNESS_HANDOFF_MSG', '').strip()
+handoff_block = ''
+if handoff_msg:
+    handoff_block = (
+        '## ⚠️ 대기 핸드오프 — 이것부터 읽고 시작\n\n'
+        '이전 세션이 /handoff 로 남긴 인계다. 다음 액션부터 확인하고, 상세는 포인터를 질의 시점에 lazy 로드한다.\n\n'
+        + handoff_msg + '\n\n---\n\n'
+    )
 header = (update_msg + '\n\n---\n\n') if update_msg else ''
-msg = header + f'''## [dcness 활성 환경]
+msg = handoff_block + header + f'''## [dcness 활성 환경]
 
 첫 응답 첫 줄에 \`[dcness 활성 확인]\` 토큰 출력 (활성 신호 — 부재 시 사용자가 룰 미적용을 즉시 인지).
 
@@ -110,6 +130,14 @@ print(json.dumps({
     }
 }))
 " 2>/dev/null
+
+# 주입 직후 archive 이동 (무손실 clear) — 다음다음 세션 stale 재주입 차단.
+# 병렬 peer 세션은 각자 SessionStart 를 발화하므로 first-consumer 가 이 mv 로 소비한다.
+if [[ -n "$DCNESS_HANDOFF_MSG" && -s "$HANDOFF_ACTIVE" ]]; then
+  HANDOFF_ARCHIVE_DIR="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/archive"
+  mkdir -p "$HANDOFF_ARCHIVE_DIR" 2>/dev/null
+  mv "$HANDOFF_ACTIVE" "$HANDOFF_ARCHIVE_DIR/$(date +%Y%m%d-%H%M%S).md" 2>/dev/null || true
+fi
 
 # 모든 실패는 silent
 exit 0

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -92,7 +92,10 @@ HANDOFF_ACTIVE="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/next-session.md"
 if [[ -s "$HANDOFF_ACTIVE" ]]; then
   HANDOFF_ARCHIVE_DIR="$PROJECT_ROOT_FOR_DOCS/.dcness-work/handoffs/archive"
   mkdir -p "$HANDOFF_ARCHIVE_DIR" 2>/dev/null
-  HANDOFF_CLAIMED="$HANDOFF_ARCHIVE_DIR/$(date +%Y%m%d-%H%M%S).md"
+  # 파일명에 프로세스 PID 를 붙여 같은 초에 소비되는 서로 다른 handoff 끼리 archive
+  # 파일명이 충돌해 덮어써지는(무손실 위반) 것을 막는다. 세션마다 별 프로세스라 PID 는
+  # 서로 다르고, 동일 src 를 노리는 병렬 mv 는 rename 원자성으로 하나만 성공한다.
+  HANDOFF_CLAIMED="$HANDOFF_ARCHIVE_DIR/$(date +%Y%m%d-%H%M%S)-$$.md"
   if mv "$HANDOFF_ACTIVE" "$HANDOFF_CLAIMED" 2>/dev/null; then
     DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_CLAIMED" 2>/dev/null || echo "")
   fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -102,7 +102,16 @@ if [[ -f "$HANDOFF_ACTIVE" && ! -L "$HANDOFF_ACTIVE" && -s "$HANDOFF_ACTIVE" ]];
   # archived 사본을 read 전 재확인해 차단한다.
   if mv "$HANDOFF_ACTIVE" "$HANDOFF_CLAIMED" 2>/dev/null \
      && [[ -f "$HANDOFF_CLAIMED" && ! -L "$HANDOFF_CLAIMED" ]]; then
-    DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_CLAIMED" 2>/dev/null || echo "")
+    # slim-inject 보호 + exec env 한도 회피 — 상한 초과 시 전문을 주입하지 않고
+    # archive 전문을 가리키는 포인터만 넣는다(무손실: 전문은 archive 사본에 보존).
+    HANDOFF_MAX_BYTES=16384
+    HANDOFF_BYTES=$(wc -c < "$HANDOFF_CLAIMED" 2>/dev/null | tr -d '[:space:]')
+    HANDOFF_BYTES=${HANDOFF_BYTES:-0}
+    if [[ "$HANDOFF_BYTES" -gt "$HANDOFF_MAX_BYTES" ]]; then
+      DCNESS_HANDOFF_MSG="대기 핸드오프가 너무 큼(${HANDOFF_BYTES}B > ${HANDOFF_MAX_BYTES}B) — slim-inject 보호를 위해 전문 주입 생략. 다음 파일을 직접 읽고 시작할 것: ${HANDOFF_CLAIMED}"
+    else
+      DCNESS_HANDOFF_MSG=$(cat "$HANDOFF_CLAIMED" 2>/dev/null || echo "")
+    fi
   fi
 fi
 export DCNESS_HANDOFF_MSG

--- a/scripts/check_public_surface.mjs
+++ b/scripts/check_public_surface.mjs
@@ -16,7 +16,7 @@ const EXPECTED = {
   advancedSkills: ['impl-loop', 'tech-review'],
   utilitySkills: ['ux'],
   internalSkills: ['canvas-design', 'compact-design'],
-  utilityCommands: ['efficiency', 'init-dcness', 'migrate-dcness', 'next-work', 'run-review', 'smart-compact'],
+  utilityCommands: ['efficiency', 'handoff', 'init-dcness', 'migrate-dcness', 'next-work', 'run-review', 'smart-compact'],
   internalAgents: [
     'architecture-validator',
     'build-worker',

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -272,6 +272,35 @@ class BashPipelineSmokeTests(unittest.TestCase):
             archived[0].read_text(encoding="utf-8"),
         )
 
+    def test_session_start_handoff_consumed_once(self) -> None:
+        """#953 — claim-first: 한 번 소비된 handoff 는 다음 SessionStart 에 재주입되지
+        않고 archive 사본도 늘지 않는다 (단일 소비자 계약, 순차 프록시)."""
+        handoffs = self.cwd / ".dcness-work" / "handoffs"
+        handoffs.mkdir(parents=True)
+        (handoffs / "next-session.md").write_text(
+            "# 핸드오프\n\n## 다음 액션\n- 단일 소비 검증\n",
+            encoding="utf-8",
+        )
+
+        first = _run_bash_hook(
+            "session-start.sh", {"sessionId": "smoke-ses-consume-1"}, cwd=self.cwd,
+        )
+        self.assertEqual(first.returncode, 0)
+        ctx1 = json.loads(first.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertIn("단일 소비 검증", ctx1)
+
+        second = _run_bash_hook(
+            "session-start.sh", {"sessionId": "smoke-ses-consume-2"}, cwd=self.cwd,
+        )
+        self.assertEqual(second.returncode, 0)
+        ctx2 = json.loads(second.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertNotIn("대기 핸드오프", ctx2)
+        self.assertNotIn("단일 소비 검증", ctx2)
+
+        # archive 사본은 1개만 (두 번째 세션이 stale 재소비/재아카이브하지 않음)
+        archived = list((handoffs / "archive").glob("*.md"))
+        self.assertEqual(len(archived), 1, f"archive 1개 기대, 실제: {archived}")
+
     def test_session_start_no_handoff_is_noop(self) -> None:
         """#953 — handoff 파일 부재 시 훅은 기존 동작 그대로 (무해)."""
         result = _run_bash_hook(

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -355,6 +355,29 @@ class BashPipelineSmokeTests(unittest.TestCase):
         # 심링크는 따라가 archive 로 옮기지도 않는다 (타겟 보존)
         self.assertTrue(secret.exists())
 
+    def test_session_start_oversize_handoff_injects_pointer_not_dump(self) -> None:
+        """#953 — 상한 초과 handoff 는 전문을 컨텍스트로 덤프하지 않고 archive 전문
+        포인터만 주입한다 (slim-inject 보호 + exec 한도 회피, 전문은 무손실 보존)."""
+        handoffs = self.cwd / ".dcness-work" / "handoffs"
+        handoffs.mkdir(parents=True)
+        bulk = "X" * 20000  # 16KB 상한 초과
+        (handoffs / "next-session.md").write_text(
+            f"# 대용량\n{bulk}\n", encoding="utf-8",
+        )
+
+        result = _run_bash_hook(
+            "session-start.sh", {"sessionId": "smoke-ses-big"}, cwd=self.cwd,
+        )
+        self.assertEqual(result.returncode, 0)
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertNotIn("XXXXXXXXXX", ctx, "대용량 handoff 전문이 컨텍스트로 덤프됨")
+        self.assertIn("너무 큼", ctx, "상한 초과 포인터 메시지 부재")
+
+        # 전문은 archive 사본에 보존 (무손실)
+        archived = list((handoffs / "archive").glob("*.md"))
+        self.assertEqual(len(archived), 1)
+        self.assertIn("XXXXXXXXXX", archived[0].read_text(encoding="utf-8"))
+
     def test_session_start_no_handoff_is_noop(self) -> None:
         """#953 — handoff 파일 부재 시 훅은 기존 동작 그대로 (무해)."""
         result = _run_bash_hook(

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -231,6 +231,60 @@ class BashPipelineSmokeTests(unittest.TestCase):
         self.assertIn("/init-dcness` 재실행으로 섹션을 보강", ctx)
         self.assertNotIn("docs/index.md` 의 `## 진행 상태 · 다음 작업` 포인터", ctx)
 
+    def test_session_start_injects_pending_handoff(self) -> None:
+        """#953 — 이전 세션이 남긴 handoff 가 additionalContext 최상단에 주입되고
+        주입 직후 archive 로 이동해 active 경로에서 사라진다 (무손실 clear)."""
+        handoffs = self.cwd / ".dcness-work" / "handoffs"
+        handoffs.mkdir(parents=True)
+        (handoffs / "next-session.md").write_text(
+            "# 다음 세션 핸드오프\n\n## 다음 액션\n- issue953 handoff 테스트 green 확인\n",
+            encoding="utf-8",
+        )
+
+        result = _run_bash_hook(
+            "session-start.sh",
+            {"sessionId": "smoke-ses-handoff"},
+            cwd=self.cwd,
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            f"stderr: {result.stderr}\nstdout: {result.stdout}",
+        )
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+        # 핸드오프 내용이 최상단(활성 안내보다 위)에 주입
+        self.assertIn("대기 핸드오프", ctx)
+        self.assertIn("issue953 handoff 테스트 green 확인", ctx)
+        self.assertLess(
+            ctx.index("대기 핸드오프"), ctx.index("[dcness 활성 환경]"),
+            "핸드오프가 활성 안내보다 위에 와야 한다",
+        )
+
+        # 소비 후 active 파일 제거 + archive 로 이동 (무손실)
+        self.assertFalse(
+            (handoffs / "next-session.md").exists(),
+            "active 핸드오프가 archive 로 이동되지 않음 — 다음 세션 stale 재주입 위험",
+        )
+        archived = list((handoffs / "archive").glob("*.md"))
+        self.assertEqual(len(archived), 1, f"archive 파일 1개 기대, 실제: {archived}")
+        self.assertIn(
+            "issue953 handoff 테스트 green 확인",
+            archived[0].read_text(encoding="utf-8"),
+        )
+
+    def test_session_start_no_handoff_is_noop(self) -> None:
+        """#953 — handoff 파일 부재 시 훅은 기존 동작 그대로 (무해)."""
+        result = _run_bash_hook(
+            "session-start.sh",
+            {"sessionId": "smoke-ses-no-handoff"},
+            cwd=self.cwd,
+        )
+        self.assertEqual(result.returncode, 0)
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertNotIn("대기 핸드오프", ctx)
+        # 파일이 없으면 archive 디렉토리조차 만들지 않는다
+        self.assertFalse((self.cwd / ".dcness-work" / "handoffs" / "archive").exists())
+
     def test_invalid_sid_silent_no_artifacts(self) -> None:
         result = _run_bash_hook(
             "session-start.sh",

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -301,6 +301,40 @@ class BashPipelineSmokeTests(unittest.TestCase):
         archived = list((handoffs / "archive").glob("*.md"))
         self.assertEqual(len(archived), 1, f"archive 1개 기대, 실제: {archived}")
 
+    def test_session_start_two_handoffs_both_archived(self) -> None:
+        """#953 — 같은 초에 소비되는 서로 다른 두 handoff 의 archive 사본이 파일명
+        충돌 없이 둘 다 보존된다 (무손실 계약). ts-only 파일명이면 덮어써져 실패."""
+        handoffs = self.cwd / ".dcness-work" / "handoffs"
+        handoffs.mkdir(parents=True)
+
+        (handoffs / "next-session.md").write_text(
+            "# H1\n\n## 다음 액션\n- first-handoff\n", encoding="utf-8",
+        )
+        r1 = _run_bash_hook(
+            "session-start.sh", {"sessionId": "smoke-ses-h1"}, cwd=self.cwd,
+        )
+        self.assertEqual(r1.returncode, 0)
+
+        (handoffs / "next-session.md").write_text(
+            "# H2\n\n## 다음 액션\n- second-handoff\n", encoding="utf-8",
+        )
+        r2 = _run_bash_hook(
+            "session-start.sh", {"sessionId": "smoke-ses-h2"}, cwd=self.cwd,
+        )
+        self.assertEqual(r2.returncode, 0)
+
+        archived = [
+            p.read_text(encoding="utf-8")
+            for p in (handoffs / "archive").glob("*.md")
+        ]
+        self.assertEqual(
+            len(archived), 2,
+            f"두 handoff 모두 보존돼야 함(무손실) — 실제 archive: {archived}",
+        )
+        joined = "\n".join(archived)
+        self.assertIn("first-handoff", joined)
+        self.assertIn("second-handoff", joined)
+
     def test_session_start_no_handoff_is_noop(self) -> None:
         """#953 — handoff 파일 부재 시 훅은 기존 동작 그대로 (무해)."""
         result = _run_bash_hook(

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -335,6 +335,26 @@ class BashPipelineSmokeTests(unittest.TestCase):
         self.assertIn("first-handoff", joined)
         self.assertIn("second-handoff", joined)
 
+    def test_session_start_symlink_handoff_not_followed(self) -> None:
+        """#953 — next-session.md 가 심링크면 따라가지 않는다. `.dcness-work/` 는
+        writable 이라 심어진 심링크(→ .env 등)를 훅이 read 하면 로컬 시크릿이 모델
+        컨텍스트로 유출되므로, 정규 파일이 아닐 때는 소비/주입하지 않는다 (codex P2)."""
+        handoffs = self.cwd / ".dcness-work" / "handoffs"
+        handoffs.mkdir(parents=True)
+        secret = self.cwd / "secret.txt"
+        secret.write_text("SECRET_CONTENT_LEAK\n", encoding="utf-8")
+        (handoffs / "next-session.md").symlink_to(secret)
+
+        result = _run_bash_hook(
+            "session-start.sh", {"sessionId": "smoke-ses-symlink"}, cwd=self.cwd,
+        )
+        self.assertEqual(result.returncode, 0)
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+        self.assertNotIn("SECRET_CONTENT_LEAK", ctx, "심링크 타겟이 컨텍스트로 유출됨")
+        self.assertNotIn("대기 핸드오프", ctx)
+        # 심링크는 따라가 archive 로 옮기지도 않는다 (타겟 보존)
+        self.assertTrue(secret.exists())
+
     def test_session_start_no_handoff_is_noop(self) -> None:
         """#953 — handoff 파일 부재 시 훅은 기존 동작 그대로 (무해)."""
         result = _run_bash_hook(


### PR DESCRIPTION
## 관련 이슈 번호

Closes #953

## 배경 및 문제

다음 세션 핸드오프가 지금은 Claude Code auto-memory(불투명·모델 임의 저장)에만 의존한다. `/smart-compact` 는 클립보드→사용자 paste 라 수동이고 *같은 세션* 압축 전용이며, 슬래시 명령 자동 실행이 불가하다. cross-session 결정적 인계를 담당하는 dcNess 산출물이 없었다.

확장 지점은 실존한다: SessionStart 훅(`hooks/session-start.sh`)이 이미 `additionalContext` 를 주입하고, `.dcness-work/handoffs/` 는 이미 `deliverables-map.md` 가 handoff 영역으로 규정한 git-excluded 작업 영역이다.

## 원인 (해당 시)

-

## 작업내용

세션을 넘기기 전 의도/결정/진행/다음 액션을 `.dcness-work/handoffs/next-session.md` 에 쓰고, 다음 세션 SessionStart 훅이 최우선 주입한 뒤 archive 로 clear 하는 warm 핸드오프 레이어.

- `commands/handoff.md` (신규): `/handoff` 명령 + 자연어 트리거 frontmatter("핸드오프 만들어줘"/"인계 문서 써줘" 등, `next-work`/`smart-compact` 와 동일 패턴). 단문 양식(다음 액션 필수 + 근거 + 포인터 링크), first-consumer-wins semantics 명시.
- `hooks/session-start.sh`: `next-session.md` 있으면 내용을 캡처해 `additionalContext` 최상단에 주입 → 주입 직후 `archive/<ts>.md` 로 이동(무손실 clear). 부재 시 기존 동작 그대로.
- `scripts/check_public_surface.mjs` + `docs/plugin/positioning.md`: 신규 공개 command `handoff` 등록(public-surface gate 정합).
- `docs/plugin/deliverables-map.md` + `docs/plugin/hooks.md`: `.dcness-work/handoffs/` 세션 인계 경로/훅 동작 SSOT 갱신.
- `tests/test_multisession_smoke.py`: 주입/archive/무동작 e2e 회귀 테스트 2건.

## 결정 근거

착수 전 선행 결정([이슈 코멘트](https://github.com/Daeguk-Sun/dcNess/issues/953#issuecomment-4889443000))을 반영:

- **경로 정합**: 이슈 본문의 `.dcness-work/handoff.md` 대신 기존 규정 디렉토리 `.dcness-work/handoffs/` 재사용. 활성 파일명은 `next-session.md` 로 고정(SessionStart 훅이 확인할 결정적 단일 경로).
- **slim-inject 원칙**: handoff 양식을 "다음 액션 1개(필수) + 근거 + 포인터" 단문으로 제한. 세션 전체 덤프 금지, 상세는 포인터 lazy 로드.
- **주입 순서**: 내용 캡처 → 최상단 주입 → 주입 직후 archive. 캡처 선행이라 이후 어떤 실패에도 내용은 archive 에 보존(무손실).
- **병렬 peer semantics**: first-consumer-wins. handoff 는 단일 소비자 인계 문서, 병렬 작업 분배는 claim board 몫. command 문서에 명시.

## 배포 경로 검증 (plug-in 영향 시)

- **배포 경로 1 (plug-in 본체)**: `hooks/session-start.sh`, `commands/handoff.md` — plugin 업데이트로 외부 활성 프로젝트에 자동 도달.
- **배포 경로 3 (사용자용 SSOT)**: `docs/plugin/positioning.md`, `docs/plugin/deliverables-map.md`, `docs/plugin/hooks.md` — plug-in SSOT 문서로 함께 배포.
- `.gitignore` 의 `.dcness-work/` 제외는 기존 `/init-dcness` 가 이미 처리(신규 배포 스텝 불필요).

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

`/handoff` 는 신규 공개 command 다.

1. **기존 risk router lane 으로 흡수 안 되나?** — handoff 는 구현 경로(gate×shape) 판정 대상이 아니라 세션 경계 인계다. workflow-router lane 에 속하지 않는다.
2. **기존 validator/reviewer 로 검증 안 되나?** — 인계 문서 작성은 검증 대상이 아니다.
3. **기존 agent 내부 단계로 못 두고 새 public 발화가 꼭 필요한가?** — `/smart-compact` 는 *같은 세션* `/compact` 압축 전용이고, cross-session 결정적 핸드오프를 담당하는 기존 표면은 없다. auto-memory 는 CC 사용자 수준 불투명 저장소라 dcNess 산출물이 아니다. 사용자가 세션 종료 시 명시 발화("다음 세션에 넘겨줘")로 트리거하는 새 진입점이 필요하다.

## Test Plan

- [x] `tests/test_multisession_smoke.py`: handoff 주입(최상단) + archive 이동 + 파일 부재 무동작 e2e (신규 2건, TDD red→green)
- [x] 전체 단위 테스트 1656건 통과
- [x] slim-inject 회귀 테스트(#596) 통과 — 무핸드오프 경로 기존 동작 보존
- [x] `check_public_surface.mjs` / `check_cross_refs.mjs` / `check_plugin_manifest.mjs` PASS
- [x] `bash -n hooks/session-start.sh` PASS

## 참고

-
