### PR TITLE
[feature] next-pointer: "뭐하지/남은 일" 트리거 + 다음 액션 단정 + focused preload 오케스트레이션 (#954)

### DIFF
--- a/commands/next-work.md
+++ b/commands/next-work.md
@@ -31,7 +31,7 @@ node "$SCRIPT" next-work --repo OWNER/REPO
 - read-only: `--apply` 를 쓰지 않고, issue/label/Project/PR 상태를 변경하지 않는다.
 - Project 좌표나 bootstrap 없이 open issue 목록만으로 동작한다.
 - 출력 계층은 L1 `in-progress` 이어하기 → L2 blocker/critical 긴급 → L3 story/feature/task/bug 후보 순서다. L2 긴급 승격은 story 를 제외한다 — story 는 priority 무관하게 소속 epic 설계 phase 로 판정하므로 항상 L3 로 흘려보낸다.
-- 이 계층은 후보 나열이다. "뭐하지 / 남은 일" 자연어 질의의 소비 계약: warm 인계(이전 세션 `/handoff`)가 있으면 그것이 이 조회보다 우선한다. warm 이 없으면 이 계층의 최상위 1개(L1>L2>L3)를 다음 액션으로 단정하고(메뉴로 남기지 않는다 — `/design <epic-path>` · `/impl` · 특정 story 중 하나 + 근거), "남은 일 브리핑" 은 계층 전체로 답한다. 단정한 액션이 가리키는 컨텍스트(해당 epic stories / 설계 산출물 유무 / 리팩터 base 브랜치)만 focused preload 한다.
+- 이 계층은 후보 나열이다. "뭐하지 / 남은 일" 자연어 질의의 소비 계약: warm 인계(이전 세션 `/handoff`)가 있으면 그것이 이 조회보다 우선한다. warm 이 없으면 이 계층의 최상위 1개(L1>L2>L3)를 다음 액션으로 단정하고(메뉴로 남기지 않는다 — `/design <epic-path>` · `/impl` · 특정 story 중 하나 + 근거), "남은 일 브리핑" 은 계층 전체로 답한다. 단, 최상위 후보에 위 phase 판정이 `판정 보류`(설계 산출물 로컬 확인 불가 / 대상 repo 불일치 등)로 나오면 `/design`·`/impl` 을 지어내지 말고 그 보류 사유를 그대로 전한다 — 확정 phase 일 때만 단정한다. 단정한 액션이 가리키는 컨텍스트(해당 epic stories / 설계 산출물 유무 / 리팩터 base 브랜치)만 focused preload 한다.
 - `subTask` 는 독립 후보에서 제외하고, body 의 `Part of #N` 부모가 L1 에 있을 때만 그 부모 아래에 중첩 표시한다.
 - story 후보는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순으로 표시한다.
 - story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. 설계 미완 epic 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, 설계 완료 epic 만 story 를 impl 후보로 승격한다. 로컬에 해당 epic 산출물이 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 판정을 보류한다.

--- a/commands/next-work.md
+++ b/commands/next-work.md
@@ -1,6 +1,6 @@
 ---
 name: next-work
-description: GitHub issue 상태와 label에서 이어하기, 긴급, 다음 작업 후보를 조회하는 read-only 유틸리티. 사용자가 "/next-work", "다음 작업", "뭐부터 하지", "진행 중 작업", "콜드스타트 시작점" 등을 말할 때 사용한다.
+description: GitHub issue 상태와 label에서 이어하기, 긴급, 다음 작업 후보를 조회하는 read-only 유틸리티. 사용자가 "/next-work", "다음 작업", "뭐하지", "뭐부터 하지", "이제 뭐해야하지", "남은 일 알려줘", "남은 일 브리핑", "이어서", "진행 중 작업", "콜드스타트 시작점" 등 다음·남은 일을 물을 때 사용한다.
 ---
 
 # Next Work — 다음 작업 read-only 조회
@@ -31,6 +31,7 @@ node "$SCRIPT" next-work --repo OWNER/REPO
 - read-only: `--apply` 를 쓰지 않고, issue/label/Project/PR 상태를 변경하지 않는다.
 - Project 좌표나 bootstrap 없이 open issue 목록만으로 동작한다.
 - 출력 계층은 L1 `in-progress` 이어하기 → L2 blocker/critical 긴급 → L3 story/feature/task/bug 후보 순서다. L2 긴급 승격은 story 를 제외한다 — story 는 priority 무관하게 소속 epic 설계 phase 로 판정하므로 항상 L3 로 흘려보낸다.
+- 이 계층은 후보 나열이다. "뭐하지 / 남은 일" 자연어 질의의 소비 계약: warm 인계(이전 세션 `/handoff`)가 있으면 그것이 이 조회보다 우선한다. warm 이 없으면 이 계층의 최상위 1개(L1>L2>L3)를 다음 액션으로 단정하고(메뉴로 남기지 않는다 — `/design <epic-path>` · `/impl` · 특정 story 중 하나 + 근거), "남은 일 브리핑" 은 계층 전체로 답한다. 단정한 액션이 가리키는 컨텍스트(해당 epic stories / 설계 산출물 유무 / 리팩터 base 브랜치)만 focused preload 한다.
 - `subTask` 는 독립 후보에서 제외하고, body 의 `Part of #N` 부모가 L1 에 있을 때만 그 부모 아래에 중첩 표시한다.
 - story 후보는 `epic-NN-<slug>` label 의 NN 오름차순, 같은 epic 안에서는 issue 번호 오름차순으로 표시한다.
 - story 는 epic 단위로 로컬 설계 산출물(`docs/epics/epic-NN-<slug>/architecture.md` + `impl/NN-*.md`) 존재를 확인해 다음 액션을 구분한다. 설계 미완 epic 은 story 를 impl 후보로 내밀지 않고 `/design <epic-path>` 를 제시하고, 설계 완료 epic 만 story 를 impl 후보로 승격한다. 로컬에 해당 epic 산출물이 없으면(repo 밖 실행 / stale checkout) `/design` 을 단정하지 않고 판정을 보류한다.

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -69,15 +69,21 @@ export DCNESS_UPDATE_MSG
 
 PROJECT_ROOT_FOR_DOCS=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 DOCS_INDEX="$PROJECT_ROOT_FOR_DOCS/docs/index.md"
+# 구조 소스(cold) 절 — docs/index.md 유무·`## 진행 상태 · 다음 작업` 섹션 유무로 분기.
+# 오케스트레이션 래퍼(트리거 어휘 + 단정 + focused preload)는 세 경우 공통이라 아래서
+# 한 번만 조립한다. 'warm 인계' 로 지칭 — no-handoff 세션에서도 항상 주입되는 포인터라
+# handoff 블록 헤더('대기 핸드오프')와 같은 문자열을 쓰면 그 부재를 검증하는 소비/부재
+# 테스트를 회귀시키므로 다른 표현을 쓴다.
 if [[ -f "$DOCS_INDEX" ]]; then
   if grep -Eq '^## 진행 상태 · 다음 작업[[:space:]]*$' "$DOCS_INDEX" 2>/dev/null; then
-    DCNESS_NEXT_POINTER_MSG='프로젝트 상태나 다음 작업을 물으면 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 포인터를 확인하고, live issue/label 상태는 `/next-work` 로 조회한다.'
+    DCNESS_NEXT_INDEX_CLAUSE='없으면 구조 소스(cold)로 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 포인터와 `/next-work`(issue/label + phase 판정)를 화해시켜 phase 를 도출한다.'
   else
-    DCNESS_NEXT_POINTER_MSG='프로젝트 상태나 다음 작업을 물으면 현재 `docs/index.md` 에 `## 진행 상태 · 다음 작업` 섹션이 없으므로 live issue/label 상태는 `/next-work` 로 조회한다. 필요하면 `/init-dcness` 재실행으로 섹션을 보강한다.'
+    DCNESS_NEXT_INDEX_CLAUSE='없으면 구조 소스(cold)로, 현재 `docs/index.md` 에 `## 진행 상태 · 다음 작업` 섹션이 없으므로 `/next-work`(issue/label + phase 판정)로 phase 를 도출한다. 필요하면 `/init-dcness` 재실행으로 섹션을 보강한다.'
   fi
 else
-  DCNESS_NEXT_POINTER_MSG='프로젝트 상태나 다음 작업을 물으면 `docs/index.md` 가 없으므로 live issue/label 상태는 `/next-work` 로 조회한다. 필요하면 `/init-dcness` 로 project docs seed 를 설치한다.'
+  DCNESS_NEXT_INDEX_CLAUSE='없으면 구조 소스(cold)로, `docs/index.md` 가 없으므로 `/next-work`(issue/label + phase 판정)로 phase 를 도출한다. 필요하면 `/init-dcness` 로 project docs seed 를 설치한다.'
 fi
+DCNESS_NEXT_POINTER_MSG='"뭐하지 / 다음 일 / 남은 일 알려줘 / 이제 뭐해야하지 / 남은 일 브리핑 / 이어서" 처럼 다음·남은 일을 물으면: (1) 위에 warm 인계(이전 세션 /handoff)가 주입돼 있으면 그 다음 액션부터 이어간다. (2) '"$DCNESS_NEXT_INDEX_CLAUSE"' (3) 소스를 종합해 다음 액션 1개를 단정한다 — 메뉴 나열이 아니라 `/design <epic-path>` · `/impl` · 특정 story 중 하나 + 근거. 남은 일 전체를 물으면 `/next-work` 계층(L1>L2>L3)으로 함께 브리핑한다. (4) 그 액션이 가리키는 문서(해당 epic stories / prd 관련 절 / 설계 산출물 유무 / 리팩터 base 브랜치)만 focused preload 해 바로 착수한다. SessionStart 통독 금지 — preload 는 이 질의(또는 skill 진입) 시점에만.'
 export DCNESS_NEXT_POINTER_MSG
 
 # === 대기 핸드오프 (warm 레이어) ===

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -83,7 +83,7 @@ if [[ -f "$DOCS_INDEX" ]]; then
 else
   DCNESS_NEXT_INDEX_CLAUSE='없으면 구조 소스(cold)로, `docs/index.md` 가 없으므로 `/next-work`(issue/label + phase 판정)로 phase 를 도출한다. 필요하면 `/init-dcness` 로 project docs seed 를 설치한다.'
 fi
-DCNESS_NEXT_POINTER_MSG='"뭐하지 / 다음 일 / 남은 일 알려줘 / 이제 뭐해야하지 / 남은 일 브리핑 / 이어서" 처럼 다음·남은 일을 물으면: (1) 위에 warm 인계(이전 세션 /handoff)가 주입돼 있으면 그 다음 액션부터 이어간다. (2) '"$DCNESS_NEXT_INDEX_CLAUSE"' (3) 소스를 종합해 다음 액션 1개를 단정한다 — 메뉴 나열이 아니라 `/design <epic-path>` · `/impl` · 특정 story 중 하나 + 근거. 남은 일 전체를 물으면 `/next-work` 계층(L1>L2>L3)으로 함께 브리핑한다. (4) 그 액션이 가리키는 문서(해당 epic stories / prd 관련 절 / 설계 산출물 유무 / 리팩터 base 브랜치)만 focused preload 해 바로 착수한다. SessionStart 통독 금지 — preload 는 이 질의(또는 skill 진입) 시점에만.'
+DCNESS_NEXT_POINTER_MSG='"프로젝트 상태 / 뭐하지 / 다음 일 / 남은 일 알려줘 / 이제 뭐해야하지 / 남은 일 브리핑 / 이어서" 처럼 프로젝트 상태나 다음·남은 일을 물으면: (1) 위에 warm 인계(이전 세션 /handoff)가 주입돼 있으면 그 다음 액션부터 이어간다. (2) '"$DCNESS_NEXT_INDEX_CLAUSE"' (3) 소스를 종합해 다음 액션 1개를 단정한다 — 단 `/next-work` 가 그 후보에 `판정 보류`(설계 phase 미확인: repo 밖 실행 / stale checkout / epic 산출물 부재)를 표시하면 `/design`·`/impl` 을 지어내지 말고 그 보류 사유를 그대로 알린다. phase 가 확정된 경우에만 `/design <epic-path>` · `/impl` · 특정 story 중 하나로 단정하고 근거를 붙인다(메뉴 나열 금지). 남은 일 전체를 물으면 `/next-work` 계층(L1>L2>L3)으로 함께 브리핑한다. (4) 단정한 액션이 가리키는 문서(해당 epic stories / prd 관련 절 / 설계 산출물 유무 / 리팩터 base 브랜치)만 focused preload 해 바로 착수한다. SessionStart 통독 금지 — preload 는 이 질의(또는 skill 진입) 시점에만.'
 export DCNESS_NEXT_POINTER_MSG
 
 # === 대기 핸드오프 (warm 레이어) ===

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -245,8 +245,9 @@ class BashPipelineSmokeTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
         ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
 
-        # 넓어진 자연어 트리거 어휘
-        for trigger in ("뭐하지", "남은 일", "이제 뭐해야하지", "남은 일 브리핑"):
+        # 넓어진 자연어 트리거 어휘. '프로젝트 상태' 는 hooks.md 계약(파일/섹션 유무별
+        # 포인터·/next-work 안내)의 진입점이므로 어휘 확장 시 떨어뜨리면 회귀.
+        for trigger in ("프로젝트 상태", "뭐하지", "남은 일", "이제 뭐해야하지", "남은 일 브리핑"):
             self.assertIn(trigger, ctx, f"트리거 어휘 '{trigger}' 누락")
         # warm 우선 (단, no-handoff 테스트가 막는 '대기 핸드오프' 문자열은 금지)
         self.assertIn("warm 인계", ctx)
@@ -255,6 +256,9 @@ class BashPipelineSmokeTests(unittest.TestCase):
         self.assertIn("다음 액션 1개", ctx)
         self.assertIn("메뉴 나열", ctx)
         self.assertIn("focused preload", ctx)
+        # /next-work 가 phase 를 증명 못해 '판정 보류' 하면 /design·/impl 를 지어내지
+        # 않도록 단정을 확정 phase 조건부로 묶는다 (스크립트 보류 가드 우회 방지).
+        self.assertIn("판정 보류", ctx)
 
     def test_session_start_injects_pending_handoff(self) -> None:
         """#953 — 이전 세션이 남긴 handoff 가 additionalContext 최상단에 주입되고

--- a/tests/test_multisession_smoke.py
+++ b/tests/test_multisession_smoke.py
@@ -231,6 +231,31 @@ class BashPipelineSmokeTests(unittest.TestCase):
         self.assertIn("/init-dcness` 재실행으로 섹션을 보강", ctx)
         self.assertNotIn("docs/index.md` 의 `## 진행 상태 · 다음 작업` 포인터", ctx)
 
+    def test_session_start_pointer_orchestrates_next_and_remaining(self) -> None:
+        """#954 — next 포인터가 "뭐하지 / 남은 일 / 이제 뭐해야하지" 류 자연어 트리거에
+        (1) warm 인계 우선, (2) 없으면 구조 소스로 phase 도출, (3) 다음 액션 1개 단정
+        (메뉴 나열 금지) + 남은 일 브리핑, (4) 그 액션 컨텍스트만 focused preload 를
+        지시하는지 검증한다. warm 인계 문구는 no-handoff 테스트가 막는 '대기 핸드오프'
+        문자열을 쓰면 안 되므로 'warm 인계' 로 표현한다."""
+        result = _run_bash_hook(
+            "session-start.sh",
+            {"sessionId": "smoke-ses-pointer-orch"},
+            cwd=self.cwd,
+        )
+        self.assertEqual(result.returncode, 0)
+        ctx = json.loads(result.stdout)["hookSpecificOutput"]["additionalContext"]
+
+        # 넓어진 자연어 트리거 어휘
+        for trigger in ("뭐하지", "남은 일", "이제 뭐해야하지", "남은 일 브리핑"):
+            self.assertIn(trigger, ctx, f"트리거 어휘 '{trigger}' 누락")
+        # warm 우선 (단, no-handoff 테스트가 막는 '대기 핸드오프' 문자열은 금지)
+        self.assertIn("warm 인계", ctx)
+        self.assertNotIn("대기 핸드오프", ctx)
+        # 다음 액션 1개 단정 (메뉴 나열 아님) + 남은 일 브리핑 + focused preload
+        self.assertIn("다음 액션 1개", ctx)
+        self.assertIn("메뉴 나열", ctx)
+        self.assertIn("focused preload", ctx)
+
     def test_session_start_injects_pending_handoff(self) -> None:
         """#953 — 이전 세션이 남긴 handoff 가 additionalContext 최상단에 주입되고
         주입 직후 archive 로 이동해 active 경로에서 사라진다 (무손실 clear)."""


### PR DESCRIPTION
## 배경·문제

새 세션에서 사용자가 자연어로 "뭐하지 / 남은 일 알려줘 / 이제 뭐해야하지 / 남은 일 브리핑" 처럼 물었을 때, 소스(handoff warm · index phase · `/next-work`)를 화해시켜 **다음 액션 1개를 단정**하고 그 액션에 필요한 컨텍스트까지 읽혀 바로 착수되길 원한다. 선행 3개(#950 epic phase 마커, #951 `/next-work` phase 모델링, #953 handoff warm)가 인프라를 깔아뒀으나, 그 소스들을 자연어 질의에 화해시키는 **오케스트레이션 지시**가 없었다.

## 근본원인

SessionStart 가 inject 하던 next-pointer 문구가 "다음 작업을 물으면 `docs/index.md` 포인터 + `/next-work` 조회" 수준에 머물러 (1) 트리거 어휘가 좁고("다음 작업"만), (2) warm/cold 소스 우선순위·단정·focused preload 지시가 없었다. `/next-work` 는 계층 나열(L1>L2>L3)까지만 하고 그 위의 "최상위 1개 단정 + preload" 소비 계약이 문서화돼 있지 않았다.

## 작업내용

- **`hooks/session-start.sh`** — next-pointer 를 재작성. 트리거 어휘를 "뭐하지 / 다음 일 / 남은 일 알려줘 / 이제 뭐해야하지 / 남은 일 브리핑 / 이어서"로 확장하고, `(1)` warm 인계(handoff) 우선 -> `(2)` 없으면 구조 소스(index phase + `/next-work`) 화해 -> `(3)` 다음 액션 1개 단정(메뉴 나열 금지, `/design`·`/impl`·특정 story + 근거) + "남은 일 브리핑"은 `/next-work` 계층 전체로 답 -> `(4)` 그 액션 컨텍스트만 focused preload 의 4단 오케스트레이션을 지시. 3-변형 index clause(section 有/無/index 無)는 유지하고 공통 래퍼로 조립.
- **`commands/next-work.md`** — description 트리거 어휘 확장 + 동작 계약에 "최상위 1개 단정 + focused preload, warm 우선, 남은 일=계층 전체 브리핑" 소비 계약 1줄 추가.
- **`tests/test_multisession_smoke.py`** — 트리거 어휘/단정/preload/warm 우선을 검증하는 회귀 테스트 선작성(TDD).

## 결정근거

- **신규 진입점 무추가** — 착수 전 선행 결정(이슈 코멘트)대로 새 skill/command/agent 를 만들지 않고 기존 표면(session-start 포인터 + `/next-work`)에 녹였다 (안티패턴 5 회피).
- **"다음 액션 1개 단정" vs "남은 일 브리핑" 공존** — 사용자 요구(단정뿐 아니라 "남은 일 브리핑"에도 반응)를 반영해, 최상위 1개는 단정하되 "남은 일 전체"는 `/next-work` 계층으로 함께 브리핑하도록 명시. AC #1(단정)과 상충하지 않는다.
- **warm 우선 문구는 'warm 인계' 로 표현** — no-handoff 세션에도 포인터가 항상 주입되므로 handoff 블록 헤더('대기 핸드오프')와 같은 문자열을 쓰면 그 부재를 검증하는 소비/부재 smoke 테스트(#953)를 회귀시킨다. 다른 표현으로 회피.

## Test Plan

- `python3.11 -m unittest tests.test_multisession_smoke` — 신규 테스트 포함 14 smoke 전부 green (3-변형 index clause + no-handoff assertNotIn 회귀 없음 재확인).
- 전체 pre-commit pytest 게이트 1661 tests OK.
- `node scripts/check_cross_refs.mjs` PASS / `node scripts/check_public_surface.mjs` PASS.

## 배포 경로 검증

- `hooks/session-start.sh` (hooks.json 등록) · `commands/next-work.md` 둘 다 **plug-in 본체(경로 #1)** — 사용자 plugin 업데이트 시 자동 적용. init-dcness 복사 대상(#2)·별도 사용자 SSOT 문서(#3) 아님.

Closes #954