### PR TITLE
[issue-962] 서브에이전트 read 경계 재설정 — 활성 plugin 지침·템플릿 선별 예외 허용

### DIFF
--- a/agents/architecture-validator.md
+++ b/agents/architecture-validator.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/architecture-validator.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/architecture-validator.md
+++ b/agents/architecture-validator.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/architecture-validator.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/architecture-validator/architecture-validator-agent.md`](architecture-validator/architecture-validator-agent.md)를 읽는다.

--- a/agents/build-worker.md
+++ b/agents/build-worker.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/build-worker.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/build-worker/build-worker-agent.md`](build-worker/build-worker-agent.md)를 읽는다.

--- a/agents/build-worker.md
+++ b/agents/build-worker.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/build-worker.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/code-validator.md
+++ b/agents/code-validator.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/code-validator.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/code-validator.md
+++ b/agents/code-validator.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/code-validator.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/code-validator/code-validator-agent.md`](code-validator/code-validator-agent.md)를 읽는다.

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/designer.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/designer/designer-agent.md`](designer/designer-agent.md)를 읽는다.

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/designer.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/engineer.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/engineer/engineer-agent.md`](engineer/engineer-agent.md)를 읽는다.

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/engineer.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/module-architect.md
+++ b/agents/module-architect.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/module-architect.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/module-architect.md
+++ b/agents/module-architect.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/module-architect.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/module-architect/module-architect-agent.md`](module-architect/module-architect-agent.md)를 읽는다.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/pr-reviewer.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/pr-reviewer/pr-reviewer-agent.md`](pr-reviewer/pr-reviewer-agent.md)를 읽는다.

--- a/agents/pr-reviewer.md
+++ b/agents/pr-reviewer.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/pr-reviewer.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/product-acceptance.md
+++ b/agents/product-acceptance.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 `product-acceptance` agent 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/product-acceptance/product-acceptance-agent.md`](product-acceptance/product-acceptance-agent.md)를 읽는다.

--- a/agents/product-acceptance.md
+++ b/agents/product-acceptance.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 `product-acceptance` agent 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/system-architect.md
+++ b/agents/system-architect.md
@@ -11,7 +11,7 @@ model: opus
 
 이 파일은 기존 `agents/system-architect.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/system-architect.md
+++ b/agents/system-architect.md
@@ -11,6 +11,8 @@ model: opus
 
 이 파일은 기존 `agents/system-architect.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/system-architect/system-architect-agent.md`](system-architect/system-architect-agent.md)를 읽는다.

--- a/agents/tech-reviewer.md
+++ b/agents/tech-reviewer.md
@@ -11,6 +11,8 @@ model: opus
 
 이 파일은 기존 `agents/tech-reviewer.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/tech-reviewer/tech-reviewer-agent.md`](tech-reviewer/tech-reviewer-agent.md)를 읽는다.

--- a/agents/tech-reviewer.md
+++ b/agents/tech-reviewer.md
@@ -11,7 +11,7 @@ model: opus
 
 이 파일은 기존 `agents/tech-reviewer.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/test-engineer.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/test-engineer.md
+++ b/agents/test-engineer.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/test-engineer.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/test-engineer/test-engineer-agent.md`](test-engineer/test-engineer-agent.md)를 읽는다.

--- a/agents/ux-architect.md
+++ b/agents/ux-architect.md
@@ -11,7 +11,7 @@ model: sonnet
 
 이 파일은 기존 `agents/ux-architect.md` 소비자를 위한 호환 진입점이다.
 
-> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (없으면 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1`, 로컬 marketplace 설치면 `$HOME/.claude/plugins/marketplaces/dcness`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
 
 첫 행동:
 

--- a/agents/ux-architect.md
+++ b/agents/ux-architect.md
@@ -11,6 +11,8 @@ model: sonnet
 
 이 파일은 기존 `agents/ux-architect.md` 소비자를 위한 호환 진입점이다.
 
+> **지침 경로 해소 (외부 활성 프로젝트).** 아래 상대경로는 현재 프로젝트 cwd 가 아니라 **활성 dcNess plugin 디렉터리 기준**이다. 호출 prompt 에 전체 지침 절대경로가 주어졌으면 그것을 Read 한다. 없으면 활성 plugin root 아래에서 찾는다 — Bash 가 있으면 `$CLAUDE_PLUGIN_ROOT` (또는 `ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* | sort -V | tail -1`), 없으면 Glob 으로 최고 버전 경로를 고른다. `${CLAUDE_PLUGIN_ROOT}` 는 이 본문에서 텍스트로 치환되지 않으니 문자 그대로 쓰지 말 것 (Bash 변수로만 유효). dcness self 저장소면 cwd 상대경로 그대로다. **경로가 안 잡혀도 "차단된 인프라 경로"로 단정하고 포기하지 말 것** — file guard 는 활성 plugin 의 `agents/**` 와 지정 `docs/plugin/**` Read 를 허용한다.
+
 첫 행동:
 
 1. [`agents/ux-architect/ux-architect-agent.md`](ux-architect/ux-architect-agent.md)를 읽는다.

--- a/docs/plugin/templates/agent-prompt-slots.md
+++ b/docs/plugin/templates/agent-prompt-slots.md
@@ -28,7 +28,7 @@ main repo 절대경로를 worktree 경로처럼 넘기지 않는다.}}
 
 ## 슬롯 해석
 
-- **슬롯 1**: 대상 단위 + 읽을 SSOT + write 경계. 같은 결정·계약·요구사항을 prompt 에 다시 복사하지 않는다. **외부 활성 프로젝트에서 sub-agent 의 *자기 전체 지침*(얇은 진입점이 가리키는 `agents/<name>/<name>-agent.md`) 경로는 cwd 상대가 아니라 활성 plugin root 기준**이므로, 메인이 그 절대경로를 슬롯 1 에 적어 준다 — `ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"; [ -z "$ROOT" ] && ROOT="$HOME/.claude/plugins/marketplaces/dcness"; INSTR="$ROOT/agents/<name>/<name>-agent.md"` (공식 배포=cache 최고버전, 로컬 marketplace 설치 fallback 포함). dcness self 저장소면 cwd 상대경로 그대로. (진입점 본문의 `${CLAUDE_PLUGIN_ROOT}` 는 텍스트 치환되지 않아 self-발견이 헤맬 수 있으니 메인이 선공급하면 확실하다.)
+- **슬롯 1**: 대상 단위 + 읽을 SSOT + write 경계. 같은 결정·계약·요구사항을 prompt 에 다시 복사하지 않는다. **외부 활성 프로젝트에서 sub-agent 의 *자기 전체 지침*(얇은 진입점이 가리키는 `agents/<name>/<name>-agent.md`) 경로는 cwd 상대가 아니라 활성 plugin root 기준**이므로, 메인이 그 절대경로를 슬롯 1 에 적어 준다 — `ROOT="${CLAUDE_PLUGIN_ROOT:-$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)}"; [ -z "$ROOT" ] && ROOT="$HOME/.claude/plugins/marketplaces/dcness"; INSTR="$ROOT/agents/<name>/<name>-agent.md"` (**활성 `CLAUDE_PLUGIN_ROOT` 우선** — carve-out 이 활성 root 만 허용하고 구버전 캐시는 차단하므로 최고버전을 먼저 고르면 highest≠active 일 때 file-guard 에 막힌다. 미설정 시에만 cache 최고버전 → 로컬 marketplace fallback). dcness self 저장소면 cwd 상대경로 그대로. (진입점 본문의 `${CLAUDE_PLUGIN_ROOT}` 는 텍스트 치환되지 않아 self-발견이 헤맬 수 있으니 메인이 선공급하면 확실하다.)
 - **슬롯 2**: worktree 활성 시 절대경로. Claude Code Task tool 에 cwd 전달 경로가 없으므로 메인이 명시한다.
 - **슬롯 3**: 그 호출에만 필요한 미기록 제약·신호. 방법 처방을 막는 가드다.
 

--- a/docs/plugin/templates/agent-prompt-slots.md
+++ b/docs/plugin/templates/agent-prompt-slots.md
@@ -28,7 +28,7 @@ main repo 절대경로를 worktree 경로처럼 넘기지 않는다.}}
 
 ## 슬롯 해석
 
-- **슬롯 1**: 대상 단위 + 읽을 SSOT + write 경계. 같은 결정·계약·요구사항을 prompt 에 다시 복사하지 않는다. **외부 활성 프로젝트에서 sub-agent 의 *자기 전체 지침*(얇은 진입점이 가리키는 `agents/<name>/<name>-agent.md`) 경로는 cwd 상대가 아니라 활성 plugin root 기준**이므로, 메인이 그 절대경로를 슬롯 1 에 적어 준다 — `INSTR="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)/agents/<name>/<name>-agent.md"`. dcness self 저장소면 cwd 상대경로 그대로. (진입점 본문의 `${CLAUDE_PLUGIN_ROOT}` 는 텍스트 치환되지 않아 self-발견이 헤맬 수 있으니 메인이 선공급하면 확실하다.)
+- **슬롯 1**: 대상 단위 + 읽을 SSOT + write 경계. 같은 결정·계약·요구사항을 prompt 에 다시 복사하지 않는다. **외부 활성 프로젝트에서 sub-agent 의 *자기 전체 지침*(얇은 진입점이 가리키는 `agents/<name>/<name>-agent.md`) 경로는 cwd 상대가 아니라 활성 plugin root 기준**이므로, 메인이 그 절대경로를 슬롯 1 에 적어 준다 — `ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"; [ -z "$ROOT" ] && ROOT="$HOME/.claude/plugins/marketplaces/dcness"; INSTR="$ROOT/agents/<name>/<name>-agent.md"` (공식 배포=cache 최고버전, 로컬 marketplace 설치 fallback 포함). dcness self 저장소면 cwd 상대경로 그대로. (진입점 본문의 `${CLAUDE_PLUGIN_ROOT}` 는 텍스트 치환되지 않아 self-발견이 헤맬 수 있으니 메인이 선공급하면 확실하다.)
 - **슬롯 2**: worktree 활성 시 절대경로. Claude Code Task tool 에 cwd 전달 경로가 없으므로 메인이 명시한다.
 - **슬롯 3**: 그 호출에만 필요한 미기록 제약·신호. 방법 처방을 막는 가드다.
 

--- a/docs/plugin/templates/agent-prompt-slots.md
+++ b/docs/plugin/templates/agent-prompt-slots.md
@@ -28,7 +28,7 @@ main repo 절대경로를 worktree 경로처럼 넘기지 않는다.}}
 
 ## 슬롯 해석
 
-- **슬롯 1**: 대상 단위 + 읽을 SSOT + write 경계. 같은 결정·계약·요구사항을 prompt 에 다시 복사하지 않는다.
+- **슬롯 1**: 대상 단위 + 읽을 SSOT + write 경계. 같은 결정·계약·요구사항을 prompt 에 다시 복사하지 않는다. **외부 활성 프로젝트에서 sub-agent 의 *자기 전체 지침*(얇은 진입점이 가리키는 `agents/<name>/<name>-agent.md`) 경로는 cwd 상대가 아니라 활성 plugin root 기준**이므로, 메인이 그 절대경로를 슬롯 1 에 적어 준다 — `INSTR="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)/agents/<name>/<name>-agent.md"`. dcness self 저장소면 cwd 상대경로 그대로. (진입점 본문의 `${CLAUDE_PLUGIN_ROOT}` 는 텍스트 치환되지 않아 self-발견이 헤맬 수 있으니 메인이 선공급하면 확실하다.)
 - **슬롯 2**: worktree 활성 시 절대경로. Claude Code Task tool 에 cwd 전달 경로가 없으므로 메인이 명시한다.
 - **슬롯 3**: 그 호출에만 필요한 미기록 제약·신호. 방법 처방을 막는 가드다.
 

--- a/evals/guard_efficacy.py
+++ b/evals/guard_efficacy.py
@@ -27,6 +27,7 @@ if str(ROOT) not in sys.path:
 from harness.agent_boundary import (  # noqa: E402
     check_bash_mutation,
     check_github_mcp_mutation,
+    check_read_allowed,
     check_write_allowed,
 )
 from harness.hooks import handle_pretooluse_agent  # noqa: E402
@@ -82,6 +83,32 @@ def _file_write(agent: str, path: str) -> Probe:
     def probe() -> tuple[Decision, str]:
         with tempfile.TemporaryDirectory() as td, _external_project_boundary():
             return _reason_decision(check_write_allowed(agent, path, cwd=Path(td)))
+
+    return probe
+
+
+def _file_read(agent: str, build_target: Callable[[Path, Path, Path], str]) -> Probe:
+    """#962 read-boundary probe — 외부 활성 프로젝트에서 활성 plugin root 기준 read 검사.
+
+    build_target(base, cwd, plugin_root) 가 대상 경로를 만든다. plugin_root 는 실제
+    배포 레이아웃(~/.claude/plugins/cache/dcness/dcness/<ver>)을 모사하며, cwd 는 외부
+    프로젝트다. 경로가 실존할 필요는 없다 (resolve 는 strict=False).
+    """
+    def probe() -> tuple[Decision, str]:
+        with tempfile.TemporaryDirectory() as td, _external_project_boundary():
+            base = Path(td)
+            cwd = base / "project"
+            cwd.mkdir()
+            plugin_root = (
+                base / ".claude" / "plugins" / "cache" / "dcness" / "dcness" / "0.13.0"
+            )
+            plugin_root.mkdir(parents=True)
+            target = build_target(base, cwd, plugin_root)
+            return _reason_decision(
+                check_read_allowed(
+                    agent, target, cwd=cwd, plugin_root=str(plugin_root)
+                )
+            )
 
     return probe
 
@@ -364,6 +391,65 @@ def build_cases() -> list[GuardCase]:
             "allow",
             "architect-owned docs remain writable by architect.",
             _file_write("architect", "docs/architecture.md"),
+        ),
+        GuardCase(
+            "read_boundary_allows_own_agent_instructions",
+            "read-boundary",
+            "allow",
+            "subagent can read its own active-plugin agents/** full instructions.",
+            _file_read(
+                "system-architect",
+                lambda b, c, r: str(
+                    r / "agents/system-architect/system-architect-agent.md"
+                ),
+            ),
+        ),
+        GuardCase(
+            "read_boundary_allows_designated_plugin_doc",
+            "read-boundary",
+            "allow",
+            "subagent can read designated docs/plugin/** references in active plugin.",
+            _file_read(
+                "module-architect", lambda b, c, r: str(r / "docs/plugin/terms.md")
+            ),
+        ),
+        GuardCase(
+            "read_boundary_blocks_plugin_loop_procedure",
+            "read-boundary",
+            "block",
+            "plugin infra doc (loop-procedure) stays blocked inside the allow zone.",
+            _file_read(
+                "module-architect",
+                lambda b, c, r: str(r / "docs/plugin/loop-procedure.md"),
+            ),
+        ),
+        GuardCase(
+            "read_boundary_blocks_plugin_hook_infra",
+            "read-boundary",
+            "block",
+            "plugin hook/guard code stays blocked (outside agents/ · docs/plugin/).",
+            _file_read(
+                "system-architect", lambda b, c, r: str(r / "hooks/file-guard.sh")
+            ),
+        ),
+        GuardCase(
+            "read_boundary_blocks_home_claude_outside_plugin",
+            "read-boundary",
+            "block",
+            "~/.claude paths outside the plugin folder (history/settings) stay blocked.",
+            _file_read(
+                "system-architect", lambda b, c, r: str(b / ".claude/history.jsonl")
+            ),
+        ),
+        GuardCase(
+            "read_boundary_blocks_project_harness_state",
+            "read-boundary",
+            "block",
+            "project .claude/harness-state read stays blocked.",
+            _file_read(
+                "system-architect",
+                lambda b, c, r: ".claude/harness-state/.sessions/x/live.json",
+            ),
         ),
         GuardCase(
             "bash_mutation_blocks_git_push",

--- a/evals/guard_efficacy.py
+++ b/evals/guard_efficacy.py
@@ -452,6 +452,16 @@ def build_cases() -> list[GuardCase]:
             ),
         ),
         GuardCase(
+            "read_boundary_blocks_nested_dot_claude_in_zone",
+            "read-boundary",
+            "block",
+            "nested .claude/ subtree inside the allow zone stays blocked.",
+            _file_read(
+                "system-architect",
+                lambda b, c, r: str(r / "agents/foo/.claude/transcript.json"),
+            ),
+        ),
+        GuardCase(
             "bash_mutation_blocks_git_push",
             "bash-mutation",
             "block",

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -300,17 +300,17 @@ READ_DENY_MATRIX: dict[str, tuple[str, ...]] = {
 # 판정 기준은 *활성* plugin root (CLAUDE_PLUGIN_ROOT — file-guard hook 이 CC 로부터
 # 자동 수신). plugin cache 에 공존하는 구버전(다른 root)은 예외 대상이 아니라 계속
 # 차단된다 (stale 버전 오선택 방지). write 경계는 무변경 — 본 예외는 Read 전용이다.
+#
+# 🔴 예외 구역 판정·검사는 모두 *plugin-relative* 경로 기준이다 (절대 norm 아님):
+#   - READ_DENY / 개별 인프라 재검사를 상대경로에 적용해, plugin root 절대경로의 우발적
+#     prefix(로컬 체크아웃 `~/src/...` 등)가 deny/infra 에 오매칭되는 것을 막는다 (codex P2).
+#   - 상대경로엔 cache `.claude/plugins/` prefix 가 없으므로, 개별 인프라 재검사에 broad
+#     `(^|/)\.claude/` 를 *그대로 유지*해도 zone 안 nested `.claude/` 서브트리(예
+#     `agents/foo/.claude/`)만 차단하고 정상 지침(`.claude/` 미포함)은 통과한다. 원 동기
+#     (인프라 탐독 방지)를 보존하며 nested 민감 경로 재오픈을 막는다 (codex P2).
 _PLUGIN_READ_ALLOW_ZONES: tuple[str, ...] = (
     r'^agents/',
     r'^docs/plugin/',
-)
-# 예외 구역 안이라도 계속 차단되는 개별 인프라 패턴 — 원 동기(인프라 탐독 토큰 낭비
-# 방지) 보존. broad `(^|/)\.claude/` 만 예외에서 제외하고 나머지 INFRA 패턴을
-# plugin-relative 경로에 재적용한다. 예: docs/plugin/loop-procedure.md 는 allow-zone
-# (docs/plugin/) 안이지만 loop-procedure 패턴에 매칭돼 계속 차단.
-_BROAD_CLAUDE_INFRA_PATTERN = r'(^|/)\.claude/'
-_PLUGIN_READ_ZONE_INFRA: tuple[str, ...] = tuple(
-    p for p in DCNESS_INFRA_PATTERNS if p != _BROAD_CLAUDE_INFRA_PATTERN
 )
 
 
@@ -713,33 +713,32 @@ def check_write_allowed(
     return None
 
 
-def _plugin_read_carveout(
+def _plugin_read_zone_rel(
     file_path: str,
     cwd: Path,
     plugin_root: Optional[str],
-) -> bool:
-    """활성 plugin 의 agents/** · 지정 docs/plugin/** read 예외 여부 (#962).
+) -> Optional[str]:
+    """활성 plugin read allow-zone(agents/·docs/plugin/) 안이면 plugin-relative 경로를,
+    아니면 None 을 반환한다 (#962).
 
-    True = broad `.claude/` 차단에서 예외 허용 (Read 전용). 판정은 활성 plugin root
-    (plugin_root, 기본 CLAUDE_PLUGIN_ROOT) 기준 — 대상과 root 를 모두 resolve() 후
-    상대화하므로 symlink/`..` 로 예외 구역을 위장한 우회는 닫힌다 (구역 밖으로
-    resolve 되면 relative_to 실패 → False → broad `.claude/` 차단으로 회귀). allow-zone
-    안이라도 개별 인프라 패턴(loop-procedure 등)에 매칭되면 False (차단 유지).
+    판정은 활성 plugin root (plugin_root, 기본 CLAUDE_PLUGIN_ROOT) 기준 — 대상과 root 를
+    모두 resolve() 후 상대화하므로 symlink/`..` 로 예외 구역을 위장한 우회는 닫힌다
+    (구역 밖으로 resolve 되면 relative_to 실패 → None). 반환된 상대경로는 호출부에서
+    (a) READ_DENY 검사 대상(절대 root prefix 우발 매칭 방지)과 (b) 개별 인프라 재검사
+    (nested `.claude/`·loop-procedure 등 차단)에 쓰인다.
     """
     if not plugin_root:
-        return False
+        return None
     try:
         root = Path(plugin_root).expanduser().resolve()
         p = Path(file_path).expanduser()
         target = (p if p.is_absolute() else (cwd / p)).resolve()
         rel = str(target.relative_to(root))
     except (OSError, ValueError, RuntimeError):
-        return False
+        return None
     if not _matches_any(rel, _PLUGIN_READ_ALLOW_ZONES):
-        return False
-    if _matches_any(rel, _PLUGIN_READ_ZONE_INFRA):
-        return False
-    return True
+        return None
+    return rel
 
 
 def check_read_allowed(
@@ -772,21 +771,28 @@ def check_read_allowed(
 
     norm = _normalize(file_path, cwd)
 
-    # READ_DENY_MATRIX (agent 별 추가 차단) 를 carve-out 보다 *먼저* 검사한다. agent 전용
-    # deny 는 plugin carve-out 예외보다 우선해야 한다 — 현행 READ_DENY 패턴(src/ 등)은
-    # plugin agents/·docs/plugin 구역과 겹치는 실경로가 없어 효과는 동일하지만, 미래에
-    # 겹치는 규칙이 추가돼도 carve-out 이 이를 우회하지 못하게 순서로 보장한다.
+    # #962 — 활성 plugin allow-zone(agents/·docs/plugin/) 판정. zone 안이면 plugin-relative
+    # 경로를 얻는다. READ_DENY·개별 인프라 재검사를 (norm 이 아니라) 이 상대경로에 적용해
+    # plugin root 절대경로의 우발적 prefix(로컬 체크아웃 `~/src/...` 등) 오매칭을 막는다 (codex P2).
+    zone_rel = _plugin_read_zone_rel(file_path, cwd, plugin_root)
+
+    # READ_DENY_MATRIX (agent 별 추가 차단) 를 carve-out 보다 *먼저* 검사한다 — agent 전용
+    # deny 는 plugin carve-out 예외보다 우선해야 하며, 미래에 겹치는 규칙이 추가돼도 carve-out
+    # 이 이를 우회하지 못하게 순서로 보장한다. zone 안이면 상대경로에, 밖이면 norm 에 적용.
     deny = READ_DENY_MATRIX.get(agent, ())
-    matched = _matches_any(norm, deny)
+    deny_target = zone_rel if zone_rel is not None else norm
+    matched = _matches_any(deny_target, deny)
     if matched:
         return (
-            f"{agent} READ_DENY_MATRIX 매칭: `{norm}` "
+            f"{agent} READ_DENY_MATRIX 매칭: `{deny_target}` "
             f"(READ_DENY_MATRIX matched `{matched}`)"
         )
 
-    # #962 — 활성 plugin 의 agents/** · 지정 docs/plugin/** 는 broad `.claude/` 차단에서
-    # 예외 허용. plugin 안 개별 인프라 패턴·plugin 밖 민감 경로는 아래 INFRA 검사로 계속 차단.
-    if _plugin_read_carveout(file_path, cwd, plugin_root):
+    # #962 carve-out — zone 안이고 개별 인프라 패턴(전체 INFRA, *상대경로* 기준)에 안 걸리면
+    # 예외 허용. 상대경로엔 cache `.claude/plugins/` prefix 가 없으므로 broad `.claude/` 는
+    # zone 안 nested `.claude/` 서브트리만 차단하고 정상 지침은 통과시킨다 (codex P2). infra
+    # 매칭 시엔 아래 norm INFRA 검사로 흘러가 차단된다 (rel 은 norm 의 suffix — 항상 매칭).
+    if zone_rel is not None and not _matches_any(zone_rel, DCNESS_INFRA_PATTERNS):
         return None
 
     matched = _matches_any(norm, DCNESS_INFRA_PATTERNS)

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -289,6 +289,31 @@ READ_DENY_MATRIX: dict[str, tuple[str, ...]] = {
 }
 
 
+# ── plugin read allow-list carve-out (#962) ────────────────────────────
+# 외부 활성 프로젝트에서 서브에이전트가 자기 plugin 의 "에이전트 소비용" 콘텐츠
+# (agents/** — 지침·템플릿·references·_shared, 그리고 지침이 읽으라고 지정한
+# docs/plugin/** 문서) 를 Read 할 수 있게, 광범위 인프라 패턴 `(^|/)\.claude/` 차단에서
+# 좁게 예외 허용한다. #614(지침 분리) 로 실제 지침이 agents/<name>/ 하위로 옮겨지면서
+# 외부 프로젝트에선 그 경로가 plugin cache(=`.claude/` 매칭) 아래에 놓여 v0.5.0 이후
+# 서브에이전트가 자기 전체 지침에 도달 못 하던 침묵 열화를 복구한다.
+#
+# 판정 기준은 *활성* plugin root (CLAUDE_PLUGIN_ROOT — file-guard hook 이 CC 로부터
+# 자동 수신). plugin cache 에 공존하는 구버전(다른 root)은 예외 대상이 아니라 계속
+# 차단된다 (stale 버전 오선택 방지). write 경계는 무변경 — 본 예외는 Read 전용이다.
+_PLUGIN_READ_ALLOW_ZONES: tuple[str, ...] = (
+    r'^agents/',
+    r'^docs/plugin/',
+)
+# 예외 구역 안이라도 계속 차단되는 개별 인프라 패턴 — 원 동기(인프라 탐독 토큰 낭비
+# 방지) 보존. broad `(^|/)\.claude/` 만 예외에서 제외하고 나머지 INFRA 패턴을
+# plugin-relative 경로에 재적용한다. 예: docs/plugin/loop-procedure.md 는 allow-zone
+# (docs/plugin/) 안이지만 loop-procedure 패턴에 매칭돼 계속 차단.
+_BROAD_CLAUDE_INFRA_PATTERN = r'(^|/)\.claude/'
+_PLUGIN_READ_ZONE_INFRA: tuple[str, ...] = tuple(
+    p for p in DCNESS_INFRA_PATTERNS if p != _BROAD_CLAUDE_INFRA_PATTERN
+)
+
+
 # ── is_infra_project() 3 OR 신호 ──────────────────────────────
 def _is_dcness_self_repo(cwd: Path) -> bool:
     """cwd 또는 그 상위에 dcness self repo 마커가 실재하나.
@@ -688,23 +713,66 @@ def check_write_allowed(
     return None
 
 
+def _plugin_read_carveout(
+    file_path: str,
+    cwd: Path,
+    plugin_root: Optional[str],
+) -> bool:
+    """활성 plugin 의 agents/** · 지정 docs/plugin/** read 예외 여부 (#962).
+
+    True = broad `.claude/` 차단에서 예외 허용 (Read 전용). 판정은 활성 plugin root
+    (plugin_root, 기본 CLAUDE_PLUGIN_ROOT) 기준 — 대상과 root 를 모두 resolve() 후
+    상대화하므로 symlink/`..` 로 예외 구역을 위장한 우회는 닫힌다 (구역 밖으로
+    resolve 되면 relative_to 실패 → False → broad `.claude/` 차단으로 회귀). allow-zone
+    안이라도 개별 인프라 패턴(loop-procedure 등)에 매칭되면 False (차단 유지).
+    """
+    if not plugin_root:
+        return False
+    try:
+        root = Path(plugin_root).expanduser().resolve()
+        p = Path(file_path).expanduser()
+        target = (p if p.is_absolute() else (cwd / p)).resolve()
+        rel = str(target.relative_to(root))
+    except (OSError, ValueError, RuntimeError):
+        return False
+    if not _matches_any(rel, _PLUGIN_READ_ALLOW_ZONES):
+        return False
+    if _matches_any(rel, _PLUGIN_READ_ZONE_INFRA):
+        return False
+    return True
+
+
 def check_read_allowed(
     agent: Optional[str],
     file_path: str,
     *,
     cwd: Optional[Path] = None,
+    plugin_root: Optional[str] = None,
 ) -> Optional[str]:
     """Read 검사 — block reason str / None=allow.
 
     메인 = 통과. is_infra_project = 통과. opt-out = 통과.
+    #962 carve-out = 활성 plugin 의 agents/** · 지정 docs/plugin/** 는 예외 허용.
     INFRA pattern = 모든 sub-agent 차단 (인프라 누설 방지).
     READ_DENY_MATRIX = agent 별 추가 차단.
+
+    plugin_root 미지정 시 CLAUDE_PLUGIN_ROOT env 로 폴백 (file-guard hook 은 이 env 를
+    CC 로부터 자동 수신 — is_infra_project 참조). env 도 없으면 carve-out 미적용.
     """
     if not agent:
         return None
     if is_infra_project(cwd):
         return None
     if is_opt_out(cwd):
+        return None
+    if cwd is None:
+        cwd = Path.cwd()
+    if plugin_root is None:
+        plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT") or None
+
+    # #962 — 활성 plugin 의 agents/** · 지정 docs/plugin/** 는 broad `.claude/` 차단에서
+    # 예외 허용. 개별 인프라 패턴·plugin 밖 민감 경로는 아래 일반 검사로 계속 차단된다.
+    if _plugin_read_carveout(file_path, cwd, plugin_root):
         return None
 
     norm = _normalize(file_path, cwd)

--- a/harness/agent_boundary.py
+++ b/harness/agent_boundary.py
@@ -752,9 +752,9 @@ def check_read_allowed(
     """Read 검사 — block reason str / None=allow.
 
     메인 = 통과. is_infra_project = 통과. opt-out = 통과.
+    READ_DENY_MATRIX = agent 별 추가 차단 (carve-out 보다 우선 — 아래 순서 주석 참조).
     #962 carve-out = 활성 plugin 의 agents/** · 지정 docs/plugin/** 는 예외 허용.
     INFRA pattern = 모든 sub-agent 차단 (인프라 누설 방지).
-    READ_DENY_MATRIX = agent 별 추가 차단.
 
     plugin_root 미지정 시 CLAUDE_PLUGIN_ROOT env 로 폴백 (file-guard hook 은 이 env 를
     CC 로부터 자동 수신 — is_infra_project 참조). env 도 없으면 carve-out 미적용.
@@ -770,17 +770,12 @@ def check_read_allowed(
     if plugin_root is None:
         plugin_root = os.environ.get("CLAUDE_PLUGIN_ROOT") or None
 
-    # #962 — 활성 plugin 의 agents/** · 지정 docs/plugin/** 는 broad `.claude/` 차단에서
-    # 예외 허용. 개별 인프라 패턴·plugin 밖 민감 경로는 아래 일반 검사로 계속 차단된다.
-    if _plugin_read_carveout(file_path, cwd, plugin_root):
-        return None
-
     norm = _normalize(file_path, cwd)
 
-    matched = _matches_any(norm, DCNESS_INFRA_PATTERNS)
-    if matched:
-        return f"인프라 path 읽기 금지: matched `{matched}` (DCNESS_INFRA_PATTERNS)"
-
+    # READ_DENY_MATRIX (agent 별 추가 차단) 를 carve-out 보다 *먼저* 검사한다. agent 전용
+    # deny 는 plugin carve-out 예외보다 우선해야 한다 — 현행 READ_DENY 패턴(src/ 등)은
+    # plugin agents/·docs/plugin 구역과 겹치는 실경로가 없어 효과는 동일하지만, 미래에
+    # 겹치는 규칙이 추가돼도 carve-out 이 이를 우회하지 못하게 순서로 보장한다.
     deny = READ_DENY_MATRIX.get(agent, ())
     matched = _matches_any(norm, deny)
     if matched:
@@ -788,6 +783,16 @@ def check_read_allowed(
             f"{agent} READ_DENY_MATRIX 매칭: `{norm}` "
             f"(READ_DENY_MATRIX matched `{matched}`)"
         )
+
+    # #962 — 활성 plugin 의 agents/** · 지정 docs/plugin/** 는 broad `.claude/` 차단에서
+    # 예외 허용. plugin 안 개별 인프라 패턴·plugin 밖 민감 경로는 아래 INFRA 검사로 계속 차단.
+    if _plugin_read_carveout(file_path, cwd, plugin_root):
+        return None
+
+    matched = _matches_any(norm, DCNESS_INFRA_PATTERNS)
+    if matched:
+        return f"인프라 path 읽기 금지: matched `{matched}` (DCNESS_INFRA_PATTERNS)"
+
     return None
 
 

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1167,6 +1167,198 @@ class ReadAllowedTests(unittest.TestCase):
             )
 
 
+class PluginReadCarveoutTests(unittest.TestCase):
+    """#962 — 외부 활성 프로젝트에서 서브에이전트가 자기 plugin 의 agents/** ·
+    지정 docs/plugin/** 를 Read 할 수 있게 broad `.claude/` 차단에서 예외 허용.
+
+    민감 영역(plugin 밖 ~/.claude/ · project harness-state)과 plugin 안 개별
+    인프라(hooks · 가드 · routing · loop-procedure · governance)는 계속 차단.
+    """
+
+    def setUp(self):
+        # is_infra_project / is_opt_out 을 결정적으로 False 로 — 외부 활성 프로젝트 모사.
+        self._infra = patch(
+            "harness.agent_boundary.is_infra_project", return_value=False
+        )
+        self._optout = patch(
+            "harness.agent_boundary.is_opt_out", return_value=False
+        )
+        self._infra.start()
+        self._optout.start()
+
+    def tearDown(self):
+        self._infra.stop()
+        self._optout.stop()
+
+    def _dirs(self, td: str) -> tuple[Path, Path]:
+        """(cwd=외부 프로젝트, plugin_root=활성 plugin cache 버전) 를 만든다."""
+        base = Path(td)
+        cwd = base / "project"
+        cwd.mkdir()
+        # 활성 plugin root 는 실제 배포 레이아웃(~/.claude/plugins/cache/...)을 모사.
+        plugin_root = (
+            base / ".claude" / "plugins" / "cache" / "dcness" / "dcness" / "0.13.0"
+        )
+        plugin_root.mkdir(parents=True)
+        return cwd, plugin_root
+
+    # ── allow: 자기 plugin 의 에이전트 소비용 콘텐츠 ─────────────────
+    def test_agent_instructions_read_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/system-architect/system-architect-agent.md")
+            self.assertIsNone(
+                check_read_allowed(
+                    "system-architect", target, cwd=cwd, plugin_root=str(root)
+                )
+            )
+
+    def test_agent_shared_read_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/_shared/agent-doc-format/agent.md")
+            self.assertIsNone(
+                check_read_allowed(
+                    "system-architect", target, cwd=cwd, plugin_root=str(root)
+                )
+            )
+
+    def test_agent_templates_read_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/system-architect/templates/decision.md")
+            self.assertIsNone(
+                check_read_allowed(
+                    "system-architect", target, cwd=cwd, plugin_root=str(root)
+                )
+            )
+
+    def test_designated_docs_plugin_read_allowed(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "docs/plugin/terms.md")
+            self.assertIsNone(
+                check_read_allowed(
+                    "module-architect", target, cwd=cwd, plugin_root=str(root)
+                )
+            )
+
+    def test_env_fallback_when_param_omitted(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/pr-reviewer/pr-reviewer-agent.md")
+            with patch.dict(
+                os.environ, {"CLAUDE_PLUGIN_ROOT": str(root)}, clear=False
+            ):
+                self.assertIsNone(
+                    check_read_allowed("pr-reviewer", target, cwd=cwd)
+                )
+
+    # ── block: plugin 안 개별 인프라는 계속 차단 (원 동기 보존) ────────
+    def test_plugin_loop_procedure_still_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "docs/plugin/loop-procedure.md")
+            reason = check_read_allowed(
+                "module-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    def test_plugin_hooks_still_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "hooks/file-guard.sh")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    def test_plugin_harness_guard_still_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "harness/agent_boundary.py")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    def test_plugin_skill_routing_still_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "skills/impl/impl-routing.md")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    def test_plugin_governance_still_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "docs/internal/governance.md")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    # ── block: 민감 영역 read 는 계속 차단 ───────────────────────────
+    def test_home_claude_outside_plugin_blocked(self):
+        # plugin 폴더 밖 ~/.claude/ (이력·transcript·설정) — 계속 차단.
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            # plugin cache 밖의 .claude 하위 민감 파일.
+            target = str(Path(td) / ".claude" / "history.jsonl")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    def test_project_harness_state_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            reason = check_read_allowed(
+                "system-architect",
+                ".claude/harness-state/.sessions/x/live.json",
+                cwd=cwd,
+                plugin_root=str(root),
+            )
+            self.assertIsNotNone(reason)
+
+    # ── block: 구버전 캐시 오선택 방지 (활성 root 아니면 예외 대상 아님) ──
+    def test_stale_plugin_version_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            stale = root.parent / "0.3.0"
+            stale.mkdir()
+            target = str(stale / "agents/system-architect/system-architect-agent.md")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    # ── block: symlink/.. 위장 우회 차단 ─────────────────────────────
+    def test_symlink_disguise_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            secret = Path(td) / ".claude" / "secret.txt"
+            secret.parent.mkdir(parents=True, exist_ok=True)
+            secret.write_text("sensitive\n", encoding="utf-8")
+            link = root / "agents" / "evil.md"
+            link.parent.mkdir(parents=True, exist_ok=True)
+            link.symlink_to(secret)
+            reason = check_read_allowed(
+                "system-architect", str(link), cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
+    # ── write 경계 무변경 (carve-out 은 read 전용) ────────────────────
+    def test_write_boundary_unchanged_for_plugin_agents(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/system-architect/system-architect-agent.md")
+            reason = check_write_allowed("engineer", target, cwd=cwd)
+            self.assertIsNotNone(reason)
+
+
 class BashHeuristicTests(unittest.TestCase):
     def test_no_indicator_returns_empty(self):
         self.assertEqual(extract_bash_paths("ls -la docs/"), [])

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1363,6 +1363,34 @@ class PluginReadCarveoutTests(unittest.TestCase):
             self.assertIsNotNone(reason)
             self.assertIn("READ_DENY_MATRIX", reason)
 
+    # ── plugin root 절대 prefix 의 우발적 deny 토큰 무시 (codex P2-A) ──
+    def test_deny_ignores_incidental_root_prefix(self):
+        # plugin root 경로 자체에 `/src/` 가 있어도(로컬 체크아웃), 정당한 지침 read 는
+        # 허용된다 — READ_DENY 는 plugin-relative 경로에만 적용되기 때문.
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            cwd = base / "project"
+            cwd.mkdir()
+            root = base / "src" / "dcness"  # 절대경로에 `/src/` 포함
+            root.mkdir(parents=True)
+            target = str(root / "agents/designer/designer-agent.md")
+            # designer READ_DENY = (^|/)src/ — norm 에 적용하면 root prefix 로 오차단.
+            self.assertIsNone(
+                check_read_allowed(
+                    "designer", target, cwd=cwd, plugin_root=str(root)
+                )
+            )
+
+    # ── zone 안 nested .claude/ 서브트리 차단 (codex P2-B) ─────────────
+    def test_nested_dot_claude_in_zone_blocked(self):
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/foo/.claude/transcript.json")
+            reason = check_read_allowed(
+                "system-architect", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+
     # ── write 경계 무변경 (carve-out 은 read 전용) ────────────────────
     def test_write_boundary_unchanged_for_plugin_agents(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -1350,6 +1350,19 @@ class PluginReadCarveoutTests(unittest.TestCase):
             )
             self.assertIsNotNone(reason)
 
+    # ── READ_DENY_MATRIX 가 carve-out 보다 우선 (codex review 관찰 1) ──
+    def test_read_deny_matrix_precedes_carveout(self):
+        # designer 의 src/ READ_DENY 는 plugin 구역과 겹치는 실경로가 없어 실해 0 이지만,
+        # 겹치는 경로(agents/designer/src/…)를 주면 carve-out 예외보다 deny 가 이긴다.
+        with tempfile.TemporaryDirectory() as td:
+            cwd, root = self._dirs(td)
+            target = str(root / "agents/designer/src/x.md")
+            reason = check_read_allowed(
+                "designer", target, cwd=cwd, plugin_root=str(root)
+            )
+            self.assertIsNotNone(reason)
+            self.assertIn("READ_DENY_MATRIX", reason)
+
     # ── write 경계 무변경 (carve-out 은 read 전용) ────────────────────
     def test_write_boundary_unchanged_for_plugin_agents(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_guard_efficacy_eval.py
+++ b/tests/test_guard_efficacy_eval.py
@@ -35,6 +35,7 @@ class GuardEfficacyEvalContractTests(unittest.TestCase):
         categories = set(report["categories"])
         for category in (
             "file-boundary",
+            "read-boundary",
             "bash-mutation",
             "mcp-mutation",
             "order-gate",
@@ -50,6 +51,9 @@ class GuardEfficacyEvalContractTests(unittest.TestCase):
         case_ids = {case["id"] for case in report["cases"]}
         for case_id in (
             "file_boundary_blocks_infra",
+            "read_boundary_allows_own_agent_instructions",
+            "read_boundary_blocks_plugin_loop_procedure",
+            "read_boundary_blocks_home_claude_outside_plugin",
             "bash_mutation_blocks_git_push",
             "mcp_mutation_blocks_pr_merge",
             "order_gate_blocks_missing_begin_step",


### PR DESCRIPTION
## 관련 이슈 번호

Closes #962

## 배경 및 문제

외부 활성 프로젝트에서 서브에이전트(예: system-architect 재진입)가 자기 전체 지침·템플릿 Read 를 차단당한 뒤 "차단된 인프라 경로"로 오판하고 조기 포기하는 동작이 v0.5.0(2026-06-06) 이후 반복 관측됐다. 침묵 열화(silent degradation)로, dcness self 저장소에서는 infra 판정으로 가드가 해제되고 파일도 cwd 에 실존해 재현 불가능했다.

## 원인

두 변경의 직교 조합 결함:
- **#82 (read 차단 도입)**: `DCNESS_INFRA_PATTERNS` 의 broad `(^|/)\.claude/` 가 전 서브에이전트 Read 에 적용된다. 하네스 이전(루트 Claude 전역 지침 시절) 목록을 이식한 것으로, plugin 이 `~/.claude/plugins/cache/...` 아래 설치되는 현재 구조 기준으로 재도출된 적이 없다.
- **#614 (지침 분리)**: `agents/<name>.md` 전체 지침을 얇은 진입점으로 축소하고 실제 지침·템플릿·references 를 `agents/<name>/` 하위로 분리했다.
- **결과**: 외부 프로젝트에서 분리된 파일들이 `~/.claude/plugins/cache/dcness/dcness/<ver>/agents/...` (=`.claude/` 매칭) 아래에 놓여 Read 가 전면 차단됐다. routing 이 소비하는 결론 토큰 계약(PASS/ESCALATE 등)도 전체 지침에만 있어 함께 도달 불가.
- **미검출 이유**: 결정적 guard-efficacy eval 이 경계 로직만 검증하고 "서브에이전트가 자기 지침에 도달 가능한가"라는 소비 채널 정합을 어떤 게이트도 보지 않았다.

## 작업내용

**1. 코드 — read carve-out (`harness/agent_boundary.py`)**
- `check_read_allowed` 에 활성 `CLAUDE_PLUGIN_ROOT` 기준 carve-out(`_plugin_read_carveout`) 추가. `plugin_root` 파라미터(미지정 시 env 폴백 — file-guard hook 이 env 를 CC 로부터 자동 수신).
- 허용/차단 매트릭스:
  - **허용**: 활성 plugin root 아래 `agents/**`(지침·템플릿·references·`_shared`) + 지정 `docs/plugin/**`.
  - **차단 유지**: 구역 안 개별 인프라(broad `.claude/` 외 나머지 INFRA 패턴 재적용 → `docs/plugin/loop-procedure.md` 등) / plugin 밖 `~/.claude/`(이력·transcript·설정) / project `.claude/harness-state/` / **구버전 캐시(활성 root 아닌 다른 버전) → stale 오선택 방지** / symlink·`..` 위장(대상·root 모두 `resolve()` 후 상대화).
- write 경계 무변경 (carve-out 은 Read 전용).

**2. 테스트 / eval (AC 명시 요구)**
- `tests/test_agent_boundary.py`: `PluginReadCarveoutTests` 15건.
- `evals/guard_efficacy.py`: `read-boundary` fixture 6건(`_file_read` probe) — allow 2 + block 4.
- `tests/test_guard_efficacy_eval.py`: `read-boundary` 카테고리·case_id 회귀 보호.

**3. AC5 경로 전달 (`agents/*.md` 12개 + `docs/plugin/templates/agent-prompt-slots.md`)**
- `${CLAUDE_PLUGIN_ROOT}` 치환 실험 결과 반영: agent 본문 텍스트 치환은 CC 버그([anthropics/claude-code#9354](https://github.com/anthropics/claude-code/issues/9354))로 미작동 → 본문에서 문자 그대로 쓰지 않는다.
- 12개 얇은 진입점(=시스템 프롬프트)에 "지침 경로는 cwd 상대가 아니라 활성 plugin root 기준" + 자가발견(Bash `$CLAUDE_PLUGIN_ROOT` / cache-glob `sort -V | tail -1` / Glob 최고버전) + **"경로 miss 를 차단으로 단정·조기 포기 금지"** 안내. 판정·안내 모두 활성 버전 기준.
- `agent-prompt-slots.md` 슬롯1: 메인이 sub-agent 자기 지침 활성 plugin 절대경로를 선공급하는 계약 추가.

## 결정 근거

- **carve-out 을 broad `.claude/` 전면 해제 대신 whitelist(agents/·docs/plugin/) + 개별 인프라 재적용**으로 한 이유: `~/.claude/` 에 실재하는 민감 데이터(history/transcript/settings) read 차단은 유지해야 하고, "인프라 탐독 토큰 낭비 방지"라는 #82 원 동기도 보존해야 하기 때문.
- **활성 root(CLAUDE_PLUGIN_ROOT) 핀**: 캐시에 구버전 5개(0.3.0~0.13.0) 공존이 실측됨. 활성 버전 외 root 는 예외 미적용 → stale 지침 오선택 차단. cache-glob `sort -V | tail -1` == 런타임 CLAUDE_PLUGIN_ROOT(=cache 최고버전) 임을 실측 확인.
- **SubagentStart hook 주입 미채택**: 사전 논의 보류(프롬프트 구성=메인 자율 / CC 버전 의존) 존중. 대신 env 기반 판정(코드) + 진입점 자가발견 + 슬롯 선공급(문서·프롬프트 계약)으로 해결.
- **#963 상호작용**: #963(agents/ 중첩 문서 오염 해소)이 콘텐츠를 `agents/` 밖으로 옮기면 whitelist 경로 정합은 나중 구현되는 #963 이 책임진다(이슈 코멘트 합의). 본 PR 은 현재 `agents/**` 레이아웃 기준.

## 배포 경로 검증 (plug-in 영향 시)

전 변경이 **plugin 본체 경로**에 닫혀 있어 plugin 버전 업만으로 기존 활성 프로젝트에 도달한다 — `/init-dcness` 재배포 의존 없음:
- `harness/agent_boundary.py` — 경로 1 (plugin 본체, hook 이 import).
- `agents/*.md` — 경로 1 (plugin 본체, 서브에이전트 시스템 프롬프트).
- `docs/plugin/templates/agent-prompt-slots.md` — 경로 3 이지만 plugin 본체 docs (메인이 참조하는 SSOT, 배포물 동봉).
- `evals/`, `tests/` — self-QA (사용자 미배포).

## Test Plan

- [x] `python3.11 -m unittest discover -s tests` — 1676 OK
- [x] `python3.11 evals/guard_efficacy.py` — read-boundary 6/6, total 39/39
- [x] `node scripts/check_cross_refs.mjs` — PASS
- [x] static-quality (ruff/mypy/bandit) — PASS
- [x] 회귀: write 경계 / 기존 read 가드 무변경 테스트 green
