### PR TITLE
[feature] design 목업 선행 분기

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ claude plugin install dcness@dcness
 
 `/impl` 이 내부적으로 구현 경로(설계도 유무 — Lite / Standard)와 검증 엄정도를 직교로 고른다.
 
-보조 진입점 — `/to-issue`(자연어를 GitHub 이슈로), `/next-work`(issue/label 에서 다음 할 일 조회), `/tech-review`(위험한 설계의 사전 기술 검증), `/impl-loop`(deep task 파일 단위 구현 러너), `/ux`(구현 없이 시안·흐름 먼저).
+보조 진입점 — `/to-issue`(자연어를 GitHub 이슈로), `/next-work`(issue/label 에서 다음 할 일 조회), `/tech-review`(위험한 설계의 사전 기술 검증), `/impl-loop`(deep task 파일 단위 구현 러너), `/ux`(구현 없이 시안·흐름·디자인 시스템/토큰 베이스라인 먼저).
 
 각 단계에서 agent 가 낸 결론(`PASS` / `IMPL_DONE` / `SPEC_GAP_FOUND` 등)이 다음 어느 단계로 이어지는지는 skill 별 `<skill>-routing.md`(mermaid 분기도 + 표 + retry + escalate)가 진본이다 — 예: [`skills/impl/impl-routing.md`](skills/impl/impl-routing.md).
 
@@ -172,7 +172,7 @@ Standard 구현 경로의 기본은 `build-worker → pr-reviewer` 이고, 풀 4
 | support | `/to-issue` | 자연어 → Issue Brief → 승인 대기 없이 GitHub 선등록 (web 에서 확인·수정) |
 | 고급 | `/tech-review` | 위험한 설계의 사전 기술 검증 |
 | 고급 | `/impl-loop` | deep impl task 파일 단위 구현 러너 |
-| 유틸 | `/ux` | 구현 없이 목업·흐름 먼저 탐색, PICK 확정본은 canvas 에 등록 |
+| 유틸 | `/ux` | 구현 없이 목업·흐름·디자인 시스템/토큰 베이스라인 먼저 탐색, PICK 확정본은 canvas 에 등록 |
 | 유틸 | `/init-dcness` | 현 프로젝트를 활성 대상에 등록 |
 | 유틸 | `/next-work` | issue/label 기반 진행 중 / 다음 할 일 조회 |
 | 유틸 | `/run-review` | 끝난 run 을 되짚어 단계별 비용·차단 분석 |

--- a/docs/plugin/agents/architecture-validator/architecture-validator-agent.md
+++ b/docs/plugin/agents/architecture-validator/architecture-validator-agent.md
@@ -9,6 +9,7 @@ module-architect epic-batch 산출물을 읽기 전용으로 검토한다. 앞�
 - 호출 시점: `/design` final epic 검증. thin bootstrap 또는 opt-in system checkpoint 직후에 별도 validator 를 끼우지 않는다.
 - 대상 epic 경로
 - PRD, stories, architecture, conventions, decisions, 선택 domain-model, impl 문서
+- UI epic 에 확정 목업이 있으면 확정 목업 경로, node-id 매핑, docs/design.md 토큰, `docs/design-variants/canvas.html`
 - 필요하면 이전 finding, 검증 범위, 재검토 맥락
 
 ## 먼저 읽을 문서
@@ -35,6 +36,7 @@ module-architect epic-batch 산출물을 읽기 전용으로 검토한다. 앞�
 - 수직 슬라이스 우선순위: 병렬 독립성이나 파일 경계를 맞추기 위해 Story 동작을 레이어별 부품 task로 찢어 실제 제품 경계 동작 책임이 비어 있지 않은가. 첫 동작 증거가 Story 마지막 task까지 밀렸는데 이유와 후속 검증이 없으면 `TASK_LOCAL` finding 으로 드러낸다.
 - 구현 순서: epic architecture 의 Story/모듈 구현 순서가 의존만이 아니라 첫 제품 경계 동작 증거를 앞당기는가. final epic 검증에서는 Story별 첫 제품 경계 동작 증거와 Story -> 모듈 매핑을 함께 보고, 앞에서 system checkpoint 가 있었다면 boundary 변경 뒤에도 그 순서가 유지되는지 확인한다.
 - 시스템 경계 변경 신호: 기존 모듈 경계, 도메인 invariant, storage policy, public API boundary, 전역 decision 을 바꾸는 요구가 module-architect 산출물에서 새로 드러났는가. 있으면 `SYSTEM_BOUNDARY` 로 분류해 system checkpoint 승격을 권고한다.
+- 디자인 입력 강제: 확정 목업이 있는 UI epic 에서 목업 미참조 설계 금지 원칙을 지키는가. epic architecture 와 impl task 의 `## 디자인 참조` 가 확정 목업 경로, node-id 매핑, docs/design.md 토큰을 대조하고, 의도적 차이를 설명하는가.
 
 ## 작업 흐름
 
@@ -45,10 +47,11 @@ module-architect epic-batch 산출물을 읽기 전용으로 검토한다. 앞�
 5. final epic 검증에서 entrypoint 를 만지는 impl 문서는 `Agent Workability` 또는 동등한 증거가 owner flow/module, entrypoint role, state owner, allowed touch, forbidden touch, validation path, future change scenario 를 남겼는지 본다.
 6. final epic 검증에서는 domain-model 작성/생략 근거가 impl 계약과 모순되지 않는지, 계약 표면 코드 SSOT 대조 증거가 있는지 확인한다. 포트, 도메인 타입, 공개 entrypoint 를 바꾸는 task 가 기존 코드와 충돌하거나 module/decision 근거 없이 새 계약을 전제하면 finding 으로 보고한다.
 7. final epic 검증에서는 신규 산출물의 계약 의미가 module responsibility / decision 에 있고 impl/compact plan 은 module/decision 참조만 남기는지 본다. 구양식 Contract Ledger / Contract References 산출물은 기존 활성 프로젝트 유효성을 위해 남을 수 있으므로 형식만으로 FAIL 하지 않는다.
-8. ux-flow·stories 동작 서술·legacy summary 의 stale 은 module responsibility / decision 과 충돌해 구현 오판을 만들 명백한 근거가 있을 때만 Must finding 으로 올린다. 단순 요약 drift 는 Should finding 으로 보고한다.
-9. Must finding은 `SYSTEM_BOUNDARY` 또는 `TASK_LOCAL` 중 하나로 분류한다. Story/task 산출물의 수직 슬라이스 증거 누락, Agent Workability 누락, 병렬성 때문에 동작이 레이어별 부품으로 찢긴 상태, 마지막 task까지 첫 제품 동작이 밀린 상태는 보통 `TASK_LOCAL` 이다. 기존 모듈 경계, 도메인 invariant, 저장 정책, public API boundary, 전역 decision 이 틀렸거나 바뀌어야 하면 `SYSTEM_BOUNDARY` 다.
-10. finding마다 파일 경로, 라인, 사실, 영향, 권장 다음 행동을 쓴다.
-11. 예시 카탈로그는 힌트로만 쓰고, 예시에 없다는 이유로 통과시키지 않는다.
+8. 확정 목업이 있는 UI epic 은 확정 목업 경로, node-id 매핑, docs/design.md 토큰이 architecture/impl 산출물에 대조 근거로 남았는지 확인한다. 산출물이 목업을 전혀 참조하지 않거나 핵심 node-id 를 구현 컴포넌트/상태로 연결하지 않으면 `TASK_LOCAL` finding 으로 보고한다. 목업 자체가 system boundary 변경을 요구하는데 system checkpoint 없이 task 로 흡수됐다면 `SYSTEM_BOUNDARY` 다.
+9. ux-flow·stories 동작 서술·legacy summary 의 stale 은 module responsibility / decision 과 충돌해 구현 오판을 만들 명백한 근거가 있을 때만 Must finding 으로 올린다. 단순 요약 drift 는 Should finding 으로 보고한다.
+10. Must finding은 `SYSTEM_BOUNDARY` 또는 `TASK_LOCAL` 중 하나로 분류한다. Story/task 산출물의 수직 슬라이스 증거 누락, Agent Workability 누락, 병렬성 때문에 동작이 레이어별 부품으로 찢긴 상태, 마지막 task까지 첫 제품 동작이 밀린 상태, 확정 목업 경로/node-id 매핑/docs/design.md 토큰 대조 누락은 보통 `TASK_LOCAL` 이다. 기존 모듈 경계, 도메인 invariant, 저장 정책, public API boundary, 전역 decision 이 틀렸거나 바뀌어야 하면 `SYSTEM_BOUNDARY` 다.
+11. finding마다 파일 경로, 라인, 사실, 영향, 권장 다음 행동을 쓴다.
+12. 예시 카탈로그는 힌트로만 쓰고, 예시에 없다는 이유로 통과시키지 않는다.
 
 ## 완료 기준
 
@@ -58,6 +61,7 @@ module-architect epic-batch 산출물을 읽기 전용으로 검토한다. 앞�
 - final epic 검증이면 Story별 첫 제품 경계 동작 증거와 compose/wiring 책임, edit target 책임을 검토했다.
 - final epic 검증이면 `domain-model.md` 작성 또는 생략 판단 근거가 impl 계약과 모순되지 않는지 검토했다.
 - 적용 가능한 경우 계약 표면 코드 SSOT 대조 증거를 검토했다.
+- 확정 목업이 있는 UI epic 이면 목업 미참조 설계 금지 원칙에 따라 확정 목업 경로, node-id 매핑, docs/design.md 토큰 대조 근거를 검토했다.
 - legacy Contract Ledger / Contract References, ux-flow, stories prose stale 을 형식만으로 Must finding 으로 올리지 않았다.
 - FAIL이면 모든 Must finding에 분류와 권장 다음 행동이 있다.
 - PASS이면 왜 system checkpoint 또는 module-architect 재진입이 필요 없는지 설명할 수 있다.

--- a/docs/plugin/agents/module-architect/module-architect-agent.md
+++ b/docs/plugin/agents/module-architect/module-architect-agent.md
@@ -11,7 +11,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, legacy contract 
 - affected module 이 있으면 해당 `docs/modules/<module-id>/architecture.md` / `conventions.md`
 - 필요하면 SPEC_GAP, validator finding, bug issue, legacy contract sync 요청
 - `/impl` Standard 구현 경로의 compact plan 요청
-- 선택적으로 확정 목업 `docs/design-variants/<screen-id>.html`, canvas 경로, UX 관련 문서
+- 선택적으로 확정 목업 `docs/design-variants/<screen-id>.html`, canvas 경로, 핵심 node-id 매핑, UX 관련 문서. `/design` stage 1 에서 확정 목업이 생성된 UI epic 은 확정 목업 경로, node-id 매핑, docs/design.md 토큰이 필수 입력이다.
 
 ## 먼저 읽을 문서
 
@@ -20,6 +20,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, legacy contract 
 - 모듈 작업: affected module 의 `docs/modules/<module-id>/architecture.md`, `conventions.md` 만 추가로 읽음. 같은 repo 의 다른 module docs 는 입력 세트에 넣지 않음
 - 상황별: 대상 epic의 `domain-model.md`, 기존 코드의 계약 표면 코드 SSOT(포트, 도메인 타입, 공개 entrypoint)
 - 상황별: `docs/design.md`, 관련 기존 impl 문서
+- UI epic 확정 목업 존재 시 필수: `docs/design-variants/<screen-id>.html`, `docs/design-variants/canvas.html`, 확정 목업 경로와 node-id 매핑
 - 참고: [`references/implementation-boundary.md`](references/implementation-boundary.md), [`references/contract-amendment.md`](references/contract-amendment.md)
 
 ## 판단 축
@@ -39,6 +40,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, legacy contract 
 - 흐름 누적 분해: 기존 대형 파일을 건드리는 task 에서 append 대신 흐름 / 섹션 모듈 신설을 선호하고, 이번 task 가 손대는 seam 까지만 분해하는가. 기준 = [`module-design-principles.md` 단일 파일 다중 흐름 누적](../_shared/module-design-principles.md#단일-파일-다중-흐름-누적).
 - Agent Operability: 다음 agent 가 edit target, state owner, validation path 를 cold-start 로 찾을 수 있게 module responsibility / public interface 와 task-local Agent Workability 가 연결되는가.
 - drift 통제: 기존 결정의 stale 사본을 새 설계로 착각하지 않는가.
+- 디자인 기준 대조: 확정 목업이 있는 UI epic 에서 목업 미참조 설계 금지 원칙을 지키는가. epic architecture 와 impl task 가 확정 목업 경로, node-id 매핑, docs/design.md 토큰을 대조 근거로 남기는가.
 
 ## 작업 흐름
 
@@ -52,7 +54,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, legacy contract 
 8. 각 task 또는 compact plan 에 대해 템플릿으로 구현 문서를 작성한다. Story/공통 impl-task 산출물에는 `Story 동작 슬라이스` 섹션을 채워 Story 완료 시 실제 검증되는 동작, 이 task가 연결하는 제품 경계, 첫 동작 증거 지점, 병렬성보다 동작 슬라이스를 우선한 결정을 남긴다. entrypoint 를 만지는 task 는 `Agent Workability` 섹션에 owner flow/module, entrypoint role, state owner, allowed touch, forbidden touch, validation path, future change scenario 를 채운다.
 9. **impl-task (Story/공통 task 분할 산출물) 한정으로** frontmatter 의 risk 메타(`risk` / `engine` / `risk_reason`)를 **task 를 자르는 시점에 함께 판정해 적는다** (compact plan 은 `/impl` Standard 구현 경로 산출물 — impl-loop dry preview 비대상이라 risk 메타 비적용). 고위험 trigger 판정 기준은 [`workflow-router.md`](../../workflow-router.md) high-risk trigger 표가 SSOT 다 — auth·security·PII / migration·destructive change / public API breakage / cross-module·cross-story interface / 외부 dependency·API. 여기에 impl-loop 런타임 고위험(외부 HTTP·네트워크 어댑터 / URL·파일·사용자 입력 파싱 / 도메인 invariant 변경)을 더한다. 이 중 하나라도 있으면 `risk: high` + `engine: 4agent` (풀 4-agent) + `risk_reason` 에 그 근거. 없으면 `risk: normal`(순수 내부 로직·문구·UI 변경은 `low`) + `engine: 2agent` (build-worker) + `risk_reason: 고위험 trigger 없음`. 이 메타가 impl-loop 진입의 엔진 선택·병렬 직렬 강등 입력이다 — 고위험 지식은 설계 시점에 이미 알 수 있으므로 진입까지 미루지 않는다. 비우면 메인이 진입 시 재추론하지만(하위호환), 채우는 것이 결정론적 기본이다.
 10. public contract를 만들거나 바꾸면 epic `architecture.md` 의 모듈 목록 책임/공개 인터페이스와 `docs/decisions/NNNN-slug.md` 를 갱신하고 impl/compact plan 은 관련 module/decision 참조만 남긴다. 신규 epic-scope decision 기록은 module-architect 가 자율 처리하지만, 기존 전역 decision 변경은 `SYSTEM_CHECKPOINT_REQUIRED` 로 checkpoint 승격한다. impl/compact plan 에 invariant/ordering/error mode/config/forbidden alternative 전문을 복제하지 않는다. task 내부 한정 private interface 는 사본 문제가 없으므로 `## 인터페이스` 에 남긴다.
-11. DB, 디자인 토큰, 외부 의존 같은 영향 축이 있으면 별도 증거를 남긴다.
+11. DB, 디자인 토큰, 외부 의존 같은 영향 축이 있으면 별도 증거를 남긴다. 확정 목업이 있는 UI epic 에서는 목업 미참조 설계 금지 원칙에 따라 `## 디자인 참조` 에 확정 목업 경로, node-id 매핑, docs/design.md 토큰 대응, 의도적 차이를 남긴다.
 12. 완료 전에 구현 세부 유출, 수용 기준 검증 가능성, Story 동작 슬라이스 증거, Agent Operability 증거, 코드 SSOT drift 를 다시 본다.
 
 ## 완료 기준
@@ -69,6 +71,7 @@ epic-batch, Standard 구현 경로 compact plan, 보강 요청, legacy contract 
 - task 분할이 있는 경우 각 impl 문서의 `depends_on`(선행 있으면 목록, 없으면 명시적 `[]`)과 `수정 허용`(bullet 당 순수 파일 경로 하나)이 채워진다. 비운 채/placeholder 잔존은 미상이고, normalizer 이후에도 남은 산문/다중 경로 bullet 은 병렬에서 직렬 강등된다.
 - 각 impl 문서(impl-task 한정) frontmatter 에 `risk` / `engine` / `risk_reason` 이 채워진다 — 고위험 trigger 보유 시 `risk: high` · `engine: 4agent`, 아니면 `normal`(또는 순수 내부 변경 `low`) · `engine: 2agent`. 🔴 템플릿의 파이프 옵션(`normal|high|low` / `2agent|4agent`)을 **반드시 하나로 골라 치환**한다 — `|` 가 남으면 소비측(impl-loop)이 placeholder=부재로 보고 추론 fallback 하므로 고위험 task 가 경량으로 샐 수 있다. `risk_reason` 은 근거 한 줄로, 비우지 않는다. 누락/placeholder 잔존 시 impl-loop 진입에서 메인 추론 fallback 으로 떨어진다(하위호환).
 - 계약 표면 코드 SSOT 대조 증거가 있다. 포트, 도메인 타입, 공개 entrypoint 를 바꾸는 task 는 module responsibility 또는 decision 으로 근거가 연결된다.
+- 확정 목업이 있는 UI epic 은 epic architecture 또는 impl task 의 `## 디자인 참조` 에 확정 목업 경로, node-id 매핑, docs/design.md 토큰 대조 근거가 있고, 목업 미참조 설계 금지 원칙을 어기지 않는다.
 - cross-task contract가 있으면 module responsibility 한 줄과 decision 문서에 의미가 있고 impl/compact plan 은 module/decision 참조만 가리킨다. 구양식 Contract Ledger / Contract References 산출물은 기존 활성 프로젝트 호환을 위해 유효하지만, 이번에 새로 쓰거나 수정하는 신규 산출물은 사본 표를 만들지 않는다.
 - `Module Design Check` 또는 동등한 문구로 모듈 설계 원칙 적용 증거가 남는다.
 - `Agent Workability` 또는 동등한 문구로 다음 agent 의 edit target, state owner, validation path 증거가 남는다.

--- a/docs/plugin/agents/ux-architect/templates/ux-flow.md
+++ b/docs/plugin/agents/ux-architect/templates/ux-flow.md
@@ -38,6 +38,7 @@ stateDiagram-v2
 
 ## 디자인 시스템
 
+- 기준:
 - color:
 - typography:
 - spacing:

--- a/docs/plugin/agents/ux-architect/ux-architect-agent.md
+++ b/docs/plugin/agents/ux-architect/ux-architect-agent.md
@@ -15,7 +15,7 @@ PRD와 현재 UI 상태를 화면 흐름, wireframe, interaction, system-level d
 
 - 필수: UX_FLOW 는 전역 최소 `docs/index.md`, `docs/prd.md`, `docs/conventions.md` 와 epic 고정 `docs/epics/<epic>/stories.md`, 대상 `docs/epics/<epic>/ux-flow.md`
 - 필수: 그 외 모드는 모드별 입력 문서
-- 상황별: `docs/design.md`, 기존 화면 코드
+- 상황별: `docs/design.md`, 기존 화면 코드, 메인이 전달한 참고 디자인 시스템 신호
 - 참고: [`templates/ux-flow.md`](templates/ux-flow.md), [`templates/refine-report.md`](templates/refine-report.md)
 
 ## 판단 축
@@ -26,6 +26,7 @@ PRD와 현재 UI 상태를 화면 흐름, wireframe, interaction, system-level d
 - 상태 커버리지: loading, empty, error, success가 필요한 화면에 있는가.
 - interaction 정합성: 사용자 시나리오와 수용 기준이 화면 행동으로 연결되는가.
 - 디자인 시스템: color, typography, spacing, radius 같은 system-level token이 일관되는가.
+- 디자인 시스템 기준: 참고 디자인 시스템 신호가 있으면 `docs/design.md` 토큰과 화면별 Designer Notes 가 그 기준을 반영하는가.
 - 범위 통제: UX 문제를 DB, API, product scope 결정으로 넘지 않는가.
 
 ## 작업 흐름
@@ -33,7 +34,7 @@ PRD와 현재 UI 상태를 화면 흐름, wireframe, interaction, system-level d
 1. 모드를 확인하고 입력이 충분한지 본다.
 2. 화면 인벤토리와 흐름을 먼저 잡고, 각 화면의 `hi-fi 목업 필요` 를 `필요/불필요` 로 표시한다.
 3. 화면별 wireframe, 상태, interaction을 작성한다.
-4. system-level design token이 필요하면 ux-architect 권한 영역만 갱신한다.
+4. system-level design token이 필요하거나 참고 디자인 시스템 신호가 전달됐으면 ux-architect 권한 영역 안에서 `docs/design.md` 를 갱신한다.
 5. 변경분만 다루는 모드에서는 기존 문서 전체를 다시 쓰지 않는다.
 6. 결론 전 판단 축을 자기 점검한다.
 
@@ -42,7 +43,7 @@ PRD와 현재 UI 상태를 화면 흐름, wireframe, interaction, system-level d
 - 모든 대상 화면이 인벤토리와 흐름에 연결된다.
 - 핵심 상태와 회복 경로가 빠지지 않는다.
 - designer가 작업할 수 있는 화면별 지시와 우선순위가 있고, `hi-fi 목업 필요` 가 `필요` 인 화면만 시안 대상으로 분리된다.
-- design.md 수정이 권한 영역 안에 있다.
+- design.md 수정이 권한 영역 안에 있고, 참고 디자인 시스템 신호가 있으면 `docs/design.md` 토큰에 반영된다.
 
 ## 권한 경계
 

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -36,7 +36,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 
 | 유틸리티 | 역할 |
 |---|---|
-| `/ux` | 구현 없이 목업과 흐름을 먼저 탐색한다. 내부 `canvas-design` wrapper 를 통해 drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록 규약을 따른다 |
+| `/ux` | 구현 없이 목업과 흐름을 먼저 탐색한다. 디자인 시스템 / 디자인 토큰 / 베이스라인 요청도 ad-hoc 문서가 아니라 `docs/design.md` 기준 신호로 정리한다. 내부 `canvas-design` wrapper 를 통해 drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록 규약을 따른다 |
 | `/init-dcness` | 프로젝트 활성화 |
 | `/migrate-dcness` | 기존 비-dcness 프로젝트를 코드 역설계로 전역 docs(`prd.md`/`architecture.md`/`conventions.md`/`decisions/`/`index.md`)를 채워 부트스트랩하는 일회성 유틸리티. `/init-dcness`(활성화)의 짝. epic/story 산출물은 만들지 않는다 |
 | `/next-work` | GitHub issue open/closed 상태, `in-progress` label, Issue Brief Priority 로 다음 작업 후보를 read-only 조회 |

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -25,10 +25,11 @@
 **gate 축** (먼저 — 어떤 구현 경로/진입점으로 진입할지):
 
 1. GitHub issue 초안/등록 요청인가? → `/to-issue`
-2. high-risk trigger 가 있나? → 설계 선행 (`/spec`·`/design`, `/impl` 밖)
-3. 목표/범위/성공 기준이 모호한가? → clarify 또는 `/spec`
-4. 설계 문서(경로)가 들어왔거나 concrete signal 이 있고 즉시 구현 경계가 명확한가? → `/impl` (설계도 있으면 Standard, 없으면 Lite)
-5. high-risk 는 없지만 구현 경계나 테스트 기준이 애매한가? → `compact-design` 산출 후 `/impl` Standard
+2. 구현 없이 목업·화면 흐름·디자인 시스템·디자인 토큰·베이스라인 요청인가? → `/ux`
+3. high-risk trigger 가 있나? → 설계 선행 (`/spec`·`/design`, `/impl` 밖)
+4. 목표/범위/성공 기준이 모호한가? → clarify 또는 `/spec`
+5. 설계 문서(경로)가 들어왔거나 concrete signal 이 있고 즉시 구현 경계가 명확한가? → `/impl` (설계도 있으면 Standard, 없으면 Lite)
+6. high-risk 는 없지만 구현 경계나 테스트 기준이 애매한가? → `compact-design` 산출 후 `/impl` Standard
 
 **shape 축** (gate 통과 후 — 구현을 어떻게 실행할지):
 

--- a/skills/design-system/SKILL.md
+++ b/skills/design-system/SKILL.md
@@ -9,7 +9,7 @@ description: /design 내부 stage 2 전용 스킬. 공개 진입점이 아니며
 
 ## 목적
 
-기존 `/design` 의 system/module 설계 pack 계약을 stage 2 로 격리한다. UI epic 에서는 stage 1 PR 로 머지된 `ux-flow.md` 와 확정 목업을 입력으로 사용하고, UI-less epic 에서는 기존처럼 UX stage 없이 한 PR 로 full design pack 을 만든다.
+기존 `/design` 의 system/module 설계 pack 계약을 stage 2 로 격리한다. UI epic 에서는 stage 1 PR 로 머지된 `ux-flow.md` 와 확정 목업을 입력으로 사용하고, UI-less epic 에서는 기존처럼 UX stage 없이 한 PR 로 full design pack 을 만든다. 확정 목업이 존재하는 epic 에서는 목업 미참조 설계 금지 원칙을 적용한다.
 
 ## 진입 조건
 
@@ -39,19 +39,20 @@ stage 2 PR 은 기존 full design pack 계약을 유지한다.
 - epic `impl/NN-*.md`
 - `docs/metrics/design-runs.jsonl`
 
-UI epic 이면 stage 1 의 `ux-flow.md`, `docs/design.md`, `docs/design-variants/` 확정본을 입력으로 읽지만 stage 2 가 UX 산출물을 다시 만드는 것이 기본값은 아니다. UX 산출물 결함이 final 검증에서 발견되면 finding 영향에 맞춰 사용자에게 되돌림을 보고한다.
+UI epic 이면 stage 1 의 `ux-flow.md`, `docs/design.md`, `docs/design-variants/` 확정본을 입력으로 읽지만 stage 2 가 UX 산출물을 다시 만드는 것이 기본값은 아니다. 확정 목업이 존재하면 확정 목업 경로, node-id 매핑, docs/design.md 토큰을 module-architect(epic-batch) 와 architecture-validator(final epic 검증) prompt 에 필수 입력으로 넣는다. 목업 미참조 설계 금지: 확정 목업이 있는데 epic architecture, impl task, final 검증 근거가 그 경로와 매핑을 전혀 대조하지 않으면 clean PASS 로 보지 않는다. UX 산출물 결함이 final 검증에서 발견되면 finding 영향에 맞춰 사용자에게 되돌림을 보고한다.
 
 ## 절차
 
 1. **Stage 선택 확인** — `/design` dispatcher 가 넘긴 epic dir 를 기준으로 full design pack 이 아직 미완인지 확인한다. 이미 완료됐으면 `/impl` 을 안내한다.
 2. **Run 시작** — worktree/base ref 는 `/design` 과 동일하게 적용하고 `begin-run design --stage design-system` 로 시작한다. 통합 브랜치 모드면 stage 2 PR 도 같은 base ref 를 사용한다.
-3. **기술 스택 체크포인트** — 기록된 스택 결정이 있으면 확인 안내 후 skip 하고, 없으면 메인이 사용자와 직접 합의한다.
-4. **조건부 system-architect** — greenfield topology 부재면 thin bootstrap 을 1회 호출한다. 기존 모듈 경계·도메인 invariant·storage policy·public API boundary·전역 decision 변경 신호가 있으면 opt-in checkpoint 를 호출한다.
-5. **module-architect(epic-batch)** — epic architecture 최소형과 epic 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성한다. Story 단위 작성 주체로 쪼개지 않는다.
-6. **mechanical pre-final checks** — normalize-scope, wave-plan, design artifact audit 를 실행하고 unresolved 신호만 final validator prompt 에 전달한다.
-7. **architecture-validator(final epic 검증)** — 기존 설계 pack 계약 그대로 final epic 검증을 수행한다. FAIL 은 `design-routing.md` 의 finding 분류에 따라 system checkpoint 또는 module-architect 로 되돌린다.
-8. **end-run + metrics freeze** — PR 생성 전에 `dcness-helper end-run` 을 실행해 `docs/metrics/design-runs.jsonl` 에 stage run 을 기록한다.
-9. **stage 2 PR** — full design pack 산출물을 stage/commit/push/PR 생성한다. main 머지 직전에는 설계 pack 요약과 diff 규모를 제시하고 사용자 확인 checkpoint 를 둔다. yolo 모드에서는 기존 `/design` 계약대로 확인을 생략할 수 있다. PR merge/main sync 후 `/impl <epic-path>` 를 안내한다.
+3. **stage 1 입력 수집** — UI epic 이면 `ux-flow.md`, `docs/design.md`, `docs/design-variants/<screen-id>.html`, `docs/design-variants/canvas.html` 을 먼저 확인한다. 확정본이 있으면 확정 목업 경로, node-id 매핑, docs/design.md 토큰을 이후 prompt 의 미기록 신호로 전달한다.
+4. **기술 스택 체크포인트** — 기록된 스택 결정이 있으면 확인 안내 후 skip 하고, 없으면 메인이 사용자와 직접 합의한다.
+5. **조건부 system-architect** — greenfield topology 부재면 thin bootstrap 을 1회 호출한다. 기존 모듈 경계·도메인 invariant·storage policy·public API boundary·전역 decision 변경 신호가 있으면 opt-in checkpoint 를 호출한다.
+6. **module-architect(epic-batch)** — epic architecture 최소형과 epic 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성한다. Story 단위 작성 주체로 쪼개지 않는다. 확정 목업이 있는 UI epic 은 목업 대조 근거를 architecture 와 impl `## 디자인 참조` 에 남긴다.
+7. **mechanical pre-final checks** — normalize-scope, wave-plan, design artifact audit 를 실행하고 unresolved 신호만 final validator prompt 에 전달한다.
+8. **architecture-validator(final epic 검증)** — 기존 설계 pack 계약 그대로 final epic 검증을 수행한다. 확정 목업이 있는 UI epic 에서는 목업 미참조 설계 금지 원칙에 따라 디자인 대조 근거를 검토한다. FAIL 은 `design-routing.md` 의 finding 분류에 따라 system checkpoint 또는 module-architect 로 되돌린다.
+9. **end-run + metrics freeze** — PR 생성 전에 `dcness-helper end-run` 을 실행해 `docs/metrics/design-runs.jsonl` 에 stage run 을 기록한다.
+10. **stage 2 PR** — full design pack 산출물을 stage/commit/push/PR 생성한다. main 머지 직전에는 설계 pack 요약과 diff 규모를 제시하고 사용자 확인 checkpoint 를 둔다. yolo 모드에서는 기존 `/design` 계약대로 확인을 생략할 수 있다. PR merge/main sync 후 `/impl <epic-path>` 를 안내한다.
 
 ## 결론 enum
 

--- a/skills/design-ux/SKILL.md
+++ b/skills/design-ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-ux
-description: /design 내부 stage 1 전용 스킬. 공개 진입점이 아니며 /design dispatcher 가 UI epic 에서 ux-flow.md 가 아직 durable 하게 머지되지 않았을 때만 호출한다. ux-architect 와 필요한 canvas-design 경로를 실행하고 `docs/epics/<epic>/ux-flow.md`, `docs/design.md`, `docs/design-variants/` 확정본을 자체 PR 로 머지해 "ux 완료 · system 미완" 상태를 main 에 남긴다.
+description: /design 내부 stage 1 전용 스킬. 공개 진입점이 아니며 /design dispatcher 가 UI epic 에서 ux-flow.md 가 아직 durable 하게 머지되지 않았을 때만 호출한다. 목업 선행 여부를 확인한 뒤 ux-architect 와 목업=예 한정 디자인 시스템 체크포인트/canvas-design 경로를 실행하고 `docs/epics/<epic>/ux-flow.md`, `docs/design.md`, `docs/design-variants/` 확정본을 자체 PR 로 머지해 "ux 완료 · system 미완" 상태를 main 에 남긴다.
 ---
 
 # design-ux — /design 내부 UX stage
@@ -25,7 +25,7 @@ UI-less epic 은 이 stage 를 호출하지 않고 `/design` dispatcher 가 곧�
 - **loop**: `design`
 - **entry_point**: `design`
 - **stage marker**: `begin-run design --stage design-ux`
-- **task_list**: ux-architect:UX_FLOW → 필요한 경우 내부 canvas-design → 사용자 PICK
+- **task_list**: 목업 선행 여부 checkpoint → ux-architect:UX_FLOW → 목업=예 한정 디자인 시스템 체크포인트 → 필요한 경우 내부 canvas-design → 사용자 PICK
 - **advance**: `UX_FLOW_READY` 또는 canvas-design `PASS` → stage 1 PR
 - **expected_steps**: 1 + 조건부 designer step. canvas-design 은 main-owned checkpoint 이며 helper begin/end-step 비대상이다.
 
@@ -46,11 +46,14 @@ architecture, domain-model, impl task 는 이 stage 에서 만들지 않는다. 
 
 1. **Stage 선택 확인** — `/design` dispatcher 가 넘긴 epic dir 를 기준으로 `stories.md` 와 UI 판정을 확인한다. `ux-flow.md` 가 이미 있으면 이 stage 를 중단하고 `design-system` 으로 돌아간다.
 2. **Run 시작** — worktree/base ref 는 `/design` 과 동일하게 적용하고 `begin-run design --stage design-ux` 로 시작한다. 통합 브랜치 모드면 stage 1 PR 도 같은 base ref 를 사용한다.
-3. **ux-architect 호출** — `UX_FLOW` 모드로 epic `ux-flow.md` 를 작성한다. 화면 인벤토리는 `hi-fi 목업 필요` 열을 유지한다.
-4. **목업 필요 화면 처리** — `hi-fi 목업 필요` 가 `필요` 인 화면만 내부 [`canvas-design`](../canvas-design/SKILL.md) 으로 넘긴다. seed 보장, designer draft, 사용자 PICK, 확정본 승격, canvas 등록은 canvas-design 계약을 따른다.
-5. **end-run + metrics freeze** — PR 생성 전에 `dcness-helper end-run` 을 실행해 `docs/metrics/design-runs.jsonl` 에 stage run 을 기록한다.
-6. **stage 1 PR** — stage 1 산출물만 stage/commit/push/PR 생성한다. PR body 의 배포 경로에는 `/design` 내부 stage 이고 공개 진입점 변화가 없음을 명시한다. main 머지 직전에는 UX 산출물 요약과 diff 규모를 제시하고 사용자 확인 checkpoint 를 둔다. yolo 모드에서는 기존 `/design` 계약대로 확인을 생략할 수 있다.
-7. **머지 후 반환** — PR merge/main sync 가 끝나면 `/design` dispatcher 로 돌아간다. 다음 durable 판정은 `ux-flow.md` 존재 + 설계 pack 부재이므로 `design-system` stage 를 선택한다.
+3. **목업 선행 여부 checkpoint** — UI epic 에서 목업 선행 여부를 1회 묻는다. 목업=예 가 아니면 목업 없음 으로 처리한다. 사용자 opt-out 발화나 yolo 모드는 yolo 기본값 = 목업 없음 이며, 기존 UX stage 흐름 그대로 ux-flow 와 text wireframe 만 durable 하게 남긴다. opt-out 정규식은 `/design` dispatcher 의 `(목업|mockup|시안|디자인)\s*(빼|없|말|나중|생략)` 를 따른다.
+4. **디자인 시스템 체크포인트 (목업=예 한정)** — docs/design.md 실존+유효 이면 확인-후-skip 한다. 부재하면 사용자에게 참고 디자인 시스템을 요청한다. 이미 `docs/design-refs/` 같은 ad-hoc 베이스라인 문서가 있으면 외부 import 1회 변환으로 `docs/design.md` 에 흡수하고, 같은 내용을 반복 import 하지 않는다. 이 결과를 ux-architect prompt 의 참고 디자인 시스템 신호로 전달한다.
+5. **ux-architect 호출** — `UX_FLOW` 모드로 epic `ux-flow.md` 를 작성한다. 화면 인벤토리는 `hi-fi 목업 필요` 열을 유지하고, 목업=예 경로에서는 `docs/design.md` 토큰을 참고 디자인 시스템 신호에 맞춰 정리한다.
+6. **목업 필요 화면 처리** — 목업=예 경로에서만 `hi-fi 목업 필요` 가 `필요` 인 화면을 내부 [`canvas-design`](../canvas-design/SKILL.md) 으로 넘긴다. seed 보장, designer draft, 사용자 PICK, 확정본 승격, canvas 등록은 canvas-design 계약을 따른다. system stage 는 사용자 PICK 확정 이후에만 진입한다.
+   - 목업 없음 경로에서는 canvas-design 을 강제하지 않는다. `hi-fi 목업 필요` 는 후속 `/ux` 또는 `/impl` 기준 확보 판단의 신호로만 남긴다.
+7. **end-run + metrics freeze** — PR 생성 전에 `dcness-helper end-run` 을 실행해 `docs/metrics/design-runs.jsonl` 에 stage run 을 기록한다.
+8. **stage 1 PR** — stage 1 산출물만 stage/commit/push/PR 생성한다. PR body 의 배포 경로에는 `/design` 내부 stage 이고 공개 진입점 변화가 없음을 명시한다. main 머지 직전에는 UX 산출물 요약, 목업 선행 여부, 확정 목업 경로와 diff 규모를 제시하고 사용자 확인 checkpoint 를 둔다. yolo 모드에서는 기존 `/design` 계약대로 확인을 생략할 수 있다.
+9. **머지 후 반환** — PR merge/main sync 가 끝나면 `/design` dispatcher 로 돌아간다. 다음 durable 판정은 `ux-flow.md` 존재 + 설계 pack 부재이므로 `design-system` stage 를 선택한다.
 
 ## 결론 enum
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design
-description: PRD/stories.md 머지 + epic/story 이슈 등록 이후, 1 epic 단위로 선택 ux-architect / module-architect / architecture-validator 를 호출하여 agent-first 설계 산출물 (선택 `docs/epics/.../ux-flow.md` + `docs/decisions/*.md` + `docs/epics/.../architecture.md` 최소형 + 선택 `docs/epics/.../domain-model.md` + `docs/epics/.../impl/*.md`) 을 작성하고 1 PR 로 머지하는 설계 루프 스킬. 기존 모듈 topology 가 전혀 없는 greenfield 첫 설계에서는 system-architect(thin bootstrap)가 큰 모듈 경계만 1회 얇게 나눈 뒤 module-architect(epic-batch)로 이어진다. 그 외 기본 경로는 module-architect(epic-batch)가 epic architecture 최소형과 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성하고, architecture-validator(final epic 검증)가 최종 검증으로 수렴한다. 기존 모듈 경계·불변조건·public API boundary 변경 신호가 있을 때만 system-architect opt-in checkpoint 로 승격한다. 사용자가 "설계해줘", "design", "epic 설계", "/design <epic-path>", "ux-flow 부터", "impl 다 만들어줘" 등을 말할 때 반드시 이 스킬을 사용한다. `/spec` 의 후속. 구현 진입은 `/impl`, story/epic 제품 검수는 `/acceptance`.
+description: PRD/stories.md 머지 + epic/story 이슈 등록 이후, 1 epic 단위로 선택 ux-architect / module-architect / architecture-validator 를 호출하여 agent-first 설계 산출물 (선택 `docs/epics/.../ux-flow.md` + `docs/design.md` + 선택 `docs/design-variants/*.html` + `docs/decisions/*.md` + `docs/epics/.../architecture.md` 최소형 + 선택 `docs/epics/.../domain-model.md` + `docs/epics/.../impl/*.md`) 을 작성하고 PR 로 머지하는 설계 루프 스킬. UI epic 은 system/module 설계 전에 목업 선행 여부를 확인하고, 목업=예 경로에서는 사용자 PICK 확정본을 system stage 입력으로 고정한다. 기존 모듈 topology 가 전혀 없는 greenfield 첫 설계에서는 system-architect(thin bootstrap)가 큰 모듈 경계만 1회 얇게 나눈 뒤 module-architect(epic-batch)로 이어진다. 그 외 기본 경로는 module-architect(epic-batch)가 epic architecture 최소형과 전체 impl 산출물을 하나의 컨텍스트에서 일괄 작성하고, architecture-validator(final epic 검증)가 최종 검증으로 수렴한다. 기존 모듈 경계·불변조건·public API boundary 변경 신호가 있을 때만 system-architect opt-in checkpoint 로 승격한다. 사용자가 "설계해줘", "design", "epic 설계", "/design <epic-path>", "ux-flow 부터", "impl 다 만들어줘" 등을 말할 때 반드시 이 스킬을 사용한다. `/spec` 의 후속. 구현 진입은 `/impl`, story/epic 제품 검수는 `/acceptance`.
 ---
 
 # Design Skill — 1 epic 단위 설계 루프
@@ -17,7 +17,7 @@ description: PRD/stories.md 머지 + epic/story 이슈 등록 이후, 1 epic 단
 
 - **loop**: `design`
 - **entry_point**: `design` (begin-run 인자 — 사용자 명시 진입)
-- **task_list** (Step 1): `/design` dispatcher 가 durable 산출물로 내부 stage 를 선택한다. stage 1 `design-ux` = ux-architect:UX_FLOW → 조건부 canvas-design → stage 1 PR. stage 2 `design-system` = [기술 스택 그릴미 또는 기록된 스택 결정 확인-후-skip — 메인 직접, helper 비대상] → module-architect(epic-batch) → architecture-validator(final epic 검증). (UI-less epic) ux-architect 제외. 모듈 topology 부재 greenfield 첫 설계면 system-architect(thin bootstrap)를 module-architect 앞에 1회 추가한다. 기존 모듈 경계·불변조건·public API boundary 변경 신호가 있으면 system-architect opt-in checkpoint 를 module-architect 앞/뒤에 끼운다.
+- **task_list** (Step 1): `/design` dispatcher 가 durable 산출물로 내부 stage 를 선택한다. stage 1 `design-ux` = 목업 선행 여부 checkpoint → ux-architect:UX_FLOW → 목업=예 한정 디자인 시스템 체크포인트 → 조건부 canvas-design → 사용자 PICK → stage 1 PR. 목업 없음 / opt-out / yolo 기본값 = 목업 없음 경로는 기존 UX stage 흐름을 유지하고 canvas-design 을 강제하지 않는다. stage 2 `design-system` = [기술 스택 그릴미 또는 기록된 스택 결정 확인-후-skip — 메인 직접, helper 비대상] → module-architect(epic-batch) → architecture-validator(final epic 검증). (UI-less epic) ux-architect 제외. 모듈 topology 부재 greenfield 첫 설계면 system-architect(thin bootstrap)를 module-architect 앞에 1회 추가한다. 기존 모듈 경계·불변조건·public API boundary 변경 신호가 있으면 system-architect opt-in checkpoint 를 module-architect 앞/뒤에 끼운다.
 - **advance**: `UX_FLOW_READY` → 선택 `PASS`(thin bootstrap) → `PASS`(epic-batch) → `PASS`(final epic 검증). opt-in system checkpoint 는 `SYSTEM_CHECKPOINT_REQUIRED` → `PASS`(system) → module-architect 재진입.
 - **expected_steps**: 3 (UI epic) / 2 (UI-less epic). 기술 스택 그릴미 또는 확인-후-skip 은 begin-step 비대상이라 미포함. thin bootstrap 또는 system checkpoint 승격 시 각각 +1.
 - **분기 규칙**: [`design-routing.md`](design-routing.md)
@@ -115,13 +115,24 @@ TaskCreate 직전 메인이 `docs/prd.md` 의 "화면 인벤토리 + 대략적 �
 - 판정은 메인 prose 자율 영역 — hook 강제 아님 ([`CLAUDE.md`](../../CLAUDE.md#dcness-강제-원칙-룰-추가설계-시-가드레일)).
 - UI-less 판정 시 expected_steps = 2, UI epic 은 3.
 
+## 목업 선행 체크포인트 (UI epic 한정)
+
+UI epic 으로 판정되고 `design-ux` stage 를 선택한 직후 메인이 목업 선행 여부를 1회 묻는다. 목업=예 경로는 system stage 는 사용자 PICK 확정 이후에만 진입한다는 계약을 둔다. 목업 없음, 사용자 opt-out, 또는 yolo 모드에서는 yolo 기본값 = 목업 없음 으로 처리해 기존 흐름 그대로 진행한다.
+
+- **목업 선행 여부 질문**: "이 UI epic 은 system/module 설계 전에 hi-fi 목업 PICK 을 먼저 확정할까요?" 처럼 사용자가 예/아니오를 판단할 수 있게 묻는다.
+- **opt-out**: 사용자 발화에 정규식 `(목업|mockup|시안|디자인)\s*(빼|없|말|나중|생략)` 매치 시 목업 없음 으로 처리한다.
+- **목업=예**: `design-ux` stage 안에서 디자인 시스템 체크포인트를 먼저 닫고, `hi-fi 목업 필요` 가 `필요` 인 화면만 canvas-design 으로 draft → 사용자 PICK → 확정본 승격 + canvas 등록을 수행한다.
+- **목업 없음**: `ux-flow.md` 와 text wireframe 은 유지하되 canvas-design PICK 을 필수화하지 않는다. 후속 `design-system` 은 확정 목업 입력 없이 기존 system/module 설계 계약으로 진행한다.
+
+디자인 시스템 체크포인트는 기술 스택 그릴미와 같은 확인-후-skip 패턴이다. `docs/design.md` 가 실존하고 현재 epic 에 유효하면 확인-후-skip 한다. 부재하거나 ad-hoc 베이스라인 문서가 있으면 사용자에게 참고 디자인 시스템을 요청하고, 외부 import 1회 변환으로 `docs/design.md` 에 흡수한 뒤 ux-architect prompt 에 참고 디자인 시스템 신호로 전달한다.
+
 ## 절차 (요약)
 
 상세 = 본 절차 + [`docs/plugin/loop-procedure.md`](../../docs/plugin/loop-procedure.md#진입-모델) Step mechanics.
 
 1. **Step 0** — 워크트리 진입 + `EnterWorktree` + branch (`docs/<epic-slug>`) + stage 선택 전 `begin-run design` 준비. 실제 stage run 은 dispatcher 판정 뒤 `begin-run design --stage design-ux` 또는 `begin-run design --stage design-system` 로 시작한다.
 2. **Step 0.5 — stage dispatcher** — durable 산출물 실존 판정으로 `design-ux` 또는 `design-system` 을 선택한다. 내부 stage 절차 전문은 각 stage skill 을 로드한다.
-3. **Step 1 — UI 판정 + topology 부재 판정 후 TaskCreate.** `design-ux` stage 에서는 ux-architect(+조건부 canvas-design) 만 TaskCreate 한다. `design-system` stage 에서는 module-architect(epic-batch) / architecture-validator(final epic 검증)를 TaskCreate 한다. UI-less epic → ux-architect 제외. greenfield 첫 설계에서 `docs/architecture.md` root anchor 의 큰 모듈 topology 가 비어 있고 어떤 `docs/epics/**/architecture.md` 에도 유효 `## 모듈 목록` row 가 없으면 system-architect(thin bootstrap)를 module-architect 앞에 1회 배치한다. 이 thin bootstrap 뒤에는 architecture-validator 를 끼우지 않고 바로 module-architect 로 간다. system checkpoint 는 기본 TaskCreate 에 넣지 않고, boundary 변경 신호가 있을 때만 추가한다.
+3. **Step 1 — UI 판정 + 목업 선행 여부 + topology 부재 판정 후 TaskCreate.** `design-ux` stage 에서는 목업 선행 여부와 디자인 시스템 체크포인트를 메인이 처리하고 ux-architect(+목업=예 한정 조건부 canvas-design) 만 TaskCreate 한다. `design-system` stage 에서는 module-architect(epic-batch) / architecture-validator(final epic 검증)를 TaskCreate 한다. UI-less epic → ux-architect 제외. greenfield 첫 설계에서 `docs/architecture.md` root anchor 의 큰 모듈 topology 가 비어 있고 어떤 `docs/epics/**/architecture.md` 에도 유효 `## 모듈 목록` row 가 없으면 system-architect(thin bootstrap)를 module-architect 앞에 1회 배치한다. 이 thin bootstrap 뒤에는 architecture-validator 를 끼우지 않고 바로 module-architect 로 간다. system checkpoint 는 기본 TaskCreate 에 넣지 않고, boundary 변경 신호가 있을 때만 추가한다.
 4. **Stage 1 — design-ux / ux-architect:UX_FLOW** (UI epic 한정) → `UX_FLOW_READY` → stage 1 PR (epic 단위 `docs/epics/epic-NN-*/ux-flow.md`, 조건부 `docs/design.md`, 조건부 `docs/design-variants/`)
    - `UX_REFINE_READY` 로 `/design` 안에서 designer 후속이 필요하면, designer 호출 전 `/ux` 의 "designer 진입 공통 preflight" 와 동일하게 `docs/design-variants/` seed 보장 후 designer 로 진행한다.
 5. **Stage 2 — design-system / 기술 스택 그릴미 또는 기록된 스택 결정 확인-후-skip** — 메인 직접, helper begin/end-step 비대상. 미기록 합의 또는 skip 사실은 thin bootstrap 이 있으면 Step 2.95 prompt 로, 없으면 Step 3 prompt 로 전달한다.

--- a/skills/design/design-routing.md
+++ b/skills/design/design-routing.md
@@ -19,7 +19,11 @@ flowchart TB
   DUX -->|DESIGN_UX_PR_MERGED| START
   DSYS --> TOPO[Step 1 topology 판정]
   TOPO -->|UI epic 또는 UI-less| BOOT{모듈 topology 부재?}
-  DUX --> UX[ux-architect]
+  DUX --> MU{목업 선행 여부}
+  MU -->|목업 없음 / opt-out / yolo| UX[ux-architect]
+  MU -->|목업=예| DSKIP{디자인 시스템 체크포인트}
+  DSKIP -->|docs/design.md 유효| UX
+  DSKIP -->|부재 / ad-hoc 베이스라인| UX
   UX -->|UX_FLOW_READY| UXPR[stage 1 PR]
   UXPR -->|DESIGN_UX_PR_MERGED| START
   UX -->|UX_REFINE_READY| SEED[design-variants seed 보장]
@@ -46,7 +50,7 @@ flowchart TB
   classDef produce fill:#e3f2fd,stroke:#1976d2,color:#0d47a1
   classDef verify fill:#e8f5e9,stroke:#388e3c,color:#1b5e20
   classDef user fill:#eeeeee,stroke:#757575,color:#212121
-  class DUX,DSYS,UX,UXPR,SA_BOOT,SA_CHECK,DS,MA_BATCH,SEED produce
+  class DUX,DSYS,UX,UXPR,SA_BOOT,SA_CHECK,DS,MA_BATCH,SEED,MU,DSKIP produce
   class AV_FINAL verify
   class U user
 ```
@@ -74,6 +78,8 @@ flowchart TB
 - **module-architect(epic-batch)** 는 공통 task와 전체 Story impl 산출물을 하나의 컨텍스트에서 일괄 작성한다. Story 단위 작성 주체로 쪼개지지 않으며, 모든 Story 에 단위 검증을 기본값으로 복원하지 않는다.
 - **architecture-validator 시점** — final epic 검증만 기본이다. 모든 impl 산출물을 한 번에 읽고 Story 간 compose/wiring, forward-ref 회수, Story별 첫 제품 경계 동작 증거, 구현 순서(첫 제품 경계 동작 앞당김), cold-seat 구현 가능성, PRD origin 대조, impl 과상세화, 코드 SSOT drift 를 검토한다. Must finding 마다 분류(`SYSTEM_BOUNDARY` / `TASK_LOCAL`) 동반. ux-flow·stories prose·legacy Contract Ledger/References 같은 비규범/구양식 층의 stale 은 형식만으로 FAIL 하지 않고 Should 로 보고한다.
 - **stage PR 경계** — `DESIGN_UX_PR_MERGED` 는 UX 산출물이 main 에 durable 해졌다는 신호다. dispatcher 는 같은 `/design` 공개 진입점으로 재판정해 system stage 로 이어간다. `DESIGN_SYSTEM_PR_MERGED` 는 full design pack 이 durable 해졌다는 신호이므로 `/impl` 로 넘어간다.
+- **목업 선행 여부 checkpoint** — UI epic 의 `design-ux` stage 는 ux-architect 호출 전에 목업 선행 여부를 1회 묻는다. 목업 없음 / opt-out / yolo 는 기존 흐름을 유지하고, 목업=예 는 디자인 시스템 체크포인트와 canvas-design 사용자 PICK 을 먼저 닫는다. 사용자 PICK 확정 이후에만 design-system stage 로 넘어간다.
+- **목업 미참조 금지** — `design-system` stage 는 확정 목업이 있는 UI epic 에서 확정 목업 경로, node-id 매핑, `docs/design.md` 토큰을 module-architect 와 architecture-validator 입력에 넣는다. 산출물이 목업 미참조 상태면 final epic 검증 PASS 로 처리하지 않고 finding 분류에 따라 module-architect 또는 system checkpoint 로 되돌린다.
 - **규모 초과 사전 가드** — Step 4 전 Story 수와 예상 full design pack 규모가 target 1,500줄 / hard warning 2,000줄 예산을 넘을 전망이면, 메인은 자동 진행 대신 사용자에게 epic 분할 또는 예외적 batch 2분할을 위임한다. 이는 대형 epic 출력 한계 방지용 escape 이며 per-Story 검증 기본값 복원이 아니다.
 - **고위험 추가 검증** — 보안·migration·public API breakage 같은 신호가 batch 작성 중 뒤늦게 드러나면 메인은 final epic 검증 전 추가 검토를 선택할 수 있다. 단 이것은 예외적 보강이지 옛 per-Story 검증 기본값의 복원이 아니다.
 

--- a/skills/ux/SKILL.md
+++ b/skills/ux/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ux
-description: 구현 없이 목업과 흐름을 먼저 탐색하는 선행 디자인 utility. UX_FLOW(신규 화면 흐름) / UX_REFINE(기존 디자인 개선) 뒤 내부 canvas-design 을 얇게 감싸 drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록으로 끝낸다. 사용자가 "/ux", "ux", "화면 플로우 짜줘", "디자인 시안", "와이어프레임", "ux 다듬어", "디자인 개선", "레이아웃 개선" 등을 말할 때 사용한다. 코드 구현은 `/impl`.
+description: 구현 없이 목업과 흐름을 먼저 탐색하는 선행 디자인 utility. UX_FLOW(신규 화면 흐름) / UX_REFINE(기존 디자인 개선) 뒤 내부 canvas-design 을 얇게 감싸 drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록으로 끝낸다. 사용자가 "/ux", "ux", "화면 플로우 짜줘", "디자인 시안", "와이어프레임", "ux 다듬어", "디자인 개선", "레이아웃 개선", "디자인 시스템", "디자인 토큰", "베이스라인" 등을 말할 때 사용한다. 코드 구현은 `/impl`.
 ---
 
 # UX Skill — 선행 디자인 탐색 wrapper
@@ -35,7 +35,7 @@ PR merge 와 main sync 를 확인한 뒤에만 완료를 보고한다. 후속 `/
 | **UX_FLOW** (ux-design-stage) | 신규 화면 플로우 정의 — PRD/스토리 화면 인벤토리 기반 와이어프레임 | ux-architect:UX_FLOW |
 | **UX_REFINE** (ux-refine-stage) | 기존 디자인의 레이아웃·비주얼 개선 (이미 화면 존재) | ux-architect:UX_REFINE |
 
-사용자 발화로 판정한다. "새 화면 / 플로우 / 와이어프레임" 은 UX_FLOW, "다듬어 / 개선 / refine / 레이아웃" 은 UX_REFINE 이다. 모호하면 사용자에게 한 번만 물어본다.
+사용자 발화로 판정한다. "새 화면 / 플로우 / 와이어프레임" 은 UX_FLOW, "다듬어 / 개선 / refine / 레이아웃" 은 UX_REFINE 이다. "디자인 시스템 / 디자인 토큰 / 베이스라인" 류 요청은 ad-hoc `docs/design-refs/` 문서를 만들지 않고 `/ux` 로 받아 `docs/design.md` 기준 신호로 정리한다. 모호하면 사용자에게 한 번만 물어본다.
 
 ## Inputs
 

--- a/tests/test_canvas_design_workflow.py
+++ b/tests/test_canvas_design_workflow.py
@@ -142,6 +142,12 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
             with self.subTest(stale=stale):
                 self.assertNotIn(stale, self.ux)
 
+    def test_ux_natural_language_routes_design_baseline_requests(self) -> None:
+        """#957 — design system/baseline requests route to /ux instead of ad-hoc docs."""
+        for needle in ("디자인 시스템", "디자인 토큰", "베이스라인"):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, self.ux)
+
     def test_ux_flow_inventory_marks_hi_fi_mockup_need_only(self) -> None:
         for text in (self.ux_architect, self.ux_flow_template):
             with self.subTest(text=text[:30]):

--- a/tests/test_design_surface.py
+++ b/tests/test_design_surface.py
@@ -270,6 +270,74 @@ class DesignSurfaceContractTests(unittest.TestCase):
         self.assertIn("stage 2 PR", design_system)
         self.assertIn("기존 설계 pack 계약", design_system)
 
+    def test_design_mockup_prefreeze_branch_contracts(self) -> None:
+        """#957 — mockup opt-in happens before system design and becomes required input."""
+        design = (ROOT / "skills" / "design" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        routing = (
+            ROOT / "skills" / "design" / "design-routing.md"
+        ).read_text(encoding="utf-8")
+        design_ux = (ROOT / "skills" / "design-ux" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        design_system = (ROOT / "skills" / "design-system" / "SKILL.md").read_text(
+            encoding="utf-8"
+        )
+        module_architect = (
+            ROOT
+            / "docs"
+            / "plugin"
+            / "agents"
+            / "module-architect"
+            / "module-architect-agent.md"
+        ).read_text(encoding="utf-8")
+        validator = (
+            ROOT
+            / "docs"
+            / "plugin"
+            / "agents"
+            / "architecture-validator"
+            / "architecture-validator-agent.md"
+        ).read_text(encoding="utf-8")
+
+        for needle in (
+            "목업 선행 여부",
+            "목업=예",
+            "목업 없음",
+            "opt-out",
+            "yolo 기본값 = 목업 없음",
+            "system stage 는 사용자 PICK 확정 이후",
+            "디자인 시스템 체크포인트",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, design)
+                self.assertIn(needle, design_ux)
+
+        for needle in (
+            "docs/design.md 실존+유효",
+            "확인-후-skip",
+            "ad-hoc 베이스라인 문서",
+            "외부 import 1회 변환",
+            "참고 디자인 시스템 신호",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, design_ux)
+
+        for needle in (
+            "확정 목업 경로",
+            "node-id 매핑",
+            "docs/design.md 토큰",
+            "목업 미참조 설계 금지",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, design_system)
+                self.assertIn(needle, module_architect)
+                self.assertIn(needle, validator)
+
+        self.assertIn("사용자 PICK 확정 이후", routing)
+        self.assertIn("목업 미참조", routing)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호
Closes #957

## 배경 및 문제
- `/design` UI epic 에서 목업이 system/module 설계 뒤로 밀리면, 검증되지 않은 구조에 화면을 끼워 맞추는 역전이 생긴다.
- `#958` stage 분리 이후 `design-ux` stage 1 안에서 목업 opt-in과 디자인 시스템 기준을 먼저 durable 하게 닫을 수 있는 계약이 필요하다.

## 원인 (해당 시)
- 기존 `design-ux` stage 는 `hi-fi 목업 필요` 화면을 canvas-design 으로 보낼 수는 있었지만, 목업 선행 여부 질문과 디자인 시스템 체크포인트, 확정 목업을 stage 2 필수 입력으로 강제하는 계약이 문서/테스트에 고정돼 있지 않았다.

## 작업내용
- `/design` 및 `design-ux`에 목업 선행 여부 checkpoint, opt-out/yolo=목업 없음, 목업=예 한정 디자인 시스템 체크포인트를 추가했다.
- `design-system`, module-architect, architecture-validator가 확정 목업 경로, node-id 매핑, `docs/design.md` 토큰을 필수 입력/검증 축으로 취급하도록 갱신했다.
- `/ux` 자연어 트리거와 공개 설명에 디자인 시스템/디자인 토큰/베이스라인 요청을 추가했다.
- `#957` 회귀 테스트를 추가해 목업 선행 분기와 `/ux` 트리거 계약을 고정했다.

## 결정 근거
- 신규 공개 진입점을 만들지 않고 기존 `/design` 내부 stage와 `/ux` utility를 확장했다. `#958` 이후의 stage 경계와 public-surface 축소 원칙에 맞다.
- 확정 목업이 존재하는 경우에만 목업 미참조 설계를 금지해, 목업 opt-out/UI-less 경로는 기존 설계 흐름을 유지한다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in 본체 경로 갱신: `skills/design/**`, `skills/design-ux/**`, `skills/design-system/**`, `skills/ux/**`.
- plug-in 문서/agent 경로 갱신: `docs/plugin/**`, `README.md`.
- `/init-dcness` 복사 파일 변경 없음. 사용자는 plug-in 업데이트로 반영된다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 신규 공개 진입점 없음. 기존 `/design` 내부 checkpoint와 기존 `/ux` utility 자연어 트리거 보강만 수행했다.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_design_surface.DesignSurfaceContractTests.test_design_mockup_prefreeze_branch_contracts tests.test_canvas_design_workflow.CanvasDesignWorkflowTests.test_ux_natural_language_routes_design_baseline_requests -v < /dev/null`
- [x] `python3.11 -m unittest tests.test_design_surface tests.test_canvas_design_workflow tests.test_surface_docs_sync tests.test_public_surface -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_design_artifact_structure.mjs --root .`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`

## 참고
- `#958` stage 분리 위에 구현했다.
