### PR TITLE
[issue-976] sub-agent 모델 티어와 codex pin 설정

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,5 +180,7 @@ PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality
 |---|---|---|---|
 | `EVAL_RUNS` / `EVAL_MODEL` / `EVAL_OUTPUT_DIR` / `EVAL_RELEASE_CHECK` / `EVAL_STRICT_CASES` | `evals/run.sh` 행동 eval — 반복 수 / 모델 / 산출물 위치 / 릴리즈 N/N 모드 / 핵심 케이스 목록 | `1` / `sonnet` / `.metrics/evals/run-*` / `0` / 핵심 2케이스 | X |
 | `DCNESS_FORCE_ENABLE` | is-active 게이트 임시 활성 (디버깅) | 미설정 | X |
+| `DCNESS_CODEX_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt timeout | validator `600`, worker `1200` | X |
+| `DCNESS_CODEX_MODEL` / `DCNESS_CODEX_EFFORT` | Codex headless wrapper model / reasoning effort opt-in override. 미설정 시 사용자 Codex config 상속 | 미설정 | X |
 | `DCNESS_PROJECTS_FILE` | `scripts/loop_diagnose.py` 의 활성 프로젝트 whitelist 경로 override (테스트용) | `~/.claude/plugins/data/dcness-dcness/projects.json` | X |
 | `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` | git hook telemetry 히트의 active run 귀속 (headless worker 컨텍스트) | 미설정 | X |

--- a/agents/architecture-validator.md
+++ b/agents/architecture-validator.md
@@ -4,7 +4,7 @@ description: >
   module-architect 산출물과 opt-in system checkpoint 산출물을 읽기 전용으로 검토하는 에이전트.
   실제 지침은 docs/plugin/agents/architecture-validator/architecture-validator-agent.md 에 있다.
 tools: Read, Glob, Grep
-model: sonnet
+model: opus
 ---
 
 # architecture-validator

--- a/agents/build-worker.md
+++ b/agents/build-worker.md
@@ -4,7 +4,7 @@ description: >
   /impl-loop 경량 엔진에서 테스트, 구현, 자체 검증을 한 번에 수행하는 에이전트.
   실제 지침은 docs/plugin/agents/build-worker/build-worker-agent.md 에 있다.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: sonnet
+model: opus
 ---
 
 # build-worker

--- a/agents/engineer.md
+++ b/agents/engineer.md
@@ -4,7 +4,7 @@ description: >
   구현 계획에 따라 src 코드를 수정하는 에이전트. 실제 지침은
   docs/plugin/agents/engineer/engineer-agent.md 에 있다.
 tools: Read, Write, Edit, Bash, Glob, Grep
-model: sonnet
+model: opus
 ---
 
 # engineer

--- a/agents/module-architect.md
+++ b/agents/module-architect.md
@@ -4,7 +4,7 @@ description: >
   epic-batch, compact plan 단위의 구현 계획 문서를 작성하는 에이전트. 실제 지침은
   docs/plugin/agents/module-architect/module-architect-agent.md 에 있다.
 tools: Read, Glob, Grep, Write, Edit, mcp__github__create_issue, mcp__github__list_issues, mcp__github__get_issue, mcp__github__update_issue
-model: sonnet
+model: opus
 ---
 
 # module-architect

--- a/agents/product-acceptance.md
+++ b/agents/product-acceptance.md
@@ -4,7 +4,7 @@ description: >
   PRD / Epic / Story / Release 단위로 제품 검수 가능성과 완료 증거를 읽기 전용으로
   확인하는 에이전트. 실제 지침은 docs/plugin/agents/product-acceptance/product-acceptance-agent.md 에 있다.
 tools: Read, Glob, Grep
-model: sonnet
+model: opus
 ---
 
 # product-acceptance

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -102,7 +102,7 @@ else
 fi
 ```
 
-Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
+Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. `DCNESS_CODEX_MODEL` 을 설정하면 wrapper 가 `-m` 모델 override 를, `DCNESS_CODEX_EFFORT` 를 설정하면 `-c model_reasoning_effort=...` override 를 전달한다. 둘 다 미설정이면 사용자 Codex config 를 그대로 상속하며, dcNess 는 특정 Codex 모델명을 하드코딩하지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
 
 **implementation provider 분기 (headless-chain 기본)**: `test-engineer` / `engineer` / `build-worker` 는 호출 직전 provider 를 resolve 한다.
 
@@ -123,7 +123,7 @@ else
 fi
 ```
 
-`dcness-implementation-chain` 은 `headless-chain`(Codex headless → Claude headless → Claude main), `codex-first`(legacy), `claude-headless`, `claude` 를 같은 routing config 로 실행한다. Headless wrapper 가 성공하면 마지막 응답을 저장하고 `end-step` 까지 수행한다. CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패한 경우에만 다음 provider 로 넘어간다. Headless provider 가 파일을 변경한 뒤 실패하거나 boundary 밖 파일을 변경하면 자동 폴백하지 않는다. chain 이 Claude main 에 도달하면 `FALLBACK_TO_CLAUDE_MAIN` 과 exit 75 를 반환하므로 메인이 기존 Agent 경로를 실행한 뒤 `--provider claude-main` 으로 `end-step` 을 기록한다. raw headless session log 는 run 디렉터리의 `headless-logs/` 파일로 보존한다. Claude headless wrapper 는 자식 `claude -p` 실행 전 부모 세션 식별 env 를 제거하되, `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 는 유지해 run 기록을 이어간다. Headless build-worker 가 `VALIDATION_BLOCKED` 를 보고하면 `ledger.jsonl` 에 `blocked` event 와 `category=headless_validation_blocked` 가 추가로 남으므로, 검증 명령 권한 문제 빈도는 `run-review` 또는 ledger 조회로 확인한다.
+`dcness-implementation-chain` 은 `headless-chain`(Codex headless → Claude headless → Claude main), `codex-first`(legacy), `claude-headless`, `claude` 를 같은 routing config 로 실행한다. Headless wrapper 가 성공하면 마지막 응답을 저장하고 `end-step` 까지 수행한다. Codex headless worker 도 `DCNESS_CODEX_MODEL` / `DCNESS_CODEX_EFFORT` 가 설정된 경우에만 같은 override 를 전달하고, 미설정 시 사용자 Codex config 를 상속한다. CLI/auth/timeout/empty-output 처럼 workspace 변경 전 실패한 경우에만 다음 provider 로 넘어간다. Headless provider 가 파일을 변경한 뒤 실패하거나 boundary 밖 파일을 변경하면 자동 폴백하지 않는다. chain 이 Claude main 에 도달하면 `FALLBACK_TO_CLAUDE_MAIN` 과 exit 75 를 반환하므로 메인이 기존 Agent 경로를 실행한 뒤 `--provider claude-main` 으로 `end-step` 을 기록한다. raw headless session log 는 run 디렉터리의 `headless-logs/` 파일로 보존한다. Claude headless wrapper 는 자식 `claude -p` 실행 전 부모 세션 식별 env 를 제거하되, `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 는 유지해 run 기록을 이어간다. Headless build-worker 가 `VALIDATION_BLOCKED` 를 보고하면 `ledger.jsonl` 에 `blocked` event 와 `category=headless_validation_blocked` 가 추가로 남으므로, 검증 명령 권한 문제 빈도는 `run-review` 또는 ledger 조회로 확인한다.
 
 #### 호출 prompt 슬림 포인터 규약
 

--- a/scripts/dcness-codex-validator
+++ b/scripts/dcness-codex-validator
@@ -22,10 +22,13 @@ Options:
 
 Environment:
   DCNESS_CODEX_TIMEOUT  Seconds per Codex attempt. Default: 600.
+  DCNESS_CODEX_MODEL    Optional Codex model override. Default: inherit user config.
+  DCNESS_CODEX_EFFORT   Optional reasoning effort override. Default: inherit user config.
 
 The wrapper runs Codex in read-only mode. On Codex CLI versions that expose
-approval flags, it also passes global -a never:
-  codex [-a never] exec -C "$PROJECT_ROOT" -s read-only --output-last-message "$TMP_PROSE"
+approval flags, it also passes global -a never. Model and effort overrides are
+only passed when the matching environment variables are set:
+  codex [-a never] [-m "$DCNESS_CODEX_MODEL"] [-c "model_reasoning_effort=$DCNESS_CODEX_EFFORT"] exec -C "$PROJECT_ROOT" -s read-only --output-last-message "$TMP_PROSE"
 
 Before running Codex, it embeds the installed dcness Codex skill from
 $CODEX_HOME/skills or the plugin bundle when available.
@@ -70,6 +73,8 @@ PROJECT_ROOT=""
 PROMPT_FILE=""
 HELPER="$SCRIPT_DIR/dcness-helper"
 CODEX_TIMEOUT="${DCNESS_CODEX_TIMEOUT:-600}"
+CODEX_MODEL="${DCNESS_CODEX_MODEL:-}"
+CODEX_EFFORT="${DCNESS_CODEX_EFFORT:-}"
 
 abs_path() {
   case "$1" in
@@ -248,6 +253,12 @@ CODEX_CMD=(codex)
 CODEX_ARGS=(exec -C "$PROJECT_ROOT" -s read-only --output-last-message "$TMP_PROSE")
 if codex --help 2>/dev/null | grep -Eq -- '(^|[[:space:]])-a,|--ask-for-approval|--approval-policy'; then
   CODEX_CMD+=( -a never )
+fi
+if [ -n "$CODEX_MODEL" ]; then
+  CODEX_CMD+=( -m "$CODEX_MODEL" )
+fi
+if [ -n "$CODEX_EFFORT" ]; then
+  CODEX_CMD+=( -c "model_reasoning_effort=$CODEX_EFFORT" )
 fi
 CODEX_ARGS+=( - )
 

--- a/scripts/dcness-codex-worker
+++ b/scripts/dcness-codex-worker
@@ -22,9 +22,12 @@ Options:
 
 Environment:
   DCNESS_CODEX_TIMEOUT  Seconds per Codex attempt. Default: 1200.
+  DCNESS_CODEX_MODEL    Optional Codex model override. Default: inherit user config.
+  DCNESS_CODEX_EFFORT   Optional reasoning effort override. Default: inherit user config.
 
-The wrapper runs Codex in workspace-write mode:
-  codex exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE"
+The wrapper runs Codex in workspace-write mode. Model and effort overrides are
+only passed when the matching environment variables are set:
+  codex [-m "$DCNESS_CODEX_MODEL"] [-c "model_reasoning_effort=$DCNESS_CODEX_EFFORT"] exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE"
 
 On success it validates changed paths against dcNess agent_boundary, reuses
 tdd-guard matching-test enforcement for Codex-changed implementation files, and stores:
@@ -71,6 +74,8 @@ PROJECT_ROOT=""
 PROMPT_FILE=""
 HELPER="$SCRIPT_DIR/dcness-helper"
 CODEX_TIMEOUT="${DCNESS_CODEX_TIMEOUT:-1200}"
+CODEX_MODEL="${DCNESS_CODEX_MODEL:-}"
+CODEX_EFFORT="${DCNESS_CODEX_EFFORT:-}"
 
 abs_path() {
   case "$1" in
@@ -237,6 +242,12 @@ AGENT_DETAIL="$SCRIPT_DIR/../docs/plugin/agents/$AGENT/$AGENT-agent.md"
 CODEX_CMD=(codex)
 if codex --help 2>/dev/null | grep -Eq -- '(^|[[:space:]])-a,|--ask-for-approval|--approval-policy'; then
   CODEX_CMD+=( -a never )
+fi
+if [ -n "$CODEX_MODEL" ]; then
+  CODEX_CMD+=( -m "$CODEX_MODEL" )
+fi
+if [ -n "$CODEX_EFFORT" ]; then
+  CODEX_CMD+=( -c "model_reasoning_effort=$CODEX_EFFORT" )
 fi
 CODEX_ARGS=(exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE" -)
 

--- a/tests/test_agent_model_tiers.py
+++ b/tests/test_agent_model_tiers.py
@@ -1,0 +1,51 @@
+"""Agent model tier contract tests."""
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _agent_model(name: str) -> str:
+    text = (ROOT / "agents" / f"{name}.md").read_text(encoding="utf-8")
+    match = re.search(r"^model:\s*(\S+)\s*$", text, flags=re.MULTILINE)
+    if not match:
+        raise AssertionError(f"agents/{name}.md is missing frontmatter model")
+    return match.group(1)
+
+
+class AgentModelTierTests(unittest.TestCase):
+    def test_high_leverage_agents_use_opus(self) -> None:
+        expected_opus = {
+            "module-architect",
+            "architecture-validator",
+            "engineer",
+            "product-acceptance",
+            "build-worker",
+            "system-architect",
+            "tech-reviewer",
+        }
+
+        for agent in expected_opus:
+            with self.subTest(agent=agent):
+                self.assertEqual(_agent_model(agent), "opus")
+
+    def test_remaining_agents_stay_sonnet(self) -> None:
+        expected_sonnet = {
+            "ux-architect",
+            "designer",
+            "test-engineer",
+            "code-validator",
+            "pr-reviewer",
+        }
+
+        for agent in expected_sonnet:
+            with self.subTest(agent=agent):
+                self.assertEqual(_agent_model(agent), "sonnet")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -153,6 +153,207 @@ class CodexValidatorWrapperTests(unittest.TestCase):
                 "sid-test\nrun-1234abcd\n",
             )
 
+    def test_passes_model_and_effort_overrides_when_env_is_set(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Review this implementation.\n", encoding="utf-8")
+
+            args_capture = tmp / "codex-args.txt"
+            prose_capture = tmp / "captured-prose.md"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "--help" ]; then
+                      echo "Usage: codex [OPTIONS]"
+                      echo "  -a, --ask-for-approval <APPROVAL_POLICY>"
+                      exit 0
+                    fi
+                    printf '%s\\n' "$@" > "$ARGS_CAPTURE"
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    printf 'Codex prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --prose-file)
+                          cp "$2" "$PROSE_CAPTURE"
+                          exit 0
+                          ;;
+                      esac
+                      shift
+                    done
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "ARGS_CAPTURE": str(args_capture),
+                    "DCNESS_CODEX_EFFORT": "xhigh",
+                    "DCNESS_CODEX_MODEL": "gpt-test-model",
+                    "DCNESS_RUN_ID": "run-abcdef01",
+                    "DCNESS_SESSION_ID": "sid-model",
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(WRAPPER),
+                    "code-validator",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            args = args_capture.read_text(encoding="utf-8")
+            self.assertIn("-m\ngpt-test-model\n", args)
+            self.assertIn("-c\nmodel_reasoning_effort=xhigh\n", args)
+
+    def test_inherits_model_and_effort_when_env_is_unset(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Review this implementation.\n", encoding="utf-8")
+
+            args_capture = tmp / "codex-args.txt"
+            prose_capture = tmp / "captured-prose.md"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "--help" ]; then
+                      echo "Usage: codex [OPTIONS]"
+                      exit 0
+                    fi
+                    printf '%s\\n' "$@" > "$ARGS_CAPTURE"
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    printf 'Codex prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --prose-file)
+                          cp "$2" "$PROSE_CAPTURE"
+                          exit 0
+                          ;;
+                      esac
+                      shift
+                    done
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.pop("DCNESS_CODEX_EFFORT", None)
+            env.pop("DCNESS_CODEX_MODEL", None)
+            env.update(
+                {
+                    "ARGS_CAPTURE": str(args_capture),
+                    "DCNESS_RUN_ID": "run-abcdef02",
+                    "DCNESS_SESSION_ID": "sid-inherit",
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(WRAPPER),
+                    "code-validator",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            args = args_capture.read_text(encoding="utf-8").splitlines()
+            self.assertNotIn("-m", args)
+            self.assertNotIn("model_reasoning_effort=xhigh", args)
+
     def test_resolves_sid_rid_without_caller_env(self) -> None:
         """issue #625 — Codex subprocess PPID/env 단절 전 wrapper 가 sid/rid 를 export."""
         with tempfile.TemporaryDirectory() as td:
@@ -499,6 +700,107 @@ class CodexWorkerWrapperTests(unittest.TestCase):
                 prose_capture.read_text(encoding="utf-8"),
                 "Worker prose\n\nPASS\n",
             )
+
+    def test_worker_passes_model_and_effort_overrides_when_env_is_set(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement the task.\n", encoding="utf-8")
+
+            args_capture = tmp / "codex-args.txt"
+            prose_capture = tmp / "captured-prose.md"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "--help" ]; then
+                      echo "Usage: codex [OPTIONS]"
+                      echo "  -a, --ask-for-approval <APPROVAL_POLICY>"
+                      exit 0
+                    fi
+                    printf '%s\\n' "$@" > "$ARGS_CAPTURE"
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    printf 'Worker prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --prose-file)
+                          cp "$2" "$PROSE_CAPTURE"
+                          exit 0
+                          ;;
+                      esac
+                      shift
+                    done
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "ARGS_CAPTURE": str(args_capture),
+                    "DCNESS_CODEX_EFFORT": "high",
+                    "DCNESS_CODEX_MODEL": "gpt-worker-model",
+                    "DCNESS_RUN_ID": "run-abcdef03",
+                    "DCNESS_SESSION_ID": "sid-worker-model",
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(WORKER),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            args = args_capture.read_text(encoding="utf-8")
+            self.assertIn("-m\ngpt-worker-model\n", args)
+            self.assertIn("-c\nmodel_reasoning_effort=high\n", args)
 
     def test_worker_success_blocks_boundary_violation_without_end_step(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## 관련 이슈 번호

Closes #976

## 배경 및 문제

sub-agent 모델 배정이 현재 역할 leverage 와 어긋나 있었다. 설계 pack 작성·검증·구현·제품 검수·경량 구현 worker는 판단 실패 비용이 큰데, 기존 frontmatter 에서는 과거 기본값인 `sonnet` 배정이 유지됐다.

Codex headless validator/worker wrapper 는 모델 관련 플래그 없이 `codex exec` 를 호출해 사용자 로컬 Codex 기본 설정을 그대로 상속했다. 그래서 프로젝트 차원에서 상위 모델이나 reasoning effort 를 opt-in 으로 pin 할 방법이 없었다.

## 원인 (해당 시)

- agent-first 설계/구현 흐름으로 역할 leverage 가 바뀐 뒤에도 `agents/*.md` 의 `model:` 값이 재정렬되지 않았다.
- `scripts/dcness-codex-validator` 와 `scripts/dcness-codex-worker` 는 timeout 만 환경변수화했고, model / reasoning effort override 는 argv 조립 계약에 없었다.

## 작업내용

- `module-architect`, `architecture-validator`, `engineer`, `product-acceptance`, `build-worker` 의 frontmatter `model:` 을 `opus` 로 승격했다.
- `system-architect`, `tech-reviewer` 는 기존 `opus` 유지, `ux-architect`, `designer`, `test-engineer`, `code-validator`, `pr-reviewer` 는 `sonnet` 유지 계약을 테스트로 고정했다.
- `DCNESS_CODEX_MODEL` 설정 시 Codex wrapper 가 `-m <model>` 을 전달하도록 추가했다.
- `DCNESS_CODEX_EFFORT` 설정 시 Codex wrapper 가 `-c model_reasoning_effort=<effort>` 를 전달하도록 추가했다.
- 두 환경변수 미설정 시에는 기존처럼 사용자 Codex config 를 상속한다.
- wrapper usage, `CLAUDE.md` 환경변수 표, `docs/plugin/loop-procedure.md` provider 설명을 갱신했다.

## 결정 근거

- 특정 Codex 모델명을 dcNess 에 하드코딩하지 않고, 사용자가 설정한 환경변수 값만 opt-in 으로 전달한다. 모델 세대 교체와 사용자 quota 차이를 wrapper가 고정하지 않기 위해서다.
- reasoning effort 는 현재 Codex CLI 가 지원하는 config override 경로인 `-c model_reasoning_effort=...` 로 전달한다.
- 새 public command/agent/gate 를 만들지 않고 기존 wrapper 계약만 확장했다.

## 배포 경로 검증 (plug-in 영향 시)

- 배포 경로 1: `agents/*.md` 와 `scripts/dcness-codex-*` 는 plug-in 본체 파일이므로 plug-in update 로 외부 활성 프로젝트에 도달한다.
- 배포 경로 3: `docs/plugin/loop-procedure.md` 는 plug-in 사용자용 절차 SSOT 이므로 plug-in update 로 함께 도달한다.
- `/init-dcness` 가 사용자 프로젝트로 복사하는 파일은 변경하지 않았다. 기존 활성 프로젝트 재배포 스텝 추가는 필요 없다.
- `CLAUDE.md` 는 dcNess self 작업 규칙 문서 갱신이다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 를 추가하지 않았다. 기존 Codex wrapper 의 opt-in 환경변수만 추가했다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_codex_validator_wrapper tests.test_agent_model_tiers -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `bash -n scripts/dcness-codex-validator scripts/dcness-codex-worker`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] git pre-commit hook during commit: pytest gate PASS

## 참고

Local Codex CLI help confirmed support for `-m/--model` and `-c key=value`; no model name is hardcoded in this PR.
