### PR TITLE
[issue-979] provider wrapper 경로 해석 보강

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -41,7 +41,14 @@ EnterWorktree(name="<skill>-{ts_short}")   # action 루프 (impl / impl-loop / d
 ### begin-run
 
 ```bash
-HELPER="$(ls -d ${CLAUDE_PLUGIN_ROOT:-$HOME/.claude/plugins/cache/dcness/dcness/*} 2>/dev/null | sort -V | tail -1)/scripts/dcness-helper"
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
 RUN_ID=$("$HELPER" begin-run <entry_point> [--issue-num N] [--design-doc <path>] [--acceptance-required])
 echo "[<entry>] run started: $RUN_ID"
 ```
@@ -93,6 +100,15 @@ active run(`entry_point=design|impl|ux`) 안에서 `begin-step` 없이 `Agent` �
 **validation provider 분기 (local opt-in)**: `code-validator` / `architecture-validator` / `pr-reviewer` 는 호출 직전 provider 를 resolve 한다.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve <agent>)
 if [ "$PROVIDER" = "codex" ]; then
   "$PLUGIN_ROOT/scripts/dcness-codex-validator" <agent> [MODE] --prompt-file "$PROMPT_FILE"
@@ -107,6 +123,15 @@ Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직�
 **implementation provider 분기 (headless-chain 기본)**: `test-engineer` / `engineer` / `build-worker` 는 호출 직전 provider 를 resolve 한다.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve <agent>)
 if [ "$PROVIDER" = "claude" ]; then
   Agent(subagent_type="<agent>", ...)

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -155,6 +155,15 @@ UI epic 으로 판정되고 `design-ux` stage 를 선택한 직후 메인이 목
 architecture-validator final epic 검증 호출 직전 provider 를 resolve 한다.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve architecture-validator)
 if [ "$PROVIDER" = "codex" ]; then
   "$PLUGIN_ROOT/scripts/dcness-codex-validator" architecture-validator --prompt-file "$PROMPT_FILE"

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -209,6 +209,15 @@ worktree branch 안 commit / push / PR 생성·머지 = **메인 Claude 전담**
 `code-validator` / `pr-reviewer` (또는 build-worker self-validate 후 pr-reviewer) 호출 직전 provider 를 local 분기 config 로 resolve 한다. config = `~/.claude/plugins/data/dcness-dcness/routing.json`.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve <agent>)
 if [ "$PROVIDER" = "codex" ]; then
   "$PLUGIN_ROOT/scripts/dcness-codex-validator" <agent> --prompt-file "$PROMPT_FILE"
@@ -224,6 +233,15 @@ wrapper 가 Codex 마지막 응답을 `/tmp` 에 받고 `dcness-helper end-step 
 `test-engineer` / `engineer` / `build-worker` 호출 직전 implementation provider 를 같은 local routing config 로 resolve 한다. 기본값은 `headless-chain` 이며, Claude-only 사용자는 `/init-dcness` custom 또는 중간 CLI 로 `claude` 로 바꾼다.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve <agent>)
 if [ "$PROVIDER" = "claude" ]; then
   # 기존 Claude Agent(subagent_type="<agent>") 경로.

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -265,6 +265,15 @@ high-risk trigger 가 있거나 사전 설계 합의가 필요한 작업은 impl
 `pr-reviewer` 는 read-only validation provider 분기 대상이다. 메인은 호출 직전 provider 를 resolve 한다.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve pr-reviewer)
 if [ "$PROVIDER" = "codex" ]; then
   "$PLUGIN_ROOT/scripts/dcness-codex-validator" pr-reviewer --prompt-file "$PROMPT_FILE"
@@ -280,6 +289,15 @@ Codex 분기는 review provider 구현일 뿐 별도 public workflow 가 아니�
 `test-engineer` / `engineer` / `build-worker` 는 implementation provider 분기 대상이다. 기본값은 `headless-chain`(Codex headless → Claude headless → Claude main)이고, Claude-only 사용자는 `/init-dcness` custom 또는 중간 CLI 로 `claude` 로 바꿀 수 있다.
 
 ```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+
 PROVIDER=$("$HELPER" routing resolve build-worker)   # 또는 test-engineer / engineer
 if [ "$PROVIDER" = "claude" ]; then
   Agent(subagent_type="build-worker", ...)

--- a/tests/test_provider_snippet_docs.py
+++ b/tests/test_provider_snippet_docs.py
@@ -1,0 +1,100 @@
+"""Provider wrapper snippet documentation regression tests."""
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+PROVIDER_WRAPPER_PATTERN = re.compile(
+    r'"\$PLUGIN_ROOT/scripts/(?:dcness-codex-validator|dcness-implementation-chain)"'
+)
+
+PLUGIN_ROOT_PRELUDE = '''PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"'''
+
+
+class ProviderSnippetDocsTests(unittest.TestCase):
+    """Published provider snippets must resolve the active plugin root first."""
+
+    def _published_docs(self):
+        for base in (ROOT / "docs" / "plugin", ROOT / "skills"):
+            yield from base.rglob("*.md")
+
+    def test_provider_wrapper_snippets_define_plugin_root_recipe(self) -> None:
+        """Provider snippets should work from an activated external project shell."""
+        docs_with_wrappers: list[Path] = []
+        for path in self._published_docs():
+            text = path.read_text(encoding="utf-8")
+            wrappers = list(PROVIDER_WRAPPER_PATTERN.finditer(text))
+            if not wrappers:
+                continue
+
+            docs_with_wrappers.append(path.relative_to(ROOT))
+            prelude_index = text.find(PLUGIN_ROOT_PRELUDE)
+            self.assertNotEqual(
+                prelude_index,
+                -1,
+                f"{path.relative_to(ROOT)} lacks the shared PLUGIN_ROOT prelude",
+            )
+            self.assertLess(
+                prelude_index,
+                min(match.start() for match in wrappers),
+                f"{path.relative_to(ROOT)} resolves PLUGIN_ROOT after wrapper use",
+            )
+
+        expected = {
+            Path("docs/plugin/loop-procedure.md"),
+            Path("skills/design/SKILL.md"),
+            Path("skills/impl/SKILL.md"),
+            Path("skills/impl-loop/SKILL.md"),
+        }
+        self.assertTrue(
+            expected.issubset(set(docs_with_wrappers)),
+            f"provider docs missing from scan: {expected - set(docs_with_wrappers)}",
+        )
+
+    def test_plugin_root_prelude_prefers_active_env_then_latest_cache(self) -> None:
+        """The shared prelude should avoid stale cache versions."""
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            cache = home / ".claude" / "plugins" / "cache" / "dcness" / "dcness"
+            for version in ("0.2.0", "0.10.0"):
+                (cache / version / "scripts").mkdir(parents=True)
+
+            script = f"{PLUGIN_ROOT_PRELUDE}\nprintf '%s\\n' \"$PLUGIN_ROOT\"\n"
+            env = {"HOME": str(home), "CLAUDE_PLUGIN_ROOT": ""}
+            result = subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.stdout.strip(), str(cache / "0.10.0"))
+
+            active = home / "active-plugin"
+            (active / "scripts").mkdir(parents=True)
+            env["CLAUDE_PLUGIN_ROOT"] = str(active)
+            result = subprocess.run(
+                ["bash", "-c", script],
+                check=True,
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.stdout.strip(), str(active))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #979

## 배경 및 문제

외부 활성 프로젝트에서 provider 분기 스니펫만 따라 Codex wrapper 를 실행하면 `$PLUGIN_ROOT` 가 정의되지 않아 `scripts/dcness-codex-validator` 를 프로젝트 상대 경로로 오추정할 수 있었습니다.

## 원인 (해당 시)

helper 호출 예시는 plugin root 를 `CLAUDE_PLUGIN_ROOT` 또는 plugin cache 에서 찾는 경로 해석 레시피를 제공했지만, validation/implementation provider wrapper 스니펫은 같은 prelude 없이 `$PLUGIN_ROOT/scripts/...` 를 바로 호출했습니다.

## 작업내용

- `docs/plugin/loop-procedure.md` 의 begin-run, validation provider, implementation provider 예시에 `PLUGIN_ROOT` 해석 prelude 를 추가했습니다.
- `skills/design/SKILL.md`, `skills/impl/SKILL.md`, `skills/impl-loop/SKILL.md` 의 provider wrapper 호출 예시에도 동일 prelude 를 추가했습니다.
- `tests/test_provider_snippet_docs.py` 를 추가해 provider wrapper 문서 스니펫이 동일 prelude 를 포함하고, `CLAUDE_PLUGIN_ROOT` 우선 및 cache 최신 버전 선택을 유지하도록 고정했습니다.

## 결정 근거

문서 스니펫을 복사해 실행하는 외부 활성 프로젝트 조건을 우선했습니다. wrapper 자체를 새 경유 명령으로 감싸는 대신 기존 `dcness-codex-validator` / `dcness-implementation-chain` 호출 계약은 유지하고, 호출 직전 root 해석만 명시해 변경 표면을 줄였습니다.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1 plug-in 본체 파일: `docs/plugin/loop-procedure.md`, `skills/design/SKILL.md`, `skills/impl/SKILL.md`, `skills/impl-loop/SKILL.md` 는 plugin 배포물에 포함됩니다.
- `/init-dcness` 복사 파일 변경은 없습니다. 기존 활성 프로젝트는 plugin 업데이트 후 같은 문서 스니펫을 받습니다.
- 사용자용 SSOT 문서 변경은 `docs/plugin/loop-procedure.md` 에 반영했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public surface 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_provider_snippet_docs -v`
- [x] `python3.11 -m unittest tests.test_skill_scenarios tests.test_provider_snippet_docs -v`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `git diff --check`
- [x] `bash scripts/check_python_tests.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`

## 참고

- `bash scripts/check.sh` 는 현재 저장소에 없어 실행 대상에서 제외했습니다.