### PR TITLE
[issue-978] Codex validator skill 신선도 보장

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -31,7 +31,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - `.gitignore`: `.claude/harness-state/` 는 core 에서 없을 때만 추가. `.dcness-work/` 는 선택형 docs seed 에서 없을 때만 추가.
 - `.github/workflows/*.yml`: 사용자가 선택한 경우 always-overwrite.
 - `docs/*`, `docs/design-variants/*`: 부재 시만 seed. 단 기존 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 섹션은 없을 때만 append.
-- Codex validator skills: `$CODEX_HOME/skills/dcness-*` always-overwrite.
+- Codex validator skills: `$CODEX_HOME/skills/dcness-*` always-overwrite. Validator wrapper 는 활성 plugin 원본을 우선 주입하고, 이 복사본은 native Codex skill 등록과 fallback 용도다.
 - Codex provider routing: core 에서는 상태만 확인하고, 선택형 확장에서 validation opt-in 과 implementation 기본값을 갱신.
 - TDD Guard: dcNess 가 **TDD 계약 + self-test** 를 소유한다. 프로젝트가 비어 있지 않으면 플랫폼 감지 또는 사람 승인된 `.dcness/tdd-hooks.json` 계약(`source_roots`, `impl_exts`, custom 플랫폼의 `test_candidate_templates`, 선택 `test_file_globs`)을 기준으로 project-local CC/Codex hook 생성을 제안하고, 생성 후보는 self-test 통과 전에는 등록하지 않는다. 생성 훅이 없으면 중앙 plug-in hook 이 안전 fallback 으로 동작한다.
 
@@ -123,7 +123,7 @@ grep -qxF '.claude/harness-state/' "$PROJECT_ROOT/.gitignore" || { printf '%s\n'
 
 ### Core Step 5 - Codex skill 배포와 routing 상태 확인
 
-`code-validator` / `architecture-validator` / `pr-reviewer` 는 Codex read-only 실행으로 보낼 수 있다. `test-engineer` / `engineer` / `build-worker` 는 headless-chain implementation 실행으로 보낼 수 있다. 사용자 repo 에 provider config 를 만들지 않는다.
+`code-validator` / `architecture-validator` / `pr-reviewer` 는 Codex read-only 실행으로 보낼 수 있다. `test-engineer` / `engineer` / `build-worker` 는 headless-chain implementation 실행으로 보낼 수 있다. 사용자 repo 에 provider config 를 만들지 않는다. Validator wrapper 는 wrapper parent 의 `codex/skills/dcness-*` 원본을 먼저 prompt 에 주입하고, 필요하면 `CLAUDE_PLUGIN_ROOT` 를 plugin root fallback 으로 확인한다. `$CODEX_HOME/skills` 배포본이 원본과 다르면 stale copy 로 보고 무시하며, plugin 원본을 찾을 수 없을 때만 배포본으로 fallback 한다.
 
 ```bash
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -32,7 +32,7 @@ core activation 완료 기준이다. 아래 항목이 끝나고 `dcness-helper s
 | project context seed/migration | `CLAUDE.md` | `scripts/dcness-context-docs` / `harness/context_docs.py` | 항상 | 부재 시 생성. 기존 파일은 cold-start 앵커만 없을 때 append | X |
 | file boundary override suggestion | `.dcness/boundary.json` 후보만 | `dcness-helper boundary-suggestions` / `harness/boundary_suggestions.py` | 항상 | read-only. 사람 승인 전 작성 없음 | X |
 | generated TDD hook 제안/생성 | `.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh` | `scripts/dcness-tdd-hooks` | 플랫폼 감지 또는 사람 승인된 project-local 계약 + 사용자 승인 시 | self-test 통과 후보만 등록. CC 검증 후 Codex 생성 | X |
-| Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite | X |
+| Codex validator skills | `$CODEX_HOME/skills/dcness-*` | `codex/skills/dcness-*` | 항상 | always-overwrite. Validator wrapper 는 활성 plugin 원본을 우선 주입하고 이 복사본은 native Codex skill 등록과 fallback 용도 | X |
 | Codex provider routing 상태 확인 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing status` | 항상 확인 | read-only | X |
 | CC hooks | Claude Code plugin hook registry | `hooks/hooks.json` | 활성 프로젝트 새 세션 | 사용자 repo 쓰기 없음 | X |
 
@@ -80,6 +80,8 @@ Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소�
 | pr-reviewer | `docs/plugin/agents/pr-reviewer/pr-reviewer-agent.md` | `codex/skills/dcness-pr-reviewer/SKILL.md` |
 
 공유 guidance 는 `docs/plugin/agents/_shared/validation-reporting-guidance.md` 를 Claude agent 가 참조하고, Codex skill 은 같은 의미 문구를 내장한다. Codex skill 은 native Codex frontmatter(`--- name: ... description: ... ---`)를 유지해야 하며, `/init-dcness` Core Step 5 가 `$CODEX_HOME/skills/dcness-*` 로 always-overwrite 배포한다. 동기화 회귀는 `tests/test_validator_handoff_guidance.py` 가 막는다.
+
+`scripts/dcness-codex-validator` 는 plugin update 직후 재-init 전에도 현행 지침을 쓰도록 활성 plugin 원본을 먼저 prompt 에 주입한다. `$CODEX_HOME` 배포본이 원본과 다르면 stale copy 로 경고한 뒤 원본을 사용한다.
 
 ## Recommended Bundle Defaults
 
@@ -185,7 +187,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | `.claude/harness-state/` gitignore 보강 | 예 | runtime state ignore 는 사용자 repo `.gitignore` append 라서 `/init-dcness` 재실행 때 적용된다. |
 | `CLAUDE.md` seed/migration 로직 갱신 | 예 | 기존 활성 프로젝트의 root `CLAUDE.md` 생성·cold-start 앵커 append 는 `/init-dcness` 재실행 때 적용된다. |
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 또는 module docs 가 있는 프로젝트는 doc-sync 채택 직후 index 집계기를 1회 실행해야 한다. 전역 architecture 요약은 온디맨드다. |
-| Codex validation routing opt-in 변경 | 예 | local plugin data 와 `$CODEX_HOME/skills` 를 갱신해야 한다. |
+| Codex validation routing opt-in 변경 | 예 | local plugin data 를 갱신하고 native Codex skill 등록/fallback 용 `$CODEX_HOME/skills` 를 최신화해야 한다. Validator wrapper 의 prompt 지침은 plugin update 된 원본을 우선 사용한다. |
 | Implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |
 | Project lifecycle 좌표 저장/변경 | 예 | repo variables 와 선택형 workflow 를 갱신해야 한다. |
 | docs/design + docs/design-variants seed 추가 | 예 | 부재 파일 seed 는 사용자 repo 에 직접 생성된다. draft 는 `docs/design-variants/drafts/` 에 두고 `.gitignore` 로 무시하되 `drafts/.gitkeep` 으로 디렉터리를 보존한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 `/init-dcness` custom design seed 를 재실행하거나 `templates/design-variants/{.gitignore,canvas.html,_lib/*,drafts/.gitkeep}` 를 `docs/design-variants/` 로 복사한다. |

--- a/harness/session_state_status.py
+++ b/harness/session_state_status.py
@@ -283,7 +283,9 @@ def collect_status_diagnostics(
             "Codex validator skills",
             "PASS" if codex_all_ok else "FAIL",
             ", ".join(f"{k}={v}" for k, v in codex_skills.items()),
-            None if codex_all_ok else "init-dcness Core Step 5 로 Codex validator skills 재배포",
+            None
+            if codex_all_ok
+            else "/init-dcness Core Step 5 로 $CODEX_HOME/skills 의 Codex validator skills 재배포",
         )
         try:
             from harness.context_docs import audit_claude_md_file

--- a/scripts/dcness-codex-validator
+++ b/scripts/dcness-codex-validator
@@ -24,14 +24,17 @@ Environment:
   DCNESS_CODEX_TIMEOUT  Seconds per Codex attempt. Default: 600.
   DCNESS_CODEX_MODEL    Optional Codex model override. Default: inherit user config.
   DCNESS_CODEX_EFFORT   Optional reasoning effort override. Default: inherit user config.
+  CLAUDE_PLUGIN_ROOT    Optional plugin root fallback. Default: wrapper parent.
 
 The wrapper runs Codex in read-only mode. On Codex CLI versions that expose
 approval flags, it also passes global -a never. Model and effort overrides are
 only passed when the matching environment variables are set:
   codex [-a never] [-m "$DCNESS_CODEX_MODEL"] [-c "model_reasoning_effort=$DCNESS_CODEX_EFFORT"] exec -C "$PROJECT_ROOT" -s read-only --output-last-message "$TMP_PROSE"
 
-Before running Codex, it embeds the installed dcness Codex skill from
-$CODEX_HOME/skills or the plugin bundle when available.
+Before running Codex, it embeds the active plugin bundle's dcness Codex skill.
+If the $CODEX_HOME/skills copy is stale, the wrapper ignores it and prints a
+refresh warning. If the plugin bundle skill is unavailable, it falls back to
+$CODEX_HOME/skills.
 
 Then it stores the final prose with:
   dcness-helper end-step <agent> [MODE] --provider codex-headless --prose-file "$TMP_PROSE"
@@ -214,16 +217,27 @@ trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
 SKILL_NAME="dcness-${AGENT}"
 CODEX_HOME_DIR="${CODEX_HOME:-${HOME:-}/.codex}"
 SKILL_FILE=""
-SKILL_CANDIDATES=(
-  "$CODEX_HOME_DIR/skills/$SKILL_NAME/SKILL.md"
-  "$SCRIPT_DIR/../codex/skills/$SKILL_NAME/SKILL.md"
-)
-for CANDIDATE in "${SKILL_CANDIDATES[@]}"; do
+PLUGIN_SKILL_FILE=""
+INSTALLED_SKILL_FILE="$CODEX_HOME_DIR/skills/$SKILL_NAME/SKILL.md"
+PLUGIN_ROOT_CANDIDATES=( "$SCRIPT_DIR/.." )
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+  PLUGIN_ROOT_CANDIDATES+=( "$CLAUDE_PLUGIN_ROOT" )
+fi
+for PLUGIN_ROOT_CANDIDATE in "${PLUGIN_ROOT_CANDIDATES[@]}"; do
+  CANDIDATE="$PLUGIN_ROOT_CANDIDATE/codex/skills/$SKILL_NAME/SKILL.md"
   if [ -f "$CANDIDATE" ]; then
-    SKILL_FILE="$CANDIDATE"
+    PLUGIN_SKILL_FILE="$CANDIDATE"
     break
   fi
 done
+if [ -n "$PLUGIN_SKILL_FILE" ]; then
+  SKILL_FILE="$PLUGIN_SKILL_FILE"
+  if [ -f "$INSTALLED_SKILL_FILE" ] && ! cmp -s "$PLUGIN_SKILL_FILE" "$INSTALLED_SKILL_FILE"; then
+    echo "[dcness-codex-validator] WARN: stale installed skill ignored: $INSTALLED_SKILL_FILE differs from active plugin source $PLUGIN_SKILL_FILE. Re-run /init-dcness Core Step 5 to refresh \$CODEX_HOME/skills." >&2
+  fi
+elif [ -f "$INSTALLED_SKILL_FILE" ]; then
+  SKILL_FILE="$INSTALLED_SKILL_FILE"
+fi
 
 {
   echo "dcNess validation agent: $AGENT"

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -18,7 +18,7 @@ WORKER = ROOT / "scripts" / "dcness-codex-worker"
 
 
 class CodexValidatorWrapperTests(unittest.TestCase):
-    def test_embeds_installed_skill_and_mode_before_prompt(self) -> None:
+    def test_embeds_plugin_skill_and_mode_before_prompt_when_installed_copy_is_stale(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             project = tmp / "project"
@@ -32,7 +32,7 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             skill_dir = codex_home / "skills" / "dcness-architecture-validator"
             skill_dir.mkdir(parents=True)
             skill_dir.joinpath("SKILL.md").write_text(
-                "# Test Skill\n\nSPECIAL_SKILL_CHECKLIST\n",
+                "# Installed Skill\n\nSTALE_INSTALLED_CHECKLIST\n",
                 encoding="utf-8",
             )
 
@@ -134,8 +134,11 @@ class CodexValidatorWrapperTests(unittest.TestCase):
             prompt = prompt_capture.read_text(encoding="utf-8")
             self.assertIn("dcNess validation agent: architecture-validator", prompt)
             self.assertIn("dcNess validation mode: SECOND", prompt)
-            self.assertIn("SPECIAL_SKILL_CHECKLIST", prompt)
+            self.assertIn("# dcness-architecture-validator", prompt)
+            self.assertNotIn("STALE_INSTALLED_CHECKLIST", prompt)
             self.assertIn("Review this implementation.", prompt)
+            self.assertIn("stale installed skill ignored", result.stderr)
+            self.assertIn("/init-dcness Core Step 5", result.stderr)
             self.assertTrue(
                 helper_args.read_text(encoding="utf-8")
                 .strip()


### PR DESCRIPTION
## 관련 이슈 번호
Closes #978

## 배경 및 문제
plugin update 후에도 $CODEX_HOME/skills/dcness-* 배포본은 /init-dcness 재실행 전까지 stale 상태로 남을 수 있다. 기존 Codex validator wrapper 는 이 배포본을 plugin 원본보다 먼저 선택해서, 폐기된 validator 판단 축이 prompt 에 조용히 주입될 수 있었다.

## 원인 (해당 시)
wrapper 의 skill 후보 순서가 $CODEX_HOME/skills 배포본 우선이었다. status 진단은 stale 을 표시했지만 validator 실행 경로 자체는 stale 배포본을 차단하지 않았다.

## 작업내용
- scripts/dcness-codex-validator 가 wrapper parent 의 plugin 원본 skill 을 먼저 prompt 에 주입하고, 필요 시 CLAUDE_PLUGIN_ROOT 를 plugin root fallback 으로 확인하도록 변경
- $CODEX_HOME/skills 배포본이 plugin 원본과 다르면 stale copy 로 경고하고 원본을 사용하도록 변경
- status 진단의 복구 문구를 /init-dcness Core Step 5 재배포로 명확화
- /init-dcness runbook 과 docs/plugin/init-dcness.md inventory 에 wrapper 신선도 계약 반영
- stale 배포본 fixture 에서 plugin 원본이 prompt 에 들어가는 회귀 테스트 추가

## 결정 근거
validator wrapper 는 plugin bundle 내부 스크립트이므로 현행 plugin 원본을 같은 bundle 에서 읽는 것이 plugin update 직후 신선도 보장에 가장 직접적이다. $CODEX_HOME/skills 복사본은 native Codex skill 등록과 plugin 원본 부재 fallback 용도로 유지하고, mismatch 는 사용자에게 /init-dcness Core Step 5 복구를 안내한다.

## 배포 경로 검증 (plug-in 영향 시)
- scripts/dcness-codex-validator 는 plug-in 본체 경로라 plugin update 로 wrapper 동작이 사용자 환경에 도달한다.
- commands/init-dcness.md 와 docs/plugin/init-dcness.md 는 plug-in 배포 문서 경로다.
- $CODEX_HOME/skills 배포본은 /init-dcness Core Step 5 always-overwrite 로 계속 갱신된다. 다만 validator wrapper 실행 prompt 는 plugin update 된 원본을 우선 사용하므로 재-init 전 stale 배포본이 조용히 이기지 않는다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public surface 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] python3.11 -m unittest tests.test_codex_validator_wrapper -v < /dev/null
- [x] python3.11 -m unittest tests.test_status_diagnostics -v < /dev/null
- [x] python3.11 -m unittest discover -s tests -v < /dev/null
- [x] node scripts/check_cross_refs.mjs
- [x] node scripts/check_public_surface.mjs
- [x] node scripts/check_plugin_manifest.mjs
- [x] node scripts/aggregate_index_map.mjs --check
- [x] node scripts/check_design_artifact_structure.mjs
- [x] bash -n scripts/dcness-codex-validator
- [x] python3.11 -m py_compile harness/session_state_status.py
- [x] PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh

## 참고
- shellcheck 는 로컬에 설치되어 있지 않아 실행하지 못함.