### PR TITLE
[issue-977] mode 검증 기준 정합화

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -80,9 +80,9 @@ TaskCreate("<agent>: <mode 또는 짧은 설명>")
 
 ```
 TaskUpdate("<task>", in_progress)
-"$HELPER" begin-step <agent> [<MODE>]
-Agent(subagent_type="<agent>", mode="<MODE>", description="...")  # 또는 provider 분기
-"$HELPER" end-step <agent> [<MODE>]   # 자유서술 방식(stdout=PROSE_LOGGED). Codex wrapper 경로는 wrapper 가 호출
+"$HELPER" begin-step <agent> [<mode>]
+Agent(subagent_type="<agent>", mode="<mode>", description="...")  # 또는 provider 분기
+"$HELPER" end-step <agent> [<mode>]   # 자유서술 방식(stdout=PROSE_LOGGED). Codex wrapper 경로는 wrapper 가 호출
 # 의무 echo (5~12 줄) — 아래 "결과 echo + 평가" 섹션
 TaskUpdate("<task>", completed)
 ```
@@ -95,7 +95,7 @@ begin-step stdout 에 `[PROMPT_SLOT_CHECK]` 가 있으면 **Agent prompt 작성 
 
 active run(`entry_point=design|impl|ux`) 안에서 `begin-step` 없이 `Agent` 를 직접 호출하거나, `begin-step` 의 agent/mode 와 다른 `Agent` 를 호출하면 PreToolUse hook 의 진행 순서 검사가 호출 전 차단한다. 정상 `/design` 은 `begin-run design` 로 시작하며 같은 gate 를 탄다. Agent 결과가 hook 에 의해 staged 된 뒤에는 반드시 `end-step` 으로 기록하고 다음 `begin-step` 으로 넘어간다.
 
-메인이 prose를 직접 Write 할 필요 없음 — PostToolUse Agent hook 이 sub 종료 시 `tool_response.text` 에서 prose 를 자동으로 `<run_dir>/<agent>[-<MODE>].md` 에 저장하고 `live.json.current_step.prose_file` 에 경로 기록. `end-step` 이 이 경로를 자동 읽는다.
+메인이 prose를 직접 Write 할 필요 없음 — PostToolUse Agent hook 이 sub 종료 시 `tool_response.text` 에서 prose 를 자동으로 `<run_dir>/<agent>[-<mode>].md` 에 저장하고 `live.json.current_step.prose_file` 에 경로 기록. `end-step` 이 이 경로를 자동 읽는다.
 
 **validation provider 분기 (local opt-in)**: `code-validator` / `architecture-validator` / `pr-reviewer` 는 호출 직전 provider 를 resolve 한다.
 
@@ -172,7 +172,7 @@ fi
 
 **worktree 활성 시 worktree 절대 경로 prompt 에 추가 명시 — MUST**: cwd 가 `.claude/worktrees/<name>/` 안이면 sub-agent prompt 에 worktree 절대 경로 명시. main repo abs path 사용 금지 — 머지 전 옛 코드 read 로 false positive (CC #31546 / #48096). 근거: CC Task tool 에 cwd parameter 부재 (#12748), subagent frontmatter cwd field 부재 (#31940) — 메인이 명시 책임.
 
-**자유서술 방식** (이슈 #280/#284): end-step stdout = `PROSE_LOGGED`. 메인 Claude 가 prose 자체 (`<run_dir>/<agent>[-<MODE>].md`) 를 직접 읽고 다음 호출을 판단한다 — 호출한 loop skill 의 `<skill>-routing.md` (분기 규칙 진본) 참조. 결정 못 하면 사용자에게 위임 (prose 본문에 "결정 불가" 명시 — issue #392: routing_telemetry cascade marker 폐기, 자연어 위임만).
+**자유서술 방식** (이슈 #280/#284): end-step stdout = `PROSE_LOGGED`. 메인 Claude 가 prose 자체 (`<run_dir>/<agent>[-<mode>].md`) 를 직접 읽고 다음 호출을 판단한다 — 호출한 loop skill 의 `<skill>-routing.md` (분기 규칙 진본) 참조. 결정 못 하면 사용자에게 위임 (prose 본문에 "결정 불가" 명시 — issue #392: routing_telemetry cascade marker 폐기, 자연어 위임만).
 
 #### 결과 echo + 평가 — MUST (5~12줄)
 
@@ -224,24 +224,25 @@ REDO 판단 신호: 결과가 질문에 제대로 답하지 못함 / 같은 tool
 **step 명명 규칙**: begin/end-step 은 `agent mode` 두 인자 형식만 허용.
 
 ```bash
-"$HELPER" begin-step <agent> [<MODE>]
-"$HELPER" end-step   <agent> [<MODE>]
+"$HELPER" begin-step <agent> [<mode>]
+"$HELPER" end-step   <agent> [<mode>]
 ```
 
 - `agent` — 소문자·하이픈만 (`^[a-z][a-z0-9-]{0,63}$`)
-- `mode` — 대문자·숫자·언더스코어만 (`^[A-Z][A-Z0-9_]{0,63}$`)
+- `mode` — legacy 대문자·숫자·언더스코어(`^[A-Z][A-Z0-9_]{0,63}$`) 또는 skill 라벨용 소문자·숫자·하이픈(`^[a-z][a-z0-9-]{0,63}$`, 단 occurrence suffix 와 충돌하는 `-<숫자>` 끝맺음 제외)
 - 콜론 표기 금지 — `"engineer:POLISH-1"` 형식은 `_validate_agent` 거부 → prose 미기록
 
 **prose 파일 자동 명명** (PostToolUse hook 이 `signal_io.signal_path` 기준 결정):
 - 단순: `<run_dir>/<agent>.md`
-- mode 보유: `<run_dir>/<agent>-<MODE>.md`
-- 같은 (agent, mode) N번째 반복: `<run_dir>/<agent>[-<MODE>]-N.md` (occurrence 카운터 자동 충돌 처리)
+- mode 보유: `<run_dir>/<agent>-<mode>.md`
+- 같은 (agent, mode) N번째 반복: `<run_dir>/<agent>[-<mode>]-N.md` (occurrence 카운터 자동 충돌 처리)
 
 | 상황 | begin/end-step | 생성 파일 |
 |---|---|---|
 | POLISH 1회 | `begin-step engineer POLISH` | `engineer-POLISH.md` |
 | POLISH 2회 | `begin-step engineer POLISH` | `engineer-POLISH-1.md` |
 | IMPL 재시도 | `begin-step engineer IMPL` | `engineer-IMPL-1.md` |
+| `/design` epic batch | `begin-step module-architect epic-batch` | `module-architect-epic-batch.md` |
 
 재호출마다 별도 begin/end-step 1쌍 필수 (DCN-30-25 안전망). `--prose-file` 명시적 전달은 legacy/override 용도로 여전히 허용.
 
@@ -275,13 +276,13 @@ phase prose 실제 기록 디렉토리 = `dcness-helper run-dir` 이 출력하�
 | `AMBIGUOUS` 재호출 1회 | 직전 동일 agent task | `TaskUpdate(<task>, in_progress)` |
 | `SPEC_GAP_FOUND` → module-architect (보강) | 신규 task (다른 agent) | `TaskCreate` 가능 |
 
-이유: retry / POLISH 는 *동일 step 의 재실행*. 신규 TaskCreate 시 같은 step 이 task list 에 중복 등장 → 진행 추적 오염. cycle 카운터는 step occurrence (`<agent>[-<MODE>]-N.md`) 로 보존되므로 task 는 1개로 유지.
+이유: retry / POLISH 는 *동일 step 의 재실행*. 신규 TaskCreate 시 같은 step 이 task list 에 중복 등장 → 진행 추적 오염. cycle 카운터는 step occurrence (`<agent>[-<mode>]-N.md`) 로 보존되므로 task 는 1개로 유지.
 
 **MUST 순서** (retry / POLISH 진입 시):
 
 ```
 TaskUpdate(<기존 task>, in_progress)   # 신규 TaskCreate 금지
-"$HELPER" begin-step <agent> [<MODE>]   # occurrence 자동 증가 → -N.md
+"$HELPER" begin-step <agent> [<mode>]   # occurrence 자동 증가 → -N.md
 Agent(...)
 ENUM=$("$HELPER" end-step ...)
 TaskUpdate(<기존 task>, completed)
@@ -443,7 +444,7 @@ review 리포트의 must-fix / waste finding / per-Agent metric 즉시 인지 + 
 
 ## run-ledger + receipt (resume / audit)
 
-`begin-run` / `begin-step` / `end-step` / `end-run` 은 prose 저장과 별개로 run_dir 안 `ledger.jsonl` 에 append-only event 를 자동 기록한다. prose 파일 (`<run_dir>/<agent>[-<MODE>].md`) 이 계속 SSOT 이고, ledger 는 긴 prose 를 매번 대화 context 에 재주입하지 않고도 resume / handoff / audit 에 필요한 상태를 담는 색인 장부다. **agent 에게 JSON 출력 형식을 강제하지 않는다** — helper 가 저장된 prose + known state 에서 receipt 를 생성한다.
+`begin-run` / `begin-step` / `end-step` / `end-run` 은 prose 저장과 별개로 run_dir 안 `ledger.jsonl` 에 append-only event 를 자동 기록한다. prose 파일 (`<run_dir>/<agent>[-<mode>].md`) 이 계속 SSOT 이고, ledger 는 긴 prose 를 매번 대화 context 에 재주입하지 않고도 resume / handoff / audit 에 필요한 상태를 담는 색인 장부다. **agent 에게 JSON 출력 형식을 강제하지 않는다** — helper 가 저장된 prose + known state 에서 receipt 를 생성한다.
 
 **자동 기록 event** (코드 경로):
 - `run_started` (begin-run) — entry_point / issue_num / design_doc(기록 시)

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -797,7 +797,10 @@ def _read_or_empty(path: Path) -> str:
 
 
 _PROSE_OCCURRENCE_SUFFIX_RE = re.compile(r"^[1-9][0-9]*$")
-_PROSE_MODE_SUFFIX_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}(?:-[1-9][0-9]*)?$")
+_PROSE_MODE_SUFFIX_RE = re.compile(
+    r"^(?:[A-Z][A-Z0-9_]{0,63}|[a-z][a-z0-9-]{0,63})"
+    r"(?:-[1-9][0-9]*)?$"
+)
 
 
 def _run_prose_paths_for_agent(rd: Path, agent: str) -> list[Path]:
@@ -821,8 +824,9 @@ def run_prose_has_pass(rd: Path, agent: str) -> bool:
     """PASS marker lookup aligned with end-step prose filenames.
 
     Accepted names are `<agent>.md`, numeric occurrence files such as
-    `<agent>-1.md`, mode-suffixed files such as `<agent>-CODE_VALIDATION.md`,
-    and mode occurrence files such as `<agent>-CODE_VALIDATION-1.md`.
+    `<agent>-1.md`, mode-suffixed files such as
+    `<agent>-CODE_VALIDATION.md` or `<agent>-epic-batch.md`, and mode
+    occurrence files such as `<agent>-CODE_VALIDATION-1.md`.
     """
     for prose in _run_prose_paths_for_agent(rd, agent):
         if "PASS" in _read_or_empty(prose):

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -514,6 +514,13 @@ def _cli_begin_step(args: Any) -> int:
         print(diagnose_sid_rid_resolution(mode="both"), file=sys.stderr)
         return 1
     mode = args.mode if args.mode else None
+    try:
+        from harness.signal_io import validate_mode_name
+
+        validate_mode_name(mode)
+    except ValueError as exc:
+        print(f"[begin-step] FAIL — {exc}", file=sys.stderr)
+        return 1
     # #700 — agent 이름 canonical 정규화. update_current_step 도 내부 정규화하지만
     # ledger checkpoint / engineer hint 까지 같은 표기로 일관시킨다.
     from harness.agent_names import normalize_agent_type

--- a/harness/signal_io.py
+++ b/harness/signal_io.py
@@ -29,6 +29,7 @@ from typing import Optional
 
 __all__ = [
     "MissingSignal",
+    "validate_mode_name",
     "signal_path",
     "write_prose",
     "read_prose",
@@ -37,7 +38,10 @@ __all__ = [
 ]
 
 _AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
-_MODE_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{0,63}$")
+_MODE_NAME_RE = re.compile(
+    r"^(?:[A-Z][A-Z0-9_]{0,63}|"
+    r"(?![a-z][a-z0-9-]*-[0-9]+$)[a-z][a-z0-9-]{0,63})$"
+)
 _RUN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 
 
@@ -94,7 +98,7 @@ def _validate_agent(agent: str) -> None:
         )
 
 
-def _validate_mode(mode: Optional[str]) -> None:
+def validate_mode_name(mode: Optional[str]) -> None:
     if mode is None:
         return
     if not isinstance(mode, str) or not _MODE_NAME_RE.match(mode):
@@ -102,6 +106,10 @@ def _validate_mode(mode: Optional[str]) -> None:
             f"invalid mode name: {mode!r} "
             f"(must match {_MODE_NAME_RE.pattern} or be None)"
         )
+
+
+def _validate_mode(mode: Optional[str]) -> None:
+    validate_mode_name(mode)
 
 
 def _validate_run_id(run_id: str) -> None:

--- a/tests/test_session_state.py
+++ b/tests/test_session_state.py
@@ -1644,6 +1644,62 @@ class CliBeginStepEndStepTests(unittest.TestCase):
         )
         self.assertTrue(prose_md.exists())
 
+    def test_begin_end_step_accepts_lower_hyphen_mode(self) -> None:
+        """issue #977 — begin-step 이 받은 소문자·하이픈 mode 를 end-step 도 수용."""
+        from harness.session_state import (
+            _cli_begin_step,
+            _cli_end_step,
+            run_dir,
+            run_prose_has_pass,
+            session_dir,
+        )
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stdout
+
+        begin_out = StringIO()
+        with redirect_stdout(begin_out):
+            rc = _cli_begin_step(
+                SimpleNamespace(agent="module-architect", mode="epic-batch")
+            )
+        self.assertEqual(rc, 0)
+        self.assertIn("ok", begin_out.getvalue())
+
+        prose_path = self.base / "tmp_epic_batch_prose.md"
+        prose_path.write_text("## 결론\nPASS\n", encoding="utf-8")
+
+        end_out = StringIO()
+        with redirect_stdout(end_out):
+            rc = _cli_end_step(
+                SimpleNamespace(
+                    agent="module-architect",
+                    mode="epic-batch",
+                    prose_file=str(prose_path),
+                )
+            )
+        self.assertEqual(rc, 0)
+        self.assertEqual(end_out.getvalue().strip(), "PROSE_LOGGED")
+
+        prose_md = (
+            session_dir(self.sid) / "runs" / self.rid /
+            "module-architect-epic-batch.md"
+        )
+        self.assertTrue(prose_md.exists())
+        self.assertTrue(run_prose_has_pass(run_dir(self.sid, self.rid), "module-architect"))
+
+    def test_begin_step_rejects_mode_that_end_step_would_reject(self) -> None:
+        """issue #977 — begin-step/end-step mode 검증 기준은 동일해야 한다."""
+        from harness.session_state import _cli_begin_step
+        from types import SimpleNamespace
+        from io import StringIO
+        from contextlib import redirect_stderr
+
+        err = StringIO()
+        with redirect_stderr(err):
+            rc = _cli_begin_step(SimpleNamespace(agent="module-architect", mode="Plan"))
+        self.assertEqual(rc, 1)
+        self.assertIn("invalid mode name", err.getvalue())
+
     def test_end_step_prose_only_mode_no_allowed_enums(self) -> None:
         """자유서술 방식 (이슈 #280/#284) — PROSE_LOGGED + prose 저장 + .steps.jsonl + stderr 요약."""
         from harness.session_state import (

--- a/tests/test_signal_io.py
+++ b/tests/test_signal_io.py
@@ -109,9 +109,18 @@ class SignalPathValidationTests(unittest.TestCase):
                 signal_path(bad, "run", base_dir=self.base)
 
     def test_invalid_mode_name(self) -> None:
-        for bad in ["plan", "Plan", "PLAN-A", "1MODE"]:
+        for bad in ["Plan", "PLAN-A", "plan_mode", "1MODE", "mode-1"]:
             with self.assertRaises(ValueError, msg=f"mode={bad!r}"):
                 signal_path("validator", "run", mode=bad, base_dir=self.base)
+
+    def test_lower_hyphen_mode_name(self) -> None:
+        path = signal_path(
+            "module-architect",
+            "r1",
+            mode="epic-batch",
+            base_dir=self.base,
+        )
+        self.assertEqual(path.name, "module-architect-epic-batch.md")
 
     def test_invalid_run_id_traversal(self) -> None:
         with self.assertRaises(ValueError):


### PR DESCRIPTION
## 관련 이슈 번호
Closes #977

## 배경 및 문제
- begin-step 은 mode 값을 그대로 current_step 에 기록하지만, end-step prose 저장은 signal_io 의 대문자/언더스코어 정규식만 허용해 `epic-batch` 같은 /design 문서 표기가 end-step 에서 실패했다.
- 그 결과 외부 활성 프로젝트의 /design stage 2 module-architect epic-batch 사이클에서 mode 생략 우회가 필요했다.

## 원인 (해당 시)
- mode 검증 기준이 end-step prose 파일명 생성 경로에만 존재했고 begin-step 경로에는 같은 검증이 없었다.
- prose PASS 탐색도 대문자 mode suffix 만 end-step 파일명으로 인정해 lowercase-hyphen mode 파일을 설계 산출 증거로 읽지 못할 수 있었다.

## 작업내용
- `harness/signal_io.py` 에 mode 검증 SSOT를 확장해 legacy `CODE_VALIDATION` 계열과 skill label `epic-batch` 계열을 함께 허용했다.
- begin-step 이 end-step 과 같은 mode 검증을 먼저 적용하도록 해 begin/end 수용 집합 비대칭을 제거했다.
- `run_prose_has_pass` 의 mode-suffixed prose 파일 인식 범위를 `module-architect-epic-batch.md`까지 확장했다.
- `docs/plugin/loop-procedure.md` 의 mode 규격과 파일명 예시를 실제 허용 기준에 맞췄다.
- `epic-batch` begin-step -> end-step 회귀 테스트와 invalid mode 대칭 테스트를 추가했다.

## 결정 근거
- mode 명명 정책 자체를 재설계하지 않고, 기존 대문자/언더스코어 계약은 유지하면서 이미 skill 문서가 안내하는 소문자/하이픈 라벨을 좁게 추가했다.
- lowercase mode 가 occurrence suffix 와 충돌하지 않도록 `-<숫자>` 끝맺음은 mode 값에서 제외했다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in 런타임 코드 경로: `harness/signal_io.py`, `harness/session_state.py`, `harness/session_state_cli.py` 변경은 plug-in 업데이트 시 외부 활성 프로젝트 helper 동작에 반영된다.
- 사용자-facing SSOT 경로: `docs/plugin/loop-procedure.md` 에 begin/end-step mode 규격과 `/design` epic-batch 예시를 반영했다.
- init-dcness 복사 파일 변경 없음. 신규 활성화/기존 활성화 프로젝트 모두 plug-in 업데이트 경로로 도달한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증

실행한 검증:
- `python3.11 -m unittest tests.test_signal_io tests.test_session_state tests.test_hooks -v`
- `python3.11 -m unittest discover -s tests -v < /dev/null` -> 1701 tests PASS
- `node scripts/check_cross_refs.mjs`
- `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- `git diff --check`
- git pre-commit hook -> 1701 tests PASS

## 참고
- commit: 77f3a7b
