### PR TITLE
[issue-970] design retry 한도 계약 복구

### DIFF
--- a/codex/skills/dcness-architecture-validator/SKILL.md
+++ b/codex/skills/dcness-architecture-validator/SKILL.md
@@ -74,6 +74,8 @@ Claude-side `architecture-validator` prompt를 복제하지 않는다. 같은 �
 
 같은 agent/mode 의 retry 또는 재검증이면 전체 배경을 반복하지 않고 직전 결과 대비 변화부터 쓴다. 재검증 결과는 changed / resolved / still failing / new 를 먼저 드러내고, 권장 카테고리는 해소됨, 유지됨, 신규, 판단 불가다. 남은 차단 finding 에는 파일/라인/명령 같은 재현 가능한 근거를 유지한다.
 
+retry 또는 재검증 호출이어도 Codex validator 는 retry counter 를 증가·리셋하지 않는다. 메인이 design-routing.md 의 provider-agnostic counter 로 자동 재진입 한도를 판단한다. 새 finding 등장, finding 분류 변경, Codex provider 사용 사실을 한도 리셋처럼 표현하지 않는다.
+
 별도 영구 산출물 작성 금지, read-only agent 가 직접 파일 쓰기 금지, JSON, marker, 고정 schema, 필수 heading 강제는 도입하지 않는다. `PASS` 단발에는 적용하지 않는다.
 
 ## 완료 기준

--- a/docs/plugin/agents/architecture-validator/architecture-validator-agent.md
+++ b/docs/plugin/agents/architecture-validator/architecture-validator-agent.md
@@ -84,6 +84,8 @@ module-architect epic-batch 산출물을 읽기 전용으로 검토한다. 앞�
 
 FAIL / ESCALATE 판단 노트와 재검증 delta-first 보고는 [`../_shared/validation-reporting-guidance.md`](../_shared/validation-reporting-guidance.md)를 따른다. 이 가이드는 출력 schema 가 아니라 메인이 다음 행동을 판단할 수 있게 실패 사실, 판단 근거, 재검증 변화량을 드러내는 의미 요구다.
 
+retry 또는 재검증 호출이어도 validator 는 retry counter 를 증가·리셋하지 않는다. 메인이 design-routing.md 의 provider-agnostic counter 로 자동 재진입 한도를 판단한다. validator 는 직전 finding 대비 resolved / still failing / new 만 판정 가능하게 쓰고, 새 finding 등장이나 분류 변경을 한도 리셋처럼 표현하지 않는다.
+
 ## 템플릿과 참고 문서
 
 - [`templates/review-report.md`](templates/review-report.md)

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -118,7 +118,7 @@ else
 fi
 ```
 
-Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. `DCNESS_CODEX_MODEL` 을 설정하면 wrapper 가 `-m` 모델 override 를, `DCNESS_CODEX_EFFORT` 를 설정하면 `-c model_reasoning_effort=...` override 를 전달한다. 둘 다 미설정이면 사용자 Codex config 를 그대로 상속하며, dcNess 는 특정 Codex 모델명을 하드코딩하지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
+Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. Claude Agent 와 Codex wrapper 모두 메인이 집계한다. Codex wrapper 는 end-step 까지 수행하지만 counter 소유자가 아니다. `DCNESS_CODEX_MODEL` 을 설정하면 wrapper 가 `-m` 모델 override 를, `DCNESS_CODEX_EFFORT` 를 설정하면 `-c model_reasoning_effort=...` override 를 전달한다. 둘 다 미설정이면 사용자 Codex config 를 그대로 상속하며, dcNess 는 특정 Codex 모델명을 하드코딩하지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
 
 **implementation provider 분기 (headless-chain 기본)**: `test-engineer` / `engineer` / `build-worker` 는 호출 직전 provider 를 resolve 한다.
 
@@ -276,7 +276,7 @@ phase prose 실제 기록 디렉토리 = `dcness-helper run-dir` 이 출력하�
 | `AMBIGUOUS` 재호출 1회 | 직전 동일 agent task | `TaskUpdate(<task>, in_progress)` |
 | `SPEC_GAP_FOUND` → module-architect (보강) | 신규 task (다른 agent) | `TaskCreate` 가능 |
 
-이유: retry / POLISH 는 *동일 step 의 재실행*. 신규 TaskCreate 시 같은 step 이 task list 에 중복 등장 → 진행 추적 오염. cycle 카운터는 step occurrence (`<agent>[-<mode>]-N.md`) 로 보존되므로 task 는 1개로 유지.
+이유: retry / POLISH 는 *동일 step 의 재실행*. 신규 TaskCreate 시 같은 step 이 task list 에 중복 등장 → 진행 추적 오염. cycle 카운터는 step occurrence (`<agent>[-<mode>]-N.md`) 로 보존되므로 task 는 1개로 유지. provider wrapper 가 `end-step` 을 대신 호출해도 retry counter 의 소유자는 메인이다. 메인은 해당 loop 의 `<skill>-routing.md` counter key 로 세며, finding 분류·파일·provider 변경만으로 같은 retry 경로의 counter 를 나누거나 리셋하지 않는다.
 
 **MUST 순서** (retry / POLISH 진입 시):
 

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -172,7 +172,7 @@ else
 fi
 ```
 
-이 절의 Codex 분기는 `architecture-validator` read-only validation 전용이다. wrapper 가 Codex 마지막 응답을 저장하고 `end-step architecture-validator --prose-file ...` 까지 수행하므로 별도 end-step 중복 호출 금지.
+이 절의 Codex 분기는 `architecture-validator` read-only validation 전용이다. wrapper 가 Codex 마지막 응답을 저장하고 `end-step architecture-validator --prose-file ...` 까지 수행하므로 별도 end-step 중복 호출 금지. retry 한도는 provider 분기와 무관하게 [`design-routing.md`](design-routing.md#final-검증-counter-계약) 를 따른다. Claude Agent 와 Codex wrapper 모두 메인이 집계한다. Codex wrapper 는 end-step 까지 수행하지만 counter 소유자가 아니다.
 
 ## 참조
 

--- a/skills/design/design-routing.md
+++ b/skills/design/design-routing.md
@@ -36,8 +36,8 @@ flowchart TB
   SA_CHECK -->|PASS| MA_BATCH
   AV_FINAL -->|PASS| M([end-run/metrics freeze 후 Step 6 PR · 사용자 확인 checkpoint · 머지 → /impl 안내])
   M -->|DESIGN_SYSTEM_PR_MERGED| DONE([/impl 안내])
-  AV_FINAL -->|"FAIL: SYSTEM_BOUNDARY ≤3"| SA_CHECK
-  AV_FINAL -->|"FAIL: TASK_LOCAL ≤3"| MA_BATCH
+  AV_FINAL -->|"FAIL: SYSTEM_BOUNDARY ≤3 shared"| SA_CHECK
+  AV_FINAL -->|"FAIL: TASK_LOCAL ≤3 shared"| MA_BATCH
   SA_CHECK -->|NEW_DEP_ESCALATE| U((사용자 · 4안))
   SA_BOOT -->|NEW_DEP_ESCALATE| U
   MA_BATCH -->|NEW_DEP_ESCALATE| U
@@ -55,7 +55,7 @@ flowchart TB
   class U user
 ```
 
-> 파랑 = 생산 agent · 초록 = 검증 agent · 회색 = 사용자 위임. 점선 = escalate. 엣지의 `≤N` = retry 한도 ([retry 한도](#retry-한도)).
+> 파랑 = 생산 agent · 초록 = 검증 agent · 회색 = 사용자 위임. 점선 = escalate. 엣지의 `≤N` = retry 한도 ([retry 한도](#retry-한도)). `SYSTEM_BOUNDARY` / `TASK_LOCAL` final FAIL 엣지는 같은 shared counter 를 쓴다.
 >
 > tech-reviewer 는 design 진입 *전* (`/tech-review` skill) 단계가 기본이다. design 중 새 외부 의존이 발견되면 사용자가 option 4 를 명시 선택한 경우에만 대상 epic 범위로 좁혀 호출한다.
 
@@ -110,6 +110,17 @@ flowchart TB
 >
 > **architecture-validator FAIL 재진입 대상 = finding 분류별** ([finding 분류 분기](#finding-분류-분기)) — final epic 검증은 `SYSTEM_BOUNDARY` → system-architect opt-in checkpoint, `TASK_LOCAL` → module-architect(epic-batch) 보강.
 > cycle 발생 시 working tree only — commit X. PASS 후에만 commit.
+
+### final 검증 counter 계약
+
+**RCA**: Android `/design` 관측에서는 final 검증 FAIL 후 새 stale 사본 finding 이 나올 때마다 "같은 경로" 판단이 흐려졌고, 그래프의 `SYSTEM_BOUNDARY` / `TASK_LOCAL` 양쪽 edge 를 분류별 별도 한도로 읽을 여지도 있었다. 그 결과 3 cycle 계약이 사용자 위임으로 전환되지 못하고 6 cycle 자동 재진입을 허용했다. 원인은 hook 강제 부재가 아니라 counter key 와 reset 금지가 문서상 충분히 실행 가능하지 않았던 것이다.
+
+- **final epic 검증 FAIL → 산출 주체 재진입 counter 는 하나**다. final validator 가 `FAIL` 을 내고 메인이 자동으로 producer 를 다시 부르기로 결정하는 순간 1 cycle 로 센다.
+- 재진입 대상은 finding 분류로 고른다. `SYSTEM_BOUNDARY` 는 system-architect opt-in checkpoint, `TASK_LOCAL` 은 module-architect(epic-batch) 보강으로 가지만 둘은 같은 final 검증 retry counter 를 공유한다.
+- `SYSTEM_BOUNDARY` / `TASK_LOCAL` 분류 전환, finding 영역 변경, 파일 변경, finding 수 변화, 새 finding 등장, provider 변경으로 counter 를 리셋하지 않는다.
+- 3 cycle 까지만 자동 재진입한다. 4번째 자동 재진입이 필요해지는 순간에는 진행을 멈추고 남은 finding, 영향, 선택지(system checkpoint 계속 / module 보강 계속 / `/spec` 재진입 / hold)를 사용자에게 위임한다.
+- Claude Agent 와 Codex wrapper 모두 메인이 집계한다. Codex wrapper 는 end-step 까지 수행하지만 counter 소유자가 아니다. counter evidence 는 `architecture-validator`, `architecture-validator-1` 같은 같은 agent occurrence 와 ledger receipt 이며, provider field 는 counter key 가 아니다.
+- 루프 재구성 이후 상설 초기 검증 stage 가 없어져도 이 계약은 남는다. 적용 대상은 design-system stage 의 final epic 검증과 그 FAIL 이 유발하는 system checkpoint 또는 epic-batch 재진입이다.
 
 > **finding 수용 자세** (점 패치 X, 근본 재설계) — 같은 영역 finding 이 2회+ 반복되면 점 패치 retry 로 한도를 소진하지 말고 근본 원인을 짚어 그 영역을 재설계한다. 진본 = [`loop-procedure.md` finding 수용 원칙](../../docs/plugin/loop-procedure.md#finding-수용-원칙-점-패치-금지-근본-수정).
 

--- a/tests/test_design_run_records.py
+++ b/tests/test_design_run_records.py
@@ -38,8 +38,8 @@ def _make_run_dir(tmp: Path, sid: str, rid: str, events: list[dict], prose: dict
     return run_dir
 
 
-def _step(agent: str, filename: str, ts: str) -> dict:
-    return {
+def _step(agent: str, filename: str, ts: str, *, provider: str | None = None) -> dict:
+    step = {
         "event": "step_completed",
         "ts": ts,
         "agent": agent,
@@ -48,6 +48,9 @@ def _step(agent: str, filename: str, ts: str) -> dict:
         "prose_file": filename,
         "prose_excerpt": "",
     }
+    if provider:
+        step["provider"] = provider
+    return step
 
 
 class DesignRunRecordTests(unittest.TestCase):
@@ -117,6 +120,57 @@ class DesignRunRecordTests(unittest.TestCase):
         self.assertNotIn("CONTRACT_PROPAGATION", record["finding_classes"])
         self.assertEqual(record["revalidation_cycles"], {"architecture-validator": 1})
         self.assertEqual(record["units"][0]["verdict"], "FAIL")
+        self.assertEqual(record["units"][2]["cycle"], 1)
+
+    def test_revalidation_cycles_are_provider_agnostic(self) -> None:
+        """#970 — Claude/Codex provider switches do not split retry counters."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            run_dir = _make_run_dir(
+                tmp,
+                "sid1",
+                "run-design-provider",
+                [
+                    {
+                        "event": "run_started",
+                        "entry_point": "design",
+                        "stage": "design-system",
+                        "ts": "2026-07-01T00:00:00+00:00",
+                    },
+                    _step(
+                        "architecture-validator",
+                        "av-claude.md",
+                        "2026-07-01T00:01:00+00:00",
+                        provider="claude-main",
+                    ),
+                    _step(
+                        "module-architect",
+                        "ma.md",
+                        "2026-07-01T00:04:00+00:00",
+                    ),
+                    _step(
+                        "architecture-validator",
+                        "av-codex.md",
+                        "2026-07-01T00:08:00+00:00",
+                        provider="codex-headless",
+                    ),
+                    {
+                        "event": "run_finished",
+                        "ts": "2026-07-01T00:10:00+00:00",
+                    },
+                ],
+                {
+                    "av-claude.md": "Must finding: SYSTEM_BOUNDARY at docs/a.md:1\nFAIL\n",
+                    "ma.md": "system checkpoint 반영\nPASS\n",
+                    "av-codex.md": "Resolved SYSTEM_BOUNDARY.\nPASS\n",
+                },
+            )
+            record = build_design_record(run_dir, repo_path=tmp)
+
+        self.assertIsNotNone(record)
+        assert record is not None
+        self.assertEqual(record["revalidation_cycles"], {"architecture-validator": 1})
+        self.assertEqual(record["units"][0]["cycle"], 0)
         self.assertEqual(record["units"][2]["cycle"], 1)
 
     def test_non_design_run_is_ignored(self) -> None:

--- a/tests/test_design_surface.py
+++ b/tests/test_design_surface.py
@@ -235,6 +235,49 @@ class DesignSurfaceContractTests(unittest.TestCase):
 
         self.assertIn("사용자 확인 checkpoint", routing)
 
+    def test_design_retry_limit_has_single_provider_agnostic_counter(self) -> None:
+        """#970 — final validation retry limit must not reset by finding or provider."""
+        design_dir = ROOT / "skills" / "design"
+        design = (design_dir / "SKILL.md").read_text(encoding="utf-8")
+        routing = (design_dir / "design-routing.md").read_text(encoding="utf-8")
+        loop_procedure = (ROOT / "docs" / "plugin" / "loop-procedure.md").read_text(
+            encoding="utf-8"
+        )
+        validator = (
+            ROOT
+            / "docs"
+            / "plugin"
+            / "agents"
+            / "architecture-validator"
+            / "architecture-validator-agent.md"
+        ).read_text(encoding="utf-8")
+        codex_validator = (
+            ROOT / "codex" / "skills" / "dcness-architecture-validator" / "SKILL.md"
+        ).read_text(encoding="utf-8")
+
+        for needle in (
+            "RCA",
+            "final epic 검증 FAIL → 산출 주체 재진입 counter 는 하나",
+            "`SYSTEM_BOUNDARY` / `TASK_LOCAL`",
+            "finding 영역 변경",
+            "새 finding 등장",
+            "리셋하지 않는다",
+            "4번째 자동 재진입",
+            "루프 재구성 이후",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, routing)
+
+        for text in (design, routing, loop_procedure):
+            with self.subTest(text=text[:60]):
+                self.assertIn("Claude Agent 와 Codex wrapper 모두 메인이 집계", text)
+                self.assertIn("Codex wrapper 는 end-step 까지 수행하지만 counter 소유자가 아니다", text)
+
+        for text in (validator, codex_validator):
+            with self.subTest(provider_doc=text[:60]):
+                self.assertIn("retry counter 를 증가·리셋하지 않는다", text)
+                self.assertIn("메인이 design-routing.md 의 provider-agnostic counter", text)
+
     def test_design_dispatches_internal_ux_and_system_stages(self) -> None:
         """#958 — /design remains public while durable artifacts select an internal stage."""
         design_dir = ROOT / "skills" / "design"


### PR DESCRIPTION
## 관련 이슈 번호
Closes #970

## 배경 및 문제
`/design` final 검증 FAIL 후 산출 주체 재진입 한도는 3 cycle 이어야 하지만, 실제 세션에서 새 finding/분류 전환/provider 경로를 별도 흐름처럼 해석할 여지가 있어 6 cycle 자동 재진입이 허용됐다.

## 원인 (해당 시)
`design-routing.md` 의 retry 표는 final 검증 FAIL 재진입을 1개 행으로 두고 있었지만, 분기 그래프는 `SYSTEM_BOUNDARY` / `TASK_LOCAL` edge 를 따로 표현했다. counter key, reset 금지, Codex wrapper 경로의 집계 주체가 명시되지 않아 메인이 finding 영역별 또는 provider별로 cycle 을 리셋해도 문서상 판정이 약했다.

## 작업내용
- final epic 검증 FAIL 재진입 counter 를 단일 provider-agnostic counter 로 명문화했다.
- `SYSTEM_BOUNDARY` / `TASK_LOCAL` 분류 전환, finding 영역 변경, 새 finding 등장, provider 변경으로 counter 를 리셋하지 않도록 기록했다.
- Claude-side architecture-validator 와 Codex mirror skill 에 validator 는 retry counter 를 증가/리셋하지 않는다는 역할 경계를 추가했다.
- provider switch 가 design run revalidation cycle 집계를 쪼개지 않는 회귀 테스트를 추가했다.

## 결정 근거
한도는 hook 강제 승격 대상이 아니라 권고/사용자 개입 계약이다. 따라서 새 강제 gate 나 telemetry 인프라를 만들지 않고, 메인이 실제 다음 행동을 판단할 수 있도록 routing SSOT 와 provider 지침을 실행 가능하게 좁혔다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in 본체 경로 갱신: `skills/design/design-routing.md`, `skills/design/SKILL.md`, `docs/plugin/loop-procedure.md`, `docs/plugin/agents/architecture-validator/architecture-validator-agent.md`, `codex/skills/dcness-architecture-validator/SKILL.md`.
- `/init-dcness` 복사 파일, workflow, hook 배포 inventory 변경 없음.
- 신규 public skill/command/agent/gate 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 기존 `/design` routing 과 validator provider 지침만 명확화했다.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_design_surface tests.test_design_run_records -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `git diff --check`
- [x] git pre-commit hook 통과 (main-block + python-tests)

## 참고
- 원격 repo 이동 안내가 있었지만 push/PR 대상은 GitHub redirect 후 `Daeguk-Sun/dcNess` 로 처리된다.
