### PR TITLE
[feature] design-variants canvas 플로우 보드 지원

### DIFF
--- a/docs/plugin/design.md
+++ b/docs/plugin/design.md
@@ -86,7 +86,7 @@ agent 는 파일 부재를 오류로 처리하지 않는다.
 
 확정본 SSOT 는 `docs/design-variants/` 한 지붕이다.
 
-- `docs/design-variants/canvas.html`: 프로젝트 전체 화면 지도와 흐름 화살표.
+- `docs/design-variants/canvas.html`: 프로젝트 전체 화면 지도와 흐름 화살표. 단순 등록은 `<iframe data-frame-id>` auto-layout 을 쓰고, 화면별 캡션·상태·노드별 높이·2D 배치가 필요하면 `.screen-node[data-node-id][data-pos][data-title][data-desc][data-states][data-h]` 로 등록한다.
 - `docs/design-variants/_lib/`: canvas/show-id helper.
 - `docs/design-variants/<screen-id>.html`: 화면별 확정본. v 접미사는 쓰지 않고 히스토리는 git 이 보존한다.
 - `docs/design-variants/drafts/`: 탐색용 draft. `.gitignore` 로 draft 파일은 무시하되 `.gitkeep` 으로 디렉터리를 보존한다.

--- a/skills/canvas-design/SKILL.md
+++ b/skills/canvas-design/SKILL.md
@@ -25,7 +25,7 @@ description: 내부 전용 UI 기준 확보 wrapper. designer draft 생성, 사�
 
 `docs/design-variants/` 한 지붕이 확정본 SSOT 다.
 
-- `docs/design-variants/canvas.html` — 프로젝트 전체 화면 지도. 확정 화면을 iframe frame 으로 등록하고, 필요하면 흐름 화살표를 둔다.
+- `docs/design-variants/canvas.html` — 프로젝트 전체 화면 지도. 확정 화면을 iframe frame 으로 등록한다. 화면별 캡션과 2D 위치가 필요한 플로우 보드는 `.screen-node` 로 등록하고, 필요하면 라벨 달린 흐름 화살표를 둔다.
 - `docs/design-variants/_lib/` — `canvas.js`, `show-ids.js` 같은 공유 helper.
 - `docs/design-variants/<screen-id>.html` — 화면별 확정본. v 접미사는 쓰지 않는다. 히스토리는 git 이 보존한다.
 - `docs/design-variants/drafts/` — 탐색용 draft. `.gitignore` 로 무시한다.
@@ -61,8 +61,9 @@ description: 내부 전용 UI 기준 확보 wrapper. designer draft 생성, 사�
    - 확정본은 v 접미사를 쓰지 않는다.
 6. **canvas frame 등록**
    - 메인이 `docs/design-variants/canvas.html` 에 `<iframe data-frame-id="<screen-id>" src="<screen-id>.html"></iframe>` 를 등록한다.
-   - 이미 같은 `data-frame-id` 가 있으면 중복 등록하지 않고 기존 frame 을 갱신한다.
-   - 화면 간 흐름이 확정돼 있으면 `svg.flow-arrows` 의 `path[data-from][data-to]` 로 연결한다. 클릭 프로토타이핑은 후속 범위다.
+   - 화면 플로우 설명이 필요하면 `<div class="screen-node" data-node-id="<screen-id>" data-pos="<col>,<row>" data-title="..." data-desc="..." data-states="..." data-h="900"><iframe src="<screen-id>.html"></iframe></div>` 로 등록한다.
+   - 이미 같은 `data-frame-id` 또는 `data-node-id` 가 있으면 중복 등록하지 않고 기존 항목을 갱신한다.
+   - 화면 간 흐름이 확정돼 있으면 `svg.flow-arrows` 의 `path[data-from][data-to][data-label][data-bend]` 로 연결한다. canvas helper 가 라벨 pill, 강조, 초기 fit-to-view 를 처리한다.
 7. **반환**
    - 확정 목업 경로: `docs/design-variants/<screen-id>.html`
    - canvas 경로: `docs/design-variants/canvas.html`

--- a/templates/design-variants/_lib/canvas.js
+++ b/templates/design-variants/_lib/canvas.js
@@ -1,62 +1,515 @@
 /* docs/design-variants/_lib/canvas.js
- * dcness plug-in 시드 — canvas.html 의 pan/zoom + iframe auto-layout + 직선 화살표.
- * canvas.html 가 <script defer src="_lib/canvas.js"> 로 import.
+ * dcness plug-in seed: pan/zoom design canvas with two compatible modes.
  *
- * canvas-design 승격 단계 책임:
- *   <iframe data-frame-id="..." src="<screen-id>.html"></iframe>  (좌표 X — auto-layout)
- *   <iframe data-frame-id="..." data-pos="<col>,<row>" src="..."></iframe>  (override 시만)
+ * Legacy grid mode:
+ *   <iframe data-frame-id="..." src="<screen-id>.html"></iframe>
+ *   <iframe data-frame-id="..." data-pos="<col>,<row>" src="..."></iframe>
+ *
+ * Flow board mode:
+ *   <div class="screen-node" data-node-id="..." data-pos="<col>,<row>"
+ *        data-title="..." data-desc="..." data-states="..." data-h="900">
+ *     <iframe src="<screen-id>.html"></iframe>
+ *   </div>
+ *
+ * Optional arrows in both modes:
  *   <svg class="flow-arrows">
- *     <path data-from="A" data-to="B" data-label="..."/>
- *   </svg>  (화살표는 optional)
+ *     <path data-from="A" data-to="B" data-label="..." data-bend="0"/>
+ *   </svg>
  *
- * 그리드: 화면 가로 = 390 (모바일) + 110 간격, 한 row 4 col, viewport=desktop 시 1280.
+ * Theme hooks:
+ *   --dcness-canvas-arrow, --dcness-canvas-font, --dcness-canvas-bg
  */
 (function () {
   'use strict';
 
   const VIEWPORT_W = { mobile: 390, tablet: 768, desktop: 1280 };
   const FRAME_H = 720;
-  const GAP = 110;
-  const COLS = 4;
+  const LEGACY_GAP = 110;
+  const LEGACY_COLS = 4;
+  const FLOW_NODE_W = 390;
+  const FLOW_FRAME_H = 900;
+  const FLOW_GAP_X = 150;
+  const FLOW_GAP_Y = 120;
+  const BOARD_PAD = 80;
+  const ZOOM_MIN = 0.2;
+  const ZOOM_MAX = 2;
 
   let zoom = 1, panX = 0, panY = 0;
+  let theme = {};
+
+  function cssVar(name, fallback) {
+    const styles = window.getComputedStyle(document.documentElement);
+    const value = styles.getPropertyValue(name).trim();
+    return value || fallback;
+  }
+
+  function readTheme() {
+    theme = {
+      arrow: cssVar('--dcness-canvas-arrow', '#6750A4'),
+      font: cssVar('--dcness-canvas-font', 'system-ui, sans-serif'),
+      bg: cssVar('--dcness-canvas-bg', '#f5f5f7'),
+      captionBg: cssVar('--dcness-canvas-caption-bg', '#ffffff'),
+      captionBorder: cssVar('--dcness-canvas-caption-border', '#d0d0d5'),
+      text: cssVar('--dcness-canvas-text', '#1f1f24'),
+      muted: cssVar('--dcness-canvas-muted', '#54545c'),
+      chipBg: cssVar('--dcness-canvas-chip-bg', '#efe7ff'),
+      chipText: cssVar('--dcness-canvas-chip-text', '#4f378b'),
+      labelBg: cssVar('--dcness-canvas-label-bg', '#ffffff'),
+      labelBorder: cssVar('--dcness-canvas-label-border', '#d7c9ff')
+    };
+  }
+
+  function cssEscape(value) {
+    if (window.CSS && typeof window.CSS.escape === 'function') {
+      return window.CSS.escape(value);
+    }
+    return String(value).replace(/["\\]/g, '\\$&');
+  }
+
+  function parsePositiveInt(value, fallback) {
+    const parsed = parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  }
+
+  function parsePos(value, fallbackCol, fallbackRow) {
+    if (!value) return { col: fallbackCol, row: fallbackRow };
+    const parts = value.split(',').map(n => parseInt(n.trim(), 10));
+    return {
+      col: Number.isFinite(parts[0]) && parts[0] >= 0 ? parts[0] : fallbackCol,
+      row: Number.isFinite(parts[1]) && parts[1] >= 0 ? parts[1] : fallbackRow
+    };
+  }
 
   function setupStage() {
     const stage = document.querySelector('.canvas');
     if (!stage) return null;
     Object.assign(stage.style, {
-      transformOrigin: '0 0', position: 'relative',
-      width: '100vw', height: '100vh', overflow: 'hidden', background: '#f5f5f7'
+      position: 'fixed',
+      inset: '0',
+      width: '100vw',
+      height: '100vh',
+      overflow: 'hidden',
+      background: theme.bg,
+      cursor: 'grab',
+      userSelect: 'none'
     });
     const inner = document.createElement('div');
     inner.className = 'canvas-inner';
-    Object.assign(inner.style, { position: 'absolute', top: '0', left: '0', transformOrigin: '0 0' });
+    Object.assign(inner.style, {
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      transformOrigin: '0 0'
+    });
     while (stage.firstChild) inner.appendChild(stage.firstChild);
     stage.appendChild(inner);
-    return inner;
+    return { stage, inner };
   }
 
   function layoutFrames(inner) {
     const frames = inner.querySelectorAll('iframe[data-frame-id]');
     let nextCol = 0, nextRow = 0;
-    frames.forEach(f => {
-      const vp = f.dataset.viewport || 'mobile';
+    frames.forEach(frame => {
+      const vp = frame.dataset.viewport || 'mobile';
       const w = VIEWPORT_W[vp] || VIEWPORT_W.mobile;
       let col, row;
-      if (f.dataset.pos) {
-        [col, row] = f.dataset.pos.split(',').map(n => parseInt(n.trim(), 10));
+      if (frame.dataset.pos) {
+        const pos = parsePos(frame.dataset.pos, nextCol, nextRow);
+        col = pos.col;
+        row = pos.row;
       } else {
-        col = nextCol; row = nextRow;
+        col = nextCol;
+        row = nextRow;
         nextCol++;
-        if (nextCol >= COLS) { nextCol = 0; nextRow++; }
+        if (nextCol >= LEGACY_COLS) { nextCol = 0; nextRow++; }
       }
-      Object.assign(f.style, {
+      Object.assign(frame.style, {
         position: 'absolute',
-        left: (col * (w + GAP)) + 'px',
-        top: (row * (FRAME_H + GAP)) + 'px',
-        width: w + 'px', height: FRAME_H + 'px',
-        border: '1px solid #d0d0d5', background: '#fff'
+        left: (col * (w + LEGACY_GAP)) + 'px',
+        top: (row * (FRAME_H + LEGACY_GAP)) + 'px',
+        width: w + 'px',
+        height: FRAME_H + 'px',
+        border: '1px solid #d0d0d5',
+        background: '#fff'
       });
+    });
+  }
+
+  function buildCaption(node) {
+    const old = node.querySelector('.node-caption');
+    if (old) old.remove();
+
+    const cap = document.createElement('div');
+    cap.className = 'node-caption';
+    Object.assign(cap.style, {
+      width: FLOW_NODE_W + 'px',
+      boxSizing: 'border-box',
+      marginTop: '10px',
+      padding: '12px 14px',
+      background: theme.captionBg,
+      border: '1px solid ' + theme.captionBorder,
+      borderRadius: '8px',
+      fontFamily: theme.font,
+      boxShadow: '0 1px 3px rgba(0,0,0,.06)'
+    });
+
+    const title = document.createElement('div');
+    title.textContent = node.dataset.title || node.dataset.nodeId || 'screen';
+    Object.assign(title.style, {
+      fontSize: '15px',
+      fontWeight: '700',
+      color: theme.text,
+      lineHeight: '1.35'
+    });
+    cap.appendChild(title);
+
+    if (node.dataset.desc) {
+      const desc = document.createElement('div');
+      desc.textContent = node.dataset.desc;
+      Object.assign(desc.style, {
+        fontSize: '13px',
+        color: theme.muted,
+        marginTop: '4px',
+        lineHeight: '1.4'
+      });
+      cap.appendChild(desc);
+    }
+
+    if (node.dataset.states) {
+      const states = document.createElement('div');
+      Object.assign(states.style, {
+        marginTop: '8px',
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '5px'
+      });
+      node.dataset.states.split('/').forEach(raw => {
+        const state = raw.trim();
+        if (!state) return;
+        const chip = document.createElement('span');
+        chip.textContent = state;
+        Object.assign(chip.style, {
+          fontSize: '11px',
+          lineHeight: '1.4',
+          color: theme.chipText,
+          background: theme.chipBg,
+          borderRadius: '999px',
+          padding: '2px 8px'
+        });
+        states.appendChild(chip);
+      });
+      cap.appendChild(states);
+    }
+
+    return cap;
+  }
+
+  function layoutScreenNodes(inner) {
+    const nodes = Array.from(inner.querySelectorAll('.screen-node'));
+    const placements = [];
+    let nextCol = 0, nextRow = 0;
+
+    nodes.forEach(node => {
+      const pos = parsePos(node.dataset.pos, nextCol, nextRow);
+      const frameH = parsePositiveInt(node.dataset.h, FLOW_FRAME_H);
+      const iframe = node.querySelector('iframe');
+      if (iframe) {
+        Object.assign(iframe.style, {
+          width: FLOW_NODE_W + 'px',
+          height: frameH + 'px',
+          border: '1px solid #c8cdd6',
+          borderRadius: '8px',
+          background: '#fff',
+          display: 'block',
+          boxSizing: 'border-box',
+          boxShadow: '0 6px 24px rgba(0,0,0,.12)'
+        });
+      }
+
+      node.appendChild(buildCaption(node));
+      Object.assign(node.style, {
+        position: 'absolute',
+        width: FLOW_NODE_W + 'px',
+        boxSizing: 'border-box',
+        left: '0',
+        top: '0',
+        zIndex: '10'
+      });
+
+      placements.push({ node, col: pos.col, row: pos.row });
+      nextCol++;
+      if (nextCol >= LEGACY_COLS) { nextCol = 0; nextRow++; }
+    });
+
+    const maxRow = placements.reduce((max, item) => Math.max(max, item.row), 0);
+    const rowHeights = new Map();
+    placements.forEach(item => {
+      rowHeights.set(item.row, Math.max(rowHeights.get(item.row) || 0, item.node.offsetHeight));
+    });
+
+    const rowTops = new Map();
+    let top = 0;
+    for (let row = 0; row <= maxRow; row++) {
+      rowTops.set(row, top);
+      top += (rowHeights.get(row) || (FLOW_FRAME_H + 100)) + FLOW_GAP_Y;
+    }
+
+    placements.forEach(item => {
+      Object.assign(item.node.style, {
+        left: (item.col * (FLOW_NODE_W + FLOW_GAP_X)) + 'px',
+        top: (rowTops.get(item.row) || 0) + 'px'
+      });
+      item.node.addEventListener('click', event => {
+        event.stopPropagation();
+        focusNode(inner, item.node.dataset.nodeId);
+      });
+    });
+  }
+
+  function readArrowSpecs(inner) {
+    const svg = inner.querySelector('svg.flow-arrows');
+    if (!svg) return [];
+    return Array.from(svg.querySelectorAll('path[data-from][data-to]')).map(path => ({
+      from: path.dataset.from,
+      to: path.dataset.to,
+      label: path.dataset.label || '',
+      bend: parseInt(path.dataset.bend, 10) || 0
+    }));
+  }
+
+  function nodeBox(inner, id, flowMode) {
+    const escaped = cssEscape(id);
+    const selector = flowMode
+      ? `.screen-node[data-node-id="${escaped}"]`
+      : `iframe[data-frame-id="${escaped}"]`;
+    const node = inner.querySelector(selector);
+    if (!node) return null;
+    return {
+      el: node,
+      x: node.offsetLeft,
+      y: node.offsetTop,
+      w: node.offsetWidth,
+      h: node.offsetHeight
+    };
+  }
+
+  function boardItems(inner) {
+    const nodes = inner.querySelectorAll('.screen-node');
+    if (nodes.length) return Array.from(nodes);
+    return Array.from(inner.querySelectorAll('iframe[data-frame-id]'));
+  }
+
+  function boardBounds(inner) {
+    const items = boardItems(inner);
+    if (!items.length) return { minX: 0, minY: 0, maxX: 0, maxY: 0, w: BOARD_PAD, h: BOARD_PAD };
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    items.forEach(item => {
+      minX = Math.min(minX, item.offsetLeft);
+      minY = Math.min(minY, item.offsetTop);
+      maxX = Math.max(maxX, item.offsetLeft + item.offsetWidth);
+      maxY = Math.max(maxY, item.offsetTop + item.offsetHeight);
+    });
+    return {
+      minX,
+      minY,
+      maxX,
+      maxY,
+      w: maxX - minX + BOARD_PAD * 2,
+      h: maxY - minY + BOARD_PAD * 2
+    };
+  }
+
+  function sizeInner(inner) {
+    const bounds = boardBounds(inner);
+    inner.style.width = (bounds.maxX + BOARD_PAD) + 'px';
+    inner.style.height = (bounds.maxY + BOARD_PAD) + 'px';
+  }
+
+  function anchors(from, to) {
+    const fromCenter = { x: from.x + from.w / 2, y: from.y + from.h / 2 };
+    const toCenter = { x: to.x + to.w / 2, y: to.y + to.h / 2 };
+    const dx = toCenter.x - fromCenter.x;
+    const dy = toCenter.y - fromCenter.y;
+    let start, end, dir;
+
+    if (Math.abs(dx) >= Math.abs(dy)) {
+      dir = 'h';
+      if (dx >= 0) {
+        start = { x: from.x + from.w, y: fromCenter.y };
+        end = { x: to.x, y: toCenter.y };
+      } else {
+        start = { x: from.x, y: fromCenter.y };
+        end = { x: to.x + to.w, y: toCenter.y };
+      }
+    } else {
+      dir = 'v';
+      if (dy >= 0) {
+        start = { x: fromCenter.x, y: from.y + from.h };
+        end = { x: toCenter.x, y: to.y };
+      } else {
+        start = { x: fromCenter.x, y: from.y };
+        end = { x: toCenter.x, y: to.y + to.h };
+      }
+    }
+
+    return { start, end, dir };
+  }
+
+  function arrowPathData(anchor, bend) {
+    const k = 70;
+    let c1, c2;
+    if (anchor.dir === 'h') {
+      const sign = anchor.end.x >= anchor.start.x ? 1 : -1;
+      c1 = { x: anchor.start.x + sign * k, y: anchor.start.y + bend };
+      c2 = { x: anchor.end.x - sign * k, y: anchor.end.y + bend };
+    } else {
+      const sign = anchor.end.y >= anchor.start.y ? 1 : -1;
+      c1 = { x: anchor.start.x + bend, y: anchor.start.y + sign * k };
+      c2 = { x: anchor.end.x + bend, y: anchor.end.y - sign * k };
+    }
+    return `M${anchor.start.x},${anchor.start.y} C${c1.x},${c1.y} ${c2.x},${c2.y} ${anchor.end.x},${anchor.end.y}`;
+  }
+
+  function drawArrowLabel(group, spec, anchor) {
+    if (!spec.label) return;
+    const ns = 'http://www.w3.org/2000/svg';
+    const bendOffset = spec.bend * 0.6;
+    const mx = (anchor.start.x + anchor.end.x) / 2 + (anchor.dir === 'v' ? bendOffset : 0);
+    const my = (anchor.start.y + anchor.end.y) / 2 + (anchor.dir === 'h' ? bendOffset : 0);
+    const width = Math.max(34, spec.label.length * 13 + 18);
+
+    const rect = document.createElementNS(ns, 'rect');
+    rect.classList.add('flow-arrow-label-bg');
+    rect.setAttribute('x', mx - width / 2);
+    rect.setAttribute('y', my - 12);
+    rect.setAttribute('width', width);
+    rect.setAttribute('height', 22);
+    rect.setAttribute('rx', 11);
+    rect.setAttribute('fill', theme.labelBg);
+    rect.setAttribute('stroke', theme.labelBorder);
+
+    const text = document.createElementNS(ns, 'text');
+    text.classList.add('flow-arrow-label-text');
+    text.textContent = spec.label;
+    text.setAttribute('x', mx);
+    text.setAttribute('y', my + 4);
+    text.setAttribute('text-anchor', 'middle');
+    text.setAttribute('font-family', theme.font);
+    text.setAttribute('font-size', 13);
+    text.setAttribute('font-weight', 600);
+    text.setAttribute('fill', theme.chipText);
+
+    group.appendChild(rect);
+    group.appendChild(text);
+  }
+
+  function drawArrows(inner, specs, flowMode) {
+    const svg = inner.querySelector('svg.flow-arrows');
+    if (!svg) return;
+
+    const bounds = boardBounds(inner);
+    Object.assign(svg.style, {
+      position: 'absolute',
+      top: '0',
+      left: '0',
+      overflow: 'visible',
+      pointerEvents: 'none',
+      zIndex: '5'
+    });
+    svg.setAttribute('width', bounds.maxX + BOARD_PAD);
+    svg.setAttribute('height', bounds.maxY + BOARD_PAD);
+    svg.innerHTML =
+      '<defs><marker id="dcness-flow-arrow-head" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">' +
+      '<path d="M0,0 L10,5 L0,10 Z" fill="' + theme.arrow + '"/></marker></defs>';
+
+    const ns = 'http://www.w3.org/2000/svg';
+    specs.forEach(spec => {
+      const from = nodeBox(inner, spec.from, flowMode);
+      const to = nodeBox(inner, spec.to, flowMode);
+      if (!from || !to) return;
+
+      const anchor = anchors(from, to);
+      const group = document.createElementNS(ns, 'g');
+      group.classList.add('flow-arrow');
+      group.dataset.from = spec.from;
+      group.dataset.to = spec.to;
+      group.dataset.label = spec.label;
+      group.style.pointerEvents = 'auto';
+      group.style.cursor = 'pointer';
+
+      const path = document.createElementNS(ns, 'path');
+      path.setAttribute('d', arrowPathData(anchor, spec.bend));
+      path.setAttribute('stroke', theme.arrow);
+      path.setAttribute('stroke-width', '2.5');
+      path.setAttribute('fill', 'none');
+      path.setAttribute('marker-end', 'url(#dcness-flow-arrow-head)');
+      path.dataset.from = spec.from;
+      path.dataset.to = spec.to;
+      path.dataset.label = spec.label;
+      path.style.pointerEvents = 'stroke';
+
+      group.appendChild(path);
+      drawArrowLabel(group, spec, anchor);
+      group.addEventListener('click', event => {
+        event.stopPropagation();
+        focusEdge(inner, spec.from, spec.to);
+      });
+      svg.appendChild(group);
+    });
+  }
+
+  function selectableNodes(inner) {
+    const nodes = inner.querySelectorAll('.screen-node');
+    if (nodes.length) return Array.from(nodes);
+    return Array.from(inner.querySelectorAll('iframe[data-frame-id]'));
+  }
+
+  function nodeId(node) {
+    return node.dataset.nodeId || node.dataset.frameId;
+  }
+
+  function styleNodeFocus(node, on, dim) {
+    node.style.opacity = dim ? '0.45' : '1';
+    node.style.outline = on ? '3px solid ' + theme.arrow : 'none';
+    node.style.outlineOffset = '4px';
+    node.style.borderRadius = on ? '8px' : '';
+  }
+
+  function focusNode(inner, id) {
+    if (!id) return;
+    selectableNodes(inner).forEach(node => {
+      const connected = nodeId(node) === id;
+      styleNodeFocus(node, connected, !connected);
+    });
+    inner.querySelectorAll('g.flow-arrow').forEach(group => {
+      const on = group.dataset.from === id || group.dataset.to === id;
+      group.style.opacity = on ? '1' : '0.2';
+      const path = group.querySelector('path');
+      if (path) path.setAttribute('stroke-width', on ? '4' : '1.5');
+    });
+  }
+
+  function focusEdge(inner, fromId, toId) {
+    selectableNodes(inner).forEach(node => {
+      const id = nodeId(node);
+      const on = id === fromId || id === toId;
+      styleNodeFocus(node, on, !on);
+    });
+    inner.querySelectorAll('g.flow-arrow').forEach(group => {
+      const on = group.dataset.from === fromId && group.dataset.to === toId;
+      group.style.opacity = on ? '1' : '0.18';
+      const path = group.querySelector('path');
+      if (path) path.setAttribute('stroke-width', on ? '4' : '1.5');
+    });
+  }
+
+  function clearFocus(inner) {
+    selectableNodes(inner).forEach(node => styleNodeFocus(node, false, false));
+    inner.querySelectorAll('g.flow-arrow').forEach(group => {
+      group.style.opacity = '1';
+      const path = group.querySelector('path');
+      if (path) path.setAttribute('stroke-width', '2.5');
     });
   }
 
@@ -65,25 +518,39 @@
   }
 
   function setupPanZoom(stage, inner) {
-    let dragging = false, lastX = 0, lastY = 0;
-    stage.addEventListener('mousedown', (e) => {
-      if (e.target.closest('iframe')) return;
-      dragging = true; lastX = e.clientX; lastY = e.clientY;
+    let dragging = false, moved = false, lastX = 0, lastY = 0;
+    stage.addEventListener('mousedown', event => {
+      if (event.target.closest('iframe')) return;
+      dragging = true;
+      moved = false;
+      lastX = event.clientX;
+      lastY = event.clientY;
       stage.style.cursor = 'grabbing';
     });
-    window.addEventListener('mousemove', (e) => {
+    window.addEventListener('mousemove', event => {
       if (!dragging) return;
-      panX += e.clientX - lastX; panY += e.clientY - lastY;
-      lastX = e.clientX; lastY = e.clientY;
+      panX += event.clientX - lastX;
+      panY += event.clientY - lastY;
+      lastX = event.clientX;
+      lastY = event.clientY;
+      moved = true;
       applyTransform(inner);
     });
-    window.addEventListener('mouseup', () => { dragging = false; stage.style.cursor = ''; });
-    stage.addEventListener('wheel', (e) => {
-      e.preventDefault();
-      const delta = -e.deltaY * 0.001;
-      const next = Math.max(0.2, Math.min(2, zoom + delta));
+    window.addEventListener('mouseup', () => {
+      dragging = false;
+      stage.style.cursor = 'grab';
+    });
+    stage.addEventListener('click', event => {
+      if (!moved && !event.target.closest('.screen-node') && !event.target.closest('g.flow-arrow')) {
+        clearFocus(inner);
+      }
+    });
+    stage.addEventListener('wheel', event => {
+      event.preventDefault();
+      const next = Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, zoom - event.deltaY * 0.0012));
       const rect = stage.getBoundingClientRect();
-      const cx = e.clientX - rect.left, cy = e.clientY - rect.top;
+      const cx = event.clientX - rect.left;
+      const cy = event.clientY - rect.top;
       panX = cx - (cx - panX) * (next / zoom);
       panY = cy - (cy - panY) * (next / zoom);
       zoom = next;
@@ -91,45 +558,59 @@
     }, { passive: false });
   }
 
-  function drawArrows(inner) {
-    const svg = inner.querySelector('svg.flow-arrows');
-    if (!svg) return;
-    Object.assign(svg.style, { position: 'absolute', top: '0', left: '0', overflow: 'visible', pointerEvents: 'none' });
-    svg.setAttribute('width', '100%'); svg.setAttribute('height', '100%');
-    if (!svg.querySelector('defs')) {
-      svg.insertAdjacentHTML('afterbegin',
-        '<defs><marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 Z" fill="#6750A4"/></marker></defs>');
-    }
-    svg.querySelectorAll('path[data-from][data-to]').forEach(p => {
-      const from = inner.querySelector(`iframe[data-frame-id="${CSS.escape(p.dataset.from)}"]`);
-      const to = inner.querySelector(`iframe[data-frame-id="${CSS.escape(p.dataset.to)}"]`);
-      if (!from || !to) return;
-      const fx = from.offsetLeft + from.offsetWidth, fy = from.offsetTop + from.offsetHeight / 2;
-      const tx = to.offsetLeft, ty = to.offsetTop + to.offsetHeight / 2;
-      p.setAttribute('d', `M${fx},${fy} L${tx},${ty}`);
-      p.setAttribute('stroke', '#6750A4'); p.setAttribute('stroke-width', '2');
-      p.setAttribute('fill', 'none'); p.setAttribute('marker-end', 'url(#arrow)');
-    });
+  function zoomToFit(stage, inner) {
+    const items = boardItems(inner);
+    if (!items.length) return;
+    const bounds = boardBounds(inner);
+    const vw = stage.clientWidth;
+    const vh = stage.clientHeight;
+    zoom = Math.min(vw / bounds.w, vh / bounds.h, 1);
+    panX = (vw - bounds.w * zoom) / 2 - (bounds.minX - BOARD_PAD) * zoom;
+    panY = (vh - bounds.h * zoom) / 2 - (bounds.minY - BOARD_PAD) * zoom;
+    applyTransform(inner);
   }
 
   function setupShowIdsBroadcast(inner) {
     const observer = new MutationObserver(() => {
       const on = document.documentElement.classList.contains('dcness-show-ids');
-      inner.querySelectorAll('iframe').forEach(f => {
-        try { f.contentWindow.postMessage(on ? 'show-ids:on' : 'show-ids:off', '*'); } catch (_) {}
+      inner.querySelectorAll('iframe').forEach(frame => {
+        try { frame.contentWindow.postMessage(on ? 'show-ids:on' : 'show-ids:off', '*'); } catch (_) {}
       });
     });
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
   }
 
   function init() {
-    const inner = setupStage();
-    if (!inner) return;
-    layoutFrames(inner);
-    drawArrows(inner);
-    setupPanZoom(document.querySelector('.canvas'), inner);
+    readTheme();
+    const context = setupStage();
+    if (!context) return;
+
+    const { stage, inner } = context;
+    const specs = readArrowSpecs(inner);
+    const flowMode = inner.querySelectorAll('.screen-node').length > 0;
+
+    if (flowMode) layoutScreenNodes(inner);
+    else layoutFrames(inner);
+
+    sizeInner(inner);
+    drawArrows(inner, specs, flowMode);
+    setupPanZoom(stage, inner);
     setupShowIdsBroadcast(inner);
     applyTransform(inner);
+
+    if (flowMode) {
+      setTimeout(() => {
+        sizeInner(inner);
+        drawArrows(inner, specs, flowMode);
+        zoomToFit(stage, inner);
+      }, 350);
+      window.addEventListener('load', () => {
+        sizeInner(inner);
+        drawArrows(inner, specs, flowMode);
+        zoomToFit(stage, inner);
+      });
+      window.addEventListener('resize', () => zoomToFit(stage, inner));
+    }
   }
 
   if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', init);

--- a/templates/design-variants/canvas.html
+++ b/templates/design-variants/canvas.html
@@ -17,9 +17,15 @@
        사용자가 위치 명시 요청 시만 data-pos="<col>,<row>" 박음.
     2. viewport 다른 frame:
          <iframe data-frame-id="..." data-viewport="desktop" src="..."></iframe>
-    3. 화살표는 optional — 사용자 명시 요청 시만 추가:
+    3. Figma형 플로우 보드가 필요하면 screen-node 로 2D 배치 + 캡션을 선언한다:
+         <div class="screen-node" data-node-id="<screen-id>" data-pos="<col>,<row>"
+              data-title="화면 제목" data-desc="화면 설명" data-states="기본 / 빈 / 로딩"
+              data-h="900">
+           <iframe src="<screen-id>.html"></iframe>
+         </div>
+    4. 화살표는 optional — 사용자 명시 요청 시만 추가:
          <svg class="flow-arrows">
-           <path data-from="login" data-to="payment-confirm" data-label="로그인 후"/>
+           <path data-from="login" data-to="payment-confirm" data-label="로그인 후" data-bend="0"/>
          </svg>
   -->
   <div class="canvas">

--- a/tests/test_canvas_design_workflow.py
+++ b/tests/test_canvas_design_workflow.py
@@ -355,6 +355,39 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
         self.assertNotIn('src="<screen-id>-v<N>.html"', canvas)
         self.assertIn("../_lib/show-ids.js", html_variant)
 
+    def test_canvas_seed_supports_flow_board_screen_nodes(self) -> None:
+        canvas_html = (
+            ROOT / "templates" / "design-variants" / "canvas.html"
+        ).read_text(encoding="utf-8")
+        canvas_js = (
+            ROOT / "templates" / "design-variants" / "_lib" / "canvas.js"
+        ).read_text(encoding="utf-8")
+
+        for needle in (
+            'class="screen-node"',
+            'data-node-id="<screen-id>"',
+            'data-title="',
+            'data-desc="',
+            'data-states="',
+            'data-h="',
+        ):
+            with self.subTest(template=needle):
+                self.assertIn(needle, canvas_html)
+
+        for needle in (
+            "querySelectorAll('.screen-node')",
+            "dataset.nodeId",
+            "dataset.h",
+            "node-caption",
+            "dataset.label",
+            "data-label",
+            "data-bend",
+            "zoomToFit",
+            "focusNode",
+        ):
+            with self.subTest(renderer=needle):
+                self.assertIn(needle, canvas_js)
+
     def _array(self, text: str, key: str) -> list[str]:
         match = re.search(rf"{key}:\s*\[([^\]]*)\]", text)
         self.assertIsNotNone(match)


### PR DESCRIPTION
## 관련 이슈 번호
Closes #960

## 배경 및 문제
기존 design-variants canvas seed 는 iframe auto-layout 과 단순 선 화살표만 지원해, 화면 플로우를 이해관계자에게 공유할 때 라벨·캡션·상태·긴 목업 높이·초기 fit-to-view 를 표현하지 못했다.

## 원인 (해당 시)
기존 renderer 가 iframe[data-frame-id] grid 만 기준으로 위치를 계산했고, flow-arrows path 의 data-label/data-bend 와 화면별 metadata 를 읽는 별도 선언 계약이 없었다.

## 작업내용
- templates/design-variants/_lib/canvas.js: .screen-node 플로우 보드 모드 추가, 캡션 카드/상태 chip 렌더링, data-h 노드별 iframe 높이, 곡선 화살표와 라벨 pill, 초기 fit-to-view, 노드/화살표 focus 강조 추가
- templates/design-variants/canvas.html: .screen-node 선언 예시와 data-bend 화살표 예시 추가
- docs/plugin/design.md, skills/canvas-design/SKILL.md: iframe fallback 과 screen-node 플로우 보드 계약 문서화
- tests/test_canvas_design_workflow.py: seed 계약 회귀 테스트 추가

## 결정 근거
- .screen-node 가 존재할 때만 플로우 보드 모드로 전환해 기존 iframe grid seed 와 공존시켰다.
- 색상/폰트는 --dcness-canvas-* CSS custom property fallback 으로 분리해 활성 프로젝트가 자체 토큰으로 override 할 수 있게 했다.
- /init-dcness copy inventory 는 이미 templates/design-variants/_lib/canvas.js 와 canvas.html 을 배포하므로, 새 공개 surface 나 새 deploy step 없이 기존 seed 경로를 갱신했다.

## 배포 경로 검증 (plug-in 영향 시)
- 경로 1: templates/design-variants/_lib/canvas.js, templates/design-variants/canvas.html 변경은 plugin 본체 seed 에 포함된다.
- 경로 2: commands/init-dcness.md 의 design seed loop 가 이미 _lib/canvas.js 와 canvas.html 을 docs/design-variants/ 로 복사하므로 신규 활성 프로젝트는 갱신된 seed 를 받는다.
- 기존 활성 프로젝트는 기존 파일을 덮어쓰지 않는 정책상 plugin update 만으로 로컬 docs/design-variants/_lib/canvas.js 가 자동 교체되지는 않는다. 필요 시 갱신된 template 파일을 해당 프로젝트 docs/design-variants/ 로 복사해야 한다.
- 경로 3: docs/plugin/design.md 와 skills/canvas-design/SKILL.md 에 사용자-facing 계약을 반영했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public skill/command/agent/gate 없음.

## Test Plan
- [x] node --check templates/design-variants/_lib/canvas.js
- [x] python3.11 -m unittest tests.test_canvas_design_workflow -v < /dev/null
- [x] node scripts/check_cross_refs.mjs
- [x] python3.11 -m unittest discover -s tests -v < /dev/null (1705 tests)
- [x] git pre-commit hook: pytest-gate PASS, git-naming PASS
- [x] Playwright CLI smoke: 임시 flow-board fixture 에서 svg.flow-arrows g.flow-arrow text selector 대기 + screenshot 렌더 확인

## 참고
- 브라우저 smoke screenshot 산출물은 /tmp/dcness-960-flow-board-smoke.png 로 확인했고, repo 커밋 대상에는 포함하지 않았다.