### PR TITLE
[docs] 모듈 CLAUDE 문서 추가

### DIFF
--- a/harness/CLAUDE.md
+++ b/harness/CLAUDE.md
@@ -1,0 +1,49 @@
+# harness 모듈 안내
+
+전역 작업 규칙은 [../CLAUDE.md](../CLAUDE.md)가 진본이다. 이 파일은 `harness/` 안에서
+어디를 먼저 볼지 좁혀 주는 컴퍼스다.
+
+## 소유 범위
+
+- Claude Code hook 핸들러, run/session 상태, file boundary, agent routing, validation prose
+  I/O를 담당하는 플러그인 런타임 코드.
+- 외부 활성 프로젝트에서 실제로 실행되는 보호 장치이므로 dcness self 에서 통과해도 사용자
+  프로젝트에서의 경로와 상태 파일을 같이 생각해야 한다.
+- 비용/효율 측정, guard telemetry, parallel wave, merge lock 같은 운영 보조 상태도 이 모듈에
+  모여 있다.
+
+## 먼저 볼 파일
+
+- [hooks.py](hooks.py): SessionStart, PreToolUse, PostToolUse, Stop 계열 hook 진입점.
+- [session_state.py](session_state.py)와 [session_state_cli.py](session_state_cli.py):
+  harness-state의 session/run/live 상태 진본.
+- [agent_boundary.py](agent_boundary.py): sub-agent Read/Write/Bash/MCP mutation 경계.
+- [signal_io.py](signal_io.py): validator/reviewer 결과 prose 파일 I/O.
+- [agent_routing.py](agent_routing.py), [agent_names.py](agent_names.py): agent 명칭 정규화와
+  provider/routing 판정.
+- [merge_lock.py](merge_lock.py), [parallel_wave.py](parallel_wave.py),
+  [wave_board.py](wave_board.py): 병렬 작업과 merge 순서 보호.
+- [context_docs.py](context_docs.py): 활성 프로젝트 `CLAUDE.md` seed, migration, audit helper.
+- [efficiency/](efficiency/): 세션 비용과 반복 패턴 분석 도구.
+
+## 수정 시 주의점
+
+- hook 계열은 기본적으로 fail-open이다. 명시적 catastrophic 위반만 block 하고, payload 파싱 실패나
+  상태 파일 손상은 사용자 작업을 멈추지 않게 처리한다.
+- harness-state 파일은 runtime interface다. schema를 바꾸면 기존 run/state를 읽는
+  경로와 cleanup 경로를 같이 본다.
+- `signal_io.py`는 prose 중심 I/O만 맡는다. marker line, status JSON, schema 강제 패턴을 되살리지
+  않는다.
+- boundary/routing 변경은 외부 활성 프로젝트의 작업 가능 영역을 바꾼다. 관련 agent 문서,
+  `docs/plugin/**`, 테스트가 같이 맞는지 확인한다.
+- subprocess probe는 shell 없이 argv와 timeout을 우선 사용한다. hook에서 hang 나면 전체 UX가
+  느려진다.
+
+## 검증
+
+- 좁은 변경은 대응 테스트를 먼저 고른다. 예: boundary는 [../tests/test_agent_boundary.py](../tests/test_agent_boundary.py),
+  hook은 [../tests/test_hooks.py](../tests/test_hooks.py), context docs는
+  [../tests/test_context_docs.py](../tests/test_context_docs.py).
+- 범위가 불명확하면 `python3.11 -m unittest discover -s tests -v < /dev/null`로 전체 unit suite를
+  돌린다.
+- 보안성 있는 경계, subprocess, 파일 권한 변경은 static-quality gate까지 확인한다.

--- a/scripts/CLAUDE.md
+++ b/scripts/CLAUDE.md
@@ -1,0 +1,44 @@
+# scripts 모듈 안내
+
+전역 작업 규칙은 [../CLAUDE.md](../CLAUDE.md)가 진본이다. 이 파일은 `scripts/`에서 gate,
+helper, 배포용 wrapper를 고칠 때의 컴퍼스다.
+
+## 소유 범위
+
+- dcness self와 외부 활성 프로젝트가 호출하는 로컬/CI gate, PR helper, GitHub helper, wrapper.
+- `commands/init-dcness.md`가 사용자 프로젝트로 복사하거나 안내하는 스크립트와 workflow template의
+  실행 진입점.
+- shell, Node.js, Python 스크립트가 섞여 있으므로 shebang과 런타임 의존성이 곧 계약이다.
+
+## 먼저 볼 파일
+
+- [hooks/](hooks/): git hook shim과 Claude Code pre-commit gate.
+- [check_git_naming.mjs](check_git_naming.mjs), [check_pr_body.mjs](check_pr_body.mjs),
+  [check_public_surface.mjs](check_public_surface.mjs), [check_cross_refs.mjs](check_cross_refs.mjs):
+  CI와 local gate의 핵심 checker.
+- [check_python_tests.sh](check_python_tests.sh), [check_static_quality.sh](check_static_quality.sh):
+  Python test/static-quality 실행 wrapper.
+- [pr-create.sh](pr-create.sh), [pr-finalize.sh](pr-finalize.sh), [pr-trailer.sh](pr-trailer.sh):
+  PR 생성/마감/trailer 보조 흐름.
+- [dcness-helper](dcness-helper), [dcness-context-docs](dcness-context-docs),
+  [dcness-codex-validator](dcness-codex-validator), [dcness-codex-worker](dcness-codex-worker):
+  사용자-facing CLI wrapper.
+- [lib/](../scripts/lib/): 여러 Node checker가 공유하는 helper.
+
+## 수정 시 주의점
+
+- `sh` shebang 파일은 POSIX shell 기준으로 유지한다. Bash 기능이 필요하면 shebang과 호출 문서를 같이 본다.
+- Node checker는 외부 패키지 없이 동작하는 경로가 기본이다. CI clean checkout에서도 같은 결과가 나야 한다.
+- stdout/stderr 문구는 테스트와 사용자 디버깅 경로가 소비할 수 있다. 실패 메시지를 바꾸면 관련 테스트도
+  의미 기준으로 갱신한다.
+- 외부 프로젝트로 복사되는 workflow/script contract를 바꾸면 [../commands/init-dcness.md](../commands/init-dcness.md)와
+  [../docs/plugin/init-dcness.md](../docs/plugin/init-dcness.md)의 inventory가 맞는지 확인한다.
+- git/gh 명령은 가능하면 non-interactive로 두고, destructive 동작은 helper의 기존 guard 흐름을 따른다.
+
+## 검증
+
+- Node checker: `node scripts/check_cross_refs.mjs`처럼 해당 checker를 직접 실행한다.
+- Shell wrapper: `bash -n scripts/pr-finalize.sh` 또는 shebang에 맞는 syntax check를 먼저 돌린다.
+- Python gate 영향: `python3.11 -m unittest discover -s tests -v < /dev/null`.
+- static-quality 관련 변경은 `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
+  형태로 venv Python을 명시해 재현한다.

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -1,0 +1,41 @@
+# templates 모듈 안내
+
+전역 작업 규칙은 [../CLAUDE.md](../CLAUDE.md)가 진본이다. 이 파일은 `templates/` 안의 배포
+seed와 workflow snippet을 고칠 때의 컴퍼스이며, 그 자체가 외부 활성 프로젝트의 공개 계약은 아니다.
+
+## 소유 범위
+
+- `/init-dcness`가 사용자 프로젝트로 복사할 수 있는 GitHub workflow snippet.
+- `/design` 계열에서 사용하는 design variant canvas seed.
+- 템플릿은 dcness self 안의 파일이지만, 내용은 사용자 프로젝트에서 실행되거나 편집될 수 있다.
+
+## 먼저 볼 파일
+
+- [github-workflows/](github-workflows/): git naming, PR body, doc path, doc sync, GitHub Project
+  lifecycle workflow snippets.
+- [design-variants/canvas.html](../templates/design-variants/canvas.html): design variant static HTML seed.
+- [design-variants/_lib/canvas.js](../templates/design-variants/_lib/canvas.js)와
+  [design-variants/_lib/show-ids.js](../templates/design-variants/_lib/show-ids.js): canvas 동작 helper.
+- [design-variants/drafts/.gitkeep](../templates/design-variants/drafts/.gitkeep): draft directory seed 유지 파일.
+- [../commands/init-dcness.md](../commands/init-dcness.md): workflow template 복사와 사용자 프로젝트 배포 흐름.
+- [../tests/test_canvas_design_workflow.py](../tests/test_canvas_design_workflow.py),
+  [../tests/test_doc_path_integrity.py](../tests/test_doc_path_integrity.py),
+  [../tests/test_index_map_aggregate.py](../tests/test_index_map_aggregate.py): 주요 회귀 테스트.
+
+## 수정 시 주의점
+
+- workflow template은 사용자 repo의 `.github/workflows/`로 복사된다. dcness self 전용 경로나 개인 환경
+  가정을 넣지 않는다.
+- workflow가 호출하는 action/script 경로, checkout pin, repo owner 표기는 관련 테스트가 계약으로 본다.
+- design variant seed는 사람이 바로 열어보고 편집하는 시작점이다. 생성된 draft 산출물과 seed 파일을 섞지
+  않는다.
+- 새 template을 추가하면 `/init-dcness` copy step, 문서 inventory, 테스트 fixture 중 누락된 경로가 없는지
+  같이 확인한다.
+- 외부 배포 영역에 내부 추적 ID나 dcness self만 아는 표현을 노출하지 않는다.
+
+## 검증
+
+- workflow template 변경: `python3.11 -m unittest tests.test_doc_path_integrity tests.test_index_map_aggregate -v < /dev/null`.
+- design variant 변경: `python3.11 -m unittest tests.test_canvas_design_workflow -v < /dev/null`.
+- 문서/링크 영향: `node scripts/check_cross_refs.mjs`.
+- 범위가 섞이면 전체 suite `python3.11 -m unittest discover -s tests -v < /dev/null`를 돌린다.

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,0 +1,44 @@
+# tests 모듈 안내
+
+전역 작업 규칙은 [../CLAUDE.md](../CLAUDE.md)가 진본이다. 이 파일은 `tests/`에서 어떤
+회귀 테스트를 먼저 볼지 좁혀 주는 컴퍼스다.
+
+## 소유 범위
+
+- Python `unittest` 기반 회귀 suite.
+- `harness/`, `scripts/`, `templates/`, `agents/`, `skills/`, `docs/plugin/`의 공개 계약과
+  guard 동작을 검증하는 테스트가 함께 있다.
+- 테스트는 제품 계약을 고정해야 하며, 현재 구현의 우연한 출력 형식을 과하게 고정하지 않는다.
+
+## 먼저 볼 파일
+
+- [test_hooks.py](test_hooks.py), [test_tdd_guard.py](test_tdd_guard.py),
+  [test_generated_tdd_hooks.py](test_generated_tdd_hooks.py): hook과 TDD guard.
+- [test_agent_boundary.py](test_agent_boundary.py), [test_agent_routing.py](test_agent_routing.py):
+  agent 권한 경계와 routing 판정.
+- [test_signal_io.py](test_signal_io.py), [test_run_review.py](test_run_review.py),
+  [test_sub_eval.py](test_sub_eval.py): prose 결과, run review, validator helper.
+- [test_git_naming.py](test_git_naming.py), [test_pr_body.py](test_pr_body.py),
+  [test_pr_trailer.py](test_pr_trailer.py), [test_pr_finalize_integration.py](test_pr_finalize_integration.py):
+  git/PR lifecycle 계약.
+- [test_doc_path_integrity.py](test_doc_path_integrity.py), [test_index_map_aggregate.py](test_index_map_aggregate.py),
+  [test_design_artifact_audit.py](test_design_artifact_audit.py): 문서/템플릿 gate.
+- [test_canvas_design_workflow.py](test_canvas_design_workflow.py): design variant 템플릿과 canvas workflow.
+- [test_public_surface.py](test_public_surface.py), [test_surface_docs_sync.py](test_surface_docs_sync.py):
+  public surface와 문서 동기화.
+
+## 수정 시 주의점
+
+- 테스트 fixture는 가능한 한 `TemporaryDirectory` 안에서 만들고 repo 상태나 네트워크에 의존하지 않는다.
+- stdin을 읽는 코드 경로가 있으면 전체 suite 실행 시 hang 나지 않도록 `< /dev/null` 재현을 염두에 둔다.
+- 실패한 테스트의 기대값만 바꾸기 전에 제품 계약이 바뀐 것인지, 구현 회귀인지 먼저 분리한다.
+- shell/node script 테스트는 실제 CLI 호출과 stderr/stdout을 같이 본다. 사용자에게 보이는 실패 메시지는
+  계약의 일부일 수 있다.
+- 시간, PID, git 상태, GitHub CLI를 다루는 테스트는 deterministic fixture와 timeout을 둔다.
+
+## 검증
+
+- 단일 파일: `python3.11 -m unittest tests.test_context_docs -v < /dev/null`처럼 모듈명을 지정한다.
+- 전체 suite: `python3.11 -m unittest discover -s tests -v < /dev/null`.
+- `templates/github-workflows/`, audited script, `harness/` 변경은 pre-commit hook이 전체 unit suite를
+  실행할 수 있다.


### PR DESCRIPTION
## 관련 이슈 번호
Closes #998

## 배경 및 문제
- AI-readiness 감사에서 harness/tests/scripts/templates 모듈의 국소 navigation 문서가 없어, 모듈 단위 작업 시 root CLAUDE.md 전체에 의존하는 상태였다.
- 이슈 #998의 acceptance는 4개 핵심 모듈 루트에 간결한 컴퍼스형 CLAUDE.md를 추가하는 것이다.

## 원인 (해당 시)
- evals만 README.md를 통해 모듈 국소 컨텍스트를 제공했고, harness/tests/scripts/templates에는 소유 범위와 주요 진입점을 좁혀 주는 문서가 없었다.

## 작업내용
- `harness/CLAUDE.md` 추가: hook/runtime state/file boundary/prose I/O 중심 navigation 정리.
- `tests/CLAUDE.md` 추가: unit suite의 주요 테스트 축과 fixture 주의점 정리.
- `scripts/CLAUDE.md` 추가: gate/helper/wrapper와 배포 관련 스크립트 navigation 정리.
- `templates/CLAUDE.md` 추가: workflow/design variant template의 배포 성격과 검증 경로 정리.

## 결정 근거
- root CLAUDE.md 재작성은 이슈 out-of-scope라 변경하지 않았다.
- 새 문서는 작업 규칙을 재기술하지 않고 root CLAUDE.md를 참조한 뒤, 모듈별 소유 범위/핵심 파일/수정 주의점/검증 경로만 짧게 제공했다.
- 문서-only 변경이라 별도 실패 테스트 추가 대신 기존 문서 gate와 전체 unit suite로 회귀를 확인했다.

## 배포 경로 검증 (plug-in 영향 시)
N/A — dcness self 내부 module navigation 문서다. 외부 활성 프로젝트로 복사되는 공개 계약, `/init-dcness` 배포 inventory, public skill/command/agent/gate 변경은 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public surface 없음.

## Test Plan
- [x] `git diff --cached --check`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_doc_path_integrity.mjs --root . --docs "harness/CLAUDE.md,tests/CLAUDE.md,scripts/CLAUDE.md,templates/CLAUDE.md"`
- [x] `python3.11 -m unittest tests.test_context_docs tests.test_doc_path_integrity tests.test_canvas_design_workflow -v`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] pre-commit hook: pytest gate PASS

## 참고
- TDD skip 사유: 문서-only navigation 추가이며, acceptance는 기존 문서 gate와 파일 존재/diff 검토로 검증 가능하다.
