### PR TITLE
[issue-1002] build-worker 위험 self-check 보강

### DIFF
--- a/docs/plugin/agents/build-worker/build-worker-agent.md
+++ b/docs/plugin/agents/build-worker/build-worker-agent.md
@@ -49,7 +49,7 @@
 
 ## 고위험 task self-check
 
-외부 HTTP/네트워크 어댑터, URL·파일·사용자 입력 같은 신뢰 경계 밖 입력 파싱, 인증/보안, PII, decision 합의 없는 도메인 invariant 변경은 build-worker self-grading drift가 가장 잘 나는 영역이다. 이런 task를 맡은 경우:
+외부 HTTP/네트워크 어댑터, URL·파일·사용자 입력 같은 신뢰 경계 밖 입력 파싱, 인증/보안, PII, 도메인 invariant 변경은 build-worker self-grading drift가 가장 잘 나는 영역이다. 이 self-check 는 엔진 승격 기준과 별개이며, decision 으로 합의된 invariant 구현에도 적용된다. 이런 task를 맡은 경우:
 
 - SSRF, path traversal, placeholder attribution, 실패를 성공처럼 반환하는 계약 위반을 테스트에 포함한다.
 - 외부 데이터가 누락되거나 실패했을 때 도메인 모델을 날조하지 않는다.

--- a/tests/test_impl_cost_aware.py
+++ b/tests/test_impl_cost_aware.py
@@ -40,6 +40,12 @@ def read_workflow_router() -> str:
     return (ROOT / "docs" / "plugin" / "workflow-router.md").read_text(encoding="utf-8")
 
 
+def read_build_worker() -> str:
+    return (
+        ROOT / "docs" / "plugin" / "agents" / "build-worker" / "build-worker-agent.md"
+    ).read_text(encoding="utf-8")
+
+
 class TestPreReadCostAware(unittest.TestCase):
     """#436 — 사전 read 의무가 cost-aware 룰 명시."""
 
@@ -177,10 +183,32 @@ class TestImplLoopRiskPreview(unittest.TestCase):
                 self.assertIn("플랫폼 SDK 표준 사용", body)
                 self.assertIn("런타임 권한 요청", body)
                 self.assertIn("decision 으로 이미 합의", body)
+                for trigger in (
+                    "migration",
+                    "destructive",
+                    "auth",
+                    "security",
+                    "PII",
+                    "compliance",
+                    "public API breakage",
+                    "외부 HTTP",
+                    "네트워크 어댑터",
+                    "신뢰 경계 밖 입력 파싱",
+                    "신규 3rd-party",
+                    "외부 서비스",
+                ):
+                    self.assertIn(trigger, body)
 
         self.assertIn("high-risk trigger 표는 설계 선행 판정 전용", router)
         self.assertIn("impl-task 엔진 판정", router)
         self.assertIn("module-architect", router)
+
+    def test_build_worker_self_check_keeps_invariant_drift_warning(self):
+        body = read_build_worker()
+        self.assertIn("도메인 invariant 변경은 build-worker self-grading drift", body)
+        self.assertIn("엔진 승격 기준과 별개", body)
+        self.assertIn("decision 으로 합의된 invariant 구현에도 적용", body)
+        self.assertNotIn("decision 합의 없는 도메인 invariant 변경은", body)
 
     def test_engine_risk_examples_match_issue_acceptance(self):
         module_architect = read_module_architect()


### PR DESCRIPTION
## 관련 이슈 번호

Part of #1002

## 배경 및 문제

- #1004 머지 후 minor 리뷰에서 build-worker self-check 가 엔진 승격 기준과 섞여 decision 합의된 invariant 구현의 drift 주의가 약해진 점이 확인됐다.
- 같은 리뷰에서 엔진 위험 기준 회귀 테스트가 제외 목록은 검증하지만 유지 목록은 5개 문서 동기화 대상으로 검증하지 않는 비대칭이 확인됐다.

## 원인 (해당 시)

- build-worker self-check 문구가 4agent 승격 기준의 decision 합의 예외를 그대로 가져와, self-grading drift 주의 목적과 섞였다.
- 테스트가 구현 시점 위험 기준의 제외 항목 위주로만 assert 해 kept trigger 누락을 잡지 못했다.

## 작업내용

- build-worker 고위험 task self-check 에서 도메인 invariant 변경을 decision 합의 여부와 무관한 drift-prone 영역으로 복원했다.
- self-check 가 엔진 승격 기준과 별개이며 decision 합의된 invariant 구현에도 적용됨을 명시했다.
- `tests/test_impl_cost_aware.py`가 kept trigger 목록까지 5개 기준 문서에서 검증하도록 보강했다.
- build-worker self-check의 invariant drift 경고가 다시 좁아지지 않도록 회귀 테스트를 추가했다.

## 결정 근거

- 엔진 승격 기준은 설계 소화 여부를 반영하지만, build-worker self-check 는 구현 중 self-grading drift 방지가 목적이라 decision 합의 여부와 직교한다.
- 기준 목록을 여러 agent/skill 문서에 inline 복제하는 현재 구조에서는 kept/excluded 양쪽 목록을 테스트로 동시에 방어하는 편이 실질적인 drift 방지책이다.

## 배포 경로 검증 (plug-in 영향 시)

- PASS — `docs/plugin/agents/build-worker/build-worker-agent.md` 와 기준 동기화 테스트를 함께 변경했고, cross-ref/public-surface/index-map 게이트를 통과했다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_impl_cost_aware -v < /dev/null`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] pre-commit hook: `pytest-gate` 1725 tests PASS + `git-naming` PASS

## 참고

- 후속 리뷰 minor 보강
