### PR TITLE
[issue-1008] init 추천 라우팅 역할 분리

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -12,7 +12,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - 사용자 발화: "init-dcness", "dcness 활성화", "/init-dcness", "이 프로젝트에 dcness 켜"
 - 새 프로젝트에 dcness plugin 사용 시작 시
 - 비활성 -> 활성 전환 시
-- project-local bootstrap 파일이나 Codex 분기 opt-in 을 새로 설치/갱신할 때
+- project-local bootstrap 파일이나 provider routing preset 을 새로 설치/갱신할 때
 
 ## 실행 원칙
 
@@ -24,7 +24,6 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - Project lifecycle SSOT: [`docs/plugin/github-project.md`](../docs/plugin/github-project.md)
 
 멱등 기준:
-
 - whitelist 활성화: 중복 제거.
 - `~/.claude/settings.json` Read 권한: 없을 때만 추가.
 - `.git/hooks/*`: thin shim always-overwrite.
@@ -32,7 +31,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 - `.github/workflows/*.yml`: 사용자가 선택한 경우 always-overwrite.
 - `docs/*`, `docs/design-variants/*`: 부재 시만 seed. 단 기존 `docs/index.md` 의 `## 진행 상태 · 다음 작업` 섹션은 없을 때만 append.
 - Codex validator skills: `$CODEX_HOME/skills/dcness-*` always-overwrite. Validator wrapper 는 활성 plugin 원본을 우선 주입하고, 이 복사본은 native Codex skill 등록과 fallback 용도다.
-- Codex provider routing: core 에서는 상태만 확인하고, 선택형 확장에서 validation opt-in 과 implementation 기본값을 갱신.
+- Codex provider routing: core 에서는 상태만 확인하고, 선택형 확장에서 추천 role-split preset 또는 custom provider 조합을 갱신.
 - TDD Guard: dcNess 가 **TDD 계약 + self-test** 를 소유한다. 프로젝트가 비어 있지 않으면 플랫폼 감지 또는 사람 승인된 `.dcness/tdd-hooks.json` 계약(`source_roots`, `impl_exts`, custom 플랫폼의 `test_candidate_templates`, 선택 `test_file_globs`)을 기준으로 project-local CC/Codex hook 생성을 제안하고, 생성 후보는 self-test 통과 전에는 등록하지 않는다. 생성 훅이 없으면 중앙 plug-in hook 이 안전 fallback 으로 동작한다.
 
 ## 공통 변수
@@ -66,7 +65,7 @@ core activation 의 성공 기준은 whitelist, Read 권한, git hook shim, runt
 - `git hook shim 3종` FAIL → Core Step 4.
 - `Codex validator skills` FAIL → Core Step 5 재실행.
 - `CLAUDE.md` 부재 또는 cold-start 앵커 부재 → Core Step 6.
-- `Provider routing` 은 INFO 로 상태만 확인한다. validation 이 이미 enabled 면 다시 쓰지 않고, implementation 은 custom 선택 때만 명시 변경한다.
+- `Provider routing` 은 INFO 로 상태만 확인한다. 추천 role-split preset 은 선택형 확장에서만 적용하고, custom 선택 때 기존 all-codex/Claude-only 조합을 명시 변경한다.
 - `Generated TDD hooks` 는 INFO/WARN 이다. 빈 프로젝트는 skip 하고, 미생성 non-empty 프로젝트는 아래 Core Step 7.5 의 역제안으로 처리한다.
 - `선택형 CI workflow` 는 INFO 다. core activation 성공/실패 판정에 넣지 않는다.
 
@@ -121,9 +120,9 @@ touch "$PROJECT_ROOT/.gitignore"
 grep -qxF '.claude/harness-state/' "$PROJECT_ROOT/.gitignore" || { printf '%s\n' '.claude/harness-state/' >> "$PROJECT_ROOT/.gitignore"; echo "[dcness] .gitignore 에 .claude/harness-state/ 추가"; }
 ```
 
-### Core Step 5 - Codex skill 배포와 routing 상태 확인
+### Core Step 5 - Codex skill 배포와 provider routing 상태 확인
 
-`code-validator` / `architecture-validator` / `pr-reviewer` 는 Codex read-only 실행으로 보낼 수 있다. `test-engineer` / `engineer` / `build-worker` 는 headless-chain implementation 실행으로 보낼 수 있다. 사용자 repo 에 provider config 를 만들지 않는다. Validator wrapper 는 wrapper parent 의 `codex/skills/dcness-*` 원본을 먼저 prompt 에 주입하고, 필요하면 `CLAUDE_PLUGIN_ROOT` 를 plugin root fallback 으로 확인한다. `$CODEX_HOME/skills` 배포본이 원본과 다르면 stale copy 로 보고 무시하며, plugin 원본을 찾을 수 없을 때만 배포본으로 fallback 한다.
+`code-validator` / `architecture-validator` / `pr-reviewer` 는 Codex read-only 또는 Claude 검증 실행으로 보낼 수 있다. `test-engineer` / `engineer` / `build-worker` 는 Claude 또는 headless-chain implementation 실행으로 보낼 수 있다. 사용자 repo 에 provider config 를 만들지 않는다. Validator wrapper 는 wrapper parent 의 `codex/skills/dcness-*` 원본을 먼저 prompt 에 주입하고, 필요하면 `CLAUDE_PLUGIN_ROOT` 를 plugin root fallback 으로 확인한다. `$CODEX_HOME/skills` 배포본이 원본과 다르면 stale copy 로 보고 무시하며, plugin 원본을 찾을 수 없을 때만 배포본으로 fallback 한다.
 
 ```bash
 CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
@@ -135,7 +134,7 @@ for DIR in dcness-code-validator dcness-architecture-validator dcness-pr-reviewe
 done
 ```
 
-이미 Codex validation routing 이 enabled 면 질문하지 않고 현재 값을 유지한다. implementation routing 은 미설정 기본값이 `headless-chain` 이며, Claude-only 사용자는 core completion 뒤 선택형 확장 custom 경로에서 `claude` 로 바꾼다.
+Core activation 은 routing 을 쓰지 않고 상태만 보여준다. 추천 bundle 의 role-split preset 은 `engineer/build-worker=headless-chain`, `test-engineer/code-validator/pr-reviewer=claude`, `architecture-validator=codex` 이며, core completion 뒤 선택형 확장에서 `enable-role-split-routing` 으로만 적용한다.
 
 ```bash
 "$HELPER" routing status
@@ -229,8 +228,8 @@ core activation 완료 뒤에만 진행한다. 기본 경로에서 선택형 항
 - `.gitignore` 에 `.dcness-work/` 가 없으면 추천 ON. `.claude/harness-state/` 는 core activation 에서 이미 보장한다.
 - UI 흔적이 있어도 `docs/design-variants/` 는 기본 skip. 특히 단일 `app/page.tsx` 정도만으로 design kit 를 설치하지 않는다.
 - GitHub Project lifecycle 은 기본 skip. `gh` 인증, Project number, PAT/secrets, field/label 복구가 얽히므로 custom 에서만 진행한다.
-- Codex validation routing 이 이미 enabled 면 skip. disabled/미설정이면 추천 bundle 에서 enable 대상으로 표시하고, custom 에서는 명시 선택으로 다룬다.
-- Implementation routing 이 명시 `claude` 가 아니면 추천 bundle 에서 `headless-chain` 유지 대상으로 표시한다. custom 에서는 `headless-chain` / `codex-first` / `claude-headless` / `claude` 중 하나를 명시 선택한다.
+- Provider routing 추천 bundle 은 `enable-role-split-routing` 단일 entrypoint 로 역할 분리 preset 을 적용한다: `engineer/build-worker=headless-chain`, `test-engineer/code-validator/pr-reviewer=claude`, `architecture-validator=codex`. 기존 활성 프로젝트가 추천 preset 만 소급 적용하려면 `"$HELPER" routing enable-role-split-routing` 뒤 `"$HELPER" routing doctor` 로 PASS 를 확인한다.
+- custom 에서는 기존 선택지를 유지한다: all-codex validation 은 `enable-codex-validation`, legacy Codex-first implementation 은 `enable-codex-implementation`, Claude-only implementation 은 `disable-codex-implementation`.
 - workflow 변경 PR 은 GitHub remote 가 있고, `gh auth status` 가 통과하고, `.github/workflows/*.yml` 변경이 있고, 현재 branch 가 `main` 이면 추천 ON. Y 선택 시 별도 질문 없이 branch 생성, workflow 파일만 stage, commit, push, PR 생성까지 진행한다. `gh` 미설치/미인증이면 자동 PR 은 skip 하고 custom/manual 안내만 남긴다.
 
 추천 출력 예시:
@@ -242,8 +241,7 @@ core activation 완료 뒤에만 진행한다. 기본 경로에서 선택형 항
  - docs: root architecture.md 감지로 docs/architecture.md skip
  - design kit: skip
  - Project lifecycle: skip
- - Codex validation routing: enable
- - Implementation routing: headless-chain
+ - Provider routing: role-split preset (engineer/build-worker=headless-chain, test-engineer/code-validator/pr-reviewer=claude, architecture-validator=codex)
  - workflow PR: gh 인증 + main branch + workflow 변경 시 자동 생성
 적용할까요? (Y/n/custom)
 ```
@@ -310,12 +308,14 @@ done
 #### Provider routing
 
 ```bash
-"$HELPER" routing enable-codex-validation        # 추천 ON 이고 현재 enabled 가 아닐 때 1회
+"$HELPER" routing enable-role-split-routing      # 추천 bundle: engineer/build-worker=headless-chain, test-engineer/code-validator/pr-reviewer=claude, architecture-validator=codex
+"$HELPER" routing enable-codex-validation        # custom: validation agent 를 모두 Codex 로 보낼 때
+"$HELPER" routing disable-codex-validation       # custom: validation agent 를 모두 Claude 로 되돌릴 때
 "$HELPER" routing enable-headless-implementation   # custom 에서 3단 headless-chain 복귀 시
 "$HELPER" routing enable-claude-headless-implementation  # custom 에서 Claude headless 우선 선택 시
 "$HELPER" routing enable-codex-implementation   # custom 에서 legacy Codex-first 선택 시
 "$HELPER" routing disable-codex-implementation  # custom 에서 Claude-only 선택 시
-"$HELPER" routing status
+"$HELPER" routing doctor
 ```
 
 #### workflow 변경 PR
@@ -411,8 +411,8 @@ custom 은 기존 세부 기능을 유지하되 이미 결정 가능한 항목�
 - CI workflow: GitHub remote 가 없거나 `.github/workflows/` 를 쓸 수 없으면 묻지 않고 skip 이유를 남긴다. 가능하면 `git-naming-validation.yml`, `pr-body-validation.yml`, `doc-path-integrity.yml`, `doc-sync.yml`, `github-project-lifecycle.yml` 을 각각 선택할 수 있다.
 - docs seed: 이미 존재하는 파일은 묻지 않는다. 단 기존 `docs/index.md` 에 진행 상태 섹션이 없으면 append 보강한다. 루트 `architecture.md` 가 있으면 `docs/architecture.md` 생성 질문을 생략하고 `root architecture.md 감지로 docs/architecture.md skip` 을 남긴다.
 - design seed: UI 프로젝트 여부가 불명확할 때만 묻는다. `docs/design.md` 는 부재 시 [`docs/plugin/design.md`](../docs/plugin/design.md) 기준 minimal template 생성 여부를 선택한다. `docs/design-variants/` 는 사용자가 명시 선택한 경우에만 설치한다. draft 는 `docs/design-variants/drafts/` 에 두고 gitignore 한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 custom design seed 를 재실행하거나 아래 파일들을 `docs/design-variants/` 로 복사해 재배포한다.
-- Codex validation routing: 현재 enabled 면 묻지 않는다. disabled/미설정이면 enable/disable 중 하나를 명시 선택한다.
-- Implementation routing: `headless-chain` / `codex-first` / `claude-headless` / `claude` 중 하나를 명시 선택한다. Claude-only 사용자는 `claude` 를 고른다.
+- Provider routing: 추천 role-split 으로 복귀하려면 `enable-role-split-routing` 을 선택한다. all-codex validation 을 원하면 `enable-codex-validation`, Claude 검증 복귀를 원하면 `disable-codex-validation` 을 명시 선택한다.
+- Implementation routing: `headless-chain` / `codex-first` / `claude-headless` / `claude` 중 하나를 명시 선택한다. Claude-only 사용자는 `disable-codex-implementation` 으로 `claude` 를 고른다.
 - GitHub Project lifecycle: custom 에서만 진행한다. 세부 계약은 [`docs/plugin/github-project.md`](../docs/plugin/github-project.md) 와 [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) 가 SSOT 다.
 - workflow 변경 PR: `.github/workflows/*.yml` 변경이 있고 현재 branch 가 `main` 이고 `gh auth status` 가 통과할 때만 선택한다. 선택 시 workflow 파일만 stage 한다.
 
@@ -474,7 +474,7 @@ record_dcness_workflow_change ".github/workflows/github-project-lifecycle.yml"
 
 - plugin uninstall/reinstall 로 whitelist 가 사라진 경우
 - 선택형 CI workflow 를 새로 깔거나 갱신하는 경우
-- Codex validation 분기를 새로 opt-in 하거나 implementation routing 을 headless-chain / Claude-only / legacy Codex-first 등으로 바꾸는 경우
+- provider routing 을 추천 role-split preset / all-codex validation / headless-chain / Claude-only / legacy Codex-first 등으로 바꾸는 경우
 - Project lifecycle bootstrap 또는 project-local seed 가 필요한 경우
 
 ```bash

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -51,8 +51,9 @@ core activation 완료 뒤 추천 bundle 1질문(`Y/n/custom`, 엔터 = Y) 또�
 | volatile workdir ignore | `.gitignore` 의 `.dcness-work/` + `.claude/harness-state/` 재확인 | `/init-dcness` append | 추천 bundle 또는 custom | 없을 때만 추가 | X |
 | design seed | `docs/design.md` | `docs/plugin/design.md` minimal 예시 | custom 선택 | 부재 시만 생성 | X |
 | design preview seed | `docs/design-variants/**` | `templates/design-variants/**` | custom 선택 | 부재 시만 생성 | X |
-| Codex validation routing 변경 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-codex-validation` / `disable-codex-validation` | disabled/미설정일 때 추천 bundle 또는 custom | opt-in 값으로 갱신 | X |
-| Implementation routing 변경 | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-headless-implementation` / `enable-claude-headless-implementation` / `enable-codex-implementation` / `disable-codex-implementation` | 추천 bundle 또는 custom | 기본 `headless-chain`, custom 에서 legacy Codex-first / Claude-headless / Claude-only 가능 | X |
+| Role-split provider routing preset | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-role-split-routing` | 추천 bundle | `engineer/build-worker=headless-chain`, `test-engineer/code-validator/pr-reviewer=claude`, `architecture-validator=codex` | X |
+| Validation routing custom | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-codex-validation` / `disable-codex-validation` | custom | all-codex validation 또는 Claude validation 복귀 | X |
+| Implementation routing custom | `~/.claude/plugins/data/dcness-dcness/routing.json` | `dcness-helper routing enable-headless-implementation` / `enable-claude-headless-implementation` / `enable-codex-implementation` / `disable-codex-implementation` | custom | `headless-chain`, legacy Codex-first, Claude-headless, Claude-only 가능 | X |
 | Project coordinates | repo variables `DCNESS_PROJECT_NUMBER`, `DCNESS_PROJECT_OWNER` | `gh variable set` | Project bootstrap 선택 | 값 갱신 | X |
 
 > 🔴 **진단 동기화 의무**: 위 inventory 에 새 복사/배포 대상(git hook · CI workflow · 권한 등)을 추가하면, `dcness-helper status` 진단표(`harness/session_state.py` 의 `collect_status_diagnostics`)에도 해당 검사 항목을 함께 추가한다. 그렇지 않으면 사용자가 설치 누락을 한눈에 확인할 수 없다.
@@ -94,8 +95,9 @@ Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소�
 - `.gitignore` 에 `.dcness-work/` 가 없으면 추천 ON. `.claude/harness-state/` 는 core activation 에서 항상 보장한다.
 - `docs/design-variants/` 는 기본 skip. 단일 `app/page.tsx` 정도의 UI 흔적만으로 design kit 를 설치하지 않는다.
 - GitHub Project lifecycle 은 기본 skip. `gh` 인증, Project number, PAT/secrets, field/label 복구가 얽히므로 custom 에서만 진행한다.
-- Codex validation routing 이 이미 enabled 면 skip. disabled/미설정이면 추천 bundle 또는 custom 에서 명시적으로 다룬다.
-- Implementation routing 은 기본 `headless-chain` 이다. 추천 bundle 은 이 값을 유지하고, custom 에서 legacy Codex-first / Claude-headless / Claude-only 로 바꿀 수 있다.
+- Provider routing 추천 bundle 은 `enable-role-split-routing` 단일 entrypoint 로 역할 분리 preset 을 적용한다: `engineer/build-worker=headless-chain`, `test-engineer/code-validator/pr-reviewer=claude`, `architecture-validator=codex`.
+- 기존 활성 프로젝트가 추천 preset 만 소급 적용하려면 `dcness-helper routing enable-role-split-routing` 실행 뒤 `dcness-helper routing doctor` 로 PASS 를 확인한다.
+- custom 에서는 기존 선택지를 유지한다. all-codex validation 은 `enable-codex-validation`, legacy Codex-first implementation 은 `enable-codex-implementation`, Claude-only implementation 은 `disable-codex-implementation` 으로 명시 선택한다.
 - workflow 변경 PR 은 GitHub remote 가 있고, `gh auth status` 가 통과하고, 이번 `/init-dcness` run 이 쓴 `.github/workflows/*.yml` 변경이 있고, 현재 branch 가 `main` 이면 추천 ON. Y 선택 시 별도 질문 없이 해당 파일만 stage 해서 branch/commit/push/PR 을 진행한다. `gh` 미설치/미인증이면 자동 PR 은 skip 하고 custom/manual 안내만 남긴다. 기존 dirty workflow 파일은 자동 포함하지 않는다.
 
 ## Already Automatic
@@ -187,8 +189,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | `.claude/harness-state/` gitignore 보강 | 예 | runtime state ignore 는 사용자 repo `.gitignore` append 라서 `/init-dcness` 재실행 때 적용된다. |
 | `CLAUDE.md` seed/migration 로직 갱신 | 예 | 기존 활성 프로젝트의 root `CLAUDE.md` 생성·cold-start 앵커 append 는 `/init-dcness` 재실행 때 적용된다. |
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 또는 module docs 가 있는 프로젝트는 doc-sync 채택 직후 index 집계기를 1회 실행해야 한다. 전역 architecture 요약은 온디맨드다. |
-| Codex validation routing opt-in 변경 | 예 | local plugin data 를 갱신하고 native Codex skill 등록/fallback 용 `$CODEX_HOME/skills` 를 최신화해야 한다. Validator wrapper 의 prompt 지침은 plugin update 된 원본을 우선 사용한다. |
-| Implementation routing 변경 | 예 | local plugin data 를 갱신해야 한다. |
+| Provider routing preset/custom 변경 | 예 | 기존 활성 프로젝트도 local plugin data 를 갱신해야 한다. 추천 preset 은 `dcness-helper routing enable-role-split-routing` 뒤 `dcness-helper routing doctor` 로 적용·검증한다. all-codex validation, headless-chain, Claude-only, legacy Codex-first 는 custom 경로로 유지한다. Native Codex skill 등록/fallback 용 `$CODEX_HOME/skills` 도 최신화된다. |
 | Project lifecycle 좌표 저장/변경 | 예 | repo variables 와 선택형 workflow 를 갱신해야 한다. |
 | docs/design + docs/design-variants seed 추가 | 예 | 부재 파일 seed 는 사용자 repo 에 직접 생성된다. draft 는 `docs/design-variants/drafts/` 에 두고 `.gitignore` 로 무시하되 `drafts/.gitkeep` 으로 디렉터리를 보존한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 `/init-dcness` custom design seed 를 재실행하거나 `templates/design-variants/{.gitignore,canvas.html,_lib/*,drafts/.gitkeep}` 를 `docs/design-variants/` 로 복사한다. |
 | TDD Guard 정책 갱신 | 아니오 | 중앙 fallback 과 self-test 본체는 plug-in update 로 갱신된다. project-local generated hook 이 없는 기존 프로젝트는 `/init-dcness` 또는 `/impl` 진입 시 생성 제안을 다시 받을 수 있다. |

--- a/harness/agent_routing.py
+++ b/harness/agent_routing.py
@@ -31,6 +31,7 @@ __all__ = [
     "implementation_provider_chain",
     "set_provider",
     "set_implementation_provider",
+    "enable_role_split_routing",
     "enable_codex_validation",
     "disable_codex_validation",
     "enable_headless_implementation",
@@ -244,6 +245,22 @@ def set_implementation_provider(
     routes = dict(cfg.get("implementation_routes", {}))
     routes[agent] = provider
     cfg["implementation_routes"] = routes
+    return save_routing(cfg, path=path)
+
+
+def enable_role_split_routing(*, path: Optional[Path] = None) -> Path:
+    """Enable the recommended role-split routing preset."""
+    cfg = load_routing(path=path)
+    cfg["routes"] = {
+        "code-validator": "claude",
+        "architecture-validator": "codex",
+        "pr-reviewer": "claude",
+    }
+    cfg["implementation_routes"] = {
+        "test-engineer": "claude",
+        "engineer": DEFAULT_IMPLEMENTATION_PROVIDER,
+        "build-worker": DEFAULT_IMPLEMENTATION_PROVIDER,
+    }
     return save_routing(cfg, path=path)
 
 

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -867,6 +867,11 @@ def _cli_routing(args: Any) -> int:
         print(f"[dcness routing] enabled Codex validation: {path}")
         print(agent_routing.format_status())
         return 0
+    if action == "enable-role-split-routing":
+        path = agent_routing.enable_role_split_routing()
+        print(f"[dcness routing] enabled role-split routing: {path}")
+        print(agent_routing.format_status())
+        return 0
     if action == "disable-codex-validation":
         path = agent_routing.disable_codex_validation()
         print(f"[dcness routing] disabled Codex validation: {path}")
@@ -1292,6 +1297,16 @@ def _build_arg_parser() -> Any:
         help="code-validator / architecture-validator / pr-reviewer 를 Codex 로 보냄",
     )
     rt_enable.set_defaults(func=_cli_routing)
+
+    rt_role_split = rt_sub.add_parser(
+        "enable-role-split-routing",
+        help=(
+            "추천 role split: engineer/build-worker=headless-chain, "
+            "test-engineer/code-validator/pr-reviewer=claude, "
+            "architecture-validator=codex"
+        ),
+    )
+    rt_role_split.set_defaults(func=_cli_routing)
 
     rt_disable = rt_sub.add_parser(
         "disable-codex-validation",

--- a/tests/test_agent_routing.py
+++ b/tests/test_agent_routing.py
@@ -67,6 +67,17 @@ class AgentRoutingTests(unittest.TestCase):
         for agent in agent_routing.ROUTABLE_IMPLEMENTATION_AGENTS:
             self.assertEqual(agent_routing.resolve_provider(agent), "codex-first")
 
+    def test_role_split_preset_routes_implementation_and_contract_roles(self) -> None:
+        agent_routing.enable_role_split_routing()
+
+        self.assertEqual(agent_routing.resolve_provider("engineer"), "headless-chain")
+        self.assertEqual(agent_routing.resolve_provider("build-worker"), "headless-chain")
+        self.assertEqual(agent_routing.resolve_provider("test-engineer"), "claude")
+        self.assertEqual(agent_routing.resolve_provider("code-validator"), "claude")
+        self.assertEqual(agent_routing.resolve_provider("pr-reviewer"), "claude")
+        self.assertEqual(agent_routing.resolve_provider("architecture-validator"), "codex")
+        self.assertEqual(agent_routing.doctor(), [])
+
     def test_set_implementation_provider_validates_agent_and_provider(self) -> None:
         agent_routing.set_implementation_provider("build-worker", "claude")
         self.assertEqual(agent_routing.resolve_provider("build-worker"), "claude")
@@ -183,6 +194,9 @@ class AgentRoutingCliTests(unittest.TestCase):
         self.assertEqual(ns.routing_cmd, "resolve")
         self.assertEqual(ns.agent, "code-validator")
 
+        ns = parser.parse_args(["routing", "enable-role-split-routing"])
+        self.assertEqual(ns.routing_cmd, "enable-role-split-routing")
+
         ns = parser.parse_args(
             ["routing", "set-implementation", "build-worker", "claude-headless"]
         )
@@ -266,6 +280,28 @@ class AgentRoutingCliTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         self.assertIn("set implementation build-worker=codex-first", out.getvalue())
 
+    def test_cli_role_split_routing_preset_and_doctor(self) -> None:
+        from harness.session_state import _cli_routing
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(SimpleNamespace(routing_cmd="enable-role-split-routing"))
+        self.assertEqual(rc, 0)
+        text = out.getvalue()
+        self.assertIn("enabled role-split routing", text)
+        self.assertIn("architecture-validator: codex", text)
+        self.assertIn("code-validator: claude", text)
+        self.assertIn("pr-reviewer: claude", text)
+        self.assertIn("test-engineer: claude", text)
+        self.assertIn("engineer: headless-chain", text)
+        self.assertIn("build-worker: headless-chain", text)
+
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(SimpleNamespace(routing_cmd="doctor"))
+        self.assertEqual(rc, 0)
+        self.assertIn("[dcness routing] doctor: PASS", out.getvalue())
+
     def test_cli_doctor_fails_on_bad_file(self) -> None:
         from harness.session_state import _cli_routing
 
@@ -276,6 +312,29 @@ class AgentRoutingCliTests(unittest.TestCase):
             rc = _cli_routing(SimpleNamespace(routing_cmd="doctor"))
         self.assertEqual(rc, 1)
         self.assertIn("status: INVALID", out.getvalue())
+
+
+class InitRoleSplitRoutingDocsTests(unittest.TestCase):
+    def test_init_docs_recommend_role_split_preset_and_keep_custom_routes(self) -> None:
+        root = Path(__file__).resolve().parents[1]
+        command = (root / "commands" / "init-dcness.md").read_text(
+            encoding="utf-8",
+        )
+        doc = (root / "docs" / "plugin" / "init-dcness.md").read_text(
+            encoding="utf-8",
+        )
+
+        for text in (command, doc):
+            with self.subTest(text=text[:40]):
+                self.assertIn("enable-role-split-routing", text)
+                self.assertIn("engineer/build-worker=headless-chain", text)
+                self.assertIn("test-engineer/code-validator/pr-reviewer=claude", text)
+                self.assertIn("architecture-validator=codex", text)
+                self.assertIn("기존 활성 프로젝트", text)
+                self.assertIn("routing doctor", text)
+                self.assertIn("enable-codex-validation", text)
+                self.assertIn("enable-codex-implementation", text)
+                self.assertIn("disable-codex-implementation", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1008

## 배경 및 문제

- `/init-dcness` 추천 bundle 이 validation all-codex 축과 implementation headless 기본값을 따로 다뤄, 구현 provider 와 검증 provider 가 같은 모델 축으로 몰릴 수 있었다.
- 추천값은 구현 실행과 계약 정의/검증 역할을 분리해야 한다.

## 원인 (해당 시)

- 기존 routing CLI 는 validation/implementation 을 각각 켜는 entrypoint 만 있고, 추천 역할 조합을 한 번에 저장하는 preset 이 없었다.

## 작업내용

- `enable_role_split_routing()` preset 추가: `engineer/build-worker=headless-chain`, `test-engineer/code-validator/pr-reviewer=claude`, `architecture-validator=codex`.
- `dcness-helper routing enable-role-split-routing` CLI 추가, 적용 직후 status 출력.
- `/init-dcness` command body 와 `docs/plugin/init-dcness.md` 의 추천 bundle 을 role-split preset 으로 갱신하고, all-codex/Claude-only/legacy custom 경로는 유지.
- routing/unit/docs 회귀 테스트 추가.

## 결정 근거

- routing schema 는 그대로 `routes` / `implementation_routes` 만 사용한다.
- 추천 bundle 에 단일 entrypoint 를 두면 신규 프로젝트와 기존 활성 프로젝트 적용 경로가 같아지고, custom 명령은 기존 호환성을 유지한다.

## 배포 경로 검증 (plug-in 영향 시)

- Harness routing preset: `harness/agent_routing.py`
- Helper CLI: `harness/session_state_cli.py`
- Plugin command body: `commands/init-dcness.md`
- User SSOT/reference: `docs/plugin/init-dcness.md`
- Regression coverage: `tests/test_agent_routing.py`

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

- 기존 risk router lane 으로 흡수 불가: `/init-dcness` bootstrap 시점의 local plugin routing config 적용 문제다.
- 기존 validator/reviewer 로 대체 불가: 검증 agent 는 local provider config 를 원자적으로 쓰는 entrypoint 가 아니다.
- 새 slash command/skill 은 추가하지 않는다. 기존 `/init-dcness` 를 사용자-facing 진입점으로 유지하고, `dcness-helper routing` 하위에 추천 preset 적용 primitive 만 추가한다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_agent_routing -v < /dev/null`
- [x] `python3.11 -m unittest tests.test_surface_docs_sync tests.test_skill_scenarios tests.test_canvas_design_workflow tests.test_validator_handoff_guidance tests.test_generated_tdd_hooks tests.test_status_diagnostics tests.test_public_surface -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `DCNESS_ROUTING_PATH=<tmp> scripts/dcness-helper routing enable-role-split-routing && ... routing doctor`
- [x] pre-commit hook pytest-gate PASS

## 참고

- Regular merge 시 issue auto-close 를 위해 PR body 에 `Closes #1008` 를 둔다.