### PR TITLE
[issue-1010] headless boundary block 기록

### DIFF
--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -76,6 +76,7 @@ __all__ = [
     "start_run",
     "update_current_step",
     "clear_current_step",
+    "mark_run_blocked",
     "evaluate_order_gate_for_step",
     "run_prose_has_pass",
     "set_pending_agent",
@@ -763,6 +764,52 @@ def clear_current_step(
     return True
 
 
+def mark_run_blocked(
+    session_id: str,
+    run_id: str,
+    *,
+    category: str,
+    agent: Optional[str] = None,
+    mode: Optional[str] = None,
+    provider: Optional[str] = None,
+    reason: Optional[str] = None,
+    raw_log: Optional[str] = None,
+    base_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Persist a run-level blocked marker in live.json.
+
+    ledger.jsonl is the audit trail; this live marker gives the next step gate a
+    cheap active-run signal. The marker is intentionally run-level, not
+    current_step-level, because boundary BLOCK means the workspace needs explicit
+    main/user intervention before any further sub-step can be trusted.
+    """
+    if not isinstance(category, str) or not category:
+        raise ValueError("category must be non-empty str")
+    live = read_live(session_id, base_dir=base_dir) or {}
+    active = live.get("active_runs", {})
+    if not isinstance(active, dict) or run_id not in active:
+        raise ValueError(f"run_id not active: {run_id}")
+
+    marker: Dict[str, Any] = {"category": category, "at": _now_iso()}
+    for key, val in (
+        ("agent", agent),
+        ("mode", mode),
+        ("provider", provider),
+        ("reason", reason),
+        ("raw_log", raw_log),
+    ):
+        if val is not None:
+            marker[key] = val
+
+    slot = dict(active[run_id])
+    slot["blocked"] = marker
+    slot["last_confirmed_at"] = marker["at"]
+    active = dict(active)
+    active[run_id] = slot
+    update_live(session_id, base_dir=base_dir, active_runs=active)
+    return marker
+
+
 def _steps_jsonl_path(sid: str, rid: str, *, base_dir: Optional[Path] = None) -> Path:
     """[deprecated] 옛 `.steps.jsonl` 경로 — ledger.jsonl 로 흡수됨 (이슈 #587).
 
@@ -910,6 +957,50 @@ def _run_entry_point(
         return ""
 
 
+def _run_engineer_boundary_block_marker(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    try:
+        marker = _slot_for_run(session_id, run_id, base_dir=base_dir).get("blocked")
+        if isinstance(marker, dict) and marker.get("category") == "engineer_boundary":
+            return marker
+    except (OSError, ValueError):
+        pass
+
+    try:
+        from harness import ledger
+
+        for event in reversed(ledger.read_events(session_id, run_id, base_dir=base_dir)):
+            if (
+                event.get("event") == "blocked"
+                and event.get("category") == "engineer_boundary"
+            ):
+                return event
+    except Exception:  # nosec B110
+        pass
+    return None
+
+
+def _boundary_block_gate_message(marker: Dict[str, Any]) -> str:
+    reason = marker.get("reason")
+    raw_log = marker.get("raw_log")
+    detail = ""
+    if isinstance(reason, str) and reason:
+        detail += f" reason={reason}"
+    if isinstance(raw_log, str) and raw_log:
+        detail += f" raw_log={raw_log}"
+    return (
+        "[순서 차단 훅: headless boundary BLOCK] 이 run 은 "
+        "headless worker boundary BLOCK(category=engineer_boundary) 기록이 있어 "
+        "다음 step 을 시작할 수 없습니다. workspace diff 와 ledger marker 를 확인한 뒤 "
+        "새 run 또는 명시적 수동 복구로 진행하세요."
+        f"{detail}"
+    )
+
+
 _IMPLEMENTATION_ORDER_GATE_AGENTS = frozenset({"engineer", "build-worker"})
 
 
@@ -931,6 +1022,12 @@ def evaluate_order_gate_for_step(
     norm_agent = normalize_agent_type(agent) or agent
     effective_mode = mode if isinstance(mode, str) and mode else None
     rd = run_dir(session_id, run_id, base_dir=base_dir)
+
+    boundary_block = _run_engineer_boundary_block_marker(
+        session_id, run_id, base_dir=base_dir
+    )
+    if boundary_block:
+        return _boundary_block_gate_message(boundary_block)
 
     if norm_agent in _IMPLEMENTATION_ORDER_GATE_AGENTS and effective_mode != "POLISH":
         lane_lite = _run_lane(session_id, run_id, base_dir=base_dir) == "lite"

--- a/scripts/dcness-claude-worker
+++ b/scripts/dcness-claude-worker
@@ -320,6 +320,52 @@ workspace_changed() {
   [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]
 }
 
+record_boundary_block() {
+  local provider="$1"
+  BOUNDARY_REASON="${BOUNDARY_PROBLEMS:-}" \
+    PYTHONPATH="$SCRIPT_DIR/.." python3 - \
+      "$RESOLVED_SID" "$RESOLVED_RID" "$AGENT" "${MODE:-}" "$provider" "$RAW_LOG" <<'PY' || true
+import os
+import sys
+
+sid, rid, agent, mode, provider, raw_log = sys.argv[1:7]
+reason = os.environ.get("BOUNDARY_REASON", "").strip()
+
+fields = {
+    "category": "engineer_boundary",
+    "agent": agent,
+    "provider": provider,
+    "reason": reason,
+    "raw_log": raw_log,
+}
+if mode:
+    fields["mode"] = mode
+
+try:
+    from harness import ledger
+
+    ledger.append_event(sid, rid, "blocked", **fields)
+except Exception as exc:  # noqa: BLE001
+    print(f"[dcness-claude-worker] WARN: ledger boundary block record failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+try:
+    from harness.session_state import mark_run_blocked
+
+    mark_run_blocked(
+        sid,
+        rid,
+        category="engineer_boundary",
+        agent=agent,
+        mode=mode or None,
+        provider=provider,
+        reason=reason,
+        raw_log=raw_log,
+    )
+except Exception as exc:  # noqa: BLE001
+    print(f"[dcness-claude-worker] WARN: live boundary block marker failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+PY
+}
+
 CLAUDE_RC=0
 run_claude_once
 CLAUDE_RC=$?
@@ -385,6 +431,7 @@ for path in sorted(paths):
 PY
 )"
 if [ -n "$BOUNDARY_PROBLEMS" ]; then
+  record_boundary_block "claude-headless"
   echo "[dcness-claude-worker] BLOCKED: Claude changed files outside ${AGENT} boundary." >&2
   echo "[dcness-claude-worker] raw log: $RAW_LOG" >&2
   printf '%s\n' "$BOUNDARY_PROBLEMS" >&2

--- a/scripts/dcness-codex-worker
+++ b/scripts/dcness-codex-worker
@@ -296,6 +296,52 @@ workspace_changed() {
   [ "$BEFORE_STATUS" != "$AFTER_STATUS" ]
 }
 
+record_boundary_block() {
+  local provider="$1"
+  BOUNDARY_REASON="${BOUNDARY_PROBLEMS:-}" \
+    PYTHONPATH="$SCRIPT_DIR/.." python3 - \
+      "$RESOLVED_SID" "$RESOLVED_RID" "$AGENT" "${MODE:-}" "$provider" "$RAW_LOG" <<'PY' || true
+import os
+import sys
+
+sid, rid, agent, mode, provider, raw_log = sys.argv[1:7]
+reason = os.environ.get("BOUNDARY_REASON", "").strip()
+
+fields = {
+    "category": "engineer_boundary",
+    "agent": agent,
+    "provider": provider,
+    "reason": reason,
+    "raw_log": raw_log,
+}
+if mode:
+    fields["mode"] = mode
+
+try:
+    from harness import ledger
+
+    ledger.append_event(sid, rid, "blocked", **fields)
+except Exception as exc:  # noqa: BLE001
+    print(f"[dcness-codex-worker] WARN: ledger boundary block record failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+
+try:
+    from harness.session_state import mark_run_blocked
+
+    mark_run_blocked(
+        sid,
+        rid,
+        category="engineer_boundary",
+        agent=agent,
+        mode=mode or None,
+        provider=provider,
+        reason=reason,
+        raw_log=raw_log,
+    )
+except Exception as exc:  # noqa: BLE001
+    print(f"[dcness-codex-worker] WARN: live boundary block marker failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+PY
+}
+
 CODEX_RC=0
 run_codex_once
 CODEX_RC=$?
@@ -355,6 +401,7 @@ for path in sorted(paths):
 PY
 )"
 if [ -n "$BOUNDARY_PROBLEMS" ]; then
+  record_boundary_block "codex-headless"
   echo "[dcness-codex-worker] BLOCKED: Codex changed files outside ${AGENT} boundary." >&2
   echo "[dcness-codex-worker] raw log: $RAW_LOG" >&2
   printf '%s\n' "$BOUNDARY_PROBLEMS" >&2

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, Dict, Optional
 
+from harness import ledger
 from harness.hooks import (
     _has_pass,
     handle_posttooluse_agent,
@@ -53,6 +54,7 @@ from harness.agent_trace import read_all as read_trace
 # issue #392 — redo_log 폐기
 from harness.session_state import (
     evaluate_order_gate_for_step,
+    mark_run_blocked,
     read_live,
     read_fail_open_events,
     read_pid_session,
@@ -581,6 +583,52 @@ class ProviderAgnosticBeginStepOrderGateTests(_PreToolBase):
             base_dir=self.base,
         )
         self.assertIsNone(message)
+
+    def test_begin_step_blocks_after_live_boundary_block_marker(self) -> None:
+        mark_run_blocked(
+            self.sid,
+            self.rid,
+            category="engineer_boundary",
+            agent="engineer",
+            mode="IMPL",
+            provider="codex-headless",
+            reason="hooks/catastrophic-gate.sh: write denied",
+            raw_log="/tmp/codex.log",
+            base_dir=self.base,
+        )
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "code-validator",
+            None,
+            base_dir=self.base,
+        )
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: headless boundary BLOCK]", message or "")
+        self.assertIn("engineer_boundary", message or "")
+        self.assertIn("hooks/catastrophic-gate.sh", message or "")
+
+    def test_begin_step_blocks_after_ledger_only_boundary_block_event(self) -> None:
+        ledger.append_event(
+            self.sid,
+            self.rid,
+            "blocked",
+            category="engineer_boundary",
+            agent="engineer",
+            mode="IMPL",
+            provider="codex-headless",
+            reason="hooks/catastrophic-gate.sh: write denied",
+            base_dir=self.base,
+        )
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "pr-reviewer",
+            None,
+            base_dir=self.base,
+        )
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: headless boundary BLOCK]", message or "")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_provider_chain.py
+++ b/tests/test_provider_chain.py
@@ -15,6 +15,7 @@ from harness.session_state import start_run, update_current_step
 ROOT = Path(__file__).resolve().parents[1]
 CLAUDE_VALIDATOR = ROOT / "scripts" / "dcness-claude-validator"
 CLAUDE_WORKER = ROOT / "scripts" / "dcness-claude-worker"
+CODEX_WORKER = ROOT / "scripts" / "dcness-codex-worker"
 CHAIN = ROOT / "scripts" / "dcness-implementation-chain"
 
 
@@ -46,6 +47,90 @@ def _write_helper(path: Path, helper_args: Path, prose_capture: Path) -> None:
 
 
 class ClaudeHeadlessWrapperTests(unittest.TestCase):
+    def _assert_worker_records_boundary_block(
+        self,
+        *,
+        wrapper: Path,
+        provider: str,
+        binary_name: str,
+        binary_script: str,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            sid = "sid-boundary-block"
+            rid = "run-0badc0de"
+            state_base = project / ".claude" / "harness-state"
+            start_run(sid, rid, "impl", base_dir=state_base, lane="lite")
+            update_current_step(sid, rid, "engineer", "IMPL", base_dir=state_base)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement this task.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+            prose_capture = tmp / "prose.md"
+            helper = tmp / "dcness-helper"
+            _write_helper(helper, helper_args, prose_capture)
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(bin_dir / binary_name, binary_script)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_RUN_ID": rid,
+                    "DCNESS_SESSION_ID": sid,
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(wrapper),
+                    "engineer",
+                    "IMPL",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            self.assertIn("changed files outside engineer boundary", result.stderr)
+            self.assertFalse(helper_args.exists())
+
+            events = ledger.read_events(sid, rid, base_dir=state_base)
+            blocked_events = [
+                event for event in events
+                if event.get("event") == "blocked"
+                and event.get("category") == "engineer_boundary"
+            ]
+            self.assertEqual(len(blocked_events), 1)
+            self.assertEqual(blocked_events[0].get("agent"), "engineer")
+            self.assertEqual(blocked_events[0].get("mode"), "IMPL")
+            self.assertEqual(blocked_events[0].get("provider"), provider)
+            self.assertIn("hooks/catastrophic-gate.sh", blocked_events[0].get("reason", ""))
+            self.assertTrue(blocked_events[0].get("raw_log", "").endswith(".log"))
+
+            from harness.session_state import read_live
+
+            live = read_live(sid, base_dir=state_base)
+            marker = live["active_runs"][rid].get("blocked")
+            self.assertIsInstance(marker, dict)
+            self.assertEqual(marker.get("category"), "engineer_boundary")
+            self.assertEqual(marker.get("provider"), provider)
+
     def test_worker_uses_hook_loading_claude_print_mode_and_records_provider(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
@@ -349,6 +434,49 @@ class ClaudeHeadlessWrapperTests(unittest.TestCase):
             self.assertEqual(blocked_events[0].get("agent"), "build-worker")
             self.assertEqual(blocked_events[0].get("provider"), "claude-headless")
             self.assertIn("build-worker.md", blocked_events[0].get("prose_file", ""))
+
+    def test_codex_worker_records_boundary_block_in_ledger_and_live_marker(self) -> None:
+        self._assert_worker_records_boundary_block(
+            wrapper=CODEX_WORKER,
+            provider="codex-headless",
+            binary_name="codex",
+            binary_script="""\
+            #!/bin/sh
+            if [ "$1" = "--help" ]; then
+              echo "Usage: codex"
+              exit 0
+            fi
+            out=""
+            while [ "$#" -gt 0 ]; do
+              if [ "$1" = "--output-last-message" ]; then
+                out="$2"
+                shift 2
+                continue
+              fi
+              shift
+            done
+            cat >/dev/null
+            mkdir -p hooks src
+            printf 'outside boundary\\n' > hooks/catastrophic-gate.sh
+            printf 'inside boundary\\n' > src/generated.py
+            printf 'Codex worker prose\\n\\nPASS\\n' > "$out"
+            """,
+        )
+
+    def test_claude_worker_records_boundary_block_in_ledger_and_live_marker(self) -> None:
+        self._assert_worker_records_boundary_block(
+            wrapper=CLAUDE_WORKER,
+            provider="claude-headless",
+            binary_name="claude",
+            binary_script="""\
+            #!/bin/sh
+            cat >/dev/null
+            mkdir -p hooks src
+            printf 'outside boundary\\n' > hooks/catastrophic-gate.sh
+            printf 'inside boundary\\n' > src/generated.py
+            printf 'Claude worker prose\\n\\nPASS\\n'
+            """,
+        )
 
     def test_validator_blocks_workspace_mutation_without_end_step(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1010

## 배경 및 문제

Headless implementation provider(Codex/Claude)가 sub-agent boundary 밖 파일을 수정하면 wrapper는 BLOCK으로 종료하지만, 기존 경로는 `end-step`까지 가지 못해 `ledger.jsonl`이나 active run state에 durable marker가 남지 않았다. 그 결과 다음 step이 같은 run에서 무심코 진행될 수 있었다.

## 원인 (해당 시)

Boundary BLOCK은 worker wrapper 내부에서 `exit 1`로 끝나는 pre-end-step 실패 경로인데, durable 상태 기록은 주로 helper `end-step`/ledger receipt 경로에 묶여 있었다. 즉, 가장 보존이 필요한 치명 BLOCK 경로가 audit/state update 전에 빠져나갔다.

## 작업내용

- `dcness-codex-worker` / `dcness-claude-worker`가 boundary violation 감지 시 `blocked` ledger event를 `category=engineer_boundary`로 기록한다.
- 같은 시점에 `live.json` active run 슬롯에 run-level `blocked` marker를 남긴다.
- provider-independent order gate가 live marker 또는 ledger-only fallback marker를 보면 다음 `begin-step`/Agent 진입을 차단한다.
- Codex/Claude headless wrapper boundary BLOCK 기록 테스트와 marker 기반 gate 차단 회귀 테스트를 추가했다.

## 결정 근거

- `VALIDATION_BLOCKED`와 달리 boundary BLOCK은 메인이 검증 명령을 대신 실행해 복구할 수 있는 상태가 아니라, workspace가 이미 역할 경계 밖으로 변한 상태다. 따라서 같은 run의 다음 step을 막고 diff/raw log/ledger 확인을 요구하는 run-level marker로 처리했다.
- live marker는 빠른 active-run 판정용이고, `ledger.jsonl`은 audit fallback으로 남겨 live state가 유실돼도 다음 gate가 같은 BLOCK을 볼 수 있게 했다.

## 배포 경로 검증 (plug-in 영향 시)

plug-in 본체 경로 변경이다: `harness/session_state.py`, `scripts/dcness-codex-worker`, `scripts/dcness-claude-worker`. 외부 활성 프로젝트는 dcness plug-in 업데이트 시 해당 harness/script 경로로 반영된다. `/init-dcness` 복사 파일이나 신규 public surface 변경은 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public skill/command/agent/gate 추가 없음.

## Test Plan

- [x] `python3.11 -m unittest tests.test_provider_chain.ClaudeHeadlessWrapperTests.test_codex_worker_records_boundary_block_in_ledger_and_live_marker tests.test_provider_chain.ClaudeHeadlessWrapperTests.test_claude_worker_records_boundary_block_in_ledger_and_live_marker tests.test_hooks.ProviderAgnosticBeginStepOrderGateTests.test_begin_step_blocks_after_live_boundary_block_marker tests.test_hooks.ProviderAgnosticBeginStepOrderGateTests.test_begin_step_blocks_after_ledger_only_boundary_block_event -v < /dev/null`
- [x] `bash -n scripts/dcness-codex-worker && bash -n scripts/dcness-claude-worker`
- [x] `python3.11 -m unittest tests.test_provider_chain tests.test_hooks -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] git pre-commit hook: `[pytest-gate] PASS`, `[git-naming] PASS`

## 참고

- Rebased onto `origin/main` after #1012 before commit.
