### PR TITLE
[feature] TDD exempt 마커 지원

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -185,6 +185,8 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **중앙 fallback 역할**: generated hook 이 없는 프로젝트에서는 TS/JS 구현 파일에 대응하는 test/spec 파일이 *존재하는지* 확인한다. 없으면 구현 파일 작성을 막는다. **test 의 존재만 검사하고, test 를 실행하지는 않는다** — green/red 판정이 아니라 "작성 전 test 가 먼저 있는가" 강제다.
 
+**파일 단위 override marker**: 테스트가 구조적으로 불필요한 파일은 파일 내용 또는 이번 `Write` / `Edit` / `apply_patch` payload 에 `tdd-exempt: <사유>` 를 남기면 해당 파일의 test 부재 차단만 통과한다. 콜론 뒤 사유는 같은 줄에 최소 1단어 이상 있어야 하며, 빈 `tdd-exempt:` 는 통과하지 않는다. 주석 형태를 권장한다. 마커는 코드에 커밋되므로 `rg "tdd-exempt:"` 로 사용 빈도를 확인하고 pr-reviewer 가 남용 여부를 검토할 수 있다.
+
 **skip 대상**:
 
 - test/spec 파일 자체 — basename 의 `.test.` / `.spec.` 접미 컨벤션 (`foo.test.ts`, `bar.spec.tsx`)
@@ -417,9 +419,10 @@ hook 또는 workflow 를 추가/삭제/이름 변경할 때 이 문서가 빠지
 |---|---|---|
 | 미활성 프로젝트 | 전체 CC hook | `is-active` 게이트에서 즉시 no-op |
 | `.no-dcness-guard` cwd marker | file-guard | file boundary / 외부 변경 차단 목록 임시 우회 |
+| `tdd-exempt: <사유>` 파일 marker | tdd-guard | 해당 파일의 test 부재 차단만 사유와 함께 override |
 | `DCNESS_INFRA=1`, `~/.claude/.dcness-infra`, dcNess self repo marker | file boundary | dcNess 자체 작업에서 infra path 보호 해제 |
 
-우회 marker 는 catastrophic-gate 와 tdd-guard 에 없다. git hook 의 `--no-verify` 우회는 가능하지만 dcNess 절차상 금지다. CI/CD workflow 는 GitHub 에 올라온 PR/issue 이벤트에서 다시 검증한다.
+catastrophic-gate 에는 marker override 가 없다. `tdd-exempt: <사유>` 는 tdd-guard 의 test 부재 차단에만 적용되며, file-guard / catastrophic-gate / git hook 을 우회하지 않는다. git hook 의 `--no-verify` 우회는 가능하지만 dcNess 절차상 금지다. CI/CD workflow 는 GitHub 에 올라온 PR/issue 이벤트에서 다시 검증한다.
 
 ## 참조
 

--- a/evals/guard_efficacy.py
+++ b/evals/guard_efficacy.py
@@ -281,7 +281,12 @@ pathlib.Path(out).write_text("Worker prose\\n\\nPASS\\n", encoding="utf-8")
     return probe
 
 
-def _tdd_guard(rel_path: str, *, matching_test: bool = False) -> Probe:
+def _tdd_guard(
+    rel_path: str,
+    *,
+    matching_test: bool = False,
+    content: str = "export const value = 1;\n",
+) -> Probe:
     def probe() -> tuple[Decision, str]:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -293,7 +298,7 @@ def _tdd_guard(rel_path: str, *, matching_test: bool = False) -> Probe:
                 timeout=10,
                 check=False,
             )
-            target = _write_file(root, rel_path, "export const value = 1;\n")
+            target = _write_file(root, rel_path, content)
             if matching_test:
                 stem = target.with_suffix("").name
                 _write_file(target.parent, f"{stem}.test.ts", "test('ok', () => {})\n")
@@ -610,6 +615,16 @@ def build_cases() -> list[GuardCase]:
             _tdd_guard("src/price.ts", matching_test=True),
         ),
         GuardCase(
+            "tdd_guard_allows_exempt_marker_with_reason",
+            "tdd-guard",
+            "allow",
+            "A committed tdd-exempt reason marker satisfies the TDD guard for that file.",
+            _tdd_guard(
+                "src/price.ts",
+                content="// tdd-exempt: DTO shell only\nexport const price = 1;\n",
+            ),
+        ),
+        GuardCase(
             "tdd_guard_allows_config_false_positive",
             "tdd-guard",
             "allow",
@@ -639,6 +654,20 @@ def build_cases() -> list[GuardCase]:
                 {
                     "src/price.ts": "export const price = 1;\n",
                     "src/price.test.ts": "test('price', () => {});\n",
+                }
+            ),
+        ),
+        GuardCase(
+            "headless_tdd_allows_worker_success_with_exempt_marker",
+            "provider-agnostic-tdd",
+            "allow",
+            "Codex worker succeeds when the changed implementation file carries an exemption reason.",
+            _headless_worker_tdd(
+                {
+                    "src/price.ts": (
+                        "// tdd-exempt: DTO shell only\n"
+                        "export const price = 1;\n"
+                    ),
                 }
             ),
         ),

--- a/harness/tdd_hooks.py
+++ b/harness/tdd_hooks.py
@@ -46,6 +46,15 @@ TEST_DIR_SEGMENTS = {
 TEST_CANDIDATE_TEMPLATES_KEY = "test_candidate_templates"
 TEST_FILE_GLOBS_KEY = "test_file_globs"
 PRESET_PLATFORMS = {"python", "web", "go", "android", "ios"}
+TDD_EXEMPT_MARKER = "tdd-exempt:"
+TDD_EXEMPT_DISPLAY = "tdd-exempt: <사유>"
+_PAYLOAD_MARKER_KEYS = (
+    "content",
+    "new_string",
+    "new_source",
+    "cell_source",
+    "source",
+)
 
 
 @dataclass(frozen=True)
@@ -106,6 +115,137 @@ def _write_json(path: Path, data: dict[str, Any]) -> None:
         json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
         encoding="utf-8",
     )
+
+
+def has_tdd_exempt_marker(text: str) -> bool:
+    """Return True when a line contains `tdd-exempt:` with a non-empty reason."""
+    if not isinstance(text, str):
+        return False
+    for line in text.splitlines():
+        _before, marker, after = line.partition(TDD_EXEMPT_MARKER)
+        if marker and after.strip():
+            return True
+    return False
+
+
+def file_has_tdd_exempt_marker(path: Path, project_root: Path) -> bool:
+    candidate = path if path.is_absolute() else project_root / path
+    try:
+        if not candidate.is_file():
+            return False
+        return has_tdd_exempt_marker(candidate.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
+def _resolved_for_match(path: Path, project_root: Path) -> Optional[Path]:
+    candidate = path if path.is_absolute() else project_root / path
+    try:
+        return candidate.resolve(strict=False)
+    except OSError:
+        return None
+
+
+def _paths_match(left: Path, right: Path, project_root: Path) -> bool:
+    left_resolved = _resolved_for_match(left, project_root)
+    right_resolved = _resolved_for_match(right, project_root)
+    if left_resolved is not None and right_resolved is not None:
+        return left_resolved == right_resolved
+    return left.as_posix() == right.as_posix()
+
+
+def _payload_mentions_path(payload: dict[str, Any], path: Path, project_root: Path) -> bool:
+    payload_paths = extract_payload_paths(payload)
+    if not payload_paths:
+        return False
+    return any(_paths_match(payload_path, path, project_root) for payload_path in payload_paths)
+
+
+def _payload_direct_marker_texts(tool_input: dict[str, Any]) -> Iterable[str]:
+    for key in _PAYLOAD_MARKER_KEYS:
+        value = tool_input.get(key)
+        if isinstance(value, str):
+            yield value
+    edits = tool_input.get("edits")
+    if isinstance(edits, list):
+        for edit in edits:
+            if not isinstance(edit, dict):
+                continue
+            for key in _PAYLOAD_MARKER_KEYS:
+                value = edit.get(key)
+                if isinstance(value, str):
+                    yield value
+
+
+def _extract_patch_text(tool_input: dict[str, Any]) -> str:
+    text_parts: list[str] = []
+    for key in ("patch", "input", "command"):
+        value = tool_input.get(key)
+        if isinstance(value, str):
+            text_parts.append(value)
+    return "\n".join(text_parts)
+
+
+def _patch_path_matches(current_path: str, path: Path, project_root: Path) -> bool:
+    current = Path(current_path)
+    return _paths_match(current, path, project_root)
+
+
+def _apply_patch_has_marker_for_path(
+    patch_text: str,
+    path: Path,
+    project_root: Path,
+) -> bool:
+    current_path: Optional[str] = None
+    current_matches = False
+    for line in patch_text.splitlines():
+        if line.startswith("*** Add File: "):
+            current_path = line[len("*** Add File: ") :].strip()
+            current_matches = _patch_path_matches(current_path, path, project_root)
+            continue
+        if line.startswith("*** Update File: "):
+            current_path = line[len("*** Update File: ") :].strip()
+            current_matches = _patch_path_matches(current_path, path, project_root)
+            continue
+        if line.startswith("*** "):
+            current_path = None
+            current_matches = False
+            continue
+        if line.startswith("+++ b/"):
+            current_path = line[len("+++ b/") :].strip()
+            current_matches = _patch_path_matches(current_path, path, project_root)
+            continue
+        if (
+            current_path
+            and current_matches
+            and line.startswith("+")
+            and not line.startswith("+++")
+        ):
+            if has_tdd_exempt_marker(line[1:]):
+                return True
+    return False
+
+
+def payload_has_tdd_exempt_marker_for_path(
+    payload: dict[str, Any],
+    path: Path,
+    project_root: Path,
+) -> bool:
+    """Check target file content and pending payload content for a justified override."""
+    if file_has_tdd_exempt_marker(path, project_root):
+        return True
+    if not _payload_mentions_path(payload, path, project_root):
+        return False
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return False
+
+    if str(payload.get("tool_name") or "") == "apply_patch":
+        patch_text = _extract_patch_text(tool_input)
+        return _apply_patch_has_marker_for_path(patch_text, path, project_root)
+
+    return any(has_tdd_exempt_marker(text) for text in _payload_direct_marker_texts(tool_input))
 
 
 def _string_list(config: dict[str, Any], key: str) -> list[str]:
@@ -550,6 +690,8 @@ def evaluate_payload(
             continue
         if has_matching_test(path, project_root, config):
             continue
+        if payload_has_tdd_exempt_marker_for_path(payload, path, project_root):
+            continue
         rel = _rel_path(path, project_root) or path
         candidates = matching_test_candidates(rel, config)
         suggested = "\n".join(f"  - {candidate.as_posix()}" for candidate in candidates[:5])
@@ -558,6 +700,8 @@ def evaluate_payload(
             "TDD GUARD[generated]: "
             f"'{rel.as_posix()}' 에 대한 매칭 테스트가 없습니다.\n"
             "구현 파일을 쓰기 전에 테스트를 먼저 작성하세요.\n"
+            f"정말 테스트가 구조적으로 불필요하면 파일에 `{TDD_EXEMPT_DISPLAY}` "
+            "마커를 사유와 함께 남기세요. 빈 사유는 통과하지 않습니다.\n"
             f"권장 위치:\n{suggested}",
         )
     return "allow", ""

--- a/hooks/tdd-guard.sh
+++ b/hooks/tdd-guard.sh
@@ -220,6 +220,27 @@ if [ -z "$FILE_PATH" ]; then
   allow
 fi
 
+has_tdd_exempt_marker_for_current_payload() {
+  python3 - "$INPUT" "$FILE_PATH" "$PROJECT_ROOT" >/dev/null 2>&1 <<'PY'
+import json
+import sys
+from pathlib import Path
+
+from harness.tdd_hooks import payload_has_tdd_exempt_marker_for_path
+
+try:
+    payload = json.loads(sys.argv[1] or "{}")
+except Exception:
+    sys.exit(1)
+if not isinstance(payload, dict):
+    sys.exit(1)
+
+path = Path(sys.argv[2])
+project_root = Path(sys.argv[3])
+sys.exit(0 if payload_has_tdd_exempt_marker_for_path(payload, path, project_root) else 1)
+PY
+}
+
 # 자동 skip — test/spec 파일 자체 + 표준 test 디렉터리 (#681)
 # 주의: 단순 *test* / *spec* 광역 glob 은 contest.ts / spectrum.ts / latest.ts 같은
 # 구현 파일을 test 파일로 오인 skip → TDD 강제를 우회시킨다 (false negative).
@@ -331,6 +352,9 @@ has_test_for() {
 }
 
 if ! has_test_for "$FILE_PATH"; then
+  if has_tdd_exempt_marker_for_current_payload; then
+    allow
+  fi
   BASE=$(basename "$FILE_PATH" | sed -E 's/\.(ts|tsx|js|jsx)$//')
   DIR=$(dirname "$FILE_PATH")
   PARENT=$(dirname "$DIR")
@@ -341,6 +365,8 @@ if ! has_test_for "$FILE_PATH"; then
   esac
   record_guard_hit "missing_test" "$FILE_PATH"
   deny "TDD GUARD: '${BASE}' 에 대한 테스트 파일이 존재하지 않습니다. 구현 코드를 작성하기 *전*에 테스트를 먼저 작성하세요.
+
+테스트가 구조적으로 불필요한 파일이면 파일 내용 또는 이번 Write/Edit payload 에 \`tdd-exempt: <사유>\` 마커를 남기세요. 콜론 뒤 사유가 비어 있으면 통과하지 않습니다.
 
 권장 위치 (먼저 시도):
   ${DIR}/${BASE}.test.ts                또는 ${DIR}/${BASE}.spec.ts

--- a/tests/test_generated_tdd_hooks.py
+++ b/tests/test_generated_tdd_hooks.py
@@ -38,6 +38,27 @@ def _run_hook(hook: Path, project: Path, file_path: Path) -> subprocess.Complete
     )
 
 
+def _run_hook_payload(
+    hook: Path,
+    project: Path,
+    payload: dict,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(hook)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        cwd=project,
+        timeout=10,
+        env={
+            **os.environ,
+            "CLAUDE_PLUGIN_ROOT": str(ROOT),
+            "DCNESS_TDD_PLUGIN_ROOT": str(ROOT),
+            "PYTHONPATH": str(ROOT),
+        },
+    )
+
+
 def _run_central_guard(
     project: Path,
     file_path: Path,
@@ -434,6 +455,7 @@ class GeneratedTddHookContractTests(unittest.TestCase):
             denied = _run_hook(hook, project, no_test)
             self.assertEqual(denied.returncode, 2, denied.stderr)
             self.assertIn("TDD GUARD", denied.stderr)
+            self.assertIn("tdd-exempt: <사유>", denied.stderr)
 
             (project / "tests").mkdir()
             (project / "tests" / "test_price.py").write_text(
@@ -447,6 +469,177 @@ class GeneratedTddHookContractTests(unittest.TestCase):
             test_file.write_text("def test_new_contract():\n    assert True\n", encoding="utf-8")
             test_allowed = _run_hook(hook, project, test_file)
             self.assertEqual(test_allowed.returncode, 0, test_allowed.stderr)
+
+    def test_generated_hook_allows_existing_file_with_tdd_exempt_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            exempt = project / "src" / "dto.py"
+            exempt.write_text(
+                "# tdd-exempt: dataclass shape only\n"
+                "class Dto:\n"
+                "    pass\n",
+                encoding="utf-8",
+            )
+
+            allowed = _run_hook(hook, project, exempt)
+
+            self.assertEqual(allowed.returncode, 0, allowed.stderr)
+
+    def test_generated_hook_rejects_empty_tdd_exempt_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            empty_reason = project / "src" / "dto.py"
+            empty_reason.write_text(
+                "# tdd-exempt:   \n"
+                "class Dto:\n"
+                "    pass\n",
+                encoding="utf-8",
+            )
+
+            denied = _run_hook(hook, project, empty_reason)
+
+            self.assertEqual(denied.returncode, 2, denied.stderr)
+
+    def test_generated_hook_allows_write_payload_with_tdd_exempt_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "cc",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            hook = project / ".claude" / "hooks" / "dcness-tdd-guard.sh"
+            target = project / "src" / "payload_dto.py"
+            payload = {
+                "tool_name": "Write",
+                "tool_input": {
+                    "file_path": str(target),
+                    "content": (
+                        "# tdd-exempt: generated dataclass only\n"
+                        "class PayloadDto:\n"
+                        "    pass\n"
+                    ),
+                },
+            }
+
+            allowed = _run_hook_payload(hook, project, payload)
+
+            self.assertEqual(allowed.returncode, 0, allowed.stderr)
+
+    def test_generated_hook_allows_apply_patch_add_file_with_tdd_exempt_reason(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td) / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+            (project / "pyproject.toml").write_text("[project]\nname='demo'\n")
+            (project / "src").mkdir()
+            (project / "src" / "existing.py").write_text("def existing():\n    return 1\n")
+
+            subprocess.run(
+                [
+                    str(TDD_HOOKS),
+                    "ensure",
+                    "--project-root",
+                    str(project),
+                    "--targets",
+                    "codex",
+                    "--plugin-root",
+                    str(ROOT),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=20,
+                env={**os.environ, "PYTHONPATH": str(ROOT)},
+            )
+
+            hook = project / ".codex" / "hooks" / "dcness-tdd-guard.sh"
+            payload = {
+                "tool_name": "apply_patch",
+                "tool_input": {
+                    "patch": (
+                        "*** Begin Patch\n"
+                        "*** Add File: src/codex_dto.py\n"
+                        "+# tdd-exempt: generated DTO only\n"
+                        "+class CodexDto:\n"
+                        "+    pass\n"
+                        "*** End Patch\n"
+                    )
+                },
+            }
+
+            allowed = _run_hook_payload(hook, project, payload)
+
+            self.assertEqual(allowed.returncode, 0, allowed.stderr)
 
     def test_central_tdd_guard_delegates_to_generated_hook_for_headless_paths(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -854,6 +854,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("Bash write target 정책", self.hooks_doc)
         self.assertIn("TDD GUARD[Bash]", self.hooks_doc)
         self.assertIn("contest.ts", self.hooks_doc)
+        self.assertIn("tdd-exempt: <사유>", self.hooks_doc)
 
     def test_backpressure_loop_is_first_class_across_stages(self) -> None:
         """#702 — 단계 간 되돌림(backpressure) 원리가 분기 규칙 SSOT 에 일급으로 명시된다."""

--- a/tests/test_tdd_guard.py
+++ b/tests/test_tdd_guard.py
@@ -92,6 +92,20 @@ def run_hook_raw(
     )
 
 
+def run_hook_payload(payload: dict, cwd: str) -> subprocess.CompletedProcess:
+    """tdd-guard.sh 를 임의 payload 로 호출한다."""
+    return subprocess.run(
+        ["bash", str(HOOK_PATH)],
+        input=json.dumps(payload),
+        capture_output=True, text=True, cwd=cwd, timeout=10,
+        env={
+            **os.environ,
+            "PYTHONPATH": str(ROOT),
+            "DCNESS_FORCE_ENABLE": "1",
+        },
+    )
+
+
 def decision(result: subprocess.CompletedProcess) -> str:
     """allow / deny 를 returncode 로 판정 — exit 0=allow / exit 2=deny."""
     if result.returncode == 0:
@@ -225,7 +239,10 @@ class TestRegressionPreserved(unittest.TestCase):
             "src/business-logic.ts",
             "export function calculatePrice(qty, unit) { return qty * unit; }\n",
         )
-        self.assertEqual(decision(run_hook(path, self._tmp)), "deny")
+        result = run_hook(path, self._tmp)
+        self.assertEqual(decision(result), "deny")
+        self.assertIn("테스트를 먼저 작성", result.stderr)
+        self.assertIn("tdd-exempt: <사유>", result.stderr)
 
     def test_src_business_logic_with_test_allowed(self):
         """일반 비즈니스 로직 + 매칭 테스트 존재 → allow."""
@@ -247,6 +264,90 @@ class TestRegressionPreserved(unittest.TestCase):
             decision(run_hook("docs/design-variants/_lib/show-ids.js", self._tmp)),
             "allow",
         )
+
+
+class TestTddExemptMarker(unittest.TestCase):
+    """사유가 있는 tdd-exempt marker 는 파일 단위 override 다."""
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        subprocess.run(["git", "init"], cwd=self._tmp, capture_output=True)
+
+    def tearDown(self):
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _touch(self, rel: str, content: str) -> str:
+        p = Path(self._tmp) / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+        return str(p)
+
+    def test_existing_file_with_tdd_exempt_reason_allowed(self):
+        path = self._touch(
+            "src/user-dto.ts",
+            "// tdd-exempt: DTO shape only; no executable logic\n"
+            "export interface UserDto { id: string }\n",
+        )
+
+        self.assertEqual(decision(run_hook(path, self._tmp)), "allow")
+
+    def test_existing_file_empty_tdd_exempt_reason_still_denied(self):
+        path = self._touch(
+            "src/user-dto.ts",
+            "// tdd-exempt:   \n"
+            "export interface UserDto { id: string }\n",
+        )
+
+        result = run_hook(path, self._tmp)
+
+        self.assertEqual(decision(result), "deny")
+        self.assertIn("tdd-exempt: <사유>", result.stderr)
+
+    def test_write_payload_with_tdd_exempt_reason_allowed_for_new_file(self):
+        target = str(Path(self._tmp) / "src" / "generated-dto.ts")
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": target,
+                "content": (
+                    "// tdd-exempt: generated DTO barrel only\n"
+                    "export type GeneratedDto = { id: string }\n"
+                ),
+            },
+        }
+
+        self.assertEqual(decision(run_hook_payload(payload, self._tmp)), "allow")
+
+    def test_edit_payload_new_string_with_tdd_exempt_reason_allowed(self):
+        target = self._touch(
+            "src/existing-dto.ts",
+            "export type ExistingDto = { id: string }\n",
+        )
+        payload = {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": target,
+                "old_string": "export type ExistingDto = { id: string }\n",
+                "new_string": (
+                    "// tdd-exempt: DTO type only\n"
+                    "export type ExistingDto = { id: string }\n"
+                ),
+            },
+        }
+
+        self.assertEqual(decision(run_hook_payload(payload, self._tmp)), "allow")
+
+    def test_write_payload_empty_tdd_exempt_reason_denied_for_new_file(self):
+        target = str(Path(self._tmp) / "src" / "generated-dto.ts")
+        payload = {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": target,
+                "content": "// tdd-exempt:   \nexport const generated = true;\n",
+            },
+        }
+
+        self.assertEqual(decision(run_hook_payload(payload, self._tmp)), "deny")
 
 
 class TestBashWriteTargets(unittest.TestCase):


### PR DESCRIPTION
## 관련 이슈 번호
Closes #1011

## 배경 및 문제
- TDD guard 는 테스트 부재 구현 파일을 계속 hard block 해야 하지만, DTO/stub/로직 무관 편집처럼 구조적으로 테스트가 불필요한 파일까지 막는 오탐에 사유 있는 통과 경로가 없었습니다.

## 원인 (해당 시)
- 중앙 TS/JS fallback 과 project-local generated hook 공통 판단 경로가 matching test 존재만 보며, 파일 내용 또는 payload 안의 사유 marker 를 계약으로 해석하지 않았습니다.

## 작업내용
- `tdd-exempt: <사유>` marker 를 공통 Python helper 로 판정하고, generated hook 과 중앙 fallback 이 같은 계약을 사용하도록 연결했습니다.
- 기존 파일 내용, `Write`/`Edit` payload, Codex `apply_patch`, headless worker 사후 TDD 검사에 대한 회귀 테스트를 추가했습니다.
- 빈 사유 marker 는 계속 deny 하며, 차단 메시지는 테스트 작성과 override marker 두 경로를 함께 안내합니다.
- `docs/plugin/hooks.md` 의 tdd-guard 상세와 우회/opt-out 표를 갱신했습니다.

## 결정 근거
- block 기본값은 유지하고 marker 는 파일 단위 test 부재 차단에만 적용했습니다.
- marker 는 같은 줄에 사유가 있어야 하므로 빈 marker 남용을 막고, 코드에 커밋되어 `rg "tdd-exempt:"` 로 사용 빈도를 확인할 수 있습니다.
- project-local generated hook 이 런타임에 `scripts/dcness-tdd-hooks run` 을 호출하는 기존 구조를 유지해 새 generated 파일 재배포 없이 plugin 업데이트로 계약이 적용됩니다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in 본체 경로 갱신: `harness/tdd_hooks.py`, `hooks/tdd-guard.sh`.
- project-local generated hook 경로: 기존 generated shell 은 plugin 의 `scripts/dcness-tdd-hooks run` 을 실행하므로 plugin 업데이트 후 같은 generated 파일이 새 marker 계약을 사용합니다. `/init-dcness` 복사 파일 변경은 없습니다.
- 사용자용 SSOT 갱신: `docs/plugin/hooks.md`.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public skill/command/agent/gate 추가 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`
- [x] `python3.11 -m unittest tests.test_tdd_guard tests.test_generated_tdd_hooks tests.test_surface_docs_sync -v < /dev/null`
- [x] `python3.11 -m unittest tests.test_guard_efficacy_eval -v < /dev/null`
- [x] `python3.11 evals/guard_efficacy.py --json`
- [x] `bash -n hooks/tdd-guard.sh`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`

## 참고
- pre-commit hook PASS: pytest gate 1741 tests + git naming.
