### PR TITLE
[issue-1009] impl pre-flight gate 강제

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -86,7 +86,7 @@ dcNess hook 은 보안 sandbox 가 아니다. file boundary 와 외부 상태 �
 
 **시점**: 메인 Claude 가 `Agent` tool 로 sub-agent 를 호출하기 직전, 그리고 `dcness-helper begin-step` 이 step 시작을 기록하기 직전. Claude Agent provider 는 전자를 타고, Codex/headless provider 는 후자를 탄다.
 
-**역할**: 작업 순서 보호와 active run 의 `begin-step -> Agent/headless worker -> end-step` 물리 순서를 강제한다. engineer/build-worker / pr-reviewer 순서 불변식은 provider 와 무관하게 같은 판정 함수를 쓴다.
+**역할**: 작업 순서 보호와 active run 의 `begin-step -> Agent/headless worker -> end-step` 물리 순서를 강제한다. engineer/build-worker / pr-reviewer 순서 불변식과 impl entry pre-flight 는 provider 와 무관하게 같은 판정 함수를 쓴다.
 
 PASS prose 판정은 `end-step` 저장 규칙과 같은 파일명을 본다. 즉 `<agent>.md`, 재호출 occurrence 인 `<agent>-1.md`, mode-suffix 인 `<agent>-MODE.md`, mode 재호출인 `<agent>-MODE-1.md` 안의 `PASS` 모두 같은 agent 의 완료 증거로 인정한다.
 
@@ -94,17 +94,21 @@ PASS prose 판정은 `end-step` 저장 규칙과 같은 파일명을 본다. 즉
 |---|---|
 | pr-reviewer gate | engineer 산출물이 있는데 code-validator PASS 없이 pr-reviewer 호출 |
 | engineer gate | 설계 산출물 없이 engineer/build-worker 가 src 구현으로 진입 — 같은 run 의 module-architect PASS *또는* `begin-run --design-doc` 으로 기록된 설계 문서 실존 *또는* `begin-run --lane lite` 로 기록된 Lite 구현 경로(#714), 셋 중 하나로 충족 |
+| impl boundary pre-flight | `begin-run --design-doc` 이 가리키는 impl/compact plan 의 `### 수정 허용` 경로가 engineer boundary(`ALLOW_MATRIX ∪ .dcness/boundary.json`)로 커버되지 않음 |
+| impl TDD pre-flight | 플랫폼 또는 project-local TDD 계약이 감지됐는데 CC+Codex generated TDD hook 이 등록되지 않았거나 생성 파일이 커밋되지 않음 |
 | 진행 순서 검사 | active run 안에서 직전 `begin-step` 과 다른 agent/mode 호출, `current_step` 부재, 이미 staged 된 stale step |
 
 **진행 순서 검사 대상**: `entry_point=design|impl|ux`. 정상 `/design` 은 `begin-run design` 로 시작하며 같은 진행 순서 검사를 탄다. module-architect 는 `/design` 기본 선두 진입, greenfield thin bootstrap 이후 진입, opt-in system checkpoint 이후 재진입 모두 별도 validator 게이트 없이 허용한다. checkpoint 필요 여부와 재진입 흐름은 `skills/design/design-routing.md` 의 agent enum(`SYSTEM_CHECKPOINT_REQUIRED`)과 `begin-step` 물리 순서 검사로만 다룬다.
 
 **engineer gate 의 design_doc 경로**: 설계(impl 문서 / compact plan)가 *별도 run* 에서 작성·머지된 뒤 구현 run 으로 진입하는 흐름(예: `/impl-loop` 풀 4-agent)에서는 같은 run 안에 module-architect prose 가 없다. 이때 `begin-run impl --design-doc <머지된 설계 문서 경로>` 로 run 에 설계 산출물을 기록하면 engineer gate 가 그 실존을 사전 조건 증거로 인정한다. 경로는 설계 산출물 규약(`docs/epics/**` / `docs/compact-plans/**`) 안의 실존 `.md` 만 허용 — 기록 시점에 resolve 절대경로로 fail-fast 검증(traversal / repo 밖 경로 거부)하고, 게이트 시점에 실존을 재확인한다. `--design-doc` 은 `entry_point=impl` run 에서만 수용된다(다른 entry_point 는 begin-run 이 거부) — design / architect-loop run 의 기존 module-architect PASS 강제는 코드 보장으로 유지된다.
 
+**impl entry pre-flight**: `engineer` / `build-worker` 의 구현 step 시작 직전에 추가로 확인한다. `--design-doc` 이 있으면 해당 impl/compact plan 의 `### 수정 허용` 경로를 `ALLOW_MATRIX ∪ .dcness/boundary.json` 과 대조한다. 미커버 경로가 있으면 `[순서 차단 훅: impl pre-flight boundary]` 로 STOP 하며, 사람 승인 후 `.dcness/boundary.json` override 가 필요하다. 또한 프로젝트 플랫폼 또는 project-local TDD 계약이 감지됐는데 CC+Codex generated hook 이 없거나 생성 파일이 커밋되지 않았으면 `[순서 차단 훅: impl pre-flight TDD]` 로 STOP 한다. 빈 프로젝트·미지원 플랫폼·dcNess self repo 는 no-op 이다.
+
 **engineer gate 의 구현 경로 면제 (#714)**: `/impl` 2축 모델의 Lite 구현 경로(설계도 없음)에 sub-agent 엔진(풀4 / 경량 build-worker)을 붙이는 4번째 조합용 면제 경로다. Lite 는 정의상 설계도가 없어 module-architect PASS 도 design_doc 도 없으므로, `begin-run impl --lane lite` 로 run 슬롯에 구현 경로를 기록하면 engineer gate 가 그 기록을 engineer/build-worker 설계 산출물 사전 조건 면제 신호로 인정한다. **면제 경계** — (1) `--lane` 값은 닫힌 enum(`lite` / `standard`)만 수용(임의 문자열 거부), (2) `--lane lite` 는 `entry_point=impl` run 에서만 수용(다른 entry_point 는 begin-run 이 거부)되어 design / architect-loop 의 module-architect PASS 강제는 영향받지 않음, (3) 면제는 *명시적으로 기록된* `lane=lite` 한정 — 값 미기록(impl-loop 풀4 / 기본)과 `lane=standard` 는 종전대로 설계 산출물을 요구(면제 누수 차단), (4) 면제는 engineer gate *하나만* 푼다 — engineer 산출물 이후 `pr-reviewer ← code-validator PASS` 잔존 보호는 구현 경로와 무관하게 그대로 강제된다(풀4 경로의 중대 차단 보호 불변).
 
 **tech-review 관례**: `/design` 진입 후 tech-reviewer 재호출은 관례상 비권장이지만 코드 차단은 아니다. /design 도중 미검증 새 외부 의존이 발견되면 design 의 `NEW_DEP_ESCALATE` 경로로 처리한다.
 
-**차단**: Claude Code PreToolUse 에서는 위반 시 `exit 2` + stderr, helper `begin-step` 에서는 비-0 종료 + stderr. engineer / pr-reviewer 게이트 위반은 `[순서 차단 훅: <gate>]`, 진행 순서 검사 위반은 `[진행 순서 검사]` 접두사를 포함한다. 게이트 자체 예외는 fail-open 계측으로 남기고 과차단하지 않는다.
+**차단**: Claude Code PreToolUse 에서는 위반 시 `exit 2` + stderr, helper `begin-step` 에서는 비-0 종료 + stderr. engineer / pr-reviewer / impl pre-flight 게이트 위반은 `[순서 차단 훅: <gate>]`, 진행 순서 검사 위반은 `[진행 순서 검사]` 접두사를 포함한다. 게이트 자체 예외는 fail-open 계측으로 남기고 과차단하지 않는다.
 차단이 발생하면 `guard-telemetry.jsonl` 에 `guard=catastrophic-gate` 로 기록된다.
 
 ### file-guard.sh

--- a/harness/boundary_suggestions.py
+++ b/harness/boundary_suggestions.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Iterable, Optional
 
 from harness.agent_boundary import check_write_allowed
+from harness.parallel_wave import parse_impl_task
 
 
 SOURCE_EXTENSIONS: frozenset[str] = frozenset(
@@ -196,6 +197,13 @@ def _pattern_for_directory(directory: str) -> str:
     return "^" + "/".join(re.escape(part) for part in directory.rstrip("/").split("/")) + "/"
 
 
+def _pattern_for_scope_path(path: str) -> str:
+    normalized = path.strip()
+    if normalized.endswith("/"):
+        return _pattern_for_directory(normalized)
+    return "^" + "/".join(re.escape(part) for part in normalized.split("/")) + "$"
+
+
 def _group_uncovered(uncovered: list[Path]) -> list[BoundarySuggestion]:
     grouped: dict[str, list[Path]] = {}
     for rel in uncovered:
@@ -226,8 +234,68 @@ def _suggestion_directory(rel: Path) -> str:
     return parent.rstrip("/") + "/"
 
 
-def collect_boundary_suggestions(cwd: Optional[Path] = None) -> BoundarySuggestionReport:
+def _suggestions_for_impl_plan_scope(paths: Iterable[str]) -> list[BoundarySuggestion]:
+    suggestions: list[BoundarySuggestion] = []
+    for rel in sorted(set(paths)):
+        suggestions.append(
+            BoundarySuggestion(
+                directory=rel,
+                pattern=_pattern_for_scope_path(rel),
+                file_count=1,
+                examples=[rel],
+            )
+        )
+    return suggestions
+
+
+def collect_impl_plan_boundary_suggestions(
+    cwd: Optional[Path],
+    impl_plan: Path,
+) -> BoundarySuggestionReport:
+    """Detect `### 수정 허용` paths not covered by the engineer boundary."""
+    root = _project_root(cwd)
+    if _is_dcness_self_repo(root):
+        return BoundarySuggestionReport(
+            project_root=str(root),
+            scanned_files=0,
+            uncovered_files=0,
+            suggestions=[],
+            reason="self_repo",
+        )
+
+    parsed = parse_impl_task(impl_plan)
+    scope_paths = sorted(parsed.scope_paths)
+    uncovered: list[str] = []
+    for rel in scope_paths:
+        reason = check_write_allowed("engineer", rel, cwd=root)
+        if reason is not None and "ALLOW_MATRIX" in reason:
+            uncovered.append(rel)
+
+    suggestions = _suggestions_for_impl_plan_scope(uncovered)
+    if suggestions:
+        report_reason = "impl_plan_uncovered"
+    elif not scope_paths:
+        report_reason = "impl_plan_scope_ambiguous"
+    else:
+        report_reason = "impl_plan_covered"
+    return BoundarySuggestionReport(
+        project_root=str(root),
+        scanned_files=len(scope_paths),
+        uncovered_files=len(uncovered),
+        suggestions=suggestions,
+        reason=report_reason,
+    )
+
+
+def collect_boundary_suggestions(
+    cwd: Optional[Path] = None,
+    *,
+    impl_plan: Optional[Path] = None,
+) -> BoundarySuggestionReport:
     """Detect source directories not covered by the effective engineer boundary."""
+    if impl_plan is not None:
+        return collect_impl_plan_boundary_suggestions(cwd, impl_plan)
+
     root = _project_root(cwd)
     if _is_dcness_self_repo(root):
         return BoundarySuggestionReport(
@@ -266,17 +334,18 @@ def format_boundary_suggestions(report: BoundarySuggestionReport) -> str:
     if report.reason == "self_repo":
         return "[dcness boundary] no-op - dcNess self repo 는 boundary override 제안 대상이 아닙니다."
     if not report.suggestions:
-        detail = (
-            "소스 파일 없음"
-            if report.reason == "empty"
-            else "코어 ALLOW_MATRIX 또는 기존 .dcness/boundary.json 으로 모두 커버됨"
-        )
+        if report.reason == "empty":
+            detail = "소스 파일 없음"
+        elif report.reason == "impl_plan_scope_ambiguous":
+            detail = "impl 계획의 `### 수정 허용` 경로를 확정할 수 없음"
+        else:
+            detail = "코어 ALLOW_MATRIX 또는 기존 .dcness/boundary.json 으로 모두 커버됨"
         return f"[dcness boundary] no-op - {detail}."
 
     add_patterns = [item.pattern for item in report.suggestions]
     sample = {"engineer": {"add": add_patterns}}
     lines = [
-        "[dcness boundary] 코어 ALLOW_MATRIX 미커버 소스 디렉터리 후보:",
+        "[dcness boundary] 코어 ALLOW_MATRIX 미커버 경로 후보:",
     ]
     for item in report.suggestions:
         examples = ", ".join(f"`{example}`" for example in item.examples)

--- a/harness/boundary_suggestions.py
+++ b/harness/boundary_suggestions.py
@@ -286,7 +286,7 @@ def collect_impl_plan_boundary_suggestions(
     return BoundarySuggestionReport(
         project_root=str(root),
         scanned_files=len(scope_paths),
-        uncovered_files=len(uncovered),
+        uncovered_files=len(blocking_reasons),
         suggestions=suggestions,
         reason=report_reason,
         blocking_reasons=blocking_reasons,

--- a/harness/boundary_suggestions.py
+++ b/harness/boundary_suggestions.py
@@ -9,7 +9,7 @@ import json
 import os
 import re
 import subprocess  # nosec B404
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Iterable, Optional
 
@@ -109,6 +109,7 @@ class BoundarySuggestionReport:
     uncovered_files: int
     suggestions: list[BoundarySuggestion]
     reason: str
+    blocking_reasons: dict[str, str] = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return asdict(self)
@@ -266,13 +267,17 @@ def collect_impl_plan_boundary_suggestions(
     parsed = parse_impl_task(impl_plan)
     scope_paths = sorted(parsed.scope_paths)
     uncovered: list[str] = []
+    blocking_reasons: dict[str, str] = {}
     for rel in scope_paths:
         reason = check_write_allowed("engineer", rel, cwd=root)
-        if reason is not None and "ALLOW_MATRIX" in reason:
+        if reason is None:
+            continue
+        blocking_reasons[rel] = reason
+        if "ALLOW_MATRIX" in reason:
             uncovered.append(rel)
 
     suggestions = _suggestions_for_impl_plan_scope(uncovered)
-    if suggestions:
+    if blocking_reasons:
         report_reason = "impl_plan_uncovered"
     elif not scope_paths:
         report_reason = "impl_plan_scope_ambiguous"
@@ -284,6 +289,7 @@ def collect_impl_plan_boundary_suggestions(
         uncovered_files=len(uncovered),
         suggestions=suggestions,
         reason=report_reason,
+        blocking_reasons=blocking_reasons,
     )
 
 
@@ -334,6 +340,21 @@ def format_boundary_suggestions(report: BoundarySuggestionReport) -> str:
     if report.reason == "self_repo":
         return "[dcness boundary] no-op - dcNess self repo 는 boundary override 제안 대상이 아닙니다."
     if not report.suggestions:
+        if report.blocking_reasons:
+            lines = [
+                "[dcness boundary] engineer/build-worker boundary 차단 경로:",
+            ]
+            for path, reason in sorted(report.blocking_reasons.items()):
+                lines.append(f"- `{path}`: {reason}")
+            lines.extend(
+                [
+                    "",
+                    "ALLOW_MATRIX 미커버 경로는 사람 승인 후 `.dcness/boundary.json` "
+                    "engineer.add override 가 필요합니다.",
+                    "INFRA/docs 등 되돌릴 수 없는 deny 경로는 impl 계획 scope 를 수정하세요.",
+                ]
+            )
+            return "\n".join(lines)
         if report.reason == "empty":
             detail = "소스 파일 없음"
         elif report.reason == "impl_plan_scope_ambiguous":
@@ -353,6 +374,20 @@ def format_boundary_suggestions(report: BoundarySuggestionReport) -> str:
             f"- `{item.directory}` ({item.file_count} files) -> "
             f"`{item.pattern}`; examples: {examples}"
         )
+    suggested_paths = {
+        example
+        for item in report.suggestions
+        for example in item.examples
+    }
+    non_override_blocks = {
+        path: reason
+        for path, reason in report.blocking_reasons.items()
+        if path not in suggested_paths
+    }
+    if non_override_blocks:
+        lines.extend(["", "override 로 열 수 없는 차단 경로:"])
+        for path, reason in sorted(non_override_blocks.items()):
+            lines.append(f"- `{path}`: {reason}")
     lines.extend(
         [
             "",

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -921,13 +921,135 @@ def _run_design_doc_exists(
     base_dir: Optional[Path] = None,
 ) -> bool:
     """현재 run 슬롯에 기록된 design_doc 이 디스크에 실존하는지."""
+    doc = _run_design_doc_path(session_id, run_id, base_dir=base_dir)
+    return bool(doc and doc.is_file())
+
+
+def _run_design_doc_path(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Optional[Path]:
+    """현재 run 슬롯의 design_doc 절대경로를 반환한다."""
     try:
         doc = _slot_for_run(session_id, run_id, base_dir=base_dir).get("design_doc")
         if not isinstance(doc, str) or not doc:
-            return False
-        return Path(doc).is_file()
+            return None
+        return Path(doc)
+    except (OSError, ValueError):
+        return None
+
+
+def _project_root_from_design_doc(doc: Path) -> Optional[Path]:
+    """`.../docs/...` 설계 산출물 경로에서 프로젝트 루트를 복원한다."""
+    try:
+        resolved = doc.resolve()
+    except (OSError, RuntimeError):
+        resolved = doc
+    parts = resolved.parts
+    for idx in range(len(parts) - 1, 0, -1):
+        if parts[idx] == "docs":
+            return Path(*parts[:idx])
+    return None
+
+
+def _is_dcness_self_project(project_root: Path) -> bool:
+    manifest = project_root / ".claude-plugin" / "plugin.json"
+    try:
+        data = json.loads(manifest.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return False
+    return isinstance(data, dict) and data.get("name") == "dcness"
+
+
+def _impl_run_project_root(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Path:
+    doc = _run_design_doc_path(session_id, run_id, base_dir=base_dir)
+    if doc is not None:
+        root = _project_root_from_design_doc(doc)
+        if root is not None:
+            return root
+    return Path.cwd().resolve()
+
+
+def _impl_plan_boundary_preflight_message(
+    session_id: str,
+    run_id: str,
+    *,
+    base_dir: Optional[Path] = None,
+) -> Optional[str]:
+    doc = _run_design_doc_path(session_id, run_id, base_dir=base_dir)
+    if doc is None or not doc.is_file():
+        return None
+    project_root = _project_root_from_design_doc(doc)
+    if project_root is None:
+        return None
+
+    try:
+        from harness.boundary_suggestions import (
+            collect_boundary_suggestions,
+            format_boundary_suggestions,
+        )
+
+        report = collect_boundary_suggestions(project_root, impl_plan=doc)
+    except Exception as exc:
+        return (
+            "[순서 차단 훅: impl pre-flight boundary] impl 계획의 `### 수정 허용` "
+            f"boundary 대조 실패: {exc}. 계획 scope 를 확인한 뒤 재시도하세요."
+        )
+    if not report.suggestions:
+        return None
+    return (
+        "[순서 차단 훅: impl pre-flight boundary] impl 계획의 `### 수정 허용` "
+        "경로 중 engineer/build-worker boundary 로 커버되지 않는 항목이 있습니다. "
+        "사람 승인 후 `.dcness/boundary.json` engineer.add override 를 기록하기 전까지 "
+        "구현 step 을 시작할 수 없습니다.\n"
+        f"{format_boundary_suggestions(report)}"
+    )
+
+
+def _generated_tdd_preflight_message(project_root: Path) -> Optional[str]:
+    if _is_dcness_self_project(project_root):
+        return None
+    try:
+        from harness.tdd_hooks import inspect_installation
+
+        report = inspect_installation(project_root)
+    except Exception as exc:
+        return (
+            "[순서 차단 훅: impl pre-flight TDD] generated TDD hook 상태 확인 실패: "
+            f"{exc}. `scripts/dcness-tdd-hooks status --project-root <project>` 로 "
+            "상태를 확인하세요."
+        )
+
+    platform = report.get("platform")
+    if not platform:
+        return None
+
+    cc_registered = bool(report.get("cc_registered"))
+    codex_registered = bool(report.get("codex_registered"))
+    committed = bool(report.get("generated_files_committed"))
+    if cc_registered and codex_registered and committed:
+        return None
+
+    uncommitted = report.get("uncommitted_generated_files") or []
+    detail = ""
+    if isinstance(uncommitted, list) and uncommitted:
+        detail = f", uncommitted={', '.join(str(item) for item in uncommitted[:5])}"
+    return (
+        "[순서 차단 훅: impl pre-flight TDD] generated TDD hook 이 구현 진입 전 "
+        "준비되지 않았습니다. "
+        f"platform={platform}, cc={cc_registered}, codex={codex_registered}, "
+        f"generated_files_committed={committed}{detail}. "
+        "사람 승인 후 `scripts/dcness-tdd-hooks ensure --project-root <project> "
+        "--targets cc,codex --plugin-root <plugin-root>` 를 실행하고 생성 파일을 "
+        "bootstrap commit 에 포함하세요."
+    )
 
 
 def _run_lane(
@@ -1045,6 +1167,16 @@ def evaluate_order_gate_for_step(
                 "시작할 때 `begin-run impl --design-doc <설계문서>` 를 기록하세요. "
                 "명시적 Lite 구현 경로라면 `begin-run impl --lane lite` 로 시작하세요."
             )
+        boundary_message = _impl_plan_boundary_preflight_message(
+            session_id, run_id, base_dir=base_dir,
+        )
+        if boundary_message:
+            return boundary_message
+        tdd_message = _generated_tdd_preflight_message(
+            _impl_run_project_root(session_id, run_id, base_dir=base_dir)
+        )
+        if tdd_message:
+            return tdd_message
 
     if norm_agent == "pr-reviewer":
         if _run_has_engineer_output(rd) and not _run_prose_has_pass(rd, "code-validator"):

--- a/harness/session_state.py
+++ b/harness/session_state.py
@@ -1002,13 +1002,14 @@ def _impl_plan_boundary_preflight_message(
             "[순서 차단 훅: impl pre-flight boundary] impl 계획의 `### 수정 허용` "
             f"boundary 대조 실패: {exc}. 계획 scope 를 확인한 뒤 재시도하세요."
         )
-    if not report.suggestions:
+    if not report.suggestions and not report.blocking_reasons:
         return None
     return (
         "[순서 차단 훅: impl pre-flight boundary] impl 계획의 `### 수정 허용` "
-        "경로 중 engineer/build-worker boundary 로 커버되지 않는 항목이 있습니다. "
-        "사람 승인 후 `.dcness/boundary.json` engineer.add override 를 기록하기 전까지 "
-        "구현 step 을 시작할 수 없습니다.\n"
+        "경로 중 engineer/build-worker boundary 로 커버되지 않거나 차단되는 항목이 "
+        "있습니다. ALLOW_MATRIX 미커버 경로는 사람 승인 후 `.dcness/boundary.json` "
+        "engineer.add override 를 기록하고, INFRA/docs 등 되돌릴 수 없는 deny 경로는 "
+        "계획 scope 를 수정하기 전까지 구현 step 을 시작할 수 없습니다.\n"
         f"{format_boundary_suggestions(report)}"
     )
 

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -807,7 +807,11 @@ def _cli_boundary_suggestions(args: Any) -> int:
         format_boundary_suggestions,
     )
 
-    report = collect_boundary_suggestions(Path(args.cwd) if args.cwd else None)
+    impl_plan = Path(args.impl_plan) if args.impl_plan else None
+    report = collect_boundary_suggestions(
+        Path(args.cwd) if args.cwd else None,
+        impl_plan=impl_plan,
+    )
     if args.json:
         print(json.dumps(report.to_dict(), ensure_ascii=False))
     else:
@@ -1264,6 +1268,11 @@ def _build_arg_parser() -> Any:
         help="#910 read-only: 비표준 소스 디렉터리 boundary override 후보 출력",
     )
     p_bsug.add_argument("--cwd", default="", help="검사할 프로젝트 cwd (기본 현재 cwd)")
+    p_bsug.add_argument(
+        "--impl-plan",
+        default="",
+        help="impl/compact plan 의 `### 수정 허용` 경로를 ALLOW_MATRIX 와 대조",
+    )
     p_bsug.add_argument("--json", action="store_true")
     p_bsug.set_defaults(func=_cli_boundary_suggestions)
 

--- a/hooks/catastrophic-gate.sh
+++ b/hooks/catastrophic-gate.sh
@@ -11,10 +11,12 @@
 #          — CC docs: PreToolUse 는 exit 2 라야 차단 + stderr 가 Claude 에 피드백.
 #            exit 1 = non-blocking error → 도구 그대로 진행 (차단 안 됨).
 #
-# 강제 룰 (3 게이트):
+# 강제 룰:
 #   - pr-reviewer 게이트 — pr-reviewer 직전 code-validator PASS 확인
 #   - engineer 게이트 — engineer 직전 설계 산출물 확인 (같은 run 의 module-architect PASS
 #     또는 begin-run --design-doc 으로 기록된 설계 문서 실존)
+#   - impl entry pre-flight — design_doc 의 `### 수정 허용` boundary 대조 +
+#     generated TDD hook 활성/커밋 확인
 #   - module-architect 게이트 — /design 첫 module-architect 단위 호출 직전 architecture-validator 1차 PASS
 
 set -uo pipefail

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -106,6 +106,15 @@ UI 작업 감지 시 engine 무관하게 구현 시퀀스 선두에 내부 [`can
 
 [`issue-lifecycle.md` mid-flow 누락 차단](../../docs/plugin/issue-lifecycle.md#mid-flow-누락-차단-pre-flight-gate) 매치 강제 — 부모 epic stories.md 상단 `**GitHub Epic Issue:** [#\d+]` 또는 `미등록 (사유: …)` 매치 0건 시 즉시 STOP + 사용자 보고. silent skip 금지.
 
+### Impl entry pre-flight (engineer/build-worker 직전, 공통 강제)
+
+deep task 구현 run 은 `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 시작한다. 이 기록을 기준으로 `begin-step engineer/build-worker` 가 `/impl` 과 같은 entry pre-flight 를 provider-independent 로 강제한다.
+
+- **Boundary pre-flight**: impl 문서의 `### 수정 허용` 경로를 `ALLOW_MATRIX ∪ .dcness/boundary.json`(engineer.add) 과 대조한다. 미커버 경로가 있으면 구현 step 시작을 STOP 하고, 사람 승인 후 `.dcness/boundary.json` override 를 기록해야 한다. 사전 확인은 `dcness-helper boundary-suggestions --impl-plan <task>` 로도 볼 수 있다.
+- **Generated TDD hook pre-flight**: 플랫폼 또는 project-local TDD 계약이 감지됐는데 CC+Codex generated hook 이 없거나 생성 파일이 커밋되지 않았으면 구현 step 시작을 STOP 한다. 사람 승인 후 `scripts/dcness-tdd-hooks ensure --targets cc,codex` 를 실행하고 생성 파일을 bootstrap commit 에 포함한다. 빈 프로젝트·미지원 플랫폼은 no-op 이다.
+
+계획 파일이 없는 일반 구현은 본 skill 비대상이며 `/impl` 이 Lite/Standard 를 판정한다. Lite 기본 경로는 메인 직접 구현이라 impl plan `### 수정 허용` 대조 대상이 아니다.
+
 ### 부모 이슈 본문 read 의무 (MUST)
 
 Pre-flight gate 통과 후, 매치된 **epic / story 이슈** 번호 *각 본문 read 의무*. **task 는 GitHub 이슈가 없다** ([`issue-lifecycle.md` 이슈 계층](../../docs/plugin/issue-lifecycle.md#이슈-계층) — PR 1개 = task 1개, PR 자체가 추적 단위) → `<task-num>` read 하지 않는다. task 컨텍스트는 impl 파일 frontmatter + 본문이 진본.
@@ -267,7 +276,7 @@ fi
 
 승격 시퀀스 = **test-engineer → engineer (IMPL) → code-validator → pr-reviewer**. 4 단계 *모두 호출* 의무 (MUST — false-clean 차단, #431).
 
-🔴 **begin-run 에 `--design-doc` 필수**: 엔진 A 는 설계(impl 문서)가 별도 run 에서 머지된 *뒤* 진입하므로 같은 run 안에 module-architect prose 가 없다 — `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 머지된 설계 문서를 run 에 기록해야 engineer 게이트(순서 차단 훅)가 IMPL 진입을 허용한다 ([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). story/epic 마감 task 이고 acceptance 기본 ON 이면 같은 begin-run 에 `--acceptance-required` 도 붙인다. 이 marker 는 Stop hook 이 pr-reviewer 직후 run 을 자동 종료하지 않고 product-acceptance 진입 turn 을 재발화하게 하는 신호다. chain 에서 다음 task 도 풀 4-agent 면 `next-task --design-doc <다음 task 의 impl 문서 경로>` 로 동일 기록하고, 다음 task 가 마감 acceptance 대상이면 `--acceptance-required` 도 함께 기록한다. advanced fallback 으로 module-architect 를 선두 추가한 run 은 같은-run PASS prose 가 생기므로 생략 가능하나, task 의 impl 문서가 이미 있으면 기록을 권장한다.
+🔴 **begin-run 에 `--design-doc` 필수**: 엔진 A 는 설계(impl 문서)가 별도 run 에서 머지된 *뒤* 진입하므로 같은 run 안에 module-architect prose 가 없다 — `begin-run impl --design-doc <task 의 impl 문서 경로>` 로 머지된 설계 문서를 run 에 기록해야 engineer 게이트(순서 차단 훅)가 IMPL 진입을 허용한다 ([`hooks.md` engineer gate](../../docs/plugin/hooks.md#catastrophic-gatesh)). 같은 기록은 impl entry pre-flight 의 boundary 대조 입력이기도 하다. story/epic 마감 task 이고 acceptance 기본 ON 이면 같은 begin-run 에 `--acceptance-required` 도 붙인다. 이 marker 는 Stop hook 이 pr-reviewer 직후 run 을 자동 종료하지 않고 product-acceptance 진입 turn 을 재발화하게 하는 신호다. chain 에서 다음 task 도 풀 4-agent 면 `next-task --design-doc <다음 task 의 impl 문서 경로>` 로 동일 기록하고, 다음 task 가 마감 acceptance 대상이면 `--acceptance-required` 도 함께 기록한다. advanced fallback 으로 module-architect 를 선두 추가한 run 은 같은-run PASS prose 가 생기므로 생략 가능하나, task 의 impl 문서가 이미 있으면 기록을 권장한다.
 
 ✅ 정상 흐름:
 1. **test-engineer** (TESTS_WRITTEN) → 테스트 선작성
@@ -288,7 +297,7 @@ fi
 시퀀스 = **build-worker (2-step: test+impl+self-validate 통합) → pr-reviewer**. deep task 보강 필요 시 module-architect 선두 (3-step).
 
 1. **begin-run + (reset) + build-worker step** — `begin-run impl --design-doc <task 의 impl 문서 경로>` (마감 acceptance 대상이면 `--acceptance-required` 추가) → **(chain 의 첫 task 또는 single 모드면 `dcness-helper prev-tasks-reset` — `begin-step` *전*, prev-tasks 초기화)** → `begin-step build-worker` → `dcness-helper run-dir` 로 `<run_dir>` 확인 → `Agent(build-worker, prompt=<impl 경로 + task slug + RUN_ID + run_dir + (begin-step stdout 의 [PREVIOUS_TASKS] 섹션 있으면 그대로 포함, #525)>)` → 반환 prose 결론 분기 (= [`impl-loop-routing.md`](impl-loop-routing.md#결론-다음-호출-매핑)). 이후 `end-step build-worker`. worker 안 phase 별 prose (`build-test.md` / `build-impl.md` / `build-validate.md`) 는 worker 자체 Write — [`loop-procedure.md` build-worker phase prose](../../docs/plugin/loop-procedure.md#build-worker-phase-prose-impl-loop-hybrid-a-한정). `<run_dir>` 는 harness-state run_dir 그대로이며 `phases/<RUN_ID>/` 별도 경로가 아니다.
-   `--design-doc` 은 build-worker 자체를 위한 값이 아니라, worker self-validate 실패나 마감 acceptance FAIL 뒤 `engineer:IMPL` 로 재진입할 때 engineer gate 의 설계 산출물 사전 조건을 만족시키는 기록이다. deep task 구현은 항상 impl 문서가 입력이므로 엔진 B 에서도 기록한다.
+   `--design-doc` 은 build-worker 자체를 위한 값이 아니라, worker self-validate 실패나 마감 acceptance FAIL 뒤 `engineer:IMPL` 로 재진입할 때 engineer gate 의 설계 산출물 사전 조건을 만족시키고, impl entry pre-flight 가 `### 수정 허용` boundary 를 대조할 수 있게 하는 기록이다. deep task 구현은 항상 impl 문서가 입력이므로 엔진 B 에서도 기록한다.
 2. **git/PR 생성 (메인)** — worker prose 의 commit message + PR 본문 초안을 임시 파일로 박고 `scripts/pr-create.sh` 통합 호출:
    ```bash
    cat > /tmp/pr-body-<slug>.md <<'PR'

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -85,9 +85,13 @@ GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecy
 
 ```bash
 "$HELPER" boundary-suggestions
+# 설계 문서 경로가 이미 있으면:
+"$HELPER" boundary-suggestions --impl-plan <docs/compact-plans/...md 또는 docs/epics/.../impl/...md>
 ```
 
-코어 `ALLOW_MATRIX` 로 커버되지 않는 비표준 소스 디렉터리가 있으면 `.dcness/boundary.json` 의 `engineer.add` 후보만 출력한다. 후보가 있으면 사람 승인 후에만 메인이 boundary 파일을 작성한다. 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다.
+코어 `ALLOW_MATRIX` 로 커버되지 않는 비표준 소스 디렉터리가 있으면 `.dcness/boundary.json` 의 `engineer.add` 후보만 출력한다. 설계 문서가 있는 Standard 경로에서는 설계 문서의 `### 수정 허용` 경로도 같은 기준으로 대조한다. 후보가 있으면 사람 승인 후에만 메인이 boundary 파일을 작성한다. 표준 레이아웃·빈 프로젝트·이미 override 로 커버된 프로젝트는 no-op 이다.
+
+이 pre-flight 는 `begin-step engineer/build-worker` 에서도 provider-independent 로 강제된다. Standard run 의 `--design-doc` 이 가리키는 impl/compact plan 안 `### 수정 허용` 경로가 `ALLOW_MATRIX ∪ .dcness/boundary.json` 으로 커버되지 않으면 구현 step 시작이 차단된다. Lite 기본 경로는 계획 파일 없이 메인 직접 구현이므로 plan-specific boundary 대조 대상이 아니다.
 
 ## Step 0.3 — generated TDD hook 부재 확인
 
@@ -103,7 +107,7 @@ GitHub issue 번호가 대상이면 구현 실행 전 [`docs/plugin/issue-lifecy
 "$PLUGIN_ROOT/scripts/dcness-tdd-hooks" ensure --project-root "$PROJECT_ROOT" --targets cc,codex --plugin-root "$PLUGIN_ROOT"
 ```
 
-빈 프로젝트, 미지원 플랫폼, 생성 실패, self-test 실패는 no-op 으로 안전 통과한다. 생성 훅이 있으면 중앙 `tdd-guard.sh` 와 headless worker 사후 검사는 그 generated hook 을 먼저 실행한다.
+빈 프로젝트와 미지원 플랫폼은 no-op 으로 안전 통과한다. 플랫폼 또는 project-local 계약이 감지된 프로젝트에서 generated hook 이 없거나 생성/self-test 가 실패하면 구현 진입 전 사용자 위임으로 멈춘다. 생성 훅이 있으면 중앙 `tdd-guard.sh` 와 headless worker 사후 검사는 그 generated hook 을 먼저 실행한다.
 
 `status` 또는 `ensure` 가 `commit-required` 를 출력하면 생성 파일(`.dcness/tdd-hooks.json`, `.claude/settings.json`, `.claude/hooks/dcness-tdd-guard.sh`, `.codex/hooks.json`, `.codex/hooks/dcness-tdd-guard.sh`)을 bootstrap commit 에 포함해야 한다. 커밋되지 않은 생성 파일은 새 worktree/headless worker 체크아웃에 없으므로 project-local TDD 계약이 재사용되지 않는다.
 
@@ -230,7 +234,7 @@ Implementation routing 이 headless 계열이면 Lite 기본 구현도 메인이
 
 Standard 는 **설계 문서(경로)가 들어온** 구현 경로다. impl 은 설계를 만들지 않는다 — 받은 설계도(`docs/compact-plans/<slug>.md` / `docs/epics/**/impl/*.md`)를 충실히 구현만 한다. 경량 설계 산출 자체는 impl 밖 내부 skill [`compact-design`](../../skills/compact-design/SKILL.md)(= `module-architect:COMPACT_PLAN` wrapper) 또는 full `/design` 이 담당하고, 그 산출물 경로가 Standard 진입의 사전 조건이다.
 
-진입 시 `begin-run impl --design-doc <설계 문서 경로>` 로 설계도를 기록한다 — 이것이 engineer 게이트의 설계 산출물 사전 조건 증거다([`hooks.md`](../../docs/plugin/hooks.md#catastrophic-gatesh)). 설계도가 (a) 이전에 머지된 설계 문서든 (b) `compact-design` 이 방금 산출한 compact plan 이든, impl 은 같은 run 에서 설계를 생성하지 않으므로 Standard 는 **항상 `--design-doc` 기록 하나로** 진입한다 (same-run module-architect step 없음).
+진입 시 `begin-run impl --design-doc <설계 문서 경로>` 로 설계도를 기록한다 — 이것이 engineer 게이트의 설계 산출물 사전 조건 증거다([`hooks.md`](../../docs/plugin/hooks.md#catastrophic-gatesh)). 설계도가 (a) 이전에 머지된 설계 문서든 (b) `compact-design` 이 방금 산출한 compact plan 이든, impl 은 같은 run 에서 설계를 생성하지 않으므로 Standard 는 **항상 `--design-doc` 기록 하나로** 진입한다 (same-run module-architect step 없음). 이 경로가 기록되면 begin-step 게이트가 `### 수정 허용` boundary 대조도 자동 수행한다.
 
 엔진(풀4/경량)은 구현 경로와 직교로 별도 판정한다 — 사용자 우선, 미지정 시 build-worker 기본이다.
 

--- a/tests/test_boundary_suggestions.py
+++ b/tests/test_boundary_suggestions.py
@@ -162,6 +162,7 @@ class BoundarySuggestionsTests(unittest.TestCase):
             report = collect_boundary_suggestions(root, impl_plan=plan)
 
             self.assertEqual("impl_plan_uncovered", report.reason)
+            self.assertEqual(1, report.uncovered_files)
             self.assertEqual([], report.suggestions)
             self.assertIn("docs/notes.md", report.blocking_reasons)
             formatted = format_boundary_suggestions(report)

--- a/tests/test_boundary_suggestions.py
+++ b/tests/test_boundary_suggestions.py
@@ -108,6 +108,46 @@ class BoundarySuggestionsTests(unittest.TestCase):
             self.assertEqual([], report.suggestions)
             self.assertEqual("covered", report.reason)
 
+    def test_impl_plan_scope_detects_nonstandard_non_source_path(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            plan = root / "docs" / "epics" / "epic-01-x" / "impl" / "01-bootstrap.md"
+            self._write(
+                plan,
+                "## Scope\n\n"
+                "### 수정 허용\n\n"
+                "- gradle/libs.versions.toml\n",
+            )
+
+            report = collect_boundary_suggestions(root, impl_plan=plan)
+
+            self.assertEqual("impl_plan_uncovered", report.reason)
+            self.assertEqual(1, len(report.suggestions))
+            suggestion = report.suggestions[0]
+            self.assertEqual("gradle/libs.versions.toml", suggestion.directory)
+            self.assertEqual(r"^gradle/libs\.versions\.toml$", suggestion.pattern)
+            self.assertEqual(["gradle/libs.versions.toml"], suggestion.examples)
+
+    def test_impl_plan_scope_respects_existing_boundary_override(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            plan = root / "docs" / "epics" / "epic-01-x" / "impl" / "01-bootstrap.md"
+            self._write(
+                plan,
+                "## Scope\n\n"
+                "### 수정 허용\n\n"
+                "- gradle/libs.versions.toml\n",
+            )
+            self._write_boundary(
+                root,
+                {"engineer": {"add": [r"^gradle/libs\.versions\.toml$"]}},
+            )
+
+            report = collect_boundary_suggestions(root, impl_plan=plan)
+
+            self.assertEqual([], report.suggestions)
+            self.assertEqual("impl_plan_covered", report.reason)
+
     def test_ignores_tests_docs_dependencies_and_build_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)
@@ -150,6 +190,40 @@ class BoundarySuggestionsTests(unittest.TestCase):
 
             self.assertEqual("uncovered", payload["reason"])
             self.assertEqual(r"^remotion/", payload["suggestions"][0]["pattern"])
+
+    def test_helper_cli_accepts_impl_plan(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            plan = root / "docs" / "compact-plans" / "bootstrap.md"
+            self._write(
+                plan,
+                "## Scope\n\n"
+                "### 수정 허용\n\n"
+                "- settings.gradle.kts\n",
+            )
+
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "harness.session_state",
+                    "boundary-suggestions",
+                    "--cwd",
+                    str(root),
+                    "--impl-plan",
+                    str(plan),
+                    "--json",
+                ],
+                cwd=str(REPO_ROOT),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(proc.stdout)
+
+            self.assertEqual("impl_plan_uncovered", payload["reason"])
+            self.assertEqual(r"^settings\.gradle\.kts$", payload["suggestions"][0]["pattern"])
 
 
 if __name__ == "__main__":

--- a/tests/test_boundary_suggestions.py
+++ b/tests/test_boundary_suggestions.py
@@ -148,6 +148,26 @@ class BoundarySuggestionsTests(unittest.TestCase):
             self.assertEqual([], report.suggestions)
             self.assertEqual("impl_plan_covered", report.reason)
 
+    def test_impl_plan_scope_reports_non_override_boundary_block(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            plan = root / "docs" / "epics" / "epic-01-x" / "impl" / "01-bootstrap.md"
+            self._write(
+                plan,
+                "## Scope\n\n"
+                "### 수정 허용\n\n"
+                "- docs/notes.md\n",
+            )
+
+            report = collect_boundary_suggestions(root, impl_plan=plan)
+
+            self.assertEqual("impl_plan_uncovered", report.reason)
+            self.assertEqual([], report.suggestions)
+            self.assertIn("docs/notes.md", report.blocking_reasons)
+            formatted = format_boundary_suggestions(report)
+            self.assertIn("boundary 차단 경로", formatted)
+            self.assertIn("계획 scope", formatted)
+
     def test_ignores_tests_docs_dependencies_and_build_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             root = Path(td)

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -665,6 +665,23 @@ class ProviderAgnosticBeginStepOrderGateTests(_PreToolBase):
 
         self.assertIsNone(message)
 
+    def test_begin_step_blocks_non_override_boundary_reason(self) -> None:
+        doc = self._write_impl_plan("- docs/notes.md")
+        self._record_design_doc_for_gate(doc)
+
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: impl pre-flight boundary]", message or "")
+        self.assertIn("docs/notes.md", message or "")
+        self.assertIn("계획 scope", message or "")
+
     def test_begin_step_blocks_detected_project_missing_generated_tdd_hooks(self) -> None:
         doc = self._write_impl_plan("- src/app.py")
         (self.base / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -584,6 +584,105 @@ class ProviderAgnosticBeginStepOrderGateTests(_PreToolBase):
         )
         self.assertIsNone(message)
 
+    def _write_impl_plan(self, scope: str, *, root: Optional[Path] = None) -> Path:
+        project_root = root or self.base
+        doc = (
+            project_root / "docs" / "epics" / "epic-01-x" / "impl" / "03-foo.md"
+        )
+        doc.parent.mkdir(parents=True, exist_ok=True)
+        doc.write_text(
+            "## Scope\n\n"
+            "### 수정 허용\n\n"
+            f"{scope}\n",
+            encoding="utf-8",
+        )
+        return doc
+
+    def _record_design_doc_for_gate(self, doc: Path) -> None:
+        self._set_slot(design_doc=str(doc.resolve()))
+
+    def test_begin_step_blocks_design_doc_scope_outside_engineer_boundary(self) -> None:
+        doc = self._write_impl_plan("- gradle/libs.versions.toml")
+        self._record_design_doc_for_gate(doc)
+
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: impl pre-flight boundary]", message or "")
+        self.assertIn("gradle/libs.versions.toml", message or "")
+        self.assertIn(".dcness/boundary.json", message or "")
+
+    def test_begin_step_allows_design_doc_scope_with_boundary_override(self) -> None:
+        doc = self._write_impl_plan("- gradle/libs.versions.toml")
+        boundary = self.base / ".dcness" / "boundary.json"
+        boundary.parent.mkdir(parents=True, exist_ok=True)
+        boundary.write_text(
+            json.dumps(
+                {"engineer": {"add": [r"^gradle/libs\.versions\.toml$"]}},
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        self._record_design_doc_for_gate(doc)
+
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+
+        self.assertIsNone(message)
+
+    def test_begin_step_design_doc_root_uses_nearest_docs_segment(self) -> None:
+        project = self.base / "parent" / "docs" / "workspace" / "project"
+        doc = self._write_impl_plan("- gradle/libs.versions.toml", root=project)
+        boundary = project / ".dcness" / "boundary.json"
+        boundary.parent.mkdir(parents=True, exist_ok=True)
+        boundary.write_text(
+            json.dumps(
+                {"engineer": {"add": [r"^gradle/libs\.versions\.toml$"]}},
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+        self._record_design_doc_for_gate(doc)
+
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+
+        self.assertIsNone(message)
+
+    def test_begin_step_blocks_detected_project_missing_generated_tdd_hooks(self) -> None:
+        doc = self._write_impl_plan("- src/app.py")
+        (self.base / "pyproject.toml").write_text("[project]\nname='x'\n", encoding="utf-8")
+        self._record_design_doc_for_gate(doc)
+
+        message = evaluate_order_gate_for_step(
+            self.sid,
+            self.rid,
+            "build-worker",
+            None,
+            base_dir=self.base,
+        )
+
+        self.assertIsNotNone(message)
+        self.assertIn("[순서 차단 훅: impl pre-flight TDD]", message or "")
+        self.assertIn("platform=python", message or "")
+        self.assertIn("dcness-tdd-hooks ensure", message or "")
+
     def test_begin_step_blocks_after_live_boundary_block_marker(self) -> None:
         mark_run_blocked(
             self.sid,


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1009

## 배경 및 문제

`/impl-loop` 가 `/impl` 진입 사전점검을 우회해 deep task 구현에서 두 보호막이 늦게 발화했다.

- impl 계획의 `### 수정 허용` 에 비표준 경로가 있어도 기존 `boundary-suggestions` 는 소스 디렉터리 스캔만 해서 미리 잡지 못했다.
- fresh 프로젝트에서 generated TDD hook 이 준비되지 않은 채 `engineer` / `build-worker` 구현 step 으로 들어갈 수 있었다.

## 원인 (해당 시)

공통 impl entry pre-flight 가 없어서 `/impl` 문서 절차와 `/impl-loop` deep task runner가 서로 다른 진입 조건을 갖고 있었다. 결과적으로 boundary / TDD hook 확인이 helper begin-step의 provider-independent order gate에 연결되지 않았다.

## 작업내용

- `boundary-suggestions --impl-plan <path>` 옵션을 추가해 impl/compact plan 의 `### 수정 허용` 경로를 `ALLOW_MATRIX ∪ .dcness/boundary.json` 기준으로 대조한다.
- `evaluate_order_gate_for_step()`의 `engineer` / `build-worker` 진입 직전에 impl plan boundary pre-flight 와 generated TDD hook pre-flight 를 강제한다.
- design_doc 경로에서 프로젝트 루트를 복원해 외부 활성 프로젝트의 `.dcness/boundary.json` 과 TDD hook 상태를 정확히 본다.
- `/impl`, `/impl-loop`, `hooks.md`, `catastrophic-gate.sh` 문서를 새 공통 entry pre-flight 계약에 맞게 갱신했다.
- boundary / begin-step 회귀 테스트를 추가했다.

## 결정 근거

- issue가 제안한 `boundary-suggestions --impl-plan` 을 그대로 추가해 기존 read-only 제안 도구를 재사용했다.
- 실제 차단은 `begin-step`/catastrophic gate 공통 판정 함수에 넣어 Claude Agent provider와 Codex/headless provider가 같은 조건을 탄다.
- Lite 기본 경로는 계획 파일 없이 메인 직접 구현이므로 plan-specific boundary 대조는 적용하지 않고, 기존 lane=lite 설계 산출물 면제 의미를 유지했다.
- dcNess self repo 는 boundary/TDD hook pre-flight 대상에서 제외해 plugin 자체 개발 흐름을 오차단하지 않는다.

## 배포 경로 검증 (plug-in 영향 시)

- plugin 본체 경로 변경: `harness/**`, `hooks/catastrophic-gate.sh`, `skills/impl*/SKILL.md`, `docs/plugin/hooks.md`.
- 사용자 도달 경로: dcness plugin 업데이트/릴리즈 배포 시 plugin cache 안의 harness, hook, skill, docs가 함께 갱신된다.
- `/init-dcness` 가 사용자 repo 로 복사하는 workflow/template 파일 변경은 없다.
- generated TDD hook 생성물은 기존 `scripts/dcness-tdd-hooks ensure` 경로를 계속 사용하며, 이번 PR은 진입 전 상태 확인과 차단 배선만 추가한다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent 는 없다. 기존 helper의 `boundary-suggestions` 옵션과 기존 begin-step/catastrophic gate의 내부 판정만 확장한다.

## Test Plan

- [x] python3.11 -m unittest tests.test_boundary_suggestions -v < /dev/null
- [x] python3.11 -m unittest tests.test_hooks.ProviderAgnosticBeginStepOrderGateTests -v < /dev/null
- [x] python3.11 -m unittest discover -s tests -v < /dev/null
- [x] node scripts/check_public_surface.mjs && node scripts/check_cross_refs.mjs && node scripts/check_plugin_manifest.mjs
- [x] PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh
- [x] python3 evals/guard_efficacy.py
- [x] node scripts/aggregate_index_map.mjs --check && node scripts/check_design_artifact_structure.mjs
- [x] git diff --check
- [x] git commit pre-commit hook: pytest-gate PASS, git-naming PASS

## 참고

- 행동 eval `bash evals/run.sh` 는 LLM 호출 기반 advisory라 이번 deterministic gate 증거에는 포함하지 않았다.
