### PR TITLE
[issue-1028] claude-worker idle-timeout 추가 (codex-worker 패리티)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,8 @@ PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality
 | `DCNESS_FORCE_ENABLE` | is-active 게이트 임시 활성 (디버깅) | 미설정 | X |
 | `DCNESS_CODEX_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt timeout | validator `600`, worker `1200` | X |
 | `DCNESS_CODEX_IDLE_TIMEOUT` | `dcness-codex-worker` Codex attempt 의 stdout/prose/workspace 무진행 조기 kill timeout | `180` | X |
+| `DCNESS_CLAUDE_TIMEOUT` | `dcness-claude-worker` Claude headless attempt timeout | `1200` | X |
+| `DCNESS_CLAUDE_IDLE_TIMEOUT` | `dcness-claude-worker` Claude attempt 의 stdout/stderr/workspace 무진행 조기 kill timeout (codex worker 와 패리티) | `180` | X |
 | `DCNESS_CODEX_MODEL` / `DCNESS_CODEX_EFFORT` | Codex headless wrapper model / reasoning effort opt-in override. 미설정 시 사용자 Codex config 상속 | 미설정 | X |
 | `DCNESS_PROJECTS_FILE` | `scripts/loop_diagnose.py` 의 활성 프로젝트 whitelist 경로 override (테스트용) | `~/.claude/plugins/data/dcness-dcness/projects.json` | X |
 | `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` | git hook telemetry 히트의 active run 귀속 (headless worker 컨텍스트) | 미설정 | X |

--- a/scripts/dcness-claude-worker
+++ b/scripts/dcness-claude-worker
@@ -21,6 +21,8 @@ Options:
 
 Environment:
   DCNESS_CLAUDE_TIMEOUT  Seconds per Claude attempt. Default: 1200.
+  DCNESS_CLAUDE_IDLE_TIMEOUT  Seconds without stdout/stderr/workspace progress
+                         before early kill. Default: 180.
 
 The wrapper runs Claude Code in print mode with hooks/plugins enabled:
   claude -p --permission-mode acceptEdits --output-format text
@@ -68,6 +70,7 @@ PROJECT_ROOT=""
 PROMPT_FILE=""
 HELPER="$SCRIPT_DIR/dcness-helper"
 CLAUDE_TIMEOUT="${DCNESS_CLAUDE_TIMEOUT:-1200}"
+CLAUDE_IDLE_TIMEOUT="${DCNESS_CLAUDE_IDLE_TIMEOUT:-180}"
 
 abs_path() {
   case "$1" in
@@ -131,6 +134,17 @@ case "$CLAUDE_TIMEOUT" in
 esac
 if [ "$CLAUDE_TIMEOUT" -lt 1 ]; then
   echo "[dcness-claude-worker] DCNESS_CLAUDE_TIMEOUT must be >= 1" >&2
+  exit 2
+fi
+
+case "$CLAUDE_IDLE_TIMEOUT" in
+  ''|*[!0-9]*)
+    echo "[dcness-claude-worker] DCNESS_CLAUDE_IDLE_TIMEOUT must be a positive integer: $CLAUDE_IDLE_TIMEOUT" >&2
+    exit 2
+    ;;
+esac
+if [ "$CLAUDE_IDLE_TIMEOUT" -lt 1 ]; then
+  echo "[dcness-claude-worker] DCNESS_CLAUDE_IDLE_TIMEOUT must be >= 1" >&2
   exit 2
 fi
 
@@ -242,12 +256,15 @@ import os
 import signal
 import subprocess
 import sys
+import time
 
 timeout = int(sys.argv[1])
-prompt = sys.argv[2]
-output = sys.argv[3]
-log = sys.argv[4]
-cmd = sys.argv[5:]
+idle_timeout = int(sys.argv[2])
+project_root = sys.argv[3]
+prompt = sys.argv[4]
+output = sys.argv[5]
+log = sys.argv[6]
+cmd = sys.argv[7:]
 
 def child_env_without_nested_session_markers():
     env = os.environ.copy()
@@ -282,6 +299,46 @@ def child_env_without_nested_session_markers():
             env.pop(key, None)
     return env, sorted(removed)
 
+def git_status():
+    try:
+        proc = subprocess.run(
+            ["git", "-C", project_root, "status", "--porcelain=v1", "-uall"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1,
+            check=False,
+        )
+    except Exception:
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return "\n".join(
+        line for line in proc.stdout.splitlines()
+        if not line[3:].startswith(".claude/harness-state/")
+    )
+
+def file_size(path):
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+def terminate(exit_code):
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+    sys.exit(exit_code)
+
 with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") as raw:
     raw.write(("COMMAND: " + " ".join(cmd) + "\n").encode("utf-8", "replace"))
     child_env, removed_env = child_env_without_nested_session_markers()
@@ -295,24 +352,47 @@ with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") 
         env=child_env,
         start_new_session=True,
     )
-    try:
-        proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(proc.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        try:
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            proc.wait()
-        sys.exit(124)
-    sys.exit(proc.returncode)
-' "$CLAUDE_TIMEOUT" "$TMP_PROMPT" "$TMP_PROSE" "$RAW_LOG" "${CLAUDE_CMD[@]}"
+    raw.flush()
+    started = time.monotonic()
+    deadline = started + timeout
+    last_progress = started
+    last_output_size = file_size(output)
+    last_log_size = file_size(log)
+    last_status = git_status()
+
+    while True:
+        rc = proc.poll()
+        if rc is not None:
+            sys.exit(rc)
+
+        now = time.monotonic()
+        output_size = file_size(output)
+        log_size = file_size(log)
+        status = git_status()
+        if (
+            output_size != last_output_size
+            or log_size != last_log_size
+            or status != last_status
+        ):
+            last_progress = now
+            last_output_size = output_size
+            last_log_size = log_size
+            last_status = status
+
+        if now >= deadline:
+            raw.write(f"\n[dcness-claude-worker] total timeout after {timeout}s\n".encode())
+            raw.flush()
+            terminate(124)
+        if now - last_progress >= idle_timeout:
+            raw.write(
+                f"\n[dcness-claude-worker] idle timeout after {idle_timeout}s "
+                "(no stdout/stderr/workspace progress)\n".encode()
+            )
+            raw.flush()
+            terminate(124)
+        sleep_for = min(1.0, max(0.05, deadline - now), max(0.05, idle_timeout - (now - last_progress)))
+        time.sleep(sleep_for)
+' "$CLAUDE_TIMEOUT" "$CLAUDE_IDLE_TIMEOUT" "$PROJECT_ROOT" "$TMP_PROMPT" "$TMP_PROSE" "$RAW_LOG" "${CLAUDE_CMD[@]}"
 }
 
 workspace_changed() {

--- a/tests/test_provider_chain.py
+++ b/tests/test_provider_chain.py
@@ -618,6 +618,90 @@ class ClaudeHeadlessWrapperTests(unittest.TestCase):
             self.assertEqual(len(logs), 1)
             self.assertIn("idle timeout after 1s", logs[0].read_text(encoding="utf-8"))
 
+    def test_claude_worker_idle_timeout_kills_zero_progress_hang(self) -> None:
+        """#1028 — zero-output Claude headless hangs are killed before the full timeout."""
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            sid = "sid-claude-idle"
+            rid = "run-00badbad"
+            state_base = project / ".claude" / "harness-state"
+            start_run(sid, rid, "impl", base_dir=state_base, lane="lite")
+            update_current_step(sid, rid, "build-worker", None, base_dir=state_base)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement this task.\n", encoding="utf-8")
+            helper_args = tmp / "helper-args.txt"
+            prose_capture = tmp / "prose.md"
+            helper = tmp / "dcness-helper"
+            _write_helper(helper, helper_args, prose_capture)
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            _write_executable(
+                bin_dir / "claude",
+                """\
+                #!/bin/sh
+                if [ "$1" = "--help" ]; then
+                  echo "Usage: claude"
+                  exit 0
+                fi
+                cat >/dev/null
+                sleep 5
+                """,
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "DCNESS_CLAUDE_IDLE_TIMEOUT": "1",
+                    "DCNESS_CLAUDE_TIMEOUT": "10",
+                    "DCNESS_RUN_ID": rid,
+                    "DCNESS_SESSION_ID": sid,
+                    "HELPER_ARGS": str(helper_args),
+                    "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+
+            result = subprocess.run(
+                [
+                    str(CLAUDE_WORKER),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+                timeout=5,
+            )
+
+            self.assertEqual(result.returncode, 124)
+            self.assertIn("failed before workspace mutation (exit 124)", result.stderr)
+            self.assertFalse(helper_args.exists())
+            logs = list(
+                (
+                    project
+                    / ".claude"
+                    / "harness-state"
+                    / ".sessions"
+                    / sid
+                    / "runs"
+                    / rid
+                    / "headless-logs"
+                ).glob("claude-headless-build-worker-*.log")
+            )
+            self.assertEqual(len(logs), 1)
+            self.assertIn("idle timeout after 1s", logs[0].read_text(encoding="utf-8"))
+
     def test_claude_worker_records_boundary_block_in_ledger_and_live_marker(self) -> None:
         self._assert_worker_records_boundary_block(
             wrapper=CLAUDE_WORKER,


### PR DESCRIPTION
## 작업내용
- `dcness-claude-worker` 의 `run_claude_once` 를 codex-worker 와 동일한 폴링 루프로 교체. output(TMP_PROSE)/raw-log(RAW_LOG)/git-status 무진행이 `idle_timeout` 이상 지속되면 `terminate(124)`.
- `DCNESS_CLAUDE_IDLE_TIMEOUT` env(기본 180) + 정수 검증 추가.
- CLAUDE.md 환경변수 표에 `DCNESS_CLAUDE_TIMEOUT` / `DCNESS_CLAUDE_IDLE_TIMEOUT` 기재.

## 배경 / 원인
codex-worker 는 `DCNESS_CODEX_IDLE_TIMEOUT`(기본 180s)로 무진행 hang 을 조기 종료하지만, claude-worker 는 하드 타임아웃(1200s)만 있어 헤드리스 claude 가 멈추거나 헛돌면 최대 20분 낭비 후에야 종료됐다. correctness 무관·evadable 아님 — 순수 낭비 시간 방지. (boundary 강제는 post-hoc git-diff 가 이미 담당.)

## 설계 주의
claude -p(text) 는 codex 와 progress 신호가 달라(스트리밍 차이) 긴 reasoning 구간 신호가 적을 수 있다. 완전 침묵(output+log+workspace 모두 무변화)일 때만 kill 하도록 다중 신호를 codex 와 동일하게 추적해 false-kill 을 완화한다. 값은 env override 가능.

## 회귀검증
- `test_claude_worker_idle_timeout_kills_zero_progress_hang` 추가 — zero-progress hang 이 idle 1s 에 `exit 124` + "idle timeout after 1s" 로그로 종료 검증.
- `python3.11 -m unittest tests.test_provider_chain` 13/13 통과.
- `bash -n` + 임베디드 python `py_compile` OK.

## 배포 경로 검증
plugin body `scripts/dcness-claude-worker` → 플러그인 업데이트로 사용자 환경 자동 도달 (경로 1). 버전 bump + release-notes 는 별도 `docs/release` PR.

Closes #1028