### PR TITLE
[docs] release 0.20.0 — claude-worker idle-timeout

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — Claude Code와 Codex를 제품 개발 루프에 묶고 순서 게이트, 역할 경계, TDD guard, 검증 가능한 작업 기록을 제공하는 agent workflow harness. release 브랜치 배포 (docs/internal/ · docs/archive/ 미포함).",
-    "version": "0.19.0"
+    "version": "0.20.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Claude Code와 Codex를 Git/PR/CI 흐름 안에서 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 묶는 agent workflow harness. (한국어 사용자 대상)",
   "author": {
     "name": "alruminum",

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -10,6 +10,23 @@
 
 ---
 
+## v0.20.0 (2026-07-10)
+
+**커밋 범위**: `v0.19.0..v0.20.0` (머지 PR 1개, #1029)
+**핵심 변경**: **헤드리스 `claude` 구현 worker 에 idle timeout 을 추가해 codex worker 와 패리티를 맞춘** minor 릴리즈. 무진행(stdout/stderr/workspace 무변화) 시 하드 타임아웃(1200s)까지 기다리지 않고 조기 종료한다.
+
+### 무엇이 바뀌나
+
+1. **`dcness-claude-worker` idle timeout — codex worker 패리티** ([#1029](https://github.com/Daeguk-Sun/dcNess/pull/1029) Closes [#1028](https://github.com/Daeguk-Sun/dcNess/issues/1028)) — 헤드리스 `claude` 구현 worker 가 하드 타임아웃(`DCNESS_CLAUDE_TIMEOUT` 기본 1200s)만 있어, 멈추거나 헛돌면 최대 20분 낭비 후에야 종료됐다. codex worker(`DCNESS_CODEX_IDLE_TIMEOUT`)와 동일한 폴링 루프로 `run_claude_once` 를 교체해 output/raw-log/git-status 무진행이 `DCNESS_CLAUDE_IDLE_TIMEOUT`(기본 180s) 이상 지속되면 `exit 124` 로 조기 종료한다. claude -p 의 progress 신호 차이로 인한 정상 세션 false-kill 을 완화하려 다중 신호를 함께 추적한다. correctness/boundary 강제(post-hoc git-diff 담당)와 무관한 순수 낭비 시간 방지다.
+
+### 자기개선 점검
+
+- Sense/Diagnose: 본 릴리즈는 worker timeout 파리티 단일 fix (guard/hook/agent/skill 미변경) 라 guard-efficacy·행동 eval 트리거 대상이 아니다.
+- Decide: 소멸 후보 없음. follow-up 없음.
+- Verify: `test_provider_chain` 13/13 (신규 idle 회귀 포함) 통과.
+
+---
+
 ## v0.19.0 (2026-07-09)
 
 **커밋 범위**: `v0.18.0..v0.19.0` (머지 PR 2개, #1018 · #1021)


### PR DESCRIPTION
## 작업내용
- `.claude-plugin/plugin.json` `version` + `.claude-plugin/marketplace.json` `metadata.version` 0.19.0 → 0.20.0.
- `docs/internal/release-notes.md` v0.20.0 엔트리 추가.

## 배경
claude-worker idle-timeout (codex worker 패리티) fix PR [#1029](https://github.com/Daeguk-Sun/dcNess/pull/1029) (Closes [#1028](https://github.com/Daeguk-Sun/dcNess/issues/1028)) 를 minor 릴리즈로 배포한다. release-sync CI 가 main push 시 release 브랜치를 자동 동기화한다.

## 회귀검증
- `plugin-manifest` PASS (dcness@0.20.0), `cross-ref` PASS.

Document-Exception-PR-Close: release-only — 버전 bump PR, issue 없음 (#1028 은 #1029 에서 close)