### PR TITLE
[docs] note cross-session handoff in to-issue

### DIFF
--- a/skills/to-issue/SKILL.md
+++ b/skills/to-issue/SKILL.md
@@ -18,6 +18,7 @@ description: 자연어 문제, 작업 후보, 계획 조각을 GitHub issue 로 
 ## 원칙
 
 - Issue Brief 는 agent 나 사람이 작업할 계약이다. 원래 대화와 코멘트는 context 이고, 작업 기준은 brief 다.
+- 이슈를 등록한 세션이 아닌 다른 세션이 처리·구현하는 것이 기본이다. 그래서 등록 세션이 이미 아는 배경·제약·의도는 대화에만 두고 생략하지 말고 Issue Brief(특히 Context)에 옮겨, 이슈 하나만 읽어도 자족적으로 착수할 수 있게 한다. 옮기는 대상은 목표와 판단 근거이지 구현 방법이 아니다.
 - 오래 살아도 유효해야 하므로 구현 파일 경로, line number, 현재 코드 구조에 의존하지 않는다.
 - 무엇을 만들지와 어떤 동작이 되어야 하는지를 쓴다. 어떻게 구현할지는 `/impl` 또는 작업자가 판단한다.
 - 코드 조각, 해결책 지시, layer-by-layer 작업 계획은 기본적으로 넣지 않는다. prototype 의 state machine, schema, type shape 가 prose 보다 결정을 정확히 담는 경우만 짧게 포함하고 prototype 출처를 명시한다.


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 이슈 없는 to-issue 스킬 지침 개선 (사용자 즉석 요청)

## 배경 및 문제

`/to-issue` 로 이슈를 등록하는 세션과 그 이슈를 실제로 처리·구현하는 세션은 기본적으로 다르다. 등록 세션이 대화에서 이미 아는 배경·제약·의도가 Issue Brief 본문으로 옮겨지지 않으면, 처리 세션은 그 컨텍스트에 접근할 수 없어 이슈가 자족적이지 않게 된다. 기존 원칙 섹션은 "Issue Brief 는 계약이고 대화는 context 다" 라고만 말할 뿐, *왜 자족적이어야 하는가* 의 전제(다른 세션이 처리한다)를 명시하지 않아 컨텍스트 이관이 약하게만 암시됐다.

## 원인 (해당 시)

-

## 작업내용

- `skills/to-issue/SKILL.md` 원칙 섹션에 bullet 1개 추가: "이슈를 등록한 세션이 아닌 다른 세션이 처리·구현하는 것이 기본이다. 그래서 등록 세션이 이미 아는 배경·제약·의도는 대화에만 두고 생략하지 말고 Issue Brief(특히 Context)에 옮겨, 이슈 하나만 읽어도 자족적으로 착수할 수 있게 한다. 옮기는 대상은 목표와 판단 근거이지 구현 방법이 아니다."
- 구현 방법 미기재·목표/AC 명확화는 기존 원칙(22~23행)·템플릿에 이미 충분해 중복 추가하지 않음 (안티패턴 1 회피).

## 결정 근거

- 위치를 원칙 섹션 최상단으로 택함 — 기존 "Issue Brief 는 계약" 원칙의 결여된 근거(다른 세션이 처리)를 바로 채우는 자리.
- `issue-fields.md` / 템플릿은 손대지 않음 — 요청의 나머지 두 요소는 이미 존재.

## 배포 경로 검증 (plug-in 영향 시)

- `skills/**` 는 CC plugin 표준 디렉토리 → **plug-in 본체(배포 경로 1)** 로 자동 로드. `init-dcness` 복사 대상 아님. 이 파일 한 개 변경이 plug-in 업데이트로 외부 활성 프로젝트에 도달. deploy 스텝 추가 불필요.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 공개 진입점 `/to-issue` 의 지침 문구 1줄 추가. surface 변화 없음.

## Test Plan

- [x] pre-commit pytest 게이트 통과 (1776 tests OK)
- [x] git-naming 게이트 통과 (branch/commit/PR 제목)
- [ ] CI: cross-ref (신규 링크 없음) / pr-body 게이트 통과

## 참고

- 행동 eval (`bash evals/run.sh`) 은 권고(CI 차단 아님)이며 지침 1줄 추가라 생략. 필요 시 머지 전 1회 실행 가능.