### PR TITLE
[issue-1035] Stop hook 라운드 진행 중 보호

### DIFF
--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -245,6 +245,7 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 **역할**:
 
 - 마지막 step 이 완료됐고 run 이 미finalized 상태면 `end-run` 을 자동 수행
+- 마지막 `end-step` 이후 새 `begin-step` 이 열린 run 은 동일 agent 재라운드여도 진행 중으로 보고 자동 `end-run` 대상에서 제외
 - 마지막 step 결론이 다음 step 으로 이어져야 하는 enum 이고 종료 agent 가 아니면 continuation signal 을 내보내 메인 turn 재발화
 - `begin-run impl --acceptance-required` 로 기록된 마감 task run 에서는 `impl-validator` 를 종료 agent 로 취급하지 않는다. `impl-validator` 결론이 `PASS` 이면 Stop hook 이 `product-acceptance` 진입용 continuation signal 을 내보내며, marker 가 없는 중간 task / `--no-acceptance` run / verify-only run 은 기존 종료 동작을 유지한다.
 - 같은 step 에서 반복 block 횟수가 한도를 넘으면 사용자/메인의 종료 의도를 존중하고 skip

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -1318,9 +1318,9 @@ def handle_stop(
     1. stop_hook_active=true → 무한 루프 방지, skip
     2. active_runs[rid] 슬롯 부재 → skip. finalized-only 상태는 run_finished 가
        없으면 end-run 후보로 유지하고, run_finished 가 있으면 이미 종료로 skip
-    3. `.steps.jsonl` 마지막 row 의 (agent, mode) 가 live.json.current_step.
-       (agent, mode) 와 일치 → end-step 완료 상태 = 종료 후보 / 불일치 →
-       begin-step 후 end-step 미호출 진행 중 → skip (false positive 회피)
+    3. live.json.current_step 이 마지막 step 이후 새 begin-step 을 가리키면
+       진행 중 → skip. 새 begin-step 판정은 begin 당시 step_completed 개수와
+       현재 개수의 짝 매칭을 우선하고, legacy 슬롯은 agent/mode 비교로 폴백한다.
     4. 위 모두 통과 → in-process `_cli_end_run` 호출.
        session_state.py:1001 안전망 → finalize-run --auto-review 자동 →
        `<run_dir>/review.md` 생성 + stderr `[REVIEW_READY]` 신호
@@ -1402,9 +1402,10 @@ def handle_stop(
         # run_finished 부재 → 아래 end-run 발사로 finalize-only run 복구
 
     # end-step 완료 매칭 검사 (false positive 회피)
-    # _read_steps_jsonl 마지막 row.(agent, mode) vs live.current_step.(agent, mode).
-    # 일치 = end-step 호출됨 (step 종료 상태) / 불일치 = begin-step 후 end-step
-    # 미호출 (sub-agent 진행 중 응답 종료 케이스 — end-run 발사 false positive).
+    # begin-step 은 current_step.steps_count_at_begin 에 당시 완료 step 개수를 기록한다.
+    # 이 값이 현재 완료 step 개수 이상이면 해당 begin-step 이 아직 end-step 으로
+    # 닫히지 않은 상태다. 동일 agent 재라운드는 agent/mode 가 같으므로 개수 짝
+    # 매칭을 먼저 봐야 한다 (#1035).
     try:
         steps = _read_steps_jsonl(sid, rid, base_dir=base_dir)
     except Exception:
@@ -1419,7 +1420,22 @@ def handle_stop(
     if isinstance(cur_step, dict):
         cur_agent = cur_step.get("agent")
         cur_mode = cur_step.get("mode")
-        # 정확 일치 검사 (mode None 도 비교)
+        steps_count_at_begin_raw = cur_step.get("steps_count_at_begin")
+        steps_count_at_begin: Optional[int]
+        if isinstance(steps_count_at_begin_raw, int) and not isinstance(
+            steps_count_at_begin_raw, bool
+        ):
+            steps_count_at_begin = steps_count_at_begin_raw
+        elif isinstance(steps_count_at_begin_raw, str):
+            try:
+                steps_count_at_begin = int(steps_count_at_begin_raw)
+            except ValueError:
+                steps_count_at_begin = None
+        else:
+            steps_count_at_begin = None
+        if steps_count_at_begin is not None and steps_count_at_begin >= len(steps):
+            return 0  # begin-step 후 end-step 미호출 — 진행 중
+        # legacy current_step 슬롯은 정확 일치 검사로 폴백 (mode None 도 비교)
         if cur_agent != last_agent or cur_mode != last_mode:
             return 0  # begin-step 후 end-step 미호출 — 진행 중
 

--- a/harness/hooks.py
+++ b/harness/hooks.py
@@ -226,6 +226,15 @@ def _mode_or_none(mode: Any) -> Optional[str]:
     return str(mode) if isinstance(mode, str) and mode else None
 
 
+def _step_count_or_none(raw: Any) -> Optional[int]:
+    if raw is None:
+        return None
+    try:
+        return int(str(raw))
+    except ValueError:
+        return None
+
+
 def _agent_mode_label(agent: str, mode: Optional[str]) -> str:
     return f"{agent}:{mode}" if mode else agent
 
@@ -308,13 +317,7 @@ def _strict_conveyor_gate_message(
         last_agent = last.get("agent")
         last_mode = _mode_or_none(last.get("mode"))
         if last_agent == step_agent and last_mode == step_mode:
-            raw_count_at_begin = cur_step.get("steps_count_at_begin")
-            count_at_begin = None
-            if raw_count_at_begin is not None:
-                try:
-                    count_at_begin = int(str(raw_count_at_begin))
-                except ValueError:
-                    count_at_begin = None
+            count_at_begin = _step_count_or_none(cur_step.get("steps_count_at_begin"))
             current_count = len(records)
             if (
                 count_at_begin is not None
@@ -1420,19 +1423,7 @@ def handle_stop(
     if isinstance(cur_step, dict):
         cur_agent = cur_step.get("agent")
         cur_mode = cur_step.get("mode")
-        steps_count_at_begin_raw = cur_step.get("steps_count_at_begin")
-        steps_count_at_begin: Optional[int]
-        if isinstance(steps_count_at_begin_raw, int) and not isinstance(
-            steps_count_at_begin_raw, bool
-        ):
-            steps_count_at_begin = steps_count_at_begin_raw
-        elif isinstance(steps_count_at_begin_raw, str):
-            try:
-                steps_count_at_begin = int(steps_count_at_begin_raw)
-            except ValueError:
-                steps_count_at_begin = None
-        else:
-            steps_count_at_begin = None
+        steps_count_at_begin = _step_count_or_none(cur_step.get("steps_count_at_begin"))
         if steps_count_at_begin is not None and steps_count_at_begin >= len(steps):
             return 0  # begin-step 후 end-step 미호출 — 진행 중
         # legacy current_step 슬롯은 정확 일치 검사로 폴백 (mode None 도 비교)

--- a/hooks/stop-end-run.sh
+++ b/hooks/stop-end-run.sh
@@ -5,7 +5,7 @@
 # stdin: CC payload (sessionId, stop_hook_active 포함)
 # 동작: harness/hooks.py 의 handle_stop 호출
 #   - stop_hook_active=true 시 즉시 skip (무한 루프 가드, 공식 docs §"Stop hook runs forever")
-#   - active_runs 슬롯 + end-step 완료 매칭 시 dcness-helper end-run 자동 호출
+#   - active_runs 슬롯 + begin/end-step 완료 매칭 시 dcness-helper end-run 자동 호출
 #   - 부산물: <run_dir>/review.md 생성 + loop-insights 누적 + active_runs 정리
 #
 # 실패 시 silent (exit 0) — Stop hook 은 block 안 함 (정상 종료 허용).

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -3090,6 +3090,54 @@ class StopHookGuardTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         end_run.assert_called_once()
 
+    def test_same_agent_new_begin_step_after_end_step_skips_auto_end_run(self):
+        """#1035 — 동일 agent 재라운드 begin-step 은 진행 중으로 보호한다."""
+        from tempfile import TemporaryDirectory
+        from unittest.mock import patch
+
+        from harness import ledger
+        from harness.session_state import (
+            clear_current_step,
+            run_dir,
+            start_run,
+            update_current_step,
+            update_live,
+        )
+
+        sid = "sid-stop-same-agent-round"
+        rid = "run-1035abcd"
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            update_live(sid, base_dir=base)
+            start_run(sid, rid, "impl", base_dir=base)
+
+            update_current_step(sid, rid, "impl-validator", None, base_dir=base)
+            prose_path = run_dir(sid, rid, base_dir=base) / "impl-validator.md"
+            prose = "round 1 validation complete\nLGTM\n"
+            prose_path.write_text(prose, encoding="utf-8")
+            ledger.append_step_completed(
+                sid,
+                rid,
+                "impl-validator",
+                None,
+                "PROSE_LOGGED",
+                prose,
+                prose_path,
+                base_dir=base,
+            )
+            clear_current_step(sid, rid, agent="impl-validator", mode=None, base_dir=base)
+
+            update_current_step(sid, rid, "impl-validator", None, base_dir=base)
+
+            env = {"DCNESS_SESSION_ID": sid, "DCNESS_RUN_ID": rid}
+            with patch.dict(os.environ, env, clear=False), patch(
+                "harness.session_state._cli_end_run", return_value=0
+            ) as end_run:
+                rc = handle_stop(stdin_data={}, base_dir=base)
+
+        self.assertEqual(rc, 0)
+        end_run.assert_not_called()
+
     def test_finalized_without_run_finished_is_end_run_candidate(self):
         """이슈 #587 (codex review) — finalize-run 후 end-run 까먹어 run_finished 없으면 Stop 이 복구."""
         from tempfile import TemporaryDirectory


### PR DESCRIPTION
## 관련 이슈 번호
Closes #1035

## 배경 및 문제
Stop hook 자동 end-run 은 run 종료 누락을 막기 위해 메인 응답 종료 시 마지막 완료 step 상태를 보고 `end-run` 을 자동 수행한다. 하지만 동일 agent가 여러 라운드를 도는 흐름에서는 `end-step` 직후 같은 agent의 새 `begin-step` 이 열려도 기존 agent/mode 비교만으로는 진행 중인 라운드를 구분하지 못했다.

## 원인 (해당 시)
기존 Stop hook 가드는 마지막 완료 step의 `(agent, mode)`와 `live.json.current_step`의 `(agent, mode)` 일치 여부만 비교했다. 동일 agent 재라운드에서는 두 값이 같기 때문에 새 `begin-step` 이후 아직 `end-step` 이 호출되지 않은 상태를 종료 후보로 오판했다.

## 작업내용
- `handle_stop`의 진행 중 run 보호 판정을 `current_step.steps_count_at_begin` 과 현재 `step_completed` 개수의 짝 매칭 기준으로 보강했다.
- 동일 agent `end-step` → 동일 agent 새 `begin-step` → Stop hook 순서에서 자동 `end-run` 이 호출되지 않는 회귀 테스트를 추가했다.
- `hooks/stop-end-run.sh` 주석과 `docs/plugin/hooks.md`에 begin/end-step 완료 매칭 계약을 반영했다.
- `steps_count_at_begin` 파싱을 `_step_count_or_none` helper 로 통합해 진행 순서 게이트와 Stop hook 이 같은 해석을 공유하게 했다.

## 결정 근거
`begin-step`이 이미 기록하는 `steps_count_at_begin` 은 해당 step이 열린 시점의 완료 step 개수다. Stop 시점에 이 값이 현재 완료 step 개수 이상이면 아직 현재 step의 `end-step` 이 기록되지 않은 상태이므로, agent/mode가 같더라도 진행 중으로 보는 것이 begin/end 짝 계약에 맞다. 이 필드가 없는 legacy 슬롯은 기존 agent/mode 비교로 폴백해 업데이트 중 run 호환성을 유지했다.

## 배포 경로 검증 (plug-in 영향 시)
- plug-in 본체 hook 경로: `hooks/stop-end-run.sh` 는 플러그인 업데이트 시 사용자 환경의 Stop hook 동작에 반영된다.
- 하네스 코드 경로: `harness/hooks.py` 는 플러그인 본체에서 Stop hook이 호출하는 SSOT 구현이다.
- 사용자-facing SSOT 문서: `docs/plugin/hooks.md` 에 Stop hook의 새 진행 중 보호 계약을 반영했다.
- `/init-dcness` 복사 파일 추가/변경은 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)
N/A — 새 public skill/command/agent/gate 없음.

## Test Plan
- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증

실행한 검증:
- `python3.11 -m unittest tests.test_hooks.StopHookGuardTests -v < /dev/null`
- `python3.11 -m unittest tests.test_hooks -v < /dev/null`
- `python3.11 -m unittest discover -s tests -v < /dev/null` (최신 main 기준 전체 suite PASS)
- `PYTHON_BIN=/tmp/dcness-quality-issue1035-venv/bin/python bash scripts/check_static_quality.sh`
- `node scripts/check_cross_refs.mjs`
- `node scripts/check_public_surface.mjs`
- `node scripts/check_plugin_manifest.mjs`
- `bash -n hooks/stop-end-run.sh`
- `git diff --check`
- git pre-commit hook: `scripts/check_python_tests.sh` PASS + git naming PASS

## 참고
- GitHub CLI issue 조회는 사용자 GraphQL API rate limit 때문에 실패했고, 이슈 본문은 공개 GitHub issue 페이지로 확인했다.
