### PR TITLE
[issue-1041] impl-loop story 경계와 task 상태를 복구합니다.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,9 @@
 ## 관련 이슈 번호
 
 <!-- 트레일러 룰 (git-spec 의 PR 트레일러 기본 룰):
-     - 중간 task → Part of #N
-     - 마지막 task → Closes #N
-     - epic 마지막 task → Closes #story + Closes #epic
+     - 단일 story → Closes #story (epic 마지막이면 Closes #epic 동봉)
+     - 통합 브랜치 story sub-PR → Part of #story + main bulk-close exception
+     - 통합 → main → 모든 story + epic 을 Closes
      - issue 없는 infra/follow-up → Document-Exception-PR-Close: <사유> -->
 Part of #N
 

--- a/docs/plugin/git-spec.md
+++ b/docs/plugin/git-spec.md
@@ -19,7 +19,7 @@
   - 공백·특수문자·대문자 금지.
   - **`feature/{desc}` 의 desc 는 `epic{N}_story` 로 시작 불가** — 그 형태는 strict 스토리 패턴(`feature/epic{N}_story{N}_{desc}`, desc ≥3자·story 숫자)만 통과한다. malformed 스토리 브랜치(`feature/epic7_story2_ui` 처럼 desc<3자 / story 비숫자)가 generic 으로 새는 것을 [`check_git_naming.mjs`](../../scripts/check_git_naming.mjs) 부정선행이 차단.
 - `feature/{desc}` 의 용도 = (1) 단발 feature, (2) **통합 브랜치** (epic 단위 long-lived feature branch + sub-PR 누적 → 마지막 한 방 main 머지). 통합 브랜치 의도는 epic issue body / stories.md 상단에 `**Base Branch:** feature/{slug}` 1줄 마커로 명시. 자세한 흐름은 [`skills/spec/SKILL.md`](../../skills/spec/SKILL.md) Step 9/10 + 본 spec 의 [PR 트레일러](#pr-트레일러-part-of-closes).
-- **공통 task (epic 단위, story 없음)**: `feature/epic{N}_common_{desc}` — `feature/{desc}` 의 epic-traceable 특수형 (module-architect 공통 호출 산출물 = `story: 공통` / `task_index: —`). 게이트는 generic feature 로 통과 (`_common` 은 `_story` 가 아니라 위 부정선행에 안 걸림). 예: `feature/epic7_common_theme_tokens`. 제목 = `[feature] {설명}`, 트레일러 = `Part of #<epic>` (부모 = epic 단일 룰, task-index trailer omit, [기본 룰](#기본-룰)).
+- **공통 task 묶음 (epic 단위, story 없음)**: `feature/epic{N}_common_{desc}` — `feature/{desc}` 의 epic-traceable 특수형 (module-architect 공통 호출 산출물 = `story: 공통` / `task_index: —`). 게이트는 generic feature 로 통과 (`_common` 은 `_story` 가 아니라 위 부정선행에 안 걸림). 예: `feature/epic7_common_theme_tokens`. 제목 = `[feature] {설명}`, PR 트레일러 = `Part of #<epic>` ([기본 룰](#기본-룰)).
 - main 직접 push 금지. 항상 branch → PR → merge.
 - 브랜치는 merge 후에도 삭제하지 않는다.
 
@@ -81,9 +81,9 @@
 ```markdown
 ## 관련 이슈 번호
 <!-- 트레일러 룰 (기본 룰):
-     - 중간 task → Part of #N
-     - 마지막 task → Closes #N
-     - epic 마지막 task → Closes #story + Closes #epic
+     - 단일 story → Closes #story (epic 마지막이면 Closes #epic 동봉)
+     - 통합 브랜치 story sub-PR → Part of #story + main bulk-close exception
+     - 통합 → main → 모든 story + epic 을 Closes
      - issue 없는 infra/follow-up → Document-Exception-PR-Close: <사유>
      under-link 보다 over-close 사고가 더 큼 — default 는 안전한 Part of -->
 Part of #N
@@ -188,7 +188,7 @@ argument 없이 호출 시 current branch 의 open PR 자동 검출. 명시 시 
 
 ### Task — GitHub 이슈 없음
 
-task 는 별도 GitHub 이슈 만들지 않음 — PR 자체가 추적 단위. 트레일러 룰 = [PR 트레일러 (Part of / Closes)](#pr-트레일러-part-of-closes).
+task 는 별도 GitHub 이슈를 만들지 않는다. build-worker 의 local commit sha 가 완료·resume 추적 단위이고, story 가 PR 경계다. 트레일러 룰 = [PR 트레일러 (Part of / Closes)](#pr-트레일러-part-of-closes).
 
 ---
 
@@ -196,10 +196,11 @@ task 는 별도 GitHub 이슈 만들지 않음 — PR 자체가 추적 단위. �
 
 ### 기본 룰
 
-- **중간 task PR**: `Part of #story-issue` (Development 섹션 자동 연결 X — 언급만)
-- **story 마지막 task PR**: `Closes #story-issue`
-- **epic 마지막 story 마지막 task PR**: `Closes #story-issue` + `Closes #epic-issue` (한 줄당 1개 또는 comma 분리)
-- **`task-index: <i>/<total>` trailer**: impl 파일 frontmatter `task_index` 값 그대로 1줄 박는다 (build-worker 가 PR 본문 초안 작성 시점에). CI 게이트 [`scripts/check_pr_body.mjs`](../../scripts/check_pr_body.mjs) 가 본 trailer 로 "Story 마지막 task PR 인가" 식별 → `i == total` 이면 `Closes`/`Fixes`/`Resolves` 1+ 강제 (`Part of` 단독 FAIL). 공통 task (`task_index: —`) 는 trailer omit (게이트 fallback path 통과).
+- **task**: local commit 이므로 PR trailer 없음. `task_index` 는 story 내부 설계 순서이며 PR close 판정 입력이 아니다.
+- **단일 story run**: base=`main` story PR 1개. `Closes #story-issue`; 이 story가 epic 마지막이면 `Closes #epic-issue`도 동봉한다.
+- **다중 story/epic run**: story마다 통합 브랜치 대상 sub-PR 1개. `Part of #story-issue`와 `Document-Exception-PR-Close: 통합 브랜치 story sub-PR — main 머지 시 일괄 close`를 넣는다.
+- **통합→main PR**: 대상 story 전부와 epic을 `Closes`로 일괄 선언한다.
+- **공통 task 묶음**: 별도 story issue가 없으므로 `Part of #epic-issue`를 사용한다.
 
 > **반드시 PR body 에 박는다 (commit message 아님)** — 본 프로젝트는 regular merge 채택 ([Git 절차](#git-절차), squash 금지). regular merge 시 GitHub auto-close 는 *PR body* 또는 *squash merge commit message* 만 인식. commit message 안 `Closes #N` 은 머지 commit 에 들어가도 auto-close 발동 X. 본 룰 mechanical 강제 = [`scripts/check_pr_body.mjs`](../../scripts/check_pr_body.mjs) + `.github/workflows/pr-body-validation.yml` (`/init-dcness` 선택형 workflow 로 사용자 repo 배포).
 >
@@ -207,12 +208,11 @@ task 는 별도 GitHub 이슈 만들지 않음 — PR 자체가 추적 단위. �
 
 ### 통합 브랜치 케이스 — base ≠ main sub-PR 의 auto-close 한계 (MUST)
 
-stories.md 상단에 `**Base Branch:** feature/<slug>` 마커 박힌 epic (= 통합 브랜치 모드, [`skills/spec/SKILL.md`](../../skills/spec/SKILL.md) Step 9/10) 의 sub-PR 은 *base = `feature/<slug>`* 로 머지된다. **GitHub auto-close 는 base = default branch (main) 인 PR 만 인식** — base ≠ main sub-PR 의 PR body `Closes #N` 은 머지 시 발동 X.
+stories.md 상단에 `**Base Branch:** feature/<slug>` 마커 박힌 epic (= 통합 브랜치 모드, [`skills/spec/SKILL.md`](../../skills/spec/SKILL.md) Step 9/10) 의 story sub-PR 은 *base = `feature/<slug>`* 로 머지된다. **GitHub auto-close 는 base = default branch (main) 인 PR 만 인식**한다.
 
 흐름:
 
-1. **각 sub-PR (base = `feature/<slug>`)** — PR body 에 평소대로 `Part of #<story>` / `Closes #<story>` 박되 머지 시 *발동 안 됨* 전제. `Document-Exception-PR-Close: 통합 브랜치 sub-PR — main 머지 시 일괄 close` 박아 `check_pr_body.mjs` 게이트 우회 가능 (자유 선택).
-   - **close 보정 자동화**: sub-PR 머지를 `$PLUGIN_ROOT/scripts/pr-finalize.sh` 로 하면 base ≠ default branch 를 감지해 (a) CI 체크 0개를 정상으로 처리하고 (b) PR body 의 독립 trailer 줄에 있는 `Closes`/`Fixes`/`Resolves` 선언이 가리키는 OPEN issue 목록을 출력한 뒤 PR 링크 코멘트와 함께 close 보정한다. 산문 인용·blockquote·list 예시는 close 대상으로 보지 않는다. 수동 CLOSE 불필요. 이미 close 된 issue 에 대한 마지막 →main 일괄 `Closes` 는 무해 (GitHub 이 무시).
+1. **각 story sub-PR (base = `feature/<slug>`)** — `Part of #<story>`만 사용해 story를 조기 close하지 않는다. sub-PR은 메인이 통합 브랜치로 머지하고, 다음 story branch는 **갱신된 통합 브랜치에서 재분기**한다.
 2. **마지막 통합 → main 머지 PR (base = main)** — PR body 에 **모든 story + epic 을 일괄 close**:
    ```
    Closes #<story1>
@@ -225,72 +225,14 @@ stories.md 상단에 `**Base Branch:** feature/<slug>` 마커 박힌 epic (= 통
 
 근거: GitHub 의 [linking-a-pull-request-to-an-issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue) 문서 — *"The pull request must be on the default branch."* 통합 브랜치 base sub-PR 은 미충족.
 
-> 별도 자동화 (sub-issue API 기반 base 무관 close 정책) 는 *추후* 자매 이슈에서 다룸. 본 단락은 *최소 명문화* — 통합 브랜치 모드 진입 사용자가 *마지막 머지 PR 에 bulk close* 박는 패턴만 인지하면 충분.
+### 적용 절차 — story/base 판정
 
-### 적용 절차 — PR 생성 직전 사전 체크 (impl 파일 frontmatter 기반)
+1. impl 파일 frontmatter의 `story`로 PR grouping key를 찾는다. 숫자 story인데 `task_index`가 `i/total` 형식이 아니면 설계 metadata drift로 중지하지만, `i == total` 여부는 PR 경계를 결정하지 않는다.
+2. stories.md의 `**Base Branch:**`가 없으면 단일 story base=`main`; 있으면 story sub-PR base=통합 브랜치다.
+3. base=`main`이면 `Closes #story`, 통합 브랜치면 `Part of #story` + bulk-close exception을 사용한다. 공통 task 묶음은 `Part of #epic`이다.
+4. 통합→main PR은 대상 story issue 목록과 epic issue를 모두 `Closes`로 적는다.
 
-판정 입력 = **impl 파일 frontmatter `task_index: <i>/<total>` + `story: <N>`**. `/design` 의 Story/공통 module-architect 단위 산출 시점에 박힘. `task_index` 의미 = 그 Story 안 task 의 순번 / 그 Story 의 총 task 수 (옛 의미: 옛 `## impl 목차` 표 행 위치 → 폐기, 이슈 [#511](https://github.com/alruminum/dcNess/issues/511)). 공통 task 는 `task_index: —`. stories.md `[ ]` 카운트 룰 폐기 (2026-05-12) — 새 stories.md 양식엔 task `[ ]` 자체 없음 (user story 만, [`spec-stories-reference.md`](../../skills/spec/spec-stories-reference.md#storiesmd-산출물) 기준).
-
-1. **task 파일 frontmatter read** — `task_index: 3/3` + `story: 1`
-2. **본 task 가 Story 마지막인지 판정** — `i == total` 이면 마지막
-3. **본 Story 가 epic 마지막인지 판정** — gh API 1 회: `gh issue list --label "epic-NN-<slug>" --milestone Story --state open --json number --jq 'length'` 가 1 (= 본 Story 만 OPEN) 이면 본 task 머지 시 epic 도 close 예정
-4. **분기**:
-   - i == total + epic 마지막 story → `Closes #${STORY_ISSUE}` + `Closes #${EPIC_ISSUE}`
-   - i == total + epic 중간 story → `Closes #${STORY_ISSUE}`
-   - i < total → `Part of #${STORY_ISSUE}`
-   - **공통 task** (`story: 공통`) → `Part of #${EPIC_ISSUE}` (task-index trailer omit). 공통 여부의 진본 신호 = `story: 공통` (task_index 형식 아님).
-   - **malformed/누락 가드 (MUST)**: 공통 형식(`—`)은 `story: 공통` 일 때만 유효하다. `story` 가 숫자(공통 아님)인데 `task_index` 가 `i/total` 형식이 아니면 — `—` 포함 무엇이든 (누락/malformed/legacy/version-skew) — **PR 생성 전 정지**. 숫자 story 의 `—` 를 공통으로 오분류해 `Part of #epic` 내보내면 story 이슈가 silent open 으로 남아 story-close 의미가 깨진다. `check_pr_body.mjs` 는 task-index 부재를 fallback(트레일러 1건)으로만 통과시켜 이 오분류를 못 잡으므로, 메인이 PR body 작성 전 본 가드를 직접 적용한다.
-
-**한 명령 구현 = [`scripts/pr-trailer.sh`](../../scripts/pr-trailer.sh)** — `"$PLUGIN_ROOT/scripts/pr-trailer.sh" <impl파일>` 이 위 1~4 판정을 수행해 트레일러 블록을 stdout 으로 출력한다 (`--base` 모드 = stories.md `**Base Branch:**` 마커 기반 PR base 출력). malformed 가드 hit 시 exit 1 로 PR 생성을 정지시킨다. 아래 bash recipe 는 스크립트의 동작 정의이자 수동 폴백이다.
-
-bash recipe (PR body 작성 직전 — 분기 키는 `STORY_NUM`, task_index 형식만으로 공통 판정 금지. 위 분기표를 그대로 PR_BODY 로 구성):
-
-```bash
-TASK_FILE="docs/epics/.../impl/NN-*.md"
-STORIES="$(dirname "$(dirname "$TASK_FILE")")/stories.md"   # epic 단위
-[ -f "$STORIES" ] || { echo "stories.md missing: $STORIES" >&2; exit 1; }
-STORY_NUM=$(awk '/^story:/ {gsub(/[",]/,""); print $2; exit}' "$TASK_FILE")        # 정식 = 숫자, 공통 = "공통"
-TASK_INDEX=$(awk '/^task_index:/ {gsub(/[",]/,""); print $2; exit}' "$TASK_FILE")  # 정식 = "3/3", 공통 = "—"
-
-if [ "$STORY_NUM" = "공통" ]; then
-  # 공통 task — Part of #<epic>. EPIC_ISSUE 미설정 시 stories.md 마커에서 파싱, 미해결이면 빈 'Part of #' 방지 위해 정지.
-  EPIC_ISSUE="${EPIC_ISSUE:-$(grep -m1 -E '^\*\*GitHub Epic Issue:\*\*' "$STORIES" 2>/dev/null | grep -oE '#[0-9]+' | head -1 | tr -d '#')}"
-  [ -n "$EPIC_ISSUE" ] || { echo "[trailer] 공통 task — epic 이슈 미해결, 정지" >&2; exit 1; }
-  PR_BODY="Part of #${EPIC_ISSUE}"
-elif printf '%s' "$TASK_INDEX" | grep -qE '^[0-9]+/[0-9]+$'; then
-  I="${TASK_INDEX%/*}"; TOTAL="${TASK_INDEX#*/}"
-  if [ "$I" = "$TOTAL" ]; then
-    PR_BODY="Closes #${STORY_ISSUE}"                       # Story 마지막 task
-    # epic 마지막 story 판정 (gh API 1회 — OPEN story 가 본 Story 뿐이면 epic 도 동봉, 위 Epic 완료 절)
-    OPEN=$(gh issue list --label "epic-${EPIC_NUM}-${EPIC_SLUG}" --milestone Story --state open --json number --jq 'length' 2>/dev/null || echo 0)
-    [ "$OPEN" = "1" ] && PR_BODY="${PR_BODY}
-Closes #${EPIC_ISSUE}"
-  else
-    PR_BODY="Part of #${STORY_ISSUE}"                      # 중간 task
-  fi
-  # task-index trailer 필수 (위 기본 룰) — check_pr_body.mjs 가 i==total 마지막 task 식별용. story task 만 부착 (공통은 omit).
-  PR_BODY="${PR_BODY}
-task-index: ${TASK_INDEX}"
-else
-  echo "[trailer] story=$STORY_NUM 인데 task_index='$TASK_INDEX' 가 i/total 도 공통(—)도 아님 — 정지" >&2
-  exit 1                                                   # malformed/누락 가드 (위 MUST) — 숫자 story 의 — 거부
-fi
-```
-
-### Development 섹션 역방향 업데이트
-
-`Closes #story-issue` PR 생성 시 필수. `Closes #story-issue` PR 생성과 동시에, 이전 `Part of #story-issue` PR 들을 찾아 body 앞에 `Fixes #story-issue` 를 추가한다. 이미 머지된 PR body 업데이트는 issue close 를 재발동하지 않으며 Development 섹션에 소급 반영된다.
-
-```bash
-ISSUE=<story-issue-number>
-REPO=<owner>/<repo>
-gh search prs --repo "$REPO" "Part of #$ISSUE" --json number --jq '.[].number' \
-  | while read num; do
-      cur=$(gh pr view "$num" --repo "$REPO" --json body --jq '.body')
-      gh pr edit "$num" --repo "$REPO" --body "Fixes #$ISSUE
-$cur"
-    done
-```
+**한 명령 구현 = [`scripts/pr-trailer.sh`](../../scripts/pr-trailer.sh)** — `"$PLUGIN_ROOT/scripts/pr-trailer.sh" <story의 impl파일>` 이 story/base 트레일러 블록을 stdout 으로 출력한다 (`--base` 모드는 stories.md marker 기반 PR base 출력). 어떤 task 파일을 넘겨도 같은 story PR 트레일러가 나오며 `task-index` trailer는 출력하지 않는다.
 
 ---
 
@@ -298,20 +240,22 @@ $cur"
 
 ### Story 완료
 
-- **조건**: story 의 모든 impl task PR merge
-- **Close**: 마지막 task PR body `Closes #story-issue` → GitHub 자동 close (regular merge auto-close)
+- **구현 완료 조건**: story 의 모든 impl task가 local commit으로 `completed`. PR 생성·머지는 runner state 수명에 영향을 주지 않는다.
+- **단일 story close**: base=`main` story PR body `Closes #story-issue` → merge 시 GitHub 자동 close.
+- **통합 브랜치 close**: story sub-PR은 `Part of`로 누적하고 마지막 통합→main PR에서 story 전부를 일괄 close.
 - 메인 Claude 사후 작업 없음 — stories.md `[x]` 체크 룰 폐기 (2026-05-12, 옛 Step 4.5 동기화 step 폐기, 상세는 git history)
 
 ### Epic 완료
 
-- **조건**: epic 의 모든 story closed
-- **Close 시점**: 마지막 story 의 마지막 task PR — 메인이 PR 생성 *직전* 1회 사전 체크:
+- **조건**: epic 의 모든 story task commit 완료 + 통합 review/acceptance PASS
+- **단일 story close 시점**: story→main PR 생성 *직전* 1회 사전 체크:
   ```bash
   gh issue list --label epic-NN-<slug> --milestone Story --state open
   ```
-  → 이 task merge 시 마지막 story close 예정이면, PR body 에 `Closes #epic-issue` 도 동봉
+  → 이 story merge 시 마지막 story close 예정이면, PR body 에 `Closes #epic-issue` 도 동봉
+- **다중 story close 시점**: 마지막 통합→main PR body에 모든 story + epic close를 동봉
 - 메인 Claude 사후 작업 없음 — `backlog.md` 자체 폐기 (2026-05-12, GitHub epic issue close 가 SSOT)
-- 별도 wrap-up PR 만들지 않음
+- 별도 변경 없는 wrap-up PR은 만들지 않는다. 통합→main PR은 story sub-PR 누적 결과를 main에 전달하는 merge PR이다.
 
 ### API 직접 close 절대금지
 

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -6,13 +6,15 @@
 ## 이슈 계층
 
 ```
-epic issue ─┬─ story issue ── (task: PR 기반, 이슈 없음)
-            └─ story issue ── (task: PR 기반, 이슈 없음)
+epic issue ─┬─ story issue ── (task: local commit, 이슈 없음)
+            └─ story issue ── (task: local commit, 이슈 없음)
 ```
 
 - **epic** = 1 개 `docs/epics/epic-NN-<slug>/stories.md` 영역 (epic 단위 stories.md 1 개 = 1 epic)
 - **story** = epic 단위 stories.md 안의 Story N 단위
-- **task** = `docs/epics/epic-NN-*/impl/NN-*.md` 단위. PR 1 개 = task 1 개. GitHub 이슈 X — PR 자체가 추적 단위
+- **task** = `docs/epics/epic-NN-*/impl/NN-*.md` 단위. 완료 경계는 local commit 이며 GitHub 이슈 X
+- **story** = task commit 묶음의 PR 경계. 단일 story 는 base=`main` PR 1개, 다중 story/epic 은 story 별 통합 브랜치 sub-PR
+- **epic** = story sub-PR × N + 마지막 통합→main PR. epic 구현을 단일 PR로 묶지 않는다.
 
 `epic-NN` 은 프로젝트 전역 번호다. milestone 은 path segment 가 아니라 stories frontmatter `milestone: vNN` 로 남긴다.
 
@@ -33,7 +35,7 @@ gh api -X POST repos/{owner}/{repo}/issues/{epic_number}/sub_issues \
 
 멱등성: 재호출 전 `gh api repos/{owner}/{repo}/issues/{epic_number} --jq '.sub_issues_summary.total'` 로 연결 상태 조회. 누락 story 만 추가 (이미 연결된 story 재추가 시 422).
 
-task 는 GitHub 이슈 X — [`git-spec.md`](git-spec.md#pr-트레일러-part-of-closes) PR 트레일러로만 추적.
+task 는 GitHub 이슈 X — local commit sha 로 추적하고, story/epic 연결·close 는 [`git-spec.md`](git-spec.md#pr-트레일러-part-of-closes) PR 트레일러를 따른다.
 
 ## Issue pre-create validation
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -327,23 +327,24 @@ RESOLVE_JSON=$("$HELPER" auto-resolve "<agent>:<enum_or_mode>")
 | 시점 | 내용 |
 |---|---|
 | build-worker PASS 직후 | task local commit sha 확인 + `dcness-story-runner mark --status completed --commit <sha>` |
-| 모든 target task completed 뒤 | batch review PR body 작성 + push + PR create |
-| impl-validator / product-acceptance PASS 뒤 | merge 또는 사용자 merge 결정 대기 |
+| 한 story 의 task 전부 completed | story PR body 작성 + push + PR create. 다중 story/epic 은 통합 브랜치로 머지하고 갱신된 ref 에서 다음 story branch 재분기 |
+| 모든 target task completed | 단일 story PR 또는 통합→main PR 의 merge candidate diff 에 impl-validator 통합 리뷰 1회 |
+| impl-validator / STORY_ACCEPTANCE × N / 필요한 EPIC_ACCEPTANCE PASS | 최종 main 대상 PR 의 사용자 merge 결정 대기 |
 
 > `docs/.../impl/NN-*.md` 는 `/design` 산출물이 *미리 머지* 된 상태 — impl-task-loop 안에서 별도 commit X. fallback 모드 (정식 위치 부재) 는 module-architect 산출물을 본 PR src commit 에 같이 포함.
 
-> **task commit = build-worker boundary only** — 이 invariant 의 진본은 *권한 경계* 다: impl 루프 worktree 의 변경은 build-worker 권한 경계([`agent_boundary.py`](../../harness/agent_boundary.py) ALLOW_MATRIX = `src/**` / test 계열)상 구현·테스트 파일뿐이라, stories.md / backlog.md 등은 애초에 worktree 에 안 들어온다. 진행 추적은 task commit sha + PR body 트레일러 (Part of / Closes) + GitHub sub-issue API 가 SSOT.
+> **task commit = build-worker boundary only** — 이 invariant 의 진본은 *권한 경계* 다: impl 루프 worktree 의 변경은 build-worker 권한 경계([`agent_boundary.py`](../../harness/agent_boundary.py) ALLOW_MATRIX = `src/**` / test 계열)상 구현·테스트 파일뿐이라, stories.md / backlog.md 등은 애초에 worktree 에 안 들어온다. 진행 추적은 task commit sha + story PR body 트레일러 (Part of / Closes) + GitHub sub-issue API 가 SSOT.
 
 규칙은 전부 git-spec 위임 — loop-procedure 는 판정 로직(브랜치명·base·트레일러)을 재서술하지 않는다:
 
 - **브랜치명** = [`git-spec.md` 브랜치](git-spec.md#브랜치) (결정 절차 = [`skills/impl-loop/SKILL.md`](../../skills/impl-loop/SKILL.md)).
 - **base 분기** = [`git-spec.md` Git 절차](git-spec.md#git-절차) (stories.md `**Base Branch:**` 마커 매치 시 통합 브랜치, 없으면 main · checkout 과 PR base 둘 다 동일 BASE).
-- **PR body 트레일러 (Part of vs Closes) 판정** = [`git-spec.md` PR 트레일러](git-spec.md#pr-트레일러-part-of-closes) 의 적용 절차 (impl 파일 frontmatter 기반).
+- **PR body 트레일러 (Part of vs Closes) 판정** = [`git-spec.md` PR 트레일러](git-spec.md#pr-트레일러-part-of-closes) 의 story/base 분기.
 - **실행** = [`scripts/pr-create.sh`](../../scripts/pr-create.sh) — `--branch / --base / --title / --body-file / --commit-msg-file` 받아 branch + add + commit + push + `gh pr create` 한 명령. body-file 은 메인이 위 트레일러 규칙대로 작성해 전달 (스크립트는 판정 X). **주의**: pr-create.sh 는 `git add -A`(worktree 전체 stage) — 위 권한 경계로 worktree 가 src-only 라 곧 src-only 커밋이 되지만, 메인이 stray non-src 변경(임시 파일·`.DS_Store` 등)을 발견하면 호출 *전* 정리하거나 명시 pathspec 으로 직접 stage 한다.
 
 ### Step 7a (impl-task-loop)
 
-PR 이미 생성된 상태 — merge only. `$PLUGIN_ROOT/scripts/pr-finalize.sh` 가 머지 + CI 대기 + default worktree sync/cleanup 을 자동 수행한다.
+story PR 경계에서만 PR 이 생성된 상태다. 다중 story/epic sub-PR 은 `$PLUGIN_ROOT/scripts/pr-finalize.sh` 로 통합 브랜치에 반영하고, 다음 branch 를 갱신된 통합 ref 에서 만든다. 단일 story→main 및 마지막 통합→main PR 은 review/acceptance 뒤 사용자 merge 정책을 따른다.
 
 ---
 

--- a/harness/story_runner.py
+++ b/harness/story_runner.py
@@ -17,16 +17,6 @@ from typing import Any, Iterable, Sequence
 
 VALID_SCOPES = {"auto", "story", "epic"}
 VALID_STATUSES = {"pending", "running", "completed", "error", "blocked"}
-VALID_STORY_STATUSES = {
-    "pending",
-    "running",
-    "implemented",
-    "completed",
-    "error",
-    "blocked",
-}
-VALID_STORY_MARK_STATUSES = {"completed", "error", "blocked"}
-STOP_STORY_STATUSES = {"error", "blocked"}
 
 
 @dataclass(frozen=True)
@@ -165,26 +155,14 @@ def build_state(
         resolved_scope = "epic"
     if resolved_scope == "story" and len(story_ids) > 1:
         raise ValueError("scope=story requires tasks from exactly one story")
-    stories = [
-        {
-            "story": story,
-            "status": "pending",
-            "task_ids": [task["id"] for task in tasks if str(task["story"]) == story],
-            "pr": None,
-        }
-        for story in story_ids
-    ]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "kind": "dcness-story-run",
         "created_at": _now_iso(),
         "updated_at": _now_iso(),
         "scope": resolved_scope,
-        "status": "pending",
         "project_root": str(root),
-        "current_task": None,
         "tasks": tasks,
-        "stories": stories,
     }
 
 
@@ -216,16 +194,33 @@ def prepare_init_state(path: Path, *, force: bool) -> Path | None:
         raise ValueError(
             f"state exists but cannot be read: {path}; use --force to replace it"
         ) from exc
-    if existing.get("status") == "completed":
+    tasks = existing.get("tasks")
+    if isinstance(tasks, list) and tasks and all(
+        task.get("status") == "completed" for task in tasks
+    ):
+        # Normalize schema-v1 states that were stranded at ready_for_review.
+        # PR metadata never participates in the task-state lifetime.
+        save_state(path, existing)
         return archive_completed_state(path)
-    status = existing.get("status") or "unknown"
+    if not isinstance(tasks, list) or not tasks:
+        raise ValueError(
+            f"state has no task records: {path}; inspect it or use --force"
+        )
+    incomplete = ", ".join(
+        f"#{task.get('id', '?')}={task.get('status', 'unknown')}"
+        for task in tasks
+        if task.get("status") != "completed"
+    )
     raise ValueError(
-        f"state exists with status={status}: {path}; resume it or use --force"
+        f"state has incomplete task(s): {incomplete}; resume it or use --force"
     )
 
 
 def save_state(path: Path, state: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    state["schema_version"] = 2
+    for derived_key in ("status", "current_task", "stories"):
+        state.pop(derived_key, None)
     state["updated_at"] = _now_iso()
     payload = json.dumps(state, ensure_ascii=False, indent=2) + "\n"
     tmp = path.with_name(f".{path.name}.tmp-{os.getpid()}")
@@ -240,116 +235,87 @@ def find_task(state: dict[str, Any], ref: str) -> dict[str, Any]:
     raise ValueError(f"task not found: {ref}")
 
 
-def find_story(state: dict[str, Any], ref: str) -> dict[str, Any]:
-    for story in state.get("stories", []):
-        if str(story.get("story")) == str(ref):
-            return story
-    raise ValueError(f"story not found: {ref}")
-
-
-def _tasks_for_story(state: dict[str, Any], story: dict[str, Any]) -> list[dict[str, Any]]:
-    task_by_id = {task.get("id"): task for task in state.get("tasks", [])}
+def _tasks_for_story(state: dict[str, Any], story: str) -> list[dict[str, Any]]:
     return [
-        task_by_id[task_id]
-        for task_id in story.get("task_ids", [])
-        if task_id in task_by_id
+        task
+        for task in state.get("tasks", [])
+        if str(task.get("story")) == story
     ]
 
 
-def _first_story_with_status(
+def _story_summary(state: dict[str, Any], story: str) -> dict[str, Any]:
+    tasks = _tasks_for_story(state, story)
+    return {
+        "story": story,
+        "task_ids": [task.get("id") for task in tasks],
+        "commits": [task.get("commit") for task in tasks],
+    }
+
+
+def _progress(state: dict[str, Any]) -> dict[str, int]:
+    tasks = state.get("tasks", [])
+    return {
+        "completed": sum(task.get("status") == "completed" for task in tasks),
+        "total": len(tasks),
+    }
+
+
+def _story_boundary_before(
     state: dict[str, Any],
-    statuses: set[str],
-) -> dict[str, Any] | None:
-    for story in state.get("stories", []):
-        if story.get("status") in statuses:
-            return story
+    pending_index: int,
+) -> str | None:
+    tasks = state.get("tasks", [])
+    if pending_index <= 0:
+        return None
+    previous_story = str(tasks[pending_index - 1].get("story"))
+    next_story = str(tasks[pending_index].get("story"))
+    if previous_story == next_story:
+        return None
+    story_tasks = _tasks_for_story(state, previous_story)
+    if story_tasks and all(task.get("status") == "completed" for task in story_tasks):
+        return previous_story
     return None
 
 
 def next_task(state: dict[str, Any]) -> dict[str, Any] | None:
-    for task in state.get("tasks", []):
-        if task.get("status") == "running":
-            return task
-    if _first_story_with_status(state, STOP_STORY_STATUSES) is not None:
-        return None
-    for task in state.get("tasks", []):
-        if task.get("status") == "pending":
-            return task
+    action = next_action(state)
+    if action.get("action") == "task":
+        return action.get("task")
     return None
 
 
 def next_action(state: dict[str, Any]) -> dict[str, Any]:
-    state_status = state.get("status")
+    tasks = state.get("tasks", [])
+
+    for task in tasks:
+        if task.get("status") in {"blocked", "error"}:
+            return {"action": task["status"], "task": task, "progress": _progress(state)}
+
     for task in state.get("tasks", []):
         if task.get("status") == "running":
-            return {"action": "task", "state_status": state_status, "task": task}
+            return {"action": "task", "task": task, "progress": _progress(state)}
 
-    for story in state.get("stories", []):
-        status = story.get("status")
-        if status in {"blocked", "error"}:
-            return {"action": status, "state_status": state_status, "story": story}
-
-    for task in state.get("tasks", []):
+    for index, task in enumerate(tasks):
         if task.get("status") == "pending":
-            return {"action": "task", "state_status": state_status, "task": task}
+            boundary_story = _story_boundary_before(state, index)
+            if boundary_story is not None:
+                return {
+                    "action": "story-pr",
+                    "story": _story_summary(state, boundary_story),
+                    "next_task": task,
+                    "progress": _progress(state),
+                }
+            return {"action": "task", "task": task, "progress": _progress(state)}
 
-    implemented_stories = [
-        story
-        for story in state.get("stories", [])
-        if story.get("status") == "implemented"
-    ]
-    if implemented_stories:
+    if tasks and all(task.get("status") == "completed" for task in tasks):
+        final_story = str(tasks[-1].get("story"))
         return {
-            "action": "batch-review",
-            "state_status": state_status,
-            "stories": implemented_stories,
+            "action": "done",
+            "final_story": _story_summary(state, final_story),
+            "progress": _progress(state),
         }
 
-    return {"action": "done", "state_status": state_status}
-
-
-def _refresh_story_statuses(state: dict[str, Any]) -> None:
-    task_by_id = {task.get("id"): task for task in state.get("tasks", [])}
-    for story in state.get("stories", []):
-        story_tasks = [
-            task_by_id[task_id]
-            for task_id in story.get("task_ids", [])
-            if task_id in task_by_id
-        ]
-        if not story_tasks:
-            continue
-        statuses = {task.get("status") for task in story_tasks}
-        if story.get("status") in {"completed", "blocked", "error"} and all(
-            status == "completed" for status in statuses
-        ):
-            continue
-        if "blocked" in statuses:
-            story["status"] = "blocked"
-        elif "error" in statuses:
-            story["status"] = "error"
-        elif all(status == "completed" for status in statuses):
-            if story.get("status") != "completed":
-                story["status"] = "implemented"
-        elif "running" in statuses or "completed" in statuses:
-            story["status"] = "running"
-        else:
-            story["status"] = "pending"
-
-    story_statuses = {story.get("status") for story in state.get("stories", [])}
-    if "blocked" in story_statuses:
-        state["status"] = "blocked"
-    elif "error" in story_statuses:
-        state["status"] = "error"
-    elif story_statuses and all(status == "completed" for status in story_statuses):
-        state["status"] = "completed"
-    elif story_statuses and all(
-        status in {"implemented", "completed"} for status in story_statuses
-    ):
-        state["status"] = "ready_for_review"
-    elif "running" in story_statuses or "implemented" in story_statuses:
-        state["status"] = "running"
-    else:
-        state["status"] = "pending"
+    return {"action": "error", "note": "invalid or empty task state", "progress": _progress(state)}
 
 
 def mark_task(
@@ -364,53 +330,21 @@ def mark_task(
     if status not in VALID_STATUSES:
         raise ValueError(f"invalid task status: {status}")
     task = find_task(state, ref)
+    if status == "completed" and not (commit or task.get("commit")):
+        raise ValueError("mark completed requires --commit")
+    if status in {"error", "blocked"} and not (note and note.strip()):
+        raise ValueError(f"mark {status} requires --note")
     task["status"] = status
     if status == "running":
         task["attempts"] = int(task.get("attempts") or 0) + 1
-        state["current_task"] = task["id"]
-        state["status"] = "running"
-    elif status in {"completed", "error", "blocked"}:
-        if state.get("current_task") == task.get("id"):
-            state["current_task"] = None
-        if status in {"error", "blocked"}:
-            state["status"] = status
     if commit is not None:
         task["commit"] = commit
     if provider is not None:
         task["provider"] = provider
     if note is not None:
         task["note"] = note
-    _refresh_story_statuses(state)
     state["updated_at"] = _now_iso()
     return task
-
-
-def mark_story(
-    state: dict[str, Any],
-    ref: str,
-    status: str,
-    *,
-    pr: str | None = None,
-    note: str | None = None,
-) -> dict[str, Any]:
-    if status not in VALID_STORY_MARK_STATUSES:
-        raise ValueError(f"invalid story status: {status}")
-    story = find_story(state, ref)
-    story_tasks = _tasks_for_story(state, story)
-    if not story_tasks:
-        raise ValueError(f"story has no tasks: {ref}")
-    if not all(task.get("status") == "completed" for task in story_tasks):
-        raise ValueError("mark-story requires all story tasks completed")
-    if status == "completed" and not pr:
-        raise ValueError("mark-story completed requires --pr")
-    story["status"] = status
-    if pr is not None:
-        story["pr"] = pr
-    if note is not None:
-        story["note"] = note
-    _refresh_story_statuses(state)
-    state["updated_at"] = _now_iso()
-    return story
 
 
 def _print(payload: Any, *, as_json: bool) -> None:
@@ -420,9 +354,10 @@ def _print(payload: Any, *, as_json: bool) -> None:
     if payload is None:
         print("next: none")
     elif isinstance(payload, dict) and payload.get("tasks"):
+        story_count = len({str(task.get("story")) for task in payload["tasks"]})
         print(
             f"{payload['scope']} story-run: "
-            f"{len(payload['tasks'])} task(s), {len(payload['stories'])} story(s)"
+            f"{len(payload['tasks'])} task(s), {story_count} story(s)"
         )
         for task in payload["tasks"]:
             print(
@@ -468,13 +403,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
     p_mark.add_argument("--note", default=None)
     p_mark.add_argument("--json", action="store_true")
 
-    p_mark_story = sub.add_parser("mark-story")
-    p_mark_story.add_argument("--state", required=True)
-    p_mark_story.add_argument("--story", required=True)
-    p_mark_story.add_argument("--status", required=True, choices=sorted(VALID_STORY_MARK_STATUSES))
-    p_mark_story.add_argument("--pr", default=None)
-    p_mark_story.add_argument("--note", default=None)
-    p_mark_story.add_argument("--json", action="store_true")
     return parser
 
 
@@ -515,19 +443,6 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
             save_state(state_path, state)
             _print(task, as_json=args.json)
-            return 0
-        if args.cmd == "mark-story":
-            state_path = Path(args.state)
-            state = load_state(state_path)
-            story = mark_story(
-                state,
-                args.story,
-                args.status,
-                pr=args.pr,
-                note=args.note,
-            )
-            save_state(state_path, state)
-            _print(story, as_json=args.json)
             return 0
     except ValueError as exc:
         parser.exit(1, f"story-runner: {exc}\n")

--- a/scripts/check_pr_body.mjs
+++ b/scripts/check_pr_body.mjs
@@ -8,15 +8,16 @@
  * 따라서 commit message 안 `Closes #N` 만으론 issue 자동 close 안 됨 — PR body 에 반드시 써야 함.
  *
  * 트레일러 종류:
- *   - Closes #N / Fixes #N / Resolves #N — auto-close 발동 (story / epic 마지막 task PR)
- *   - Part of #N                          — 단순 언급, auto-close 발동 X (중간 task PR default)
- *   - task-index: i/total                  — impl 파일 frontmatter task_index 미러 (build-worker 가 박음)
+ *   - Closes #N / Fixes #N / Resolves #N — default branch 머지 시 auto-close 발동
+ *   - Part of #N                          — 단순 언급, auto-close 발동 X
  *
  * 게이트 동작:
  *   1. Document-Exception-PR-Close 마커 매치 → PASS (검사 우회)
- *   2. task-index: i/total 매치 + i == total (Story 마지막 task) → Closes/Fixes/Resolves 1+ 강제 (Part of 단독 FAIL)
- *   3. task-index: i/total 매치 + i < total (중간 task) → 트레일러 1+ 강제 (기존 동작)
- *   4. task-index 부재 (dcness self / non-impl PR) → 트레일러 1+ 강제 (fallback, 기존 동작)
+ *   2. issue 트레일러 1+ 매치 → PASS
+ *
+ * task 는 local commit 이고 PR 경계는 story 다. 이 gate 는 task-index 로 PR
+ * close 시점을 추론하지 않는다. story/integration base 별 trailer 선택은
+ * git-spec 과 pr-trailer.sh 가 담당한다.
  *
  * 사용:
  *   node scripts/check_pr_body.mjs --body "<PR body 전체>"
@@ -31,8 +32,6 @@
  */
 
 const TRAILER_RE = /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?|part\s+of)\s*#\d+/i;
-const CLOSE_TRAILER_RE = /(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?)\s*#\d+/i;
-const TASK_INDEX_RE = /^\s*task-index:\s*(\d+)\/(\d+)\s*$/im;
 const EXCEPTION_RE = /^\s*Document-Exception-PR-Close:\s*\S+/im;
 
 function readStdin() {
@@ -69,36 +68,6 @@ async function main() {
     process.exit(0);
   }
 
-  const taskIndexMatch = body.match(TASK_INDEX_RE);
-  if (taskIndexMatch) {
-    const i = parseInt(taskIndexMatch[1], 10);
-    const total = parseInt(taskIndexMatch[2], 10);
-    if (i === total) {
-      if (CLOSE_TRAILER_RE.test(body)) {
-        const match = body.match(CLOSE_TRAILER_RE)[0];
-        console.log(`[pr-body] PASS — Story 마지막 task (task-index: ${i}/${total}) + close-keyword 트레일러 매치: "${match}"`);
-        process.exit(0);
-      }
-      console.error(`[pr-body] FAIL — Story 마지막 task (task-index: ${i}/${total}) 인데 close-keyword 트레일러 부재.`);
-      console.error('  필수 (하나 이상, auto-close 발동):');
-      console.error('    Closes #N   |  Close #N   |  Closed #N');
-      console.error('    Fixes #N    |  Fix #N     |  Fixed #N');
-      console.error('    Resolves #N |  Resolve #N |  Resolved #N');
-      console.error('');
-      console.error('  현재 `Part of #N` 만 박혀있다면: 머지 시 issue 자동 close 안 됨 → silent open 잔존 사고 차단.');
-      console.error('  SSOT: docs/plugin/git-spec.md 의 PR 트레일러 기본 룰 (Story 마지막 task = Closes 강제)');
-      console.error('');
-      console.error('  예외 우회 (통합 브랜치 sub-PR 등 main 외 base 머지):');
-      console.error('    Document-Exception-PR-Close: <사유>');
-      process.exit(1);
-    }
-    if (TRAILER_RE.test(body)) {
-      const match = body.match(TRAILER_RE)[0];
-      console.log(`[pr-body] PASS — 중간 task (task-index: ${i}/${total}) + 트레일러 매치: "${match}"`);
-      process.exit(0);
-    }
-  }
-
   if (TRAILER_RE.test(body)) {
     const match = body.match(TRAILER_RE)[0];
     console.log(`[pr-body] PASS — 트레일러 매치: "${match}"`);
@@ -107,10 +76,10 @@ async function main() {
 
   console.error('[pr-body] FAIL — PR body 에 issue 트레일러 부재.');
   console.error('  허용 패턴 (대소문자 무관, 1+ 매치):');
-  console.error('    Closes #N   |  Close #N   |  Closed #N        ← auto-close 발동 (마지막 task PR)');
+  console.error('    Closes #N   |  Close #N   |  Closed #N        ← default branch 머지 시 auto-close 발동');
   console.error('    Fixes #N    |  Fix #N     |  Fixed #N         ← auto-close 발동');
   console.error('    Resolves #N |  Resolve #N |  Resolved #N      ← auto-close 발동');
-  console.error('    Part of #N                                     ← 단순 언급 (중간 task PR default)');
+  console.error('    Part of #N                                     ← 단순 언급');
   console.error('');
   console.error('  근거: 본 프로젝트는 regular merge 채택 — GitHub auto-close 는 *PR body* 만 인식.');
   console.error('       commit message 안 Closes #N 만으론 issue 자동 close 안 됨.');

--- a/scripts/pr-trailer.sh
+++ b/scripts/pr-trailer.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
-# dcness pr-trailer — impl task 파일 frontmatter 기반 PR body 트레일러 자동 생성
+# dcness pr-trailer — impl task 의 story key 기반 PR body 트레일러 자동 생성
 #
 # 룰 SSOT = docs/plugin/git-spec.md 의 "PR 트레일러 (Part of / Closes)" 절.
 # 본 스크립트는 그 적용 절차(수동 bash recipe)의 한 명령 구현이다 — 메인이 PR body
-# 작성 직전 frontmatter 를 손으로 읽고 분기하던 수작업을 대체한다.
+# 작성 직전 frontmatter 와 stories.md 를 손으로 읽고 분기하던 수작업을 대체한다.
+# task 파일은 story grouping key 를 찾는 입력이며 task_index 는 PR 경계가 아니다.
 #
 # 사용:
 #   scripts/pr-trailer.sh <impl-task-file>          # 트레일러 블록을 stdout 출력
@@ -14,14 +15,14 @@
 #   - stderr = 판정 근거 / WARN / ERROR.
 #
 # 분기 (git-spec 기본 룰):
-#   - story: 공통           → Part of #<epic>            (task-index omit)
-#   - task_index i < total  → Part of #<story> + task-index
-#   - task_index i == total → Closes #<story> (+ epic 마지막 story 면 Closes #<epic>) + task-index
-#   - malformed (숫자 story 인데 i/total 형식 아님) → exit 1 (PR 생성 정지 — git-spec MUST 가드)
+#   - story: 공통 → Part of #<epic>
+#   - story PR, base=main → Closes #<story> (+ epic 마지막 story 면 Closes #<epic>)
+#   - story sub-PR, base=통합 브랜치 → Part of #<story> + final main bulk-close exception
+#   - malformed (숫자 story 인데 task_index 가 i/total 형식 아님) → exit 1
 #
 # 통합 브랜치: stories.md 상단 `**Base Branch:** feature/<slug>` 마커가 있으면
-# base = 그 값. base ≠ main 이면 Closes 는 머지 시 미발동(GitHub 은 default branch
-# 머지만 auto-close) — pr-finalize.sh 가 머지 후 close 보정한다.
+# base = 그 값. sub-PR 은 story 를 조기 close 하지 않고 마지막 통합→main PR 이
+# 모든 story + epic 을 일괄 close 한다.
 
 set -e
 
@@ -81,23 +82,25 @@ if [ "$STORY_NUM" != "공통" ] && [ -n "$STORY_NUM" ]; then
 fi
 
 if [ "$STORY_NUM" = "공통" ]; then
-  # 공통 task — Part of #<epic>, task-index omit (git-spec 기본 룰)
+  # 공통 task group — 별도 story issue 가 없으므로 epic 에 연결한다.
   if [ -z "$EPIC_ISSUE" ]; then
     echo "[pr-trailer] ERROR: 공통 task 인데 $STORIES 에 '**GitHub Epic Issue:** #N' 마커 미해결 — 빈 'Part of #' 방지 위해 정지" >&2
     exit 1
   fi
   TRAILER="Part of #${EPIC_ISSUE}"
-  echo "[pr-trailer] 공통 task → Part of #${EPIC_ISSUE} (task-index omit)" >&2
+  echo "[pr-trailer] 공통 task group → Part of #${EPIC_ISSUE}" >&2
 elif printf '%s' "$TASK_INDEX" | grep -qE '^[0-9]+/[0-9]+$'; then
   if [ -z "$STORY_ISSUE" ]; then
     echo "[pr-trailer] ERROR: story $STORY_NUM 의 '**GitHub Issue:** #N' 마커를 $STORIES 에서 못 찾음 — 이슈 미등록이면 등록 후 재시도" >&2
     exit 1
   fi
-  I="${TASK_INDEX%/*}"
-  TOTAL="${TASK_INDEX#*/}"
-  if [ "$I" = "$TOTAL" ]; then
+  if [ "$BASE" != "main" ]; then
+    TRAILER="Part of #${STORY_ISSUE}
+Document-Exception-PR-Close: 통합 브랜치 story sub-PR — main 머지 시 일괄 close"
+    echo "[pr-trailer] 통합 브랜치 story $STORY_NUM sub-PR → Part of #${STORY_ISSUE}; 마지막 통합→main PR 에서 일괄 close" >&2
+  else
     TRAILER="Closes #${STORY_ISSUE}"
-    echo "[pr-trailer] story $STORY_NUM 마지막 task (${TASK_INDEX}) → Closes #${STORY_ISSUE}" >&2
+    echo "[pr-trailer] story $STORY_NUM PR → Closes #${STORY_ISSUE}" >&2
     # epic 마지막 story 판정 — epic 라벨은 stories.md 디렉토리명(epic-NN-<slug>) 우선,
     # 없으면 epic 이슈의 라벨에서 조회. OPEN story 가 본 story 뿐이면 epic 도 동봉.
     EPIC_LABEL=$(basename "$(dirname "$STORIES")" | grep -E '^epic-[0-9]+-' || true)
@@ -116,19 +119,10 @@ Closes #${EPIC_ISSUE}"
     elif [ -n "$EPIC_ISSUE" ]; then
       echo "[pr-trailer] WARN: epic 라벨(epic-NN-<slug>) 미해결 — epic 마지막 story 판정 skip" >&2
     fi
-  else
-    TRAILER="Part of #${STORY_ISSUE}"
-    echo "[pr-trailer] story $STORY_NUM 중간 task (${TASK_INDEX}) → Part of #${STORY_ISSUE}" >&2
   fi
-  TRAILER="${TRAILER}
-task-index: ${TASK_INDEX}"
 else
   echo "[pr-trailer] ERROR: story=$STORY_NUM 인데 task_index='$TASK_INDEX' 가 i/total 도 공통(—)도 아님 — malformed/누락 가드, PR 생성 정지 (git-spec PR 트레일러 MUST)" >&2
   exit 1
-fi
-
-if [ "$BASE" != "main" ]; then
-  echo "[pr-trailer] base=$BASE (통합 브랜치) — GitHub auto-close 는 default branch 머지만 인식하므로 Closes 는 머지 시 미발동. pr-finalize.sh 가 머지 후 close 보정." >&2
 fi
 
 echo "$TRAILER"

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -14,9 +14,9 @@ description: Story/공통 impl task 파일(SDD 설계도)을 받아 단일 build
 - **loop**: `impl-task-loop` (UI 감지 시 `impl-ui-design-loop`)
 - **entry_point**: `impl`
 - **implementation**: `build-worker` 하나. `build-worker` 는 test + impl + self-validate + task local commit 을 수행한다.
-- **review**: 모든 대상 task 가 implemented/completed 된 뒤 merge candidate diff 를 대상으로 `impl-validator` 1회 통합 리뷰.
+- **review**: 모든 대상 task 가 completed 된 뒤 merge candidate diff 를 대상으로 `impl-validator` 1회 통합 리뷰.
 - **main-owned**: push / PR 생성 / PR merge / issue mutation 은 메인 전담.
-- **state**: `dcness-story-runner` 가 task 순서, task commit, story status, batch review 경계를 소유한다.
+- **state**: `dcness-story-runner` 가 task 순서와 task commit 상태만 저장하고 story PR/run 종결은 task 에서 계산한다.
 - **분기 규칙**: [`impl-loop-routing.md`](impl-loop-routing.md)
 
 UI expected_steps 의 `canvas-design` 은 진행 뷰용 main-owned checkpoint 이며 helper begin/end-step 비대상이다. draft 가 필요할 때 ledger 에 기록되는 실제 Agent step 은 `begin-step designer` 다.
@@ -136,11 +136,20 @@ phase prose:
 - build-worker 가 환경 제약으로 검증 명령을 실행하지 못해 `VALIDATION_BLOCKED` 를 보고하면, 메인이 같은 worktree cwd 에서 worker 가 남긴 명령을 직접 실행한다.
 - 검증 미실행 상태로 commit/push/PR 진행 금지.
 
-## story/epic runner state (#1019)
+## story/epic runner task 단일 상태 (#1019, #1041)
 
-`/impl-loop` 은 story/epic run state 를 자연어로 암기하지 않는다. 진입 직후 `dcness-story-runner plan/init` 이 impl task 목록을 정렬하고, task 상태와 batch-review 경계를 만든다. 실행 중에는 `dcness-story-runner mark` 와 `dcness-story-runner next-action` 만으로 다음 행동을 고른다.
+`/impl-loop` 은 story/epic 진행을 자연어로 암기하지 않는다. 진입 직후 `dcness-story-runner plan/init` 이 impl task 목록을 정렬한다. state file 에는 각 task 의 `pending / running / completed / error / blocked` 와 `attempts / commit / provider / note` 만 저장한다. story/run status 와 PR 번호는 저장하지 않는다.
 
-실행 단위는 **task commit** 과 **batch review PR** 이다. build-worker 가 각 task local commit 을 만든 뒤 `dcness-story-runner mark --status completed --commit <sha>` 로 state 를 갱신한다. story 의 모든 task 가 completed 되면 story status 는 `implemented` 가 된다. 모든 target story/task 가 implemented/completed 되면 `next-action` 은 `action=batch-review` 를 반환하고 run status 는 `ready_for_review` 가 된다. 그 전에는 story PR 로 멈추지 않고 다음 task 로 진행한다.
+실행 단위는 **task commit** 과 **story sub-PR** 이다. build-worker 가 각 task local commit 을 만든 뒤 `dcness-story-runner mark --status completed --commit <sha>` 로 state 를 갱신한다. `error` / `blocked` 는 서로 다른 task 상태로 기록하고 `--note <사유>` 를 반드시 남긴다.
+
+`next-action` 의 파생 결과만 다음 행동을 정한다.
+
+- `action=task`: 미완 task 를 build-worker 로 실행한다.
+- `action=story-pr`: 직전 story 의 task commit 이 모두 완료됐다. 응답의 `story` 로 story sub-PR 을 만들고, `next_task` 는 그 PR 반영 뒤 시작할 task 다.
+- `action=done`: 모든 task commit 이 완료됐다. `final_story` 로 마지막 story PR 을 만든 뒤 invocation 전체 merge candidate 를 리뷰한다.
+- `action=error` / `action=blocked`: 해당 task 의 note 를 근거로 retry 또는 사용자 위임한다.
+
+task 가 모두 completed 면 run 은 PR 생성·머지 여부와 무관하게 종결된 것이다. 다음 `init` 은 기존 state 를 `story-run.completed-<UTC>.json` 으로 자동 보관하고 `--force` 없이 새 run 을 시작한다.
 
 ```bash
 "$PLUGIN_ROOT/scripts/dcness-story-runner" plan <impl-glob-or-dir>
@@ -151,27 +160,34 @@ phase prose:
 
 완료 state 는 `story-run.completed-<UTC>.json` 으로 보관한다. 이 state file 은 직렬 chain driver 전용이며, 메인이 path glob 를 다시 정렬하거나 frontmatter 를 재해석하지 않는다.
 
+story PR 경계:
+
+- 단일 story run: `final_story` PR 1개, base=`main`. review/acceptance 뒤 사람 merge 결정을 기다린다.
+- 다중 story/epic run: story 별 branch 와 sub-PR 의 base는 `stories.md`의 통합 브랜치다. `action=story-pr`마다 메인이 sub-PR을 만들고 통합 브랜치로 즉시 머지한다. 다음 story branch는 **갱신된 통합 브랜치에서 재분기**한다.
+- 마지막 `action=done`: 마지막 story sub-PR까지 통합한 뒤 통합→main PR 1개를 만든다. 사람 머지 게이트는 이 PR 한 곳이다. epic을 단일 구현 PR로 묶지 않는다.
+
 dry preview echo:
 
 ```text
-전체: K task commit · batch review PR 1개
+전체: K task commit · S story sub-PR · 다중 story 면 통합→main PR 1개
 acceptance 경계: story #<M>…#<N> · epic #<E>   ← 머지 전 검수 대상 (기본 ON, --no-acceptance 시 생략)
 ```
 
 issue close 가 실제 발동되는 story PR 또는 epic 마감 PR 을 포함한 chain 은 task 수와 무관하게 계획 표 echo + `진행할까요? (Y/n)` 1회 확인 후 진입한다. 확인 응답 전에는 task1 또는 마감 PR 머지로 진입하지 않는다. 통합 브랜치 sub-PR(base ≠ default) 의 `Closes` 는 그 시점에 실제 close 를 발동하지 않으므로 sub-PR chain 진입 확인 기준에서는 제외하고, 마지막 main 머지 PR 직전에 1회 확인한다. yolo 모드에서는 생략한다.
 
-## Batch review / PR / merge
+## Story PR / integrated review / merge
 
-모든 target task 가 implemented/completed 된 뒤 메인이 push 하고 PR 을 만든다. `impl-validator review 출력은 merge candidate 경계에서 1회` 수행한다. 단일 story 는 해당 PR diff 를, 다중 story/통합 브랜치는 합쳐진 diff 를 넘긴다.
+story 의 target task 가 completed 될 때마다 메인이 story PR 을 만든다. 다중 story run 은 story sub-PR 을 통합 브랜치에 누적하되, `impl-validator review 출력은 merge candidate 경계에서 1회`만 수행한다. 단일 story 는 열린 story→main PR diff 를, 다중 story/epic 은 모든 sub-PR 이 반영된 통합→main diff 를 넘긴다.
 
 정상 순서:
 
-1. build-worker task commit 들이 worktree branch 에 누적되어 있고 `git status --porcelain` 이 clean 인지 확인한다.
-2. PR body 를 `.github/PULL_REQUEST_TEMPLATE.md` 에 맞춰 작성한다.
-3. `scripts/pr-create.sh` 또는 repo git-spec 절차로 push/PR 생성은 메인이 수행한다.
-4. `begin-step impl-validator` → build-worker provider 의 반대편으로 review provider 를 resolve 하고, `impl-validator` 가 merged diff 를 1회 리뷰한다.
-5. `PASS` 후 close 발동 여부에 따라 product-acceptance 를 수행한다.
-6. merge 는 `$PLUGIN_ROOT/scripts/pr-finalize.sh <PR>` 로 진행한다. 사용자 merge 결정이 필요한 repo 에서는 여기서 멈춘다.
+1. 한 story 의 build-worker task commit 들과 `git status --porcelain` clean 을 확인한다.
+2. `scripts/pr-create.sh` 또는 repo git-spec 절차로 story PR 을 만든다.
+3. 다중 story/epic 이면 story sub-PR 을 통합 브랜치로 머지하고 remote 통합 ref 를 갱신한 뒤, 다음 story branch 를 그 ref 에서 새로 만든다. 단일 story PR 은 열린 채 유지한다.
+4. 모든 story PR 경계를 처리한 뒤 다중 story/epic 은 통합→main PR 을 만든다.
+5. `begin-step impl-validator` → build-worker provider 의 반대편으로 review provider 를 resolve 하고, `impl-validator` 가 merged diff 를 1회 리뷰한다.
+6. `PASS` 후 `STORY_ACCEPTANCE` × N, epic close 시 `EPIC_ACCEPTANCE` 를 수행한다.
+7. 단일 story→main 또는 통합→main PR 은 사용자 merge 결정이 필요한 repo 에서 멈춘다.
 
 `impl-validator FAIL` 이면 메인이 root cause 를 고친 뒤 새 commit 을 PR branch 에 append 하거나, 이미 머지된 뒤라면 fix PR 을 만든다. 단일 story PR 은 해당 PR branch 에 append 한다. story PR 이 2개 이상인 run 에서 FAIL 보정이 필요하면 downstream rebase 없이 통합 fix PR 1개를 만든다. 같은 finding 을 줄 단위 점 패치로 반복하지 않는다. cycle 한도는 routing 문서가 소유한다.
 
@@ -188,7 +204,7 @@ REVIEW_PROVIDER=$("$HELPER" routing resolve impl-validator --implementation-prov
 
 story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후에만 마감 PR 을 머지**한다. 기본 ON — `--no-acceptance` 또는 "검수 없이" 발화 시에만 생략한다.
 
-batch review PR 이 여러 story 를 닫으면 `product-acceptance:STORY_ACCEPTANCE` 를 story × N 으로 수행한 뒤, epic close 가 실제 발동되면 `product-acceptance:EPIC_ACCEPTANCE` 를 1회 수행한다. gap 수정 commit 이 생기면 이전 STORY PASS 는 stale 이므로 STORY_ACCEPTANCE 부터 다시 돌린다.
+최종 main 대상 PR 이 여러 story 를 닫으면 `product-acceptance:STORY_ACCEPTANCE` 를 story × N 으로 수행한 뒤, epic close 가 실제 발동되면 `product-acceptance:EPIC_ACCEPTANCE` 를 1회 수행한다. gap 수정 commit 이 생기면 이전 STORY PASS 는 stale 이므로 STORY_ACCEPTANCE 부터 다시 돌린다.
 
 product-acceptance 는 read-only 라 `gh` 호출 불가다. PR 목록·검증 결과·동작 증거·UI 목업 정합 증거는 메인이 prompt 에 직접 담는다. UI task 는 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 함께 넣어 목업 불일치와 화면 증거 부재를 판정할 수 있게 한다. 핵심 AC 증거가 mock-only green 이거나 대상 사용자에게 부적합한 입력/진행 동선이면 gap 이다.
 
@@ -225,14 +241,14 @@ chain 안에서는 매 task 전수 review.md 출력을 하지 않는다. 메인 
 build-worker: N tests RED→GREEN · M files +X -Y · validate PASS|FAIL · commit <sha>
 finding: <PASS 시 "없음" / FAIL·NICE TO HAVE 시 1-2 문장>
 PR <#NNN> merged · closes #<MMM>
-next: <다음 task slug 진입 | batch-review | 정지 사유>
+next: <다음 task slug 진입 | story-pr | integrated-review | 정지 사유>
 ```
 
 close 발동 PR 은 acceptance 줄을 `PR <#NNN> merged` 앞에 추가한다. 디스크의 `<run_dir>/review.md` 는 원본 그대로 저장한다.
 
 ## 종료 조건
 
-전체 완료 후 메인은 처리 N/N, task commit sha, batch review PR URL, impl-validator round, acceptance 결과를 보고한다. clean 판정 전에는 다음 흔적을 확인한다.
+전체 완료 후 메인은 처리 N/N, task commit sha, story sub-PR URL, 최종 main 대상 PR URL, impl-validator round, acceptance 결과를 보고한다. clean 판정 전에는 다음 흔적을 확인한다.
 
 - build-worker phase prose 3개.
 - build-worker local commit sha.
@@ -249,7 +265,8 @@ close 발동 PR 은 acceptance 줄을 `PR <#NNN> merged` 앞에 추가한다. �
 - task N 개를 한 build-worker 호출에 묶어 한 번에 처리.
 - task commit/mark 전 다음 task 진입.
 - build-worker 가 push / PR 생성 / merge / issue mutation 수행.
-- impl-validator batch review 없이 PR 생성·머지.
+- story sub-PR 을 건너뛰고 epic 구현을 단일 PR 로 묶기.
+- 모든 구현 뒤 impl-validator 통합 리뷰 없이 최종 main 대상 PR 을 머지하기.
 - story/epic close 발동 PR 에서 acceptance 생략 또는 FAIL 미해소 상태로 `$PLUGIN_ROOT/scripts/pr-finalize.sh` 강행.
 - TaskCreate / TaskUpdate skip.
 - chain 전체 완료 후 자율 작업 (이슈 등록 / cleanup / 분석) 진입 시 `post-task-begin` marker 누락.

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -21,8 +21,11 @@ flowchart TB
   GATE -->|fail| RETRY
   MARK --> NEXT[next-action]
   NEXT -->|task| BW
-  NEXT -->|batch-review| PR[메인 push + PR 생성]
-  PR --> IV[impl-validator merged diff review]
+  NEXT -->|story-pr| SPR[story sub-PR 생성 + 통합 브랜치 merge]
+  SPR --> REBRANCH[갱신된 통합 브랜치에서 재분기]
+  REBRANCH --> BW
+  NEXT -->|done + final_story| FPR[마지막 story PR + 최종 main 대상 PR]
+  FPR --> IV[impl-validator merged diff review 1회]
   IV -->|PASS| ACC{close 발동?}
   IV -->|FAIL| FIX[메인 root-cause 수정 + commit append]
   FIX --> IV
@@ -43,7 +46,7 @@ canvas-design 은 UI 작업의 main-owned checkpoint 이며 helper begin/end-ste
 | step | 결론 → 다음 |
 |---|---|
 | **build-worker** | `PASS` + local commit sha + clean status → `dcness-story-runner mark --status completed --commit <sha>` 후 `next-action` · `TESTS_FAIL` → build-worker rework(≤3) · `SPEC_GAP_FOUND` → design-doc 보강 또는 사용자 위임 · `VALIDATION_BLOCKED` → 메인이 같은 worktree cwd 에서 worker 가 남긴 검증 명령 실행, exit 0 이면 PASS 와 동일, 실패면 build-worker rework(≤3), 메인도 실행 불가면 사용자 위임 · `IMPLEMENTATION_ESCALATE` → 사용자 |
-| **dcness-story-runner `next-action`** | `task` → 다음 task build-worker · `batch-review` → 메인 push + PR 생성 + impl-validator · `blocked` / `error` → retry 한도 내 재시도 또는 사용자 위임 · `done` → 완료 보고 |
+| **dcness-story-runner `next-action`** | `task` → 다음 task build-worker · `story-pr` → 직전 story sub-PR 생성·통합 브랜치 merge 후 응답의 `next_task` 를 갱신된 통합 브랜치에서 재분기 · `done` → `final_story` PR 경계를 처리하고 최종 main 대상 PR 생성 + impl-validator · `blocked` / `error` → task note 를 근거로 retry 한도 내 재시도 또는 사용자 위임 |
 | **impl-validator** | merged diff `PASS` → close 발동 여부 확인 · `FAIL`(`[spec-gap]` 또는 `[quality-gap]`) → 메인 root-cause 수정. 단일 story PR 은 commit append, story PR 이 2개 이상이거나 이미 머지된 뒤라면 downstream rebase 없이 통합 fix PR 1개 + 재리뷰(≤3) · `ESCALATE` → 사용자 |
 | **product-acceptance** | `PASS` → merge 진행. story×N 과 epic 대상이면 모두 PASS 필요 · `FAIL` auto-fixable gap → build-worker rework + commit append + impl-validator 재리뷰 + acceptance 재검수(≤3) · `FAIL` 비자동 gap / round 초과 / `ESCALATE` → 사용자 |
 
@@ -64,7 +67,7 @@ story/epic close 를 실제 발동하는 PR 의 impl-validator `PASS` 후 · mer
 
 impl-validator 는 계획 대비 구현 정합과 merge candidate diff 위험을 검토한다. 여러 PR 이 합쳐진 story 동작과 여러 story 가 합쳐진 epic 동작의 사용자 관찰 가능 동작은 마감 product-acceptance 가 맡는다.
 
-여러 PR 이 합쳐진 story 동작은 batch review PR 의 merge candidate diff 와 acceptance 증거를 함께 보고 판정한다. 여러 story 가 합쳐진 epic 동작도 같은 원칙으로 product-acceptance 가 맡는다. product-acceptance 는 개별 task green 이 아니라 story/epic close 시점의 사용자 동작 전체를 검수한다.
+여러 task commit 이 합쳐진 story 동작은 story PR 과 acceptance 증거를 함께 보고 판정한다. 여러 story sub-PR 이 합쳐진 epic 동작도 같은 원칙으로 product-acceptance 가 맡는다. product-acceptance 는 개별 task green 이 아니라 story/epic close 시점의 사용자 동작 전체를 검수한다.
 
 - story close: `STORY_ACCEPTANCE`
 - 여러 story close: `STORY_ACCEPTANCE` 를 story × N
@@ -77,8 +80,9 @@ auto-fixable gap: PRD/AC 미충족, 검수 증거 부족, 스모크 실패, mock
 ## clean / blocked 판정
 
 - task clean = build-worker PASS + phase prose 3개 + local commit sha + clean status + story-runner mark.
-- batch review clean = 모든 target task implemented/completed + PR 생성 + impl-validator PASS.
-- close 발동 clean = batch review clean + 필요한 product-acceptance PASS.
+- story boundary clean = 해당 story 의 모든 task completed + story PR 생성. 다중 story 면 통합 브랜치 merge + 다음 branch 재분기까지 확인.
+- integrated review clean = 모든 target task completed + 모든 story PR 경계 처리 + 최종 main 대상 PR 생성 + impl-validator PASS.
+- close 발동 clean = integrated review clean + 필요한 product-acceptance PASS.
 - verify-only clean = 검증 명령 exit 0 + 변경 0 + validator PASS.
 
 false-clean 의심 시 blocked. 예: phase prose 부재, commit sha 부재, 검증 미실행, impl-validator PASS 부재, acceptance PASS 부재, PR/merge 흔적 부재.

--- a/tests/test_impl_cost_aware.py
+++ b/tests/test_impl_cost_aware.py
@@ -103,7 +103,7 @@ class TestPreReadCostAware(unittest.TestCase):
 
 
 class TestImplLoopSingleEngine(unittest.TestCase):
-    """#1023 — impl-loop uses a single build-worker engine and batch review."""
+    """#1023/#1041 — one build-worker, story PRs, one integrated review."""
 
     def test_impl_loop_declares_single_build_worker_engine(self):
         skill = read_impl_skill()
@@ -118,16 +118,19 @@ class TestImplLoopSingleEngine(unittest.TestCase):
                 self.assertNotIn("2agent", body)
                 self.assertNotIn("4agent", body)
 
-    def test_batch_review_boundary_replaces_story_pr_stop(self):
+    def test_story_pr_boundary_keeps_one_integrated_review(self):
         skill = read_impl_skill()
         for needle in (
-            "batch-review",
-            "ready_for_review",
-            "그 전에는 story PR 로 멈추지 않고 다음 task 로 진행",
+            "action=story-pr",
+            "story sub-PR",
+            "갱신된 통합 브랜치에서 재분기",
             "impl-validator review 출력은 merge candidate 경계에서 1회",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, skill)
+        for stale in ("batch-review", "ready_for_review", "mark-story"):
+            with self.subTest(stale=stale):
+                self.assertNotIn(stale, skill)
 
     def test_impl_task_template_does_not_emit_engine_taxonomy(self):
         template = (

--- a/tests/test_pr_body.py
+++ b/tests/test_pr_body.py
@@ -1,11 +1,8 @@
 """Regression tests for the PR-body trailer gate (scripts/check_pr_body.mjs).
 
-규칙 SSOT = docs/plugin/git-spec.md 의 PR 트레일러. 본 테스트는 게이트가 task-index 트레일러 기반
-분기를 올바로 강제하는지 검증한다 — 특히 codex 리뷰 F2-b 회귀:
-  - 공통 task (task_index: —) 는 task-index trailer 가 omit 되고 `Part of #N` 으로 통과해야 함
-    (Story 마지막 task 로 오판돼 Closes 강제되면 안 됨)
-  - Story 마지막 task (i == total) 는 Closes/Fixes/Resolves 강제, Part of 단독 FAIL
-  - 중간 task (i < total) 는 트레일러 1건이면 통과
+규칙 SSOT = docs/plugin/git-spec.md 의 PR 트레일러. task 는 local commit 이고
+PR 경계는 story 이므로 gate 는 task_index 로 close 시점을 추론하지 않는다. issue
+트레일러 1건 또는 명시적 exception 만 강제한다.
 
 node 미설치 환경에서는 skip.
 """
@@ -40,17 +37,13 @@ class PrBodyGateTests(unittest.TestCase):
     def assertFail(self, body: str) -> None:
         self.assertEqual(_run(body), 1, f"기대 FAIL 인데 PASS:\n{body}")
 
-    def test_common_task_part_of_passes(self) -> None:
-        # 공통 task — task-index trailer 없음 + Part of → fallback path 통과 (F2-b 회귀)
+    def test_part_of_passes(self) -> None:
         self.assertPass("## 작업내용\n공통 task — 테마 토큰\n\nPart of #42\n")
 
-    def test_story_last_task_requires_close(self) -> None:
-        # i == total → Closes 강제
+    def test_legacy_task_index_does_not_change_story_pr_rule(self) -> None:
         self.assertPass("작업\n\ntask-index: 3/3\nCloses #42\n")
-        self.assertFail("작업\n\ntask-index: 3/3\nPart of #42\n")  # Part of 단독 FAIL
-
-    def test_mid_task_part_of_passes(self) -> None:
         self.assertPass("작업\n\ntask-index: 1/3\nPart of #42\n")
+        self.assertPass("작업\n\ntask-index: 3/3\nPart of #42\n")
 
     def test_empty_body_fails(self) -> None:
         self.assertFail("")

--- a/tests/test_pr_trailer.py
+++ b/tests/test_pr_trailer.py
@@ -1,7 +1,7 @@
-"""pr-trailer.sh 행동 테스트 — impl frontmatter 기반 PR 트레일러 자동 생성.
+"""pr-trailer.sh 행동 테스트 — story PR 트레일러 자동 생성.
 
-git-spec "PR 트레일러 (Part of / Closes)" 적용 절차의 한 명령 구현이 분기표대로
-동작하는지 fixture 저장소 + 가짜 gh 스텁으로 검증한다.
+task 파일은 story grouping key 를 찾는 입력일 뿐이며 task_index 는 PR 경계를
+결정하지 않는다.
 """
 from __future__ import annotations
 
@@ -83,25 +83,24 @@ class PrTrailerTests(unittest.TestCase):
             cwd=self.root,
         )
 
-    def test_middle_task_part_of_story(self) -> None:
+    def test_any_story_task_selects_story_close_trailer(self) -> None:
         task = self._task("01-first.md", "1", "1/2")
         result = self._run(str(task))
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "Part of #11\ntask-index: 1/2")
+        self.assertEqual(result.stdout.strip(), "Closes #11")
+        self.assertNotIn("task-index", result.stdout)
 
     def test_last_task_closes_story_only_when_epic_has_open_stories(self) -> None:
         task = self._task("02-last.md", "1", "2/2")
         result = self._run(str(task), open_story_count="2")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "Closes #11\ntask-index: 2/2")
+        self.assertEqual(result.stdout.strip(), "Closes #11")
 
     def test_last_task_of_last_story_closes_epic_too(self) -> None:
         task = self._task("02-last.md", "2", "2/2")
         result = self._run(str(task), open_story_count="1")
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(
-            result.stdout.strip(), "Closes #12\nCloses #10\ntask-index: 2/2"
-        )
+        self.assertEqual(result.stdout.strip(), "Closes #12\nCloses #10")
 
     def test_common_task_part_of_epic_without_task_index(self) -> None:
         task = self._task("00-common.md", "공통", "—")
@@ -142,7 +141,7 @@ class PrTrailerTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertEqual(result.stdout.strip(), "main")
 
-    def test_integration_base_warns_autoclose_not_firing(self) -> None:
+    def test_integration_story_sub_pr_defers_close_to_main(self) -> None:
         (self.epic_dir / "stories.md").write_text(
             "**Base Branch:** feature/shorts-template\n\n" + STORIES_BODY,
             encoding="utf-8",
@@ -150,9 +149,13 @@ class PrTrailerTests(unittest.TestCase):
         task = self._task("01-first.md", "1", "1/2")
         result = self._run(str(task))
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "Part of #11\ntask-index: 1/2")
+        self.assertEqual(
+            result.stdout.strip(),
+            "Part of #11\n"
+            "Document-Exception-PR-Close: 통합 브랜치 story sub-PR — main 머지 시 일괄 close",
+        )
         self.assertIn("통합 브랜치", result.stderr)
-        self.assertIn("pr-finalize", result.stderr)
+        self.assertIn("일괄 close", result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_skill_scenarios.py
+++ b/tests/test_skill_scenarios.py
@@ -82,7 +82,7 @@ class SkillScenarioRegressionTests(unittest.TestCase):
             r"build-worker.*impl-validator",
         )
         self.assertIn("단일 구현 엔진 `build-worker`", self.impl_loop_skill)
-        self.assertIn("batch-review", self.impl_loop_skill)
+        self.assertIn("action=story-pr", self.impl_loop_skill)
 
     # ----- 시나리오 2a — build-worker phase prose 3개 -----
     def test_build_worker_requires_three_phase_prose_files(self) -> None:

--- a/tests/test_story_runner.py
+++ b/tests/test_story_runner.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from harness.story_runner import build_state, mark_story, mark_task, next_action, next_task
+from harness.story_runner import build_state, mark_task, next_action, next_task
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -68,17 +68,18 @@ class StoryRunnerTests(unittest.TestCase):
         )
         return path
 
-    def test_plan_sorts_tasks_and_groups_story_pr_boundaries(self) -> None:
+    def test_plan_sorts_tasks_without_persisting_derived_story_or_run_state(self) -> None:
         state = build_state([str(self.impl_dir)], cwd=self.root, scope="epic")
 
         self.assertEqual(state["scope"], "epic")
+        self.assertEqual(state["schema_version"], 2)
         self.assertEqual(
             [Path(task["path"]).name for task in state["tasks"]],
             ["01-ui.md", "02-api.md", "03-common.md"],
         )
-        self.assertEqual([story["story"] for story in state["stories"]], ["1", "공통"])
-        self.assertEqual(state["stories"][0]["task_ids"], [1, 2])
-        self.assertEqual(state["stories"][1]["task_ids"], [3])
+        self.assertNotIn("stories", state)
+        self.assertNotIn("status", state)
+        self.assertNotIn("current_task", state)
         for task in state["tasks"]:
             self.assertNotIn("risk", task)
             self.assertNotIn("engine", task)
@@ -97,41 +98,46 @@ class StoryRunnerTests(unittest.TestCase):
 
         self.assertIsNone(next_task(state))
         action = next_action(state)
-        self.assertEqual(action["action"], "batch-review")
-        self.assertEqual([story["story"] for story in action["stories"]], ["1"])
-        self.assertEqual(state["status"], "ready_for_review")
-        self.assertEqual(state["stories"][0]["status"], "implemented")
+        self.assertEqual(action["action"], "done")
+        self.assertEqual(action["final_story"]["story"], "1")
+        self.assertEqual(action["final_story"]["task_ids"], [1, 2])
+        self.assertEqual(action["final_story"]["commits"], ["abc123", "def456"])
+        self.assertEqual(action["progress"], {"completed": 2, "total": 2})
 
-        mark_story(state, "1", "completed", pr="https://github.test/pr/1")
-        self.assertEqual(state["status"], "completed")
-        self.assertEqual(state["stories"][0]["status"], "completed")
-        self.assertEqual(state["stories"][0]["pr"], "https://github.test/pr/1")
-
-    def test_next_continues_across_story_without_story_pr_boundary(self) -> None:
+    def test_next_stops_at_story_pr_boundary_before_later_story(self) -> None:
         state = build_state([str(self.impl_dir)], cwd=self.root, scope="epic")
 
         mark_task(state, "1", "completed", commit="abc123")
         self.assertEqual(next_task(state)["id"], 2)
         mark_task(state, "2", "completed", commit="def456")
 
+        self.assertIsNone(next_task(state))
+        action = next_action(state)
+        self.assertEqual(action["action"], "story-pr")
+        self.assertEqual(action["story"]["story"], "1")
+        self.assertEqual(action["story"]["task_ids"], [1, 2])
+        self.assertEqual(action["next_task"]["id"], 3)
+
+        # story-pr 생성·통합 브랜치 머지는 state 에 저장하지 않는다. 갱신된
+        # 통합 브랜치에서 재분기한 뒤 next_task 를 running 으로 mark 하면 전진한다.
+        mark_task(state, "3", "running", provider="claude-headless")
         self.assertEqual(next_task(state)["id"], 3)
         self.assertEqual(next_action(state)["task"]["id"], 3)
-        self.assertEqual(state["stories"][0]["status"], "implemented")
-        self.assertEqual(state["status"], "running")
 
-    def test_mark_story_is_story_pr_boundary_only(self) -> None:
-        state = build_state([str(self.impl_dir / "01-ui.md"), str(self.impl_dir / "02-api.md")], cwd=self.root)
+    def test_completed_requires_commit_and_failure_states_require_note(self) -> None:
+        state = build_state([str(self.impl_dir / "01-ui.md")], cwd=self.root)
 
-        with self.assertRaisesRegex(ValueError, "invalid story status"):
-            mark_story(state, "1", "ready_for_review")
-        with self.assertRaisesRegex(ValueError, "requires all story tasks completed"):
-            mark_story(state, "1", "completed", pr="https://github.test/pr/1")
+        with self.assertRaisesRegex(ValueError, "completed requires --commit"):
+            mark_task(state, "1", "completed")
+        with self.assertRaisesRegex(ValueError, "blocked requires --note"):
+            mark_task(state, "1", "blocked")
+        with self.assertRaisesRegex(ValueError, "error requires --note"):
+            mark_task(state, "1", "error")
 
-        mark_task(state, "1", "completed", commit="abc123")
-        mark_task(state, "2", "completed", commit="def456")
-
-        with self.assertRaisesRegex(ValueError, "requires --pr"):
-            mark_story(state, "1", "completed")
+        mark_task(state, "1", "blocked", note="dependency unavailable")
+        action = next_action(state)
+        self.assertEqual(action["action"], "blocked")
+        self.assertEqual(action["task"]["note"], "dependency unavailable")
 
     def test_script_init_next_mark_round_trip(self) -> None:
         state_path = self.root / ".dcness-work" / "story-run.json"
@@ -212,8 +218,9 @@ class StoryRunnerTests(unittest.TestCase):
             check=True,
         )
         ready = json.loads(state_path.read_text(encoding="utf-8"))
-        self.assertEqual(ready["status"], "ready_for_review")
-        self.assertEqual(ready["stories"][0]["status"], "implemented")
+        self.assertNotIn("status", ready)
+        self.assertNotIn("stories", ready)
+        self.assertTrue(all(task["status"] == "completed" for task in ready["tasks"]))
 
         action = subprocess.run(
             [str(SCRIPT), "next-action", "--state", str(state_path), "--json"],
@@ -224,31 +231,19 @@ class StoryRunnerTests(unittest.TestCase):
             check=True,
         )
         action_payload = json.loads(action.stdout)
-        self.assertEqual(action_payload["action"], "batch-review")
-        self.assertEqual([story["story"] for story in action_payload["stories"]], ["1"])
+        self.assertEqual(action_payload["action"], "done")
+        self.assertEqual(action_payload["final_story"]["story"], "1")
 
-        subprocess.run(
-            [
-                str(SCRIPT),
-                "mark-story",
-                "--state",
-                str(state_path),
-                "--story",
-                "1",
-                "--status",
-                "completed",
-                "--pr",
-                "https://github.test/pr/1",
-            ],
+        removed = subprocess.run(
+            [str(SCRIPT), "mark-story", "--state", str(state_path)],
             cwd=ROOT,
             env=env,
             text=True,
             capture_output=True,
-            check=True,
+            check=False,
         )
-        done = json.loads(state_path.read_text(encoding="utf-8"))
-        self.assertEqual(done["status"], "completed")
-        self.assertEqual(done["stories"][0]["pr"], "https://github.test/pr/1")
+        self.assertEqual(removed.returncode, 2)
+        self.assertIn("invalid choice", removed.stderr)
 
         reinit = subprocess.run(
             [
@@ -269,11 +264,11 @@ class StoryRunnerTests(unittest.TestCase):
             check=True,
         )
         reinit_payload = json.loads(reinit.stdout)
-        self.assertEqual(reinit_payload["status"], "pending")
+        self.assertNotIn("status", reinit_payload)
         archives = list(state_path.parent.glob("story-run.completed-*.json"))
         self.assertEqual(len(archives), 1)
         archived = json.loads(archives[0].read_text(encoding="utf-8"))
-        self.assertEqual(archived["status"], "completed")
+        self.assertTrue(all(task["status"] == "completed" for task in archived["tasks"]))
 
     def test_script_init_refuses_active_state_without_force(self) -> None:
         state_path = self.root / ".dcness-work" / "story-run.json"
@@ -314,7 +309,52 @@ class StoryRunnerTests(unittest.TestCase):
         )
 
         self.assertEqual(duplicate.returncode, 1)
-        self.assertIn("state exists with status=pending", duplicate.stderr)
+        self.assertIn("state has incomplete task(s): #1=pending", duplicate.stderr)
+
+    def test_init_archives_legacy_ready_for_review_when_tasks_are_completed(self) -> None:
+        state_path = self.root / ".dcness-work" / "story-run.json"
+        state_path.parent.mkdir(parents=True)
+        legacy = build_state(
+            [str(self.impl_dir / "01-ui.md")], cwd=self.root, scope="story"
+        )
+        legacy["schema_version"] = 1
+        legacy["status"] = "ready_for_review"
+        legacy["current_task"] = None
+        legacy["tasks"][0]["status"] = "completed"
+        legacy["tasks"][0]["commit"] = "abc123"
+        legacy["stories"] = [
+            {"story": "1", "status": "implemented", "task_ids": [1], "pr": None}
+        ]
+        state_path.write_text(json.dumps(legacy), encoding="utf-8")
+        env = {**os.environ, "PYTHONPATH": str(ROOT)}
+
+        reinit = subprocess.run(
+            [
+                str(SCRIPT),
+                "init",
+                str(self.impl_dir / "01-ui.md"),
+                "--cwd",
+                str(self.root),
+                "--state",
+                str(state_path),
+                "--json",
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        fresh = json.loads(reinit.stdout)
+        self.assertEqual(fresh["schema_version"], 2)
+        archives = list(state_path.parent.glob("story-run.completed-*.json"))
+        self.assertEqual(len(archives), 1)
+        archived = json.loads(archives[0].read_text(encoding="utf-8"))
+        self.assertEqual(archived["schema_version"], 2)
+        self.assertNotIn("status", archived)
+        self.assertNotIn("current_task", archived)
+        self.assertNotIn("stories", archived)
 
 
 if __name__ == "__main__":

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -780,7 +780,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("일반 `/impl` 구현은 메인이 맡고", self.readme)
 
     def test_issue_1019_impl_loop_uses_story_runner_boundaries(self) -> None:
-        """#1019/#1023 — impl-loop uses deterministic state, task commits, and batch review."""
+        """#1019/#1023/#1041 — task state, story PRs, and one integrated review."""
         script = ROOT / "scripts" / "dcness-story-runner"
         self.assertTrue(script.exists())
         self.assertTrue(script.stat().st_mode & 0o111)
@@ -788,8 +788,11 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             "dcness-story-runner",
             "next-action",
             "task commit",
-            "batch review PR",
-            "action=batch-review",
+            "story sub-PR",
+            "action=story-pr",
+            "final_story",
+            "task 단일 상태",
+            "갱신된 통합 브랜치에서 재분기",
             "story-run.completed-<UTC>.json",
             "직렬 chain driver 전용",
             "impl-validator review 출력은 merge candidate 경계에서 1회",
@@ -800,6 +803,9 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             "PR 1개 = task 1개",
             "N task = N run = N review.md",
             "예상 PR K개",
+            "batch review PR 1개",
+            "ready_for_review",
+            "mark-story",
         ):
             with self.subTest(stale=stale):
                 self.assertNotIn(stale, self.impl_loop_skill)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1041

## 배경 및 문제

`/impl-loop` 문서가 invocation 끝의 통합 리뷰 경계와 PR 산출 경계를 합쳐 `batch review PR 1개`로 기술하고 있었습니다. 동시에 story-runner가 task/story/run 3계층 파생 상태를 저장하고, 절차에 배선되지 않은 `mark-story --pr` 없이는 `ready_for_review`에서 완료될 수 없어 다음 run 진입이 `--force` 없이 막혔습니다.

## 원인 (해당 시)

- #1023의 “통합 리뷰 1회”를 “통합 PR 1개”로 잘못 확장해 story별 sub-PR 경계가 사라졌습니다.
- task 상태에서 계산 가능한 story/run 상태와 PR 번호를 별도로 영속화해, 호출되지 않는 수동 전이가 run 수명을 결정했습니다.
- git-spec·issue-lifecycle·PR body gate가 task=PR 구 모델을 유지해 task=commit 계약과 충돌했습니다.

## 작업내용

- `dcness-story-runner` schema v2를 task 5상태(`pending/running/completed/error/blocked`)로 플랫화하고 `mark-story`를 제거했습니다.
- `next-action`이 `task` / `story-pr` / `done(final_story)` / `error` / `blocked`를 task 상태에서 계산하도록 변경했습니다.
- 모든 task가 commit 완료된 legacy `ready_for_review` state도 다음 `init`에서 정규화·자동 아카이브해 #1040 재현 경로를 제거했습니다.
- story별 sub-PR, 통합 브랜치 즉시 반영, 갱신된 통합 ref 재분기, 마지막 통합→main 사람 merge gate를 impl-loop skill/routing과 plugin SSOT에 복구했습니다.
- `pr-trailer.sh`와 PR body gate를 task-index PR 판정에서 story/base 판정으로 전환하고 회귀 테스트를 갱신했습니다.

## 결정 근거

- PR 생성·머지는 task 구현 완료와 다른 외부 상태이므로 runner state 수명에서 분리했습니다.
- 다중 story sub-PR은 `Part of #story`로 통합 브랜치에 누적하고 최종 통합→main PR에서 story·epic을 일괄 close해 acceptance 이전 조기 close를 피했습니다.
- impl-validator 통합 리뷰 1회, STORY_ACCEPTANCE × N, EPIC_ACCEPTANCE, retry/escalate, TDD, TaskCreate/TaskUpdate, resume 기록 계약은 유지했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/story_runner.py`, `skills/impl-loop/**`, `docs/plugin/**`, `scripts/dcness-story-runner`, `scripts/pr-trailer.sh`는 plugin 본체 경로로 다음 plugin release에서 외부 활성 프로젝트에 도달합니다.
- `scripts/check_pr_body.mjs`는 배포된 `.github/actions/pr-body/action.yml`이 plugin root에서 직접 호출하므로 별도 init 복사 inventory 변경이 필요 없습니다.
- 신규 public skill/command/agent/gate 및 신규 복사 대상은 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 `/impl-loop`와 내부 helper 계약만 복구했으며 신규 public surface가 없습니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,781 tests OK
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `bash -n scripts/pr-trailer.sh && node --check scripts/check_pr_body.mjs && git diff --check`
- [x] pre-commit hook full unittest + git naming gate

## 참고

- 병렬 peer session의 claim board / merge lock 계약은 이슈 범위대로 변경하지 않았습니다.
