### PR TITLE
[issue-1043] impl-loop story 교차 배치를 차단합니다.

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -326,6 +326,7 @@ RESOLVE_JSON=$("$HELPER" auto-resolve "<agent>:<enum_or_mode>")
 
 | 시점 | 내용 |
 |---|---|
+| runner `plan/init` | path 정렬 뒤 동일 frontmatter `story` 값의 비연속 재등장을 state 변경 전에 차단하고 관련 task 경로를 보고한다. runner 는 story 순서를 임의 재정렬하지 않는다. |
 | build-worker PASS 직후 | task local commit sha 확인 + `dcness-story-runner mark --status completed --commit <sha>` |
 | 한 story 의 task 전부 completed | story PR body 작성 + push + PR create. 다중 story/epic 은 통합 브랜치로 머지하고 갱신된 ref 에서 다음 story branch 재분기 |
 | 모든 target task completed | 단일 story PR 또는 통합→main PR 의 merge candidate diff 에 impl-validator 통합 리뷰 1회 |

--- a/harness/story_runner.py
+++ b/harness/story_runner.py
@@ -136,6 +136,30 @@ def task_from_path(path: Path, *, cwd: Path | None = None) -> ImplTask:
     )
 
 
+def _validate_story_contiguity(tasks: Sequence[ImplTask]) -> None:
+    story_indexes: dict[str, list[int]] = {}
+    for index, task in enumerate(tasks):
+        story_indexes.setdefault(task.story, []).append(index)
+
+    violations: list[str] = []
+    for story, indexes in story_indexes.items():
+        if all(right == left + 1 for left, right in zip(indexes, indexes[1:])):
+            continue
+        crossing = " -> ".join(
+            f"{task.path} (story={task.story})"
+            for task in tasks[indexes[0] : indexes[-1] + 1]
+        )
+        violations.append(f"story={story}: {crossing}")
+
+    if violations:
+        details = "; ".join(violations)
+        raise ValueError(
+            "non-contiguous story group(s) after path sorting: "
+            f"{details}; rename or relocate task paths so each story forms one "
+            "contiguous block; the runner will not reorder tasks automatically"
+        )
+
+
 def build_state(
     inputs: Sequence[str],
     *,
@@ -145,10 +169,12 @@ def build_state(
     if scope not in VALID_SCOPES:
         raise ValueError(f"invalid scope: {scope}")
     root = (cwd or Path.cwd()).resolve()
-    tasks = [
-        task_from_path(path, cwd=root).to_state(idx)
-        for idx, path in enumerate(discover_tasks(inputs, cwd=root), start=1)
+    impl_tasks = [
+        task_from_path(path, cwd=root)
+        for path in discover_tasks(inputs, cwd=root)
     ]
+    _validate_story_contiguity(impl_tasks)
+    tasks = [task.to_state(idx) for idx, task in enumerate(impl_tasks, start=1)]
     story_ids = sorted({str(task["story"]) for task in tasks})
     resolved_scope = "story" if scope == "auto" and len(story_ids) == 1 else scope
     if resolved_scope == "auto":
@@ -417,8 +443,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 0
         if args.cmd == "init":
             state_path = Path(args.state)
-            prepare_init_state(state_path, force=args.force)
             state = build_state(args.paths, cwd=cwd, scope=args.scope)
+            prepare_init_state(state_path, force=args.force)
             save_state(state_path, state)
             _print(state, as_json=args.json)
             return 0

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -138,7 +138,7 @@ phase prose:
 
 ## story/epic runner task 단일 상태 (#1019, #1041)
 
-`/impl-loop` 은 story/epic 진행을 자연어로 암기하지 않는다. 진입 직후 `dcness-story-runner plan/init` 이 impl task 목록을 정렬한다. state file 에는 각 task 의 `pending / running / completed / error / blocked` 와 `attempts / commit / provider / note` 만 저장한다. story/run status 와 PR 번호는 저장하지 않는다.
+`/impl-loop` 은 story/epic 진행을 자연어로 암기하지 않는다. 진입 직후 `dcness-story-runner plan/init` 이 impl task 목록을 path 순으로 정렬한다. 정렬 결과에서 같은 frontmatter `story` 값(숫자 story 와 `공통` 모두)이 둘 이상의 비연속 block 으로 재등장하면 `plan/init` 은 관련 task 경로를 보고하고 fail-fast 한다. `init` 은 이 검증을 기존 state 의 아카이브·교체보다 먼저 수행해 실패 시 state 를 변경하지 않는다. story 간 의존성을 표현할 수 있는 path 순서를 runner 가 임의로 재정렬하지 않으며, 각 story 가 한 연속 block 인 입력은 기존 순서를 그대로 보존한다. state file 에는 각 task 의 `pending / running / completed / error / blocked` 와 `attempts / commit / provider / note` 만 저장한다. story/run status 와 PR 번호는 저장하지 않는다.
 
 실행 단위는 **task commit** 과 **story sub-PR** 이다. build-worker 가 각 task local commit 을 만든 뒤 `dcness-story-runner mark --status completed --commit <sha>` 로 state 를 갱신한다. `error` / `blocked` 는 서로 다른 task 상태로 기록하고 `--note <사유>` 를 반드시 남긴다.
 

--- a/tests/test_story_runner.py
+++ b/tests/test_story_runner.py
@@ -85,6 +85,159 @@ class StoryRunnerTests(unittest.TestCase):
             self.assertNotIn("engine", task)
             self.assertNotIn("risk_reason", task)
 
+    def test_plan_preserves_contiguous_story_blocks_in_path_order(self) -> None:
+        common = self._write_task(
+            "00-common.md",
+            story="공통",
+            task_index="",
+            title="Shared setup",
+        )
+        story_two = self._write_task(
+            "04-story-two.md",
+            story="2",
+            task_index="1/1",
+            title="Story two",
+        )
+
+        state = build_state(
+            [
+                str(story_two),
+                str(self.impl_dir / "02-api.md"),
+                str(common),
+                str(self.impl_dir / "01-ui.md"),
+            ],
+            cwd=self.root,
+            scope="epic",
+        )
+
+        self.assertEqual(
+            [Path(task["path"]).name for task in state["tasks"]],
+            ["00-common.md", "01-ui.md", "02-api.md", "04-story-two.md"],
+        )
+        self.assertEqual(
+            [task["story"] for task in state["tasks"]],
+            ["공통", "1", "1", "2"],
+        )
+
+    def test_plan_applies_contiguity_rule_to_common_story(self) -> None:
+        common_start = self._write_task(
+            "00-common-start.md",
+            story="공통",
+            task_index="",
+            title="Shared setup",
+        )
+        common_again = self._write_task(
+            "02-common-again.md",
+            story="공통",
+            task_index="",
+            title="Shared follow-up",
+        )
+
+        with self.assertRaisesRegex(ValueError, "story=공통") as raised:
+            build_state(
+                [
+                    str(common_again),
+                    str(self.impl_dir / "01-ui.md"),
+                    str(common_start),
+                ],
+                cwd=self.root,
+                scope="epic",
+            )
+
+        self.assertIn("00-common-start.md", str(raised.exception))
+        self.assertIn("01-ui.md", str(raised.exception))
+        self.assertIn("02-common-again.md", str(raised.exception))
+
+    def test_script_plan_and_init_reject_non_contiguous_story_without_touching_state(
+        self,
+    ) -> None:
+        crossing = self._write_task(
+            "03-story-one-again.md",
+            story="1",
+            task_index="3/3",
+            title="Story one again",
+        )
+        story_two = self._write_task(
+            "02-story-two.md",
+            story="2",
+            task_index="1/1",
+            title="Story two",
+        )
+        paths = [
+            str(self.impl_dir / "01-ui.md"),
+            str(story_two),
+            str(crossing),
+        ]
+        env = {**os.environ, "PYTHONPATH": str(ROOT)}
+
+        plan = subprocess.run(
+            [str(SCRIPT), "plan", *paths, "--cwd", str(self.root)],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(plan.returncode, 1)
+        self.assertIn("non-contiguous story group", plan.stderr)
+        self.assertIn("story=1", plan.stderr)
+        for name in ("01-ui.md", "02-story-two.md", "03-story-one-again.md"):
+            self.assertIn(name, plan.stderr)
+
+        state_path = self.root / ".dcness-work" / "story-run.json"
+        init_without_state = subprocess.run(
+            [
+                str(SCRIPT),
+                "init",
+                *paths,
+                "--cwd",
+                str(self.root),
+                "--state",
+                str(state_path),
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(init_without_state.returncode, 1)
+        self.assertFalse(state_path.exists())
+
+        existing = build_state(
+            [str(self.impl_dir / "01-ui.md")], cwd=self.root, scope="story"
+        )
+        existing["tasks"][0]["status"] = "completed"
+        existing["tasks"][0]["commit"] = "abc123"
+        state_path.parent.mkdir(parents=True)
+        state_path.write_text(json.dumps(existing, ensure_ascii=False), encoding="utf-8")
+        original = state_path.read_bytes()
+
+        init_with_completed_state = subprocess.run(
+            [
+                str(SCRIPT),
+                "init",
+                *paths,
+                "--cwd",
+                str(self.root),
+                "--state",
+                str(state_path),
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+        self.assertEqual(init_with_completed_state.returncode, 1)
+        self.assertIn("non-contiguous story group", init_with_completed_state.stderr)
+        self.assertEqual(state_path.read_bytes(), original)
+        self.assertEqual(
+            list(state_path.parent.glob("story-run.completed-*.json")), []
+        )
+
     def test_mark_resume_transitions(self) -> None:
         state = build_state([str(self.impl_dir / "01-ui.md"), str(self.impl_dir / "02-api.md")], cwd=self.root)
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1043

## 배경 및 문제

`dcness-story-runner`가 path 순으로 task를 정렬한 뒤 story 경계를 파생하지만, 동일한 story가 `Story 1 → Story 2 → Story 1`처럼 비연속 block으로 재등장하는 입력을 허용했습니다. 이 상태로 `/impl-loop`를 진행하면 실행 branch에 앞 story commit이 남아 다른 story sub-PR에 혼입될 수 있었습니다.

## 원인 (해당 시)

- runner가 story grouping key의 연속성을 검증하지 않았습니다.
- `init`이 새 입력을 검증하기 전에 기존 완료 state를 정규화·아카이브해, 잘못된 입력에서도 기존 state가 먼저 변경될 수 있었습니다.

## 작업내용

- path 정렬 뒤 frontmatter `story` 값의 비연속 재등장을 검출하고, 문제 story와 첫 block부터 재등장까지 교차된 task 경로를 포함해 `plan`과 `init`을 fail-fast하도록 했습니다.
- `init`의 새 state 계산·검증을 기존 state 준비보다 앞세워 실패 시 신규 생성, 아카이브, 교체, 부분 수정을 막았습니다.
- 숫자 story와 `공통`의 동일 규칙, 정상 연속 block의 기존 순서 보존, CLI 오류와 state 불변성을 회귀 테스트로 고정했습니다.
- 자동 story 재정렬을 하지 않는 정책을 `/impl-loop` skill과 runner 절차 문서에 동기화했습니다.

## 결정 근거

- path 순서는 story 간 의존성을 표현할 수 있으므로 runner가 자동 재정렬하지 않고, 사용자가 task path를 명시적으로 고치도록 진단합니다.
- 검증을 state mutation보다 먼저 수행해 invalid input 경로를 순수 preflight로 유지합니다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/story_runner.py`, `skills/impl-loop/SKILL.md`, `docs/plugin/loop-procedure.md`는 plugin 본체 경로로 다음 plugin update에서 외부 활성 프로젝트에 도달합니다.
- `scripts/dcness-story-runner`는 plugin root의 `harness.story_runner`를 호출하므로 wrapper나 `/init-dcness` 복사 inventory 변경은 필요하지 않습니다.
- 기존 활성 사용자는 `claude plugin update dcness@dcness`로 재배포받을 수 있습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 `/impl-loop` 내부 runner의 입력 검증만 강화하며 새 public surface를 추가하지 않습니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_story_runner -v < /dev/null` — 10 tests OK
- [x] `python3.11 -m unittest discover -s tests -q < /dev/null` — 1,784 tests OK
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `git diff --check`
- [ ] `EVAL_OUTPUT_DIR=/tmp/dcness-1043-evals EVAL_RUNS=1 bash evals/run.sh` — 권고 eval 5/6 PASS. `story-slice-skeleton` E2는 현행 main 지침이 Must AC의 upload 전달 경계를 뒤 Story에 두면 gap으로 판정하도록 요구하지만 fixture 정답표는 이를 지적하지 말라고 요구하는 baseline 계약 불일치로 FAIL(이번 diff와 무관).
- [x] pre-commit hook full unittest + git naming gate — 1,784 tests OK

## 참고

- dependency graph 해석, story 자동 재정렬, 병렬 claim/merge-lock 계약은 변경하지 않습니다.
