### PR TITLE
[issue-1051] AC 표기 변형 감사 우회 차단

### DIFF
--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -51,7 +51,7 @@ gh issue create --title "<title>" --body-file <brief.md> --label "<IssueType>"
 
 `scripts/check_issue_body.mjs` 가 실패하면 `gh issue create` 를 실행하지 않는다. 실제 issue 생성 preflight 는 `--labels` 를 함께 넘겨 label 계약까지 검증하고, 본문 초안만 점검할 때만 `--body-only` 를 명시한다. GitHub issue 생성·등록은 직접 `gh issue create` 대신 `/to-issue` 를 기본 경로로 사용한다 (작업 흐름 중 자발적으로 남기는 후속 이슈 포함). `/to-issue` 외 대화나 agent workflow 가 issue 를 생성하는 경우에도 같은 pre-create validation 을 통과하고 IssueType 라벨을 붙여야 한다.
 
-`--require-complete` 는 새 CI hard gate 가 아니라 close 직전 메인이 같은 validator 를 재사용하는 로컬 감사 옵션이다. `--acceptance-only` 와 함께 쓰면 Issue Brief 와 Story/Epic issue body 에 공통으로 적용되며, target GitHub issue AC 에 미체크 항목이 하나라도 있으면 실패한다. 신규 issue 의 `[command]`/`[agent-read]` 분류는 pre-create 에서 강제하고, 이미 존재하는 무분류 legacy AC 는 close 감사에서 소급 태깅하지 않는다. legacy 사람 판정 항목은 사용자가 직접 체크한 뒤에만 전항목 완료가 된다. Acceptance criteria 섹션 자체가 없는 구양식 issue 는 `legacy/no AC` 로 보고하며, 존재하지 않는 체크리스트를 소급 생성하지 않는다.
+`--require-complete` 는 새 CI hard gate 가 아니라 close 직전 메인이 같은 validator 를 재사용하는 로컬 감사 옵션이다. `--acceptance-only` 와 함께 쓰면 Issue Brief 와 Story/Epic issue body 에 공통으로 적용되며, target GitHub issue AC 에 미체크 항목이 하나라도 있으면 실패한다. close 감사는 bold field(`**Acceptance criteria:**`)와 Markdown heading(`## Acceptance criteria`) 섹션을 모두 인식하고, `-`와 `*` 체크박스 불릿을 같은 AC 목록으로 집계한다. 신규 issue 의 `[command]`/`[agent-read]` 분류는 pre-create 에서 강제하고, 이미 존재하는 무분류 legacy AC 는 close 감사에서 소급 태깅하지 않는다. legacy 사람 판정 항목은 사용자가 직접 체크한 뒤에만 전항목 완료가 된다. Acceptance criteria 섹션 자체가 없는 구양식 issue 는 `legacy/no AC` 로 보고하며, 존재하지 않는 체크리스트를 소급 생성하지 않는다.
 
 ## Issue/label Status lifecycle
 

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -51,7 +51,7 @@ gh issue create --title "<title>" --body-file <brief.md> --label "<IssueType>"
 
 `scripts/check_issue_body.mjs` 가 실패하면 `gh issue create` 를 실행하지 않는다. 실제 issue 생성 preflight 는 `--labels` 를 함께 넘겨 label 계약까지 검증하고, 본문 초안만 점검할 때만 `--body-only` 를 명시한다. GitHub issue 생성·등록은 직접 `gh issue create` 대신 `/to-issue` 를 기본 경로로 사용한다 (작업 흐름 중 자발적으로 남기는 후속 이슈 포함). `/to-issue` 외 대화나 agent workflow 가 issue 를 생성하는 경우에도 같은 pre-create validation 을 통과하고 IssueType 라벨을 붙여야 한다.
 
-`--require-complete` 는 새 CI hard gate 가 아니라 close 직전 메인이 같은 validator 를 재사용하는 로컬 감사 옵션이다. `--acceptance-only` 와 함께 쓰면 Issue Brief 와 Story/Epic issue body 에 공통으로 적용되며, target GitHub issue AC 에 미체크 항목이 하나라도 있으면 실패한다. close 감사는 bold field(`**Acceptance criteria:**`)와 Markdown heading(`## Acceptance criteria`) 섹션을 모두 인식하고, `-`와 `*` 체크박스 불릿을 같은 AC 목록으로 집계한다. 신규 issue 의 `[command]`/`[agent-read]` 분류는 pre-create 에서 강제하고, 이미 존재하는 무분류 legacy AC 는 close 감사에서 소급 태깅하지 않는다. legacy 사람 판정 항목은 사용자가 직접 체크한 뒤에만 전항목 완료가 된다. Acceptance criteria 섹션 자체가 없는 구양식 issue 는 `legacy/no AC` 로 보고하며, 존재하지 않는 체크리스트를 소급 생성하지 않는다.
+`--require-complete` 는 새 CI hard gate 가 아니라 close 직전 메인이 같은 validator 를 재사용하는 로컬 감사 옵션이다. `--acceptance-only` 와 함께 쓰면 Issue Brief 와 Story/Epic issue body 에 공통으로 적용되며, target GitHub issue AC 에 미체크 항목이 하나라도 있으면 실패한다. close 감사는 Acceptance criteria 와 human verification 의 bold field·Markdown heading 섹션을 모두 인식하고, `-`·`*`·`+` 체크박스 불릿을 같은 checklist 문법으로 집계한다. 신규 issue 의 `[command]`/`[agent-read]` 분류는 pre-create 에서 강제하고, 이미 존재하는 무분류 legacy AC 는 close 감사에서 소급 태깅하지 않는다. legacy 사람 판정 항목은 사용자가 직접 체크한 뒤에만 전항목 완료가 된다. Acceptance criteria 섹션 자체가 없는 구양식 issue 는 `legacy/no AC` 로 보고하며, 존재하지 않는 체크리스트를 소급 생성하지 않는다.
 
 ## Issue/label Status lifecycle
 

--- a/scripts/check_issue_body.mjs
+++ b/scripts/check_issue_body.mjs
@@ -80,13 +80,35 @@ export function parseFieldSection(body, fieldName) {
   return (nextField === -1 ? remainder : remainder.slice(0, nextField)).trim();
 }
 
-const ACCEPTANCE_CHECKBOX = /^\s*-\s+\[([ xX])\]\s+(.+?)\s*$/;
+function parseHeadingSection(body, headingName) {
+  const text = String(body ?? '');
+  const headingRegex = new RegExp(
+    String.raw`^[ \t]{0,3}#{1,6}[ \t]+${escapeRegex(headingName)}[ \t]*:?[ \t]*#*[ \t]*$`,
+    'im',
+  );
+  const match = headingRegex.exec(text);
+  if (!match) return null;
+
+  const start = match.index + match[0].length;
+  const remainder = text.slice(start);
+  const nextHeading = remainder.search(/^[ \t]{0,3}#{1,6}[ \t]+\S/m);
+  return (nextHeading === -1 ? remainder : remainder.slice(0, nextHeading)).trim();
+}
+
+function parseAcceptanceSection(body) {
+  return (
+    parseFieldSection(body, 'Acceptance criteria')
+    ?? parseHeadingSection(body, 'Acceptance criteria')
+  );
+}
+
+const ACCEPTANCE_CHECKBOX = /^\s*[-*]\s+\[([ xX])\]\s+(.+?)\s*$/;
 const VERIFICATION_CLASS = /^\[(command|agent-read)\]\s+(.+)$/i;
 const STORY_VERIFICATION_CLASS = /^(AC-\d{3,})\s+\[(command|agent-read)\]:?\s+(.+)$/i;
 const GENERIC_ACCEPTANCE = /^(?:구현(?:이|은)?\s*완료(?:된다|되어야 한다)|정상(?:적으로)?\s*동작(?:한다|해야 한다)|문제없이\s*동작(?:한다|해야 한다)|works?\s+(?:correctly|as expected)|implementation\s+is\s+complete)[.!。]?$/i;
 
 export function parseAcceptanceCriteria(body) {
-  const section = parseFieldSection(body, 'Acceptance criteria') ?? '';
+  const section = parseAcceptanceSection(body) ?? '';
   return section
     .split(/\r?\n/)
     .map((line, index) => ({ line: index + 1, text: line.trim() }))

--- a/scripts/check_issue_body.mjs
+++ b/scripts/check_issue_body.mjs
@@ -95,26 +95,30 @@ function parseHeadingSection(body, headingName) {
   return (nextHeading === -1 ? remainder : remainder.slice(0, nextHeading)).trim();
 }
 
-function parseAcceptanceSection(body) {
-  return (
-    parseFieldSection(body, 'Acceptance criteria')
-    ?? parseHeadingSection(body, 'Acceptance criteria')
-  );
+function parseNamedSection(body, ...sectionNames) {
+  for (const sectionName of sectionNames) {
+    const section = (
+      parseFieldSection(body, sectionName)
+      ?? parseHeadingSection(body, sectionName)
+    );
+    if (section !== null) return section;
+  }
+  return null;
 }
 
-const ACCEPTANCE_CHECKBOX = /^\s*[-*]\s+\[([ xX])\]\s+(.+?)\s*$/;
+const CHECKBOX_ITEM = /^\s*[-*+]\s+\[([ xX])\]\s+(.+?)\s*$/;
 const VERIFICATION_CLASS = /^\[(command|agent-read)\]\s+(.+)$/i;
 const STORY_VERIFICATION_CLASS = /^(AC-\d{3,})\s+\[(command|agent-read)\]:?\s+(.+)$/i;
 const GENERIC_ACCEPTANCE = /^(?:구현(?:이|은)?\s*완료(?:된다|되어야 한다)|정상(?:적으로)?\s*동작(?:한다|해야 한다)|문제없이\s*동작(?:한다|해야 한다)|works?\s+(?:correctly|as expected)|implementation\s+is\s+complete)[.!。]?$/i;
 
 export function parseAcceptanceCriteria(body) {
-  const section = parseAcceptanceSection(body) ?? '';
+  const section = parseNamedSection(body, 'Acceptance criteria') ?? '';
   return section
     .split(/\r?\n/)
     .map((line, index) => ({ line: index + 1, text: line.trim() }))
-    .filter(({ text }) => ACCEPTANCE_CHECKBOX.test(text))
+    .filter(({ text }) => CHECKBOX_ITEM.test(text))
     .map(({ line, text }) => {
-      const checkbox = text.match(ACCEPTANCE_CHECKBOX);
+      const checkbox = text.match(CHECKBOX_ITEM);
       const criterion = checkbox[2].trim();
       const classified = criterion.match(VERIFICATION_CLASS);
       const storyClassified = criterion.match(STORY_VERIFICATION_CLASS);
@@ -206,11 +210,13 @@ export function validateIssueBody({
     }
   }
 
-  const humanVerification = (
-    parseFieldSection(text, 'Human verification / 사람 확인 안내')
-    ?? parseFieldSection(text, '사람 확인 안내')
+  const humanVerification = parseNamedSection(
+    text,
+    'Human verification / 사람 확인 안내',
+    'Human verification',
+    '사람 확인 안내',
   );
-  if (humanVerification && humanVerification.split(/\r?\n/).some((line) => ACCEPTANCE_CHECKBOX.test(line))) {
+  if (humanVerification && humanVerification.split(/\r?\n/).some((line) => CHECKBOX_ITEM.test(line))) {
     failures.push('human verification items must not use checkboxes');
   }
 

--- a/scripts/create_epic_story_issues.sh
+++ b/scripts/create_epic_story_issues.sh
@@ -281,7 +281,7 @@ while IFS= read -r STORY_LINE; do
     flag { print }
   ' "$STORIES")
   STORY_BODY=$(printf '%s\n' "$STORY_BODY" | sed -E \
-    's/^- (AC-[0-9]{3,} \[(command|agent-read)\]:)/- [ ] \1/')
+    's/^[[:space:]]*-[[:space:]]+(AC-[0-9]{3,}[[:space:]]+\[([Cc][Oo][Mm][Mm][Aa][Nn][Dd]|[Aa][Gg][Ee][Nn][Tt]-[Rr][Ee][Aa][Dd])\])([[:space:]]*:?[[:space:]]+)(.+)$/- [ ] \1\3\4/')
 
   echo "[issue-create] story $STORY_N 생성 — '$STORY_TITLE'"
   STORY_LABELS=( -l story -l "$VNN" )

--- a/scripts/report_ac_coverage.mjs
+++ b/scripts/report_ac_coverage.mjs
@@ -53,7 +53,7 @@ export function parseStoryAcceptance(markdown) {
     if (!currentStory) continue;
 
     const declaration = line.match(
-      /^\s*-\s+(AC-\d{3,})\s+\[(?:command|agent-read)\]\s*:/i,
+      /^\s*-\s+(AC-\d{3,})\s+\[(?:command|agent-read)\]\s*:?\s+.+$/i,
     );
     if (!declaration) continue;
 

--- a/tests/test_acceptance_contract_hierarchy.py
+++ b/tests/test_acceptance_contract_hierarchy.py
@@ -177,6 +177,21 @@ class AcceptanceCoverageReporterTests(unittest.TestCase):
         self.assertIn("Unknown AC references: none", result.stdout)
         self.assertIn("Technical REQ: REQ-TECH-001", result.stdout)
 
+    def test_story_ac_inventory_tolerates_case_spacing_and_optional_colon(self) -> None:
+        variant = STORIES.replace(
+            "AC-001 [command]:",
+            "AC-001 [COMMAND] ",
+        ).replace(
+            "AC-002 [agent-read]:",
+            "AC-002   [Agent-Read] :",
+        )
+
+        result = _run_report(variant, {"02-verify.md": FINAL_TASK})
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("Coverage: 2/2 (100.0%)", result.stdout)
+        self.assertIn("Final task coverage: 2/2 (100.0%)", result.stdout)
+
     def test_gaps_are_reported_without_turning_advisory_into_a_blocking_gate(self) -> None:
         incomplete = FINAL_TASK.replace(
             "| REQ-004 | Story AC | source 기록 관찰 | `(from AC-002)` | "

--- a/tests/test_create_epic_story_issues.py
+++ b/tests/test_create_epic_story_issues.py
@@ -182,6 +182,24 @@ class CreateEpicStoryBoardTests(unittest.TestCase):
         self.assertIn("- [ ] AC-001 [command]", gh_log)
         self.assertIn("- [ ] AC-1002 [agent-read]", gh_log)
 
+    def test_story_acceptance_materialize_tolerates_case_and_spacing(self):
+        stories = STORIES_NEW.replace(
+            "- AC-001 [command]:",
+            "-  AC-001 [COMMAND] :",
+        ).replace(
+            "- AC-1002 [agent-read]:",
+            "-   AC-1002   [Agent-Read]  ",
+        )
+
+        result, gh_log, _, _ = self._run(stories, {})
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("- [ ] AC-001 [COMMAND] :", gh_log)
+        self.assertRegex(
+            gh_log,
+            r"- \[ \] AC-1002\s+\[Agent-Read\]\s+Given",
+        )
+
     def test_skips_board_when_no_coords_but_still_creates_issues(self):
         result, gh_log, node_log, _ = self._run(STORIES_NEW, {})
         self.assertEqual(0, result.returncode, result.stderr)

--- a/tests/test_issue_body_validation.py
+++ b/tests/test_issue_body_validation.py
@@ -349,6 +349,26 @@ class IssueBodyValidationTests(unittest.TestCase):
         self.assertEqual(1, result.returncode)
         self.assertIn("human verification", result.stderr)
 
+    def test_heading_human_verification_plus_checkbox_is_rejected(self) -> None:
+        story_body = textwrap.dedent(
+            """
+            ## Acceptance criteria
+            - [x] AC-001 [command]: Given input, When the test runs, Then it exits zero.
+
+            ## 사람 확인 안내
+            + [ ] 사람이 시각 결과를 승인한다.
+            """
+        ).strip()
+
+        result = run_validator(
+            story_body,
+            "--acceptance-only",
+            "--require-complete",
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("human verification", result.stderr)
+
 
 class IssueBodyValidationDocsTests(unittest.TestCase):
     def test_issue_lifecycle_documents_pre_create_validation_not_hard_gate(self) -> None:

--- a/tests/test_issue_body_validation.py
+++ b/tests/test_issue_body_validation.py
@@ -189,6 +189,41 @@ class IssueBodyValidationTests(unittest.TestCase):
         self.assertEqual(1, result.returncode)
         self.assertIn("unchecked acceptance criteria", result.stderr)
 
+    def test_close_audit_rejects_unchecked_heading_acceptance_criteria(self) -> None:
+        body = textwrap.dedent(
+            """
+            ## Acceptance criteria
+
+            - [ ] [command] The close audit detects this unchecked criterion.
+            """
+        ).strip()
+
+        result = run_validator(
+            body,
+            "--acceptance-only",
+            "--require-complete",
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("unchecked acceptance criteria remain: 1", result.stderr)
+
+    def test_close_audit_counts_asterisk_acceptance_checkbox(self) -> None:
+        body = textwrap.dedent(
+            """
+            **Acceptance criteria:**
+            * [ ] [command] The close audit counts an asterisk checklist item.
+            """
+        ).strip()
+
+        result = run_validator(
+            body,
+            "--acceptance-only",
+            "--require-complete",
+        )
+
+        self.assertEqual(1, result.returncode)
+        self.assertIn("unchecked acceptance criteria remain: 1", result.stderr)
+
     def test_close_preflight_accepts_checked_acceptance_criteria(self) -> None:
         body = VALID_BODY.replace("- [ ]", "- [x]")
 


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1051

## 배경 및 문제

issue close audit가 흔한 Markdown AC 표기 변형을 놓치면 미체크 AC가 있어도 legacy/no AC PASS로 종료되어 close 가능 신호로 오인될 수 있었습니다. stories.md의 Story AC 표기가 조금만 달라도 issue body 체크박스가 생성되지 않아 같은 우회 경로가 생겼습니다.

## 원인 (해당 시)

- close audit의 AC 섹션 탐색이 bold field 한 형식에만 결합돼 있었습니다.
- 체크박스 정규식이 hyphen 불릿만 허용했습니다.
- Story AC materialize와 coverage reporter 정규식의 허용 문법이 서로 달랐습니다.
- human verification 탐색은 bold field에만 결합돼 있었습니다.

## 작업내용

- Markdown heading 형식의 Acceptance criteria 섹션을 close audit 대상에 포함했습니다.
- hyphen, asterisk, plus 체크박스 불릿을 동일하게 집계합니다.
- Story AC의 검증 주체 대소문자, 공백, 선택적 콜론 변형을 미체크 체크박스로 materialize합니다.
- coverage reporter도 동일한 Story AC 표기 변형을 인벤토리에 포함합니다.
- human verification의 bold field와 Markdown heading 탐색을 AC와 같은 공용 helper로 통합했습니다.
- 회귀 테스트와 외부 사용자 계약 문서를 동기화했습니다.

## 결정 근거

구양식 무 AC issue의 하위호환은 유지하면서, 실제 AC 또는 human verification 섹션이 있는 경우에만 인식 문법을 넓혔습니다. materialize, close audit, coverage reporter가 허용하는 Story AC 문법을 맞춰 advisory inventory 누락도 방지했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- scripts/check_issue_body.mjs, scripts/create_epic_story_issues.sh, scripts/report_ac_coverage.mjs는 plug-in 본체에서 직접 배포되는 경로이므로 plug-in 업데이트 후 외부 활성 프로젝트에 도달합니다.
- docs/plugin/issue-lifecycle.md에 외부 사용자 close audit 계약을 동기화했습니다.
- init-dcness 복사 inventory 대상 파일이 아니므로 commands/init-dcness.md 변경은 필요하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 close audit, issue 생성, advisory coverage 내부 동작만 보강했으며 신규 public surface는 없습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] python3.11 -m unittest discover -s tests: 1,825 tests PASS
- [x] Node 및 shell 스크립트 문법 검사 PASS
- [x] static-quality: ruff, mypy, Bandit PASS
- [x] public-surface, plugin-manifest, cross-ref, index-map, design-artifact PASS

## 참고

- 각 구현 전에 신규 회귀 테스트가 실패하는 것을 확인했습니다.