### PR TITLE
[issue-1052] close audit 실행 경로와 coverage 진단 정합화

### DIFF
--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -42,7 +42,7 @@ task 는 GitHub 이슈 X — local commit sha 로 추적하고, story/epic 연�
 에이전트 workflow 가 `gh issue create` 를 실행하기 전에는 Issue Brief 본문과 repo label 매핑을 로컬에서 먼저 검증한다. 이 검증은 사람의 GitHub UI issue 생성을 막는 hard gate 가 아니다. 목적은 dcNess/Codex/Claude workflow 가 issue 생성 전에 같은 문서 형식과 IssueType/Priority/label 계약을 따르도록 하는 것이다. Acceptance criteria 체크박스는 `[command]` 또는 `[agent-read]` 로 분류된 agent-verifiable 항목만 허용하고, human verification 은 별도 안내에 체크박스 없이 둔다.
 
 ```bash
-node scripts/check_issue_body.mjs \
+node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
   --body-file <brief.md> \
   --labels "<IssueType>"
 
@@ -105,7 +105,7 @@ Project 미러까지 원하면 `--owner` / `--project` 를 명시하거나 repo 
 close 를 발동하는 PR 의 CI와 최종 review 증거가 확정된 뒤, merge 전 메인은 진입 preflight 에서 한 번 읽어 보관한 target GitHub issue AC snapshot 과 구현·검증 증거를 완료 후보 issue 별로 전수 대조한다. task/story 진행 중 issue 를 다시 조회하거나 수정하지 않는다. close 경계의 기존 GitHub 조회가 있으면 최신 body 확인을 그 호출에 얹고, 자동 판정 가능한 AC 를 모두 충족한 뒤 체크박스 write 를 issue 별로 이 경계에서 한 번 수행한다. 갱신 body 는 각각 다음 명령이 PASS 해야 한다.
 
 ```bash
-node scripts/check_issue_body.mjs \
+node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
   --body-file <issue-body.md> \
   --acceptance-only \
   --require-complete

--- a/scripts/report_ac_coverage.mjs
+++ b/scripts/report_ac_coverage.mjs
@@ -226,6 +226,9 @@ async function main() {
     console.error(`[ac-coverage] stories file not found: ${args.stories}`);
     return 2;
   }
+  if (!existsSync(args['impl-dir'])) {
+    console.log(`[ac-coverage] impl directory not found: ${args['impl-dir']}`);
+  }
 
   const storyData = parseStoryAcceptance(readFileSync(args.stories, 'utf8'));
   const implData = parseImplRequirements(args['impl-dir']);

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -193,7 +193,7 @@ story 의 target task 가 completed 될 때마다 메인이 story PR 을 만든�
 close 를 발동하는 최종 PR 은 CI green, product-acceptance 와 impl-validator PASS 만으로 clean 이 아니다. 이 최종 증거가 확정된 뒤 메인이 `Closes` 대상 story/epic issue 각각의 target GitHub issue AC 전항목 증거를 대조하고 자동 판정 가능한 체크박스를 모두 check 한 뒤, 이슈 본문 write 를 issue 별 close 경계에서 한 번 수행한다. 진행 중 task/story 경계에서는 issue mutation 이나 재조회를 추가하지 않는다. 각 최종 body 는 다음 감사가 PASS 해야 한다.
 
 ```bash
-node scripts/check_issue_body.mjs \
+node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
   --body-file <issue-body.md> \
   --acceptance-only \
   --require-complete

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -145,7 +145,7 @@ UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 �
    - dcNess plugin 배포물 변경이면 PR body 에 배포 경로 검증을 적는다.
 8. CI / merge policy
    - PR 생성 후 CI 를 확인한다.
-   - CI green 과 최종 review 증거가 확정된 뒤, target issue 를 `Closes` 하는 PR 경계에서 메인이 보관한 AC 증거를 전수 대조한다. `Closes` 대상이 여러 개면 issue 별로 모두 수행한다. 자동 판정 가능한 항목을 모두 충족한 뒤 이슈 본문 체크박스 write 를 issue 별 close 경계에서 한 번 수행하고, 같은 body 를 `node scripts/check_issue_body.mjs --body-file <issue-body.md> --acceptance-only --require-complete` 로 감사한다. 진행 중에는 issue mutation 을 하지 않는다.
+   - CI green 과 최종 review 증거가 확정된 뒤, target issue 를 `Closes` 하는 PR 경계에서 메인이 보관한 AC 증거를 전수 대조한다. `Closes` 대상이 여러 개면 issue 별로 모두 수행한다. 자동 판정 가능한 항목을 모두 충족한 뒤 이슈 본문 체크박스 write 를 issue 별 close 경계에서 한 번 수행하고, 같은 body 를 `node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" --body-file <issue-body.md> --acceptance-only --require-complete` 로 감사한다. 진행 중에는 issue mutation 을 하지 않는다.
    - 머지는 host repo 정책을 따른다. 사용자 승인 대기 정책 repo 에서는 임의 머지하지 않는다.
 
 최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, 격리 `impl-validator`, 단위 commit/PR, CI, false-clean 방지다. TDD 게이트는 삭제하지 않는다.

--- a/skills/to-issue/SKILL.md
+++ b/skills/to-issue/SKILL.md
@@ -96,7 +96,7 @@ Acceptance criteria 체크박스는 agent-verifiable 항목만 두고 각 항목
 등록 전 preflight 로 Issue Brief 본문과 repo label 이 실제 계약에 맞는지 확인한다. Project field/option 은 선택적 backfill 대상이다. 보드(Project)나 field/option 이 없거나 불완전하면 등록을 멈추지 말고, 사용자가 원할 때만 `node scripts/github_project_lifecycle.mjs bootstrap --apply` (보드 자체가 없으면 `gh project create` + `gh project link` 를 먼저) 로 셋업하고, 좌표를 `gh variable set DCNESS_PROJECT_NUMBER --body <number>` / `gh variable set DCNESS_PROJECT_OWNER --body <owner>` 로 저장한 뒤 Project 등록을 backfill 한다. 거부하면 보드 없이 issue 만 등록한다. 어떤 경우에도 Project 상태는 등록 자체를 막지 않는다.
 
 ```bash
-node scripts/check_issue_body.mjs \
+node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
   --body-file <brief.md> \
   --labels "<IssueType>"
 

--- a/tests/test_acceptance_contract_hierarchy.py
+++ b/tests/test_acceptance_contract_hierarchy.py
@@ -83,6 +83,27 @@ depends_on: [01-build]
 
 
 class AcceptanceHierarchySurfaceTests(unittest.TestCase):
+    def test_external_issue_validation_commands_use_plugin_root(self) -> None:
+        external_docs = [
+            *sorted((ROOT / "skills").rglob("*.md")),
+            *sorted((ROOT / "docs/plugin").rglob("*.md")),
+        ]
+        plugin_command = 'node "$PLUGIN_ROOT/scripts/check_issue_body.mjs"'
+        command_lines = [
+            (path, line)
+            for path in external_docs
+            for line in path.read_text(encoding="utf-8").splitlines()
+            if "node " in line and "check_issue_body.mjs" in line
+        ]
+        offenders = [
+            str(path.relative_to(ROOT))
+            for path, line in command_lines
+            if plugin_command not in line
+        ]
+
+        self.assertTrue(command_lines)
+        self.assertEqual([], offenders)
+
     def test_prd_stops_before_acceptance_criteria(self) -> None:
         template = (ROOT / "skills/spec/templates/prd.md").read_text(encoding="utf-8")
         reference = (ROOT / "skills/spec/spec-prd-reference.md").read_text(
@@ -191,6 +212,14 @@ class AcceptanceCoverageReporterTests(unittest.TestCase):
         self.assertEqual(0, result.returncode, result.stderr)
         self.assertIn("Coverage: 2/2 (100.0%)", result.stdout)
         self.assertIn("Final task coverage: 2/2 (100.0%)", result.stdout)
+
+    def test_missing_impl_directory_is_reported_without_blocking(self) -> None:
+        result = _run_report(STORIES, {})
+
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("impl directory not found:", result.stdout)
+        self.assertIn("Coverage: 0/2 (0.0%)", result.stdout)
+        self.assertIn("advisory report", result.stdout)
 
     def test_gaps_are_reported_without_turning_advisory_into_a_blocking_gate(self) -> None:
         incomplete = FINAL_TASK.replace(


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1052

## 배경 및 문제

외부 활성 프로젝트는 dcNess 저장소 루트가 아니라 plug-in 설치 위치의 스크립트를 실행해야 하지만, close audit와 issue pre-create 예시 일부가 저장소 루트 상대 경로를 사용하고 있었습니다. 또한 AC coverage reporter는 잘못된 impl 디렉토리 경로를 실제 0 coverage와 구분하지 못했습니다.

## 원인 (해당 시)

- close audit / pre-create 문서가 초기 저장소 내부 실행 관례인 `node scripts/...` 표기를 유지했습니다.
- reporter의 재귀 파일 탐색이 존재하지 않는 디렉토리를 빈 입력으로 처리하면서 입력 경로 오류를 출력하지 않았습니다.
- Story AC 콜론 선택 문법 비대칭은 선행 PR #1054에서 코드와 회귀 테스트가 반영되어 있었으므로 이번 PR은 해당 계약을 보존·재검증했습니다.

## 작업내용

- `skills/**`와 `docs/plugin/**`의 issue validator 실행 예시 5곳을 `node "$PLUGIN_ROOT/scripts/check_issue_body.mjs"`로 통일했습니다.
- impl 디렉토리가 없으면 reporter stdout에 누락 경로를 명시하고 advisory 종료코드 0과 coverage report 출력을 유지했습니다.
- 외부 실행 경로 규약, impl 디렉토리 누락, Story AC 선택적 콜론 계약을 regression test로 고정했습니다.

## 결정 근거

경로 오타는 report 상단의 명시적 진단으로 드러내되 기존 advisory 계약을 깨지 않도록 stderr usage error나 비정상 종료로 승격하지 않았습니다. 외부 실행 예시는 활성 plug-in의 실제 배포 위치를 가리키는 `$PLUGIN_ROOT` 규약을 사용했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `skills/impl/SKILL.md`, `skills/impl-loop/SKILL.md`, `skills/to-issue/SKILL.md`는 plug-in 본체 경로로 업데이트 후 외부 활성 프로젝트에 직접 도달합니다.
- `docs/plugin/issue-lifecycle.md`는 외부 사용자 lifecycle SSOT의 실행 예시를 같은 규약으로 동기화합니다.
- `scripts/report_ac_coverage.mjs`와 `scripts/check_issue_body.mjs`는 plug-in 설치 경로에서 직접 실행되므로 `/init-dcness` 복사 inventory 변경은 필요하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 내부 스크립트와 문서 실행 계약만 보강하며 신규 public surface는 없습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null`: 1,833 tests PASS
- [x] pre-commit pytest gate: 1,833 tests PASS
- [x] static-quality: ruff, mypy, Bandit PASS
- [x] cross-ref, public-surface, plugin-manifest, index-map, design-artifact, doc-path PASS
- [x] `node --check scripts/report_ac_coverage.mjs` PASS
- [x] GitHub CI: 9 checks PASS
- [x] issue #1052 close audit: acceptance criteria complete (3)

## 참고

- 신규 테스트가 구현 전에 각각 문서 경로 4파일과 impl 디렉토리 무경고 동작을 실패로 재현했습니다.
- 자체 diff review 1/3에서 MUST FIX 없이 PASS했습니다.