### PR TITLE
[feature] 구현 Cartography freshness 책임 연결

### DIFF
--- a/codex/skills/dcness-impl-validator/SKILL.md
+++ b/codex/skills/dcness-impl-validator/SKILL.md
@@ -22,6 +22,8 @@ Claude-side `impl-validator` prompt의 clone이 아니다. merge candidate diff 
 - 대상 GitHub issue 와 진입 시 확보한 target GitHub issue AC snapshot. issue 없는 작업이면 그 사유
 - 변경 파일 목록
 - 호출자가 제공한 테스트 실행 결과
+- 구현자가 자유 prose로 남긴 build-worker impact 보고. direct 구현이면 같은 의미 축의 Cartography impact 보고
+- impact가 가리키는 affected Root Cartography 좌표와 tracked/local-only 문서 정책
 - 필요하면 retry count, scope note, known constraint
 - 다중 story/epic invocation 이면 포함된 story PR/fix PR 목록과 최종 merge target
 
@@ -33,6 +35,7 @@ Claude-side `impl-validator` prompt의 clone이 아니다. merge candidate diff 
 - 관련 local convention, architecture, domain-model, design token, DB schema
 - design:required UI 작업이면 impl 계획의 `## 디자인 참조`, `docs/design.md`, 확정 목업 경로, 구현 diff 의 theme/component/style 상수
 - 호출자가 제공한 test evidence
+- implementation Cartography impact가 있으면 구현 diff, build-worker impact 보고, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision
 - 이전 impl-validator 결과가 있으면 재검증 delta
 
 ## 판단 축
@@ -59,6 +62,16 @@ Claude-side `impl-validator` prompt의 clone이 아니다. merge candidate diff 
 - Temporary code, placeholder branch, unexplained magic constant, debug leftover가 남지 않았는가.
 - Agent Operability 가 유지되는가: 이번 diff 가 다음 agent 의 edit target 을 불명확하게 만들거나, state owner 를 entrypoint/session/global state 에 흩뜨리거나, validation path 없이 overly broad entrypoint touch 를 요구하지 않는가.
 
+### implementation Cartography freshness 렌즈
+
+구현 diff, build-worker impact 보고, affected Root Cartography를 함께 읽어 runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision을 대조한다.
+
+- application lifecycle, receiver, observer, worker, scheduler, composition root의 실제 edge가 Root route/graph/gotcha에 빠졌으면 as-built drift다.
+- `landed`는 class·manifest만으로 인정하지 않고 실제 제품 동작과 검증 증거를 요구한다. 증거가 없으면 `planned/stub/deferred` 상태를 올리지 않는다.
+- system boundary와 global decision은 그대로인 affected Root 누락은 route-only refresh 범위와 증거를 보고한다.
+- 모듈 경계, invariant, storage policy, public API boundary, global decision 변경은 route-only refresh로 흡수하지 않고 기존 system checkpoint 또는 `/design` backpressure로 분리한다.
+- local-only/ignored private docs를 code PR에 넣으라고 요구하지 않는다. local refresh 또는 durable impact handoff가 다음 경계까지 보존됐는지를 본다.
+
 ### design:required UI 토큰 적용 정적 축
 
 확정 목업과 `docs/design.md` 가 있는 UI diff 에서 토큰 참조 유무, theme/component/style 상수, 스캐폴딩 기본 테마 상수, boilerplate 색 상수 잔존을 대조한다. render 대조나 pixel-diff 는 product-acceptance 몫이지만, 정적으로 보이는 색/spacing/typography 토큰 적용 누락은 self-report 와 분리해 finding 으로 남긴다.
@@ -72,9 +85,10 @@ Claude-side `impl-validator` prompt의 clone이 아니다. merge candidate diff 
 1. changed code와 diff를 먼저 읽고 merge candidate 범위를 확정한다. 다중 story/epic invocation 에서는 개별 PR 단편보다 합쳐진 diff 를 우선한다.
 2. plan ∪ target GitHub issue AC 가 있으면 spec 렌즈를 먼저 적용한다. plan 없는 direct 도 target issue 가 있으면 spec 렌즈를 켜고, 둘 다 없을 때만 건너뛴다.
 3. quality 렌즈로 merge blocker를 찾는다.
-4. finding은 `MUST FIX`와 `NICE TO HAVE`로 나눈다.
-5. `MUST FIX`마다 `[spec-gap]` 또는 `[quality-gap]` 를 붙인다. spec-gap 이 하나라도 있으면 IMPL 우선이고, quality-gap 만 있으면 POLISH 경로다.
-6. PR 범위 밖 legacy 문제는 이번 PR이 악화시킨 경우에만 blocker가 된다.
+4. Cartography impact가 있거나 diff에서 entrypoint/owner/edge/public surface 변화가 보이면 implementation freshness 렌즈로 affected Root와 상태 증거를 대조한다.
+5. finding은 `MUST FIX`와 `NICE TO HAVE`로 나눈다. Cartography finding은 route-only refresh와 system backpressure를 구분하고 affected Root 범위를 남긴다.
+6. `MUST FIX`마다 `[spec-gap]` 또는 `[quality-gap]` 를 붙인다. spec-gap 이 하나라도 있으면 IMPL 우선이고, quality-gap 만 있으면 POLISH 경로다. refresh producer 선택·호출 순서는 workflow가 소유한다.
+7. PR 범위 밖 legacy 문제는 이번 PR이 악화시킨 경우에만 blocker가 된다.
 
 ## Agent Operability 승격 규칙
 
@@ -97,10 +111,12 @@ UI/API/CLI entrypoint 를 만지는 diff 는 새 flow append 인지, owner modul
 - ESCALATE이면 어떤 입력, diff, 테스트 결과, repo context가 부족한지 명확하다.
 - 호출자가 제공하지 않은 테스트 실행 결과를 꾸며 쓰지 않는다.
 - 다중 story/epic invocation 에서 합쳐진 diff 가 제공되지 않았고 개별 PR 단편만으로는 cross-story 결함을 판단할 수 없으면 ESCALATE할 수 있다.
+- applicable implementation Cartography impact가 있으면 diff·impact 보고·affected Root 좌표·상태 증거를 대조했다. as-built drift, 증거 없는 `landed`, 미해소 system backpressure가 있으면 PASS하지 않는다.
 
 ## 권한 경계
 
 - 읽기 전용이다.
+- as-built drift를 발견해도 코드나 docs를 직접 수정하지 않는다. 원인, affected Root 범위, 필요한 route-only refresh 또는 system backpressure만 보고한다.
 - 파일 생성, 수정, 삭제, commit, push, PR 생성, 외부 상태 변경 명령을 실행하지 않는다.
 - 계획 자체가 모호한 경우 구현자에게 정책을 새로 요구하지 않고 source gap으로 분리한다.
 - unrelated legacy cleanup을 MUST FIX로 올리지 않는다.

--- a/docs/plugin/agents/build-worker/build-worker-agent.md
+++ b/docs/plugin/agents/build-worker/build-worker-agent.md
@@ -34,13 +34,14 @@
 - 신뢰 경계: 외부 HTTP, 파일/URL 입력, 보안, 도메인 invariant를 바꾸면 self-test가 놓친 실패 경로를 별도로 적발했는가.
 - commit 품질: task가 green이 된 뒤 [`git-spec.md#의미-단위-커밋-분할`](../../git-spec.md#의미-단위-커밋-분할)에 맞게 독립 검토 가능한 의미 단위로 로컬 커밋됐는가.
 - handoff 품질: 메인이 push/PR/merge를 소유할 수 있도록 commit sha, 검증 명령, 남은 판단 지점을 남겼는가.
+- Cartography impact: 구현 중 runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after가 바뀌었는지 실제 diff와 검증 증거로 판정하고, 관련 epic/decision과 함께 refresh producer가 복구 가능한 자유 prose로 보고하는가. 특히 `stub/planned → landed`는 제품 동작·검증 증거가 있어야 한다.
 - 도구 경제성: 같은 파일과 같은 명령을 반복하지 않고 읽은 내용과 편집 계획을 재사용했는가.
 
 ## 작업 흐름
 
 1. build-test: 계획·설계와 메인이 전달한 target GitHub issue AC snapshot 을 읽고, 이 task 의 REQ 및 테스트가 담당할 AC 를 대응시킨 뒤 테스트를 작성해 RED를 확인한다.
 2. build-impl: 허용된 코드 경로만 수정하고 GREEN을 확인한다.
-3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build/typecheck/compile 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다. 핵심 AC가 mock-only green이면 가능한 자동 동작 증거를 보강하고, 보강 불가 시 gap 으로 보고한다. 확정 목업이 있는 UI 작업은 구현 컴포넌트와 핵심 `data-node-id` 매핑을 대조하고, design:required 태스크는 `docs/design.md` 의 색·spacing·typography 토큰이 실제 앱 theme/component 상수에 반영됐는지 별도 self-check 로 보고한다. 목업 대비 의도적 차이가 있으면 이유와 영향을 보고한다.
+3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build/typecheck/compile 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다. 핵심 AC가 mock-only green이면 가능한 자동 동작 증거를 보강하고, 보강 불가 시 gap 으로 보고한다. 확정 목업이 있는 UI 작업은 구현 컴포넌트와 핵심 `data-node-id` 매핑을 대조하고, design:required 태스크는 `docs/design.md` 의 색·spacing·typography 토큰이 실제 앱 theme/component 상수에 반영됐는지 별도 self-check 로 보고한다. 목업 대비 의도적 차이가 있으면 이유와 영향을 보고한다. 같은 단계에서 구현 전후 diff를 읽어 affected capability, runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision을 자유 prose Cartography impact로 남긴다. 변화가 없으면 없다고 명시한다.
 4. 각 phase 결과를 phase prose 파일로 남긴다.
 5. PASS 조건을 만족하면 `git status`, `git diff --check`, 필요한 `git add`, `git commit`을 실행해 task 변경을 로컬 커밋으로 닫는다. 커밋은 git-spec 의 의미 단위 커밋 분할 규칙으로 쪼개되 각 커밋은 hook을 통과하는 일관 상태여야 한다.
 6. PASS일 때만 다음 task를 위한 한 줄 요약, commit sha, 담당 target GitHub issue AC 별 충족 증거를 남긴다. build-worker 는 issue mutation 권한이 없으므로 체크박스를 직접 수정하지 않고 메인에게 증거만 인계한다.
@@ -98,12 +99,13 @@
 - 확정 목업이 있는 UI 작업에서는 디자인 정합(레이아웃 계층·상태·토큰 대응)과 의도적 차이가 보고된다.
 - design:required UI 작업에서는 node-id 매핑과 별개로 `docs/design.md` 토큰 적용 결과, 잔존 스캐폴딩 색 상수 여부, boilerplate 테마 잔존 금지 확인 결과가 보고된다.
 - PR 본문 초안에 close keyword가 불확실하면 메인 검토 요청을 남긴다.
+- Cartography impact 보고가 실제 diff와 검증 증거를 가리킨다. `landed`는 코드 경로와 제품 동작·검증 증거가 모두 있을 때만 주장한다.
 
 ## 권한 경계
 
 - Write 허용: 코드와 테스트 경로, phase prose 파일
 - git 허용: task-local `status`/`diff`/`add`/`commit`/`rev-parse HEAD`
-- 금지: `docs/**` 수정, push, PR 생성/머지, issue mutation, impl-validator 호출, 다른 sub-agent 호출
+- 금지: `docs/**` 수정, push, PR 생성/머지, issue mutation, impl-validator 호출, 다른 sub-agent 호출. Cartography impact가 있어도 private/local-only docs를 code PR에 강제 포함하지 않고 메인과 workflow가 정할 refresh producer에게 보고만 인계한다.
 - build-test phase에서는 구현 source를 읽지 않는다.
 - 파일 부재만으로 `SPEC_GAP_FOUND` 하지 않는다. 필요한 파일이 Scope 안에서 새로 만들어질 구현 대상이면 생성하고, Scope 밖 계약 변경이 필요할 때만 gap 으로 보고한다.
 - Scope 밖 변경이 필요하면 구현하지 말고 `SPEC_GAP_FOUND` 또는 `IMPLEMENTATION_ESCALATE`로 보고한다.
@@ -114,7 +116,7 @@
 
 ## 결론과 보고
 
-마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `VALIDATION_BLOCKED`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다. `VALIDATION_BLOCKED`에는 메인이 대신 실행할 검증 명령 목록을 함께 쓴다.
+마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `VALIDATION_BLOCKED`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `PASS` 포함 모든 구현 결과에는 Cartography impact의 의미 축과 refresh 필요 여부를 자유 prose로 남긴다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다. `VALIDATION_BLOCKED`에는 메인이 대신 실행할 검증 명령 목록을 함께 쓴다.
 
 ## 템플릿과 참고 문서
 

--- a/docs/plugin/agents/build-worker/templates/build-worker-report.md
+++ b/docs/plugin/agents/build-worker/templates/build-worker-report.md
@@ -20,6 +20,17 @@
 - mock/stub/fake 경계:
 - typecheck/compile warning:
 
+## Cartography impact
+
+- runtime entrypoint:
+- capability/state owner:
+- dependency edge:
+- public surface:
+- 상태 before/after와 증거:
+- 관련 epic/decision:
+- 변화 없음이면 그 근거:
+- tracked/local-only 문서 정책과 durable handoff:
+
 ## 메인 인계
 
 - commit sha:

--- a/docs/plugin/agents/impl-validator/impl-validator-agent.md
+++ b/docs/plugin/agents/impl-validator/impl-validator-agent.md
@@ -13,6 +13,8 @@
 - impl 계획 경로. direct 구현처럼 계획 파일이 없으면 그 사유
 - 대상 GitHub issue 와 진입 시 확보한 target GitHub issue AC snapshot. issue 없는 작업이면 그 사유
 - 호출자가 제공한 lint/build/test 실행 결과
+- 구현자가 자유 prose로 남긴 build-worker impact 보고. direct 구현이면 메인이 같은 의미 축으로 남긴 Cartography impact 보고
+- impact가 가리키는 affected Root Cartography 좌표와 프로젝트의 tracked/local-only 문서 정책
 - 필요하면 이전 impl-validator 결과와 retry round
 - 다중 story/epic invocation 이면 포함된 story PR/fix PR 목록과 최종 merge target
 
@@ -22,6 +24,7 @@
 - 필수: [`../_shared/validation-reporting-guidance.md`](../_shared/validation-reporting-guidance.md)
 - 계획 파일이 있으면 필수: 해당 impl 계획, architecture, domain-model, design reference 중 계획이 지시한 문서
 - 대상 issue 가 있으면 필수: target GitHub issue AC snapshot 과 호출자가 제시한 항목별 검증 증거
+- Cartography impact가 있으면 필수: 구현 diff, build-worker impact 보고, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision
 - 상황별: project convention, DB schema, API contract, design token
 - design:required UI 작업 상황별 필수: impl 계획의 `## 디자인 참조`, `docs/design.md`, 확정 목업 경로, 구현 diff 의 theme/component/style 상수
 - 상황별: 용어·공개 진입점·분기 표현을 검증할 때만 [`docs/plugin/terms.md`](../../terms.md)
@@ -56,6 +59,16 @@
 - 문서 영향: 이번 diff 가 PRD / stories / architecture / decisions / module responsibility / 사용자-facing 문서의 기존 진술을 stale 하게 만들었는가. 이번 diff 가 기존 장기 문서를 무효화했는지 확인한다.
 - Agent Operability: 다음 agent 의 edit target, state owner, validation path 를 흐리게 만들지 않는가.
 
+### implementation Cartography freshness 렌즈
+
+구현 diff, build-worker impact 보고, affected Root Cartography를 함께 읽는다. runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision이 서로 맞는지 검토한다.
+
+- as-built drift: application lifecycle, receiver, observer, worker, scheduler, composition root에 실제 dependency edge가 생겼는데 Root route/graph/gotcha에 없지 않은가.
+- 상태 증거: `landed`는 class·manifest 존재가 아니라 실제 제품 동작과 검증 증거가 있을 때만 인정하는가. 증거가 없으면 기존 `planned/stub/deferred` 상태를 올리지 않는다.
+- route-only refresh: system boundary와 global decision은 그대로인데 affected Root 좌표만 stale하면 필요한 좌표, before/after, 증거를 finding에 남긴다. validator는 docs를 직접 수정하거나 refresh producer를 선택·호출하지 않는다.
+- system backpressure: 모듈 경계, invariant, storage policy, public API boundary, global decision이 바뀌면 route-only refresh로 흡수하지 않고 기존 system checkpoint 또는 `/design` backpressure가 필요하다고 보고한다.
+- 문서 정책: tracked 문서는 repo 계약대로 갱신 여부를 보되, local-only/ignored private docs를 code PR에 포함하라고 요구하지 않는다. 대신 local refresh 또는 durable impact handoff가 다음 경계까지 보존됐는지 확인한다.
+
 ### design:required UI 토큰 적용 정적 축
 
 확정 목업과 `docs/design.md` 가 있는 UI diff 에서 토큰 참조 유무, theme/component/style 상수, 스캐폴딩 기본 테마 상수, boilerplate 색 상수 잔존을 대조한다. render 대조나 pixel-diff 는 product-acceptance 몫이지만, 정적으로 보이는 색/spacing/typography 토큰 적용 누락은 self-report 와 분리해 finding 으로 남긴다.
@@ -70,10 +83,11 @@
 1. 변경 파일과 diff 중심으로 실제 검증 범위를 확정한다. 다중 story/epic invocation 에서 개별 PR 조각이 아니라 합쳐진 merge candidate diff 를 우선한다.
 2. plan ∪ target GitHub issue AC 가 있으면 spec 렌즈를 먼저 적용한다. 계획 없는 direct 도 target issue 가 있으면 spec 렌즈를 켜고, 둘 다 없을 때만 건너뛴다.
 3. quality 렌즈로 유지보수성, merge risk, 보안·운영 risk, 테스트 신뢰도를 본다.
-4. finding 은 `MUST FIX`와 `NICE TO HAVE`로 나누고, `MUST FIX`마다 `[spec-gap]` 또는 `[quality-gap]` 를 붙인다.
-5. `[spec-gap]` 이 하나라도 있으면 build-worker rework 또는 설계 보강으로 돌린다. `[quality-gap]` 만 있으면 메인 root-cause 수정 또는 build-worker rework 로 돌린다.
-6. 같은 영역 반복 FAIL이면 "점 수정 금지, 근본 재설계 또는 escalate"를 finding에 명시한다.
-7. PASS이면 총평만 짧게 쓴다.
+4. Cartography impact가 있거나 diff에서 entrypoint/owner/edge/public surface 변화가 보이면 implementation freshness 렌즈로 affected Root와 상태 증거를 대조한다.
+5. finding 은 `MUST FIX`와 `NICE TO HAVE`로 나누고, `MUST FIX`마다 `[spec-gap]` 또는 `[quality-gap]` 를 붙인다. Cartography drift finding에는 route-only refresh인지 system backpressure인지와 affected Root 범위를 함께 쓴다.
+6. `[spec-gap]` 이 하나라도 있으면 build-worker rework 또는 설계 보강으로 돌린다. `[quality-gap]` 만 있으면 메인 root-cause 수정 또는 build-worker rework 로 돌린다. producer 선택과 호출 순서는 workflow가 소유하므로 validator가 정하지 않는다.
+7. 같은 영역 반복 FAIL이면 "점 수정 금지, 근본 재설계 또는 escalate"를 finding에 명시한다.
+8. PASS이면 총평만 짧게 쓴다.
 
 ## Agent Operability 승격 규칙
 
@@ -86,12 +100,14 @@ UI/API/CLI entrypoint 를 만지는 diff 는 새 flow append 인지, owner modul
 - ESCALATE이면 어떤 입력, 권한, diff, 테스트 결과, repo context가 부족한지 명확하다.
 - 계획 파일이 필요하다고 호출자가 명시했는데 실제로 없으면 ESCALATE할 수 있다. 단 direct 경로의 계획 부재는 ESCALATE 사유가 아니다.
 - 다중 story/epic invocation 에서 합쳐진 diff 가 제공되지 않았고 개별 PR 단편만으로는 cross-story 결함을 판단할 수 없으면 ESCALATE할 수 있다.
+- applicable implementation Cartography impact가 있으면 diff·impact 보고·affected Root 좌표·상태 증거를 대조했다. route-only drift나 system backpressure가 남아 있으면 PASS하지 않는다.
 
 ## 권한 경계
 
 - 읽기 전용이다.
 - Bash를 쓰지 않는다.
 - 파일을 수정하지 않는다.
+- as-built drift를 발견해도 docs를 직접 수정하지 않는다. 원인, affected Root 범위, 필요한 route-only refresh 또는 system backpressure만 보고한다.
 - 존재하지 않는 함수, 필드, 경로를 추측해 FAIL로 쓰지 않는다.
 - PR 범위 밖 레거시를 MUST FIX로 만들지 않는다.
 - NICE TO HAVE를 MUST FIX로 과장하지 않는다.

--- a/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
+++ b/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
@@ -14,6 +14,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 구현 증거: PR URL, 변경 파일 목록, 테스트 결과, smoke 결과, 정적 타입검사/compile 결과, 실데이터(non-mock) 통합 테스트, UI 자동화, 화면/API/CLI 동작 설명 중 호출자가 제공한 항목
 - UI 검수 증거: UI story/epic 이면 호출자가 제공한 확정 목업 경로(`docs/design-variants/<screen-id>.html`), canvas 경로, 핵심 `data-node-id` 매핑, 구현 화면 스크린샷 또는 동등한 화면 증거 경로
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제 제품 경계 실행 여부
+- epic 구현에 대한 build-worker/impl-validator Cartography impact 보고, affected Root Cartography 좌표, tracked/local-only 문서 정책
 - 이전 acceptance 결과가 있으면 gap 재검수 맥락
 
 ## 먼저 읽을 문서
@@ -110,6 +111,9 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 - UI epic 이면 story 별 확정 목업과 최종 구현 화면 증거가 서로 이어지는지 보고, 화면 증거 부재나 cross-story 목업 불일치를 gap 으로 분리한다.
 - 여러 story 가 합쳐진 사용자 흐름이 내부 schema/payload 조립이 아니라 대상 사용자의 자연스러운 입력/진행 동선으로 이어진다.
 - 보안/권한/데이터 리스크가 새로 생겼는데 별도 후속 없이 묻히지 않았다.
+- capability 상태 감사: epic이 인수한 `planned`, `stub`, `deferred` capability와 구현 후 `landed` 주장을 affected Root Cartography, 실제 runtime entrypoint, 제품 동작·검증 증거와 대조한다. class·manifest 존재만으로 `landed`를 허용하지 않는다.
+- freshness 분기: 제품 동작은 PASS해도 Root route/state만 stale하면 route-only refresh 범위와 durable impact handoff를 gap으로 남긴다. system boundary/global decision 변경이면 route-only refresh로 흡수하지 않고 기존 system checkpoint 또는 `/design` backpressure로 분리한다.
+- 문서 정책: local-only/ignored private docs를 code PR에 강제 포함하지 않고 local refresh 또는 durable impact handoff가 다음 경계까지 보존됐는지 확인한다.
 - 비용, 성능, migration, 배포 설정 같은 운영 리스크가 출시 판단을 막지 않는지 확인한다.
 - 남은 gap 은 `/impl`, `/design`, `/spec`, `/ux`, `/to-issue`, 사용자 위임 같은 후속으로 분기 가능하게 쓴다.
 - 성능 병목 / 리팩토링 필요는 `/to-issue` 후보 + `/impl` 또는 `/design` 으로 제안한다.
@@ -127,7 +131,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 
 1. mode 와 검수 단위를 확인한다.
 2. 기준 문서에서 Story AC, Epic 완료 기준, PRD 유저 시나리오, release readiness 기준을 추출한다.
-3. 구현 증거를 읽고 각 기준이 어떤 PR, 테스트, smoke, 정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, 화면/API/CLI 설명과 연결되는지 대조한다.
+3. 구현 증거를 읽고 각 기준이 어떤 PR, 테스트, smoke, 정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, 화면/API/CLI 설명과 연결되는지 대조한다. EPIC_ACCEPTANCE이면 epic이 인수한 capability의 상태 before/after, affected Root 좌표, 실제 동작·검증 증거도 함께 대조한다.
 4. 대상 사용자를 식별하고 핵심 입력/진행 동선이 제품 언어인지, 내부 구현 계약을 사용자에게 떠넘기는지 대조한다.
 5. 충족된 기준, mock-only green 인 기준, 화면 증거 부재 기준, 목업 불일치 기준, 사용자 동선 부적합 기준, 증거 없는 기준을 분리한다.
 6. gap 이 있으면 기준 문서, 증거, 누락 사실, 후속 분기를 함께 쓴다.
@@ -146,6 +150,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 - 자동으로 issue 를 만들지 않는다. gap issue 생성이 필요하면 `/to-issue` 사용자 승인 후속으로 분기만 제안한다.
 - 사람 full E2E 는 MVP acceptance 범위 밖이다. 사람 E2E 부재만으로 story acceptance 를 FAIL 로 만들지 않는다. 대신 자동 동작 증거가 핵심 AC 를 닫는지 본다.
 - 파일/라인/링크 근거가 없으면 추측하지 않는다.
+- EPIC_ACCEPTANCE에서 증거 없는 `landed`, 미해소 route-only refresh, system boundary backpressure가 있으면 사용자 동작 PASS만으로 전체 PASS하지 않는다.
 
 ## 권한 경계
 
@@ -165,6 +170,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 - gap 별 후속 분기
 - UI story/epic 이면 확정 목업 경로, 구현 화면 스크린샷 또는 화면 증거 경로, UI 목업 정합 판정 결과
 - STORY / EPIC 검수 보고에는 사용자가 지금 직접 확인할 수 있는 실행 동선(실행 명령, 화면 진입 경로 등) 안내. 호출자 제공 증거에서 확인된 동선만 쓰고, 불명이면 불명이라고 쓴다. 확인 가능한 동작이 아직 없으면 그 사실을 쓴다.
+- EPIC 검수 보고에는 epic이 인수한 capability 상태, affected Root 좌표, 상태 증거, route-only refresh 또는 system backpressure 여부를 포함한다.
 
 마지막 단락에는 `PASS`, `FAIL`, `ESCALATE` 중 하나를 쓴다.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -136,6 +136,9 @@ golden 파일 형식:
 | `flow-ownership-owner-good` | (합성) 새 flow owner module 을 만들고 entrypoint 는 dispatch 만 바꾸는 diff | owner module + dispatch 구조 자체를 결함으로 지적하면 안 된다 |
 | `module-state-contract-bad` | (합성) same-identity update·source failure 보존·idempotence·producer/consumer scope가 빠진 cross-story 설계 초안 | module-architect가 task 분할 전에 계약/owner/scope/acceptance gap을 보강하거나 적절히 escalate해야 한다 |
 | `module-state-contract-good` | (합성) full-state update·source failure 보존·반복 no-change와 producer/consumer scope가 닫힌 설계 초안 | module-architect가 상태성만으로 불필요하게 재설계하거나 checkpoint를 요구하면 안 된다 |
+| `cartography-validator-drift` | (합성) Application lifecycle이 data observer를 직접 wiring했지만 Root graph에는 edge가 없는 구현 diff | impl-validator가 as-built drift를 찾고 route-only refresh 범위를 보고하되 직접 문서를 수정하지 않아야 한다 |
+| `cartography-refresh` | (합성) system boundary 변화 없이 scheduler entrypoint가 `planned → landed`가 됐고 Root는 stale인 local-only docs 프로젝트 | route-only refresh와 durable handoff를 요구하되 private docs를 code PR에 강제 포함하지 않아야 한다 |
+| `cartography-system-checkpoint` | (합성) landed public REST boundary 제거와 capability owner 이동이 섞인 구현 diff | route-only refresh로 흡수하지 않고 system checkpoint 또는 `/design` backpressure를 요구해야 한다 |
 
 > L3 실사고 케이스의 축 한계 — 정직하게 기록한다:
 > - **순서 축은 깨끗하게 재현된다**: 핵심 약속(완성 쇼츠) 검증이 뒤 story 로 밀린 것을 지금 지침이 reliable 하게 잡는다(3/3). 이게 youTubeGenerator #214 의 설계단 원인이다.

--- a/evals/cases/cartography-refresh/architecture.md
+++ b/evals/cases/cartography-refresh/architecture.md
@@ -1,0 +1,7 @@
+# Architecture Cartography
+
+## Runtime entrypoint routes
+
+| trigger | entrypoint | owner | state | evidence | epic/decision |
+|---|---|---|---|---|---|
+| nightly export | epic-21 planned route | ExportService | planned | accepted epic | epic-21 / ADR-0021 |

--- a/evals/cases/cartography-refresh/diff.md
+++ b/evals/cases/cartography-refresh/diff.md
@@ -8,4 +8,16 @@ new file mode 100644
 +
 +def run_nightly_export(service: ExportService) -> None:
 +    service.export_due_items()
+diff --git a/tests/integration/test_nightly_export.py b/tests/integration/test_nightly_export.py
+new file mode 100644
+--- /dev/null
++++ b/tests/integration/test_nightly_export.py
+@@
++def test_scheduler_callback_reaches_real_export_service(tmp_path):
++    service = ExportService(output_dir=tmp_path)
++    service.add_due_item("message-1")
++
++    run_nightly_export(service)
++
++    assert (tmp_path / "message-1.json").is_file()
 ```

--- a/evals/cases/cartography-refresh/diff.md
+++ b/evals/cases/cartography-refresh/diff.md
@@ -1,0 +1,11 @@
+```diff
+diff --git a/src/jobs/nightly_export.py b/src/jobs/nightly_export.py
+new file mode 100644
+--- /dev/null
++++ b/src/jobs/nightly_export.py
+@@
++from export.service import ExportService
++
++def run_nightly_export(service: ExportService) -> None:
++    service.export_due_items()
+```

--- a/evals/cases/cartography-refresh/docs-policy.md
+++ b/evals/cases/cartography-refresh/docs-policy.md
@@ -1,0 +1,3 @@
+# Documentation policy
+
+`docs/architecture.md`는 local-only이며 gitignored다. 구현 impact는 durable implementation report에 남기고 local Root를 갱신하되 code PR에는 private docs를 포함하지 않는다.

--- a/evals/cases/cartography-refresh/expected.md
+++ b/evals/cases/cartography-refresh/expected.md
@@ -1,0 +1,6 @@
+# 정답표 — 계약 수준
+
+- [E1][MUST] 새 scheduler entrypoint와 `planned → landed` 증거가 Root에 아직 반영되지 않은 route-only refresh 필요성을 지적한다.
+- [E2][MUST] system boundary나 global decision 변경은 없다고 구분하고, 필요한 affected Root 좌표와 상태 증거를 producer handoff에 남기도록 보고한다.
+- [E3][MUST] local-only/ignored 문서 정책을 존중해 private docs를 code PR에 포함하라고 요구하지 않는다.
+- [E4][MUST] 읽기 전용 검수자가 문서를 직접 수정하지 않고 최종 결론을 PASS로 내리지 않는다.

--- a/evals/cases/cartography-refresh/impact.md
+++ b/evals/cases/cartography-refresh/impact.md
@@ -1,0 +1,9 @@
+# Build impact
+
+- runtime entrypoint: `src/jobs/nightly_export.py` 신규
+- capability/state owner: 기존 ExportService 유지
+- dependency edge: Scheduler → nightly_export → ExportService 신규
+- public surface: 내부 scheduler callback 추가, 기존 외부 API 변화 없음
+- state before/after: nightly export route `planned → landed`
+- evidence: `tests/integration/test_nightly_export.py`가 scheduler callback에서 실제 ExportService 호출을 검증
+- related epic/decision: epic-21 export, ADR-0021

--- a/evals/cases/cartography-refresh/impl.md
+++ b/evals/cases/cartography-refresh/impl.md
@@ -1,0 +1,3 @@
+# Nightly export scheduler wiring
+
+기존 ExportService를 호출하는 scheduler composition entrypoint를 구현한다. capability owner와 global decision은 바꾸지 않는다.

--- a/evals/cases/cartography-refresh/prompt.md
+++ b/evals/cases/cartography-refresh/prompt.md
@@ -1,0 +1,12 @@
+너는 impl-validator 검수 agent 다. 먼저 {{REPO_ROOT}}/docs/plugin/agents/impl-validator/impl-validator-agent.md 를 Read 하고 그 지침을 그대로 따른다.
+
+입력:
+- 검수 단위: 로컬 PR diff
+- 구현 계획: {{CASE_DIR}}/impl.md
+- 변경 diff: {{CASE_DIR}}/diff.md
+- build-worker impact 보고: {{CASE_DIR}}/impact.md
+- affected Root Cartography: {{CASE_DIR}}/architecture.md
+- 프로젝트 문서 정책: {{CASE_DIR}}/docs-policy.md
+- 대상 GitHub issue: 없음 (synthetic plan/diff case)
+
+목적: 구현 자체의 적합성과 별개로 route-only Cartography freshness가 다음 durable 경계 전에 보존되는지 검토한다. 읽기 전용이다. 파일 수정과 Bash를 쓰지 않는다(Read만 사용). 마지막 단락에 PASS / FAIL / ESCALATE 중 하나를 써라.

--- a/evals/cases/cartography-system-checkpoint/architecture.md
+++ b/evals/cases/cartography-system-checkpoint/architecture.md
@@ -1,0 +1,7 @@
+# Architecture Cartography
+
+## Runtime entrypoint routes
+
+| trigger | entrypoint | owner | state | evidence | epic/decision |
+|---|---|---|---|---|---|
+| public message POST | `src/api/messages.py` | IngestGateway | landed | API integration test | epic-03 / ADR-0004 |

--- a/evals/cases/cartography-system-checkpoint/diff.md
+++ b/evals/cases/cartography-system-checkpoint/diff.md
@@ -1,0 +1,16 @@
+```diff
+diff --git a/src/api/messages.py b/src/api/messages.py
+deleted file mode 100644
+--- a/src/api/messages.py
++++ /dev/null
+@@
+-def post_message(payload):
+-    return IngestGateway().accept(payload)
+diff --git a/src/stream/ingress.py b/src/stream/ingress.py
+new file mode 100644
+--- /dev/null
++++ b/src/stream/ingress.py
+@@
++class StreamIngress:
++    def accept(self, event): ...
+```

--- a/evals/cases/cartography-system-checkpoint/expected.md
+++ b/evals/cases/cartography-system-checkpoint/expected.md
@@ -1,0 +1,5 @@
+# 정답표 — 계약 수준
+
+- [E1][MUST] landed public REST boundary를 제거하고 capability owner를 바꾸는 diff는 route-only refresh가 아니라 system boundary와 global decision 변경이라고 지적한다.
+- [E2][MUST] affected Root 좌표만 고쳐 통과시키지 않고 기존 system checkpoint 또는 `/design` backpressure가 필요하다고 보고한다.
+- [E3][MUST] 읽기 전용 검수자가 코드나 문서를 직접 수정하지 않고 최종 결론을 PASS로 내리지 않는다.

--- a/evals/cases/cartography-system-checkpoint/impact.md
+++ b/evals/cases/cartography-system-checkpoint/impact.md
@@ -1,0 +1,8 @@
+# Build impact
+
+- runtime entrypoint: public REST removed, event stream added
+- capability/state owner: IngestGateway → StreamIngress
+- dependency edge: external client → REST removed; broker → StreamIngress added
+- public surface: breaking change
+- state before/after: REST route landed → removed, stream route planned → landed
+- related epic/decision: epic-03 ingest, ADR-0004 public REST contract

--- a/evals/cases/cartography-system-checkpoint/impl.md
+++ b/evals/cases/cartography-system-checkpoint/impl.md
@@ -1,0 +1,3 @@
+# Ingest event stream cutover
+
+기존 public REST ingest를 제거하고 event stream만 지원한다. 구현 계획에는 global decision 변경 승인이 없다.

--- a/evals/cases/cartography-system-checkpoint/prompt.md
+++ b/evals/cases/cartography-system-checkpoint/prompt.md
@@ -1,0 +1,11 @@
+너는 impl-validator 검수 agent 다. 먼저 {{REPO_ROOT}}/docs/plugin/agents/impl-validator/impl-validator-agent.md 를 Read 하고 그 지침을 그대로 따른다.
+
+입력:
+- 검수 단위: 로컬 PR diff
+- 구현 계획: {{CASE_DIR}}/impl.md
+- 변경 diff: {{CASE_DIR}}/diff.md
+- build-worker impact 보고: {{CASE_DIR}}/impact.md
+- affected Root Cartography: {{CASE_DIR}}/architecture.md
+- 대상 GitHub issue: 없음 (synthetic plan/diff case)
+
+목적: 구현 영향이 route-only refresh인지 system boundary/global decision backpressure인지 구분한다. 읽기 전용이다. 파일 수정과 Bash를 쓰지 않는다(Read만 사용). 마지막 단락에 PASS / FAIL / ESCALATE 중 하나를 써라.

--- a/evals/cases/cartography-validator-drift/architecture.md
+++ b/evals/cases/cartography-validator-drift/architecture.md
@@ -1,0 +1,11 @@
+# Architecture Cartography
+
+## Runtime entrypoint routes
+
+| trigger | entrypoint | owner | next boundary | state | evidence |
+|---|---|---|---|---|---|
+| SMS receive | `app/src/main/kotlin/example/SmsReceiver.kt` | SmsIngress | MessageStore | landed | SmsReceiverTest |
+
+## Dependency graph
+
+- SmsReceiver → MessageStore

--- a/evals/cases/cartography-validator-drift/diff.md
+++ b/evals/cases/cartography-validator-drift/diff.md
@@ -1,0 +1,18 @@
+```diff
+diff --git a/app/src/main/kotlin/example/App.kt b/app/src/main/kotlin/example/App.kt
+--- a/app/src/main/kotlin/example/App.kt
++++ b/app/src/main/kotlin/example/App.kt
+@@
++import example.data.MessageObserver
+ class App : Application() {
++  private val observer = MessageObserver()
+   override fun onCreate() {
+     super.onCreate()
++    observer.start()
+   }
++  override fun onTerminate() {
++    observer.stop()
++    super.onTerminate()
++  }
+ }
+```

--- a/evals/cases/cartography-validator-drift/diff.md
+++ b/evals/cases/cartography-validator-drift/diff.md
@@ -15,4 +15,20 @@ diff --git a/app/src/main/kotlin/example/App.kt b/app/src/main/kotlin/example/Ap
 +    super.onTerminate()
 +  }
  }
+diff --git a/app/src/test/kotlin/example/AppObserverIntegrationTest.kt b/app/src/test/kotlin/example/AppObserverIntegrationTest.kt
+new file mode 100644
+--- /dev/null
++++ b/app/src/test/kotlin/example/AppObserverIntegrationTest.kt
+@@
++class AppObserverIntegrationTest {
++  @Test fun applicationLifecycleStartsAndStopsObserver() {
++    val observer = RecordingMessageObserver()
++    val app = App(observer)
++
++    app.onCreate()
++    assertTrue(observer.started)
++    app.onTerminate()
++    assertTrue(observer.stopped)
++  }
++}
 ```

--- a/evals/cases/cartography-validator-drift/expected.md
+++ b/evals/cases/cartography-validator-drift/expected.md
@@ -1,0 +1,6 @@
+# 정답표 — 계약 수준
+
+- [E1][MUST] app-root가 MessageObserver를 lifecycle wiring한 as-built dependency edge가 구현 diff에는 있지만 root graph에는 없다는 drift를 지적한다.
+- [E2][MUST] 코드 구현 자체를 되돌리거나 module task를 다시 쓰게 하지 않고, route-only refresh가 필요한 affected Root 좌표와 상태 증거를 producer handoff로 넘기는 후속을 제시한다.
+- [E3][MUST] 읽기 전용 검수자가 문서 수정 권한을 침범하지 않고 최종 결론을 PASS로 내리지 않는다.
+- [E4][MUST_NOT] 고정 JSON, marker 또는 새 정형 status payload를 요구하지 않는다.

--- a/evals/cases/cartography-validator-drift/impact.md
+++ b/evals/cases/cartography-validator-drift/impact.md
@@ -1,0 +1,3 @@
+# Build impact
+
+App lifecycle wiring now starts and stops the existing MessageObserver. The owner remains the data module. This adds the as-built edge `App -> MessageObserver` and changes the observer capability from planned to landed based on `AppObserverIntegrationTest`.

--- a/evals/cases/cartography-validator-drift/impl.md
+++ b/evals/cases/cartography-validator-drift/impl.md
@@ -1,0 +1,3 @@
+# Message observer lifecycle wiring
+
+`App.kt`가 기존 `MessageObserver`를 시작·종료 lifecycle에 연결한다. owner는 data module에 남고 app-root는 composition wiring만 소유한다. integration test로 observer start/stop을 검증한다.

--- a/evals/cases/cartography-validator-drift/prompt.md
+++ b/evals/cases/cartography-validator-drift/prompt.md
@@ -1,0 +1,11 @@
+너는 impl-validator 검수 agent 다. 먼저 {{REPO_ROOT}}/docs/plugin/agents/impl-validator/impl-validator-agent.md 를 Read 하고 그 지침을 그대로 따른다.
+
+입력:
+- 검수 단위: 로컬 PR diff
+- 구현 계획: {{CASE_DIR}}/impl.md
+- 변경 diff: {{CASE_DIR}}/diff.md
+- 현재 root Cartography: {{CASE_DIR}}/architecture.md
+- build-worker Cartography impact 보고: {{CASE_DIR}}/impact.md
+- 대상 GitHub issue: 없음 (synthetic plan/diff case)
+
+목적: 구현 diff의 as-built dependency edge와 상태 전환이 root Cartography 및 impact 보고와 맞는지 검토한다. 읽기 전용이다. 파일 수정과 Bash를 쓰지 않는다(Read만 사용). 마지막 단락에 PASS / FAIL / ESCALATE 중 하나를 써라.

--- a/tests/test_architecture_freshness_responsibility.py
+++ b/tests/test_architecture_freshness_responsibility.py
@@ -1,0 +1,108 @@
+"""Implementation-stage Cartography freshness contracts for issue #1058."""
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class ArchitectureFreshnessResponsibilityTests(unittest.TestCase):
+    def test_issue_1059_bounded_root_contract_is_preserved(self) -> None:
+        module = read(
+            "docs/plugin/agents/module-architect/module-architect-agent.md"
+        )
+        architecture_validator = read(
+            "docs/plugin/agents/architecture-validator/architecture-validator-agent.md"
+        )
+        system = read(
+            "docs/plugin/agents/system-architect/system-architect-agent.md"
+        )
+
+        self.assertIn(
+            "Root 갱신 조건에 해당하는 `docs/architecture.md` Cartography route",
+            module,
+        )
+        self.assertIn("Root Cartography", architecture_validator)
+        self.assertIn("landed/stub/planned/deferred", system)
+        self.assertNotIn("전역 Cartography의 단일 write owner", system)
+        self.assertNotIn("Root Cartography를 직접 수정하지 않는다", module)
+
+    def test_build_worker_reports_implementation_cartography_impact(self) -> None:
+        worker = read("docs/plugin/agents/build-worker/build-worker-agent.md")
+        report = read(
+            "docs/plugin/agents/build-worker/templates/build-worker-report.md"
+        )
+
+        for text in (worker, report):
+            for meaning in (
+                "runtime entrypoint",
+                "owner",
+                "dependency edge",
+                "public surface",
+                "before/after",
+                "관련 epic/decision",
+            ):
+                self.assertIn(meaning, text)
+        self.assertIn("자유 prose", worker)
+        self.assertIn("`docs/**` 수정", worker)
+        self.assertIn("local-only", worker)
+
+    def test_both_impl_validators_detect_as_built_drift_read_only(self) -> None:
+        validators = (
+            read("docs/plugin/agents/impl-validator/impl-validator-agent.md"),
+            read("codex/skills/dcness-impl-validator/SKILL.md"),
+        )
+
+        for validator in validators:
+            self.assertIn("build-worker impact 보고", validator)
+            self.assertIn("affected Root Cartography", validator)
+            self.assertIn("as-built drift", validator)
+            self.assertIn("dependency edge", validator)
+            self.assertIn("landed", validator)
+            self.assertIn("route-only refresh", validator)
+            self.assertIn("system boundary", validator)
+            self.assertIn("읽기 전용", validator)
+
+    def test_epic_acceptance_audits_inherited_capability_states(self) -> None:
+        acceptance = read(
+            "docs/plugin/agents/product-acceptance/product-acceptance-agent.md"
+        )
+
+        self.assertIn("epic이 인수한", acceptance)
+        for state in ("planned", "stub", "deferred", "landed"):
+            self.assertIn(state, acceptance)
+        self.assertIn("제품 동작·검증 증거", acceptance)
+        self.assertIn("route-only refresh", acceptance)
+
+    def test_as_built_drift_fixture_has_lifecycle_edge_missing_from_root(self) -> None:
+        case = ROOT / "evals/cases/cartography-validator-drift"
+        prompt = (case / "prompt.md").read_text(encoding="utf-8")
+        expected = (case / "expected.md").read_text(encoding="utf-8")
+        diff = (case / "diff.md").read_text(encoding="utf-8")
+        root_map = (case / "architecture.md").read_text(encoding="utf-8")
+
+        self.assertIn("impl-validator", prompt)
+        self.assertIn("MessageObserver", diff)
+        self.assertNotIn("MessageObserver", root_map)
+        self.assertIn("route-only refresh", expected)
+        self.assertIn("문서 수정 권한", expected)
+
+    def test_eval_suite_covers_refresh_and_system_backpressure(self) -> None:
+        route_only = read("evals/cases/cartography-refresh/expected.md")
+        system_change = read(
+            "evals/cases/cartography-system-checkpoint/expected.md"
+        )
+
+        self.assertIn("route-only refresh", route_only)
+        self.assertIn("local-only", route_only)
+        self.assertIn("system boundary", system_change)
+        self.assertIn("/design", system_change)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1058

## 배경 및 문제

#1059가 확정한 design-stage bounded Root Cartography 계약 뒤에서 실제 구현의 runtime entrypoint, owner, dependency edge, public surface, 상태 전환이 agent handoff와 코드 검증·epic acceptance에 연결되지 않았다.

## 원인 (해당 시)

구현 agent 보고, read-only impl-validator, product acceptance가 각자 동작·품질 증거는 다뤘지만 implementation Cartography impact를 공통 의미 축으로 인계하고 as-built Root drift를 검증하는 계약이 없었다.

## 작업내용

- build-worker 자유 prose 보고와 report template에 Cartography impact 의미 축을 추가했다.
- Claude/Codex impl-validator가 구현 diff, impact 보고, affected Root 좌표를 대조해 as-built drift와 상태 증거를 검토하도록 했다.
- route-only refresh와 system boundary backpressure를 구분하고 read-only/docs 정책을 보존했다.
- EPIC_ACCEPTANCE가 epic이 인수한 capability 상태와 실제 제품 동작·검증 증거를 감사하도록 했다.
- #1059 bounded Root 권한 보존 회귀 테스트와 3개 행동 eval fixture를 추가했다.

## 결정 근거

- #1059의 module-architect bounded Root write와 architecture-validator 계약은 변경하지 않았다.
- workflow 연결과 refresh producer 선택·호출 순서는 #1057이 소유하므로 이 PR에서 skill routing을 바꾸지 않았다.
- 전체 행동 eval은 #1057까지 연결한 통합 상태에서 후속 eval 이슈로 실행한다.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1: `docs/plugin/agents/**`, `codex/skills/**`와 관련 template은 dcness plug-in 본체로 배포되어 plug-in 업데이트 시 외부 활성 프로젝트에 도달한다.
- `/init-dcness` 복사 파일과 신규 공개 진입점은 추가하지 않았다. 기존 활성 프로젝트는 plug-in 업데이트만 필요하다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 build-worker, impl-validator, product-acceptance 내부 계약만 확장했다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,845 tests PASS
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] doc sync / cross-ref / plugin manifest / ruff / mypy / Bandit — PASS
- [x] 행동 eval fixture 3종과 eval harness 계약 테스트 PASS — 전체 `bash evals/run.sh` 실행은 #1057 workflow integration AC에서 통합 판정

## 참고

- 전체 행동 eval AC를 #1057로 이관했고, #1058 본문은 자동 판정 AC 8개 체크 + `require-complete` PASS 상태다.
