### PR TITLE
[feature] 제품 outcome scorecard와 운영 baseline 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ GitHub issue 를 대상으로 하는 dcness self 구현은 진입 때 읽은 본
 | [`docs/plugin/terms.md`](docs/plugin/terms.md) | 용어·공개 진입점·분기 표현·사용자 표시 메시지 수정/리뷰 시 |
 | [`docs/plugin/positioning.md`](docs/plugin/positioning.md) | 공개 workflow 진입점의 기본/고급/유틸리티/내부 agent 분류 수정 시 |
 | [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md) | 자유 형식 작업 요청을 어떤 workflow 로 보낼지 (구현 경로 — gate 축 × shape 축) 판단 시 |
+| [`docs/plugin/outcome-scorecard.md`](docs/plugin/outcome-scorecard.md) | process·Agent effectiveness·실제 제품 outcome의 비교 필드·denominator·주장 경계를 수정/리뷰 시 |
 | [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현·효율 benchmark 문구 수정 시 |
 | [`docs/plugin/design.md`](docs/plugin/design.md) | `design.md` 토큰 규격·Static HTML 시안 규약 수정 시 |
 | [`docs/plugin/git-spec.md`](docs/plugin/git-spec.md) | 브랜치·커밋·PR 네이밍 규칙 SSOT — 모든 커밋 작업에 적용 |

--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -1,0 +1,63 @@
+# 제품 outcome scorecard 운영 baseline
+
+> 측정 시점 snapshot. 값은 계속 쌓이는 runtime ledger의 영구 headline이 아니며, 재현 명령과 원천 범위를 함께 읽는다.
+
+## 재현 명령
+
+plugin checkout 또는 활성 plugin root를 `DCN`으로 지정한 뒤 실행한다.
+
+```sh
+python3 "$DCN"/harness/outcome_scorecard.py \
+  --redact-paths \
+  --measured-at 2026-07-11T13:46:46Z \
+  --as-of 2026-07-11T13:46:46Z \
+  --source-ref source-1242b5d736 \
+  --source-ref source-d640b1b95d
+
+python3 "$DCN"/harness/outcome_scorecard.py \
+  --redact-paths \
+  --measured-at 2026-07-11T13:46:46Z \
+  --as-of 2026-07-11T13:46:46Z \
+  --source-ref source-1242b5d736 \
+  --source-ref source-d640b1b95d \
+  --json
+```
+
+기본 원천은 active-project registry다. snapshot 시점 registry 5개 항목 중 완료 run 근거가 있는 source 프로젝트 2개만 분모에 들어갔다. 절대경로와 프로젝트 이름은 공개 snapshot에서 가리고, registry 위치와 경로 digest로 만든 stable source ref를 남긴다. 재현 명령은 이 두 ref를 명시적으로 고정하므로 registry 재정렬이나 새 프로젝트 추가가 source 집합을 바꾸지 않는다. 고정한 ref가 사라지거나 해당 runtime ledger를 읽을 수 없으면 재현기는 분모를 조용히 줄이는 대신 오류로 종료한다.
+
+| source ref | 원천 위치 | finished/candidate run |
+|---|---|---:|
+| `source-1242b5d736` | active-project registry entry #3의 `.claude/harness-state/.sessions` | 12/13 |
+| `source-d640b1b95d` | active-project registry entry #5의 `.claude/harness-state/.sessions` | 14/15 |
+
+## 2026-07-11 snapshot
+
+측정 시각과 관측 cutoff는 `2026-07-11T13:46:46Z`다. source 프로젝트 2, cutoff 전에 시작한 candidate run directory 28, cutoff 전에 receipt로 닫힌 finished run 26이다. 이후 추가된 run은 같은 snapshot 재현에서 제외된다.
+
+| 영역 | 지표 | 값 | 분자/분모 | source 수 | 해석 경계 |
+|---|---|---:|---:|---:|---|
+| process | finished run 포함 | 92.9% | 26/28 | 2 | 불완전 run 2개는 집계에서 제외 |
+| process | PR merge | 100.0% | 7/7 | 2 | `pr_created`가 있는 measurable PR만 분모; 제품 성공률 아님 |
+| process | blocked event | 0.0% | 0/26 finished run | 2 | cutoff 이하의 명시적 `blocked` event만 집계 |
+| process | guard 결과 | 측정 불가 | 0/0 | 2 | 선택한 legacy ledger baseline에 일관된 guard telemetry가 없음 |
+| process | regression | 측정 불가 | 0/0 | 2 | 같은 조건의 반복 제품 journey 증거가 없음 |
+| process | impl-validator 재작업 | 100.0% | 2/2 | 2 | 해당 agent의 판정 가능한 verdict만 분모; 다른 validator 역할과 합치지 않음 |
+| process | validator verdict | 33건 | 33/26 finished run | 2 | architecture-validator FAIL 10/PASS 6, code-validator FAIL 7/PASS 8, impl-validator FAIL 2 |
+| process | waste finding | 57건 | 57/26 finished run | 2 | `TOOL_REPEAT_HIGH` 42, `MISSING_CONCLUSION_ENUM` 7, `MUST_FIX_LEAK` 7, `END_STEP_SKIP` 1 |
+| Agent effectiveness | 탐색 정확도·비용·오경로·영향 누락·context 재작업·복구 | 측정 불가 | 0/0 | 2 | 현재 ledger에 comparable paired trial이 없음 |
+| product outcome | 실제 제품 AC와 사용자 journey | 측정 불가 | 0/0 | 2 | 앱/API/CLI/UI journey 실행 결과가 현재 ledger에 없음 |
+| trial metadata | task/repo 유형, model/provider, variant, trial, token/wall-clock, 사람 개입 | 측정 불가 | 0/0 | 2 | legacy run 전체에 일관된 한 record가 없음 |
+
+`7/7` merge는 PR 운영 결과다. guard PASS나 validator FAIL도 과정 evidence다. 세 값 중 어느 것도 실제 제품 AC 성공률로 바꾸지 않으며, merge 비율을 제품 전체 성공으로 해석하는 결론을 두지 않는다.
+
+## Agent effectiveness 입력 경계
+
+- Cartography freshness에서 얻을 수 있는 것: 현재 SSOT·runtime entrypoint·capability owner 후보, affected route의 stale 여부와 갱신·재검증 기록.
+- Codebase Sanity에서 얻을 수 있는 것: 감사 code revision, 실제 scope, 명령·warning·coverage 근거, dead-code 분류와 unknown.
+- 아직 측정할 수 없는 것: 첫 올바른 대상 선택 정확도와 시간, 불필요한 read/tool 양, 오경로, 영향 범위 누락, context 기인 validator 재작업, cross-session 복구 성공의 paired before/after.
+
+기능 또는 receipt가 존재한다는 사실은 마지막 항목들의 개선 증거가 아니다. 후속 trial이 생길 때까지 `측정 불가`를 실패나 개선으로 추정하지 않는다.
+
+## 사용 가능한 주장
+
+이 snapshot은 source 2개와 finished run 26개라는 cross-project process baseline 조건은 충족한다. 그러나 비교 variant별 반복 trial과 실제 product outcome이 없으므로 공개 우위 주장은 할 수 없다. 같은 fixture의 1+1 paired screening은 개인 경량화 `keep` / `remove` / `hold` 판단에만 사용할 수 있다.

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -14,6 +14,7 @@ dcNess 는 측정 인프라를 plug-in 본체에 같이 배포한다.
 | [`scripts/measure_main_turns.py`](../../scripts/measure_main_turns.py) | Claude Code 세션의 메인 assistant turn 분포 (tool / text-only / thinking-only) + tool histogram + sub-agent 호출 분포 | 직접 실행 |
 | [`harness/run_review.py`](../../harness/run_review.py) | run 1개의 step별 비용·토큰 + 낭비(waste) finding | `/run-review` skill |
 | [`harness/benchmark_aggregate.py`](../../harness/benchmark_aggregate.py) | 여러 run 가로질러 fleet 집계 (PR 머지 성공률 / review rejection / escalate / blocked / waste top-N / 재발 개선 후보) | 직접 실행 |
+| [`harness/outcome_scorecard.py`](../../harness/outcome_scorecard.py) | 활성 프로젝트를 가로질러 process, Agent effectiveness, 실제 제품 outcome을 분리하고 모든 집계에 denominator·source 수·측정일을 붙임 | 직접 실행 |
 
 guard 효능 재현은 별도다. dcNess 소스 checkout 에서만 제공되는
 `evals/guard_efficacy.py` 는 LLM 없이 hook/function 진입점을 직접 호출해 file boundary,
@@ -54,6 +55,10 @@ hook/function 의 결정적 allow/block 성능을 대신하지 않는다.
 ## 지표 구분
 
 한 표에 서로 다른 지표를 섞어 "좋아졌다"로 뭉개지 않는다.
+
+비교 단위와 측정 불가 처리, Agent effectiveness와 실제 제품 결과의 전체 의미 계약은
+[`outcome-scorecard.md`](outcome-scorecard.md)가 소유한다. 본 문서는 기존 측정 도구의
+재현 recipe와 공개 숫자 해석을 소유한다.
 
 | 지표 | 의미 | 산출 근거 |
 |---|---|---|
@@ -206,6 +211,17 @@ done
    `pr_merge_success_ratio`, `pr_reviewer_rejection_count/review_count`,
    `blocked_event_count`, `escalate_count`, `waste_top`, `improvement_candidates`,
    source count, 한계.
+
+여러 활성 프로젝트를 한 번에 같은 scorecard로 재현하려면 다음 명령을 쓴다. 현재 ledger에
+없는 제품 AC/journey와 탐색 효과는 다른 process 지표로 채우지 않고 `측정 불가`로 출력한다.
+
+```sh
+python3 "$DCN"/harness/outcome_scorecard.py --redact-paths
+python3 "$DCN"/harness/outcome_scorecard.py --redact-paths --json
+```
+
+시점 snapshot과 원천 registry 위치는 [`outcome-baseline.md`](../internal/outcome-baseline.md)에
+보존한다.
 
 ### fleet 실측 (외부 활성 프로젝트 1곳)
 

--- a/docs/plugin/outcome-scorecard.md
+++ b/docs/plugin/outcome-scorecard.md
@@ -1,0 +1,91 @@
+# 제품 결과 scorecard 계약
+
+> **Status**: ACTIVE
+> **Scope**: 하네스 과정, agent의 실제 작업 능력, 제품 결과를 같은 관측 단위에서 비교하되 서로 대체하지 않는 측정 계약.
+
+## 세 영역
+
+| 영역 | 답하는 질문 | 대체할 수 없는 것 |
+|---|---|---|
+| **과정·merge** | guard·validator·PR 흐름이 실행되고 재작업과 낭비가 얼마나 생겼는가 | 실제 제품 outcome, Agent effectiveness |
+| **Agent effectiveness** | agent가 올바른 맥락과 변경 대상을 더 정확하고 적은 탐색으로 찾아 작업했는가 | 기능·문서가 존재한다는 사실, PR merge |
+| **실제 제품 outcome** | 사용자에게 약속한 제품 AC와 핵심 journey가 실제 제품 경계에서 성공했는가 | 테스트 수, guard PASS, validator verdict, PR merge |
+
+세 영역은 한 scorecard에 나란히 둘 수 있지만 합산 점수로 뭉개지 않는다. 과정 지표가 green이어도 제품 AC·journey 증거가 없으면 제품 결과는 `측정 불가`다. 관측하지 못한 값을 0, 실패, 개선으로 바꾸거나 다른 영역의 지표로 채우지 않는다.
+
+## 비교 단위와 공통 필드
+
+비교 가능한 최소 단위는 같은 목표와 검증 경계를 가진 trial이다. 문단·표·JSON 중 특정 출력 형식을 강제하지 않지만, 비교할 때 다음 의미가 함께 있어야 한다.
+
+| 의미 | 기록할 내용 |
+|---|---|
+| 작업 맥락 | task 유형, repo 유형, 목표/AC 식별자, 위험도 |
+| 실행 조건 | model, provider, harness variant, trial ID와 같은 조건의 전체 trial 수 |
+| denominator | 각 비율의 분자·분모, source 프로젝트 수, 측정일 또는 run 범위 |
+| 비용 | wall-clock, input/output token, cost와 측정 근거 |
+| 사람 개입 | 개입 횟수, 이유, 복구에 든 작업 |
+| 결과 증거 | 실행 증거 종류(command, API/CLI/UI journey, screenshot/log, 실제 통합 경계 등), evidence 위치 |
+
+필드가 legacy run에 없으면 `측정 불가`와 이유를 남긴다. 서로 다른 task 유형이나 repo 유형을 하나의 variant 효과처럼 합치지 않는다.
+
+## 과정·merge 영역
+
+과정 영역은 최소한 finished run, validator verdict와 재작업, guard/blocked 신호, PR 생성·merge, regression, waste 신호를 분리한다.
+
+- finished run은 완료 event와 읽을 수 있는 receipt가 함께 있는 run만 센다.
+- validator 재작업률은 FAIL 분자와 판정 가능한 verdict 분모를 함께 둔다.
+- PR merge율은 `pr_created`를 분모로 하고 같은 PR의 `pr_merged`만 분자로 센다. 분모가 없으면 `측정 불가`다.
+- waste count는 finished run 노출량을 denominator로 같이 제시한다.
+- guard PASS·validator FAIL·PR merge는 하네스 과정의 증거이며 실제 제품 성공률로 표현하지 않는다.
+
+## Agent effectiveness 영역
+
+Agent effectiveness는 하네스 기능 보유 여부가 아니라 같은 조건에서 agent의 실제 작업 능력이 어떻게 달라졌는지를 본다.
+
+| 관측 항목 | 의미 |
+|---|---|
+| SSOT·runtime entrypoint·capability owner 탐색 정확도 | 첫 선택이 현재 코드와 문서의 진짜 owner를 가리키는가 |
+| 첫 올바른 변경 대상까지의 비용 | 걸린 시간, tool/read 양, 불필요한 파일 읽기와 tool 반복 |
+| 오경로 | stale 문서, 잘못된 owner/entrypoint, 폐기된 경로를 선택한 횟수 |
+| 영향 범위 누락 | 필요한 producer/consumer, 상태 전이, 테스트 또는 공개 경계를 빠뜨렸는가 |
+| context 기인 재작업 | 구현 결함이 아니라 필요한 맥락 누락 때문에 validator가 되돌린 횟수 |
+| cross-session 복구 | 다음 세션이 결정·현재 상태·다음 변경 대상을 정확히 복구했는가 |
+
+Cartography freshness는 SSOT·entrypoint·owner 후보와 stale 여부의 입력 증거를 제공한다. Codebase Sanity는 code revision, 감사 scope, 경고·unknown·잔존 경로의 입력 증거를 제공한다. 두 기능이 존재하거나 PASS했다는 사실만으로 탐색 정확도·시간·재작업 감소가 입증되지는 않는다. 비교 trial의 before/after 또는 paired 관측이 없으면 effectiveness는 `측정 불가`다.
+
+## 실제 제품 outcome 영역
+
+제품 outcome은 제품 AC와 핵심 사용자 journey를 실제 경계에서 실행한 증거로 기록한다.
+
+- AC별 pass/fail/측정 불가와 실행 증거 종류를 보존한다.
+- journey는 앱 기동, API/CLI/UI 결과, 실데이터 통합 경계처럼 AC에 맞는 실제 경계를 통과해야 한다.
+- mock-only green, guard PASS, validator PASS, PR merge만으로 outcome PASS를 만들지 않는다.
+- regression은 이전에 통과한 제품 동작이 같은 조건에서 깨졌는지 별도 필드로 둔다.
+
+## 주장 가능 범위
+
+### 개인 경량화 판단
+
+같은 task 또는 저장된 fixture에서 baseline과 후보를 한 번씩 실행하는 **1+1 paired screening**을 허용한다. 명확한 새 제품 AC gap·사람 복구·regression이 없고 비용 또는 사람 개입이 개선됐는지 보고 `keep` / `remove` / `hold`를 정하는 개인 판단용이다. 일반화나 공개 우위 근거가 아니다.
+
+### 공개 우위 주장
+
+공개 우위를 말하려면 다음 조건을 모두 충족한다.
+
+- source 프로젝트 최소 2개와 총 20개 이상의 finished run.
+- 모든 headline 값에 분자·denominator·source 프로젝트 수·측정일·재현 명령.
+- 같은 task/repo 유형 안에서 비교 variant마다 2회 이상의 반복 trial. 1+1 screening만으로는 부족하다.
+- 실제 제품 outcome이 포함되고, process/merge나 Agent effectiveness로 대체되지 않는다.
+- 측정 불가, 작은 표본, provider/model 차이와 관측 한계를 수치와 같은 위치에 둔다.
+
+## 현재 baseline 재현
+
+외부 활성 프로젝트의 현재 process baseline은 [`outcome-baseline.md`](../internal/outcome-baseline.md)에 시점 snapshot으로 남긴다. 재현기는 기존 fleet 집계기를 재사용한다.
+
+```sh
+python3 "$DCN"/harness/outcome_scorecard.py --redact-paths
+python3 "$DCN"/harness/outcome_scorecard.py --redact-paths --json
+```
+
+이 명령이 출력하는 제품 outcome과 Agent effectiveness의 `측정 불가`는 실패 판정이 아니라 해당 증거가 아직 ledger에 없다는 뜻이다.
+시점 snapshot을 고정할 때는 `--measured-at <ISO-8601>`과 `--as-of <ISO-8601>`을 함께 쓰고, baseline에 포함한 stable ref마다 `--source-ref <ref>`를 반복한다. cutoff는 기존 run에 나중에 append된 event도 제외하고, source ref 고정은 registry 순서 변경이나 새 프로젝트 추가가 과거 source 집합을 바꾸지 못하게 한다. 고정한 ref가 registry에서 사라지거나 해당 runtime ledger를 읽을 수 없으면 재현기는 조용히 분모를 줄이지 않고 오류로 종료한다.

--- a/harness/benchmark_aggregate.py
+++ b/harness/benchmark_aggregate.py
@@ -35,6 +35,7 @@ import re
 import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -115,6 +116,7 @@ class FleetReport:
     pr_merge_orphan_count: int
     pr_merge_success_ratio: Optional[float]
     waste_top: list  # [(pattern, count), ...] count desc
+    waste_counts: dict  # complete, untruncated pattern -> count mapping
     success_measurable: bool
     recurrence_threshold: int
     improvement_candidates: list[ImprovementCandidate]
@@ -179,12 +181,32 @@ def _pr_event_key(event: dict, run_dir: Path, index: int) -> str:
     return f"event:{run_dir}:{index}"
 
 
-def _run_event_counts(run_dir: Path) -> tuple[int, set[str], set[str]]:
+def _event_at_or_before(event: dict, cutoff: Optional[datetime]) -> bool:
+    if cutoff is None:
+        return True
+    value = event.get("ts")
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc) <= cutoff.astimezone(timezone.utc)
+
+
+def _run_event_counts(
+    run_dir: Path,
+    event_cutoff: Optional[datetime] = None,
+) -> tuple[int, set[str], set[str]]:
     """(blocked 이벤트 수, pr_created keys, pr_merged keys) — 1회 스캔."""
     blocked = 0
     pr_created: set[str] = set()
     pr_merged: set[str] = set()
     for idx, ev in enumerate(ledger.read_events_at(run_dir)):
+        if not _event_at_or_before(ev, event_cutoff):
+            continue
         e = ev.get("event")
         if e == "blocked":
             blocked += 1
@@ -201,6 +223,7 @@ def aggregate_runs(
     top: int = 10,
     recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
     repo_override=None,
+    event_cutoff: Optional[datetime] = None,
 ) -> FleetReport:
     """run_dir 목록을 fleet 집계한다.
 
@@ -233,7 +256,7 @@ def aggregate_runs(
         if ep:
             by_entry_point[ep] += 1
 
-        blocked, created, merged = _run_event_counts(run_dir)
+        blocked, created, merged = _run_event_counts(run_dir, event_cutoff)
         blocked_event_count += blocked
         pr_created_keys.update(created)
         pr_merged_keys.update(merged)
@@ -242,7 +265,11 @@ def aggregate_runs(
         # detect_wastes 를 per-run review 와 동일하게 수행. 수동 parse_steps +
         # detect_wastes 만 하면 invocation 의존 waste(END_STEP_SKIP 등)가 누락된다.
         repo_path = repo_override or _repo_path_for_run(run_dir) or run_dir
-        report = run_review.build_report(run_dir, Path(repo_path))
+        report = run_review.build_report(
+            run_dir,
+            Path(repo_path),
+            event_cutoff=event_cutoff,
+        )
         for s in report.steps:
             verdict = _step_verdict(s)
             if verdict:
@@ -285,6 +312,7 @@ def aggregate_runs(
         pr_merge_orphan_count=pr_merge_orphan_count,
         pr_merge_success_ratio=pr_merge_success_ratio,
         waste_top=waste_counter.most_common(top),
+        waste_counts=dict(waste_counter),
         success_measurable=pr_merge_success_ratio is not None,
         recurrence_threshold=recurrence_threshold,
         improvement_candidates=_build_improvement_candidates(
@@ -298,7 +326,8 @@ def aggregate_runs(
 def aggregate_sessions(sessions_root, *, entry_point: Optional[str] = None,
                        top: int = 10,
                        recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
-                       repo_override=None) -> FleetReport:
+                       repo_override=None,
+                       event_cutoff: Optional[datetime] = None) -> FleetReport:
     """sessions-root 아래 모든 run 을 집계한다. entry_point 지정 시 그 진입점만."""
     sessions_root = Path(sessions_root)
     run_dirs = run_review.list_runs(sessions_root)
@@ -309,6 +338,7 @@ def aggregate_sessions(sessions_root, *, entry_point: Optional[str] = None,
         top=top,
         recurrence_threshold=recurrence_threshold,
         repo_override=repo_override,
+        event_cutoff=event_cutoff,
     )
 
 
@@ -447,6 +477,7 @@ def main(argv: Optional[list] = None) -> int:
             "pr_merge_orphan_count": report.pr_merge_orphan_count,
             "pr_merge_success_ratio": report.pr_merge_success_ratio,
             "waste_top": report.waste_top,
+            "waste_counts": report.waste_counts,
             "success_measurable": report.success_measurable,
             "recurrence_threshold": report.recurrence_threshold,
             "improvement_candidates": [

--- a/harness/outcome_scorecard.py
+++ b/harness/outcome_scorecard.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Cross-project process/effectiveness/product-outcome scorecard.
+
+The current run ledger can reproduce process evidence. It does not contain enough
+information to synthesize product outcomes, agent-effectiveness outcomes, or complete
+trial metadata, so those axes stay explicitly unmeasured until their own evidence is
+provided.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from harness import ledger, run_review  # noqa: E402
+from harness.benchmark_aggregate import FleetReport, aggregate_runs  # noqa: E402
+
+
+DEFAULT_PROJECTS_FILE = (
+    Path.home() / ".claude" / "plugins" / "data" / "dcness-dcness" / "projects.json"
+)
+UNMEASURED = "측정 불가"
+
+
+class SourceRefNotFound(ValueError):
+    def __init__(self, missing: list[str]) -> None:
+        self.missing = missing
+        super().__init__(f"source ref not found: {', '.join(missing)}")
+
+
+class SourceDataUnavailable(ValueError):
+    def __init__(self, unavailable: list[str]) -> None:
+        self.unavailable = unavailable
+        super().__init__(f"source data unavailable: {', '.join(unavailable)}")
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_ts(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_projects(path: Path) -> list[Path]:
+    try:
+        payload = json.loads(path.expanduser().read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    raw_projects = payload.get("projects") if isinstance(payload, dict) else None
+    if not isinstance(raw_projects, list):
+        return []
+
+    projects: list[Path] = []
+    seen: set[str] = set()
+    for raw in raw_projects:
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        try:
+            project = Path(raw).expanduser().resolve()
+        except (OSError, ValueError):
+            continue
+        key = str(project)
+        if key in seen:
+            continue
+        seen.add(key)
+        projects.append(project)
+    return projects
+
+
+def _source_ref(project: Path) -> str:
+    digest = hashlib.sha256(str(project).encode("utf-8")).hexdigest()[:10]
+    return f"source-{digest}"
+
+
+def _candidate_run_dirs(sessions_root: Path) -> list[Path]:
+    if not sessions_root.is_dir():
+        return []
+    candidates: set[Path] = set()
+    for filename in ("ledger.jsonl", ".steps.jsonl"):
+        for path in sessions_root.glob(f"*/runs/*/{filename}"):
+            candidates.add(path.parent)
+    return sorted(candidates)
+
+
+def _run_event_times(run_dir: Path) -> list[datetime]:
+    values = [
+        parsed
+        for event in ledger.read_events_at(run_dir)
+        if (parsed := _parse_ts(event.get("ts"))) is not None
+    ]
+    if values or not (run_dir / ".steps.jsonl").is_file():
+        return values
+    try:
+        lines = (run_dir / ".steps.jsonl").read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return []
+    for line in lines:
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict) and (parsed := _parse_ts(row.get("ts"))) is not None:
+            values.append(parsed)
+    return values
+
+
+def _started_by(run_dir: Path, cutoff: Optional[datetime]) -> bool:
+    if cutoff is None:
+        return True
+    times = _run_event_times(run_dir)
+    return bool(times) and min(times) <= cutoff
+
+
+def _finished_by(run_dir: Path, cutoff: Optional[datetime]) -> bool:
+    if cutoff is None:
+        return True
+    events = ledger.read_events_at(run_dir)
+    finished = [
+        parsed
+        for event in events
+        if event.get("event") == "run_finished"
+        if (parsed := _parse_ts(event.get("ts"))) is not None
+    ]
+    if finished:
+        return any(parsed <= cutoff for parsed in finished)
+    times = _run_event_times(run_dir)
+    # Legacy .steps.jsonl has no run_finished marker: every readable step receipt is
+    # historically a finished-run signal. Later appends must not remove the earlier
+    # snapshot; parse_steps(event_cutoff=...) filters the post-cutoff rows themselves.
+    return any(parsed <= cutoff for parsed in times)
+
+
+def _metric(
+    *,
+    measured_at: str,
+    source_project_count: int,
+    numerator: int,
+    denominator: int,
+    value: Any,
+    unit: str,
+    evidence: str,
+    measurable: bool = True,
+) -> dict[str, Any]:
+    return {
+        "status": "관측" if measurable else UNMEASURED,
+        "value": value if measurable else None,
+        "numerator": numerator,
+        "denominator": denominator,
+        "unit": unit,
+        "source_project_count": source_project_count,
+        "measured_at": measured_at,
+        "evidence": evidence,
+    }
+
+
+def _fleet_json(report: FleetReport) -> dict[str, Any]:
+    return {
+        "run_count": report.run_count,
+        "by_entry_point": report.by_entry_point,
+        "agent_conclusions": report.agent_conclusions,
+        "pr_reviewer_rejection_count": report.pr_reviewer_rejection_count,
+        "pr_reviewer_review_count": report.pr_reviewer_review_count,
+        "pr_created_count": report.pr_created_count,
+        "pr_merge_success_count": report.pr_merge_success_count,
+        "pr_merged_count": report.pr_merged_count,
+        "blocked_event_count": report.blocked_event_count,
+        "waste_top": report.waste_top,
+        "waste_counts": report.waste_counts,
+    }
+
+
+def build_scorecard(
+    projects_file: Path | str = DEFAULT_PROJECTS_FILE,
+    *,
+    measured_at: Optional[str] = None,
+    as_of: Optional[str] = None,
+    source_refs: Optional[list[str]] = None,
+    redact_paths: bool = False,
+) -> dict[str, Any]:
+    """Aggregate finished runs from every configured project with observable data."""
+    measured_at = measured_at or _now_iso()
+    cutoff = _parse_ts(as_of)
+    if as_of and cutoff is None:
+        raise ValueError(f"invalid --as-of timestamp: {as_of}")
+    projects_file = Path(projects_file).expanduser().resolve()
+    configured = _load_projects(projects_file)
+    configured_with_refs = [(_source_ref(project), project) for project in configured]
+    if source_refs is not None:
+        requested = list(dict.fromkeys(source_refs))
+        by_ref = {source_ref: project for source_ref, project in configured_with_refs}
+        missing = [source_ref for source_ref in requested if source_ref not in by_ref]
+        if missing:
+            raise SourceRefNotFound(missing)
+        selected = [(source_ref, by_ref[source_ref]) for source_ref in requested]
+    else:
+        selected = configured_with_refs
+    registry_indexes = {
+        source_ref: index
+        for index, (source_ref, _project) in enumerate(configured_with_refs, start=1)
+    }
+
+    sources: list[dict[str, Any]] = []
+    fleets: list[FleetReport] = []
+    candidate_run_count = 0
+    unavailable_sources: list[str] = []
+    for source_ref, project in selected:
+        index = registry_indexes[source_ref]
+        sessions_root = project / ".claude" / "harness-state" / ".sessions"
+        candidate_dirs = [
+            run_dir
+            for run_dir in _candidate_run_dirs(sessions_root)
+            if _started_by(run_dir, cutoff)
+        ]
+        if not candidate_dirs:
+            if source_refs is not None:
+                unavailable_sources.append(source_ref)
+            continue
+        finished_dirs = [
+            run_dir
+            for run_dir in run_review.list_runs(sessions_root)
+            if _finished_by(run_dir, cutoff)
+        ]
+        fleet = aggregate_runs(finished_dirs, event_cutoff=cutoff)
+        if fleet.run_count == 0:
+            if source_refs is not None:
+                unavailable_sources.append(source_ref)
+            continue
+        candidates = len(candidate_dirs)
+        candidate_run_count += candidates
+        fleets.append(fleet)
+        source = {
+            "source_ref": source_ref,
+            "projects_file_index": index,
+            "source_location": f"active-project registry entry #{index}",
+            "candidate_run_count": candidates,
+            "finished_run_count": fleet.run_count,
+            "fleet": _fleet_json(fleet),
+        }
+        if not redact_paths:
+            source["project_path"] = str(project)
+            source["sessions_root"] = str(sessions_root)
+        sources.append(source)
+
+    if unavailable_sources:
+        raise SourceDataUnavailable(unavailable_sources)
+
+    source_count = len(sources)
+    finished_runs = sum(fleet.run_count for fleet in fleets)
+    pr_created = sum(fleet.pr_created_count for fleet in fleets)
+    pr_merged = sum(fleet.pr_merge_success_count for fleet in fleets)
+    review_rejections = sum(fleet.pr_reviewer_rejection_count for fleet in fleets)
+    review_verdicts = sum(fleet.pr_reviewer_review_count for fleet in fleets)
+    blocked_events = sum(fleet.blocked_event_count for fleet in fleets)
+
+    conclusions: dict[str, Counter[str]] = defaultdict(Counter)
+    waste: Counter[str] = Counter()
+    for fleet in fleets:
+        for agent, distribution in fleet.agent_conclusions.items():
+            conclusions[agent].update(distribution)
+        waste.update(fleet.waste_counts)
+    validator_conclusions = {
+        agent: dict(sorted(distribution.items()))
+        for agent, distribution in sorted(conclusions.items())
+        if agent.endswith("validator")
+    }
+    validator_verdict_count = sum(
+        sum(distribution.values()) for distribution in validator_conclusions.values()
+    )
+    waste_count = sum(waste.values())
+
+    process = {
+        "finished_runs": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=finished_runs,
+            denominator=candidate_run_count,
+            value=(finished_runs / candidate_run_count if candidate_run_count else None),
+            unit="finished runs / candidate run directories",
+            evidence="run_finished plus a valid readable receipt",
+            measurable=candidate_run_count > 0,
+        ),
+        "pr_merge_success": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=pr_merged,
+            denominator=pr_created,
+            value=(pr_merged / pr_created if pr_created else None),
+            unit="matching pr_merged / pr_created",
+            evidence="PR lifecycle events; orphan merges never enter the numerator",
+            measurable=pr_created > 0,
+        ),
+        "blocked_events": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=blocked_events,
+            denominator=finished_runs,
+            value=(blocked_events / finished_runs if finished_runs else None),
+            unit="blocked events / finished-run exposure",
+            evidence="blocked lifecycle events at or before the snapshot cutoff",
+            measurable=finished_runs > 0,
+        ),
+        "guard_results": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=0,
+            denominator=0,
+            value=None,
+            unit="guard results / eligible guard executions",
+            evidence="guard telemetry is not part of the selected ledger baseline",
+            measurable=False,
+        ),
+        "regressions": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=0,
+            denominator=0,
+            value=None,
+            unit="product regressions / repeated product journeys",
+            evidence="repeated product-journey evidence is absent from the ledger",
+            measurable=False,
+        ),
+        "impl_validator_rework": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=review_rejections,
+            denominator=review_verdicts,
+            value=(review_rejections / review_verdicts if review_verdicts else None),
+            unit="FAIL / impl-validator review verdicts",
+            evidence="impl-validator conclusion prose or compatible legacy verdict",
+            measurable=review_verdicts > 0,
+        ),
+        "validator_verdicts": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=validator_verdict_count,
+            denominator=finished_runs,
+            value=validator_conclusions,
+            unit="validator conclusions over finished-run exposure",
+            evidence="validator step conclusion distribution",
+            measurable=finished_runs > 0,
+        ),
+        "waste_signals": _metric(
+            measured_at=measured_at,
+            source_project_count=source_count,
+            numerator=waste_count,
+            denominator=finished_runs,
+            value=dict(waste.most_common()),
+            unit="waste findings over finished-run exposure",
+            evidence="run_review waste detector reused by benchmark_aggregate",
+            measurable=finished_runs > 0,
+        ),
+    }
+
+    unmeasured_context = {
+        "status": UNMEASURED,
+        "source_project_count": source_count,
+        "measured_at": measured_at,
+        "as_of": as_of,
+    }
+    return {
+        "measured_at": measured_at,
+        "as_of": as_of,
+        "projects_file": (
+            "active-project registry (path redacted)"
+            if redact_paths
+            else str(projects_file)
+        ),
+        "configured_project_count": len(configured),
+        "source_project_count": source_count,
+        "sources": sources,
+        "process_evidence": process,
+        "agent_effectiveness": {
+            **unmeasured_context,
+            "reason": (
+                "현재 ledger는 SSOT·entrypoint·owner 탐색 정확도, 첫 올바른 대상까지의 "
+                "비용, 오경로, 영향 누락, context 기인 재작업, cross-session 복구를 "
+                "비교 가능한 trial로 기록하지 않는다."
+            ),
+        },
+        "product_outcome": {
+            **unmeasured_context,
+            "reason": (
+                "현재 ledger에는 실행된 제품 AC 또는 사용자 journey 결과가 없다. "
+                "guard·validator·PR evidence는 이를 대체하지 않는다."
+            ),
+        },
+        "trial_metadata": {
+            **unmeasured_context,
+            "reason": (
+                "legacy run은 task/repo 유형, model/provider, harness variant, trial "
+                "identity, 사람 개입, wall-clock, token, cost를 하나의 비교 가능한 "
+                "record로 일관되게 보존하지 않는다."
+            ),
+        },
+        "claim_boundaries": {
+            "personal_screening": (
+                "같은 task/fixture의 1+1 paired screening은 개인 keep/remove/hold "
+                "판단에만 사용할 수 있다."
+            ),
+            "public_superiority": (
+                "최소 2개 source 프로젝트, 총 20개 finished run, 지표별 명시적 "
+                "denominator, 비교 variant별 반복 trial이 필요하며 1+1 결과만으로는 "
+                "주장할 수 없다."
+            ),
+        },
+    }
+
+
+def _ratio_cell(metric: dict[str, Any]) -> str:
+    numerator = int(metric.get("numerator") or 0)
+    denominator = int(metric.get("denominator") or 0)
+    if metric.get("status") == UNMEASURED:
+        return f"{UNMEASURED} ({numerator}/{denominator})"
+    value = metric.get("value")
+    if isinstance(value, float):
+        return f"{value * 100:.1f}% ({numerator}/{denominator})"
+    return f"{numerator}/{denominator}"
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines = [
+        "# Cross-project outcome scorecard",
+        "",
+        f"- 측정 시각: `{report['measured_at']}`",
+        f"- 관측 cutoff: `{report.get('as_of') or '없음 (현재 전체)'}`",
+        f"- source 프로젝트: {report['source_project_count']}",
+        f"- 활성 registry 항목: {report['configured_project_count']}",
+        f"- 원천 registry: `{report['projects_file']}`",
+        "",
+        "## 과정·merge 지표",
+        "",
+        "| 지표 | 값 (분자/분모) | source 수 | 측정일 |",
+        "|---|---|---:|---|",
+    ]
+    labels = {
+        "finished_runs": "완료 run 포함률",
+        "pr_merge_success": "PR merge 성공률",
+        "blocked_events": "blocked event 노출률",
+        "guard_results": "guard 결과",
+        "regressions": "제품 regression",
+        "impl_validator_rework": "impl-validator 재작업률",
+        "validator_verdicts": "validator verdict 분포",
+        "waste_signals": "waste 신호",
+    }
+    for key, metric in report["process_evidence"].items():
+        value = _ratio_cell(metric)
+        if isinstance(metric.get("value"), dict):
+            details = json.dumps(metric["value"], ensure_ascii=False, sort_keys=True)
+            value = f"{value}; `{details}`"
+        lines.append(
+            f"| {labels[key]} | {value} | {metric['source_project_count']} | "
+            f"`{metric['measured_at']}` |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "과정 지표는 하네스·리뷰·PR 흐름의 관측값이다. 제품 성공률이 아니다.",
+            "",
+            "## Agent effectiveness",
+            "",
+            f"- 상태: **{report['agent_effectiveness']['status']}**",
+            f"- 이유: {report['agent_effectiveness']['reason']}",
+            "",
+            "## 실제 제품 outcome",
+            "",
+            f"- 상태: **{report['product_outcome']['status']}**",
+            f"- 이유: {report['product_outcome']['reason']}",
+            "",
+            "## Trial metadata",
+            "",
+            f"- 상태: **{report['trial_metadata']['status']}**",
+            f"- 이유: {report['trial_metadata']['reason']}",
+            "",
+            "## 주장 가능 범위",
+            "",
+            f"- 개인 판단: {report['claim_boundaries']['personal_screening']}",
+            f"- 공개 우위: {report['claim_boundaries']['public_superiority']}",
+            "",
+            "## 원천",
+            "",
+            "| source | registry 위치 | finished/candidate |",
+            "|---|---|---:|",
+        ]
+    )
+    for source in report["sources"]:
+        lines.append(
+            f"| `{source['source_ref']}` | {source['source_location']} | "
+            f"{source['finished_run_count']}/{source['candidate_run_count']} |"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="active projects의 process/effectiveness/product outcome scorecard"
+    )
+    parser.add_argument(
+        "--projects-file",
+        default=str(DEFAULT_PROJECTS_FILE),
+        help="active projects registry JSON",
+    )
+    parser.add_argument(
+        "--measured-at",
+        default=None,
+        help="reproducible snapshot timestamp (ISO-8601; default: now UTC)",
+    )
+    parser.add_argument(
+        "--as-of",
+        default=None,
+        help="이 시각 이하에서 시작·완료된 run만 포함하는 snapshot cutoff",
+    )
+    parser.add_argument(
+        "--source-ref",
+        action="append",
+        default=None,
+        help="registry reorder/addition과 무관하게 포함할 stable source ref (repeatable)",
+    )
+    parser.add_argument(
+        "--redact-paths",
+        action="store_true",
+        help="project and registry absolute paths를 stable source ref로 대체",
+    )
+    parser.add_argument("--json", action="store_true", help="JSON 출력")
+    args = parser.parse_args(argv)
+
+    try:
+        report = build_scorecard(
+            args.projects_file,
+            measured_at=args.measured_at,
+            as_of=args.as_of,
+            source_refs=args.source_ref,
+            redact_paths=args.redact_paths,
+        )
+    except SourceRefNotFound as exc:
+        print(json.dumps(
+            {"error": "source_ref_not_found", "missing": exc.missing},
+            ensure_ascii=False,
+        ))
+        return 2
+    except SourceDataUnavailable as exc:
+        print(json.dumps(
+            {"error": "source_data_unavailable", "unavailable": exc.unavailable},
+            ensure_ascii=False,
+        ))
+        return 2
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(render_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -737,12 +737,23 @@ def _extract_conclusion_enum(prose: str) -> str:
     return ""
 
 
-def parse_steps(run_dir: Path) -> list[StepRecord]:
+def parse_steps(
+    run_dir: Path,
+    *,
+    event_cutoff: Optional[datetime] = None,
+) -> list[StepRecord]:
     # 이슈 #587 — ledger.jsonl 의 step_completed event 읽기 (옛 .steps.jsonl 폴백 내장).
     from harness import ledger
 
     steps: list[StepRecord] = []
     raw = ledger.read_step_completed_at(run_dir)
+    if event_cutoff is not None:
+        raw = [
+            rec
+            for rec in raw
+            if (parsed := _parse_iso(rec.get("ts", ""))) is not None
+            and parsed <= event_cutoff
+        ]
     if not raw:
         return steps
 
@@ -1678,8 +1689,9 @@ def build_report(
     *,
     include_recurrence: bool = False,
     recurrence_threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+    event_cutoff: Optional[datetime] = None,
 ) -> RunReport:
-    steps = parse_steps(run_dir)
+    steps = parse_steps(run_dir, event_cutoff=event_cutoff)
 
     # DCN-CHG-20260430-20: per-Agent invocation 매칭 — wastes 탐지 *전*에 enrichment.
     invocations: list[dict] = []

--- a/tests/test_benchmark_aggregate.py
+++ b/tests/test_benchmark_aggregate.py
@@ -356,6 +356,41 @@ class TestWasteTop(unittest.TestCase):
             rep = aggregate_runs([r])
             self.assertIsInstance(rep.waste_top, list)
 
+    def test_full_waste_counts_are_not_truncated_by_display_top_limit(self):
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            retry = _make_run_dir_ledger(
+                tmp,
+                "s1",
+                "run-wfull001",
+                _run_events(
+                    "impl",
+                    [
+                        _step("impl-validator", "v.md", enum="FAIL"),
+                        _step(
+                            "impl-validator",
+                            "v.md",
+                            enum="FAIL",
+                            ts="2026-06-01T00:02:00Z",
+                        ),
+                    ],
+                ),
+                {"v.md": "동일 실패 반복\nFAIL\n"},
+            )
+            missing = _make_run_dir_ledger(
+                tmp,
+                "s1",
+                "run-wfull002",
+                _run_events("impl", [_step("engineer", "e.md")]),
+                {"e.md": "결론 enum이 없는 보고\n"},
+            )
+
+            report = aggregate_runs([retry, missing], top=1)
+
+            self.assertEqual(len(report.waste_top), 1)
+            self.assertIn("RETRY_SAME_FAIL", report.waste_counts)
+            self.assertIn("MISSING_CONCLUSION_ENUM", report.waste_counts)
+
 
 class TestImprovementCandidates(unittest.TestCase):
     def _run_with_retry_waste(self, tmp: Path, rid: str) -> Path:

--- a/tests/test_outcome_scorecard.py
+++ b/tests/test_outcome_scorecard.py
@@ -1,0 +1,415 @@
+"""Cross-project outcome scorecard contract and aggregation tests."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from harness import ledger
+from harness.outcome_scorecard import (
+    SourceDataUnavailable,
+    build_scorecard,
+    main,
+    render_markdown,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_run(
+    project: Path,
+    run_id: str,
+    *,
+    verdict: str,
+    finished: bool = True,
+    pr_number: int | None = None,
+    date: str = "2026-07-01",
+    blocked: bool = False,
+    future_pr_number: int | None = None,
+    future_verdict: str | None = None,
+) -> None:
+    run_dir = (
+        project
+        / ".claude"
+        / "harness-state"
+        / ".sessions"
+        / "session-1"
+        / "runs"
+        / run_id
+    )
+    run_dir.mkdir(parents=True, exist_ok=True)
+    prose = f"독립 검토 결과\n{verdict}\n"
+    prose_path = run_dir / "impl-validator.md"
+    prose_path.write_text(prose, encoding="utf-8")
+    events = [
+        {
+            "event": "run_started",
+            "entry_point": "impl",
+            "ts": f"{date}T00:00:00Z",
+        },
+        {
+            "event": "step_completed",
+            "agent": "impl-validator",
+            "enum": "PROSE_LOGGED",
+            "prose_file": str(prose_path),
+            "sha256": ledger.sha256_text(prose),
+            "ts": f"{date}T00:01:00Z",
+        },
+    ]
+    if pr_number is not None:
+        url = f"https://example.invalid/repo/pull/{pr_number}"
+        events.extend(
+            [
+                {
+                    "event": "pr_created",
+                    "pr_number": pr_number,
+                    "url": url,
+                    "ts": f"{date}T00:02:00Z",
+                },
+                {
+                    "event": "pr_merged",
+                    "pr_number": pr_number,
+                    "url": url,
+                    "ts": f"{date}T00:03:00Z",
+                },
+            ]
+        )
+    if blocked:
+        events.append(
+            {"event": "blocked", "reason": "fixture", "ts": f"{date}T00:03:30Z"}
+        )
+    if finished:
+        events.append({"event": "run_finished", "ts": f"{date}T00:04:00Z"})
+    if future_pr_number is not None:
+        future_url = f"https://example.invalid/repo/pull/{future_pr_number}"
+        events.extend(
+            [
+                {
+                    "event": "pr_created",
+                    "pr_number": future_pr_number,
+                    "url": future_url,
+                    "ts": "2026-07-12T00:02:00Z",
+                },
+                {
+                    "event": "pr_merged",
+                    "pr_number": future_pr_number,
+                    "url": future_url,
+                    "ts": "2026-07-12T00:03:00Z",
+                },
+            ]
+        )
+    if future_verdict is not None:
+        future_prose = f"cutoff 이후 독립 검토\n{future_verdict}\n"
+        future_prose_path = run_dir / "impl-validator-future.md"
+        future_prose_path.write_text(future_prose, encoding="utf-8")
+        events.append(
+            {
+                "event": "step_completed",
+                "agent": "impl-validator",
+                "enum": "PROSE_LOGGED",
+                "prose_file": str(future_prose_path),
+                "sha256": ledger.sha256_text(future_prose),
+                "ts": "2026-07-12T00:05:00Z",
+            }
+        )
+    with (run_dir / "ledger.jsonl").open("w", encoding="utf-8") as stream:
+        for event in events:
+            stream.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+
+class OutcomeScorecardAggregationTests(unittest.TestCase):
+    def _fixture(self, root: Path) -> Path:
+        project_a = root / "private-project-a"
+        project_b = root / "private-project-b"
+        empty = root / "empty-project"
+        for project in (project_a, project_b, empty):
+            project.mkdir()
+        _write_run(
+            project_a,
+            "run-a0000001",
+            verdict="FAIL",
+            blocked=True,
+            future_pr_number=9,
+            future_verdict="PASS",
+        )
+        _write_run(project_a, "run-a0000002", verdict="PASS", finished=False)
+        _write_run(project_b, "run-b0000001", verdict="PASS", pr_number=7)
+        _write_run(
+            project_b,
+            "run-future01",
+            verdict="FAIL",
+            pr_number=8,
+            date="2026-07-12",
+        )
+        projects_file = root / "projects.json"
+        projects_file.write_text(
+            json.dumps(
+                {"version": 1, "projects": [str(project_a), str(project_b), str(empty)]}
+            ),
+            encoding="utf-8",
+        )
+        return projects_file
+
+    def test_cross_project_report_preserves_denominators_and_unmeasured_axes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            projects_file = self._fixture(Path(directory))
+            report = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                redact_paths=True,
+            )
+
+        self.assertEqual(report["source_project_count"], 2)
+        self.assertEqual(report["configured_project_count"], 3)
+        process = report["process_evidence"]
+        self.assertEqual(process["finished_runs"]["numerator"], 2)
+        self.assertEqual(process["finished_runs"]["denominator"], 3)
+        self.assertEqual(process["pr_merge_success"]["numerator"], 1)
+        self.assertEqual(process["pr_merge_success"]["denominator"], 1)
+        self.assertEqual(process["impl_validator_rework"]["numerator"], 1)
+        self.assertEqual(process["impl_validator_rework"]["denominator"], 2)
+        self.assertEqual(process["blocked_events"]["numerator"], 1)
+        self.assertEqual(process["blocked_events"]["denominator"], 2)
+        self.assertEqual(process["guard_results"]["status"], "측정 불가")
+        self.assertEqual(process["regressions"]["status"], "측정 불가")
+        for metric in process.values():
+            self.assertEqual(metric["source_project_count"], 2)
+            self.assertEqual(metric["measured_at"], "2026-07-11T00:00:00Z")
+
+        self.assertEqual(report["agent_effectiveness"]["status"], "측정 불가")
+        self.assertEqual(report["product_outcome"]["status"], "측정 불가")
+        self.assertEqual(report["trial_metadata"]["status"], "측정 불가")
+        serialized = json.dumps(report, ensure_ascii=False)
+        self.assertNotIn("private-project-a", serialized)
+        self.assertNotIn("private-project-b", serialized)
+
+    def test_pinned_source_refs_ignore_registry_reordering_and_new_projects(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            projects_file = self._fixture(root)
+            first = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                redact_paths=True,
+            )
+            pinned = [source["source_ref"] for source in first["sources"]]
+            registry = json.loads(projects_file.read_text(encoding="utf-8"))
+            new_project = root / "new-project"
+            new_project.mkdir()
+            _write_run(new_project, "run-new00001", verdict="FAIL", pr_number=10)
+            registry["projects"] = [
+                str(new_project),
+                registry["projects"][1],
+                registry["projects"][0],
+                registry["projects"][2],
+            ]
+            projects_file.write_text(json.dumps(registry), encoding="utf-8")
+
+            replay = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                source_refs=pinned,
+                redact_paths=True,
+            )
+
+        self.assertEqual(replay["source_project_count"], 2)
+        self.assertEqual(
+            replay["process_evidence"]["pr_merge_success"]["numerator"], 1
+        )
+        self.assertEqual(
+            {source["source_ref"] for source in replay["sources"]}, set(pinned)
+        )
+
+    def test_pinned_source_fails_closed_when_registered_runtime_data_disappears(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            projects_file = self._fixture(root)
+            first = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                redact_paths=True,
+            )
+            pinned = [source["source_ref"] for source in first["sources"]]
+            shutil.rmtree(
+                root
+                / "private-project-a"
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+            )
+
+            with self.assertRaises(SourceDataUnavailable) as raised:
+                build_scorecard(
+                    projects_file,
+                    measured_at="2026-07-11T00:00:00Z",
+                    as_of="2026-07-11T00:00:00Z",
+                    source_refs=pinned,
+                    redact_paths=True,
+                )
+
+        self.assertEqual(raised.exception.unavailable, [pinned[0]])
+
+    def test_legacy_run_replay_ignores_steps_appended_after_cutoff(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "legacy-project"
+            run_dir = (
+                project
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "session-1"
+                / "runs"
+                / "run-legacy01"
+            )
+            run_dir.mkdir(parents=True)
+            steps_file = run_dir / ".steps.jsonl"
+            before = {
+                "agent": "impl-validator",
+                "enum": "PASS",
+                "ts": "2026-07-01T00:01:00Z",
+            }
+            after = {
+                "agent": "impl-validator",
+                "enum": "FAIL",
+                "ts": "2026-07-12T00:01:00Z",
+            }
+            steps_file.write_text(json.dumps(before) + "\n", encoding="utf-8")
+            projects_file = root / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(project)]}),
+                encoding="utf-8",
+            )
+            initial = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                redact_paths=True,
+            )
+            with steps_file.open("a", encoding="utf-8") as stream:
+                stream.write(json.dumps(after) + "\n")
+
+            replay = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                source_refs=[initial["sources"][0]["source_ref"]],
+                redact_paths=True,
+            )
+
+        self.assertEqual(replay["process_evidence"]["finished_runs"]["numerator"], 1)
+        self.assertEqual(
+            replay["sources"][0]["fleet"]["agent_conclusions"],
+            initial["sources"][0]["fleet"]["agent_conclusions"],
+        )
+
+    def test_markdown_separates_process_effectiveness_and_product_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            report = build_scorecard(
+                self._fixture(Path(directory)),
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                redact_paths=True,
+            )
+        markdown = render_markdown(report)
+        for heading in (
+            "## 과정·merge 지표",
+            "## Agent effectiveness",
+            "## 실제 제품 outcome",
+            "## 주장 가능 범위",
+        ):
+            self.assertIn(heading, markdown)
+        self.assertIn("1/1", markdown)
+        self.assertIn("측정 불가", markdown)
+        self.assertIn("source 프로젝트: 2", markdown)
+        self.assertIn("2026-07-11T00:00:00Z", markdown)
+
+    def test_cli_emits_json_without_synthetic_outcome(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            projects_file = self._fixture(Path(directory))
+            output = io.StringIO()
+            with contextlib.redirect_stdout(output):
+                result = main(
+                    [
+                        "--projects-file",
+                        str(projects_file),
+                        "--measured-at",
+                        "2026-07-11T00:00:00Z",
+                        "--as-of",
+                        "2026-07-11T00:00:00Z",
+                        "--source-ref",
+                        "source-placeholder",
+                        "--redact-paths",
+                        "--json",
+                    ]
+                )
+        self.assertEqual(result, 2)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["error"], "source_ref_not_found")
+
+
+class OutcomeScorecardDocumentTests(unittest.TestCase):
+    def test_scorecard_contract_defines_required_axes_and_fields(self) -> None:
+        contract = (ROOT / "docs" / "plugin" / "outcome-scorecard.md").read_text(
+            encoding="utf-8"
+        )
+        for axis in ("과정·merge", "Agent effectiveness", "실제 제품 outcome"):
+            self.assertIn(axis, contract)
+        for field in (
+            "task 유형",
+            "repo 유형",
+            "model",
+            "provider",
+            "harness variant",
+            "trial",
+            "denominator",
+            "token",
+            "wall-clock",
+            "사람 개입",
+            "실행 증거 종류",
+        ):
+            self.assertIn(field, contract)
+        for effectiveness in (
+            "SSOT",
+            "runtime entrypoint",
+            "capability owner",
+            "첫 올바른 변경 대상",
+            "불필요한 파일 읽기",
+            "오경로",
+            "영향 범위 누락",
+            "context 기인 재작업",
+            "cross-session 복구",
+        ):
+            self.assertIn(effectiveness, contract)
+        self.assertIn("기능이 존재", contract)
+        self.assertIn("측정 불가", contract)
+        self.assertIn("1+1", contract)
+        self.assertIn("공개 우위", contract)
+
+    def test_baseline_records_reproduction_source_counts_and_limits(self) -> None:
+        baseline = (ROOT / "docs" / "internal" / "outcome-baseline.md").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("harness/outcome_scorecard.py", baseline)
+        self.assertIn("source 프로젝트 2", baseline)
+        self.assertIn("26/28", baseline)
+        self.assertIn("7/7", baseline)
+        self.assertIn("TOOL_REPEAT_HIGH", baseline)
+        self.assertIn("측정 불가", baseline)
+        self.assertNotIn("제품 성공률 100%", baseline)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1066

## 배경 및 문제

- 기존 ledger에는 finished run, validator, PR, waste 같은 과정 증거가 있었지만 제품 outcome 및 Agent effectiveness와 구분된 운영 baseline이 없었습니다.
- 관측하지 않은 값을 process 지표로 대신하거나 0으로 추정하지 않으면서, 외부 활성 프로젝트의 실제 데이터를 재현할 scorecard가 필요했습니다.

## 원인 (해당 시)

- 과정 증거와 제품 결과의 의미 계약, 공통 denominator, 고정 가능한 source/cutoff가 하나의 재현 경로로 연결돼 있지 않았습니다.

## 작업내용

- process·Agent effectiveness·실제 제품 outcome을 분리하고 공통 trial/denominator/evidence 필드를 정의했습니다.
- active-project registry의 finished run을 집계하는 `harness/outcome_scorecard.py`와 2026-07-11 운영 baseline을 추가했습니다.
- stable source ref와 event cutoff를 고정하고, source 또는 runtime ledger가 사라지면 분모를 조용히 축소하지 않고 실패하도록 했습니다.
- 기존 fleet 집계에 전체 waste 분포를 추가하고, legacy/ledger cutoff 및 source registry drift 회귀 테스트를 보강했습니다.

## 결정 근거

- guard·validator·PR merge는 과정 증거로만 유지하고 실제 제품 AC/journey가 없으면 product outcome을 `측정 불가`로 둡니다.
- 공개 우위 주장은 복수 프로젝트·명시 denominator·반복 trial·실제 product outcome이 모두 있을 때만 허용하고, 1+1 비교는 개인 screening으로 제한했습니다.
- baseline 재현은 source ref와 cutoff를 함께 고정해 registry 재정렬·추가 및 post-cutoff append가 과거 snapshot을 바꾸지 않도록 했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/outcome_scorecard.py`, `harness/benchmark_aggregate.py`, `harness/run_review.py`, `docs/plugin/**`는 plug-in 본체 경로이므로 사용자가 plug-in을 업데이트하면 활성 외부 프로젝트에서 직접 실행할 수 있습니다.
- `/init-dcness`가 사용자 저장소로 복사하는 파일은 추가하지 않았으므로 init deploy inventory 변경이나 재실행은 필요하지 않습니다.
- CLI는 active-project registry를 통해 외부 활성 프로젝트의 runtime ledger를 읽으며 dcNess self 저장소에만 고립되지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill, command, agent, gate를 추가하지 않았습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 — `python3.11 -m unittest discover -s tests -q < /dev/null` (1,865 tests)
- [x] 회귀 검증 — `python3.11 evals/guard_efficacy.py` (39/39), targeted 130 tests, ruff/mypy/Bandit, cross-ref/public-surface/doc-path/diff check

## 참고

- 고정 baseline 재현: source 2개, finished 26/28, measurable PR 7/7, blocked 0/26, validator verdict 33건, waste 57/26.
- 독립 Codex 2차 검토의 구체적 Must finding은 모두 회귀 테스트와 함께 수정했습니다. 최종 3차 호출은 Codex 사용 한도로 실행되지 않았으며 저장소 필수 gate에는 포함되지 않습니다.
