### PR TITLE
[issue-1073] eval claude -p 하네스 격리로 세션 baseline 43k→27k 낮춤

### DIFF
--- a/evals/run.sh
+++ b/evals/run.sh
@@ -110,10 +110,11 @@ for case_dir in "$ROOT"/evals/cases/*/; do
 
     # 하네스 무주입 격리 (#1073) — --safe-mode 가 CLAUDE.md·skills·hooks·MCP·user settings
     # customization 을 전부 끄고(OAuth 인증은 유지), --tools 가 도구 schema 를 제한한다.
-    # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 지침을 Read 하므로 --tools "Read" +
-    # --add-dir "$ROOT" 로 repo 접근만 유지한다. baseline 실측 43,455 → ~2,755.
+    # 검수자는 {{REPO_ROOT}} agent 지침을 Read 하고 일부 케이스는 {{CASE_DIR}} fixture 를
+    # 파일명 없이 열거(Glob)해야 하므로 --tools Read Glob + --add-dir "$ROOT"(지침) +
+    # --add-dir "$sandbox"(fixture) 로 repo·fixture 접근만 유지한다. baseline 43,455 → ~3,067.
     # (--bare 는 OAuth/keychain 을 못 읽어 "Not logged in" 이라 쓰지 않는다.)
-    if ! report="$(claude -p "$prompt" --model "$MODEL" --safe-mode --tools "Read" --add-dir "$ROOT" --add-dir "$sandbox" 2>/dev/null)"; then
+    if ! report="$(claude -p "$prompt" --model "$MODEL" --safe-mode --tools Read Glob --add-dir "$ROOT" --add-dir "$sandbox" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 검수 실행 실패"
       record_eval_result "failed" "report" "" "" 1 0 0 0
       continue

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -94,11 +94,6 @@ for case_dir in "$ROOT"/evals/cases/*/; do
   # 블라인드 보장 — fixture 만 sandbox 로 복사 (정답표/프롬프트 제외). sandbox 이름은
   # 케이스명을 포함하지 않는다 — 검수 agent 가 repo 의 정답표 경로를 역추적하지 못하게.
   sandbox="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-XXXXXX")"
-  # 하네스 무주입 격리 (#1073) — claude -p 를 CLAUDE.md 없는 빈 cwd 에서 실행해
-  # CLAUDE.md auto-discovery·hook·skills·tool schema 주입을 차단한다. 이 격리 없이
-  # repo cwd 에서 돌면 세션당 ~43k baseline 을 짊어져 fan-out 시 quota 를 폭식한다.
-  # --bare 는 구독 인증(OAuth/keychain)을 못 읽어 "Not logged in" 이므로 쓰지 않는다.
-  neutral_cwd="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-cwd-XXXXXX")"
   for f in "$case_path"/*; do
     base="$(basename "$f")"
     case "$base" in prompt.md | expected.md) continue ;; esac
@@ -113,9 +108,12 @@ for case_dir in "$ROOT"/evals/cases/*/; do
     report_file="$case_output/run-$i-report.md"
     judge_file="$case_output/run-$i-judge.md"
 
-    # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 지침을 Read 해야 하므로 --add-dir "$ROOT"
-    # 로 repo 접근만 유지하고, cwd 는 중립(CLAUDE.md 없음) 으로 둔다.
-    if ! report="$(cd "$neutral_cwd" && claude -p "$prompt" --model "$MODEL" --allowedTools "Read" --add-dir "$ROOT" --add-dir "$sandbox" 2>/dev/null)"; then
+    # 하네스 무주입 격리 (#1073) — --safe-mode 가 CLAUDE.md·skills·hooks·MCP·user settings
+    # customization 을 전부 끄고(OAuth 인증은 유지), --tools 가 도구 schema 를 제한한다.
+    # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 지침을 Read 하므로 --tools "Read" +
+    # --add-dir "$ROOT" 로 repo 접근만 유지한다. baseline 실측 43,455 → ~2,755.
+    # (--bare 는 OAuth/keychain 을 못 읽어 "Not logged in" 이라 쓰지 않는다.)
+    if ! report="$(claude -p "$prompt" --model "$MODEL" --safe-mode --tools "Read" --add-dir "$ROOT" --add-dir "$sandbox" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 검수 실행 실패"
       record_eval_result "failed" "report" "" "" 1 0 0 0
       continue
@@ -134,8 +132,10 @@ $expected
 [검수 보고]
 $report"
 
-    # 채점자는 정답표+보고가 프롬프트에 인라인 — repo 접근 0 필요. 도구까지 제거해 최소화.
-    if ! grade="$(cd "$neutral_cwd" && claude -p "$judge_prompt" --model "$MODEL" --allowedTools "" 2>/dev/null)"; then
+    # 채점자는 정답표+보고가 프롬프트에 인라인 — repo 접근 0 필요. --safe-mode + --tools ""
+    # 로 customization·도구를 전부 끈다. baseline 실측 43,455 → ~1,857.
+    # (--allowedTools "" 는 permission 만 비우고 tool schema 는 남으므로 쓰지 않는다.)
+    if ! grade="$(claude -p "$judge_prompt" --model "$MODEL" --safe-mode --tools "" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 채점 실행 실패"
       report_chars="${#report}"
       report_bytes="$(byte_len "$report")"
@@ -164,7 +164,7 @@ $report"
     fi
   done
 
-  rm -rf "$sandbox" "$neutral_cwd"
+  rm -rf "$sandbox"
   echo "[eval] $case_name — 정답 $pass/$RUNS"
   [ "$pass" -gt 0 ] || overall_fail=1
   if [ "$RELEASE_CHECK" = "1" ] && is_strict_case "$case_name" && [ "$pass" -ne "$RUNS" ]; then

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -94,6 +94,11 @@ for case_dir in "$ROOT"/evals/cases/*/; do
   # 블라인드 보장 — fixture 만 sandbox 로 복사 (정답표/프롬프트 제외). sandbox 이름은
   # 케이스명을 포함하지 않는다 — 검수 agent 가 repo 의 정답표 경로를 역추적하지 못하게.
   sandbox="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-XXXXXX")"
+  # 하네스 무주입 격리 (#1073) — claude -p 를 CLAUDE.md 없는 빈 cwd 에서 실행해
+  # CLAUDE.md auto-discovery·hook·skills·tool schema 주입을 차단한다. 이 격리 없이
+  # repo cwd 에서 돌면 세션당 ~43k baseline 을 짊어져 fan-out 시 quota 를 폭식한다.
+  # --bare 는 구독 인증(OAuth/keychain)을 못 읽어 "Not logged in" 이므로 쓰지 않는다.
+  neutral_cwd="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-cwd-XXXXXX")"
   for f in "$case_path"/*; do
     base="$(basename "$f")"
     case "$base" in prompt.md | expected.md) continue ;; esac
@@ -108,7 +113,9 @@ for case_dir in "$ROOT"/evals/cases/*/; do
     report_file="$case_output/run-$i-report.md"
     judge_file="$case_output/run-$i-judge.md"
 
-    if ! report="$(claude -p "$prompt" --model "$MODEL" --allowedTools "Read" --add-dir "$sandbox" 2>/dev/null)"; then
+    # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 지침을 Read 해야 하므로 --add-dir "$ROOT"
+    # 로 repo 접근만 유지하고, cwd 는 중립(CLAUDE.md 없음) 으로 둔다.
+    if ! report="$(cd "$neutral_cwd" && claude -p "$prompt" --model "$MODEL" --allowedTools "Read" --add-dir "$ROOT" --add-dir "$sandbox" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 검수 실행 실패"
       record_eval_result "failed" "report" "" "" 1 0 0 0
       continue
@@ -127,7 +134,8 @@ $expected
 [검수 보고]
 $report"
 
-    if ! grade="$(claude -p "$judge_prompt" --model "$MODEL" 2>/dev/null)"; then
+    # 채점자는 정답표+보고가 프롬프트에 인라인 — repo 접근 0 필요. 도구까지 제거해 최소화.
+    if ! grade="$(cd "$neutral_cwd" && claude -p "$judge_prompt" --model "$MODEL" --allowedTools "" 2>/dev/null)"; then
       echo "[eval] $case_name run $i: 채점 실행 실패"
       report_chars="${#report}"
       report_bytes="$(byte_len "$report")"
@@ -156,7 +164,7 @@ $report"
     fi
   done
 
-  rm -rf "$sandbox"
+  rm -rf "$sandbox" "$neutral_cwd"
   echo "[eval] $case_name — 정답 $pass/$RUNS"
   [ "$pass" -gt 0 ] || overall_fail=1
   if [ "$RELEASE_CHECK" = "1" ] && is_strict_case "$case_name" && [ "$pass" -ne "$RUNS" ]; then

--- a/tests/test_eval_harness_isolation.py
+++ b/tests/test_eval_harness_isolation.py
@@ -1,11 +1,14 @@
-"""evals/run.sh 의 claude -p 호출이 dcNess 하네스(CLAUDE.md / hook / skills / tool
-정의)를 주입당하지 않도록 격리하는 계약 테스트 (#1073).
+"""evals/run.sh 의 claude -p 호출이 dcNess 하네스(CLAUDE.md / skills / hooks / MCP /
+user settings / tool schema)를 주입당하지 않도록 격리하는 계약 테스트 (#1073).
 
-행동 eval 은 케이스마다 claude -p 를 검수·채점 2회 부른다. 이 호출이 repo cwd 에서
-돌면 CLAUDE.md auto-discovery + hook + skills 가 매번 주입돼 세션당 ~43k baseline 을
-짊어진다(실측). fan-out 실행에서는 이 baseline 이 quota 를 폭식한다. 검수자는 agent
-지침 Read 를 위해 repo 접근만 유지하고, 채점자는 순수 텍스트 판정이라 도구가 0 필요하다.
-이 테스트는 격리 계약이 run.sh 에서 회귀하지 않도록 박는다.
+행동 eval 은 케이스마다 claude -p 를 검수·채점 2회 부른다. 이 호출이 customization 을
+지고 돌면 세션당 ~43k baseline 을 짊어져(실측) fan-out 시 quota 를 폭식한다. --safe-mode
+가 CLAUDE.md·skills·hooks·MCP·user settings 를 전부 끄면서(OAuth 인증은 유지) baseline
+을 무너뜨리고, --tools 가 도구 schema 를 제한한다. 검수자는 agent 지침 Read 를 위해
+--tools "Read" + --add-dir "$ROOT" 로 repo 접근만 유지한다.
+
+실측 baseline: 43,455 → --safe-mode 19,287 → --tools "" 10,493 →
+--safe-mode --tools "" 1,529 (repo cwd 에서도 1,857). 검수자(--tools "Read") 2,755.
 """
 
 import unittest
@@ -19,39 +22,44 @@ class EvalHarnessIsolationTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.src = RUN_SH.read_text(encoding="utf-8")
+        cls.claude_calls = [
+            line
+            for line in cls.src.splitlines()
+            if "claude -p" in line and not line.lstrip().startswith("#")
+        ]
 
     def test_run_sh_exists(self):
         self.assertTrue(RUN_SH.is_file(), "evals/run.sh 가 있어야 한다")
 
-    def test_both_claude_calls_use_neutral_cwd(self):
-        # 검수자·채점자 두 claude -p 모두 CLAUDE.md 없는 중립 cwd 에서 실행해
-        # auto-discovery / hook / skills 주입을 차단한다.
-        count = self.src.count('cd "$neutral_cwd" && claude -p')
-        self.assertEqual(
-            count, 2,
-            "검수자·채점자 두 claude -p 호출 모두 중립 cwd 를 써야 한다",
-        )
+    def test_two_claude_calls(self):
+        self.assertEqual(len(self.claude_calls), 2, "검수·채점 두 claude -p 호출")
 
-    def test_reviewer_keeps_repo_access(self):
-        # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 를 Read 하므로 repo 접근 유지.
+    def test_both_calls_use_safe_mode(self):
+        # 두 호출 모두 --safe-mode 로 CLAUDE.md/skills/hooks/MCP/user settings 차단.
+        for call in self.claude_calls:
+            self.assertIn("--safe-mode", call, f"--safe-mode 누락: {call}")
+
+    def test_reviewer_keeps_repo_access_with_read_tool(self):
+        # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 를 Read 하므로 repo 접근 + Read 도구 유지.
         self.assertIn('--add-dir "$ROOT"', self.src)
+        self.assertIn('--tools "Read"', self.src)
 
-    def test_judge_removes_tools(self):
-        # 채점자는 정답표+보고가 프롬프트에 인라인 — 도구 schema 주입 제거.
-        self.assertIn('--allowedTools ""', self.src)
+    def test_judge_disables_all_tools(self):
+        # 채점자는 정답표+보고 인라인 — 도구 schema 를 전부 제거.
+        self.assertIn('--tools ""', self.src)
+
+    def test_no_allowedtools_empty(self):
+        # --allowedTools "" 는 permission 만 비우고 tool schema 는 남아 baseline 을 못 줄인다.
+        # 도구 제거는 --tools 로 한다 (codex P2). 주석 설명 언급은 허용; 호출 라인만 검사.
+        for call in self.claude_calls:
+            self.assertNotIn(
+                "--allowedTools", call, f"claude -p 호출에 --allowedTools 금지: {call}"
+            )
 
     def test_no_bare_flag(self):
-        # --bare 는 구독 인증(OAuth/keychain)을 못 읽어 "Not logged in" — 실제 claude -p
-        # 호출에서 금지한다. (주석의 설명 언급은 허용; 호출 라인만 검사)
-        for line in self.src.splitlines():
-            if line.lstrip().startswith("#"):
-                continue
-            if "claude -p" in line:
-                self.assertNotIn("--bare", line, f"claude -p 호출에 --bare 금지: {line}")
-
-    def test_neutral_cwd_created_and_cleaned(self):
-        self.assertIn('neutral_cwd="$(mktemp -d', self.src)
-        self.assertIn('rm -rf "$sandbox" "$neutral_cwd"', self.src)
+        # --bare 는 구독 인증(OAuth/keychain)을 못 읽어 "Not logged in" — 실제 호출에서 금지.
+        for call in self.claude_calls:
+            self.assertNotIn("--bare", call, f"claude -p 호출에 --bare 금지: {call}")
 
 
 if __name__ == "__main__":

--- a/tests/test_eval_harness_isolation.py
+++ b/tests/test_eval_harness_isolation.py
@@ -1,0 +1,58 @@
+"""evals/run.sh 의 claude -p 호출이 dcNess 하네스(CLAUDE.md / hook / skills / tool
+정의)를 주입당하지 않도록 격리하는 계약 테스트 (#1073).
+
+행동 eval 은 케이스마다 claude -p 를 검수·채점 2회 부른다. 이 호출이 repo cwd 에서
+돌면 CLAUDE.md auto-discovery + hook + skills 가 매번 주입돼 세션당 ~43k baseline 을
+짊어진다(실측). fan-out 실행에서는 이 baseline 이 quota 를 폭식한다. 검수자는 agent
+지침 Read 를 위해 repo 접근만 유지하고, 채점자는 순수 텍스트 판정이라 도구가 0 필요하다.
+이 테스트는 격리 계약이 run.sh 에서 회귀하지 않도록 박는다.
+"""
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RUN_SH = ROOT / "evals" / "run.sh"
+
+
+class EvalHarnessIsolationTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.src = RUN_SH.read_text(encoding="utf-8")
+
+    def test_run_sh_exists(self):
+        self.assertTrue(RUN_SH.is_file(), "evals/run.sh 가 있어야 한다")
+
+    def test_both_claude_calls_use_neutral_cwd(self):
+        # 검수자·채점자 두 claude -p 모두 CLAUDE.md 없는 중립 cwd 에서 실행해
+        # auto-discovery / hook / skills 주입을 차단한다.
+        count = self.src.count('cd "$neutral_cwd" && claude -p')
+        self.assertEqual(
+            count, 2,
+            "검수자·채점자 두 claude -p 호출 모두 중립 cwd 를 써야 한다",
+        )
+
+    def test_reviewer_keeps_repo_access(self):
+        # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 를 Read 하므로 repo 접근 유지.
+        self.assertIn('--add-dir "$ROOT"', self.src)
+
+    def test_judge_removes_tools(self):
+        # 채점자는 정답표+보고가 프롬프트에 인라인 — 도구 schema 주입 제거.
+        self.assertIn('--allowedTools ""', self.src)
+
+    def test_no_bare_flag(self):
+        # --bare 는 구독 인증(OAuth/keychain)을 못 읽어 "Not logged in" — 실제 claude -p
+        # 호출에서 금지한다. (주석의 설명 언급은 허용; 호출 라인만 검사)
+        for line in self.src.splitlines():
+            if line.lstrip().startswith("#"):
+                continue
+            if "claude -p" in line:
+                self.assertNotIn("--bare", line, f"claude -p 호출에 --bare 금지: {line}")
+
+    def test_neutral_cwd_created_and_cleaned(self):
+        self.assertIn('neutral_cwd="$(mktemp -d', self.src)
+        self.assertIn('rm -rf "$sandbox" "$neutral_cwd"', self.src)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eval_harness_isolation.py
+++ b/tests/test_eval_harness_isolation.py
@@ -3,12 +3,17 @@ user settings / tool schema)를 주입당하지 않도록 격리하는 계약 �
 
 행동 eval 은 케이스마다 claude -p 를 검수·채점 2회 부른다. 이 호출이 customization 을
 지고 돌면 세션당 ~43k baseline 을 짊어져(실측) fan-out 시 quota 를 폭식한다. --safe-mode
-가 CLAUDE.md·skills·hooks·MCP·user settings 를 전부 끄면서(OAuth 인증은 유지) baseline
-을 무너뜨리고, --tools 가 도구 schema 를 제한한다. 검수자는 agent 지침 Read 를 위해
---tools "Read" + --add-dir "$ROOT" 로 repo 접근만 유지한다.
+가 CLAUDE.md·skills·hooks·MCP·user settings 를 전부 끄면서(OAuth 인증 유지) baseline 을
+무너뜨리고, --tools 가 도구 schema 를 제한한다.
 
-실측 baseline: 43,455 → --safe-mode 19,287 → --tools "" 10,493 →
---safe-mode --tools "" 1,529 (repo cwd 에서도 1,857). 검수자(--tools "Read") 2,755.
+- 검수자: {{REPO_ROOT}} agent 지침 Read + 일부 케이스의 {{CASE_DIR}} fixture 열거(Glob)
+  가 필요하므로 --tools Read Glob + --add-dir "$ROOT" + --add-dir "$sandbox" 로 접근 유지.
+- 채점자: 정답표+보고가 프롬프트에 인라인 → repo 접근 0, --tools "" 로 도구 전체 제거.
+
+실측 baseline: 43,455 → 검수자(--tools Read Glob) 3,067 / 채점자(--tools "") 1,857.
+
+role-specific 계약은 스크립트 전체가 아니라 각 호출 라인에 대해 검사한다 — 그래야
+검수자/채점자 플래그가 뒤바뀌는 회귀를 잡는다.
 """
 
 import unittest
@@ -28,38 +33,39 @@ class EvalHarnessIsolationTest(unittest.TestCase):
             if "claude -p" in line and not line.lstrip().startswith("#")
         ]
 
+    def _reviewer(self):
+        cands = [c for c in self.claude_calls if '"$prompt"' in c]
+        self.assertEqual(len(cands), 1, "검수자 호출('$prompt')은 정확히 1개")
+        return cands[0]
+
+    def _judge(self):
+        cands = [c for c in self.claude_calls if '"$judge_prompt"' in c]
+        self.assertEqual(len(cands), 1, "채점자 호출('$judge_prompt')은 정확히 1개")
+        return cands[0]
+
     def test_run_sh_exists(self):
         self.assertTrue(RUN_SH.is_file(), "evals/run.sh 가 있어야 한다")
 
     def test_two_claude_calls(self):
         self.assertEqual(len(self.claude_calls), 2, "검수·채점 두 claude -p 호출")
 
-    def test_both_calls_use_safe_mode(self):
-        # 두 호출 모두 --safe-mode 로 CLAUDE.md/skills/hooks/MCP/user settings 차단.
-        for call in self.claude_calls:
-            self.assertIn("--safe-mode", call, f"--safe-mode 누락: {call}")
+    def test_reviewer_isolation(self):
+        r = self._reviewer()
+        self.assertIn("--safe-mode", r, "검수자 customization 차단")
+        # fixture 열거(Glob) + agent 지침 Read
+        self.assertIn("--tools Read Glob", r)
+        self.assertIn('--add-dir "$ROOT"', r, "agent 지침 접근")
+        self.assertIn('--add-dir "$sandbox"', r, "fixture 접근")
+        self.assertNotIn("--allowedTools", r, "permission-only 플래그로 schema 못 줄임")
+        self.assertNotIn("--bare", r, "구독 인증 유지")
 
-    def test_reviewer_keeps_repo_access_with_read_tool(self):
-        # 검수자는 {{REPO_ROOT}}/docs/plugin/agents/... 를 Read 하므로 repo 접근 + Read 도구 유지.
-        self.assertIn('--add-dir "$ROOT"', self.src)
-        self.assertIn('--tools "Read"', self.src)
-
-    def test_judge_disables_all_tools(self):
-        # 채점자는 정답표+보고 인라인 — 도구 schema 를 전부 제거.
-        self.assertIn('--tools ""', self.src)
-
-    def test_no_allowedtools_empty(self):
-        # --allowedTools "" 는 permission 만 비우고 tool schema 는 남아 baseline 을 못 줄인다.
-        # 도구 제거는 --tools 로 한다 (codex P2). 주석 설명 언급은 허용; 호출 라인만 검사.
-        for call in self.claude_calls:
-            self.assertNotIn(
-                "--allowedTools", call, f"claude -p 호출에 --allowedTools 금지: {call}"
-            )
-
-    def test_no_bare_flag(self):
-        # --bare 는 구독 인증(OAuth/keychain)을 못 읽어 "Not logged in" — 실제 호출에서 금지.
-        for call in self.claude_calls:
-            self.assertNotIn("--bare", call, f"claude -p 호출에 --bare 금지: {call}")
+    def test_judge_isolation(self):
+        j = self._judge()
+        self.assertIn("--safe-mode", j, "채점자 customization 차단")
+        self.assertIn('--tools ""', j, "도구 schema 전체 제거")
+        self.assertNotIn("--add-dir", j, "채점자는 repo 접근 불필요")
+        self.assertNotIn("--allowedTools", j)
+        self.assertNotIn("--bare", j)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Part of #1073

<!-- eval 채점 정확성 full 회귀(bash evals/run.sh 18케이스)가 실제 LLM 실행·quota 소모라
     human verification 대기. 사람이 확인 후 이슈를 close 하도록 Part of 로 둔다. -->

## 배경 및 문제

codex 가 dcNess eval 을 fan-out 으로 대량 병렬 호출했을 때 usage quota(session limit) 절반이 순식간에 소진됐다. 추적 결과 `evals/run.sh` 채점자 세션 baseline 이 **43,455 tok** — 순수 채점 프롬프트(정답표+보고 인라인, 수천 tok) 대비 ~40k 가 하네스(CLAUDE.md + skills + hooks + MCP + tool schema) 주입 낭비였다. 어느 실행에서 세션 75개가 각자 cache_write 120~210k 를 반복해 quota 를 폭식했다.

## 원인

`claude -p` 가 기본적으로 CLAUDE.md auto-discovery + skills + hooks + MCP + user settings + 전체 tool schema 를 로드한다. 채점자(130행)는 repo 접근이 0 필요한데도 전체 하네스를 짊어졌고, 검수자(111행)는 agent 지침 Read 만 필요한데 customization 전부를 로드했다.

## 작업내용

- 검수자: `--safe-mode --tools Read Glob --add-dir "$ROOT"(agent 지침) --add-dir "$sandbox"(fixture)` — customization 차단 + 필요한 Read/Glob·경로만 유지
- 채점자: `--safe-mode --tools ""` — customization·도구 전부 차단 (프롬프트 자족적)
- 회귀 계약 테스트 `tests/test_eval_harness_isolation.py` — 검수자/채점자 각 호출 라인별 격리 계약 assert

## 결정 근거

codex 리뷰 2라운드를 근본 반영:

- **중립 cwd 는 불충분** — CLAUDE.md 만 끄고 skills/hooks/MCP/user settings 는 cwd 무관하게 로드됨(실측 32k). → `--safe-mode`(all customizations off, OAuth 인증 유지, `err=false` 실측)로 대체.
- **`--allowedTools ""` 는 permission 만 비우고 tool schema 는 잔존** → `--tools` 로 도구 목록 자체를 제한.
- **`--tools "Read"` 는 Glob 제거로 fixture 열거 케이스(`cartography-lifecycle-smoke`)를 깨뜨림** → `--tools Read Glob` 으로 fixture discovery 복원.
- `--bare`(최소 baseline)는 OAuth/keychain 을 못 읽어 `"Not logged in"` 실측 → 금지.

baseline 실측 사다리:

| 조합 | baseline |
|---|---:|
| 현재 (기본 claude -p) | 43,455 |
| 중립 cwd (CLAUDE.md 만 off) | 32,276 |
| `--safe-mode` | 19,287 |
| **채점자 `--safe-mode --tools ""`** | **1,857** |
| **검수자 `--safe-mode --tools Read Glob`** | **3,067** |

채점자 43,455 → 1,857 (**96% 절감**), 검수자 → 3,067 (**93% 절감**). fan-out 세션 수십~수백 개 × 절감분 = 수백만 토큰 회수.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 운영 작업. `evals/` 는 dcNess self QA 도구로 plug-in 배포물이 아니다(`evals/README.md`). 외부 활성 프로젝트로 복사·배포되지 않는다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 skill/command/agent/gate 추가 없음. 기존 eval 하네스 내부 구현만 수정.

## Test Plan

- [x] `bash -n evals/run.sh` 문법
- [x] 회귀 계약 테스트 4/4 (`tests/test_eval_harness_isolation.py` — 검수자/채점자 개별 라인 격리 assert)
- [x] 격리 조합 baseline 실측 — 채점자 1,857 / 검수자 3,067 (`--safe-mode` 인증 `err=false`)
- [x] codex 리뷰 3라운드 수렴 (P2×2 → P2/P3 → clean PASS)
- [ ] **eval 채점 정확성 full 회귀** (`bash evals/run.sh` 18케이스) — `human verification 대기`. 실제 LLM 18케이스 실행이라 quota 소모 → 사용자 실행 몫. codex 3차가 검수자 Read/Glob 접근 유지를 확인했고, 로직상 회귀 위험 낮음(검수자 지침 접근 유지 + 채점자 프롬프트 자족).

## 참고

- codex fan-out 동시 실행 폭 상한, codex `app-server-broker` leak(고아 45개, PPID=1)은 별도 repo/진입점 소관 — #1073 follow-up 으로 분리.
