### PR TITLE
[epic1064][story1067] non-UI journey evidence 계약 연결

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,7 @@ GitHub issue 를 대상으로 하는 dcness self 구현은 진입 때 읽은 본
 | [`docs/plugin/positioning.md`](docs/plugin/positioning.md) | 공개 workflow 진입점의 기본/고급/유틸리티/내부 agent 분류 수정 시 |
 | [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md) | 자유 형식 작업 요청을 어떤 workflow 로 보낼지 (구현 경로 — gate 축 × shape 축) 판단 시 |
 | [`docs/plugin/outcome-scorecard.md`](docs/plugin/outcome-scorecard.md) | process·Agent effectiveness·실제 제품 outcome의 비교 필드·denominator·주장 경계를 수정/리뷰 시 |
+| [`docs/plugin/product-journey.md`](docs/plugin/product-journey.md) | 외부 활성 프로젝트의 non-UI 핵심 journey 실행 계약·receipt·scorecard 연결을 수정/리뷰 시 |
 | [`docs/plugin/decision-completeness.md`](docs/plugin/decision-completeness.md) | `/spec`·`/design`에서 구현 방향을 바꾸는 결정 범위·근거 상태·질문/위임·완료 의미를 수정/리뷰 시 |
 | [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현·효율 benchmark 문구 수정 시 |
 | [`docs/plugin/design.md`](docs/plugin/design.md) | `design.md` 토큰 규격·Static HTML 시안 규약 수정 시 |
@@ -149,6 +150,7 @@ cp scripts/hooks/post-checkout .git/hooks/post-checkout && chmod +x .git/hooks/p
 python3.11 -m unittest discover -s tests -v < /dev/null   # stdin 리다이렉트 필수 — 안 닫으면 stdin 읽는 테스트가 무한 hang (#723)
 python3.11 -m unittest tests.test_signal_io -v   # 단일 모듈
 node scripts/check_public_surface.mjs
+PYTHON_BIN=python3.11 scripts/dcness-product-journey run --project-root <external-project> --config <project-local-contract>
 
 # static-quality: system python 은 PEP 668 (externally-managed) 로 pip install 거부 — venv 사용
 python3.11 -m venv /tmp/dcness-quality-venv && /tmp/dcness-quality-venv/bin/pip install -q -r requirements-quality.txt

--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -50,6 +50,25 @@ python3 "$DCN"/harness/outcome_scorecard.py \
 
 `7/7` merge는 PR 운영 결과다. guard PASS나 validator FAIL도 과정 evidence다. 세 값 중 어느 것도 실제 제품 AC 성공률로 바꾸지 않으며, merge 비율을 제품 전체 성공으로 해석하는 결론을 두지 않는다.
 
+## 2026-07-12 non-UI 제품 journey pilot
+
+2026-07-11 process snapshot은 그대로 고정하고, 이후 처음 생성된 product outcome 표본을 별도 slice로 추가한다. active-project registry의 `source-d640b1b95d`에서 `yt-make-intake-cli`를 실제 CLI entrypoint와 filesystem session 경계로 실행했다. helper가 start, health, journey assertion, cleanup을 순서대로 실행했고 `2026-07-12T07:36:43Z` receipt를 남겼다.
+
+```sh
+python3.11 "$DCN"/harness/outcome_scorecard.py \
+  --redact-paths \
+  --measured-at 2026-07-12T07:37:00Z \
+  --as-of 2026-07-12T07:37:00Z \
+  --source-ref source-d640b1b95d \
+  --json
+```
+
+| 영역 | 결과 | denominator / source | 실행 증거 | 사람 개입 | 해석 경계 |
+|---|---|---|---|---:|---|
+| product outcome | journey PASS 1/1, 제품 AC 1/1 | journey 1, AC 1, source 1 | `cli, command, log` + sha256 receipt | 사람 개입 0 | 단일 외부 활성 프로젝트의 단일 non-UI pilot이며 공개 우위 근거가 아님 |
+
+대상 AC는 `AC-421`이고 assertion은 자연어 prompt intake가 실제 session 파일을 만들며 선택한 `history_culture` category와 원문 prompt를 보존하는지 확인했다. `mock` adapter를 쓰지 않았고 실행 후 생성 상태는 cleanup했다. receipt와 log는 해당 source 프로젝트의 ignored `.dcness-work/product-journey/yt-make-intake-pilot-20260712/`에 남아 있으며 공개 문서에는 절대경로를 기록하지 않는다.
+
 ## Agent effectiveness 입력 경계
 
 - Cartography freshness에서 얻을 수 있는 것: 현재 SSOT·runtime entrypoint·capability owner 후보, affected route의 stale 여부와 갱신·재검증 기록.

--- a/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
+++ b/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
@@ -12,6 +12,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 검수 단위: spec / story / epic / release 식별자
 - 기준 문서: `docs/index.md`, 기능·유저 시나리오를 담은 `docs/prd.md`, Story AC·Epic 완료 기준을 담은 `docs/epics/<epic>/stories.md`, `docs/decisions/`, epic architecture/impl 문서, issue 본문 중 호출자가 제공한 경로
 - 구현 증거: PR URL, 변경 파일 목록, 테스트 결과, smoke 결과, 정적 타입검사/compile 결과, 실데이터(non-mock) 통합 테스트, UI 자동화, 화면/API/CLI 동작 설명 중 호출자가 제공한 항목
+- non-UI journey receipt: 호출자가 제공한 `receipt.json`과 단계별 log. `app_started`, `journey_executed`, assertion 평가·결과, 대상 AC, command exit, evidence sha256을 포함한다.
 - UI 검수 증거: UI story/epic 이면 호출자가 제공한 확정 목업 경로(`docs/design-variants/<screen-id>.html`), canvas 경로, 핵심 `data-node-id` 매핑, 구현 화면 스크린샷 또는 동등한 화면 증거 경로
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제 제품 경계 실행 여부
 - epic 구현에 대한 build-worker/impl-validator Cartography impact 보고, affected Root Cartography 좌표, tracked/local-only 문서 정책
@@ -37,6 +38,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 실데이터(non-mock) 통합 테스트는 실제 parser, renderer, DB/schema, filesystem, network adapter wrapper, local fixture 같은 제품 경계를 통과해야 한다. 외부 서비스를 반드시 live 호출하라는 뜻은 아니다.
 - UI 자동화는 브라우저/앱 자동화, component interaction, screenshot/assertion, visual smoke 같은 증거를 포함한다. 사람의 수동 E2E만 요구하지 않는다.
 - mock/stub/fake 기반 unit test 는 보조 증거다. 핵심 AC가 mock-only green으로만 뒷받침되고 API/CLI/UI/통합 wiring/compile-time contract 중 어떤 실제 경계도 확인되지 않았으면 gap 이다.
+- project-local journey receipt가 있으면 `app_started=true`, `journey_executed=true`, assertion `evaluated=true`와 `passed=true`, non-mock boundary, 대상 AC 대응을 함께 확인한다. 하나라도 빠지거나 receipt outcome이 FAIL이면 제품 outcome PASS로 판정하지 않는다. receipt와 log는 읽기 전용으로 대조하며 검증자가 다시 실행하거나 수정하지 않는다.
 - TypeScript, typed Python, Rust, Go 처럼 정적 타입검사나 compile gate 가 의미 있는 stack 에서 typecheck/compile 증거가 전혀 없으면 품질 게이트 warning 으로 보고한다. warning 자체만으로 FAIL 을 만들지는 않지만, 그 부재 때문에 핵심 AC의 wiring/contract 동작을 증명할 수 없으면 FAIL gap 이다.
 
 ### UI 목업 정합 판정 (STORY / EPIC 공통)
@@ -100,6 +102,7 @@ story 구현 완료 직후 호출된다. 해당 story 의 수용 기준이 구�
 - Story AC 가 없는 구양식에서 `완료 시 확인 가능한 동작` 줄이 있으면, 그 동작이 실제 동작 증거로 닫혔는지 하위호환 기준으로 대조한다.
 - 핵심 AC 의 입력/진행 동선이 대상 사용자에게 적합한 제품 언어로 닫힌다.
 - 테스트나 smoke 증거가 실제 실행 결과로 남아 있다.
+- project-local journey를 사용했다면 receipt가 Story AC와 command/log evidence를 연결하고 app_started·journey_executed·assertion 결과를 명시한다.
 - mock-only green 으로만 닫힌 핵심 AC 를 gap 으로 분리한다.
 - UI story 이면 확정 목업과 구현 화면 증거를 Read 로 열어 대조하고, 화면 증거 부재와 목업 불일치를 gap 으로 분리한다.
 - 내부 계약을 사용자가 직접 조립해야만 수행되는 핵심 흐름을 gap 으로 분리한다.

--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -190,6 +190,7 @@ epic `tech-review.md` 는 `/design` 중 `NEW_DEP_ESCALATE` option 4 로 새 외�
 | `.dcness-work/handoffs/` | run 간 임시 handoff + 세션 간 warm 인계 (`/handoff` 가 쓰는 활성 `next-session.md`, SessionStart 소비 후 `archive/<ts>.md`) |
 | `.dcness-work/reviews/` | tech-review evidence, HTML report, logs |
 | `.dcness-work/reports/` | 온디맨드 집계 리포트, 재생성 가능한 임시 요약 |
+| `.dcness-work/product-journey/` | project-local non-UI journey의 단계별 log와 sha256 receipt |
 
 `/init-dcness` 는 사용자 프로젝트 `.gitignore` 에 `.dcness-work/` 를 추가한다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -70,6 +70,8 @@ Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소�
 
 `docs/index.md` 의 epic/module 표와 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. 전역 architecture 인간용 요약은 필요할 때 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 로 `.dcness-work/reports/architecture-map.md` 에 온디맨드 생성한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
+non-UI 제품 journey runner도 사용자 repo에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-product-journey`)로 제공한다. project-local 계약 `.dcness/product-journey.json`은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다. 실행 receipt와 log는 기존 ignored `.dcness-work/product-journey/`에 남고 [`outcome-scorecard.md`](outcome-scorecard.md)가 집계한다. 계약과 판정 경계는 [`product-journey.md`](product-journey.md)가 소유한다.
+
 ## Provider Mirror Sync
 
 `impl-validator`, `architecture-validator` 의 판단 축·결론 어휘·FAIL/ESCALATE 보고 가이드를 바꾸는 PR 은 Claude 경로와 Codex mirror 를 같은 PR 안에서 함께 갱신한다.

--- a/docs/plugin/outcome-scorecard.md
+++ b/docs/plugin/outcome-scorecard.md
@@ -62,6 +62,8 @@ Cartography freshness는 SSOT·entrypoint·owner 후보와 stale 여부의 입�
 - mock-only green, guard PASS, validator PASS, PR merge만으로 outcome PASS를 만들지 않는다.
 - regression은 이전에 통과한 제품 동작이 같은 조건에서 깨졌는지 별도 필드로 둔다.
 
+non-UI journey 실행 계약과 receipt 필드는 [`product-journey.md`](product-journey.md)가 소유한다. `harness/outcome_scorecard.py`는 해당 helper가 `.dcness-work/product-journey/`에 남긴 유효 receipt를 읽어 journey PASS/전체와 제품 AC passed/total, source 수, 사람 개입, 실행 증거 종류를 별도로 집계한다.
+
 ## 주장 가능 범위
 
 ### 개인 경량화 판단

--- a/docs/plugin/product-journey.md
+++ b/docs/plugin/product-journey.md
@@ -1,0 +1,100 @@
+# Project-local 제품 journey 실행 계약
+
+> **Status**: ACTIVE
+> **Scope**: 외부 활성 프로젝트의 non-UI 핵심 journey 한 건을 실제 제품 경계에서 실행하고 product-acceptance가 읽을 receipt를 생성한다.
+
+## 책임 경계
+
+프로젝트가 실행 방법을 선언하고 dcNess plugin helper가 순서대로 실행한다. 특정 언어, 프레임워크, 테스트 도구를 요구하지 않는다.
+
+1. `start`: 앱·서비스·CLI 진입점을 시작한다.
+2. `health`: 다음 journey를 실행할 준비가 됐는지 확인한다.
+3. `journey`: API·CLI·실데이터 통합 경계에서 대상 AC assertion을 평가한다.
+4. `cleanup`: 성공·실패와 무관하게 종료·정리한다.
+5. `evidence_dir`: command exit와 log, 대상 AC, 실행 시각을 연결하는 receipt 위치다.
+
+메인 workflow가 실행 증거를 만들고 `product-acceptance`는 receipt와 대상 Story AC를 읽기 전용으로 대조한다. 검증 agent가 구현이나 receipt를 수정하지 않는다. UI 화면 상태와 screenshot 증거는 이 계약의 범위가 아니며 별도 UI pilot에서 공통 필드 위에 확장한다.
+
+## 프로젝트 계약
+
+기본 위치는 `.dcness/product-journey.json`이다. 다른 위치를 사용할 때는 helper의 `--config`로 명시한다.
+
+```json
+{
+  "version": 1,
+  "journey_id": "account-export-cli",
+  "target_ac": ["AC-EXPORT-1"],
+  "boundary": "cli",
+  "assertion": {
+    "description": "export 명령이 실제 저장소에서 대상 파일을 생성하고 내용을 검증한다",
+    "source": "journey_exit"
+  },
+  "human_intervention_count": 0,
+  "env": {
+    "APP_ENV": "acceptance"
+  },
+  "commands": {
+    "start": {
+      "argv": ["./bin/app", "--version"],
+      "mode": "command",
+      "timeout_sec": 30
+    },
+    "health": {
+      "argv": ["./bin/app", "doctor"],
+      "timeout_sec": 30
+    },
+    "journey": {
+      "argv": ["./scripts/assert-export-journey.sh"],
+      "timeout_sec": 120
+    },
+    "cleanup": {
+      "argv": ["./scripts/cleanup-export-journey.sh"],
+      "timeout_sec": 30
+    }
+  },
+  "evidence_dir": ".dcness-work/product-journey"
+}
+```
+
+### 필드 의미
+
+| 필드 | 계약 |
+|---|---|
+| `journey_id` | 소문자·숫자·`.`·`_`·`-`로 된 안정 식별자 |
+| `target_ac` | journey assertion이 대조할 Story AC 식별자. 한 개 이상 필수 |
+| `boundary` | `api`, `cli`, `integration`, `mock`. `mock`은 fixture용이며 outcome PASS 불가 |
+| `assertion.description` | command가 무엇을 판정하는지 제품 언어로 설명 |
+| `assertion.source` | `journey_exit`이면 journey exit 0을 assertion PASS로 사용. `none`은 미평가 fixture이며 PASS 불가 |
+| `human_intervention_count` | 실행 중 사람이 개입한 횟수. 없으면 0 |
+| `env` | 네 단계에 공통으로 추가할 문자열 환경 변수 |
+| `commands.*.argv` | shell 문자열이 아닌 argv 배열. shell이 필요하면 프로젝트가 `bash -lc`를 명시적으로 선택 |
+| `commands.*.timeout_sec` | 단계별 600초 이하 timeout |
+| `commands.start.mode` | 장기 실행 앱은 `service`, 종료되는 CLI 진입점은 `command` |
+| `commands.start.startup_grace_sec` | service가 조기 종료하지 않았는지 확인할 유예 시간 |
+| `evidence_dir` | `.dcness-work/product-journey/` 아래의 project-relative 위치 |
+
+start가 실패하거나 service가 유예 시간 안에 종료되면 `app_not_started`다. health가 실패하면 journey를 실행하지 않고 `journey_not_executed`로 남긴다. journey가 실행되지 않았거나 `assertion.source=none`이면 `assertion_not_evaluated`다. `mock` boundary는 모든 command가 exit 0이어도 `mock_only_boundary`이므로 PASS가 아니다. cleanup은 항상 실행하며 실패하면 전체 outcome도 FAIL이다.
+
+## 실행과 receipt
+
+```sh
+"$PLUGIN_ROOT/scripts/dcness-product-journey" run \
+  --project-root "$PROJECT_ROOT" \
+  --config .dcness/product-journey.json
+```
+
+성공은 exit 0, 실행된 제품 gap은 exit 1, 잘못된 계약은 exit 2다. 각 run은 `evidence_dir/<run-id>/`에 단계별 log와 `receipt.json`을 남긴다. receipt는 다음 의미를 포함한다.
+
+- 실제 시작 여부 `app_started`, journey 실행 여부 `journey_executed`.
+- assertion의 설명·근거·평가 여부·결과.
+- 단계별 argv, exit code, timeout, wall-clock과 log 위치.
+- 대상 AC의 passed/total denominator, 사람 개입, 실행 증거 종류.
+- log별 sha256과 failure reason.
+
+`harness/outcome_scorecard.py`는 helper receipt 중 구조가 유효하고 snapshot cutoff 안에 있는 것만 읽는다. journey PASS/전체 실행 수와 제품 AC passed/total을 각각 보존하며 guard·validator·PR 지표를 제품 outcome 분자에 넣지 않는다.
+
+## 배포와 보존
+
+helper와 runtime은 plugin 본체의 `scripts/dcness-product-journey`, `harness/product_journey.py`로 배포된다. 사용자 repo에 helper 사본을 복사하지 않는다. 프로젝트 계약은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다.
+
+계약을 팀과 공유해야 하면 `.dcness/product-journey.json`을 프로젝트가 명시적으로 관리한다. 실행 log와 receipt는 재생성 가능한 실측 evidence이므로 gitignore 대상 `.dcness-work/product-journey/`에 둔다.

--- a/harness/outcome_scorecard.py
+++ b/harness/outcome_scorecard.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python3
-"""Cross-project process/effectiveness/product-outcome scorecard.
+"""Cross-project process, effectiveness, and product-outcome scorecard.
 
-The current run ledger can reproduce process evidence. It does not contain enough
-information to synthesize product outcomes, agent-effectiveness outcomes, or complete
-trial metadata, so those axes stay explicitly unmeasured until their own evidence is
-provided.
+Run ledgers provide process evidence. Project-local journey receipts provide product
+outcomes. Agent-effectiveness and complete legacy trial metadata stay unmeasured until
+their own evidence exists; no axis substitutes for another.
 """
 
 from __future__ import annotations
@@ -23,7 +22,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from harness import ledger, run_review  # noqa: E402
+from harness import ledger, product_journey, run_review  # noqa: E402
 from harness.benchmark_aggregate import FleetReport, aggregate_runs  # noqa: E402
 
 
@@ -224,6 +223,11 @@ def build_scorecard(
         for index, (source_ref, _project) in enumerate(configured_with_refs, start=1)
     }
 
+    journey_receipts: list[tuple[str, dict[str, Any]]] = []
+    for source_ref, project in selected:
+        for receipt in product_journey.read_receipts(project, cutoff=cutoff):
+            journey_receipts.append((source_ref, receipt))
+
     sources: list[dict[str, Any]] = []
     fleets: list[FleetReport] = []
     candidate_run_count = 0
@@ -382,6 +386,11 @@ def build_scorecard(
         "measured_at": measured_at,
         "as_of": as_of,
     }
+    product_outcome = _product_outcome(
+        journey_receipts,
+        measured_at=measured_at,
+        as_of=as_of,
+    )
     return {
         "measured_at": measured_at,
         "as_of": as_of,
@@ -402,13 +411,7 @@ def build_scorecard(
                 "비교 가능한 trial로 기록하지 않는다."
             ),
         },
-        "product_outcome": {
-            **unmeasured_context,
-            "reason": (
-                "현재 ledger에는 실행된 제품 AC 또는 사용자 journey 결과가 없다. "
-                "guard·validator·PR evidence는 이를 대체하지 않는다."
-            ),
-        },
+        "product_outcome": product_outcome,
         "trial_metadata": {
             **unmeasured_context,
             "reason": (
@@ -428,6 +431,76 @@ def build_scorecard(
                 "주장할 수 없다."
             ),
         },
+    }
+
+
+def _product_outcome(
+    receipts: list[tuple[str, dict[str, Any]]],
+    *,
+    measured_at: str,
+    as_of: Optional[str],
+) -> dict[str, Any]:
+    if not receipts:
+        return {
+            "status": UNMEASURED,
+            "source_project_count": 0,
+            "measured_at": measured_at,
+            "as_of": as_of,
+            "reason": (
+                "project-local product journey receipt가 없다. guard·validator·PR "
+                "evidence는 실제 제품 outcome을 대체하지 않는다."
+            ),
+        }
+
+    passed_journeys = sum(
+        1 for _source_ref_value, receipt in receipts if receipt["outcome"] == "PASS"
+    )
+    ac_passed = sum(int(receipt["product_ac"]["passed"]) for _, receipt in receipts)
+    ac_total = sum(int(receipt["product_ac"]["total"]) for _, receipt in receipts)
+    human_interventions = sum(
+        int(receipt.get("human_intervention_count") or 0) for _, receipt in receipts
+    )
+    evidence_types = sorted(
+        {
+            evidence_type
+            for _, receipt in receipts
+            for evidence_type in receipt.get("evidence_types", [])
+            if isinstance(evidence_type, str)
+        }
+    )
+    source_count = len({source_ref_value for source_ref_value, _ in receipts})
+    journeys = [
+        {
+            "source_ref": source_ref_value,
+            "run_id": receipt["run_id"],
+            "journey_id": receipt["journey_id"],
+            "measured_at": receipt["measured_at"],
+            "outcome": receipt["outcome"],
+            "boundary": receipt["boundary"],
+            "target_ac": receipt["target_ac"],
+            "product_ac": receipt["product_ac"],
+            "human_intervention_count": receipt.get("human_intervention_count", 0),
+            "evidence_types": receipt.get("evidence_types", []),
+            "receipt_path": receipt["receipt_path"],
+        }
+        for source_ref_value, receipt in receipts
+    ]
+    return {
+        "status": "관측",
+        "source_project_count": source_count,
+        "measured_at": measured_at,
+        "as_of": as_of,
+        "numerator": passed_journeys,
+        "denominator": len(receipts),
+        "value": passed_journeys / len(receipts),
+        "product_ac": {"passed": ac_passed, "total": ac_total},
+        "human_intervention_count": human_interventions,
+        "evidence_types": evidence_types,
+        "journeys": journeys,
+        "reason": (
+            "helper-generated project-local receipt만 집계했다. 과정·merge 지표는 "
+            "분자나 분모에 포함하지 않았다."
+        ),
     }
 
 
@@ -508,6 +581,19 @@ def render_markdown(report: dict[str, Any]) -> str:
             "|---|---|---:|",
         ]
     )
+    outcome = report["product_outcome"]
+    if outcome["status"] != UNMEASURED:
+        lines[lines.index("## Trial metadata"):lines.index("## Trial metadata")] = [
+            f"- journey PASS: {outcome['numerator']}/{outcome['denominator']}",
+            (
+                "- 제품 AC: "
+                f"{outcome['product_ac']['passed']}/{outcome['product_ac']['total']}"
+            ),
+            f"- source 프로젝트: {outcome['source_project_count']}",
+            f"- 사람 개입: {outcome['human_intervention_count']}",
+            f"- 실행 증거 종류: {', '.join(outcome['evidence_types'])}",
+            "",
+        ]
     for source in report["sources"]:
         lines.append(
             f"| `{source['source_ref']}` | {source['source_location']} | "

--- a/harness/product_journey.py
+++ b/harness/product_journey.py
@@ -486,31 +486,67 @@ def _is_valid_receipt(payload: object, project_root: Path, receipt_path: Path) -
         return False
     if _parse_ts(payload.get("measured_at")) is None:
         return False
+    for key in ("run_id", "journey_id"):
+        value = payload.get(key)
+        if not isinstance(value, str) or not _ID_RE.fullmatch(value):
+            return False
+    boundary = payload.get("boundary")
+    if boundary not in _BOUNDARIES:
+        return False
     target_ac = payload.get("target_ac")
     product_ac = payload.get("product_ac")
     if not isinstance(target_ac, list) or not target_ac or not isinstance(product_ac, dict):
         return False
+    if any(not isinstance(item, str) or not item.strip() for item in target_ac):
+        return False
     passed = product_ac.get("passed")
     total = product_ac.get("total")
-    if not isinstance(passed, int) or not isinstance(total, int):
+    if (
+        not isinstance(passed, int)
+        or isinstance(passed, bool)
+        or not isinstance(total, int)
+        or isinstance(total, bool)
+    ):
         return False
     if total != len(target_ac) or passed < 0 or passed > total:
+        return False
+    intervention = payload.get("human_intervention_count")
+    if (
+        not isinstance(intervention, int)
+        or isinstance(intervention, bool)
+        or intervention < 0
+    ):
+        return False
+    evidence_types = payload.get("evidence_types")
+    if not isinstance(evidence_types, list) or any(
+        not isinstance(item, str) or not item for item in evidence_types
+    ):
+        return False
+    failure_reasons = payload.get("failure_reasons")
+    if not isinstance(failure_reasons, list) or any(
+        not isinstance(item, str) or not item for item in failure_reasons
+    ):
         return False
     required_bools = ("app_started", "journey_executed")
     if any(not isinstance(payload.get(key), bool) for key in required_bools):
         return False
     assertion = payload.get("assertion")
-    if not isinstance(assertion, dict) or any(
-        not isinstance(assertion.get(key), bool) for key in ("evaluated", "passed")
-    ):
+    if not isinstance(assertion, dict):
+        return False
+    if any(not isinstance(assertion.get(key), bool) for key in ("evaluated", "passed")):
+        return False
+    if not isinstance(assertion.get("description"), str) or not assertion["description"]:
+        return False
+    if assertion.get("source") not in _ASSERTION_SOURCES:
         return False
     if payload["outcome"] == "PASS" and not (
-        payload["boundary"] != "mock"
+        boundary != "mock"
         and payload["app_started"]
         and payload["journey_executed"]
         and assertion["evaluated"]
         and assertion["passed"]
         and passed == total
+        and not failure_reasons
     ):
         return False
     return _evidence_matches_receipt(payload, project_root, receipt_path)
@@ -535,6 +571,10 @@ def _evidence_matches_receipt(
         return False
     if set(commands) != set(evidence_sha256):
         return False
+    if not {"start", "cleanup"}.issubset(commands):
+        return False
+    if payload["outcome"] == "PASS" and set(commands) != set(_PHASES):
+        return False
     canonical_root = (project_root / EVIDENCE_ROOT_REL).resolve()
     for phase, result in commands.items():
         if phase not in _PHASES or not isinstance(result, dict):
@@ -555,8 +595,16 @@ def _evidence_matches_receipt(
             return False
         if result.get("log_path") != declared_log:
             return False
-        if _sha256_file(log_path) != declared_hash:
+        try:
+            actual_hash = _sha256_file(log_path)
+        except OSError:
             return False
+        if actual_hash != declared_hash:
+            return False
+    if payload["outcome"] == "PASS":
+        for phase in ("health", "journey", "cleanup"):
+            if commands[phase].get("exit_code") != 0:
+                return False
     return True
 
 

--- a/harness/product_journey.py
+++ b/harness/product_journey.py
@@ -1,0 +1,588 @@
+#!/usr/bin/env python3
+"""Run a project-local non-UI product journey and emit a verifiable receipt."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import signal
+import subprocess  # nosec B404
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, BinaryIO, Optional
+
+
+CONFIG_REL = Path(".dcness/product-journey.json")
+EVIDENCE_ROOT_REL = Path(".dcness-work/product-journey")
+SCHEMA_VERSION = 1
+RECEIPT_TYPE = "dcness.product-journey"
+_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,63}$")
+_BOUNDARIES = {"api", "cli", "integration", "mock"}
+_ASSERTION_SOURCES = {"journey_exit", "none"}
+_PHASES = ("start", "health", "journey", "cleanup")
+
+
+class JourneyConfigError(ValueError):
+    """Raised when the project-local journey contract is invalid."""
+
+
+@dataclass(frozen=True)
+class JourneyRunResult:
+    exit_code: int
+    receipt_path: Path
+    receipt: dict[str, Any]
+
+
+@dataclass
+class _ServiceHandle:
+    process: subprocess.Popen[bytes]
+    stream: BinaryIO
+    started_at: float
+
+
+def _now_iso() -> str:
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def _parse_ts(value: object) -> Optional[datetime]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _read_object(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise JourneyConfigError(f"cannot read config: {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise JourneyConfigError(f"invalid JSON config: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise JourneyConfigError("config root must be an object")
+    return payload
+
+
+def _require_text(payload: dict[str, Any], key: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise JourneyConfigError(f"{key} must be a non-empty string")
+    return value.strip()
+
+
+def _command_spec(commands: dict[str, Any], phase: str) -> dict[str, Any]:
+    raw = commands.get(phase)
+    if not isinstance(raw, dict):
+        raise JourneyConfigError(f"commands.{phase} must be an object")
+    argv = raw.get("argv")
+    if (
+        not isinstance(argv, list)
+        or not argv
+        or any(not isinstance(item, str) or not item for item in argv)
+    ):
+        raise JourneyConfigError(f"commands.{phase}.argv must be non-empty strings")
+    timeout = raw.get("timeout_sec", 60)
+    if not isinstance(timeout, (int, float)) or isinstance(timeout, bool):
+        raise JourneyConfigError(f"commands.{phase}.timeout_sec must be numeric")
+    if timeout <= 0 or timeout > 600:
+        raise JourneyConfigError(f"commands.{phase}.timeout_sec must be in (0, 600]")
+    return raw
+
+
+def _resolve_evidence_root(project_root: Path, raw: object) -> Path:
+    if not isinstance(raw, str) or not raw.strip():
+        raise JourneyConfigError("evidence_dir must be a non-empty relative path")
+    relative = Path(raw)
+    if relative.is_absolute():
+        raise JourneyConfigError("evidence_dir must be project-relative")
+    resolved = (project_root / relative).resolve()
+    canonical = (project_root / EVIDENCE_ROOT_REL).resolve()
+    try:
+        resolved.relative_to(canonical)
+    except ValueError as exc:
+        raise JourneyConfigError(
+            f"evidence_dir must stay under {EVIDENCE_ROOT_REL.as_posix()}"
+        ) from exc
+    return resolved
+
+
+def _validated_config(
+    project_root: Path, config_path: Path
+) -> tuple[dict[str, Any], Path]:
+    config = _read_object(config_path)
+    if config.get("version") != SCHEMA_VERSION:
+        raise JourneyConfigError(f"version must be {SCHEMA_VERSION}")
+    journey_id = _require_text(config, "journey_id")
+    if not _ID_RE.fullmatch(journey_id):
+        raise JourneyConfigError("journey_id must match [a-z0-9][a-z0-9._-]{2,63}")
+    target_ac = config.get("target_ac")
+    if (
+        not isinstance(target_ac, list)
+        or not target_ac
+        or any(not isinstance(item, str) or not item.strip() for item in target_ac)
+    ):
+        raise JourneyConfigError("target_ac must contain at least one non-empty AC id")
+    boundary = config.get("boundary")
+    if boundary not in _BOUNDARIES:
+        raise JourneyConfigError(f"boundary must be one of {sorted(_BOUNDARIES)}")
+    assertion = config.get("assertion")
+    if not isinstance(assertion, dict):
+        raise JourneyConfigError("assertion must be an object")
+    _require_text(assertion, "description")
+    if assertion.get("source") not in _ASSERTION_SOURCES:
+        raise JourneyConfigError(
+            f"assertion.source must be one of {sorted(_ASSERTION_SOURCES)}"
+        )
+    intervention = config.get("human_intervention_count", 0)
+    if not isinstance(intervention, int) or isinstance(intervention, bool) or intervention < 0:
+        raise JourneyConfigError("human_intervention_count must be a non-negative integer")
+    commands = config.get("commands")
+    if not isinstance(commands, dict):
+        raise JourneyConfigError("commands must be an object")
+    for phase in _PHASES:
+        _command_spec(commands, phase)
+    start_mode = commands["start"].get("mode")
+    if start_mode not in {"command", "service"}:
+        raise JourneyConfigError("commands.start.mode must be command or service")
+    grace = commands["start"].get("startup_grace_sec", 0.2)
+    if not isinstance(grace, (int, float)) or isinstance(grace, bool):
+        raise JourneyConfigError("commands.start.startup_grace_sec must be numeric")
+    if grace < 0 or grace > 30:
+        raise JourneyConfigError("commands.start.startup_grace_sec must be in [0, 30]")
+    env = config.get("env", {})
+    if not isinstance(env, dict) or any(
+        not isinstance(key, str) or not isinstance(value, str)
+        for key, value in env.items()
+    ):
+        raise JourneyConfigError("env must map strings to strings")
+    evidence_root = _resolve_evidence_root(
+        project_root, config.get("evidence_dir", EVIDENCE_ROOT_REL.as_posix())
+    )
+    return config, evidence_root
+
+
+def _relative(path: Path, root: Path) -> str:
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(65536), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _run_command(
+    spec: dict[str, Any], project_root: Path, env: dict[str, str], log_path: Path
+) -> dict[str, Any]:
+    argv = list(spec["argv"])
+    timeout = float(spec.get("timeout_sec", 60))
+    started = time.monotonic()
+    timed_out = False
+    exit_code = 127
+    with log_path.open("wb") as stream:
+        try:
+            completed = subprocess.run(  # nosec B603
+                argv,
+                cwd=project_root,
+                env=env,
+                stdout=stream,
+                stderr=subprocess.STDOUT,
+                timeout=timeout,
+                check=False,
+            )
+            exit_code = completed.returncode
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            exit_code = 124
+        except OSError as exc:
+            stream.write(f"failed to execute: {exc}\n".encode("utf-8"))
+    return {
+        "argv": argv,
+        "exit_code": exit_code,
+        "timed_out": timed_out,
+        "duration_ms": round((time.monotonic() - started) * 1000),
+        "log_path": _relative(log_path, project_root),
+    }
+
+
+def _start_service(
+    spec: dict[str, Any], project_root: Path, env: dict[str, str], log_path: Path
+) -> tuple[_ServiceHandle | None, dict[str, Any]]:
+    argv = list(spec["argv"])
+    stream = log_path.open("wb")
+    started = time.monotonic()
+    try:
+        process = subprocess.Popen(  # nosec B603
+            argv,
+            cwd=project_root,
+            env=env,
+            stdout=stream,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+    except OSError as exc:
+        stream.write(f"failed to execute: {exc}\n".encode("utf-8"))
+        stream.close()
+        return None, {
+            "argv": argv,
+            "exit_code": 127,
+            "timed_out": False,
+            "duration_ms": round((time.monotonic() - started) * 1000),
+            "log_path": _relative(log_path, project_root),
+        }
+    time.sleep(float(spec.get("startup_grace_sec", 0.2)))
+    exit_code = process.poll()
+    if exit_code is not None:
+        stream.close()
+        return None, {
+            "argv": argv,
+            "exit_code": exit_code,
+            "timed_out": False,
+            "duration_ms": round((time.monotonic() - started) * 1000),
+            "log_path": _relative(log_path, project_root),
+        }
+    return _ServiceHandle(process, stream, started), {
+        "argv": argv,
+        "exit_code": None,
+        "timed_out": False,
+        "duration_ms": round((time.monotonic() - started) * 1000),
+        "log_path": _relative(log_path, project_root),
+    }
+
+
+def _stop_service(handle: _ServiceHandle, result: dict[str, Any]) -> None:
+    process = handle.process
+    if process.poll() is None:
+        try:
+            os.killpg(process.pid, signal.SIGTERM)
+            process.wait(timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                os.killpg(process.pid, signal.SIGKILL)
+            except OSError:
+                pass
+            try:
+                process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                pass
+    handle.stream.close()
+    result["exit_code"] = process.poll() if process.poll() is not None else 124
+    result["duration_ms"] = round((time.monotonic() - handle.started_at) * 1000)
+
+
+def _append_once(values: list[str], value: str) -> None:
+    if value not in values:
+        values.append(value)
+
+
+def _write_receipt(path: Path, receipt: dict[str, Any]) -> None:
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(
+        json.dumps(receipt, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+
+
+def run_from_config(
+    project_root: Path | str,
+    *,
+    config_path: Path | str = CONFIG_REL,
+    run_id: Optional[str] = None,
+    measured_at: Optional[str] = None,
+) -> JourneyRunResult:
+    """Execute start/health/journey/cleanup and return the generated receipt."""
+    root = Path(project_root).expanduser().resolve()
+    raw_config_path = Path(config_path).expanduser()
+    resolved_config = (
+        raw_config_path.resolve()
+        if raw_config_path.is_absolute()
+        else (root / raw_config_path).resolve()
+    )
+    try:
+        resolved_config.relative_to(root)
+    except ValueError as exc:
+        raise JourneyConfigError("config must stay inside the project root") from exc
+    config, evidence_root = _validated_config(root, resolved_config)
+    selected_run_id = run_id or f"run-{int(time.time())}"
+    if not _ID_RE.fullmatch(selected_run_id):
+        raise JourneyConfigError("run_id must match [a-z0-9][a-z0-9._-]{2,63}")
+    selected_measured_at = measured_at or _now_iso()
+    if _parse_ts(selected_measured_at) is None:
+        raise JourneyConfigError("measured_at must be ISO-8601")
+    run_dir = evidence_root / selected_run_id
+    try:
+        run_dir.mkdir(parents=True, exist_ok=False)
+    except FileExistsError as exc:
+        raise JourneyConfigError(f"run_id already exists: {selected_run_id}") from exc
+    receipt_path = run_dir / "receipt.json"
+    env = os.environ.copy()
+    env.update(config.get("env", {}))
+    commands = config["commands"]
+    command_results: dict[str, dict[str, Any]] = {}
+    log_paths = {phase: run_dir / f"{phase}.log" for phase in _PHASES}
+    failures: list[str] = []
+    service: _ServiceHandle | None = None
+
+    if config["boundary"] == "mock":
+        _append_once(failures, "mock_only_boundary")
+
+    start_spec = commands["start"]
+    if start_spec["mode"] == "service":
+        service, command_results["start"] = _start_service(
+            start_spec, root, env, log_paths["start"]
+        )
+        app_started = service is not None
+    else:
+        command_results["start"] = _run_command(
+            start_spec, root, env, log_paths["start"]
+        )
+        app_started = command_results["start"]["exit_code"] == 0
+
+    journey_executed = False
+    assertion_evaluated = False
+    assertion_passed = False
+    if not app_started:
+        _append_once(failures, "app_not_started")
+        _append_once(failures, "journey_not_executed")
+        _append_once(failures, "assertion_not_evaluated")
+    else:
+        command_results["health"] = _run_command(
+            commands["health"], root, env, log_paths["health"]
+        )
+        if command_results["health"]["exit_code"] != 0:
+            _append_once(failures, "health_failed")
+            _append_once(failures, "journey_not_executed")
+            _append_once(failures, "assertion_not_evaluated")
+        else:
+            command_results["journey"] = _run_command(
+                commands["journey"], root, env, log_paths["journey"]
+            )
+            journey_executed = True
+            if config["assertion"]["source"] == "journey_exit":
+                assertion_evaluated = True
+                assertion_passed = command_results["journey"]["exit_code"] == 0
+                if not assertion_passed:
+                    _append_once(failures, "journey_failed")
+            else:
+                _append_once(failures, "assertion_not_evaluated")
+
+    command_results["cleanup"] = _run_command(
+        commands["cleanup"], root, env, log_paths["cleanup"]
+    )
+    if command_results["cleanup"]["exit_code"] != 0:
+        _append_once(failures, "cleanup_failed")
+    if service is not None:
+        _stop_service(service, command_results["start"])
+
+    outcome = (
+        "PASS"
+        if not failures
+        and app_started
+        and journey_executed
+        and assertion_evaluated
+        and assertion_passed
+        else "FAIL"
+    )
+    target_ac = [str(item).strip() for item in config["target_ac"]]
+    evidence_paths = {
+        phase: _relative(path, root)
+        for phase, path in log_paths.items()
+        if path.is_file()
+    }
+    evidence_paths["receipt"] = _relative(receipt_path, root)
+    evidence_sha256 = {
+        phase: _sha256_file(path)
+        for phase, path in log_paths.items()
+        if path.is_file()
+    }
+    receipt = {
+        "schema_version": SCHEMA_VERSION,
+        "receipt_type": RECEIPT_TYPE,
+        "run_id": selected_run_id,
+        "journey_id": config["journey_id"],
+        "config_path": _relative(resolved_config, root),
+        "measured_at": selected_measured_at,
+        "finished_at": _now_iso(),
+        "outcome": outcome,
+        "boundary": config["boundary"],
+        "target_ac": target_ac,
+        "product_ac": {
+            "passed": len(target_ac) if outcome == "PASS" else 0,
+            "total": len(target_ac),
+        },
+        "human_intervention_count": config.get("human_intervention_count", 0),
+        "evidence_types": sorted({"command", config["boundary"], "log"}),
+        "evidence_paths": evidence_paths,
+        "evidence_sha256": evidence_sha256,
+        "app_started": app_started,
+        "journey_executed": journey_executed,
+        "assertion": {
+            "description": config["assertion"]["description"],
+            "source": config["assertion"]["source"],
+            "evaluated": assertion_evaluated,
+            "passed": assertion_passed,
+        },
+        "commands": command_results,
+        "failure_reasons": failures,
+    }
+    _write_receipt(receipt_path, receipt)
+    return JourneyRunResult(0 if outcome == "PASS" else 1, receipt_path, receipt)
+
+
+def read_receipts(
+    project_root: Path | str, *, cutoff: Optional[datetime] = None
+) -> list[dict[str, Any]]:
+    """Read structurally valid helper-generated receipts for scorecard aggregation."""
+    root = Path(project_root).expanduser().resolve()
+    evidence_root = root / EVIDENCE_ROOT_REL
+    if not evidence_root.is_dir():
+        return []
+    receipts: list[dict[str, Any]] = []
+    for path in sorted(evidence_root.rglob("receipt.json")):
+        if path.is_symlink():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not _is_valid_receipt(payload, root, path):
+            continue
+        measured = _parse_ts(payload.get("measured_at"))
+        if cutoff is not None and (measured is None or measured > cutoff):
+            continue
+        normalized = dict(payload)
+        normalized["receipt_path"] = _relative(path, root)
+        receipts.append(normalized)
+    return receipts
+
+
+def _is_valid_receipt(payload: object, project_root: Path, receipt_path: Path) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        return False
+    if payload.get("receipt_type") != RECEIPT_TYPE:
+        return False
+    if payload.get("outcome") not in {"PASS", "FAIL"}:
+        return False
+    if _parse_ts(payload.get("measured_at")) is None:
+        return False
+    target_ac = payload.get("target_ac")
+    product_ac = payload.get("product_ac")
+    if not isinstance(target_ac, list) or not target_ac or not isinstance(product_ac, dict):
+        return False
+    passed = product_ac.get("passed")
+    total = product_ac.get("total")
+    if not isinstance(passed, int) or not isinstance(total, int):
+        return False
+    if total != len(target_ac) or passed < 0 or passed > total:
+        return False
+    required_bools = ("app_started", "journey_executed")
+    if any(not isinstance(payload.get(key), bool) for key in required_bools):
+        return False
+    assertion = payload.get("assertion")
+    if not isinstance(assertion, dict) or any(
+        not isinstance(assertion.get(key), bool) for key in ("evaluated", "passed")
+    ):
+        return False
+    if payload["outcome"] == "PASS" and not (
+        payload["boundary"] != "mock"
+        and payload["app_started"]
+        and payload["journey_executed"]
+        and assertion["evaluated"]
+        and assertion["passed"]
+        and passed == total
+    ):
+        return False
+    return _evidence_matches_receipt(payload, project_root, receipt_path)
+
+
+def _evidence_matches_receipt(
+    payload: dict[str, Any], project_root: Path, receipt_path: Path
+) -> bool:
+    commands = payload.get("commands")
+    evidence_paths = payload.get("evidence_paths")
+    evidence_sha256 = payload.get("evidence_sha256")
+    if not isinstance(commands, dict):
+        return False
+    if not isinstance(evidence_paths, dict):
+        return False
+    if not isinstance(evidence_sha256, dict):
+        return False
+    declared_receipt = evidence_paths.get("receipt")
+    if not isinstance(declared_receipt, str):
+        return False
+    if (project_root / declared_receipt).resolve() != receipt_path.resolve():
+        return False
+    if set(commands) != set(evidence_sha256):
+        return False
+    canonical_root = (project_root / EVIDENCE_ROOT_REL).resolve()
+    for phase, result in commands.items():
+        if phase not in _PHASES or not isinstance(result, dict):
+            return False
+        exit_code = result.get("exit_code")
+        if not isinstance(exit_code, int) or isinstance(exit_code, bool):
+            return False
+        declared_log = evidence_paths.get(phase)
+        declared_hash = evidence_sha256.get(phase)
+        if not isinstance(declared_log, str) or not isinstance(declared_hash, str):
+            return False
+        log_path = (project_root / declared_log).resolve()
+        try:
+            log_path.relative_to(canonical_root)
+        except ValueError:
+            return False
+        if log_path.is_symlink() or not log_path.is_file():
+            return False
+        if result.get("log_path") != declared_log:
+            return False
+        if _sha256_file(log_path) != declared_hash:
+            return False
+    return True
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="project-local non-UI product journey runner"
+    )
+    parser.add_argument("command", choices=["run"])
+    parser.add_argument("--project-root", default=".")
+    parser.add_argument("--config", default=CONFIG_REL.as_posix())
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--measured-at", default=None)
+    args = parser.parse_args(argv)
+    try:
+        result = run_from_config(
+            args.project_root,
+            config_path=args.config,
+            run_id=args.run_id,
+            measured_at=args.measured_at,
+        )
+    except JourneyConfigError as exc:
+        print(f"[product-journey] contract error: {exc}", file=sys.stderr)
+        return 2
+    print(result.receipt_path)
+    return result.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/harness/product_journey.py
+++ b/harness/product_journey.py
@@ -549,6 +549,8 @@ def _is_valid_receipt(payload: object, project_root: Path, receipt_path: Path) -
         and not failure_reasons
     ):
         return False
+    if payload["outcome"] == "FAIL" and (passed != 0 or not failure_reasons):
+        return False
     return _evidence_matches_receipt(payload, project_root, receipt_path)
 
 

--- a/scripts/dcness-product-journey
+++ b/scripts/dcness-product-journey
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Execute a project-local non-UI product journey contract.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="$(dirname "$SCRIPT_DIR")"
+export PYTHONPATH="${PLUGIN_ROOT}:${PYTHONPATH:-}"
+PYTHON_BIN="${PYTHON_BIN:-python3.11}"
+
+exec "$PYTHON_BIN" -m harness.product_journey "$@"

--- a/skills/acceptance/SKILL.md
+++ b/skills/acceptance/SKILL.md
@@ -136,22 +136,29 @@ mode: EPIC_ACCEPTANCE
 
 ### Cartography freshness 후속
 
-standalone `/acceptance`는 읽기 전용을 유지하며 stale Root를 직접 수정하지 않는다. product-acceptance prose의 gap을 메인이 읽고 다음 producer를 명시한다.
+standalone `/acceptance`는 tracked 구현·설계에 대해 읽기 전용을 유지하며 stale Root를 직접 수정하지 않는다. 명시된 project-local journey 계약 실행이 만드는 ignored evidence만 예외다. product-acceptance prose의 gap을 메인이 읽고 다음 producer를 명시한다.
 
 - 영향 없음 또는 Root와 일치: 기존 완료 후보 보고를 계속한다.
 - system boundary가 유지된 route/state/as-built edge 또는 capability 상태 drift: 기존 `module-architect:CARTOGRAPHY_REFRESH`가 affected Root Cartography 좌표만 bounded refresh해야 한다고 보고한다. local-only/ignored private docs는 code PR에 강제 포함하지 않고 canonical local Root 갱신 또는 exact durable impact handoff를 다음 producer에 남긴다. durable impact handoff만으로 freshness가 해소되지는 않으므로 canonical local Root refresh 확인 전에는 PASS하지 않는다.
 - system boundary·global decision 변경: route-only refresh로 흡수하지 않고 `/design --revise` 또는 system checkpoint backpressure를 보고한다.
 
-standalone `/acceptance`는 producer를 직접 호출하거나 파일을 수정하지 않는다. direct `/impl`에서 acceptance가 생략되더라도 impl-validator 종료 경계가 최소 Cartography freshness 책임을 가진다.
+standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을 수정하지 않는다. project-local journey 계약이 있으면 ignored `.dcness-work/product-journey/` evidence만 생성할 수 있다. direct `/impl`에서 acceptance가 생략되더라도 impl-validator 종료 경계가 최소 Cartography freshness 책임을 가진다.
 
 ## 절차
 
 1. 입력 단위가 story 인지 epic 인지 확인한다.
-2. story면 `product-acceptance:STORY_ACCEPTANCE`, epic이면 `product-acceptance:EPIC_ACCEPTANCE` 를 호출한다.
-3. `PASS`면 완료 후보로 보고한다.
-4. `FAIL`이면 자동 수정하지 않고 gap 목록과 후속 분기를 prose 로 보고한다. Cartography gap이면 affected Root Cartography, `module-architect:CARTOGRAPHY_REFRESH` 또는 `/design --revise`/system checkpoint, local-only/ignored 정책의 durable impact handoff를 포함한다.
-5. `ESCALATE`면 어떤 기준 문서, 구현 증거, 사용자 결정이 부족한지 보고하고 대기한다.
-6. standalone `/acceptance` 종료 직후 기존 `/run-review` 유틸리티의 context audit 옵션을 1회 실행해 CLAUDE.md/AGENTS.md 현행화 후보만 read-only 로 출력한다.
+2. non-UI 핵심 journey가 검수 대상이고 `.dcness/product-journey.json` 또는 호출자가 지정한 동등한 project-local 계약이 있으면, 메인이 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `dcness-product-journey`를 실행한다. 생성된 receipt와 log 경로를 다음 prompt에 넣는다. exit 1 receipt도 gap 증거로 전달하며 mock-only/app-not-started/journey 미실행/assertion 미평가를 PASS로 바꾸지 않는다.
+3. story면 `product-acceptance:STORY_ACCEPTANCE`, epic이면 `product-acceptance:EPIC_ACCEPTANCE` 를 호출한다.
+4. `PASS`면 완료 후보로 보고한다.
+5. `FAIL`이면 자동 수정하지 않고 gap 목록과 후속 분기를 prose 로 보고한다. Cartography gap이면 affected Root Cartography, `module-architect:CARTOGRAPHY_REFRESH` 또는 `/design --revise`/system checkpoint, local-only/ignored 정책의 durable impact handoff를 포함한다.
+6. `ESCALATE`면 어떤 기준 문서, 구현 증거, 사용자 결정이 부족한지 보고하고 대기한다.
+7. standalone `/acceptance` 종료 직후 기존 `/run-review` 유틸리티의 context audit 옵션을 1회 실행해 CLAUDE.md/AGENTS.md 현행화 후보만 read-only 로 출력한다.
+
+```bash
+"$PLUGIN_ROOT/scripts/dcness-product-journey" run \
+  --project-root "$PROJECT_ROOT" \
+  --config .dcness/product-journey.json
+```
 
 ```bash
 "$PLUGIN_ROOT/scripts/dcness-review" --context-audit --repo "$PROJECT_ROOT"
@@ -162,7 +169,7 @@ standalone `/acceptance`는 producer를 직접 호출하거나 파일을 수정�
 
 ## 워크트리
 
-`/acceptance` 는 read-only 검수 skill 이므로 워크트리 자동 진입 없음. GitHub issue 생성, 코드 수정, PR 생성/머지는 수행하지 않는다.
+`/acceptance` 는 검수 skill 이므로 워크트리 자동 진입 없음. 메인이 명시된 project-local journey 계약을 실행할 때만 ignored `.dcness-work/product-journey/` evidence를 생성할 수 있다. `product-acceptance` agent는 계속 읽기 전용이며 GitHub issue 생성, 구현 코드 수정, PR 생성/머지는 수행하지 않는다.
 
 ## 참조
 
@@ -170,3 +177,4 @@ standalone `/acceptance`는 producer를 직접 호출하거나 파일을 수정�
 - agent: [`agents/product-acceptance.md`](../../agents/product-acceptance.md)
 - 공개 진입점: [`docs/plugin/positioning.md`](../../docs/plugin/positioning.md)
 - 용어 사전: [`docs/plugin/terms.md`](../../docs/plugin/terms.md)
+- 제품 journey 계약: [`docs/plugin/product-journey.md`](../../docs/plugin/product-journey.md)

--- a/skills/acceptance/acceptance-routing.md
+++ b/skills/acceptance/acceptance-routing.md
@@ -42,7 +42,7 @@ flowchart TB
 | `product-acceptance:EPIC_ACCEPTANCE` `FAIL` | Epic 완료 기준·Story AC, cross-story 동작 gap, mock-only green, 화면 증거 부재, 목업 불일치, cross-story 사용자 동선 부적합, security/ops risk 를 보고하고 후속 분기를 제안한다. |
 | `ESCALATE` | 기준 문서, 구현 PR 목록, 권한, 사용자 결정 부족을 보고하고 대기한다. |
 
-Cartography freshness gap은 standalone `/acceptance`의 읽기 전용 경계를 유지하면서 다음 producer까지 비지 않게 한다.
+Cartography freshness gap은 standalone `/acceptance`의 tracked 구현·설계 읽기 전용 경계를 유지하면서 다음 producer까지 비지 않게 한다. project-local journey 계약 실행이 만드는 ignored evidence는 이 경계를 바꾸지 않는다.
 
 | Cartography 결과 | 다음 producer |
 |---|---|
@@ -50,7 +50,7 @@ Cartography freshness gap은 standalone `/acceptance`의 읽기 전용 경계를
 | system boundary 유지 + route/state/as-built edge 또는 capability 상태 drift | `module-architect:CARTOGRAPHY_REFRESH`가 affected Root Cartography만 bounded refresh. local-only/ignored이면 canonical local refresh 또는 durable impact handoff를 보존하고 private docs를 code PR에 강제 포함하지 않음. durable impact handoff만으로 freshness가 해소되지는 않으며 canonical local Root refresh 확인 전에는 PASS 금지 |
 | system boundary·global decision 변경 | route-only patch 금지. `/design --revise` 또는 system checkpoint backpressure 보고 |
 
-standalone `/acceptance`는 이 producer를 직접 호출하지 않고 gap과 근거를 보고한다. product-acceptance와 acceptance skill은 모두 읽기 전용이다.
+standalone `/acceptance`는 이 producer를 직접 호출하지 않고 gap과 근거를 보고한다. product-acceptance는 완전한 읽기 전용이고, acceptance 메인은 명시된 journey 계약의 ignored evidence만 생성하며 tracked 구현·설계는 수정하지 않는다.
 
 ## 깊이 차이
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -231,6 +231,8 @@ story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후
 
 product-acceptance 는 read-only 라 `gh` 호출 불가다. PR 목록·검증 결과·동작 증거·UI 목업 정합 증거와 build-worker Cartography impact, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision을 메인이 prompt 에 직접 담는다. UI task 는 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 함께 넣어 목업 불일치와 화면 증거 부재를 판정할 수 있게 한다. 핵심 AC 증거가 mock-only green 이거나 대상 사용자에게 부적합한 입력/진행 동선이면 gap 이다.
 
+non-UI 핵심 journey가 마감 AC이고 project-local 계약이 있으면, 메인이 product-acceptance 호출 직전에 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `"$PLUGIN_ROOT/scripts/dcness-product-journey" run --project-root "$PROJECT_ROOT" --config <contract>`를 실행한다. 생성된 receipt와 log를 prompt에 넣는다. exit 1은 구현 gap 증거이며 mock-only, app-not-started, journey 미실행, assertion 미평가를 PASS로 세지 않는다. helper가 쓰는 영역은 ignored `.dcness-work/product-journey/`로 한정되고 product-acceptance agent는 수정하지 않는다.
+
 호출:
 
 ```text

--- a/tests/test_outcome_scorecard.py
+++ b/tests/test_outcome_scorecard.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import io
 import json
 import shutil
@@ -123,6 +124,68 @@ def _write_run(
             stream.write(json.dumps(event, ensure_ascii=False) + "\n")
 
 
+def _write_product_journey_receipt(
+    project: Path,
+    run_id: str,
+    *,
+    outcome: str,
+    measured_at: str = "2026-07-10T00:00:00Z",
+) -> None:
+    receipt_dir = project / ".dcness-work" / "product-journey" / run_id
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    passed = 1 if outcome == "PASS" else 0
+    evidence_paths = {
+        "receipt": f".dcness-work/product-journey/{run_id}/receipt.json"
+    }
+    evidence_sha256: dict[str, str] = {}
+    commands: dict[str, dict[str, object]] = {}
+    for phase in ("start", "health", "journey", "cleanup"):
+        content = f"{phase} fixture log\n"
+        log_path = receipt_dir / f"{phase}.log"
+        log_path.write_text(content, encoding="utf-8")
+        relative = f".dcness-work/product-journey/{run_id}/{phase}.log"
+        evidence_paths[phase] = relative
+        evidence_sha256[phase] = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        commands[phase] = {
+            "argv": ["fixture", phase],
+            "exit_code": 0,
+            "timed_out": False,
+            "duration_ms": 1,
+            "log_path": relative,
+        }
+    (receipt_dir / "receipt.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "receipt_type": "dcness.product-journey",
+                "run_id": run_id,
+                "journey_id": "fixture-non-ui",
+                "measured_at": measured_at,
+                "outcome": outcome,
+                "boundary": "cli",
+                "target_ac": ["AC-FIXTURE-1"],
+                "product_ac": {"passed": passed, "total": 1},
+                "human_intervention_count": 0,
+                "evidence_types": ["command", "cli", "log"],
+                "evidence_paths": evidence_paths,
+                "evidence_sha256": evidence_sha256,
+                "commands": commands,
+                "app_started": True,
+                "journey_executed": True,
+                "assertion": {
+                    "description": "fixture assertion",
+                    "source": "journey_exit",
+                    "evaluated": True,
+                    "passed": outcome == "PASS",
+                },
+                "failure_reasons": [] if outcome == "PASS" else ["journey_failed"],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+
 class OutcomeScorecardAggregationTests(unittest.TestCase):
     def _fixture(self, root: Path) -> Path:
         project_a = root / "private-project-a"
@@ -189,6 +252,36 @@ class OutcomeScorecardAggregationTests(unittest.TestCase):
         serialized = json.dumps(report, ensure_ascii=False)
         self.assertNotIn("private-project-a", serialized)
         self.assertNotIn("private-project-b", serialized)
+
+    def test_product_journey_receipts_fill_outcome_without_process_substitution(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            projects_file = self._fixture(root)
+            project_a = root / "private-project-a"
+            _write_product_journey_receipt(project_a, "journey-pass", outcome="PASS")
+            _write_product_journey_receipt(project_a, "journey-fail", outcome="FAIL")
+
+            report = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                redact_paths=True,
+            )
+
+        outcome = report["product_outcome"]
+        self.assertEqual(outcome["status"], "관측")
+        self.assertEqual(outcome["numerator"], 1)
+        self.assertEqual(outcome["denominator"], 2)
+        self.assertEqual(outcome["product_ac"], {"passed": 1, "total": 2})
+        self.assertEqual(outcome["source_project_count"], 1)
+        self.assertEqual(outcome["human_intervention_count"], 0)
+        self.assertEqual(outcome["evidence_types"], ["cli", "command", "log"])
+        self.assertEqual(len(outcome["journeys"]), 2)
+        serialized = json.dumps(outcome, ensure_ascii=False)
+        self.assertNotIn("private-project-a", serialized)
+        self.assertEqual(
+            report["process_evidence"]["pr_merge_success"]["denominator"], 1
+        )
 
     def test_pinned_source_refs_ignore_registry_reordering_and_new_projects(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -409,6 +502,22 @@ class OutcomeScorecardDocumentTests(unittest.TestCase):
         self.assertIn("TOOL_REPEAT_HIGH", baseline)
         self.assertIn("측정 불가", baseline)
         self.assertNotIn("제품 성공률 100%", baseline)
+
+    def test_baseline_records_non_ui_product_journey_pilot(self) -> None:
+        baseline = (ROOT / "docs" / "internal" / "outcome-baseline.md").read_text(
+            encoding="utf-8"
+        )
+        for evidence in (
+            "yt-make-intake-cli",
+            "source-d640b1b95d",
+            "journey PASS 1/1",
+            "제품 AC 1/1",
+            "사람 개입 0",
+            "cli, command, log",
+            "2026-07-12T07:36:43Z",
+        ):
+            self.assertIn(evidence, baseline)
+        self.assertNotIn("/Users/dc.kim/project/youTubeGenerator", baseline)
 
 
 if __name__ == "__main__":

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -1,0 +1,227 @@
+"""Project-local non-UI product journey execution contract tests."""
+
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from harness.product_journey import CONFIG_REL, read_receipts, run_from_config
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def _command(code: str) -> dict[str, object]:
+    return {"argv": [sys.executable, "-c", code], "timeout_sec": 10}
+
+
+def _write_config(root: Path, payload: dict[str, object]) -> Path:
+    path = root / CONFIG_REL
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+    return path
+
+
+class ProductJourneyExecutionTests(unittest.TestCase):
+    def _base_config(self) -> dict[str, object]:
+        return {
+            "version": 1,
+            "journey_id": "fixture-cli-journey",
+            "target_ac": ["AC-FIXTURE-1"],
+            "boundary": "cli",
+            "assertion": {
+                "description": "journey command evaluates the promised behavior",
+                "source": "journey_exit",
+            },
+            "human_intervention_count": 0,
+            "commands": {
+                "start": {
+                    **_command("print('cli started')"),
+                    "mode": "command",
+                },
+                "health": _command("print('healthy')"),
+                "journey": _command("print('assertion passed')"),
+                "cleanup": _command("print('cleaned')"),
+            },
+            "evidence_dir": ".dcness-work/product-journey",
+        }
+
+    def test_service_journey_records_commands_assertion_logs_and_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            port = _free_port()
+            config = self._base_config()
+            config["journey_id"] = "http-service-journey"
+            config["boundary"] = "api"
+            config["commands"] = {
+                "start": {
+                    "argv": [
+                        sys.executable,
+                        "-m",
+                        "http.server",
+                        str(port),
+                        "--bind",
+                        "127.0.0.1",
+                    ],
+                    "mode": "service",
+                    "startup_grace_sec": 0.2,
+                    "timeout_sec": 10,
+                },
+                "health": _command(
+                    "import urllib.request; "
+                    f"assert urllib.request.urlopen('http://127.0.0.1:{port}', timeout=2).status == 200"
+                ),
+                "journey": _command(
+                    "import urllib.request; "
+                    f"body=urllib.request.urlopen('http://127.0.0.1:{port}', timeout=2).read(); "
+                    "assert b'directory listing' in body.lower()"
+                ),
+                "cleanup": _command("print('cleanup hook ran')"),
+            }
+            config_path = _write_config(root, config)
+
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="pilot-success",
+                measured_at="2026-07-12T08:00:00Z",
+            )
+            receipt = json.loads(result.receipt_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(receipt["outcome"], "PASS")
+        self.assertTrue(receipt["app_started"])
+        self.assertTrue(receipt["journey_executed"])
+        self.assertEqual(receipt["assertion"].get("evaluated"), True)
+        self.assertEqual(receipt["assertion"].get("passed"), True)
+        self.assertEqual(receipt["target_ac"], ["AC-FIXTURE-1"])
+        self.assertEqual(receipt["product_ac"], {"passed": 1, "total": 1})
+        self.assertEqual(receipt["human_intervention_count"], 0)
+        self.assertIn("api", receipt["evidence_types"])
+        for phase in ("start", "health", "journey", "cleanup"):
+            self.assertIn("argv", receipt["commands"][phase])
+            self.assertIsInstance(receipt["commands"][phase]["exit_code"], int)
+            self.assertIn(phase, receipt["evidence_sha256"])
+        self.assertFalse(Path(receipt["evidence_paths"]["receipt"]).is_absolute())
+
+    def test_mock_app_not_started_journey_skipped_and_unmeasured_assertion_never_pass(
+        self,
+    ) -> None:
+        cases = {
+            "mock-only": {
+                "boundary": "mock",
+                "expected": "mock_only_boundary",
+            },
+            "app-not-started": {
+                "start": {**_command("raise SystemExit(3)"), "mode": "command"},
+                "expected": "app_not_started",
+            },
+            "journey-not-executed": {
+                "health": _command("raise SystemExit(4)"),
+                "expected": "journey_not_executed",
+            },
+            "assertion-not-evaluated": {
+                "assertion": {"description": "declared but not evaluated", "source": "none"},
+                "expected": "assertion_not_evaluated",
+            },
+        }
+        for name, mutation in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                config = self._base_config()
+                commands = dict(config["commands"])
+                if "boundary" in mutation:
+                    config["boundary"] = mutation["boundary"]
+                if "start" in mutation:
+                    commands["start"] = mutation["start"]
+                if "health" in mutation:
+                    commands["health"] = mutation["health"]
+                if "assertion" in mutation:
+                    config["assertion"] = mutation["assertion"]
+                config["commands"] = commands
+                config_path = _write_config(root, config)
+
+                result = run_from_config(
+                    root,
+                    config_path=config_path,
+                    run_id=name,
+                    measured_at="2026-07-12T08:00:00Z",
+                )
+                receipt = json.loads(result.receipt_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(result.exit_code, 1)
+            self.assertEqual(receipt["outcome"], "FAIL")
+            self.assertIn(mutation["expected"], receipt["failure_reasons"])
+            self.assertEqual(receipt["product_ac"]["passed"], 0)
+
+    def test_tampered_log_invalidates_receipt_for_scorecard_consumers(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = _write_config(root, self._base_config())
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="tamper-check",
+                measured_at="2026-07-12T08:00:00Z",
+            )
+            self.assertEqual(len(read_receipts(root)), 1)
+            journey_log = root / result.receipt["evidence_paths"]["journey"]
+            journey_log.write_text("tampered\n", encoding="utf-8")
+
+            receipts = read_receipts(root)
+
+        self.assertEqual(receipts, [])
+
+
+class ProductJourneyContractDocumentTests(unittest.TestCase):
+    def test_contract_and_main_workflows_define_execution_and_read_only_handoff(
+        self,
+    ) -> None:
+        contract = (ROOT / "docs/plugin/product-journey.md").read_text(encoding="utf-8")
+        acceptance = (ROOT / "skills/acceptance/SKILL.md").read_text(encoding="utf-8")
+        impl_loop = (ROOT / "skills/impl-loop/SKILL.md").read_text(encoding="utf-8")
+        product_acceptance = (
+            ROOT
+            / "docs/plugin/agents/product-acceptance/product-acceptance-agent.md"
+        ).read_text(encoding="utf-8")
+        init_contract = (ROOT / "docs/plugin/init-dcness.md").read_text(encoding="utf-8")
+        deliverables = (ROOT / "docs/plugin/deliverables-map.md").read_text(
+            encoding="utf-8"
+        )
+
+        for term in (
+            "start",
+            "health",
+            "journey",
+            "cleanup",
+            "evidence_dir",
+            "journey_exit",
+            "mock_only_boundary",
+            ".dcness-work/product-journey",
+        ):
+            self.assertIn(term, contract)
+        for workflow in (acceptance, impl_loop):
+            self.assertIn("dcness-product-journey", workflow)
+            self.assertIn("product-acceptance", workflow)
+            self.assertIn("receipt", workflow)
+        self.assertIn("app_started", product_acceptance)
+        self.assertIn("journey_executed", product_acceptance)
+        self.assertIn("assertion", product_acceptance)
+        self.assertIn("읽기 전용", product_acceptance)
+        self.assertIn("사용자 repo에 복사하지", init_contract)
+        self.assertIn("dcness-product-journey", init_contract)
+        self.assertIn(".dcness-work/product-journey/", deliverables)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import json
 import socket
 import sys
@@ -181,6 +182,41 @@ class ProductJourneyExecutionTests(unittest.TestCase):
             receipts = read_receipts(root)
 
         self.assertEqual(receipts, [])
+
+    def test_malformed_or_incomplete_pass_receipts_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config_path = _write_config(root, self._base_config())
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="malformed-check",
+                measured_at="2026-07-12T08:00:00Z",
+            )
+            original = json.loads(result.receipt_path.read_text(encoding="utf-8"))
+            mutations = {
+                "missing-run-id": lambda receipt: receipt.pop("run_id"),
+                "non-string-ac": lambda receipt: receipt.update(target_ac=[1]),
+                "negative-human-intervention": lambda receipt: receipt.update(
+                    human_intervention_count=-1
+                ),
+                "pass-with-failure": lambda receipt: receipt.update(
+                    failure_reasons=["forged"]
+                ),
+                "pass-without-cleanup": lambda receipt: (
+                    receipt["commands"].pop("cleanup"),
+                    receipt["evidence_paths"].pop("cleanup"),
+                    receipt["evidence_sha256"].pop("cleanup"),
+                ),
+            }
+            for name, mutate in mutations.items():
+                with self.subTest(name=name):
+                    candidate = copy.deepcopy(original)
+                    mutate(candidate)
+                    result.receipt_path.write_text(
+                        json.dumps(candidate, ensure_ascii=False), encoding="utf-8"
+                    )
+                    self.assertEqual(read_receipts(root), [])
 
 
 class ProductJourneyContractDocumentTests(unittest.TestCase):

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -208,6 +208,15 @@ class ProductJourneyExecutionTests(unittest.TestCase):
                     receipt["evidence_paths"].pop("cleanup"),
                     receipt["evidence_sha256"].pop("cleanup"),
                 ),
+                "fail-with-passed-ac": lambda receipt: (
+                    receipt.update(outcome="FAIL", failure_reasons=["journey_failed"]),
+                    receipt["assertion"].update(passed=False),
+                ),
+                "fail-without-reason": lambda receipt: (
+                    receipt.update(outcome="FAIL"),
+                    receipt["product_ac"].update(passed=0),
+                    receipt["assertion"].update(passed=False),
+                ),
             }
             for name, mutate in mutations.items():
                 with self.subTest(name=name):


### PR DESCRIPTION
## 관련 이슈 번호
Closes #1067

## 배경 및 문제
product-acceptance는 전달된 증거를 읽기 전용으로 판정하지만, 외부 활성 프로젝트가 앱·서비스·CLI를 실제로 시작해 non-UI 핵심 journey를 실행하고 증거를 생성하는 공통 계약이 없었습니다. 그 결과 mock-only green, 앱 미기동, assertion 미평가 상태를 제품 outcome과 분리해 집계할 수 없었습니다.

## 원인 (해당 시)
실행 증거의 producer와 read-only product-acceptance consumer 사이에 project-local start/health/journey/cleanup 계약 및 scorecard가 신뢰할 receipt 규약이 없었습니다.

## 작업내용
- project-local JSON 계약을 읽어 start → health → journey assertion → cleanup을 실행하는 plugin helper를 추가했습니다.
- command exit, log, 대상 AC, 사람 개입, evidence 종류와 sha256을 receipt로 남기고 변조된 evidence는 scorecard에서 제외합니다.
- standalone acceptance와 impl-loop가 receipt를 read-only product-acceptance에 전달하도록 계약을 연결했습니다.
- outcome scorecard가 journey PASS/전체와 제품 AC passed/total을 process 지표와 분리해 집계하도록 확장했습니다.
- 외부 활성 프로젝트의 실제 CLI intake journey를 실행해 journey 1/1, 제품 AC 1/1, 사람 개입 0 pilot을 기록했습니다.

## 결정 근거
- 새 공개 command/agent나 범용 E2E 플랫폼을 추가하지 않고 plugin 내부 helper와 opt-in project-local 계약으로 제한했습니다.
- UI 화면/screenshot 증거는 범위에서 제외하고 non-UI API/CLI/integration boundary만 다룹니다.
- 사용자 repo에는 helper를 복사하지 않고 plugin update로 배포하며, 실행 산출물은 ignored `.dcness-work/product-journey/`에 둡니다.
- product-acceptance agent는 구현과 receipt를 수정하지 않는 read-only 역할을 유지합니다.

## Test Plan
- [x] project-local service 성공 경로와 command/log/cleanup receipt 검증
- [x] mock-only, app-not-started, journey 미실행, assertion 미평가 fixture가 PASS가 아님을 검증
- [x] log 변조 receipt가 scorecard에서 제외되는지 검증
- [x] 외부 활성 프로젝트 실제 non-UI CLI pilot exit 0 및 scorecard 1/1 집계
- [x] `python3.11 -m unittest discover -s tests -q < /dev/null` — 1,901 tests PASS
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- [x] static-quality — ruff, mypy, Bandit PASS
- [x] public-surface, plugin-manifest, cross-ref, doc-sync gate PASS

## 참고
- 배포 경로 검증: `scripts/dcness-product-journey`, `harness/product_journey.py`, `docs/plugin/product-journey.md`는 plugin 본체로 배포됩니다. 사용자 repo 복사 대상은 없고 project-local 계약만 opt-in입니다.
- 실제 pilot receipt는 source ref `source-d640b1b95d`의 ignored `.dcness-work/product-journey/yt-make-intake-pilot-20260712/receipt.json`에 남겼으며 공개 문서에는 절대경로를 기록하지 않았습니다.
