### PR TITLE
[epic1064][story1069] lean ablation 실증 기록

### DIFF
--- a/docs/internal/lean-ablation-2026-07.md
+++ b/docs/internal/lean-ablation-2026-07.md
@@ -1,0 +1,49 @@
+# 2026-07 lean ablation — TOOL_REPEAT_HIGH lesson metadata
+
+## 후보와 안전 경계
+
+외부 활성 프로젝트 2곳의 finished run 26개에서 `TOOL_REPEAT_HIGH`가 42건
+관측됐다. 이 신호가 재발하면 다음 같은 agent/mode의 prompt에 고정 행동 문장과
+`hits/last/evidence`를 붙이는 프로젝트-로컬 `[LESSONS]`가 생성된다. 첫 후보는 행동
+문장을 제거하는 것이 아니라 가변 메타데이터만 줄이는 선택형 context 축소다. 기대
+절감 지표는 input token이며, fixture 기준 20 token과 전체 input의 0.05%를 사전
+meaningful 경계로 뒀다.
+
+order, file boundary, external-state mutation, TDD guard는 후보에서 제외했다. 활성
+프로젝트의 live run이나 guard를 끄지 않았고, 동일 frozen fixture의 read-only `/tmp`
+복사본에서만 shadow와 paired screening을 실행했다.
+
+## deterministic → shadow → paired 결과
+
+재현 명령:
+
+```sh
+python3.11 evals/lean_ablation.py \
+  evals/lean-ablation/tool-repeat-lesson-metadata.json --json
+```
+
+tracked fixture 네 파일의 SHA-256을 record가 검증한다. baseline prompt는 683 bytes,
+metadata를 뺀 variant는 576 bytes여서 shadow상 107 bytes가 줄었다. 두 조건의 task,
+fixture, response schema, provider/model(`openai-codex` / `gpt-5.6-sol`, medium)은
+동일했다.
+
+| 조건 | 제품 AC | MUST-FIX / 회귀 / 사람 개입 | 동일 tool/input 반복 | input token (cached) | output token | wall-clock |
+|---|---:|---:|---:|---:|---:|---:|
+| baseline 1회 | 2/2 | 0 / 0 / 0 | 0 | 38,874 (24,064) | 355 | 15.36s |
+| metadata 축소 1회 | 2/2 | 0 / 0 / 0 | 0 | 40,659 (26,112) | 366 | 13.81s |
+
+variant는 품질 gap을 만들지 않았지만 사전 주지표 input token이 1,785 증가했다.
+wall-clock 1.55초 감소는 단일 표본 변동과 충돌하며 remove 근거로 쓰지 않는다.
+첫 pair에서 주지표 절감이 음수로 명확했으므로 추가 1+1을 실행하지 않았다.
+2026-07 epic 공통 추가 LLM trial 누계는 2/4이고, #1070 paired screening은 같은 달에
+실행하지 않았다. 지원되지 않는 모델명으로 inference 전에 HTTP 400이 난 preflight는
+trial에 포함하지 않았다.
+
+## 결정
+
+결정은 **keep**이다. `TOOL_REPEAT_HIGH` 행동 문장과 `hits/last/evidence` 메타데이터를
+현행 유지한다. 107-byte shadow 절감은 실제 총 input token 감소로 재현되지 않았고,
+개인 판단용 단일 fixture라 일반 우위나 열위를 주장하지 않는다. 후속 조치는 남은
+7월 trial을 소진하지 않고, 다른 달에 telemetry가 다시 후보로 올릴 때만 재평가하는
+것이다. 원시 조건·수치·한계는
+`evals/lean-ablation/tool-repeat-lesson-metadata.json`과 `evidence/`가 보존한다.

--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -80,3 +80,21 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
 ## 사용 가능한 주장
 
 이 snapshot은 source 2개와 finished run 26개라는 cross-project process baseline 조건은 충족한다. 그러나 비교 variant별 반복 trial과 실제 product outcome이 없으므로 공개 우위 주장은 할 수 없다. 같은 fixture의 1+1 paired screening은 개인 경량화 `keep` / `remove` / `hold` 판단에만 사용할 수 있다.
+
+## 2026-07 lean ablation pilot
+
+`TOOL_REPEAT_HIGH` 42건/finished run 26개/source 2곳과 직접 연결된 선택형
+`[LESSONS]`의 `hits/last/evidence` prompt metadata 축소를 평가했다. hard safety
+guard는 live disable하지 않았고 frozen read-only fixture의 deterministic 비교,
+shadow prompt 비교, 동일 `openai-codex` / `gpt-5.6-sol` 조건의 1+1 screening 순서를
+지켰다.
+
+| variant | trial | 제품 AC | MUST-FIX / 회귀 / 사람 개입 | input/output token | wall-clock | 결정 입력 |
+|---|---:|---:|---:|---:|---:|---|
+| baseline | 1 | 2/2 | 0 / 0 / 0 | 38,874 / 355 | 15.36s | full lesson metadata |
+| metadata 축소 | 1 | 2/2 | 0 / 0 / 0 | 40,659 / 366 | 13.81s | prompt 107 bytes 감소 |
+
+주지표 input token이 감소하지 않아 첫 pair에서 **keep**으로 종료했다. 실행 월
+`2026-07`, epic 공통 추가 LLM trial 누계 `2/4`, #1070 같은 달 screening 없음이다.
+단일 frozen fixture 결과이므로 공개 superiority 근거가 아니다. 재현 계약, fixture
+hash, evidence와 한계는 [`lean-ablation-2026-07.md`](lean-ablation-2026-07.md)에 있다.

--- a/evals/lean-ablation/baseline-prompt.md
+++ b/evals/lean-ablation/baseline-prompt.md
@@ -1,0 +1,11 @@
+현재 디렉터리의 파일만 읽고 `route_message`의 현재 runtime entrypoint, capability
+owner 파일, stale 경로를 판정한다. `registry.json`의 등록과 실제 구현을 근거로
+응답한다. 파일을 수정하지 않는다.
+
+제품 AC:
+
+1. `entrypoint`가 `src/runtime.py::dispatch`다.
+2. `owner`가 `src/runtime.py`이고 `stale_path`가 `legacy/router.py`다.
+
+[LESSONS: system-architect]
+- `TOOL_REPEAT_HIGH`: 같은 tool/input 반복 호출을 멈추고 첫 결과를 재사용한다. 재확인은 grep, offset, 더 좁은 입력으로 수행한다. (hits=5, last=2026-07-06T13:39:43+00:00, evidence=run_id=run-7e60f967 path=<redacted>/system-architect.md)

--- a/evals/lean-ablation/evidence/baseline.md
+++ b/evals/lean-ablation/evidence/baseline.md
@@ -1,0 +1,18 @@
+# Baseline trial evidence
+
+- execution: `2026-07-12`, isolated `/tmp` fixture copy, read-only sandbox
+- provider/model: `openai-codex` / `gpt-5.6-sol`, reasoning effort `medium`
+- frozen task SHA-256: `f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70`
+- prompt: `evals/lean-ablation/baseline-prompt.md` (`683` bytes)
+- condition: lesson sentence plus `hits/last/evidence` metadata
+- command executions: `2`, unique commands: `2`, identical command repeats: `0`
+- wall-clock: `15.36s`
+- token usage: input `38,874` (cached `24,064`), output `355`, reasoning output `9`
+- cost: `측정 불가` (ChatGPT-account Codex execution exposed token counts but no per-trial billed cost)
+- product AC: `2/2`; MUST-FIX `0`; regression `0`; human intervention `0`
+
+Final response:
+
+```json
+{"entrypoint":"src/runtime.py::dispatch","owner":"src/runtime.py","stale_path":"legacy/router.py","reason":"registry.json은 route_message를 src/runtime.py::dispatch로 등록하며, 해당 파일에 실제 dispatch 구현이 있습니다. legacy/router.py의 route_message는 stale implementation으로 명시되어 있고 RuntimeError를 발생시킵니다."}
+```

--- a/evals/lean-ablation/evidence/variant.md
+++ b/evals/lean-ablation/evidence/variant.md
@@ -1,0 +1,18 @@
+# Variant trial evidence
+
+- execution: `2026-07-12`, isolated `/tmp` fixture copy, read-only sandbox
+- provider/model: `openai-codex` / `gpt-5.6-sol`, reasoning effort `medium`
+- frozen task SHA-256: `f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70`
+- prompt: `evals/lean-ablation/variant-prompt.md` (`576` bytes)
+- condition: lesson sentence retained; `hits/last/evidence` metadata removed
+- command executions: `2`, unique commands: `2`, identical command repeats: `0`
+- wall-clock: `13.81s`
+- token usage: input `40,659` (cached `26,112`), output `366`, reasoning output `13`
+- cost: `측정 불가` (ChatGPT-account Codex execution exposed token counts but no per-trial billed cost)
+- product AC: `2/2`; MUST-FIX `0`; regression `0`; human intervention `0`
+
+Final response:
+
+```json
+{"entrypoint":"src/runtime.py::dispatch","owner":"src/runtime.py","stale_path":"legacy/router.py","reason":"registry.json이 route_message를 src/runtime.py::dispatch로 등록하고, 해당 함수가 실제 정상 구현입니다. legacy/router.py의 route_message는 스스로 stale 구현임을 명시하며 RuntimeError를 발생시키므로 stale 경로입니다."}
+```

--- a/evals/lean-ablation/fixture/README.md
+++ b/evals/lean-ablation/fixture/README.md
@@ -1,0 +1,5 @@
+# Frozen read-reuse fixture
+
+`route_message`의 현재 runtime entrypoint와 소유자를 찾아라. 이 문서는 과거
+`legacy/router.py`가 진입점이었다고 설명하지만, 실제 등록 상태는 `registry.json`과
+도달 가능한 구현을 기준으로 판정해야 한다.

--- a/evals/lean-ablation/fixture/legacy/router.py
+++ b/evals/lean-ablation/fixture/legacy/router.py
@@ -1,0 +1,5 @@
+"""Stale implementation retained only as an ablation distractor."""
+
+
+def route_message(message: str) -> str:
+    raise RuntimeError("stale path")

--- a/evals/lean-ablation/fixture/registry.json
+++ b/evals/lean-ablation/fixture/registry.json
@@ -1,0 +1,3 @@
+{
+  "route_message": "src/runtime.py::dispatch"
+}

--- a/evals/lean-ablation/fixture/src/runtime.py
+++ b/evals/lean-ablation/fixture/src/runtime.py
@@ -1,0 +1,5 @@
+"""Current framework-reachable message route."""
+
+
+def dispatch(message: str) -> str:
+    return message.strip()

--- a/evals/lean-ablation/response-schema.json
+++ b/evals/lean-ablation/response-schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["entrypoint", "owner", "stale_path", "reason"],
+  "properties": {
+    "entrypoint": {"type": "string"},
+    "owner": {"type": "string"},
+    "stale_path": {"type": "string"},
+    "reason": {"type": "string"}
+  }
+}

--- a/evals/lean-ablation/task.md
+++ b/evals/lean-ablation/task.md
@@ -1,0 +1,12 @@
+# Frozen task: read reuse
+
+현재 디렉터리의 파일만 읽고 `route_message`의 현재 runtime entrypoint, capability
+owner 파일, stale 경로를 판정한다. `registry.json`의 등록과 실제 구현을 근거로
+응답한다. 파일을 수정하지 않는다.
+
+제품 AC:
+
+1. `entrypoint`가 `src/runtime.py::dispatch`다.
+2. `owner`가 `src/runtime.py`이고 `stale_path`가 `legacy/router.py`다.
+
+baseline과 variant의 유일한 차이는 prompt 끝의 `[LESSONS]` 표현이다.

--- a/evals/lean-ablation/tool-repeat-lesson-metadata.json
+++ b/evals/lean-ablation/tool-repeat-lesson-metadata.json
@@ -58,6 +58,8 @@
     "excluded_preflight": "A gpt-5.2-codex request failed with HTTP 400 before inference and is not counted as a trial."
   },
   "paired_screening": {
+    "task_path": "evals/lean-ablation/task.md",
+    "task_sha256": "f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70",
     "trials": [
       {
         "variant": "baseline",
@@ -79,7 +81,8 @@
         "wall_clock_seconds": 15.36,
         "identical_tool_input_repeats": 0,
         "cost_usd": null,
-        "evidence": "evals/lean-ablation/evidence/baseline.md"
+        "evidence": "evals/lean-ablation/evidence/baseline.md",
+        "evidence_sha256": "e061b6ee6b05f11d9c56ead142e64da4cdab40c9793910c43698495689370015"
       },
       {
         "variant": "variant",
@@ -101,7 +104,8 @@
         "wall_clock_seconds": 13.81,
         "identical_tool_input_repeats": 0,
         "cost_usd": null,
-        "evidence": "evals/lean-ablation/evidence/variant.md"
+        "evidence": "evals/lean-ablation/evidence/variant.md",
+        "evidence_sha256": "76885a91a9dfd2f5e7a915a528499b2faf5aaaed89f9297dbe4cf23831f7b809"
       }
     ]
   },

--- a/evals/lean-ablation/tool-repeat-lesson-metadata.json
+++ b/evals/lean-ablation/tool-repeat-lesson-metadata.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": 1,
+  "candidate": {
+    "id": "tool-repeat-lesson-metadata",
+    "component": "TOOL_REPEAT_HIGH lesson hits/last/evidence prompt metadata",
+    "optional_reason": "The metadata is advisory context appended after begin-step; it is not an order, file-boundary, external-state, or TDD guard.",
+    "telemetry": {
+      "pattern": "TOOL_REPEAT_HIGH",
+      "count": 42,
+      "finished_run_denominator": 26,
+      "source_project_count": 2,
+      "evidence": "docs/internal/outcome-baseline.md"
+    },
+    "expected_saving_metric": "input_tokens",
+    "meaningful_reduction": {
+      "absolute": 20,
+      "relative": 0.0005
+    }
+  },
+  "safety": {
+    "hard_guards_excluded": [
+      "order",
+      "file-boundary",
+      "external-state",
+      "tdd"
+    ],
+    "live_hard_guard_disabled": false
+  },
+  "deterministic": {
+    "passed": true,
+    "command": "python3.11 evals/lean_ablation.py evals/lean-ablation/tool-repeat-lesson-metadata.json --json",
+    "baseline_prompt_path": "evals/lean-ablation/baseline-prompt.md",
+    "variant_prompt_path": "evals/lean-ablation/variant-prompt.md",
+    "baseline_prompt_bytes": 683,
+    "variant_prompt_bytes": 576,
+    "baseline_prompt_sha256": "b819b208bac5adfb2e52958daa6503ab11e3bda63396aca35b2524446346295e",
+    "variant_prompt_sha256": "1d361468d8e2479ba44844e555bd6a107105e9a03c993f199b06472ccc6dfb51",
+    "fixture_hashes": {
+      "evals/lean-ablation/fixture/README.md": "968ac7c5cb34a819350c2db890c305b09576802d181d71475a7c12ebc75da6a8",
+      "evals/lean-ablation/fixture/registry.json": "3dbfcd5242c305f394c43e6a9f2fd51fa1e286770eb9f0adaecc69e1b2eab22c",
+      "evals/lean-ablation/fixture/src/runtime.py": "6a78a4b70319ec51133306a89ddafe5ad353a6a75d244389632230255f0ea223",
+      "evals/lean-ablation/fixture/legacy/router.py": "0a9895b6094b80b78f6f11a22e204e645789976ce368e6a880ef21aba9a0216a"
+    }
+  },
+  "shadow": {
+    "passed": true,
+    "live_product_affected": false,
+    "baseline_prompt_sha256": "b819b208bac5adfb2e52958daa6503ab11e3bda63396aca35b2524446346295e",
+    "variant_prompt_sha256": "1d361468d8e2479ba44844e555bd6a107105e9a03c993f199b06472ccc6dfb51",
+    "prompt_bytes_saved": 107,
+    "note": "Both conditions used identical read-only copies of the frozen fixture under /tmp; no activated-project run or live guard was changed."
+  },
+  "budget": {
+    "execution_month": "2026-07",
+    "monthly_cap": 4,
+    "used_before": 0,
+    "agent_effectiveness_screening_month": null,
+    "excluded_preflight": "A gpt-5.2-codex request failed with HTTP 400 before inference and is not counted as a trial."
+  },
+  "paired_screening": {
+    "trials": [
+      {
+        "variant": "baseline",
+        "task_id": "frozen-read-reuse-v1",
+        "input_sha256": "f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70",
+        "model": "gpt-5.6-sol",
+        "provider": "openai-codex",
+        "product_ac": {
+          "passed": 2,
+          "total": 2
+        },
+        "must_fix_count": 0,
+        "regression_count": 0,
+        "human_intervention_count": 0,
+        "input_tokens": 38874,
+        "cached_input_tokens": 24064,
+        "output_tokens": 355,
+        "reasoning_output_tokens": 9,
+        "wall_clock_seconds": 15.36,
+        "identical_tool_input_repeats": 0,
+        "cost_usd": null,
+        "evidence": "evals/lean-ablation/evidence/baseline.md"
+      },
+      {
+        "variant": "variant",
+        "task_id": "frozen-read-reuse-v1",
+        "input_sha256": "f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70",
+        "model": "gpt-5.6-sol",
+        "provider": "openai-codex",
+        "product_ac": {
+          "passed": 2,
+          "total": 2
+        },
+        "must_fix_count": 0,
+        "regression_count": 0,
+        "human_intervention_count": 0,
+        "input_tokens": 40659,
+        "cached_input_tokens": 26112,
+        "output_tokens": 366,
+        "reasoning_output_tokens": 13,
+        "wall_clock_seconds": 13.81,
+        "identical_tool_input_repeats": 0,
+        "cost_usd": null,
+        "evidence": "evals/lean-ablation/evidence/variant.md"
+      }
+    ]
+  },
+  "decision": "keep",
+  "follow_up": "Keep the existing TOOL_REPEAT_HIGH lesson metadata. Reconsider only after a future telemetry-selected candidate month; do not spend the remaining two July trials on an already negative input-token result.",
+  "limitations": [
+    "One frozen read-only fixture and one baseline/variant pair; this is a personal screening, not public superiority evidence.",
+    "Input token totals include shared Codex runtime context and cache behavior, so the deterministic 107-byte prompt delta did not translate into lower total input tokens.",
+    "Per-trial billed cost was unavailable from the ChatGPT-account Codex execution.",
+    "No activated-project product run or hard safety guard was disabled."
+  ]
+}

--- a/evals/lean-ablation/variant-prompt.md
+++ b/evals/lean-ablation/variant-prompt.md
@@ -1,0 +1,11 @@
+현재 디렉터리의 파일만 읽고 `route_message`의 현재 runtime entrypoint, capability
+owner 파일, stale 경로를 판정한다. `registry.json`의 등록과 실제 구현을 근거로
+응답한다. 파일을 수정하지 않는다.
+
+제품 AC:
+
+1. `entrypoint`가 `src/runtime.py::dispatch`다.
+2. `owner`가 `src/runtime.py`이고 `stale_path`가 `legacy/router.py`다.
+
+[LESSONS: system-architect]
+- `TOOL_REPEAT_HIGH`: 같은 tool/input 반복 호출을 멈추고 첫 결과를 재사용한다. 재확인은 grep, offset, 더 좁은 입력으로 수행한다.

--- a/evals/lean_ablation.py
+++ b/evals/lean_ablation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -24,6 +25,7 @@ ALLOWED_METRICS = {
 }
 REQUIRED_HARD_GUARDS = {"order", "file-boundary", "external-state", "tdd"}
 ROOT = Path(__file__).resolve().parents[1]
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 def _mapping(value: Any, field: str, errors: list[str]) -> dict[str, Any]:
@@ -203,10 +205,24 @@ def _collect_trials(
     record: dict[str, Any], metric: str, errors: list[str]
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     screening = _mapping(record.get("paired_screening"), "paired_screening", errors)
+    task_sha = screening.get("task_sha256")
+    if not isinstance(task_sha, str) or not SHA256_RE.fullmatch(task_sha):
+        errors.append("paired_task_sha256_invalid")
+        task_sha = ""
+    _verify_artifact(
+        screening.get("task_path"),
+        task_sha,
+        None,
+        "paired_task",
+        errors,
+    )
     trials_raw = screening.get("trials")
     trials = trials_raw if isinstance(trials_raw, list) else []
     if not isinstance(trials_raw, list):
         errors.append("paired_screening_trials_must_be_array")
+    expected_sequence = ["baseline", "variant"] * (len(trials) // 2)
+    if [trial.get("variant") for trial in trials if isinstance(trial, dict)] != expected_sequence:
+        errors.append("trial_sequence_invalid")
     baselines: list[dict[str, Any]] = []
     variants: list[dict[str, Any]] = []
     conditions: set[tuple[Any, Any, Any, Any]] = set()
@@ -227,8 +243,28 @@ def _collect_trials(
                 trial.get("provider"),
             )
         )
-        if not str(trial.get("evidence") or "").strip():
+        for identity_field in ("task_id", "model", "provider"):
+            if not str(trial.get(identity_field) or "").strip():
+                errors.append(f"trial_{index}_{identity_field}_required")
+        input_sha = trial.get("input_sha256")
+        if not isinstance(input_sha, str) or not SHA256_RE.fullmatch(input_sha):
+            errors.append(f"trial_{index}_input_sha256_invalid")
+        elif task_sha and input_sha != task_sha:
+            errors.append(f"trial_{index}_input_sha256_mismatch")
+        evidence = trial.get("evidence")
+        evidence_sha = trial.get("evidence_sha256")
+        if not str(evidence or "").strip():
             errors.append(f"trial_{index}_evidence_required")
+        if not isinstance(evidence_sha, str) or not SHA256_RE.fullmatch(evidence_sha):
+            errors.append(f"trial_{index}_evidence_sha256_invalid")
+        else:
+            _verify_artifact(
+                evidence,
+                evidence_sha,
+                None,
+                f"trial_{index}_evidence",
+                errors,
+            )
         _trial_quality(trial, errors, index)
         _number(trial.get(str(metric)), f"trial_{index}_{metric}", errors)
     if len(conditions) != 1:

--- a/evals/lean_ablation.py
+++ b/evals/lean_ablation.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Validate one evidence-backed, budget-capped lean ablation record.
+
+This is an internal evaluation surface, not a plugin command. It keeps the
+deterministic-first, shadow-only safety, paired-screening budget, and
+keep/remove/hold decision rules executable without invoking an LLM itself.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ALLOWED_DECISIONS = {"keep", "remove", "hold"}
+ALLOWED_METRICS = {
+    "input_tokens",
+    "output_tokens",
+    "wall_clock_seconds",
+    "human_intervention_count",
+}
+REQUIRED_HARD_GUARDS = {"order", "file-boundary", "external-state", "tdd"}
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _mapping(value: Any, field: str, errors: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{field}_must_be_object")
+    return {}
+
+
+def _number(value: Any, field: str, errors: list[str]) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    errors.append(f"{field}_must_be_number")
+    return 0.0
+
+
+def _verify_artifact(
+    path_value: Any,
+    expected_sha: Any,
+    expected_bytes: Any,
+    field: str,
+    errors: list[str],
+) -> None:
+    if not isinstance(path_value, str) or not path_value:
+        return
+    path = ROOT / path_value
+    try:
+        content = path.read_bytes()
+    except OSError:
+        errors.append(f"{field}_artifact_unreadable")
+        return
+    actual_sha = hashlib.sha256(content).hexdigest()
+    if expected_sha and actual_sha != expected_sha:
+        errors.append(f"{field}_sha256_mismatch")
+    if expected_bytes is not None and len(content) != int(expected_bytes):
+        errors.append(f"{field}_byte_count_mismatch")
+
+
+def _trial_quality(trial: dict[str, Any], errors: list[str], index: int) -> tuple:
+    product_ac = _mapping(trial.get("product_ac"), f"trial_{index}_product_ac", errors)
+    passed = _number(product_ac.get("passed"), f"trial_{index}_ac_passed", errors)
+    total = _number(product_ac.get("total"), f"trial_{index}_ac_total", errors)
+    must_fix = _number(
+        trial.get("must_fix_count"), f"trial_{index}_must_fix_count", errors
+    )
+    regressions = _number(
+        trial.get("regression_count"), f"trial_{index}_regression_count", errors
+    )
+    human = _number(
+        trial.get("human_intervention_count"),
+        f"trial_{index}_human_intervention_count",
+        errors,
+    )
+    if passed < 0 or total <= 0 or passed > total:
+        errors.append(f"trial_{index}_invalid_product_ac")
+    if min(must_fix, regressions, human) < 0:
+        errors.append(f"trial_{index}_negative_quality_count")
+    return passed, total, must_fix, regressions, human
+
+
+def _candidate_contract(
+    record: dict[str, Any], errors: list[str]
+) -> tuple[dict[str, Any], str, float, float]:
+    candidate = _mapping(record.get("candidate"), "candidate", errors)
+    telemetry = _mapping(candidate.get("telemetry"), "candidate_telemetry", errors)
+    if telemetry.get("pattern") != "TOOL_REPEAT_HIGH":
+        errors.append("candidate_not_linked_to_tool_repeat_high")
+    if _number(telemetry.get("count"), "telemetry_count", errors) <= 0:
+        errors.append("telemetry_count_must_be_positive")
+    if _number(
+        telemetry.get("finished_run_denominator"),
+        "telemetry_finished_run_denominator",
+        errors,
+    ) <= 0:
+        errors.append("telemetry_denominator_must_be_positive")
+    if _number(
+        telemetry.get("source_project_count"),
+        "telemetry_source_project_count",
+        errors,
+    ) <= 0:
+        errors.append("telemetry_source_count_must_be_positive")
+    if not str(candidate.get("optional_reason") or "").strip():
+        errors.append("optional_reason_required")
+
+    metric = candidate.get("expected_saving_metric")
+    if metric not in ALLOWED_METRICS:
+        errors.append("unsupported_expected_saving_metric")
+        metric = "input_tokens"
+    threshold = _mapping(
+        candidate.get("meaningful_reduction"), "meaningful_reduction", errors
+    )
+    absolute_threshold = _number(
+        threshold.get("absolute"), "meaningful_reduction_absolute", errors
+    )
+    relative_threshold = _number(
+        threshold.get("relative"), "meaningful_reduction_relative", errors
+    )
+    if absolute_threshold <= 0 or not 0 < relative_threshold < 1:
+        errors.append("meaningful_reduction_threshold_invalid")
+    return candidate, str(metric), absolute_threshold, relative_threshold
+
+
+def _setup_contract(
+    record: dict[str, Any], errors: list[str]
+) -> tuple[float, float, str, int, int]:
+    safety = _mapping(record.get("safety"), "safety", errors)
+    excluded = set(safety.get("hard_guards_excluded") or [])
+    missing_guards = sorted(REQUIRED_HARD_GUARDS - excluded)
+    if missing_guards:
+        errors.append("hard_guard_exclusions_missing:" + ",".join(missing_guards))
+    if safety.get("live_hard_guard_disabled") is not False:
+        errors.append("live_hard_guard_disabled")
+
+    deterministic = _mapping(record.get("deterministic"), "deterministic", errors)
+    if deterministic.get("passed") is not True:
+        errors.append("deterministic_fixture_not_passed")
+    baseline_bytes = _number(
+        deterministic.get("baseline_prompt_bytes"),
+        "deterministic_baseline_prompt_bytes",
+        errors,
+    )
+    variant_bytes = _number(
+        deterministic.get("variant_prompt_bytes"),
+        "deterministic_variant_prompt_bytes",
+        errors,
+    )
+    if baseline_bytes <= variant_bytes:
+        errors.append("deterministic_variant_not_smaller")
+
+    _verify_artifact(
+        deterministic.get("baseline_prompt_path"),
+        deterministic.get("baseline_prompt_sha256"),
+        deterministic.get("baseline_prompt_bytes"),
+        "baseline_prompt",
+        errors,
+    )
+    _verify_artifact(
+        deterministic.get("variant_prompt_path"),
+        deterministic.get("variant_prompt_sha256"),
+        deterministic.get("variant_prompt_bytes"),
+        "variant_prompt",
+        errors,
+    )
+    fixture_hashes = deterministic.get("fixture_hashes")
+    if isinstance(fixture_hashes, dict):
+        for fixture_path, expected_sha in fixture_hashes.items():
+            _verify_artifact(
+                fixture_path,
+                expected_sha,
+                None,
+                "fixture_" + str(fixture_path).replace("/", "_"),
+                errors,
+            )
+
+    shadow = _mapping(record.get("shadow"), "shadow", errors)
+    if shadow.get("passed") is not True:
+        errors.append("shadow_comparison_not_passed")
+    if shadow.get("live_product_affected") is not False:
+        errors.append("shadow_affected_live_product")
+
+    budget = _mapping(record.get("budget"), "budget", errors)
+    execution_month = str(budget.get("execution_month") or "")
+    if len(execution_month) != 7 or execution_month[4:5] != "-":
+        errors.append("execution_month_invalid")
+    cap = int(_number(budget.get("monthly_cap"), "monthly_cap", errors))
+    used_before = int(_number(budget.get("used_before"), "used_before", errors))
+    if cap != 4:
+        errors.append("monthly_cap_must_equal_four")
+    if used_before < 0:
+        errors.append("used_before_negative")
+    if budget.get("agent_effectiveness_screening_month") == execution_month:
+        errors.append("same_month_agent_effectiveness_screening")
+    return baseline_bytes, variant_bytes, execution_month, cap, used_before
+
+
+def _collect_trials(
+    record: dict[str, Any], metric: str, errors: list[str]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    screening = _mapping(record.get("paired_screening"), "paired_screening", errors)
+    trials_raw = screening.get("trials")
+    trials = trials_raw if isinstance(trials_raw, list) else []
+    if not isinstance(trials_raw, list):
+        errors.append("paired_screening_trials_must_be_array")
+    baselines: list[dict[str, Any]] = []
+    variants: list[dict[str, Any]] = []
+    conditions: set[tuple[Any, Any, Any, Any]] = set()
+    for index, raw in enumerate(trials):
+        trial = _mapping(raw, f"trial_{index}", errors)
+        variant = trial.get("variant")
+        if variant not in {"baseline", "variant"}:
+            errors.append(f"trial_{index}_variant_invalid")
+        elif variant == "baseline":
+            baselines.append(trial)
+        else:
+            variants.append(trial)
+        conditions.add(
+            (
+                trial.get("task_id"),
+                trial.get("input_sha256"),
+                trial.get("model"),
+                trial.get("provider"),
+            )
+        )
+        if not str(trial.get("evidence") or "").strip():
+            errors.append(f"trial_{index}_evidence_required")
+        _trial_quality(trial, errors, index)
+        _number(trial.get(str(metric)), f"trial_{index}_{metric}", errors)
+    if len(conditions) != 1:
+        errors.append("paired_conditions_mismatch")
+    if len(baselines) != len(variants) or len(baselines) not in {1, 2}:
+        errors.append("baseline_variant_count_mismatch")
+    return baselines, variants
+
+
+def _variant_quality_worse(
+    baselines: list[dict[str, Any]],
+    variants: list[dict[str, Any]],
+    errors: list[str],
+) -> bool:
+    quality_worse = False
+    for index, (baseline, variant) in enumerate(zip(baselines, variants)):
+        b_quality = _trial_quality(baseline, errors, index * 2)
+        v_quality = _trial_quality(variant, errors, index * 2 + 1)
+        b_passed, b_total, b_must_fix, b_regressions, b_human = b_quality
+        v_passed, v_total, v_must_fix, v_regressions, v_human = v_quality
+        if (
+            v_total != b_total
+            or v_passed < b_passed
+            or v_must_fix > b_must_fix
+            or v_regressions > b_regressions
+            or v_human > b_human
+        ):
+            quality_worse = True
+    return quality_worse
+
+
+def _screening_contract(
+    record: dict[str, Any],
+    metric: str,
+    absolute_threshold: float,
+    relative_threshold: float,
+    cap: int,
+    used_before: int,
+    errors: list[str],
+) -> dict[str, Any]:
+    baselines, variants = _collect_trials(record, metric, errors)
+    trial_count = len(baselines) + len(variants)
+    if trial_count not in {2, 4}:
+        errors.append("trial_count_must_be_two_or_four")
+    epic_total = used_before + trial_count
+    if epic_total > cap:
+        errors.append("monthly_trial_cap_exceeded")
+    quality_worse = _variant_quality_worse(baselines, variants, errors)
+    baseline_values = [float(trial.get(str(metric), 0)) for trial in baselines]
+    variant_values = [float(trial.get(str(metric), 0)) for trial in variants]
+    baseline_mean = sum(baseline_values) / len(baseline_values) if baselines else 0.0
+    variant_mean = sum(variant_values) / len(variant_values) if variants else 0.0
+    absolute_reduction = baseline_mean - variant_mean
+    relative_reduction = (
+        absolute_reduction / baseline_mean if baseline_mean > 0 else 0.0
+    )
+    meaningful = (
+        absolute_reduction >= absolute_threshold
+        and relative_reduction >= relative_threshold
+    )
+
+    if quality_worse or absolute_reduction <= 0:
+        derived_decision = "keep"
+    elif meaningful:
+        derived_decision = "remove"
+    elif trial_count == 2:
+        derived_decision = "additional_pair_required"
+        errors.append("additional_pair_required")
+    else:
+        derived_decision = "hold"
+    return {
+        "trial_count": trial_count,
+        "epic_total": epic_total,
+        "quality_worse": quality_worse,
+        "baseline_mean": baseline_mean,
+        "variant_mean": variant_mean,
+        "absolute_reduction": absolute_reduction,
+        "relative_reduction": relative_reduction,
+        "derived_decision": derived_decision,
+    }
+
+
+def _validate_recorded_decision(
+    record: dict[str, Any], derived_decision: str, errors: list[str]
+) -> tuple[Any, list[Any]]:
+    recorded_decision = record.get("decision")
+    if recorded_decision not in ALLOWED_DECISIONS:
+        errors.append("recorded_decision_invalid")
+    elif derived_decision in ALLOWED_DECISIONS and recorded_decision != derived_decision:
+        errors.append(
+            f"recorded_decision_mismatch:{recorded_decision}!={derived_decision}"
+        )
+    if not str(record.get("follow_up") or "").strip():
+        errors.append("follow_up_required")
+    limitations = record.get("limitations")
+    if not isinstance(limitations, list) or not limitations:
+        errors.append("limitations_required")
+    return recorded_decision, limitations if isinstance(limitations, list) else []
+
+
+def evaluate(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    errors: list[str] = []
+    if record.get("schema_version") != 1:
+        errors.append("unsupported_schema_version")
+
+    candidate, metric, absolute_threshold, relative_threshold = _candidate_contract(
+        record, errors
+    )
+    baseline_bytes, variant_bytes, execution_month, cap, used_before = (
+        _setup_contract(record, errors)
+    )
+    screening = _screening_contract(
+        record,
+        metric,
+        absolute_threshold,
+        relative_threshold,
+        cap,
+        used_before,
+        errors,
+    )
+    derived_decision = str(screening["derived_decision"])
+    recorded_decision, limitations = _validate_recorded_decision(
+        record, derived_decision, errors
+    )
+
+    report = {
+        "candidate_id": candidate.get("id"),
+        "decision": (
+            derived_decision if derived_decision in ALLOWED_DECISIONS else recorded_decision
+        ),
+        "trial_count": screening["trial_count"],
+        "epic_monthly_trial_total": screening["epic_total"],
+        "execution_month": execution_month,
+        "quality_worse": screening["quality_worse"],
+        "metric": metric,
+        "baseline_mean": screening["baseline_mean"],
+        "variant_mean": screening["variant_mean"],
+        "absolute_reduction": screening["absolute_reduction"],
+        "relative_reduction": screening["relative_reduction"],
+        "deterministic_prompt_bytes_saved": baseline_bytes - variant_bytes,
+        "limitations": limitations,
+        "status": "PASS" if not errors else "FAIL",
+    }
+    return report, errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="validate one lean ablation record")
+    parser.add_argument("record", type=Path)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+    try:
+        payload = json.loads(args.record.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"record_unreadable: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(payload, dict):
+        print("record_must_be_object", file=sys.stderr)
+        return 2
+
+    report, errors = evaluate(payload)
+    if args.json:
+        print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    else:
+        print(
+            f"{report['status']} {report['candidate_id']}: {report['decision']} "
+            f"({report['trial_count']} trial, {report['metric']} "
+            f"{report['relative_reduction']:.1%})"
+        )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lean_ablation.py
+++ b/tests/test_lean_ablation.py
@@ -17,7 +17,7 @@ def _trial(variant: str, *, tokens: int, ac_passed: int = 2) -> dict:
     return {
         "variant": variant,
         "task_id": "frozen-read-reuse-v1",
-        "input_sha256": "a" * 64,
+        "input_sha256": "f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70",
         "model": "gpt-5.2-codex",
         "provider": "openai-codex",
         "product_ac": {"passed": ac_passed, "total": 2},
@@ -27,7 +27,8 @@ def _trial(variant: str, *, tokens: int, ac_passed: int = 2) -> dict:
         "input_tokens": tokens,
         "output_tokens": 100,
         "wall_clock_seconds": 10.0,
-        "evidence": "evals/lean-ablation/evidence/example.jsonl",
+        "evidence": "evals/lean-ablation/task.md",
+        "evidence_sha256": "f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70",
     }
 
 
@@ -74,7 +75,11 @@ def _record(trials: list[dict]) -> dict:
             "used_before": 0,
             "agent_effectiveness_screening_month": None,
         },
-        "paired_screening": {"trials": trials},
+        "paired_screening": {
+            "task_path": "evals/lean-ablation/task.md",
+            "task_sha256": "f8ef929c35dec53fde0e753908e7bc44e1dcadc9101f01a366ec53567e11dd70",
+            "trials": trials,
+        },
         "decision": "remove",
         "follow_up": "drop volatile metadata while retaining the lesson text",
         "limitations": ["single frozen fixture", "not public superiority evidence"],
@@ -182,6 +187,31 @@ class LeanAblationProtocolTests(unittest.TestCase):
         self.assertEqual(result.returncode, 2)
         self.assertIn("same_month_agent_effectiveness_screening", result.stderr)
         self.assertIn("live_hard_guard_disabled", result.stderr)
+
+    def test_rejects_empty_condition_identity_even_when_both_trials_match(self) -> None:
+        trials = [_trial("baseline", tokens=1000), _trial("variant", tokens=850)]
+        for trial in trials:
+            trial["task_id"] = ""
+            trial["model"] = ""
+            trial["provider"] = ""
+        record = _record(trials)
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("trial_0_task_id_required", result.stderr)
+        self.assertIn("trial_0_model_required", result.stderr)
+        self.assertIn("trial_0_provider_required", result.stderr)
+
+    def test_rejects_reversed_variant_order(self) -> None:
+        record = _record(
+            [_trial("variant", tokens=850), _trial("baseline", tokens=1000)]
+        )
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("trial_sequence_invalid", result.stderr)
 
     def test_recorded_pilot_is_self_consistent(self) -> None:
         result = subprocess.run(

--- a/tests/test_lean_ablation.py
+++ b/tests/test_lean_ablation.py
@@ -1,0 +1,202 @@
+"""Lean ablation protocol and recorded pilot contract tests (#1069)."""
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "evals" / "lean_ablation.py"
+PILOT = ROOT / "evals" / "lean-ablation" / "tool-repeat-lesson-metadata.json"
+
+
+def _trial(variant: str, *, tokens: int, ac_passed: int = 2) -> dict:
+    return {
+        "variant": variant,
+        "task_id": "frozen-read-reuse-v1",
+        "input_sha256": "a" * 64,
+        "model": "gpt-5.2-codex",
+        "provider": "openai-codex",
+        "product_ac": {"passed": ac_passed, "total": 2},
+        "must_fix_count": 0,
+        "regression_count": 0,
+        "human_intervention_count": 0,
+        "input_tokens": tokens,
+        "output_tokens": 100,
+        "wall_clock_seconds": 10.0,
+        "evidence": "evals/lean-ablation/evidence/example.jsonl",
+    }
+
+
+def _record(trials: list[dict]) -> dict:
+    return {
+        "schema_version": 1,
+        "candidate": {
+            "id": "tool-repeat-lesson-metadata",
+            "component": "TOOL_REPEAT_HIGH lesson hits/last/evidence prompt metadata",
+            "optional_reason": "advisory context; not an order or access guard",
+            "telemetry": {
+                "pattern": "TOOL_REPEAT_HIGH",
+                "count": 42,
+                "finished_run_denominator": 26,
+                "source_project_count": 2,
+            },
+            "expected_saving_metric": "input_tokens",
+            "meaningful_reduction": {"absolute": 40, "relative": 0.05},
+        },
+        "safety": {
+            "hard_guards_excluded": [
+                "order",
+                "file-boundary",
+                "external-state",
+                "tdd",
+            ],
+            "live_hard_guard_disabled": False,
+        },
+        "deterministic": {
+            "passed": True,
+            "command": "python3.11 evals/lean_ablation.py RECORD",
+            "baseline_prompt_bytes": 320,
+            "variant_prompt_bytes": 180,
+        },
+        "shadow": {
+            "passed": True,
+            "live_product_affected": False,
+            "baseline_prompt_sha256": "b" * 64,
+            "variant_prompt_sha256": "c" * 64,
+        },
+        "budget": {
+            "execution_month": "2026-07",
+            "monthly_cap": 4,
+            "used_before": 0,
+            "agent_effectiveness_screening_month": None,
+        },
+        "paired_screening": {"trials": trials},
+        "decision": "remove",
+        "follow_up": "drop volatile metadata while retaining the lesson text",
+        "limitations": ["single frozen fixture", "not public superiority evidence"],
+    }
+
+
+class LeanAblationProtocolTests(unittest.TestCase):
+    def _run(self, record: dict) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "record.json"
+            path.write_text(json.dumps(record), encoding="utf-8")
+            return subprocess.run(
+                ["python3.11", str(RUNNER), str(path), "--json"],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+    def test_clear_first_pair_accepts_remove_without_extra_trials(self) -> None:
+        result = self._run(
+            _record(
+                [
+                    _trial("baseline", tokens=1000),
+                    _trial("variant", tokens=850),
+                ]
+            )
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["decision"], "remove")
+        self.assertEqual(report["trial_count"], 2)
+        self.assertEqual(report["epic_monthly_trial_total"], 2)
+
+    def test_quality_loss_forces_keep_even_when_variant_is_cheaper(self) -> None:
+        record = _record(
+            [
+                _trial("baseline", tokens=1000),
+                _trial("variant", tokens=800, ac_passed=1),
+            ]
+        )
+        record["decision"] = "keep"
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["decision"], "keep")
+
+    def test_no_saving_is_a_clear_keep_without_extra_trials(self) -> None:
+        record = _record(
+            [
+                _trial("baseline", tokens=1000),
+                _trial("variant", tokens=1100),
+            ]
+        )
+        record["decision"] = "keep"
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertEqual(report["decision"], "keep")
+        self.assertEqual(report["trial_count"], 2)
+
+    def test_ambiguous_first_pair_requires_one_more_pair(self) -> None:
+        record = _record(
+            [
+                _trial("baseline", tokens=1000),
+                _trial("variant", tokens=980),
+            ]
+        )
+        record["decision"] = "hold"
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("additional_pair_required", result.stderr)
+
+    def test_four_trial_cap_allows_hold_after_ambiguous_repeat(self) -> None:
+        record = _record(
+            [
+                _trial("baseline", tokens=1000),
+                _trial("variant", tokens=980),
+                _trial("baseline", tokens=990),
+                _trial("variant", tokens=970),
+            ]
+        )
+        record["decision"] = "hold"
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(json.loads(result.stdout)["decision"], "hold")
+
+    def test_rejects_budget_collision_or_live_hard_guard_ablation(self) -> None:
+        record = _record(
+            [_trial("baseline", tokens=1000), _trial("variant", tokens=850)]
+        )
+        record["budget"]["agent_effectiveness_screening_month"] = "2026-07"
+        record["safety"]["live_hard_guard_disabled"] = True
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("same_month_agent_effectiveness_screening", result.stderr)
+        self.assertIn("live_hard_guard_disabled", result.stderr)
+
+    def test_recorded_pilot_is_self_consistent(self) -> None:
+        result = subprocess.run(
+            ["python3.11", str(RUNNER), str(PILOT), "--json"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        report = json.loads(result.stdout)
+        self.assertIn(report["decision"], {"keep", "remove", "hold"})
+        self.assertLessEqual(report["epic_monthly_trial_total"], 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1069

## 배경 및 문제

외부 활성 프로젝트 2곳의 finished run 26개에서 `TOOL_REPEAT_HIGH`가 42건 관측됐지만, 비용 인상만으로 선택형 구성요소를 제거하면 품질·복구 비용을 악화시킬 수 있었습니다. 월 4회 추가 LLM trial 상한 안에서 deterministic → shadow → paired screening 순서와 keep/remove/hold 판정을 재현 가능하게 남길 필요가 있었습니다.

## 원인 (해당 시)

기존 outcome scorecard는 개인 1+1 screening의 필드와 주장 경계를 정의했지만, hard guard 제외·월 예산·동일 조건·품질 fail-closed·첫 명확 결과 조기 종료를 한 record에서 기계적으로 감사하는 lean ablation 실행 계약과 실제 표본은 없었습니다.

## 작업내용

- `TOOL_REPEAT_HIGH` `[LESSONS]`의 `hits/last/evidence` metadata를 첫 선택형 축소 후보로 고정했습니다.
- frozen fixture, full/compact prompt, SHA-256 artifact 검증, 월 trial 예산과 same-month #1070 충돌을 감사하는 `evals/lean_ablation.py`를 추가했습니다.
- 동일 `openai-codex` / `gpt-5.6-sol` 조건의 1+1 screening에서 양쪽 제품 AC 2/2, MUST-FIX·회귀·사람 개입 0을 확인했습니다.
- variant input token이 1,785 증가해 첫 pair에서 `keep`으로 종료하고, 2026-07 epic 공통 trial 누계를 2/4로 기록했습니다.
- scorecard baseline과 내부 decision 문서에 표본, 조건, 한계, 후속 조치를 연결했습니다.

## 결정 근거

shadow prompt는 107 bytes 줄었지만 실제 총 input token 감소로 재현되지 않았습니다. wall-clock 1.55초 감소는 단일 표본 변동과 주지표 악화가 충돌하므로 remove 근거로 쓰지 않았습니다. 결과가 명확해 남은 2회 trial을 소진하지 않고 현행 metadata를 유지합니다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self의 internal eval·evidence 작업입니다. `agents/**`, `commands/**`, `hooks/**`, init-dcness 복사 파일, plugin 사용자 계약/동작은 변경하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 skill/command/agent/gate를 추가하지 않습니다. `evals/lean_ablation.py`는 저장소 내부 evidence validator입니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,910 passed
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 passed
- [x] `python3.11 evals/lean_ablation.py evals/lean-ablation/tool-repeat-lesson-metadata.json --json` — PASS / keep / 2 trial
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/bandit PASS
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] `node scripts/check_cross_refs.mjs` — PASS
- [x] `node scripts/check_doc_path_integrity.mjs` — PASS
- [x] `node scripts/check_plugin_manifest.mjs` — PASS
- [x] `git diff --check` — PASS

## 참고

- 지원되지 않는 `gpt-5.2-codex` 이름으로 inference 전에 HTTP 400이 난 preflight는 trial에 포함하지 않았습니다.
- 단일 frozen fixture의 개인 의사결정 근거이며 공개 superiority 근거가 아닙니다.
