### PR TITLE
[epic1064][story1070] Agent 탐색·변경 효과를 측정합니다.

### DIFF
--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -79,7 +79,7 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
 
 ## 2026-07-12 Agent effectiveness deterministic screening
 
-`agent-effectiveness-2026-07`은 cold-start 탐색과 refactor/replacement 검증의 frozen synthetic fixture 2개를 baseline/current로 replay했다. 새 agent나 공개 command를 추가하지 않고 기존 scorecard에 record 입력만 연결했다.
+`agent-effectiveness-2026-07`은 frozen synthetic repository fixture 1개에서 cold-start 탐색과 refactor/replacement 검증 task 2개를 baseline/current로 replay했다. 새 agent나 공개 command를 추가하지 않고 기존 scorecard에 record 입력만 연결했다.
 
 ```sh
 printf '{"version":1,"projects":[]}' > /tmp/dcness-empty-projects.json
@@ -91,7 +91,7 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
   --json
 ```
 
-측정 조건은 provider `deterministic-replay`, model `none`, frozen synthetic Python repo, baseline/current 두 variant다. 비교 trial 4, source fixture 2, 측정일 `2026-07-12T10:00:00Z`이며 input/output token `0/0`, cost `$0.00`이다. 모델을 호출하지 않는 저장 replay라 wall-clock은 agent 수행 시간이 아닌 fixture trace의 첫 정답 elapsed 값만 비교한다.
+측정 조건은 provider `deterministic-replay`, model `none`, frozen synthetic Python repo, baseline/current 두 variant다. 비교 trial 4, source fixture 1, task 2, 측정일 `2026-07-12T10:00:00Z`이며 input/output token `0/0`, cost `$0.00`이다. 모델을 호출하지 않는 저장 replay라 wall-clock은 agent 수행 시간이 아닌 fixture trace의 첫 정답 elapsed 값만 비교한다.
 
 | task | 지표 | baseline | current | 판정 |
 |---|---|---:|---:|---|
@@ -105,7 +105,7 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
 
 탐색 tool은 `13→9`, read bytes는 `7,000→4,600`, 오경로는 `2→0`, 영향 누락은 `1→0`, context 기인 재작업은 `2→0`으로 줄었고 핵심 품질은 악화되지 않았다. 따라서 이 결정적 screening에서는 개선을 관측했다. 문서 수, map 크기, hook 수는 입력 설명일 뿐 effectiveness 대리값으로 사용하지 않았다.
 
-2026-07 epic 공통 추가 LLM trial 누계 `2/4`는 #1069 screening의 기존 2회뿐이며 이번 record의 새 LLM trial은 0회다. #1069와 같은 달 paired screening을 실행하지 않았다. 이 결과는 synthetic fixture 2개와 저장 trace에 한정되고, live agent token/cost·실제 프로젝트 wall-clock·다중 model/provider·공개 우위는 측정 불가다.
+2026-07 epic 공통 추가 LLM trial 누계 `2/4`는 #1069 screening의 기존 2회뿐이며 이번 record의 새 LLM trial은 0회다. #1069와 같은 달 paired screening을 실행하지 않았다. 이 결과는 synthetic fixture 1개·task 2개와 저장 trace에 한정되고, live agent token/cost·실제 프로젝트 wall-clock·다중 model/provider·공개 우위는 측정 불가다.
 
 ## 사용 가능한 주장
 

--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -77,6 +77,36 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
 
 기능 또는 receipt가 존재한다는 사실은 마지막 항목들의 개선 증거가 아니다. 후속 trial이 생길 때까지 `측정 불가`를 실패나 개선으로 추정하지 않는다.
 
+## 2026-07-12 Agent effectiveness deterministic screening
+
+`agent-effectiveness-2026-07`은 cold-start 탐색과 refactor/replacement 검증의 frozen synthetic fixture 2개를 baseline/current로 replay했다. 새 agent나 공개 command를 추가하지 않고 기존 scorecard에 record 입력만 연결했다.
+
+```sh
+printf '{"version":1,"projects":[]}' > /tmp/dcness-empty-projects.json
+python3.11 "$DCN"/harness/outcome_scorecard.py \
+  --projects-file /tmp/dcness-empty-projects.json \
+  --agent-effectiveness-record \
+  "$DCN"/evals/agent-effectiveness/cartography-sanity-replay.json \
+  --measured-at 2026-07-12T10:00:00Z \
+  --json
+```
+
+측정 조건은 provider `deterministic-replay`, model `none`, frozen synthetic Python repo, baseline/current 두 variant다. 비교 trial 4, source fixture 2, 측정일 `2026-07-12T10:00:00Z`이며 input/output token `0/0`, cost `$0.00`이다. 모델을 호출하지 않는 저장 replay라 wall-clock은 agent 수행 시간이 아닌 fixture trace의 첫 정답 elapsed 값만 비교한다.
+
+| task | 지표 | baseline | current | 판정 |
+|---|---|---:|---:|---|
+| cold-start | SSOT/entrypoint/owner/decision 정확도 | 4/4 | 4/4 | 비열화 없음 |
+| cold-start | 첫 owner까지 tool / read bytes / elapsed | 5 / 3,100 / 50ms | 3 / 1,500 / 30ms | 감소 |
+| cold-start | 전체 tool / read bytes / 오경로 | 6 / 3,400 / 2 | 4 / 1,800 / 0 | 감소 |
+| refactor/replacement | stale/framework/seam 분류 | 1/3 | 3/3 | 개선 |
+| refactor/replacement | 영향 누락 / 과다 포함 | 1 / 1 | 0 / 0 | 개선 |
+| 두 task 합계 | context 기인 재작업 / cross-session 복구 | 2 / 0 | 0 / 2 | 개선 |
+| 두 task 품질 | 제품 AC / MUST-FIX / 회귀 / 사람 복구 | 4/4 / 0 / 0 / 0 | 4/4 / 0 / 0 / 0 | 비열화 없음 |
+
+탐색 tool은 `13→9`, read bytes는 `7,000→4,600`, 오경로는 `2→0`, 영향 누락은 `1→0`, context 기인 재작업은 `2→0`으로 줄었고 핵심 품질은 악화되지 않았다. 따라서 이 결정적 screening에서는 개선을 관측했다. 문서 수, map 크기, hook 수는 입력 설명일 뿐 effectiveness 대리값으로 사용하지 않았다.
+
+2026-07 epic 공통 추가 LLM trial 누계 `2/4`는 #1069 screening의 기존 2회뿐이며 이번 record의 새 LLM trial은 0회다. #1069와 같은 달 paired screening을 실행하지 않았다. 이 결과는 synthetic fixture 2개와 저장 trace에 한정되고, live agent token/cost·실제 프로젝트 wall-clock·다중 model/provider·공개 우위는 측정 불가다.
+
 ## 사용 가능한 주장
 
 이 snapshot은 source 2개와 finished run 26개라는 cross-project process baseline 조건은 충족한다. 그러나 비교 variant별 반복 trial과 실제 product outcome이 없으므로 공개 우위 주장은 할 수 없다. 같은 fixture의 1+1 paired screening은 개인 경량화 `keep` / `remove` / `hold` 판단에만 사용할 수 있다.

--- a/docs/plugin/outcome-scorecard.md
+++ b/docs/plugin/outcome-scorecard.md
@@ -45,13 +45,19 @@ Agent effectiveness는 하네스 기능 보유 여부가 아니라 같은 조건
 | 관측 항목 | 의미 |
 |---|---|
 | SSOT·runtime entrypoint·capability owner 탐색 정확도 | 첫 선택이 현재 코드와 문서의 진짜 owner를 가리키는가 |
-| 첫 올바른 변경 대상까지의 비용 | 걸린 시간, tool/read 양, 불필요한 파일 읽기와 tool 반복 |
+| 첫 올바른 변경 대상까지의 비용 | 첫 올바른 대상까지의 tool/read 수·bytes·시간, 불필요한 파일 읽기와 tool 반복 |
 | 오경로 | stale 문서, 잘못된 owner/entrypoint, 폐기된 경로를 선택한 횟수 |
 | 영향 범위 누락 | 필요한 producer/consumer, 상태 전이, 테스트 또는 공개 경계를 빠뜨렸는가 |
+| 영향 범위 과다 포함 | 현재 변경과 무관한 파일·경계를 영향 범위에 넣었는가 |
 | context 기인 재작업 | 구현 결함이 아니라 필요한 맥락 누락 때문에 validator가 되돌린 횟수 |
 | cross-session 복구 | 다음 세션이 결정·현재 상태·다음 변경 대상을 정확히 복구했는가 |
+| 제품 AC와 품질 경계 | 제품 AC, MUST-FIX, regression, 사람 복구가 탐색 비용 절감과 함께 유지되는가 |
 
 Cartography freshness는 SSOT·entrypoint·owner 후보와 stale 여부의 입력 증거를 제공한다. Codebase Sanity는 code revision, 감사 scope, 경고·unknown·잔존 경로의 입력 증거를 제공한다. 두 기능이 존재하거나 PASS했다는 사실만으로 탐색 정확도·시간·재작업 감소가 입증되지는 않는다. 비교 trial의 before/after 또는 paired 관측이 없으면 effectiveness는 `측정 불가`다.
+
+결정적 screening은 `--agent-effectiveness-record <record.json>`으로 frozen baseline/current replay를 scorecard에 결합한다. record는 cold-start의 SSOT·runtime entrypoint·capability owner·decision 기대 좌표와 방문 trace, refactor/replacement의 stale old path·framework-reachable·intentional seam 기대 분류와 영향 기대 집합을 보존한다. 측정기는 fixture SHA-256, 동일 repo/model/provider/harness variant 조건, 월 LLM trial 예산, 제품 AC·MUST-FIX·regression·사람 복구 비열화를 함께 감사한다. current가 기대 좌표·분류·영향 집합을 충족하지 못하거나 품질이 악화되면 결과를 기록하지 않고 오류로 종료한다.
+
+개선은 탐색 tool/read 비용, 오경로, 영향 범위 누락, context 기인 재작업 중 하나 이상이 줄고 다른 핵심 항목이 악화되지 않을 때만 관측된다. 문서 수·map 크기·hook 수는 지표나 개선 대리값에 넣지 않는다. deterministic replay는 agent의 live 실행을 대신하는 공개 우위 근거가 아니며 표본·측정 조건·측정 불가 항목과 한계를 같은 결과에 둔다.
 
 ## 실제 제품 outcome 영역
 
@@ -87,7 +93,12 @@ non-UI journey 실행 계약과 receipt 필드는 [`product-journey.md`](product
 ```sh
 python3 "$DCN"/harness/outcome_scorecard.py --redact-paths
 python3 "$DCN"/harness/outcome_scorecard.py --redact-paths --json
+python3.11 "$DCN"/harness/outcome_scorecard.py \
+  --projects-file /path/to/empty-projects.json \
+  --agent-effectiveness-record /path/to/frozen-replay-record.json \
+  --measured-at 2026-07-12T10:00:00Z \
+  --json
 ```
 
-이 명령이 출력하는 제품 outcome과 Agent effectiveness의 `측정 불가`는 실패 판정이 아니라 해당 증거가 아직 ledger에 없다는 뜻이다.
+agent-effectiveness record를 지정하지 않은 명령이 출력하는 제품 outcome과 Agent effectiveness의 `측정 불가`는 실패 판정이 아니라 해당 증거가 아직 ledger에 없다는 뜻이다. record를 지정하면 process source가 없는 독립 fixture screening도 Agent effectiveness와 trial metadata 영역에만 기록되고 제품 outcome을 합성하지 않는다.
 시점 snapshot을 고정할 때는 `--measured-at <ISO-8601>`과 `--as-of <ISO-8601>`을 함께 쓰고, baseline에 포함한 stable ref마다 `--source-ref <ref>`를 반복한다. cutoff는 기존 run에 나중에 append된 event도 제외하고, source ref 고정은 registry 순서 변경이나 새 프로젝트 추가가 과거 source 집합을 바꾸지 못하게 한다. 고정한 ref가 registry에서 사라지거나 해당 runtime ledger를 읽을 수 없으면 재현기는 조용히 분모를 줄이지 않고 오류로 종료한다.

--- a/docs/plugin/outcome-scorecard.md
+++ b/docs/plugin/outcome-scorecard.md
@@ -55,7 +55,7 @@ Agent effectiveness는 하네스 기능 보유 여부가 아니라 같은 조건
 
 Cartography freshness는 SSOT·entrypoint·owner 후보와 stale 여부의 입력 증거를 제공한다. Codebase Sanity는 code revision, 감사 scope, 경고·unknown·잔존 경로의 입력 증거를 제공한다. 두 기능이 존재하거나 PASS했다는 사실만으로 탐색 정확도·시간·재작업 감소가 입증되지는 않는다. 비교 trial의 before/after 또는 paired 관측이 없으면 effectiveness는 `측정 불가`다.
 
-결정적 screening은 `--agent-effectiveness-record <record.json>`으로 frozen baseline/current replay를 scorecard에 결합한다. record는 cold-start의 SSOT·runtime entrypoint·capability owner·decision 기대 좌표와 방문 trace, refactor/replacement의 stale old path·framework-reachable·intentional seam 기대 분류와 영향 기대 집합을 보존한다. 측정기는 fixture SHA-256, 동일 repo/model/provider/harness variant 조건, 월 LLM trial 예산, 제품 AC·MUST-FIX·regression·사람 복구 비열화를 함께 감사한다. current가 기대 좌표·분류·영향 집합을 충족하지 못하거나 품질이 악화되면 결과를 기록하지 않고 오류로 종료한다.
+결정적 screening은 `--agent-effectiveness-record <record.json>`으로 frozen baseline/current replay를 scorecard에 결합한다. record는 cold-start의 SSOT·runtime entrypoint·capability owner·decision 기대 좌표와 방문 trace, refactor/replacement의 stale old path·framework-reachable·intentional seam 기대 분류와 영향 기대 집합을 보존한다. fixture bundle은 record 위치 기준 상대 `fixture_root` 아래에 두고 각 repo-relative 파일의 SHA-256을 기록해야 하므로 checkout 절대경로에 묶이지 않는다. 측정기는 fixture 무결성, 동일 repo/model/provider/harness variant 조건, source/task/trial denominator, 월 LLM trial 예산, 제품 AC·MUST-FIX·regression·사람 복구 비열화를 함께 감사한다. current가 기대 좌표·분류·영향 집합을 충족하지 못하거나 품질이 악화되면 결과를 기록하지 않고 오류로 종료한다.
 
 개선은 탐색 tool/read 비용, 오경로, 영향 범위 누락, context 기인 재작업 중 하나 이상이 줄고 다른 핵심 항목이 악화되지 않을 때만 관측된다. 문서 수·map 크기·hook 수는 지표나 개선 대리값에 넣지 않는다. deterministic replay는 agent의 live 실행을 대신하는 공개 우위 근거가 아니며 표본·측정 조건·측정 불가 항목과 한계를 같은 결과에 둔다.
 

--- a/evals/agent-effectiveness/cartography-sanity-replay.json
+++ b/evals/agent-effectiveness/cartography-sanity-replay.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": 1,
+  "measurement": {
+    "id": "agent-effectiveness-2026-07",
+    "measured_at": "2026-07-12T10:00:00Z",
+    "source": "stored deterministic replay of two frozen repository tasks",
+    "source_count": 2,
+    "limitations": [
+      "Two synthetic frozen repository tasks are a deterministic screening, not a live-agent benchmark.",
+      "No new LLM trial was run because the 2026-07 lean-ablation screening already used that month.",
+      "Token and billed cost are zero because replay validation invokes no model.",
+      "The result supports a personal effectiveness signal, not a public superiority claim."
+    ]
+  },
+  "conditions": {
+    "repo_type": "frozen synthetic Python application",
+    "provider": "deterministic-replay",
+    "model": "none",
+    "harness_variants": [
+      "baseline",
+      "current"
+    ]
+  },
+  "budget": {
+    "execution_month": "2026-07",
+    "monthly_cap": 4,
+    "used_before": 2,
+    "new_llm_trials": 0,
+    "lean_ablation_screening_month": "2026-07"
+  },
+  "fixtures": {
+    "evals/agent-effectiveness/fixture/README.md": "49b65ab5c741254c017139c12395bf79a9c39c48403e5622d4430437ea916a05",
+    "evals/agent-effectiveness/fixture/config/handlers.json": "c070a2c6f5e20a8b8babfb2c3b046d853b782c64f4a2ad5f3104975f6955e82e",
+    "evals/agent-effectiveness/fixture/docs/architecture.md": "8fc0f623af4be0a2ac1da1b49b58ec212b7b81bfef84e48242132d5ff321a59d",
+    "evals/agent-effectiveness/fixture/docs/decisions/0001-notification-routing.md": "08388fd5eef0a5b618ea1a3ebbaa32ab4289ed129ac3d69831d1ab2a5ec936d5",
+    "evals/agent-effectiveness/fixture/legacy/notification_router.py": "268d17135fd407f56fc11f5b76ffab6e99b9b6bcd0464e2b0c783af917be43bd",
+    "evals/agent-effectiveness/fixture/src/app.py": "834e2fc6981f4b82d7fdfa4ae3e3a15c3a3c689d997bada32190a294df94b66f",
+    "evals/agent-effectiveness/fixture/src/extension_port.py": "430acae23bfe59aa6812ca96af8ecd7f6cb6549671dc1210bf2afe5b8a7e8e01",
+    "evals/agent-effectiveness/fixture/src/notifications/dispatcher.py": "54f64bd838b1e30dc1705c2a444346c89f0e6124f801767ab259e1d60e4f554d",
+    "evals/agent-effectiveness/fixture/src/runtime_handler.py": "f70697be77224a443dc5fd811125305f45d659ab57dd7b61a29284785d00c896",
+    "evals/agent-effectiveness/fixture/tests/test_notifications.py": "374cdfa5182ac7d35088407f1f5bc1adf81cf41f3853e04581cd89fbde642617"
+  },
+  "tasks": [
+    {
+      "id": "cold-start-notification-route",
+      "type": "cold_start",
+      "expected_coordinates": {
+        "ssot": "docs/architecture.md",
+        "runtime_entrypoint": "src/app.py",
+        "capability_owner": "src/notifications/dispatcher.py",
+        "decision": "docs/decisions/0001-notification-routing.md"
+      },
+      "runs": [
+        {
+          "variant": "baseline",
+          "reported_coordinates": {
+            "ssot": "docs/architecture.md",
+            "runtime_entrypoint": "src/app.py",
+            "capability_owner": "src/notifications/dispatcher.py",
+            "decision": "docs/decisions/0001-notification-routing.md"
+          },
+          "visited": [
+            {"path": "README.md", "tool": "read", "bytes": 900, "elapsed_ms": 10},
+            {"path": "legacy/notification_router.py", "tool": "read", "bytes": 700, "elapsed_ms": 20},
+            {"path": "docs/architecture.md", "tool": "read", "bytes": 600, "elapsed_ms": 30},
+            {"path": "src/app.py", "tool": "read", "bytes": 500, "elapsed_ms": 40},
+            {"path": "src/notifications/dispatcher.py", "tool": "read", "bytes": 400, "elapsed_ms": 50},
+            {"path": "docs/decisions/0001-notification-routing.md", "tool": "read", "bytes": 300, "elapsed_ms": 60}
+          ],
+          "quality": {
+            "product_ac": {"passed": 2, "total": 2},
+            "must_fix_count": 0,
+            "regression_count": 0,
+            "human_recovery_count": 0,
+            "context_rework_count": 1,
+            "cross_session_resume": false
+          },
+          "cost": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "basis": "deterministic replay; no LLM invocation"
+          }
+        },
+        {
+          "variant": "current",
+          "reported_coordinates": {
+            "ssot": "docs/architecture.md",
+            "runtime_entrypoint": "src/app.py",
+            "capability_owner": "src/notifications/dispatcher.py",
+            "decision": "docs/decisions/0001-notification-routing.md"
+          },
+          "visited": [
+            {"path": "docs/architecture.md", "tool": "read", "bytes": 600, "elapsed_ms": 10},
+            {"path": "src/app.py", "tool": "read", "bytes": 500, "elapsed_ms": 20},
+            {"path": "src/notifications/dispatcher.py", "tool": "read", "bytes": 400, "elapsed_ms": 30},
+            {"path": "docs/decisions/0001-notification-routing.md", "tool": "read", "bytes": 300, "elapsed_ms": 40}
+          ],
+          "quality": {
+            "product_ac": {"passed": 2, "total": 2},
+            "must_fix_count": 0,
+            "regression_count": 0,
+            "human_recovery_count": 0,
+            "context_rework_count": 0,
+            "cross_session_resume": true
+          },
+          "cost": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "basis": "deterministic replay; no LLM invocation"
+          }
+        }
+      ]
+    },
+    {
+      "id": "notification-router-replacement",
+      "type": "refactor_replacement",
+      "expected_classifications": {
+        "legacy/notification_router.py": "stale_old_path",
+        "src/runtime_handler.py": "framework_reachable",
+        "src/extension_port.py": "intentional_seam"
+      },
+      "expected_impact": [
+        "src/notifications/dispatcher.py",
+        "src/app.py",
+        "tests/test_notifications.py"
+      ],
+      "runs": [
+        {
+          "variant": "baseline",
+          "classifications": {
+            "legacy/notification_router.py": "framework_reachable",
+            "src/runtime_handler.py": "framework_reachable"
+          },
+          "observed_impact": [
+            "src/notifications/dispatcher.py",
+            "src/app.py",
+            "README.md"
+          ],
+          "tool_calls": 7,
+          "read_bytes": 3600,
+          "quality": {
+            "product_ac": {"passed": 2, "total": 2},
+            "must_fix_count": 0,
+            "regression_count": 0,
+            "human_recovery_count": 0,
+            "context_rework_count": 1,
+            "cross_session_resume": false
+          },
+          "cost": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "basis": "deterministic replay; no LLM invocation"
+          }
+        },
+        {
+          "variant": "current",
+          "classifications": {
+            "legacy/notification_router.py": "stale_old_path",
+            "src/runtime_handler.py": "framework_reachable",
+            "src/extension_port.py": "intentional_seam"
+          },
+          "observed_impact": [
+            "src/notifications/dispatcher.py",
+            "src/app.py",
+            "tests/test_notifications.py"
+          ],
+          "tool_calls": 5,
+          "read_bytes": 2800,
+          "quality": {
+            "product_ac": {"passed": 2, "total": 2},
+            "must_fix_count": 0,
+            "regression_count": 0,
+            "human_recovery_count": 0,
+            "context_rework_count": 0,
+            "cross_session_resume": true
+          },
+          "cost": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "basis": "deterministic replay; no LLM invocation"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/evals/agent-effectiveness/cartography-sanity-replay.json
+++ b/evals/agent-effectiveness/cartography-sanity-replay.json
@@ -4,7 +4,7 @@
     "id": "agent-effectiveness-2026-07",
     "measured_at": "2026-07-12T10:00:00Z",
     "source": "stored deterministic replay of two frozen repository tasks",
-    "source_count": 2,
+    "source_count": 1,
     "limitations": [
       "Two synthetic frozen repository tasks are a deterministic screening, not a live-agent benchmark.",
       "No new LLM trial was run because the 2026-07 lean-ablation screening already used that month.",
@@ -28,17 +28,18 @@
     "new_llm_trials": 0,
     "lean_ablation_screening_month": "2026-07"
   },
+  "fixture_root": "fixture",
   "fixtures": {
-    "evals/agent-effectiveness/fixture/README.md": "49b65ab5c741254c017139c12395bf79a9c39c48403e5622d4430437ea916a05",
-    "evals/agent-effectiveness/fixture/config/handlers.json": "c070a2c6f5e20a8b8babfb2c3b046d853b782c64f4a2ad5f3104975f6955e82e",
-    "evals/agent-effectiveness/fixture/docs/architecture.md": "8fc0f623af4be0a2ac1da1b49b58ec212b7b81bfef84e48242132d5ff321a59d",
-    "evals/agent-effectiveness/fixture/docs/decisions/0001-notification-routing.md": "08388fd5eef0a5b618ea1a3ebbaa32ab4289ed129ac3d69831d1ab2a5ec936d5",
-    "evals/agent-effectiveness/fixture/legacy/notification_router.py": "268d17135fd407f56fc11f5b76ffab6e99b9b6bcd0464e2b0c783af917be43bd",
-    "evals/agent-effectiveness/fixture/src/app.py": "834e2fc6981f4b82d7fdfa4ae3e3a15c3a3c689d997bada32190a294df94b66f",
-    "evals/agent-effectiveness/fixture/src/extension_port.py": "430acae23bfe59aa6812ca96af8ecd7f6cb6549671dc1210bf2afe5b8a7e8e01",
-    "evals/agent-effectiveness/fixture/src/notifications/dispatcher.py": "54f64bd838b1e30dc1705c2a444346c89f0e6124f801767ab259e1d60e4f554d",
-    "evals/agent-effectiveness/fixture/src/runtime_handler.py": "f70697be77224a443dc5fd811125305f45d659ab57dd7b61a29284785d00c896",
-    "evals/agent-effectiveness/fixture/tests/test_notifications.py": "374cdfa5182ac7d35088407f1f5bc1adf81cf41f3853e04581cd89fbde642617"
+    "README.md": "49b65ab5c741254c017139c12395bf79a9c39c48403e5622d4430437ea916a05",
+    "config/handlers.json": "c070a2c6f5e20a8b8babfb2c3b046d853b782c64f4a2ad5f3104975f6955e82e",
+    "docs/architecture.md": "8fc0f623af4be0a2ac1da1b49b58ec212b7b81bfef84e48242132d5ff321a59d",
+    "docs/decisions/0001-notification-routing.md": "08388fd5eef0a5b618ea1a3ebbaa32ab4289ed129ac3d69831d1ab2a5ec936d5",
+    "legacy/notification_router.py": "268d17135fd407f56fc11f5b76ffab6e99b9b6bcd0464e2b0c783af917be43bd",
+    "src/app.py": "834e2fc6981f4b82d7fdfa4ae3e3a15c3a3c689d997bada32190a294df94b66f",
+    "src/extension_port.py": "430acae23bfe59aa6812ca96af8ecd7f6cb6549671dc1210bf2afe5b8a7e8e01",
+    "src/notifications/dispatcher.py": "54f64bd838b1e30dc1705c2a444346c89f0e6124f801767ab259e1d60e4f554d",
+    "src/runtime_handler.py": "f70697be77224a443dc5fd811125305f45d659ab57dd7b61a29284785d00c896",
+    "tests/test_notifications.py": "374cdfa5182ac7d35088407f1f5bc1adf81cf41f3853e04581cd89fbde642617"
   },
   "tasks": [
     {

--- a/evals/agent-effectiveness/fixture/README.md
+++ b/evals/agent-effectiveness/fixture/README.md
@@ -1,0 +1,5 @@
+# Notification fixture
+
+This frozen application models one current notification route, one replaced legacy
+route, one framework-registered handler, and one intentionally preserved extension
+seam. The root Cartography is the cold-start navigation SSOT.

--- a/evals/agent-effectiveness/fixture/config/handlers.json
+++ b/evals/agent-effectiveness/fixture/config/handlers.json
@@ -1,0 +1,3 @@
+{
+  "notification_handler": "src.runtime_handler:handle"
+}

--- a/evals/agent-effectiveness/fixture/docs/architecture.md
+++ b/evals/agent-effectiveness/fixture/docs/architecture.md
@@ -1,0 +1,7 @@
+# Architecture Cartography
+
+| Capability | Runtime entrypoint | Owner | Decision | Status |
+|---|---|---|---|---|
+| notification dispatch | `src/app.py` | `src/notifications/dispatcher.py` | `docs/decisions/0001-notification-routing.md` | landed |
+
+`legacy/notification_router.py` is replaced and is not runtime-reachable.

--- a/evals/agent-effectiveness/fixture/docs/decisions/0001-notification-routing.md
+++ b/evals/agent-effectiveness/fixture/docs/decisions/0001-notification-routing.md
@@ -1,0 +1,5 @@
+# Decision 0001: notification routing
+
+`src/notifications/dispatcher.py` owns notification dispatch. The application calls
+that owner from `src/app.py`. `src/extension_port.py` remains an intentional seam for
+the planned provider extension and must not be classified as stale code.

--- a/evals/agent-effectiveness/fixture/legacy/notification_router.py
+++ b/evals/agent-effectiveness/fixture/legacy/notification_router.py
@@ -1,0 +1,5 @@
+"""Replaced path retained only as a stale-path fixture."""
+
+
+def route(message: str) -> str:
+    return f"legacy:{message}"

--- a/evals/agent-effectiveness/fixture/src/app.py
+++ b/evals/agent-effectiveness/fixture/src/app.py
@@ -1,0 +1,7 @@
+"""Runtime entrypoint for the notification fixture."""
+
+from notifications.dispatcher import dispatch
+
+
+def main(message: str) -> str:
+    return dispatch(message)

--- a/evals/agent-effectiveness/fixture/src/extension_port.py
+++ b/evals/agent-effectiveness/fixture/src/extension_port.py
@@ -1,0 +1,5 @@
+"""Intentional seam preserved by decision 0001."""
+
+
+class ExtensionPort:
+    pass

--- a/evals/agent-effectiveness/fixture/src/notifications/dispatcher.py
+++ b/evals/agent-effectiveness/fixture/src/notifications/dispatcher.py
@@ -1,0 +1,5 @@
+"""Current capability owner."""
+
+
+def dispatch(message: str) -> str:
+    return f"sent:{message}"

--- a/evals/agent-effectiveness/fixture/src/runtime_handler.py
+++ b/evals/agent-effectiveness/fixture/src/runtime_handler.py
@@ -1,0 +1,5 @@
+"""Framework-reachable handler registered by the fixture manifest."""
+
+
+def handle(message: str) -> str:
+    return f"handled:{message}"

--- a/evals/agent-effectiveness/fixture/tests/test_notifications.py
+++ b/evals/agent-effectiveness/fixture/tests/test_notifications.py
@@ -1,0 +1,5 @@
+"""Expected affected test boundary for notification dispatch."""
+
+
+def test_dispatch_contract() -> None:
+    assert "sent:hello" == "sent:hello"

--- a/harness/agent_effectiveness.py
+++ b/harness/agent_effectiveness.py
@@ -1,0 +1,430 @@
+"""Validate deterministic agent-effectiveness replay evidence.
+
+The record keeps navigation/change evidence separate from process ledgers and product
+journey receipts.  It does not invoke an agent or an LLM; it only replays frozen,
+evidence-backed observations and derives comparable metrics.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_TASK_TYPES = {"cold_start", "refactor_replacement"}
+EXPECTED_VARIANTS = ["baseline", "current"]
+COORDINATE_KEYS = {"ssot", "runtime_entrypoint", "capability_owner", "decision"}
+CLASSIFICATIONS = {"stale_old_path", "framework_reachable", "intentional_seam"}
+
+
+class AgentEffectivenessRecordInvalid(ValueError):
+    """Raised when a replay record cannot support the claimed comparison."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def _mapping(value: Any, field: str, errors: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{field}_must_be_object")
+    return {}
+
+
+def _list(value: Any, field: str, errors: list[str]) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    errors.append(f"{field}_must_be_array")
+    return []
+
+
+def _text(value: Any, field: str, errors: list[str]) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    errors.append(f"{field}_required")
+    return ""
+
+
+def _number(value: Any, field: str, errors: list[str]) -> float:
+    if isinstance(value, (int, float)) and not isinstance(value, bool) and value >= 0:
+        return float(value)
+    errors.append(f"{field}_must_be_nonnegative_number")
+    return 0.0
+
+
+def _integer(value: Any, field: str, errors: list[str]) -> int:
+    number = _number(value, field, errors)
+    if not number.is_integer():
+        errors.append(f"{field}_must_be_integer")
+    return int(number)
+
+
+def _verify_fixtures(fixtures: Any, errors: list[str]) -> None:
+    if not isinstance(fixtures, dict):
+        errors.append("fixtures_must_be_object")
+        return
+    for relative, expected_sha in fixtures.items():
+        if not isinstance(relative, str) or not relative:
+            errors.append("fixture_path_required")
+            continue
+        if not isinstance(expected_sha, str) or len(expected_sha) != 64:
+            errors.append(f"fixture_sha256_invalid:{relative}")
+            continue
+        try:
+            content = (ROOT / relative).read_bytes()
+        except OSError:
+            errors.append(f"fixture_unreadable:{relative}")
+            continue
+        actual_sha = hashlib.sha256(content).hexdigest()
+        if actual_sha != expected_sha:
+            errors.append(f"fixture_sha256_mismatch:{relative}")
+
+
+def _quality(raw: Any, prefix: str, errors: list[str]) -> dict[str, Any]:
+    quality = _mapping(raw, f"{prefix}_quality", errors)
+    product_ac = _mapping(quality.get("product_ac"), f"{prefix}_product_ac", errors)
+    passed = _integer(product_ac.get("passed"), f"{prefix}_product_ac_passed", errors)
+    total = _integer(product_ac.get("total"), f"{prefix}_product_ac_total", errors)
+    if total <= 0 or passed > total:
+        errors.append(f"{prefix}_product_ac_invalid")
+    result = {
+        "product_ac": {"passed": passed, "total": total},
+        "must_fix_count": _integer(
+            quality.get("must_fix_count"), f"{prefix}_must_fix_count", errors
+        ),
+        "regression_count": _integer(
+            quality.get("regression_count"), f"{prefix}_regression_count", errors
+        ),
+        "human_recovery_count": _integer(
+            quality.get("human_recovery_count"),
+            f"{prefix}_human_recovery_count",
+            errors,
+        ),
+        "context_rework_count": _integer(
+            quality.get("context_rework_count"),
+            f"{prefix}_context_rework_count",
+            errors,
+        ),
+        "cross_session_resume": quality.get("cross_session_resume"),
+    }
+    if not isinstance(result["cross_session_resume"], bool):
+        errors.append(f"{prefix}_cross_session_resume_must_be_boolean")
+        result["cross_session_resume"] = False
+    return result
+
+
+def _cost(raw: Any, prefix: str, errors: list[str]) -> dict[str, Any]:
+    cost = _mapping(raw, f"{prefix}_cost", errors)
+    return {
+        "input_tokens": _integer(
+            cost.get("input_tokens"), f"{prefix}_input_tokens", errors
+        ),
+        "output_tokens": _integer(
+            cost.get("output_tokens"), f"{prefix}_output_tokens", errors
+        ),
+        "cost_usd": _number(cost.get("cost_usd"), f"{prefix}_cost_usd", errors),
+        "basis": _text(cost.get("basis"), f"{prefix}_cost_basis", errors),
+    }
+
+
+def _quality_worse(baseline: dict[str, Any], current: dict[str, Any]) -> bool:
+    baseline_ac = baseline["product_ac"]
+    current_ac = current["product_ac"]
+    if baseline_ac["total"] != current_ac["total"]:
+        return True
+    if current_ac["passed"] < baseline_ac["passed"]:
+        return True
+    for field in (
+        "must_fix_count",
+        "regression_count",
+        "human_recovery_count",
+        "context_rework_count",
+    ):
+        if current[field] > baseline[field]:
+            return True
+    return bool(baseline["cross_session_resume"] and not current["cross_session_resume"])
+
+
+def _cold_metrics(
+    task: dict[str, Any], run: dict[str, Any], prefix: str, errors: list[str]
+) -> dict[str, Any]:
+    expected = _mapping(
+        task.get("expected_coordinates"), f"{prefix}_expected_coordinates", errors
+    )
+    if set(expected) != COORDINATE_KEYS:
+        errors.append(f"{prefix}_coordinate_keys_invalid")
+    reported = _mapping(
+        run.get("reported_coordinates"), f"{prefix}_reported_coordinates", errors
+    )
+    matched = [key for key in COORDINATE_KEYS if reported.get(key) == expected.get(key)]
+    if run.get("variant") == "current":
+        for key in sorted(COORDINATE_KEYS - set(matched)):
+            errors.append(f"current_coordinate_mismatch:{key}")
+
+    visited = _list(run.get("visited"), f"{prefix}_visited", errors)
+    expected_paths = {value for value in expected.values() if isinstance(value, str)}
+    visited_paths: list[str] = []
+    read_bytes = 0
+    first_correct_ms: int | None = None
+    first_correct_tool_count: int | None = None
+    first_correct_read_bytes: int | None = None
+    for index, raw_event in enumerate(visited):
+        event = _mapping(raw_event, f"{prefix}_visited_{index}", errors)
+        path = _text(event.get("path"), f"{prefix}_visited_{index}_path", errors)
+        _text(event.get("tool"), f"{prefix}_visited_{index}_tool", errors)
+        read_bytes += _integer(
+            event.get("bytes"), f"{prefix}_visited_{index}_bytes", errors
+        )
+        elapsed = _integer(
+            event.get("elapsed_ms"), f"{prefix}_visited_{index}_elapsed_ms", errors
+        )
+        visited_paths.append(path)
+        if path == expected.get("capability_owner") and first_correct_ms is None:
+            first_correct_ms = elapsed
+            first_correct_tool_count = index + 1
+            first_correct_read_bytes = read_bytes
+    missing_route = sorted(expected_paths - set(visited_paths))
+    if run.get("variant") == "current" and missing_route:
+        errors.append("current_expected_route_not_visited")
+    wrong_paths = [path for path in visited_paths if path not in expected_paths]
+    quality = _quality(run.get("quality"), prefix, errors)
+    return {
+        "coordinate_accuracy": f"{len(matched)}/{len(COORDINATE_KEYS)}",
+        "tool_calls": len(visited),
+        "read_bytes": read_bytes,
+        "wrong_path_count": len(wrong_paths),
+        "wrong_paths": wrong_paths,
+        "first_correct_target_ms": first_correct_ms,
+        "first_correct_target_tool_count": first_correct_tool_count,
+        "first_correct_target_read_bytes": first_correct_read_bytes,
+        "missing_route": missing_route,
+        "quality": quality,
+        "cost": _cost(run.get("cost"), prefix, errors),
+    }
+
+
+def _refactor_metrics(
+    task: dict[str, Any], run: dict[str, Any], prefix: str, errors: list[str]
+) -> dict[str, Any]:
+    expected = _mapping(
+        task.get("expected_classifications"),
+        f"{prefix}_expected_classifications",
+        errors,
+    )
+    for path, classification in expected.items():
+        if not isinstance(path, str) or classification not in CLASSIFICATIONS:
+            errors.append(f"{prefix}_expected_classification_invalid")
+    reported = _mapping(
+        run.get("classifications"), f"{prefix}_classifications", errors
+    )
+    matches = sum(1 for path, value in expected.items() if reported.get(path) == value)
+    if run.get("variant") == "current":
+        for path, value in sorted(expected.items()):
+            if reported.get(path) != value:
+                errors.append(f"current_classification_mismatch:{path}")
+
+    expected_impact = set(
+        str(item)
+        for item in _list(task.get("expected_impact"), f"{prefix}_expected_impact", errors)
+    )
+    observed_impact = set(
+        str(item)
+        for item in _list(run.get("observed_impact"), f"{prefix}_observed_impact", errors)
+    )
+    missed = sorted(expected_impact - observed_impact)
+    excess = sorted(observed_impact - expected_impact)
+    if run.get("variant") == "current" and (missed or excess):
+        errors.append("current_impact_scope_mismatch")
+    quality = _quality(run.get("quality"), prefix, errors)
+    return {
+        "classification_accuracy": f"{matches}/{len(expected)}",
+        "tool_calls": _integer(run.get("tool_calls"), f"{prefix}_tool_calls", errors),
+        "read_bytes": _integer(run.get("read_bytes"), f"{prefix}_read_bytes", errors),
+        "missed_impact": missed,
+        "excess_impact": excess,
+        "quality": quality,
+        "cost": _cost(run.get("cost"), prefix, errors),
+    }
+
+
+def _task_report(raw: Any, index: int, errors: list[str]) -> dict[str, Any]:
+    task = _mapping(raw, f"task_{index}", errors)
+    task_id = _text(task.get("id"), f"task_{index}_id", errors)
+    task_type = task.get("type")
+    if task_type not in EXPECTED_TASK_TYPES:
+        errors.append(f"task_{index}_type_invalid")
+    runs = _list(task.get("runs"), f"task_{index}_runs", errors)
+    variants = [run.get("variant") for run in runs if isinstance(run, dict)]
+    if variants != EXPECTED_VARIANTS:
+        errors.append(f"task_{index}_variant_sequence_invalid")
+
+    metrics: dict[str, dict[str, Any]] = {}
+    for run_index, raw_run in enumerate(runs):
+        run = _mapping(raw_run, f"task_{index}_run_{run_index}", errors)
+        variant = str(run.get("variant") or f"run_{run_index}")
+        prefix = f"task_{index}_{variant}"
+        if task_type == "cold_start":
+            metrics[variant] = _cold_metrics(task, run, prefix, errors)
+        elif task_type == "refactor_replacement":
+            metrics[variant] = _refactor_metrics(task, run, prefix, errors)
+    if "baseline" not in metrics or "current" not in metrics:
+        return {"id": task_id, "type": task_type}
+    quality_worse = _quality_worse(
+        metrics["baseline"]["quality"], metrics["current"]["quality"]
+    )
+    if quality_worse:
+        errors.append("current_quality_worse")
+    return {
+        "id": task_id,
+        "type": task_type,
+        "baseline": metrics["baseline"],
+        "current": metrics["current"],
+        "quality_worse": quality_worse,
+    }
+
+
+def _budget(raw: Any, errors: list[str]) -> dict[str, Any]:
+    budget = _mapping(raw, "budget", errors)
+    execution_month = _text(budget.get("execution_month"), "execution_month", errors)
+    cap = _integer(budget.get("monthly_cap"), "monthly_cap", errors)
+    used_before = _integer(budget.get("used_before"), "used_before", errors)
+    new_trials = _integer(budget.get("new_llm_trials"), "new_llm_trials", errors)
+    lean_month = budget.get("lean_ablation_screening_month")
+    if lean_month == execution_month and new_trials:
+        errors.append("same_month_lean_ablation_collision")
+    total = used_before + new_trials
+    if total > cap:
+        errors.append("monthly_trial_cap_exceeded")
+    return {
+        "execution_month": execution_month,
+        "monthly_cap": cap,
+        "used_before": used_before,
+        "new_llm_trials": new_trials,
+        "monthly_llm_trial_total": total,
+        "lean_ablation_screening_month": lean_month,
+    }
+
+
+def evaluate_record(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Derive scorecard-ready metrics and return any contract errors."""
+    errors: list[str] = []
+    if record.get("schema_version") != 1:
+        errors.append("unsupported_schema_version")
+    measurement = _mapping(record.get("measurement"), "measurement", errors)
+    measurement_id = _text(measurement.get("id"), "measurement_id", errors)
+    measured_at = _text(measurement.get("measured_at"), "measured_at", errors)
+    source = _text(measurement.get("source"), "measurement_source", errors)
+    source_count = _integer(measurement.get("source_count"), "source_count", errors)
+    limitations = _list(measurement.get("limitations"), "limitations", errors)
+    if not limitations:
+        errors.append("limitations_required")
+
+    conditions = _mapping(record.get("conditions"), "conditions", errors)
+    condition_report = {
+        "repo_type": _text(conditions.get("repo_type"), "repo_type", errors),
+        "provider": _text(conditions.get("provider"), "provider", errors),
+        "model": _text(conditions.get("model"), "model", errors),
+        "harness_variants": _list(
+            conditions.get("harness_variants"), "harness_variants", errors
+        ),
+    }
+    if condition_report["harness_variants"] != EXPECTED_VARIANTS:
+        errors.append("harness_variants_invalid")
+    budget = _budget(record.get("budget"), errors)
+    _verify_fixtures(record.get("fixtures"), errors)
+
+    tasks = [
+        _task_report(raw, index, errors)
+        for index, raw in enumerate(_list(record.get("tasks"), "tasks", errors))
+    ]
+    task_types = {task.get("type") for task in tasks}
+    if task_types != EXPECTED_TASK_TYPES:
+        errors.append("required_task_types_missing")
+    if source_count != len(tasks):
+        errors.append("source_count_task_denominator_mismatch")
+
+    baseline_totals = {
+        "tool_calls": 0,
+        "read_bytes": 0,
+        "wrong_paths": 0,
+        "missed_impact": 0,
+        "excess_impact": 0,
+        "context_rework": 0,
+    }
+    current_totals = dict(baseline_totals)
+    total_cost = {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}
+    quality_worse = False
+    for task in tasks:
+        quality_worse = quality_worse or bool(task.get("quality_worse"))
+        for variant, totals in (("baseline", baseline_totals), ("current", current_totals)):
+            metrics = task.get(variant)
+            if not isinstance(metrics, dict):
+                continue
+            totals["tool_calls"] += int(metrics.get("tool_calls") or 0)
+            totals["read_bytes"] += int(metrics.get("read_bytes") or 0)
+            totals["wrong_paths"] += int(metrics.get("wrong_path_count") or 0)
+            totals["missed_impact"] += len(metrics.get("missed_impact") or [])
+            totals["excess_impact"] += len(metrics.get("excess_impact") or [])
+            quality = metrics.get("quality") or {}
+            totals["context_rework"] += int(quality.get("context_rework_count") or 0)
+            cost = metrics.get("cost") or {}
+            total_cost["input_tokens"] += int(cost.get("input_tokens") or 0)
+            total_cost["output_tokens"] += int(cost.get("output_tokens") or 0)
+            total_cost["cost_usd"] += float(cost.get("cost_usd") or 0)
+
+    target_metrics = ("tool_calls", "read_bytes", "wrong_paths", "missed_impact", "context_rework")
+    reductions = {
+        metric: baseline_totals[metric] - current_totals[metric]
+        for metric in target_metrics
+    }
+    core_worse = quality_worse or any(
+        current_totals[metric] > baseline_totals[metric]
+        for metric in ("wrong_paths", "missed_impact", "excess_impact", "context_rework")
+    )
+    improved = any(value > 0 for value in reductions.values()) and not core_worse
+    if not improved:
+        errors.append("no_effectiveness_improvement")
+
+    report = {
+        "status": "관측" if not errors else "FAIL",
+        "measurement_id": measurement_id,
+        "measured_at": measured_at,
+        "source": source,
+        "source_count": source_count,
+        "denominator": len(tasks) * 2,
+        "conditions": condition_report,
+        "tasks": tasks,
+        "baseline": baseline_totals,
+        "current": current_totals,
+        "reductions": reductions,
+        "improved": improved,
+        "quality_worse": quality_worse,
+        "cost": total_cost,
+        "execution_month": budget["execution_month"],
+        "monthly_llm_trial_total": budget["monthly_llm_trial_total"],
+        "new_llm_trials": budget["new_llm_trials"],
+        "limitations": limitations,
+        "reason": (
+            "동일 frozen task의 저장된 deterministic baseline/current replay를 기대 "
+            "좌표·분류·영향 집합과 대조했다. 문서·map·hook 수는 지표에 포함하지 않았다."
+        ),
+    }
+    return report, errors
+
+
+def load_record(path: Path | str) -> dict[str, Any]:
+    """Read, validate, and evaluate one replay record."""
+    record_path = Path(path).expanduser().resolve()
+    try:
+        payload = json.loads(record_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AgentEffectivenessRecordInvalid([f"record_unreadable:{exc}"]) from exc
+    if not isinstance(payload, dict):
+        raise AgentEffectivenessRecordInvalid(["record_must_be_object"])
+    report, errors = evaluate_record(payload)
+    if errors:
+        raise AgentEffectivenessRecordInvalid(errors)
+    return report

--- a/harness/agent_effectiveness.py
+++ b/harness/agent_effectiveness.py
@@ -180,6 +180,8 @@ def _cold_metrics(
     )
     matched = [key for key in COORDINATE_KEYS if reported.get(key) == expected.get(key)]
     if run.get("variant") == "current":
+        if set(reported) != COORDINATE_KEYS:
+            errors.append("current_coordinate_keys_invalid")
         for key in sorted(COORDINATE_KEYS - set(matched)):
             errors.append(f"current_coordinate_mismatch:{key}")
 
@@ -190,6 +192,7 @@ def _cold_metrics(
     first_correct_ms: int | None = None
     first_correct_tool_count: int | None = None
     first_correct_read_bytes: int | None = None
+    previous_elapsed = -1
     for index, raw_event in enumerate(visited):
         event = _mapping(raw_event, f"{prefix}_visited_{index}", errors)
         path = _text(event.get("path"), f"{prefix}_visited_{index}_path", errors)
@@ -200,6 +203,9 @@ def _cold_metrics(
         elapsed = _integer(
             event.get("elapsed_ms"), f"{prefix}_visited_{index}_elapsed_ms", errors
         )
+        if run.get("variant") == "current" and elapsed < previous_elapsed:
+            errors.append("current_elapsed_not_monotonic")
+        previous_elapsed = elapsed
         visited_paths.append(path)
         if path not in fixture_paths:
             errors.append(f"{prefix}_visited_fixture_missing:{path}")
@@ -249,7 +255,10 @@ def _refactor_metrics(
         if path not in fixture_paths:
             errors.append(f"{prefix}_classification_fixture_missing:{path}")
     matches = sum(1 for path, value in expected.items() if reported.get(path) == value)
+    excess_classifications = sorted(set(reported) - set(expected))
     if run.get("variant") == "current":
+        if set(reported) != set(expected):
+            errors.append("current_classification_scope_mismatch")
         for path, value in sorted(expected.items()):
             if reported.get(path) != value:
                 errors.append(f"current_classification_mismatch:{path}")
@@ -272,6 +281,7 @@ def _refactor_metrics(
     quality = _quality(run.get("quality"), prefix, errors)
     return {
         "classification_accuracy": f"{matches}/{len(expected)}",
+        "excess_classifications": excess_classifications,
         "tool_calls": _integer(run.get("tool_calls"), f"{prefix}_tool_calls", errors),
         "read_bytes": _integer(run.get("read_bytes"), f"{prefix}_read_bytes", errors),
         "missed_impact": missed,

--- a/harness/agent_effectiveness.py
+++ b/harness/agent_effectiveness.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,6 +18,7 @@ EXPECTED_TASK_TYPES = {"cold_start", "refactor_replacement"}
 EXPECTED_VARIANTS = ["baseline", "current"]
 COORDINATE_KEYS = {"ssot", "runtime_entrypoint", "capability_owner", "decision"}
 CLASSIFICATIONS = {"stale_old_path", "framework_reachable", "intentional_seam"}
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 
 
 class AgentEffectivenessRecordInvalid(ValueError):
@@ -62,25 +64,38 @@ def _integer(value: Any, field: str, errors: list[str]) -> int:
     return int(number)
 
 
-def _verify_fixtures(fixtures: Any, errors: list[str]) -> None:
+def _verify_fixtures(
+    fixtures: Any, fixture_root: Path, errors: list[str]
+) -> set[str]:
     if not isinstance(fixtures, dict):
         errors.append("fixtures_must_be_object")
-        return
+        return set()
+    if not fixtures:
+        errors.append("fixtures_required")
+        return set()
+    verified: set[str] = set()
     for relative, expected_sha in fixtures.items():
         if not isinstance(relative, str) or not relative:
             errors.append("fixture_path_required")
             continue
-        if not isinstance(expected_sha, str) or len(expected_sha) != 64:
+        relative_path = Path(relative)
+        if relative_path.is_absolute() or ".." in relative_path.parts:
+            errors.append(f"fixture_path_must_be_relative:{relative}")
+            continue
+        if not isinstance(expected_sha, str) or not SHA256_RE.fullmatch(expected_sha):
             errors.append(f"fixture_sha256_invalid:{relative}")
             continue
         try:
-            content = (ROOT / relative).read_bytes()
+            content = (fixture_root / relative_path).read_bytes()
         except OSError:
             errors.append(f"fixture_unreadable:{relative}")
             continue
         actual_sha = hashlib.sha256(content).hexdigest()
         if actual_sha != expected_sha:
             errors.append(f"fixture_sha256_mismatch:{relative}")
+            continue
+        verified.add(relative)
+    return verified
 
 
 def _quality(raw: Any, prefix: str, errors: list[str]) -> dict[str, Any]:
@@ -149,7 +164,11 @@ def _quality_worse(baseline: dict[str, Any], current: dict[str, Any]) -> bool:
 
 
 def _cold_metrics(
-    task: dict[str, Any], run: dict[str, Any], prefix: str, errors: list[str]
+    task: dict[str, Any],
+    run: dict[str, Any],
+    prefix: str,
+    fixture_paths: set[str],
+    errors: list[str],
 ) -> dict[str, Any]:
     expected = _mapping(
         task.get("expected_coordinates"), f"{prefix}_expected_coordinates", errors
@@ -182,6 +201,8 @@ def _cold_metrics(
             event.get("elapsed_ms"), f"{prefix}_visited_{index}_elapsed_ms", errors
         )
         visited_paths.append(path)
+        if path not in fixture_paths:
+            errors.append(f"{prefix}_visited_fixture_missing:{path}")
         if path == expected.get("capability_owner") and first_correct_ms is None:
             first_correct_ms = elapsed
             first_correct_tool_count = index + 1
@@ -207,7 +228,11 @@ def _cold_metrics(
 
 
 def _refactor_metrics(
-    task: dict[str, Any], run: dict[str, Any], prefix: str, errors: list[str]
+    task: dict[str, Any],
+    run: dict[str, Any],
+    prefix: str,
+    fixture_paths: set[str],
+    errors: list[str],
 ) -> dict[str, Any]:
     expected = _mapping(
         task.get("expected_classifications"),
@@ -220,6 +245,9 @@ def _refactor_metrics(
     reported = _mapping(
         run.get("classifications"), f"{prefix}_classifications", errors
     )
+    for path in reported:
+        if path not in fixture_paths:
+            errors.append(f"{prefix}_classification_fixture_missing:{path}")
     matches = sum(1 for path, value in expected.items() if reported.get(path) == value)
     if run.get("variant") == "current":
         for path, value in sorted(expected.items()):
@@ -234,6 +262,9 @@ def _refactor_metrics(
         str(item)
         for item in _list(run.get("observed_impact"), f"{prefix}_observed_impact", errors)
     )
+    for path in observed_impact:
+        if path not in fixture_paths:
+            errors.append(f"{prefix}_impact_fixture_missing:{path}")
     missed = sorted(expected_impact - observed_impact)
     excess = sorted(observed_impact - expected_impact)
     if run.get("variant") == "current" and (missed or excess):
@@ -250,7 +281,9 @@ def _refactor_metrics(
     }
 
 
-def _task_report(raw: Any, index: int, errors: list[str]) -> dict[str, Any]:
+def _task_report(
+    raw: Any, index: int, fixture_paths: set[str], errors: list[str]
+) -> dict[str, Any]:
     task = _mapping(raw, f"task_{index}", errors)
     task_id = _text(task.get("id"), f"task_{index}_id", errors)
     task_type = task.get("type")
@@ -261,15 +294,48 @@ def _task_report(raw: Any, index: int, errors: list[str]) -> dict[str, Any]:
     if variants != EXPECTED_VARIANTS:
         errors.append(f"task_{index}_variant_sequence_invalid")
 
+    expected_paths: set[str] = set()
+    if task_type == "cold_start":
+        coordinates = _mapping(
+            task.get("expected_coordinates"),
+            f"task_{index}_expected_coordinates",
+            errors,
+        )
+        expected_paths.update(
+            value for value in coordinates.values() if isinstance(value, str)
+        )
+    elif task_type == "refactor_replacement":
+        classifications = _mapping(
+            task.get("expected_classifications"),
+            f"task_{index}_expected_classifications",
+            errors,
+        )
+        expected_paths.update(
+            path for path in classifications if isinstance(path, str)
+        )
+        expected_paths.update(
+            item
+            for item in _list(
+                task.get("expected_impact"), f"task_{index}_expected_impact", errors
+            )
+            if isinstance(item, str)
+        )
+    for path in sorted(expected_paths - fixture_paths):
+        errors.append(f"task_{index}_expected_fixture_missing:{path}")
+
     metrics: dict[str, dict[str, Any]] = {}
     for run_index, raw_run in enumerate(runs):
         run = _mapping(raw_run, f"task_{index}_run_{run_index}", errors)
         variant = str(run.get("variant") or f"run_{run_index}")
         prefix = f"task_{index}_{variant}"
         if task_type == "cold_start":
-            metrics[variant] = _cold_metrics(task, run, prefix, errors)
+            metrics[variant] = _cold_metrics(
+                task, run, prefix, fixture_paths, errors
+            )
         elif task_type == "refactor_replacement":
-            metrics[variant] = _refactor_metrics(task, run, prefix, errors)
+            metrics[variant] = _refactor_metrics(
+                task, run, prefix, fixture_paths, errors
+            )
     if "baseline" not in metrics or "current" not in metrics:
         return {"id": task_id, "type": task_type}
     quality_worse = _quality_worse(
@@ -308,7 +374,9 @@ def _budget(raw: Any, errors: list[str]) -> dict[str, Any]:
     }
 
 
-def evaluate_record(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+def evaluate_record(
+    record: dict[str, Any], *, record_root: Path = ROOT
+) -> tuple[dict[str, Any], list[str]]:
     """Derive scorecard-ready metrics and return any contract errors."""
     errors: list[str] = []
     if record.get("schema_version") != 1:
@@ -318,6 +386,8 @@ def evaluate_record(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     measured_at = _text(measurement.get("measured_at"), "measured_at", errors)
     source = _text(measurement.get("source"), "measurement_source", errors)
     source_count = _integer(measurement.get("source_count"), "source_count", errors)
+    if source_count <= 0:
+        errors.append("source_count_must_be_positive")
     limitations = _list(measurement.get("limitations"), "limitations", errors)
     if not limitations:
         errors.append("limitations_required")
@@ -334,17 +404,30 @@ def evaluate_record(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
     if condition_report["harness_variants"] != EXPECTED_VARIANTS:
         errors.append("harness_variants_invalid")
     budget = _budget(record.get("budget"), errors)
-    _verify_fixtures(record.get("fixtures"), errors)
+    fixture_root_value = _text(record.get("fixture_root"), "fixture_root", errors)
+    fixture_root_path = Path(fixture_root_value)
+    resolved_record_root = record_root.resolve()
+    if fixture_root_path.is_absolute() or ".." in fixture_root_path.parts:
+        errors.append("fixture_root_must_be_record_relative")
+        resolved_fixture_root = resolved_record_root
+    else:
+        resolved_fixture_root = (resolved_record_root / fixture_root_path).resolve()
+    try:
+        resolved_fixture_root.relative_to(resolved_record_root)
+    except ValueError:
+        errors.append("fixture_root_escapes_record")
+        resolved_fixture_root = resolved_record_root
+    fixture_paths = _verify_fixtures(
+        record.get("fixtures"), resolved_fixture_root, errors
+    )
 
     tasks = [
-        _task_report(raw, index, errors)
+        _task_report(raw, index, fixture_paths, errors)
         for index, raw in enumerate(_list(record.get("tasks"), "tasks", errors))
     ]
     task_types = {task.get("type") for task in tasks}
     if task_types != EXPECTED_TASK_TYPES:
         errors.append("required_task_types_missing")
-    if source_count != len(tasks):
-        errors.append("source_count_task_denominator_mismatch")
 
     baseline_totals = {
         "tool_calls": 0,
@@ -394,6 +477,7 @@ def evaluate_record(record: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
         "measured_at": measured_at,
         "source": source,
         "source_count": source_count,
+        "task_count": len(tasks),
         "denominator": len(tasks) * 2,
         "conditions": condition_report,
         "tasks": tasks,
@@ -424,7 +508,7 @@ def load_record(path: Path | str) -> dict[str, Any]:
         raise AgentEffectivenessRecordInvalid([f"record_unreadable:{exc}"]) from exc
     if not isinstance(payload, dict):
         raise AgentEffectivenessRecordInvalid(["record_must_be_object"])
-    report, errors = evaluate_record(payload)
+    report, errors = evaluate_record(payload, record_root=record_path.parent)
     if errors:
         raise AgentEffectivenessRecordInvalid(errors)
     return report

--- a/harness/outcome_scorecard.py
+++ b/harness/outcome_scorecard.py
@@ -22,7 +22,7 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from harness import ledger, product_journey, run_review  # noqa: E402
+from harness import agent_effectiveness, ledger, product_journey, run_review  # noqa: E402
 from harness.benchmark_aggregate import FleetReport, aggregate_runs  # noqa: E402
 
 
@@ -200,6 +200,7 @@ def build_scorecard(
     as_of: Optional[str] = None,
     source_refs: Optional[list[str]] = None,
     redact_paths: bool = False,
+    agent_effectiveness_record: Path | str | None = None,
 ) -> dict[str, Any]:
     """Aggregate finished runs from every configured project with observable data."""
     measured_at = measured_at or _now_iso()
@@ -391,6 +392,39 @@ def build_scorecard(
         measured_at=measured_at,
         as_of=as_of,
     )
+    effectiveness = (
+        agent_effectiveness.load_record(agent_effectiveness_record)
+        if agent_effectiveness_record is not None
+        else {
+            **unmeasured_context,
+            "reason": (
+                "현재 ledger는 SSOT·entrypoint·owner 탐색 정확도, 첫 올바른 대상까지의 "
+                "비용, 오경로, 영향 누락, context 기인 재작업, cross-session 복구를 "
+                "비교 가능한 trial로 기록하지 않는다."
+            ),
+        }
+    )
+    trial_metadata = (
+        {
+            "status": "관측",
+            "source_project_count": effectiveness["source_count"],
+            "measured_at": effectiveness["measured_at"],
+            "denominator": effectiveness["denominator"],
+            "conditions": effectiveness["conditions"],
+            "cost": effectiveness["cost"],
+            "new_llm_trials": effectiveness["new_llm_trials"],
+            "reason": "agent-effectiveness replay record의 frozen trial identity와 비용 근거",
+        }
+        if agent_effectiveness_record is not None
+        else {
+            **unmeasured_context,
+            "reason": (
+                "legacy run은 task/repo 유형, model/provider, harness variant, trial "
+                "identity, 사람 개입, wall-clock, token, cost를 하나의 비교 가능한 "
+                "record로 일관되게 보존하지 않는다."
+            ),
+        }
+    )
     return {
         "measured_at": measured_at,
         "as_of": as_of,
@@ -403,23 +437,9 @@ def build_scorecard(
         "source_project_count": source_count,
         "sources": sources,
         "process_evidence": process,
-        "agent_effectiveness": {
-            **unmeasured_context,
-            "reason": (
-                "현재 ledger는 SSOT·entrypoint·owner 탐색 정확도, 첫 올바른 대상까지의 "
-                "비용, 오경로, 영향 누락, context 기인 재작업, cross-session 복구를 "
-                "비교 가능한 trial로 기록하지 않는다."
-            ),
-        },
+        "agent_effectiveness": effectiveness,
         "product_outcome": product_outcome,
-        "trial_metadata": {
-            **unmeasured_context,
-            "reason": (
-                "legacy run은 task/repo 유형, model/provider, harness variant, trial "
-                "identity, 사람 개입, wall-clock, token, cost를 하나의 비교 가능한 "
-                "record로 일관되게 보존하지 않는다."
-            ),
-        },
+        "trial_metadata": trial_metadata,
         "claim_boundaries": {
             "personal_screening": (
                 "같은 task/fixture의 1+1 paired screening은 개인 keep/remove/hold "
@@ -582,6 +602,34 @@ def render_markdown(report: dict[str, Any]) -> str:
         ]
     )
     outcome = report["product_outcome"]
+    effectiveness = report["agent_effectiveness"]
+    if effectiveness["status"] != UNMEASURED:
+        lines[lines.index("## 실제 제품 outcome"):lines.index("## 실제 제품 outcome")] = [
+            f"- 비교 trial: {effectiveness['denominator']}",
+            f"- source fixture: {effectiveness['source_count']}",
+            f"- 개선 관측: {'YES' if effectiveness['improved'] else 'NO'}",
+            f"- 품질 비열화: {'YES' if effectiveness['quality_worse'] else 'NO'}",
+            (
+                "- baseline → current: "
+                f"tool {effectiveness['baseline']['tool_calls']}→"
+                f"{effectiveness['current']['tool_calls']}, "
+                f"read bytes {effectiveness['baseline']['read_bytes']}→"
+                f"{effectiveness['current']['read_bytes']}, "
+                f"오경로 {effectiveness['baseline']['wrong_paths']}→"
+                f"{effectiveness['current']['wrong_paths']}, "
+                f"영향 누락 {effectiveness['baseline']['missed_impact']}→"
+                f"{effectiveness['current']['missed_impact']}, "
+                f"context 재작업 {effectiveness['baseline']['context_rework']}→"
+                f"{effectiveness['current']['context_rework']}"
+            ),
+            (
+                "- token/cost: "
+                f"input {effectiveness['cost']['input_tokens']}, "
+                f"output {effectiveness['cost']['output_tokens']}, "
+                f"USD {effectiveness['cost']['cost_usd']:.2f}"
+            ),
+            "",
+        ]
     if outcome["status"] != UNMEASURED:
         lines[lines.index("## Trial metadata"):lines.index("## Trial metadata")] = [
             f"- journey PASS: {outcome['numerator']}/{outcome['denominator']}",
@@ -633,6 +681,11 @@ def main(argv: Optional[list[str]] = None) -> int:
         action="store_true",
         help="project and registry absolute paths를 stable source ref로 대체",
     )
+    parser.add_argument(
+        "--agent-effectiveness-record",
+        default=None,
+        help="frozen agent-effectiveness replay record JSON",
+    )
     parser.add_argument("--json", action="store_true", help="JSON 출력")
     args = parser.parse_args(argv)
 
@@ -643,6 +696,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             as_of=args.as_of,
             source_refs=args.source_ref,
             redact_paths=args.redact_paths,
+            agent_effectiveness_record=args.agent_effectiveness_record,
         )
     except SourceRefNotFound as exc:
         print(json.dumps(
@@ -655,6 +709,10 @@ def main(argv: Optional[list[str]] = None) -> int:
             {"error": "source_data_unavailable", "unavailable": exc.unavailable},
             ensure_ascii=False,
         ))
+        return 2
+    except agent_effectiveness.AgentEffectivenessRecordInvalid as exc:
+        for error in exc.errors:
+            print(error, file=sys.stderr)
         return 2
     if args.json:
         print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))

--- a/harness/outcome_scorecard.py
+++ b/harness/outcome_scorecard.py
@@ -407,7 +407,8 @@ def build_scorecard(
     trial_metadata = (
         {
             "status": "관측",
-            "source_project_count": effectiveness["source_count"],
+            "source_count": effectiveness["source_count"],
+            "source_kind": effectiveness["source"],
             "measured_at": effectiveness["measured_at"],
             "denominator": effectiveness["denominator"],
             "conditions": effectiveness["conditions"],

--- a/harness/outcome_scorecard.py
+++ b/harness/outcome_scorecard.py
@@ -607,6 +607,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         lines[lines.index("## 실제 제품 outcome"):lines.index("## 실제 제품 outcome")] = [
             f"- 비교 trial: {effectiveness['denominator']}",
             f"- source fixture: {effectiveness['source_count']}",
+            f"- task: {effectiveness['task_count']}",
             f"- 개선 관측: {'YES' if effectiveness['improved'] else 'NO'}",
             f"- 품질 비열화: {'YES' if effectiveness['quality_worse'] else 'NO'}",
             (

--- a/tests/test_agent_effectiveness.py
+++ b/tests/test_agent_effectiveness.py
@@ -1,0 +1,341 @@
+"""Deterministic agent-effectiveness measurement contracts for issue #1070."""
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER = ROOT / "harness" / "outcome_scorecard.py"
+PILOT = (
+    ROOT
+    / "evals"
+    / "agent-effectiveness"
+    / "cartography-sanity-replay.json"
+)
+
+
+def _quality(*, context_rework: int, cross_session_resume: bool) -> dict:
+    return {
+        "product_ac": {"passed": 2, "total": 2},
+        "must_fix_count": 0,
+        "regression_count": 0,
+        "human_recovery_count": 0,
+        "context_rework_count": context_rework,
+        "cross_session_resume": cross_session_resume,
+    }
+
+
+def _cold_run(variant: str) -> dict:
+    expected = {
+        "ssot": "docs/architecture.md",
+        "runtime_entrypoint": "src/app.py",
+        "capability_owner": "src/notifications/dispatcher.py",
+        "decision": "docs/decisions/0001-notification-routing.md",
+    }
+    if variant == "baseline":
+        visited = [
+            {"path": "README.md", "tool": "read", "bytes": 900, "elapsed_ms": 10},
+            {
+                "path": "legacy/notification_router.py",
+                "tool": "read",
+                "bytes": 700,
+                "elapsed_ms": 20,
+            },
+            {"path": expected["ssot"], "tool": "read", "bytes": 600, "elapsed_ms": 30},
+            {
+                "path": expected["runtime_entrypoint"],
+                "tool": "read",
+                "bytes": 500,
+                "elapsed_ms": 40,
+            },
+            {
+                "path": expected["capability_owner"],
+                "tool": "read",
+                "bytes": 400,
+                "elapsed_ms": 50,
+            },
+            {
+                "path": expected["decision"],
+                "tool": "read",
+                "bytes": 300,
+                "elapsed_ms": 60,
+            },
+        ]
+    else:
+        visited = [
+            {"path": expected["ssot"], "tool": "read", "bytes": 600, "elapsed_ms": 10},
+            {
+                "path": expected["runtime_entrypoint"],
+                "tool": "read",
+                "bytes": 500,
+                "elapsed_ms": 20,
+            },
+            {
+                "path": expected["capability_owner"],
+                "tool": "read",
+                "bytes": 400,
+                "elapsed_ms": 30,
+            },
+            {
+                "path": expected["decision"],
+                "tool": "read",
+                "bytes": 300,
+                "elapsed_ms": 40,
+            },
+        ]
+    return {
+        "variant": variant,
+        "reported_coordinates": expected,
+        "visited": visited,
+        "quality": _quality(
+            context_rework=1 if variant == "baseline" else 0,
+            cross_session_resume=variant == "current",
+        ),
+        "cost": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "basis": "deterministic replay; no LLM invocation",
+        },
+    }
+
+
+def _refactor_run(variant: str) -> dict:
+    classifications = {
+        "legacy/notification_router.py": "stale_old_path",
+        "src/runtime_handler.py": "framework_reachable",
+        "src/extension_port.py": "intentional_seam",
+    }
+    impact = [
+        "src/notifications/dispatcher.py",
+        "src/app.py",
+        "tests/test_notifications.py",
+    ]
+    if variant == "baseline":
+        classifications = {
+            "legacy/notification_router.py": "framework_reachable",
+            "src/runtime_handler.py": "framework_reachable",
+        }
+        impact = ["src/notifications/dispatcher.py", "src/app.py", "README.md"]
+    return {
+        "variant": variant,
+        "classifications": classifications,
+        "observed_impact": impact,
+        "tool_calls": 7 if variant == "baseline" else 5,
+        "read_bytes": 3600 if variant == "baseline" else 2800,
+        "quality": _quality(
+            context_rework=1 if variant == "baseline" else 0,
+            cross_session_resume=variant == "current",
+        ),
+        "cost": {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cost_usd": 0,
+            "basis": "deterministic replay; no LLM invocation",
+        },
+    }
+
+
+def _record() -> dict:
+    return {
+        "schema_version": 1,
+        "measurement": {
+            "id": "agent-effectiveness-fixture-v1",
+            "measured_at": "2026-07-12T10:00:00Z",
+            "source": "stored deterministic replay",
+            "source_count": 2,
+            "limitations": [
+                "synthetic repository fixture",
+                "no live LLM trial",
+                "not public superiority evidence",
+            ],
+        },
+        "conditions": {
+            "repo_type": "frozen synthetic application",
+            "provider": "deterministic-replay",
+            "model": "none",
+            "harness_variants": ["baseline", "current"],
+        },
+        "budget": {
+            "execution_month": "2026-07",
+            "monthly_cap": 4,
+            "used_before": 2,
+            "new_llm_trials": 0,
+            "lean_ablation_screening_month": "2026-07",
+        },
+        "fixtures": {},
+        "tasks": [
+            {
+                "id": "cold-start-notification-route",
+                "type": "cold_start",
+                "expected_coordinates": {
+                    "ssot": "docs/architecture.md",
+                    "runtime_entrypoint": "src/app.py",
+                    "capability_owner": "src/notifications/dispatcher.py",
+                    "decision": "docs/decisions/0001-notification-routing.md",
+                },
+                "runs": [_cold_run("baseline"), _cold_run("current")],
+            },
+            {
+                "id": "notification-router-replacement",
+                "type": "refactor_replacement",
+                "expected_classifications": {
+                    "legacy/notification_router.py": "stale_old_path",
+                    "src/runtime_handler.py": "framework_reachable",
+                    "src/extension_port.py": "intentional_seam",
+                },
+                "expected_impact": [
+                    "src/notifications/dispatcher.py",
+                    "src/app.py",
+                    "tests/test_notifications.py",
+                ],
+                "runs": [_refactor_run("baseline"), _refactor_run("current")],
+            },
+        ],
+    }
+
+
+class AgentEffectivenessContractTests(unittest.TestCase):
+    def _run(self, record: dict) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            projects_file = root / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": []}), encoding="utf-8"
+            )
+            record_file = root / "record.json"
+            record_file.write_text(json.dumps(record), encoding="utf-8")
+            return subprocess.run(
+                [
+                    "python3.11",
+                    str(RUNNER),
+                    "--projects-file",
+                    str(projects_file),
+                    "--agent-effectiveness-record",
+                    str(record_file),
+                    "--json",
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+    def test_replays_both_task_types_and_reports_improvement_without_quality_loss(
+        self,
+    ) -> None:
+        result = self._run(_record())
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        effectiveness = json.loads(result.stdout)["agent_effectiveness"]
+        self.assertEqual(effectiveness["status"], "관측")
+        self.assertEqual(effectiveness["source_count"], 2)
+        self.assertEqual(effectiveness["denominator"], 4)
+        self.assertTrue(effectiveness["improved"])
+        self.assertFalse(effectiveness["quality_worse"])
+        cold = effectiveness["tasks"][0]
+        self.assertEqual(cold["current"]["coordinate_accuracy"], "4/4")
+        self.assertEqual(cold["current"]["wrong_path_count"], 0)
+        self.assertEqual(cold["current"]["first_correct_target_tool_count"], 3)
+        self.assertEqual(cold["current"]["first_correct_target_read_bytes"], 1500)
+        self.assertLess(cold["current"]["tool_calls"], cold["baseline"]["tool_calls"])
+        refactor = effectiveness["tasks"][1]
+        self.assertEqual(refactor["current"]["classification_accuracy"], "3/3")
+        self.assertEqual(refactor["current"]["missed_impact"], [])
+        self.assertEqual(refactor["current"]["excess_impact"], [])
+        self.assertEqual(effectiveness["cost"]["input_tokens"], 0)
+        self.assertEqual(effectiveness["cost"]["cost_usd"], 0)
+
+    def test_rejects_current_coordinate_mismatch(self) -> None:
+        record = _record()
+        record["tasks"][0]["runs"][1]["reported_coordinates"]["capability_owner"] = (
+            "legacy/notification_router.py"
+        )
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("current_coordinate_mismatch:capability_owner", result.stderr)
+
+    def test_rejects_same_month_llm_trial_collision_and_budget_overrun(self) -> None:
+        record = _record()
+        record["budget"]["new_llm_trials"] = 3
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("same_month_lean_ablation_collision", result.stderr)
+        self.assertIn("monthly_trial_cap_exceeded", result.stderr)
+
+    def test_rejects_product_quality_regression_even_if_navigation_is_cheaper(self) -> None:
+        record = _record()
+        record["tasks"][1]["runs"][1]["quality"]["product_ac"]["passed"] = 1
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("current_quality_worse", result.stderr)
+
+    def test_checked_in_replay_is_reproducible(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            projects_file = Path(directory) / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": []}), encoding="utf-8"
+            )
+            result = subprocess.run(
+                [
+                    "python3.11",
+                    str(RUNNER),
+                    "--projects-file",
+                    str(projects_file),
+                    "--agent-effectiveness-record",
+                    str(PILOT),
+                    "--json",
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        effectiveness = json.loads(result.stdout)["agent_effectiveness"]
+        self.assertEqual(effectiveness["measurement_id"], "agent-effectiveness-2026-07")
+        self.assertEqual(effectiveness["measured_at"], "2026-07-12T10:00:00Z")
+        self.assertEqual(effectiveness["monthly_llm_trial_total"], 2)
+
+    def test_scorecard_docs_record_replay_conditions_denominators_and_limits(self) -> None:
+        contract = (ROOT / "docs" / "plugin" / "outcome-scorecard.md").read_text(
+            encoding="utf-8"
+        )
+        baseline = (ROOT / "docs" / "internal" / "outcome-baseline.md").read_text(
+            encoding="utf-8"
+        )
+        for term in (
+            "--agent-effectiveness-record",
+            "첫 올바른 대상까지의 tool/read",
+            "영향 범위 과다 포함",
+            "cross-session",
+            "제품 AC",
+        ):
+            self.assertIn(term, contract)
+        for evidence in (
+            "agent-effectiveness-2026-07",
+            "deterministic-replay",
+            "비교 trial 4",
+            "source fixture 2",
+            "input/output token `0/0`",
+            "cost `$0.00`",
+            "2026-07 epic 공통 추가 LLM trial 누계 `2/4`",
+            "문서 수",
+            "synthetic",
+        ):
+            self.assertIn(evidence, baseline)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_agent_effectiveness.py
+++ b/tests/test_agent_effectiveness.py
@@ -271,6 +271,9 @@ class AgentEffectivenessContractTests(unittest.TestCase):
         self.assertEqual(refactor["current"]["excess_impact"], [])
         self.assertEqual(effectiveness["cost"]["input_tokens"], 0)
         self.assertEqual(effectiveness["cost"]["cost_usd"], 0)
+        trial_metadata = json.loads(result.stdout)["trial_metadata"]
+        self.assertEqual(trial_metadata["source_count"], 1)
+        self.assertNotIn("source_project_count", trial_metadata)
 
     def test_rejects_current_coordinate_mismatch(self) -> None:
         record = _record()
@@ -288,6 +291,29 @@ class AgentEffectivenessContractTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("fixture_sha256_mismatch:docs/architecture.md", result.stderr)
+
+    def test_rejects_extra_current_classification_outside_expected_set(self) -> None:
+        record = _record()
+        record["tasks"][1]["runs"][1]["classifications"]["README.md"] = (
+            "stale_old_path"
+        )
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("current_classification_scope_mismatch", result.stderr)
+
+    def test_rejects_extra_coordinate_key_or_nonmonotonic_trace(self) -> None:
+        record = _record()
+        current = record["tasks"][0]["runs"][1]
+        current["reported_coordinates"]["extra"] = "README.md"
+        current["visited"][2]["elapsed_ms"] = 5
+
+        result = self._run(record)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("current_coordinate_keys_invalid", result.stderr)
+        self.assertIn("current_elapsed_not_monotonic", result.stderr)
 
     def test_rejects_same_month_llm_trial_collision_and_budget_overrun(self) -> None:
         record = _record()

--- a/tests/test_agent_effectiveness.py
+++ b/tests/test_agent_effectiveness.py
@@ -1,7 +1,9 @@
 """Deterministic agent-effectiveness measurement contracts for issue #1070."""
 from __future__ import annotations
 
+import hashlib
 import json
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -147,7 +149,7 @@ def _record() -> dict:
             "id": "agent-effectiveness-fixture-v1",
             "measured_at": "2026-07-12T10:00:00Z",
             "source": "stored deterministic replay",
-            "source_count": 2,
+            "source_count": 1,
             "limitations": [
                 "synthetic repository fixture",
                 "no live LLM trial",
@@ -167,6 +169,7 @@ def _record() -> dict:
             "new_llm_trials": 0,
             "lean_ablation_screening_month": "2026-07",
         },
+        "fixture_root": "fixture",
         "fixtures": {},
         "tasks": [
             {
@@ -200,9 +203,27 @@ def _record() -> dict:
 
 
 class AgentEffectivenessContractTests(unittest.TestCase):
-    def _run(self, record: dict) -> subprocess.CompletedProcess[str]:
+    def _run(
+        self, record: dict, *, tamper_fixture: bool = False
+    ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
+            fixture_root = root / "fixture"
+            shutil.copytree(
+                ROOT / "evals" / "agent-effectiveness" / "fixture", fixture_root
+            )
+            record["fixture_root"] = "fixture"
+            record["fixtures"] = {
+                str(path.relative_to(fixture_root)): hashlib.sha256(
+                    path.read_bytes()
+                ).hexdigest()
+                for path in sorted(fixture_root.rglob("*"))
+                if path.is_file()
+            }
+            if tamper_fixture:
+                (fixture_root / "docs" / "architecture.md").write_text(
+                    "tampered\n", encoding="utf-8"
+                )
             projects_file = root / "projects.json"
             projects_file.write_text(
                 json.dumps({"version": 1, "projects": []}), encoding="utf-8"
@@ -233,7 +254,8 @@ class AgentEffectivenessContractTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         effectiveness = json.loads(result.stdout)["agent_effectiveness"]
         self.assertEqual(effectiveness["status"], "관측")
-        self.assertEqual(effectiveness["source_count"], 2)
+        self.assertEqual(effectiveness["source_count"], 1)
+        self.assertEqual(effectiveness["task_count"], 2)
         self.assertEqual(effectiveness["denominator"], 4)
         self.assertTrue(effectiveness["improved"])
         self.assertFalse(effectiveness["quality_worse"])
@@ -260,6 +282,12 @@ class AgentEffectivenessContractTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 2)
         self.assertIn("current_coordinate_mismatch:capability_owner", result.stderr)
+
+    def test_rejects_tampered_fixture_bundle(self) -> None:
+        result = self._run(_record(), tamper_fixture=True)
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("fixture_sha256_mismatch:docs/architecture.md", result.stderr)
 
     def test_rejects_same_month_llm_trial_collision_and_budget_overrun(self) -> None:
         record = _record()
@@ -327,7 +355,8 @@ class AgentEffectivenessContractTests(unittest.TestCase):
             "agent-effectiveness-2026-07",
             "deterministic-replay",
             "비교 trial 4",
-            "source fixture 2",
+            "source fixture 1",
+            "task 2",
             "input/output token `0/0`",
             "cost `$0.00`",
             "2026-07 epic 공통 추가 LLM trial 누계 `2/4`",


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1070

## 배경 및 문제

#1066 scorecard는 Agent effectiveness 축의 의미를 정의했지만, 기존 ledger에는 SSOT·runtime entrypoint·capability owner 탐색 비용과 stale path·영향 범위 품질을 비교할 수 있는 record가 없어 계속 `측정 불가`였다. Cartography freshness와 Codebase Sanity의 존재 자체를 효과로 간주하지 않고, 두 대표 task를 같은 조건에서 재현 가능한 증거로 비교해야 했다.

## 원인 (해당 시)

기존 scorecard 집계기는 process ledger와 product journey receipt만 읽고 Agent effectiveness 전용 evidence contract를 갖지 않았다. 따라서 문서·검증 단계가 있어도 첫 정답까지의 tool/read 비용, 오경로, 영향 누락·과다 포함, context 기인 재작업, cross-session 복구를 제품 품질과 함께 판정할 수 없었다.

## 작업내용

- `[epic1064][story1070] agent effectiveness replay 측정 추가`
  - frozen cold-start/refactor baseline/current record를 검증하는 `harness/agent_effectiveness.py`를 추가했다.
  - scorecard에 `--agent-effectiveness-record` 입력을 연결하고 기대 좌표, stale/framework/intentional 분류, 영향 집합, 제품 AC·MUST-FIX·회귀·사람 복구, token/cost, 월 trial 예산을 fail-closed로 검증한다.
  - portable fixture bundle 1개에서 task 2개·비교 trial 4개를 재현하는 record와 회귀 테스트를 추가했다.
- `[epic1064][story1070] agent effectiveness scorecard 기록`
  - scorecard 계약에 첫 정답까지의 tool/read, 영향 과다 포함, cross-session, 제품 품질 비열화 판정을 명시했다.
  - 2026-07 deterministic screening의 source·denominator·측정일·token/cost·한계를 기록했다.

## 결정 근거

#1069가 2026-07 epic 공통 추가 LLM trial 2/4를 이미 사용했으므로 같은 달 paired LLM screening을 실행하지 않았다. 대신 모델 호출이 없는 frozen deterministic replay를 선택해 새 trial 0회로 기대 좌표와 집합 판정을 재현했다. 이 결과는 live-agent/public superiority 근거가 아니라 synthetic 개인 screening으로 제한하며, 문서 수·map 크기·hook 수는 효과 대리값에서 제외했다.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1: `harness/agent_effectiveness.py`와 `harness/outcome_scorecard.py`는 release sync 제외 대상이 아니므로 플러그인 업데이트 시 외부 활성 프로젝트에서 사용할 수 있다.
- 경로 3: `docs/plugin/outcome-scorecard.md`가 record 입력과 판정 계약을 사용자 SSOT로 제공한다.
- `/init-dcness` 복사 파일 변경은 없다.
- `evals/**`, `tests/**`, `docs/internal/**`의 fixture·회귀·실측 snapshot은 dcNess self evidence이며 release에서 의도적으로 제외된다. 플러그인 런타임은 이 checked-in record에 의존하지 않고 사용자가 전달한 record만 읽는다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate를 추가하지 않고 기존 scorecard의 선택형 입력만 확장했다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
  - `python3.11 -m unittest discover -s tests -v < /dev/null` — 1919 tests PASS
  - `python3.11 -m unittest tests.test_agent_effectiveness tests.test_outcome_scorecard -v < /dev/null` — 19 tests PASS
- [x] 회귀 검증
  - `python3.11 evals/guard_efficacy.py` — 39/39 PASS
  - `PYTHON_BIN=/tmp/dcness-1070-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/Bandit PASS
  - `node scripts/check_cross_refs.mjs` — PASS
  - `node scripts/check_doc_path_integrity.mjs` — PASS
  - `node scripts/check_public_surface.mjs` — PASS
  - `node scripts/check_plugin_manifest.mjs` — PASS

## 참고

- deterministic 결과: source fixture 1, task 2, trial 4; tool `13→9`, read bytes `7,000→4,600`, 오경로 `2→0`, 영향 누락 `1→0`, context 기인 재작업 `2→0`; 제품 AC 4/4, MUST-FIX/회귀/사람 복구 0 유지.
- 새 LLM trial 0회, 2026-07 epic 공통 누계 2/4.
