### PR TITLE
[epic1064][story1071] 공개 evidence freshness gate 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,35 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-as of v0.12.0 + Unreleased (2026-07-05), 로컬 실측 기준:
+<!-- public-evidence-snapshot {"plugin_version":"0.21.0","measured_at":"2026-07-12","unit_tests":{"passed":1924,"total":1924},"guard":{"passed":39,"total":39},"source_project_count":2} -->
 
-| 항목 | 결과 | 재현 명령 |
-|---|---:|---|
-| 단위 테스트 | 1627 tests PASS | `python3.11 -m unittest discover -s tests -v < /dev/null` |
-| 결정적 guard eval | 33/33 PASS | `python3 evals/guard_efficacy.py --json` |
-| GitHub Actions gate | 11 workflows | `find .github/workflows -maxdepth 1 -type f -name '*.yml' \| wc -l` |
+현재 공개 snapshot은 **v0.21.0, 2026-07-12 측정**이다. 숫자마다 분모와 source 수를
+붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
+
+| evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
+|---|---|---|---|---|
+| 하네스·기계적 guard | unittest 1,924/1,924 PASS, 결정적 guard 39/39 PASS | test 1,924, guard case 39 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| Agent effectiveness | 탐색 tool 13→9, read 7,000→4,600 bytes, 오경로 2→0, 영향 누락 1→0 | baseline/current trial 4, task 2 / synthetic fixture 1 | [`docs/internal/outcome-baseline.md`](docs/internal/outcome-baseline.md#2026-07-12-agent-effectiveness-deterministic-screening)의 고정 record 명령 | live agent·실제 프로젝트·다중 model 우위가 아니다 |
+| PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
+| 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |
+| 비용·경량화 | prompt 107 bytes 축소에도 input token 38,874→40,659; **keep** | baseline/variant trial 2 / frozen fixture 1 | `python3.11 evals/lean_ablation.py evals/lean-ablation/tool-repeat-lesson-metadata.json --json` | 단일 pair의 wall-clock·token 변동을 일반 비용 우위로 쓰지 않는다 |
+
+결정 완전성 회고는 실제 작업 2건에서 불필요한 재질문 없이 구현 방향을 바꾸는 미결정
+각 1건을 드러냈고 사람이 확인했다. 행동 eval judge 보정은 고정 report 2건의 사람 판정과
+저장 judge 판정 9/9가 일치했다. 각각
+[`decision-completeness-pilots.md`](docs/internal/decision-completeness-pilots.md)와
+[`core-incidents-v1`](evals/calibration/core-incidents-v1/README.md)에 표본·재현 절차·한계를
+보존한다. 두 결과도 제품 outcome이나 다중 프로젝트 우위 근거로 승격하지 않는다.
+
+`node scripts/check_public_evidence.mjs`는 실제 전체 unittest와 guard eval을 실행하고,
+manifest version·test 수·guard 수가 이 표와
+[`benchmark.md`](docs/plugin/benchmark.md#현재-공개-evidence-snapshot)에서 어긋나면 실패한다.
+개별 원명령도 그대로 통과해야 한다.
+
+```sh
+python3.11 -m unittest discover -s tests -v < /dev/null
+python3.11 evals/guard_efficacy.py
+```
 
 최근 릴리즈별 변경 상세는 [`docs/internal/release-notes.md`](docs/internal/release-notes.md)에 남긴다.
 
@@ -91,7 +113,7 @@ dcNess의 file boundary와 mutation denylist는 보안 sandbox가 아니다. 목
 
 dcNess 는 무거운 절차를 항상 켜 두지 않는다. 문서 수정이나 한 줄 버그픽스는 가볍게 지나가고, 새 기능이나 위험이 큰 작업일 때만 설계·검토 절차를 끌어올린다. 그래서 작은 작업에는 부담이 적고, 큰 작업에는 안전하다.
 
-다른 스킬 기반 하네스([Superpowers](https://github.com/obra/superpowers), [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) 등)와 결이 다르다. 그쪽은 방법론과 다양한 도구 연동이 강점이다. dcNess 는 노출하는 표면을 작게 유지하는 대신, 작업 순서·파일 경계를 코드로 지키는 거버넌스와 run 단위 replay 에 집중한다. 실측 수치와 재현 명령은 [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md)에 있다.
+다른 스킬 기반 하네스([Superpowers](https://github.com/obra/superpowers), [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) 등)와 비교할 때 기능 개수나 관심도 지표를 품질 대리값으로 쓰지 않는다. 강제 경계, Agent effectiveness, 실행 검수, eval, 운영 표본, 생태계를 서로 다른 축으로 비교해야 한다. dcNess 는 그중 작업 순서·파일 경계를 코드로 지키는 거버넌스와 run 단위 replay 에 집중한다. 실측 수치와 재현 명령은 [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md)에 있다.
 
 ## 설치 & 활성화
 

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -5,6 +5,45 @@
 > 공개된 표본은 작다. headline 숫자는 항상 표본 수, 출처 수, 한계를 같은 단락에 둔다.
 > 표본이 작으면 일반 성능 주장이 아니라 pilot / anecdote 로만 다룬다.
 
+## 현재 공개 Evidence snapshot
+
+<!-- public-evidence-snapshot {"plugin_version":"0.21.0","measured_at":"2026-07-12","unit_tests":{"passed":1924,"total":1924},"guard":{"passed":39,"total":39},"source_project_count":2} -->
+
+현재 plugin version은 **v0.21.0**, 측정일은 **2026-07-12**다. 아래 표의 최대
+source 프로젝트 수는 2이며, 영역별 실제 source와 denominator는 각 행에 다시 적는다.
+process, Agent effectiveness, product outcome, 비용을 합산한 단일 성공 점수는 만들지 않는다.
+
+| evidence 영역 | 관측값 | denominator | source 수 | 재현 명령 | 한계 |
+|---|---|---:|---:|---|---|
+| 하네스 정의·기계적 guard | unittest 1,924/1,924 PASS; guard fixture 39/39 PASS | test 1,924; guard 39 | dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 테스트와 fixture 계약의 과정 evidence다. 보안 증명·제품 성공률이 아니다 |
+| Agent effectiveness | tool 13→9; read 7,000→4,600 bytes; wrong path 2→0; missed impact 1→0; context rework 2→0 | baseline/current trial 4, task 2 | synthetic fixture 1 | `printf '{"version":1,"projects":[]}' > /tmp/dcness-empty-projects.json && python3.11 harness/outcome_scorecard.py --projects-file /tmp/dcness-empty-projects.json --agent-effectiveness-record evals/agent-effectiveness/cartography-sanity-replay.json --measured-at 2026-07-12T10:00:00Z --json` | deterministic 저장 replay다. live agent token/cost, 실제 프로젝트 wall-clock, 다중 model/provider는 측정 불가 |
+| PR·validator 운영 | finished 26/28; PR merge 7/7; validator verdict 33/26 finished run | candidate run 28; measurable PR 7; finished run 26 | 외부 활성 프로젝트 2 | [`outcome-baseline.md`](../internal/outcome-baseline.md#재현-명령)의 두 source-ref 고정 명령 | merge·validator FAIL은 제품 성공률이 아니다. 선택한 legacy ledger의 guard와 regression은 측정 불가 |
+| 실제 제품 outcome | non-UI journey 1/1 PASS; 제품 AC 1/1 | journey 1; AC 1 | 외부 활성 프로젝트 1 | [`outcome-baseline.md`](../internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 CLI/filesystem pilot이다. UI·다른 제품·공개 우위로 일반화할 수 없다 |
+| 비용·경량화 | prompt 107 bytes 감소; input token 38,874→40,659; 결정 `keep` | baseline/variant trial 2 | frozen fixture 1 | `python3.11 evals/lean_ablation.py evals/lean-ablation/tool-repeat-lesson-metadata.json --json` | billed cost 측정 불가. 단일 pair의 wall-clock 감소를 우위 근거로 쓰지 않는다 |
+
+### 구현 전 결정 pilot과 행동 eval 보정
+
+| evidence | 관측값 | denominator / source | 재현·원천 | 한계 |
+|---|---|---|---|---|
+| 결정 완전성 회고 | 실제 작업 2건 모두에서 이미 정해진 선택은 재질문하지 않고 구현 방향을 바꾸는 미결정 1건씩 표면화; 사람 확인 완료 | 회고 2 / 실제 작업 source 2 | [`decision-completeness-pilots.md`](../internal/decision-completeness-pilots.md)의 원본 hash와 대조 위치 | 회고 표본이며 제품 성공률·질문 절감률을 산출하지 않는다 |
+| 행동 eval judge 보정 | 사람 golden과 저장 judge 판정 9/9 일치 | 비교 9, report 2 / 고정 calibration set 1 | `python3 evals/calibrate_judge.py evals/calibration/core-incidents-v1 --golden evals/golden/core-incidents-v1.json --expect-golden-version core-incidents-v1-human-v1 --expect-subset-version core-incidents-v1` | 2026-07-05 Sonnet report 2건의 고정 재채점이다. 현재 모든 agent 행동이나 제품 outcome을 뜻하지 않는다 |
+
+### freshness와 drift 검출
+
+기본 검증 명령은 실제로 `python3.11 -m unittest discover -s tests -v`와
+`python3.11 evals/guard_efficacy.py --json`을 실행한다. 그 결과를 README와 이 문서의
+동일 snapshot marker, `.claude-plugin/plugin.json` version과 비교하므로 version·test·guard
+중 하나라도 현재 checkout과 달라지면 exit 1이다.
+
+```sh
+node scripts/check_public_evidence.mjs
+```
+
+이 gate는 source-ref runtime ledger나 ignored journey receipt를 공개 저장소에 복제하지
+않는다. 운영·제품·effectiveness 숫자의 원천과 고정 cutoff는
+[`outcome-baseline.md`](../internal/outcome-baseline.md)가 소유하며, 원천이 없는 환경에서는
+기록된 snapshot을 재현한 것처럼 가장하지 않고 `측정 불가`로 남긴다.
+
 ## 무엇을 측정하나
 
 dcNess 는 측정 인프라를 plug-in 본체에 같이 배포한다.

--- a/scripts/check_public_evidence.mjs
+++ b/scripts/check_public_evidence.mjs
@@ -1,0 +1,199 @@
+#!/usr/bin/env node
+
+/**
+ * Verify that public evidence numbers match the current checkout.
+ *
+ * By default this runs the full unittest suite and deterministic guard eval. Fixture
+ * output flags exist so the checker itself can be tested without recursively running
+ * the repository suite.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+
+function fail(message) {
+  process.stderr.write(`[public-evidence] FAIL — ${message}\n`);
+  process.exitCode = 1;
+}
+
+
+function parseArgs(argv) {
+  const options = { root: process.cwd(), python: process.env.PYTHON_BIN || 'python3.11' };
+  for (let index = 0; index < argv.length; index += 1) {
+    const flag = argv[index];
+    if (!['--root', '--python', '--test-output', '--guard-output'].includes(flag)) {
+      throw new Error(`unknown argument: ${flag}`);
+    }
+    const value = argv[index + 1];
+    if (!value) {
+      throw new Error(`missing value for ${flag}`);
+    }
+    options[flag.slice(2).replace('-', '_')] = value;
+    index += 1;
+  }
+  if (Boolean(options.test_output) !== Boolean(options.guard_output)) {
+    throw new Error('--test-output and --guard-output must be supplied together');
+  }
+  options.root = resolve(options.root);
+  return options;
+}
+
+
+function readJson(path, label) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new Error(`${label} is unreadable JSON: ${error.message}`);
+  }
+}
+
+
+function snapshotFrom(path, label) {
+  const text = readFileSync(path, 'utf8');
+  const matches = [...text.matchAll(/<!-- public-evidence-snapshot (\{[^\n]+\}) -->/g)];
+  if (matches.length !== 1) {
+    throw new Error(`${label} must contain exactly one public-evidence-snapshot marker`);
+  }
+  try {
+    return JSON.parse(matches[0][1]);
+  } catch (error) {
+    throw new Error(`${label} public-evidence-snapshot is invalid JSON: ${error.message}`);
+  }
+}
+
+
+function run(command, args, root, label) {
+  const result = spawnSync(command, args, {
+    cwd: root,
+    encoding: 'utf8',
+    input: '',
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) {
+    throw new Error(`${label} could not start: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const detail = `${result.stdout || ''}${result.stderr || ''}`.trim();
+    throw new Error(`${label} failed with exit ${result.status}${detail ? `: ${detail}` : ''}`);
+  }
+  return `${result.stdout || ''}${result.stderr || ''}`;
+}
+
+
+function parseTestCount(output) {
+  const matches = [...output.matchAll(/Ran (\d+) tests? in /g)];
+  if (matches.length !== 1 || !/\nOK(?:\s|$)/.test(output)) {
+    throw new Error('unittest output must contain one successful `Ran N tests` summary');
+  }
+  return Number(matches[0][1]);
+}
+
+
+function parseGuard(output) {
+  let payload;
+  try {
+    payload = JSON.parse(output);
+  } catch (error) {
+    throw new Error(`guard output is invalid JSON: ${error.message}`);
+  }
+  const passed = payload?.total?.passed;
+  const failed = payload?.total?.failed;
+  const total = payload?.total?.total;
+  if (![passed, failed, total].every(Number.isInteger) || passed + failed !== total) {
+    throw new Error('guard output has an invalid total summary');
+  }
+  if (failed !== 0) {
+    throw new Error(`guard eval reported ${failed} failed case(s)`);
+  }
+  return { passed, total };
+}
+
+
+function validateSnapshot(snapshot) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(snapshot.measured_at || '')) {
+    throw new Error('snapshot measured_at must be YYYY-MM-DD');
+  }
+  if (!Number.isInteger(snapshot.source_project_count) || snapshot.source_project_count < 1) {
+    throw new Error('snapshot source_project_count must be a positive integer');
+  }
+  for (const key of ['unit_tests', 'guard']) {
+    const metric = snapshot[key];
+    if (!metric || !Number.isInteger(metric.passed) || !Number.isInteger(metric.total)) {
+      throw new Error(`snapshot ${key} must contain integer passed/total`);
+    }
+  }
+}
+
+
+function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+    const manifest = readJson(resolve(options.root, '.claude-plugin/plugin.json'), 'plugin manifest');
+    const readmeSnapshot = snapshotFrom(resolve(options.root, 'README.md'), 'README.md');
+    const benchmarkSnapshot = snapshotFrom(
+      resolve(options.root, 'docs/plugin/benchmark.md'),
+      'docs/plugin/benchmark.md',
+    );
+    validateSnapshot(readmeSnapshot);
+
+    if (JSON.stringify(readmeSnapshot) !== JSON.stringify(benchmarkSnapshot)) {
+      fail('README/benchmark snapshot drift');
+      return;
+    }
+    if (manifest.version !== readmeSnapshot.plugin_version) {
+      fail(`plugin version drift: manifest=${manifest.version}, docs=${readmeSnapshot.plugin_version}`);
+      return;
+    }
+
+    const testOutput = options.test_output
+      ? readFileSync(resolve(options.test_output), 'utf8')
+      : run(
+          options.python,
+          ['-m', 'unittest', 'discover', '-s', 'tests', '-v'],
+          options.root,
+          'unittest suite',
+        );
+    const guardOutput = options.guard_output
+      ? readFileSync(resolve(options.guard_output), 'utf8')
+      : run(
+          options.python,
+          ['evals/guard_efficacy.py', '--json'],
+          options.root,
+          'guard efficacy eval',
+        );
+    const testCount = parseTestCount(testOutput);
+    const guard = parseGuard(guardOutput);
+
+    const documentedTests = readmeSnapshot.unit_tests;
+    if (documentedTests.passed !== testCount || documentedTests.total !== testCount) {
+      fail(
+        `unit test drift: runtime=${testCount}/${testCount}, ` +
+          `docs=${documentedTests.passed}/${documentedTests.total}`,
+      );
+      return;
+    }
+    const documentedGuard = readmeSnapshot.guard;
+    if (documentedGuard.passed !== guard.passed || documentedGuard.total !== guard.total) {
+      fail(
+        `guard drift: runtime=${guard.passed}/${guard.total}, ` +
+          `docs=${documentedGuard.passed}/${documentedGuard.total}`,
+      );
+      return;
+    }
+
+    process.stdout.write(
+      `[public-evidence] PASS — version=${manifest.version}, ` +
+        `tests=${testCount}/${testCount}, guard=${guard.passed}/${guard.total}, ` +
+        `measured_at=${readmeSnapshot.measured_at}, ` +
+        `source_projects=${readmeSnapshot.source_project_count}\n`,
+    );
+  } catch (error) {
+    fail(error.message);
+  }
+}
+
+
+main();

--- a/tests/test_public_evidence.py
+++ b/tests/test_public_evidence.py
@@ -1,0 +1,127 @@
+"""Public evidence freshness gate regression tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "scripts" / "check_public_evidence.mjs"
+
+
+class PublicEvidenceGateTests(unittest.TestCase):
+    def _fixture(self, root: Path, *, version: str = "1.2.3", tests: int = 7) -> None:
+        (root / ".claude-plugin").mkdir(parents=True)
+        (root / ".claude-plugin" / "plugin.json").write_text(
+            json.dumps({"name": "dcness", "version": version}), encoding="utf-8"
+        )
+        snapshot = {
+            "plugin_version": version,
+            "measured_at": "2026-07-12",
+            "unit_tests": {"passed": tests, "total": tests},
+            "guard": {"passed": 3, "total": 3},
+            "source_project_count": 2,
+        }
+        marker = f"<!-- public-evidence-snapshot {json.dumps(snapshot)} -->\n"
+        (root / "README.md").write_text(marker, encoding="utf-8")
+        docs = root / "docs" / "plugin"
+        docs.mkdir(parents=True)
+        (docs / "benchmark.md").write_text(marker, encoding="utf-8")
+        (root / "unittest.txt").write_text(
+            f"Ran {tests} tests in 0.100s\n\nOK\n", encoding="utf-8"
+        )
+        (root / "guard.json").write_text(
+            json.dumps({"total": {"passed": 3, "failed": 0, "total": 3}}),
+            encoding="utf-8",
+        )
+
+    def _run(self, root: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "node",
+                str(CHECKER),
+                "--root",
+                str(root),
+                "--test-output",
+                str(root / "unittest.txt"),
+                "--guard-output",
+                str(root / "guard.json"),
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_fixture_snapshot_passes_with_matching_runtime_measurements(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._fixture(root)
+            result = self._run(root)
+
+        self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+        self.assertIn("PASS", result.stdout)
+        self.assertIn("tests=7/7", result.stdout)
+        self.assertIn("guard=3/3", result.stdout)
+
+    def test_version_drift_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._fixture(root)
+            manifest = root / ".claude-plugin" / "plugin.json"
+            manifest.write_text(
+                json.dumps({"name": "dcness", "version": "1.2.4"}),
+                encoding="utf-8",
+            )
+            result = self._run(root)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("plugin version drift", result.stderr)
+
+    def test_test_count_drift_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._fixture(root, tests=7)
+            (root / "unittest.txt").write_text(
+                "Ran 8 tests in 0.100s\n\nOK\n", encoding="utf-8"
+            )
+            result = self._run(root)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unit test drift", result.stderr)
+
+    def test_guard_count_drift_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._fixture(root)
+            (root / "guard.json").write_text(
+                json.dumps({"total": {"passed": 4, "failed": 0, "total": 4}}),
+                encoding="utf-8",
+            )
+            result = self._run(root)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("guard drift", result.stderr)
+
+    def test_readme_and_benchmark_snapshot_drift_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self._fixture(root)
+            benchmark = root / "docs" / "plugin" / "benchmark.md"
+            benchmark.write_text(
+                benchmark.read_text(encoding="utf-8").replace(
+                    '"source_project_count": 2', '"source_project_count": 1'
+                ),
+                encoding="utf-8",
+            )
+            result = self._run(root)
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("README/benchmark snapshot drift", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1071
Part of #1064

## 배경 및 문제

README Evidence가 v0.12.0·1,627 tests·33/33 guard에 머물러 현재 v0.21.0 및 후속 제품·운영 측정과 어긋났습니다. 과정 수치와 실제 제품 outcome도 한눈에 구분되지 않아 내부 gate 수치가 제품 성공으로 오해될 여지가 있었습니다.

## 원인 (해당 시)

공개 수치를 수동으로 복사했지만 manifest version, 전체 test 결과, guard eval 결과와 문서 snapshot을 다시 대조하는 freshness 경로가 없었습니다.

## 작업내용

- README와 benchmark에 2026-07-12 현재 evidence snapshot을 source·denominator·재현 명령·한계와 함께 기록했습니다.
- 하네스/guard, Agent effectiveness, PR·validator 운영, 제품 outcome, 비용·경량화 결과를 독립 영역으로 분리했습니다.
- 결정 완전성 pilot과 행동 eval calibration 결과를 표본 및 주장 한계와 함께 연결했습니다.
- `scripts/check_public_evidence.mjs`가 manifest version과 실제 unittest·guard 결과를 README/benchmark snapshot에 대조하도록 추가했습니다.
- version/test/guard/문서 간 drift를 검증하는 회귀 테스트 5개를 추가했습니다.

## 결정 근거

README와 benchmark에 동일한 machine-readable snapshot을 두고 기본 checker가 실제 전체 suite를 실행하도록 했습니다. runtime ledger와 ignored journey receipt는 공개 저장소로 복제하지 않고 고정 source-ref·cutoff를 소유한 기존 outcome baseline에 연결했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `scripts/check_public_evidence.mjs`와 `docs/plugin/benchmark.md`는 plug-in 본체 경로이므로 사용자가 plug-in version을 갱신하면 함께 도달합니다.
- README는 저장소 공개 evidence 진입점입니다.
- init-dcness 복사 파일이나 기존 활성 프로젝트 재배포 대상은 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 skill/command/agent 또는 required CI gate를 추가하지 않고 저장소 evidence 점검 스크립트만 추가했습니다.

## Test Plan

- [x] `node scripts/check_public_evidence.mjs` — v0.21.0, tests 1,924/1,924, guard 39/39 PASS
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,924 tests PASS (pre-commit hook 포함)
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- [x] cross-ref, public-surface, plugin-manifest, index-map, design-artifact gate PASS
- [x] ruff, mypy, Bandit static-quality gate PASS

## 참고

- Epic #1064는 별도 사람 확인 안내가 남아 있어 이번 PR에서 자동 close하지 않습니다.
