### PR TITLE
[issue-955] init-dcness 비활성화 안내를 실존 경로로 정정

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ claude plugin install dcness@dcness
 설치만으로는 아무것도 걸리지 않는다. 기본값은 **비활성**(그냥 통과)이다. 적용할 프로젝트에서 Claude Code 세션을 열고 활성화해야 한다.
 
 ```
-/init-dcness        # 현 프로젝트를 활성 대상에 등록 (+ 파일 읽기 권한 / git hook 자동 셋업)
+/init-dcness        # 현 프로젝트를 활성 대상에 등록 (+ 파일 읽기 권한 / git hook 자동 셋업). 비활성화("dcness 꺼줘")도 같은 스킬이 처리
 ```
 
 `/init-dcness` 가 출력하는 진단표에서 `whitelist 활성` 이 PASS 이고 FAIL 이 0 이면 정상이다(INFO·선택 WARN 은 정상).
@@ -173,7 +173,7 @@ claude plugin install dcness@dcness
 | 고급 | `/tech-review` | 위험한 설계의 사전 기술 검증 |
 | 고급 | `/impl-loop` | deep impl task 파일 단위 구현 러너 |
 | 유틸 | `/ux` | 구현 없이 목업·흐름·디자인 시스템/토큰 베이스라인 먼저 탐색, PICK 확정본은 canvas 에 등록 |
-| 유틸 | `/init-dcness` | 현 프로젝트를 활성 대상에 등록 |
+| 유틸 | `/init-dcness` | 현 프로젝트를 활성 대상에 등록·해제 |
 | 유틸 | `/next-work` | issue/label 기반 진행 중 / 다음 할 일 조회 |
 | 유틸 | `/run-review` | 끝난 run 을 되짚어 단계별 비용·차단 분석 |
 | 유틸 | `/smart-compact` | 컨텍스트 압축 + 다음 세션 resume prompt 생성 |

--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -1,6 +1,6 @@
 ---
 name: init-dcness
-description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하는 부트스트랩 스킬. dcNess 는 디폴트로 모든 프로젝트에서 비활성 (hook pass-through). 본 스킬 호출 시 현재 cwd 의 main repo 를 plugin-scoped whitelist (`~/.claude/plugins/data/dcness-dcness/projects.json`) 에 추가해 SessionStart / PreToolUse Agent 훅이 발화하기 시작한다. 사용자가 "init-dcness", "dcness 활성화", "이 프로젝트에 dcness 켜", "dcness 시작", "/init-dcness" 등을 말할 때 사용. 비활성화는 `/disable-dcness` (또는 본 스킬에서 status 확인 후 안내).
+description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하는 부트스트랩 스킬. dcNess 는 디폴트로 모든 프로젝트에서 비활성 (hook pass-through). 본 스킬 호출 시 현재 cwd 의 main repo 를 plugin-scoped whitelist (`~/.claude/plugins/data/dcness-dcness/projects.json`) 에 추가해 SessionStart / PreToolUse Agent 훅이 발화하기 시작한다. 사용자가 "init-dcness", "dcness 활성화", "이 프로젝트에 dcness 켜", "dcness 시작", "/init-dcness" 등을 말할 때 사용. 비활성화 요청("dcness 꺼줘", "dcness 비활성화", "disable dcness")도 본 스킬이 처리한다 — 본문 비활성화 절차(helper `disable`)로 현재 프로젝트를 whitelist 에서 제거한다.
 ---
 
 # Init dcNess Skill - 프로젝트 활성화
@@ -10,6 +10,7 @@ description: 현재 프로젝트를 dcNess plugin 활성 대상으로 등록하�
 ## 언제 사용
 
 - 사용자 발화: "init-dcness", "dcness 활성화", "/init-dcness", "이 프로젝트에 dcness 켜"
+- 비활성화 발화: "dcness 꺼줘", "dcness 비활성화", "disable dcness" — core activation 대신 [비활성화](#비활성화) 절차만 수행
 - 새 프로젝트에 dcness plugin 사용 시작 시
 - 비활성 -> 활성 전환 시
 - project-local bootstrap 파일이나 provider routing preset 을 새로 설치/갱신할 때
@@ -488,6 +489,18 @@ FAIL 이 0 이면 core activation 은 완료 상태다. INFO·NA 행과 선택 W
 `claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness` 시 `~/.claude/plugins/data/dcness-dcness/` 가 정리되어 whitelist 가 사라진다. 재설치 후 각 활성 프로젝트마다 `/init-dcness` 를 다시 실행한다.
 
 `~/.claude/settings.json` 의 Read 권한은 재설치 후에도 보존된다. `/init-dcness` 재실행 시 이미 있으면 skip 한다.
+
+## 비활성화
+
+사용자가 비활성화를 요청하면 core activation 절차 대신 아래만 수행한다. [공통 변수](#공통-변수)의 `PLUGIN_ROOT` / `HELPER` 정의를 먼저 실행한다.
+
+```bash
+"$HELPER" disable
+```
+
+whitelist 에서 현재 프로젝트 root 항목만 제거한다. plug-in 중앙 hook 은 매 호출 `is-active` 를 확인하므로 현재 세션에서도 즉시 pass-through 되고, SessionStart 가 이미 주입한 안내만 세션 재시작으로 사라진다. 단 `DCNESS_FORCE_ENABLE=1` 이 설정된 프로세스는 whitelist 와 무관하게 활성이 유지되므로, 설정돼 있으면 해제한 뒤 Claude Code 를 재시작해야 비활성이 완성된다. 상위 디렉토리의 활성 항목으로 상속 활성된 중첩 repo 도 현재 root 항목 제거만으로는 꺼지지 않는다 — 실행 후 `"$HELPER" status` 로 비활성을 확인한다. 중첩 repo 만 선별해서 끄는 것은 미지원이며, 상위 repo 에서 disable 을 실행하면 상위와 그 하위 전체가 함께 비활성화된다는 영향 범위를 사용자에게 안내한 뒤 진행한다.
+
+나머지 설치물은 whitelist 와 무관하게 남아 계속 동작하므로 완전 제거를 원하면 dcNess 가 설치한 파일만 항목별로 정리한다 — `CLAUDE.md` 의 dcNess 안내(기존 파일에 append 한 경우 `## dcNess Cold Start` 섹션 삭제, seed 가 파일을 새로 생성한 경우 Architecture·Workflow 섹션의 dcNess/워크플로 안내 줄까지 정리), dcNess shim 4종 `pre-commit`·`commit-msg`·`post-checkout`·`pre-push`(파일 삭제 — `git rev-parse --path-format=absolute --git-path hooks` 가 해석한 경로와 `.git/hooks` 양쪽에서 dcNess shim 인지 확인 후 삭제: linked worktree 는 common dir, `core.hooksPath` 구성은 두 위치에 사본이 있을 수 있음), generated TDD hook(`.claude/settings.json` / `.codex/hooks.json` 의 `dcness-tdd-guard.sh` 등록 제거 + `.claude/hooks/dcness-tdd-guard.sh` · `.codex/hooks/dcness-tdd-guard.sh` · `.dcness/tdd-hooks.json` 파일 삭제), 설치한 dcNess workflow 템플릿 `git-naming-validation.yml`·`pr-body-validation.yml`·`doc-path-integrity.yml`·`doc-sync.yml`·`github-project-lifecycle.yml`(remote 에서 PR 차단 지속 — PR 로 삭제). 프로젝트 자체 소유 hook/workflow 는 삭제 대상이 아니다. 재활성화는 core activation 재실행이다.
 
 ## 참조
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -205,6 +205,13 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 
 seed 문서는 사용자 프로젝트 내용물이므로 사용자가 별도 작업 PR 에 포함할지 직접 판단한다.
 
+## Deactivation
+
+비활성화는 별도 command 가 아니라 `/init-dcness` 스킬이 겸한다("dcness 꺼줘" 류 발화). 실행 절차와 잔존물 정리 목록은 [`commands/init-dcness.md`](../../commands/init-dcness.md#비활성화) 의 비활성화 섹션이 runbook 진본이다.
+
+- `dcness-helper disable` 은 whitelist 에서 현재 main repo 항목만 제거한다. plug-in 중앙 hook 은 매 호출 `is-active` 판정이므로 즉시 pass-through 된다 (`DCNESS_FORCE_ENABLE=1` 프로세스 제외).
+- project-local 설치물(CLAUDE.md 의 dcNess 안내, git hook shim 4종, generated TDD hook, CI workflow 템플릿)은 whitelist 와 무관하게 잔존한다. 완전 제거는 runbook 의 dcNess 소유물 한정 항목별 정리를 따른다.
+
 ## References
 
 - [`hooks.md`](hooks.md) - CC hook / git hook / CI layer policy

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -39,7 +39,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 | 유틸리티 | 역할 |
 |---|---|
 | `/ux` | 구현 없이 목업과 흐름을 먼저 탐색한다. 디자인 시스템 / 디자인 토큰 / 베이스라인 요청도 ad-hoc 문서가 아니라 `docs/design.md` 기준 신호로 정리한다. 내부 `canvas-design` wrapper 를 통해 drafts 반복 → 사용자 PICK → 확정본 승격 + canvas 등록 규약을 따른다 |
-| `/init-dcness` | 프로젝트 활성화 |
+| `/init-dcness` | 프로젝트 활성화. 비활성화(whitelist 제거) 요청도 같은 진입점이 처리한다 |
 | `/migrate-dcness` | 기존 비-dcness 프로젝트를 코드 역설계로 전역 docs(`prd.md`/`architecture.md`/`conventions.md`/`decisions/`/`index.md`)를 채워 부트스트랩하는 일회성 유틸리티. `/init-dcness`(활성화)의 짝. epic/story 산출물은 만들지 않는다 |
 | `/next-work` | GitHub issue open/closed 상태, `in-progress` label, Issue Brief Priority 로 다음 작업 후보를 read-only 조회 |
 | `/run-review` | 끝난 run 사후 분석 |

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -675,9 +675,10 @@ class SurfaceDocsSyncTests(unittest.TestCase):
 
     def test_init_doc_is_execution_runbook_not_hook_policy_reference(self) -> None:
         """#690 — /init-dcness 는 실행 절차만 두고 자동 hook 설명은 SSOT 링크로 내린다."""
+        # 예산 520: 비활성화 절차 섹션 추가(#955)로 실측 ~510줄 — reference 회귀 방지 가드는 유지
         self.assertLess(
             len(self.init_doc.splitlines()),
-            500,
+            520,
             msg="/init-dcness public entrypoint 가 다시 장황한 reference 문서가 됨",
         )
         for stale in (


### PR DESCRIPTION
## 관련 이슈 번호
Closes #955

## 배경 및 문제
- `/init-dcness` 스킬 frontmatter description 이 존재하지 않는 `/disable-dcness` slash command 를 비활성화 진입점으로 광고했다 (doc-vs-reality 불일치, #948 계열).
- 실동작 비활성화 경로는 helper `disable` 서브커맨드뿐이며, 자연어 비활성화 요청("dcness 꺼줘")을 잡는 계약된 절차가 command 본문에 없었다.

## 원인 (해당 시)
- 비활성화 UX 가 활성화와 달리 공개 계약 없이 온보딩 힌트 해석에 의존했고, description 은 실물이 없는 `/disable-dcness` 를 선광고한 채 남아 있었다.

## 작업내용
- `commands/init-dcness.md`: frontmatter description 의 `/disable-dcness` 주장 제거, 비활성화 트리거 발화("dcness 꺼줘", "dcness 비활성화", "disable dcness") 명시
- `commands/init-dcness.md`: "언제 사용" 에 비활성화 발화 항목 추가, `## 비활성화` 섹션 신설 — helper `disable` 실행 절차, whitelist 만 제거되는 범위, 새 세션부터 pass-through + 세션 재시작 안내
- `tests/test_surface_docs_sync.py`: init-dcness runbook 라인 예산 500 → 520 (원본이 499줄로 마진 0 — 신규 절차 성장분 반영, 장황 reference 회귀 방지 가드는 유지)

## 결정 근거
- 이슈의 방향 후보 중 (a) 문서 정정 채택. (b) `/disable-dcness` 실물 command 추가는 신규 공개 진입점 justification (positioning 계약) 이 필요하고 외부 실수요 근거가 없으며, 실동작 메커니즘(helper `disable`)이 이미 존재·정상 작동. 공개 surface 무증가로 활성/비활성 안내 정합을 확보.
- description 트리거 발화 + 본문 절차 섹션으로 자연어 비활성화 요청 처리를 계약화해 "세션 Claude 의 온보딩 힌트 해석 의존" 갭을 해소.

## 배포 경로 검증
- `commands/init-dcness.md` = plug-in 본체 파일 (경로 1) — 사용자가 plugin 버전 업데이트를 받으면 자동 적용. init-dcness 가 복사·배포하는 파일 및 사용자용 SSOT 문서 갱신은 불필요 (`docs/plugin/init-dcness.md` 에 `/disable-dcness` 언급 없음을 grep 으로 확인).
- `tests/**` 는 내부 전용으로 배포 경로 없음.

## Test Plan
- [x] `python3.11 -m unittest discover -s tests` 전체 1919 PASS
- [x] `node scripts/check_cross_refs.mjs` PASS (104 파일, dead link/anchor 0건)
- [x] `node scripts/check_public_surface.mjs` PASS
- [x] `node scripts/check_plugin_manifest.mjs` PASS

## 참고
-
