### PR TITLE
[issue-1064] evidence 문구와 Linux 경로 비식별화 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.21.0","measured_at":"2026-07-13","unit_tests":{"passed":1930,"total":1930},"guard":{"passed":39,"total":39},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.22.0","measured_at":"2026-07-13","unit_tests":{"passed":1932,"total":1932},"guard":{"passed":39,"total":39},"source_project_count":2} -->
 
-현재 공개 snapshot은 **v0.21.0, 2026-07-13 측정**이다. 숫자마다 분모와 source 수를
+현재 공개 snapshot은 **v0.22.0, 2026-07-13 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,930/1,930 PASS, 결정적 guard 39/39 PASS | test 1,930, guard case 39 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,932/1,932 PASS, 결정적 guard 39/39 PASS | test 1,932, guard case 39 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -7,15 +7,15 @@
 
 ## 현재 공개 Evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.21.0","measured_at":"2026-07-13","unit_tests":{"passed":1930,"total":1930},"guard":{"passed":39,"total":39},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.22.0","measured_at":"2026-07-13","unit_tests":{"passed":1932,"total":1932},"guard":{"passed":39,"total":39},"source_project_count":2} -->
 
-현재 plugin version은 **v0.21.0**, 측정일은 **2026-07-12**다. 아래 표의 최대
+현재 plugin version은 **v0.22.0**, 측정일은 **2026-07-13**이다. 아래 표의 최대
 source 프로젝트 수는 2이며, 영역별 실제 source와 denominator는 각 행에 다시 적는다.
 process, Agent effectiveness, product outcome, 비용을 합산한 단일 성공 점수는 만들지 않는다.
 
 | evidence 영역 | 관측값 | denominator | source 수 | 재현 명령 | 한계 |
 |---|---|---:|---:|---|---|
-| 하네스 정의·기계적 guard | unittest 1,930/1,930 PASS; guard fixture 39/39 PASS | test 1,930; guard 39 | dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 테스트와 fixture 계약의 과정 evidence다. 보안 증명·제품 성공률이 아니다 |
+| 하네스 정의·기계적 guard | unittest 1,932/1,932 PASS; guard fixture 39/39 PASS | test 1,932; guard 39 | dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 테스트와 fixture 계약의 과정 evidence다. 보안 증명·제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 | 실측 fixture 1 | `printf '{"version":1,"projects":[]}' > /tmp/dcness-empty-projects.json && python3.11 harness/outcome_scorecard.py --projects-file /tmp/dcness-empty-projects.json --agent-effectiveness-record evals/agent-effectiveness/cartography-sanity-real.json --measured-at 2026-07-12T15:17:58Z --json` | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1)이다. downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 측정 불가다. 1차 거부→계약 개선→2차 채택 경위와 host metadata를 비식별화한 trace, 세션 ID·SHA-256·capture/rebuild 명령 provenance가 [`outcome-baseline.md`](../internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)에 공개된다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished 26/28; PR merge 7/7; validator verdict 33/26 finished run | candidate run 28; measurable PR 7; finished run 26 | 외부 활성 프로젝트 2 | [`outcome-baseline.md`](../internal/outcome-baseline.md#재현-명령)의 두 source-ref 고정 명령 | merge·validator FAIL은 제품 성공률이 아니다. 선택한 legacy ledger의 guard와 regression은 측정 불가 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS; 제품 AC 1/1 | journey 1; AC 1 | 외부 활성 프로젝트 1 | [`outcome-baseline.md`](../internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 CLI/filesystem pilot이다. UI·다른 제품·공개 우위로 일반화할 수 없다 |

--- a/evals/agent-effectiveness/cartography-sanity-real.json
+++ b/evals/agent-effectiveness/cartography-sanity-real.json
@@ -10,7 +10,7 @@
       "One frozen fixture and one paired run (1+1) give a single live measurement signal, not a statistical generalization.",
       "Each trial consists of two task-isolated headless invocations, so the 1+1 screening used 4 LLM invocations counted as 2 trials.",
       "visited only contains successful Read events on fixture files; Glob/Grep calls and failed reads remain in the raw traces referenced by provenance.",
-      "Cross-session resume was outside this measurement, so both variants record false.",
+      "Cross-session resume was outside this measurement, so both variants record it as unmeasured (null).",
       "Attempt 1 on 2026-07-13 (traces preserved under evidence/real-2026-07-attempt1/) was rejected by the fail-closed validator: both variants over-included two framework-route files in the refactor impact set. The current contract then gained an explicit impact-boundary rule and this attempt 2 with the amended contract is the adopted paired run; no same-setup rerun selection occurred.",
       "Executed in the same month as the 2026-07 lean-ablation screening; the month-separation budget rule was retired by user decision on 2026-07-13.",
       "The 2026-07 trial cap was raised from 4 to 6 by user decision on 2026-07-13 to fund attempt 2; attempt-1 trials stay counted in used_before."

--- a/evals/agent_effectiveness_measure.py
+++ b/evals/agent_effectiveness_measure.py
@@ -32,6 +32,7 @@ ROOT = Path(__file__).resolve().parents[1]
 FIXTURE_DIR = ROOT / "evals" / "agent-effectiveness" / "fixture"
 RECORD_DIR = ROOT / "evals" / "agent-effectiveness"
 JSON_BLOCK_RE = re.compile(r"```json\s*(\{.*?\})\s*```", re.DOTALL)
+HOST_HOME_PREFIX_RE = re.compile(r"/(?:Users|home)/[^/\\\s\"']+")
 
 EXPECTED_COORDINATES = {
     "ssot": "docs/architecture.md",
@@ -126,7 +127,7 @@ def _sanitize_string(value: str, sandbox: str) -> str:
     for source, target in sorted(replacements.items(), key=lambda item: len(item[0]), reverse=True):
         if source:
             result = result.replace(source, target)
-    return result
+    return HOST_HOME_PREFIX_RE.sub("<HOME>", result)
 
 
 def _sanitize_trace_value(value: Any, sandbox: str) -> Any:
@@ -583,7 +584,7 @@ def build_record(args: argparse.Namespace) -> dict[str, Any]:
                 "Grep calls and failed reads remain in the raw traces referenced by "
                 "provenance.",
                 "Cross-session resume was outside this measurement, so both variants "
-                "record false.",
+                "record it as unmeasured (null).",
                 "Attempt 1 on 2026-07-13 (traces preserved under "
                 "evidence/real-2026-07-attempt1/) was rejected by the fail-closed "
                 "validator: both variants over-included two framework-route files in "

--- a/harness/agent_effectiveness.py
+++ b/harness/agent_effectiveness.py
@@ -28,6 +28,7 @@ LIVE_PROVENANCE_RUNS = {
     "refactor.current",
 }
 PRIVATE_TRACE_INIT_FIELDS = {"agents", "plugins", "skills", "slash_commands", "uuid"}
+HOST_HOME_PATH_RE = re.compile(r"(?:/Users/|/home/|\\\\Users\\\\)")
 
 
 class AgentEffectivenessRecordInvalid(ValueError):
@@ -501,7 +502,7 @@ def _verify_live_provenance(
         if PRIVATE_TRACE_INIT_FIELDS & set(init):
             errors.append(f"{prefix}_private_init_metadata_present")
         serialized = json.dumps(events, ensure_ascii=False)
-        if "/Users/" in serialized or "\\Users\\" in serialized:
+        if HOST_HOME_PATH_RE.search(serialized):
             errors.append(f"{prefix}_host_home_path_present")
 
 

--- a/tests/test_agent_effectiveness.py
+++ b/tests/test_agent_effectiveness.py
@@ -462,6 +462,7 @@ class AgentEffectivenessContractTests(unittest.TestCase):
             )
             trace_text = trace.read_text(encoding="utf-8")
             self.assertNotIn("/Users/", trace_text)
+            self.assertNotIn("/home/", trace_text)
             self.assertNotIn('"plugins"', trace_text)
             self.assertNotIn('"uuid"', trace_text)
 
@@ -498,6 +499,38 @@ class AgentEffectivenessContractTests(unittest.TestCase):
 
         self.assertIn("provenance_must_be_object", errors)
         self.assertIn("provenance_run_set_invalid", errors)
+
+    def test_trace_sanitizer_redacts_linux_home_path(self) -> None:
+        sanitized = measure._sanitize_string(
+            "/home/alice/work/project/file.py",
+            "/tmp/dcness-sandbox/repo",
+        )
+
+        self.assertEqual(sanitized, "<HOME>/work/project/file.py")
+
+    def test_live_record_rejects_linux_home_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            record_root = Path(directory) / "agent-effectiveness"
+            shutil.copytree(LIVE.parent, record_root)
+            record = json.loads(
+                (record_root / LIVE.name).read_text(encoding="utf-8")
+            )
+            run = record["provenance"]["runs"]["cold-start.baseline"]
+            trace = record_root / run["trace_file"]
+            trace.write_text(
+                trace.read_text(encoding="utf-8").replace(
+                    "<SANDBOX>/repo", "/home/alice/work/repo"
+                ),
+                encoding="utf-8",
+            )
+            run["trace_sha256"] = hashlib.sha256(trace.read_bytes()).hexdigest()
+
+            _, errors = evaluate_record(record, record_root=record_root)
+
+        self.assertIn(
+            "provenance_cold-start_baseline_host_home_path_present",
+            errors,
+        )
 
     def test_live_runner_timeout_fires_without_stdout(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1064

## 배경 및 문제

- PR #1091 후속 감사에서 benchmark snapshot 날짜와 prose 날짜가 달랐고, cross-session 값을 null로 저장하면서 limitation은 false라고 설명하는 모순이 발견됐습니다.
- 비식별화 검증이 macOS /Users 경로만 검사해 Linux /home 경로를 놓쳤습니다.
- 동시에 머지된 v0.22.0 릴리즈가 manifest만 올려 README와 benchmark 공개 snapshot이 v0.21.0에 남았습니다.

## 원인 (해당 시)

- 측정일과 limitation 문구가 record schema 변경 뒤 함께 갱신되지 않았습니다.
- sanitizer와 validator의 host-home 탐지가 현재 실행 호스트의 홈 경로 및 /Users 패턴에만 의존했습니다.
- 릴리즈 version bump와 public-evidence snapshot 갱신이 분리됐습니다.

## 작업내용

- benchmark prose 측정일을 2026-07-13으로 교정했습니다.
- cross-session limitation을 unmeasured (null) 의미로 교정하고 기존 trace에서 record를 재생성했습니다.
- /home/<user> 경로를 <HOME>으로 치환하고, live provenance validator가 /home 경로를 거부하도록 강화했습니다.
- sanitizer와 fail-closed validator의 Linux 경로 회귀 테스트 2건을 추가했습니다.
- README와 benchmark snapshot을 v0.22.0, unittest 1,932/1,932로 동기화했습니다.

## 결정 근거

- 측정하지 않은 값을 false로 표현하면 실패와 미관측을 혼동하므로 null 의미를 문구에도 그대로 유지합니다.
- 생성 단계의 치환과 검증 단계의 거부를 함께 두어 기존·외부 생성 record도 fail-closed로 보호합니다.
- 기존 trace만 재사용했으며 새 LLM trial은 실행하지 않았습니다.

## 배포 경로 검증 (plug-in 영향 시)

- harness/agent_effectiveness.py와 evals/agent_effectiveness_measure.py는 plug-in 본체의 측정·검증 경로에서 직접 배포됩니다.
- docs/plugin/benchmark.md는 사용자-facing benchmark SSOT에서 직접 배포됩니다.
- README와 tests는 dcNess self 공개 근거·회귀 검증 경로입니다.
- 별도 복제본이나 init-dcness 복사 inventory 변경은 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 측정기·validator의 비식별화 계약만 강화했으며 새 public surface는 없습니다.

## Test Plan

- [x] tests.test_agent_effectiveness 15/15
- [x] unittest 전체 1,932/1,932
- [x] public-evidence v0.22.0, tests 1,932/1,932, guard 39/39
- [x] Ruff, mypy, Bandit
- [x] cross-ref, public-surface, doc-path, design-artifact, diff check

## 참고

- Agent effectiveness 수치 15→13과 개선 결론은 변경되지 않습니다.
- 사용자 소유 untracked .claude/ai-readiness/는 작업 범위에서 제외했습니다.