### PR TITLE
[feature] UI journey 실행 증거 pilot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ GitHub issue 를 대상으로 하는 dcness self 구현은 진입 때 읽은 본
 | [`docs/plugin/positioning.md`](docs/plugin/positioning.md) | 공개 workflow 진입점의 기본/고급/유틸리티/내부 agent 분류 수정 시 |
 | [`docs/plugin/workflow-router.md`](docs/plugin/workflow-router.md) | 자유 형식 작업 요청을 어떤 workflow 로 보낼지 (구현 경로 — gate 축 × shape 축) 판단 시 |
 | [`docs/plugin/outcome-scorecard.md`](docs/plugin/outcome-scorecard.md) | process·Agent effectiveness·실제 제품 outcome의 비교 필드·denominator·주장 경계를 수정/리뷰 시 |
-| [`docs/plugin/product-journey.md`](docs/plugin/product-journey.md) | 외부 활성 프로젝트의 non-UI 핵심 journey 실행 계약·receipt·scorecard 연결을 수정/리뷰 시 |
+| [`docs/plugin/product-journey.md`](docs/plugin/product-journey.md) | 외부 활성 프로젝트의 핵심 journey 실행 계약·UI 증거·receipt·scorecard 연결을 수정/리뷰 시 |
 | [`docs/plugin/decision-completeness.md`](docs/plugin/decision-completeness.md) | `/spec`·`/design`에서 구현 방향을 바꾸는 결정 범위·근거 상태·질문/위임·완료 의미를 수정/리뷰 시 |
 | [`docs/plugin/benchmark.md`](docs/plugin/benchmark.md) | 측정 재현·효율 benchmark 문구 수정 시 |
 | [`docs/plugin/design.md`](docs/plugin/design.md) | `design.md` 토큰 규격·Static HTML 시안 규약 수정 시 |

--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -86,7 +86,7 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
 |---|---|---|---|---:|---|
 | product outcome | journey PASS 1/1, 제품 AC 1/1 | journey 1, AC 1, source 1 | `ui, screenshot, command, log` + sha256 receipt | 실행 중 사람 개입 0 | 단일 외부 활성 프로젝트의 단일 UI pilot이며 공개 우위 근거가 아님 |
 
-receipt는 `landing` → `onboarding` → final `underage-rejection` 세 단계의 설명·대상 AC와 screenshot SHA-256을 연결한다. 브라우저 assertion log는 거부 안내, 입력 미저장 안내, 결과 미노출을 모두 PASS로 남겼다. 증거는 해당 source 프로젝트의 ignored `.dcness-work/product-journey/ui-pilot-issue1080-20260713/`에 보존하며 공개 문서에는 절대경로를 기록하지 않는다. 화면 evidence가 사용자 관점에서 충분한지는 issue의 별도 human verification으로 남긴다.
+receipt는 `landing` → `onboarding` → `underage-rejection` → final `profile-absent` 네 단계의 설명·대상 AC와 screenshot SHA-256을 연결한다. 브라우저 assertion log는 거부 안내, 입력 미저장 안내, 결과 미노출에 더해 거부 후 `/results`를 직접 열어도 profile-required 상태인 것을 모두 PASS로 남겼다. 증거는 해당 source 프로젝트의 ignored `.dcness-work/product-journey/ui-pilot-issue1080-20260713/`에 보존하며 공개 문서에는 절대경로를 기록하지 않는다. 화면 evidence가 사용자 관점에서 충분한지는 issue의 별도 human verification으로 남긴다.
 
 ## Agent effectiveness 입력 경계
 

--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -69,6 +69,25 @@ python3.11 "$DCN"/harness/outcome_scorecard.py \
 
 대상 AC는 `AC-421`이고 assertion은 자연어 prompt intake가 실제 session 파일을 만들며 선택한 `history_culture` category와 원문 prompt를 보존하는지 확인했다. `mock` adapter를 쓰지 않았고 실행 후 생성 상태는 cleanup했다. receipt와 log는 해당 source 프로젝트의 ignored `.dcness-work/product-journey/yt-make-intake-pilot-20260712/`에 남아 있으며 공개 문서에는 절대경로를 기록하지 않는다.
 
+## 2026-07-13 UI 제품 journey pilot
+
+기존 project-local 실행 계약에 `boundary=ui`와 단계별 화면 evidence만 추가해 active-project registry의 `source-5509daf5ed`에서 `finsight-underage-ui` journey로 실제 Next 앱과 Chromium을 실행했다. 랜딩의 `무료로 시작` CTA를 눌러 온보딩으로 이동하고, 미성년 생년월일과 이용 동의를 제출한 뒤 결과 화면으로 넘어가지 않으며 거부·미저장 안내가 표시되는지 `AC-001`과 대조했다. 외부 OAuth·DB 호출은 프로젝트의 acceptance 설정으로 차단했지만, 검증 경계인 실제 앱 기동·브라우저 클릭·Next server action·렌더 화면은 mock으로 대체하지 않았다.
+
+```sh
+python3.11 "$DCN"/harness/outcome_scorecard.py \
+  --redact-paths \
+  --measured-at 2026-07-13T03:00:00Z \
+  --as-of 2026-07-13T03:00:00Z \
+  --source-ref source-5509daf5ed \
+  --json
+```
+
+| 영역 | 결과 | denominator / source | 실행 증거 | 사람 개입 | 해석 경계 |
+|---|---|---|---|---:|---|
+| product outcome | journey PASS 1/1, 제품 AC 1/1 | journey 1, AC 1, source 1 | `ui, screenshot, command, log` + sha256 receipt | 실행 중 사람 개입 0 | 단일 외부 활성 프로젝트의 단일 UI pilot이며 공개 우위 근거가 아님 |
+
+receipt는 `landing` → `onboarding` → final `underage-rejection` 세 단계의 설명·대상 AC와 screenshot SHA-256을 연결한다. 브라우저 assertion log는 거부 안내, 입력 미저장 안내, 결과 미노출을 모두 PASS로 남겼다. 증거는 해당 source 프로젝트의 ignored `.dcness-work/product-journey/ui-pilot-issue1080-20260713/`에 보존하며 공개 문서에는 절대경로를 기록하지 않는다. 화면 evidence가 사용자 관점에서 충분한지는 issue의 별도 human verification으로 남긴다.
+
 ## Agent effectiveness 입력 경계
 
 - Cartography freshness에서 얻을 수 있는 것: 현재 SSOT·runtime entrypoint·capability owner 후보, affected route의 stale 여부와 갱신·재검증 기록.

--- a/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
+++ b/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
@@ -12,7 +12,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 검수 단위: spec / story / epic / release 식별자
 - 기준 문서: `docs/index.md`, 기능·유저 시나리오를 담은 `docs/prd.md`, Story AC·Epic 완료 기준을 담은 `docs/epics/<epic>/stories.md`, `docs/decisions/`, epic architecture/impl 문서, issue 본문 중 호출자가 제공한 경로
 - 구현 증거: PR URL, 변경 파일 목록, 테스트 결과, smoke 결과, 정적 타입검사/compile 결과, 실데이터(non-mock) 통합 테스트, UI 자동화, 화면/API/CLI 동작 설명 중 호출자가 제공한 항목
-- non-UI journey receipt: 호출자가 제공한 `receipt.json`과 단계별 log. `app_started`, `journey_executed`, assertion 평가·결과, 대상 AC, command exit, evidence sha256을 포함한다.
+- 제품 journey receipt: 호출자가 제공한 `receipt.json`과 단계별 log. `app_started`, `journey_executed`, assertion 평가·결과, 대상 AC, command exit, evidence sha256을 포함한다. UI boundary이면 `ui_evidence.steps`의 화면·상태·log path와 최종 단계 AC 대응도 함께 읽는다.
 - UI 검수 증거: UI story/epic 이면 호출자가 제공한 확정 목업 경로(`docs/design-variants/<screen-id>.html`), canvas 경로, 핵심 `data-node-id` 매핑, 구현 화면 스크린샷 또는 동등한 화면 증거 경로
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제 제품 경계 실행 여부
 - epic 구현에 대한 build-worker/impl-validator Cartography impact 보고, affected Root Cartography 좌표, tracked/local-only 문서 정책
@@ -38,7 +38,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 실데이터(non-mock) 통합 테스트는 실제 parser, renderer, DB/schema, filesystem, network adapter wrapper, local fixture 같은 제품 경계를 통과해야 한다. 외부 서비스를 반드시 live 호출하라는 뜻은 아니다.
 - UI 자동화는 브라우저/앱 자동화, component interaction, screenshot/assertion, visual smoke 같은 증거를 포함한다. 사람의 수동 E2E만 요구하지 않는다.
 - mock/stub/fake 기반 unit test 는 보조 증거다. 핵심 AC가 mock-only green으로만 뒷받침되고 API/CLI/UI/통합 wiring/compile-time contract 중 어떤 실제 경계도 확인되지 않았으면 gap 이다.
-- project-local journey receipt가 있으면 `app_started=true`, `journey_executed=true`, assertion `evaluated=true`와 `passed=true`, non-mock boundary, 대상 AC 대응을 함께 확인한다. 하나라도 빠지거나 receipt outcome이 FAIL이면 제품 outcome PASS로 판정하지 않는다. receipt와 log는 읽기 전용으로 대조하며 검증자가 다시 실행하거나 수정하지 않는다.
+- project-local journey receipt가 있으면 `app_started=true`, `journey_executed=true`, assertion `evaluated=true`와 `passed=true`, non-mock boundary, 대상 AC 대응을 함께 확인한다. UI boundary이면 두 단계 이상의 `ui_evidence.steps`, 모든 대상 AC를 덮는 final 단계, 각 evidence의 `present=true`와 SHA-256, 실제 화면 상태 설명을 추가로 확인한다. 하나라도 빠지거나 receipt outcome이 FAIL이면 제품 outcome PASS로 판정하지 않는다. receipt와 log·screenshot은 읽기 전용으로 대조하며 검증자가 다시 실행하거나 수정하지 않는다.
 - TypeScript, typed Python, Rust, Go 처럼 정적 타입검사나 compile gate 가 의미 있는 stack 에서 typecheck/compile 증거가 전혀 없으면 품질 게이트 warning 으로 보고한다. warning 자체만으로 FAIL 을 만들지는 않지만, 그 부재 때문에 핵심 AC의 wiring/contract 동작을 증명할 수 없으면 FAIL gap 이다.
 
 ### UI 목업 정합 판정 (STORY / EPIC 공통)

--- a/docs/plugin/deliverables-map.md
+++ b/docs/plugin/deliverables-map.md
@@ -190,7 +190,7 @@ epic `tech-review.md` 는 `/design` 중 `NEW_DEP_ESCALATE` option 4 로 새 외�
 | `.dcness-work/handoffs/` | run 간 임시 handoff + 세션 간 warm 인계 (`/handoff` 가 쓰는 활성 `next-session.md`, SessionStart 소비 후 `archive/<ts>.md`) |
 | `.dcness-work/reviews/` | tech-review evidence, HTML report, logs |
 | `.dcness-work/reports/` | 온디맨드 집계 리포트, 재생성 가능한 임시 요약 |
-| `.dcness-work/product-journey/` | project-local non-UI journey의 단계별 log와 sha256 receipt |
+| `.dcness-work/product-journey/` | project-local 제품 journey의 단계별 log·선택적 UI 화면 증거·sha256 receipt |
 
 `/init-dcness` 는 사용자 프로젝트 `.gitignore` 에 `.dcness-work/` 를 추가한다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -70,7 +70,7 @@ Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소�
 
 `docs/index.md` 의 epic/module 표와 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. 전역 architecture 인간용 요약은 필요할 때 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 로 `.dcness-work/reports/architecture-map.md` 에 온디맨드 생성한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
-non-UI 제품 journey runner도 사용자 repo에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-product-journey`)로 제공한다. project-local 계약 `.dcness/product-journey.json`은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다. 실행 receipt와 log는 기존 ignored `.dcness-work/product-journey/`에 남고 [`outcome-scorecard.md`](outcome-scorecard.md)가 집계한다. 계약과 판정 경계는 [`product-journey.md`](product-journey.md)가 소유한다.
+제품 journey runner도 사용자 repo에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-product-journey`)로 제공한다. project-local 계약 `.dcness/product-journey.json`은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다. UI journey도 같은 계약과 helper를 재사용하고 project-owned command가 단계별 화면 증거를 생성한다. 실행 receipt와 log는 기존 ignored `.dcness-work/product-journey/`에 남고 [`outcome-scorecard.md`](outcome-scorecard.md)가 집계한다. 계약과 판정 경계는 [`product-journey.md`](product-journey.md)가 소유한다.
 
 ## Provider Mirror Sync
 

--- a/docs/plugin/outcome-scorecard.md
+++ b/docs/plugin/outcome-scorecard.md
@@ -68,7 +68,7 @@ Cartography freshness는 SSOT·entrypoint·owner 후보와 stale 여부의 입�
 - mock-only green, guard PASS, validator PASS, PR merge만으로 outcome PASS를 만들지 않는다.
 - regression은 이전에 통과한 제품 동작이 같은 조건에서 깨졌는지 별도 필드로 둔다.
 
-non-UI journey 실행 계약과 receipt 필드는 [`product-journey.md`](product-journey.md)가 소유한다. `harness/outcome_scorecard.py`는 해당 helper가 `.dcness-work/product-journey/`에 남긴 유효 receipt를 읽어 journey PASS/전체와 제품 AC passed/total, source 수, 사람 개입, 실행 증거 종류를 별도로 집계한다.
+제품 journey 실행 계약과 receipt 필드는 [`product-journey.md`](product-journey.md)가 소유한다. `harness/outcome_scorecard.py`는 해당 helper가 `.dcness-work/product-journey/`에 남긴 유효 receipt를 읽어 journey PASS/전체와 제품 AC passed/total, source 수, 사람 개입, 실행 증거 종류를 별도로 집계한다. `--source-ref`로 고정한 source가 process run ledger 없이 유효 product journey receipt만 가진 경우에도 제품 outcome source로 재현할 수 있으며, process 축은 `측정 불가`로 남긴다. ledger와 receipt가 모두 없을 때만 `source_data_unavailable`이다.
 
 ## 주장 가능 범위
 

--- a/docs/plugin/product-journey.md
+++ b/docs/plugin/product-journey.md
@@ -1,7 +1,7 @@
 # Project-local 제품 journey 실행 계약
 
 > **Status**: ACTIVE
-> **Scope**: 외부 활성 프로젝트의 non-UI 핵심 journey 한 건을 실제 제품 경계에서 실행하고 product-acceptance가 읽을 receipt를 생성한다.
+> **Scope**: 외부 활성 프로젝트의 핵심 journey 한 건을 실제 제품 경계에서 실행하고 product-acceptance가 읽을 receipt를 생성한다. UI journey는 같은 실행 계약에 단계별 화면 증거만 선택적으로 추가한다.
 
 ## 책임 경계
 
@@ -9,11 +9,11 @@
 
 1. `start`: 앱·서비스·CLI 진입점을 시작한다.
 2. `health`: 다음 journey를 실행할 준비가 됐는지 확인한다.
-3. `journey`: API·CLI·실데이터 통합 경계에서 대상 AC assertion을 평가한다.
+3. `journey`: API·CLI·UI·실데이터 통합 경계에서 대상 AC assertion을 평가한다.
 4. `cleanup`: 성공·실패와 무관하게 종료·정리한다.
 5. `evidence_dir`: command exit와 log, 대상 AC, 실행 시각을 연결하는 receipt 위치다.
 
-메인 workflow가 실행 증거를 만들고 `product-acceptance`는 receipt와 대상 Story AC를 읽기 전용으로 대조한다. 검증 agent가 구현이나 receipt를 수정하지 않는다. UI 화면 상태와 screenshot 증거는 이 계약의 범위가 아니며 별도 UI pilot에서 공통 필드 위에 확장한다.
+메인 workflow가 실행 증거를 만들고 `product-acceptance`는 receipt와 대상 Story AC를 읽기 전용으로 대조한다. 검증 agent가 구현이나 receipt를 수정하지 않는다. UI 경계도 네 command와 같은 assertion 판정을 재사용하며, helper가 브라우저를 직접 자동화하지 않는다. 프로젝트가 소유한 journey command가 화면을 조작하고 screenshot·상태 파일을 남긴다.
 
 ## 프로젝트 계약
 
@@ -62,7 +62,7 @@
 |---|---|
 | `journey_id` | 소문자·숫자·`.`·`_`·`-`로 된 안정 식별자 |
 | `target_ac` | journey assertion이 대조할 Story AC 식별자. 한 개 이상 필수 |
-| `boundary` | `api`, `cli`, `integration`, `mock`. `mock`은 fixture용이며 outcome PASS 불가 |
+| `boundary` | `api`, `cli`, `integration`, `ui`, `mock`. `mock`은 fixture용이며 outcome PASS 불가 |
 | `assertion.description` | command가 무엇을 판정하는지 제품 언어로 설명 |
 | `assertion.source` | `journey_exit`이면 journey exit 0을 assertion PASS로 사용. `none`은 미평가 fixture이며 PASS 불가 |
 | `human_intervention_count` | 실행 중 사람이 개입한 횟수. 없으면 0 |
@@ -74,6 +74,44 @@
 | `evidence_dir` | `.dcness-work/product-journey/` 아래의 project-relative 위치 |
 
 start가 실패하거나 service가 유예 시간 안에 종료되면 `app_not_started`다. health가 실패하면 journey를 실행하지 않고 `journey_not_executed`로 남긴다. journey가 실행되지 않았거나 `assertion.source=none`이면 `assertion_not_evaluated`다. `mock` boundary는 모든 command가 exit 0이어도 `mock_only_boundary`이므로 PASS가 아니다. cleanup은 항상 실행하며 실패하면 전체 outcome도 FAIL이다.
+
+## UI 증거 확장
+
+`boundary=ui`는 위 project-local 계약을 바꾸지 않고 `ui_evidence.steps`만 추가한다. 최소 두 단계가 필요하며 `final=true`인 단계들이 `target_ac` 전부를 덮어야 한다. 각 evidence path는 해당 run directory 내부의 상대 경로이고 type은 `screenshot`, `state`, `log` 중 하나다.
+
+```json
+{
+  "boundary": "ui",
+  "target_ac": ["AC-ONBOARD-1"],
+  "ui_evidence": {
+    "steps": [
+      {
+        "step_id": "onboarding",
+        "description": "생년월일과 동의를 입력한 화면",
+        "target_ac": ["AC-ONBOARD-1"],
+        "final": false,
+        "evidence": [
+          {"path": "onboarding.png", "type": "screenshot"}
+        ]
+      },
+      {
+        "step_id": "result",
+        "description": "제출 뒤 제품 AC를 판정하는 최종 화면",
+        "target_ac": ["AC-ONBOARD-1"],
+        "final": true,
+        "evidence": [
+          {"path": "result.png", "type": "screenshot"},
+          {"path": "browser-assertions.log", "type": "log"}
+        ]
+      }
+    ]
+  }
+}
+```
+
+helper는 command 환경에 `DCNESS_PRODUCT_JOURNEY_RUN_DIR` 절대경로를 주입한다. 프로젝트 journey command는 이 위치에 선언한 파일을 생성한다. receipt에는 project-relative path, 존재 여부, SHA-256을 단계별로 기록한다. 파일이 없거나 비어 있거나 run directory 밖 symlink면 `ui_evidence_missing`으로 FAIL한다. screenshot 파일 자체가 assertion을 대신하지 않으며, `journey_exit=0`이 단계별 화면 assertion 평가를 증명해야 한다.
+
+이는 UI 전용 실행기나 범용 E2E 플랫폼이 아니다. 기존 Playwright, AppTest, XCUITest 같은 project-local 도구 또는 수동으로 보존된 자동화 driver를 journey command가 선택하고, dcNess helper는 실행 순서·receipt·무결성만 맡는다.
 
 ## 실행과 receipt
 
@@ -88,6 +126,7 @@ start가 실패하거나 service가 유예 시간 안에 종료되면 `app_not_s
 - 실제 시작 여부 `app_started`, journey 실행 여부 `journey_executed`.
 - assertion의 설명·근거·평가 여부·결과.
 - 단계별 argv, exit code, timeout, wall-clock과 log 위치.
+- UI journey이면 핵심 단계 설명·대상 AC·최종 단계 여부·screenshot/state/log path와 SHA-256.
 - 대상 AC의 passed/total denominator, 사람 개입, 실행 증거 종류.
 - log별 sha256과 failure reason.
 

--- a/harness/outcome_scorecard.py
+++ b/harness/outcome_scorecard.py
@@ -228,6 +228,7 @@ def build_scorecard(
     for source_ref, project in selected:
         for receipt in product_journey.read_receipts(project, cutoff=cutoff):
             journey_receipts.append((source_ref, receipt))
+    journey_source_refs = {source_ref for source_ref, _receipt in journey_receipts}
 
     sources: list[dict[str, Any]] = []
     fleets: list[FleetReport] = []
@@ -242,7 +243,7 @@ def build_scorecard(
             if _started_by(run_dir, cutoff)
         ]
         if not candidate_dirs:
-            if source_refs is not None:
+            if source_refs is not None and source_ref not in journey_source_refs:
                 unavailable_sources.append(source_ref)
             continue
         finished_dirs = [
@@ -252,7 +253,7 @@ def build_scorecard(
         ]
         fleet = aggregate_runs(finished_dirs, event_cutoff=cutoff)
         if fleet.run_count == 0:
-            if source_refs is not None:
+            if source_refs is not None and source_ref not in journey_source_refs:
                 unavailable_sources.append(source_ref)
             continue
         candidates = len(candidate_dirs)

--- a/harness/product_journey.py
+++ b/harness/product_journey.py
@@ -394,16 +394,22 @@ def _collect_ui_evidence(
                     )
                 except OSError:
                     present = False
+            evidence_hash: str | None = None
             if present:
-                present_types.add(declared["type"])
-            else:
+                try:
+                    evidence_hash = _sha256_file(declared_path)
+                except OSError:
+                    present = False
+            if not present:
                 complete = False
+            else:
+                present_types.add(declared["type"])
             collected_evidence.append(
                 {
                     "path": declared_path.relative_to(project_root).as_posix(),
                     "type": declared["type"],
                     "present": present,
-                    "sha256": _sha256_file(declared_path) if present else None,
+                    "sha256": evidence_hash,
                 }
             )
         collected_steps.append(

--- a/harness/product_journey.py
+++ b/harness/product_journey.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run a project-local non-UI product journey and emit a verifiable receipt."""
+"""Run a project-local product journey and emit a verifiable receipt."""
 
 from __future__ import annotations
 
@@ -23,9 +23,11 @@ EVIDENCE_ROOT_REL = Path(".dcness-work/product-journey")
 SCHEMA_VERSION = 1
 RECEIPT_TYPE = "dcness.product-journey"
 _ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{2,63}$")
-_BOUNDARIES = {"api", "cli", "integration", "mock"}
+_BOUNDARIES = {"api", "cli", "integration", "mock", "ui"}
 _ASSERTION_SOURCES = {"journey_exit", "none"}
 _PHASES = ("start", "health", "journey", "cleanup")
+_UI_EVIDENCE_TYPES = {"log", "screenshot", "state"}
+_RUN_DIR_ENV = "DCNESS_PRODUCT_JOURNEY_RUN_DIR"
 
 
 class JourneyConfigError(ValueError):
@@ -122,6 +124,71 @@ def _resolve_evidence_root(project_root: Path, raw: object) -> Path:
     return resolved
 
 
+def _validated_ui_evidence(config: dict[str, Any]) -> None:
+    boundary = config.get("boundary")
+    raw_ui = config.get("ui_evidence")
+    if boundary != "ui":
+        if raw_ui is not None:
+            raise JourneyConfigError("ui_evidence is only valid for boundary=ui")
+        return
+    if not isinstance(raw_ui, dict):
+        raise JourneyConfigError("ui_evidence must be an object for boundary=ui")
+    steps = raw_ui.get("steps")
+    if not isinstance(steps, list) or len(steps) < 2:
+        raise JourneyConfigError("ui_evidence.steps must contain at least two steps")
+    target_ac = {str(item).strip() for item in config["target_ac"]}
+    step_ids: set[str] = set()
+    final_ac: set[str] = set()
+    for index, step in enumerate(steps):
+        prefix = f"ui_evidence.steps[{index}]"
+        if not isinstance(step, dict):
+            raise JourneyConfigError(f"{prefix} must be an object")
+        step_id = _require_text(step, "step_id")
+        if not _ID_RE.fullmatch(step_id):
+            raise JourneyConfigError(f"{prefix}.step_id must be a valid id")
+        if step_id in step_ids:
+            raise JourneyConfigError(f"{prefix}.step_id must be unique")
+        step_ids.add(step_id)
+        _require_text(step, "description")
+        step_ac = step.get("target_ac")
+        if (
+            not isinstance(step_ac, list)
+            or not step_ac
+            or any(not isinstance(item, str) or not item.strip() for item in step_ac)
+        ):
+            raise JourneyConfigError(f"{prefix}.target_ac must contain AC ids")
+        normalized_ac = {item.strip() for item in step_ac}
+        if not normalized_ac.issubset(target_ac):
+            raise JourneyConfigError(f"{prefix}.target_ac must be declared in target_ac")
+        is_final = step.get("final")
+        if not isinstance(is_final, bool):
+            raise JourneyConfigError(f"{prefix}.final must be boolean")
+        if is_final:
+            final_ac.update(normalized_ac)
+        evidence = step.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            raise JourneyConfigError(f"{prefix}.evidence must not be empty")
+        for evidence_index, item in enumerate(evidence):
+            item_prefix = f"{prefix}.evidence[{evidence_index}]"
+            if not isinstance(item, dict):
+                raise JourneyConfigError(f"{item_prefix} must be an object")
+            raw_path = _require_text(item, "path")
+            relative = Path(raw_path)
+            if relative.is_absolute() or ".." in relative.parts:
+                raise JourneyConfigError(
+                    f"{item_prefix}.path must stay inside the run directory"
+                )
+            if item.get("type") not in _UI_EVIDENCE_TYPES:
+                raise JourneyConfigError(
+                    f"{item_prefix}.type must be one of "
+                    f"{sorted(_UI_EVIDENCE_TYPES)}"
+                )
+    if final_ac != target_ac:
+        raise JourneyConfigError(
+            "final UI steps must cover every AC declared in target_ac"
+        )
+
+
 def _validated_config(
     project_root: Path, config_path: Path
 ) -> tuple[dict[str, Any], Path]:
@@ -141,6 +208,7 @@ def _validated_config(
     boundary = config.get("boundary")
     if boundary not in _BOUNDARIES:
         raise JourneyConfigError(f"boundary must be one of {sorted(_BOUNDARIES)}")
+    _validated_ui_evidence(config)
     assertion = config.get("assertion")
     if not isinstance(assertion, dict):
         raise JourneyConfigError("assertion must be an object")
@@ -302,6 +370,54 @@ def _write_receipt(path: Path, receipt: dict[str, Any]) -> None:
     temporary.replace(path)
 
 
+def _collect_ui_evidence(
+    config: dict[str, Any], run_dir: Path, project_root: Path
+) -> tuple[dict[str, Any], bool, set[str]]:
+    collected_steps: list[dict[str, Any]] = []
+    complete = True
+    present_types: set[str] = set()
+    for step in config["ui_evidence"]["steps"]:
+        collected_evidence: list[dict[str, Any]] = []
+        for declared in step["evidence"]:
+            declared_path = run_dir / declared["path"]
+            path = declared_path.resolve()
+            try:
+                path.relative_to(run_dir.resolve())
+            except ValueError:
+                present = False
+            else:
+                try:
+                    present = (
+                        declared_path.is_file()
+                        and not declared_path.is_symlink()
+                        and declared_path.stat().st_size > 0
+                    )
+                except OSError:
+                    present = False
+            if present:
+                present_types.add(declared["type"])
+            else:
+                complete = False
+            collected_evidence.append(
+                {
+                    "path": declared_path.relative_to(project_root).as_posix(),
+                    "type": declared["type"],
+                    "present": present,
+                    "sha256": _sha256_file(declared_path) if present else None,
+                }
+            )
+        collected_steps.append(
+            {
+                "step_id": step["step_id"],
+                "description": step["description"],
+                "target_ac": [str(item).strip() for item in step["target_ac"]],
+                "final": step["final"],
+                "evidence": collected_evidence,
+            }
+        )
+    return {"steps": collected_steps}, complete, present_types
+
+
 def run_from_config(
     project_root: Path | str,
     *,
@@ -336,6 +452,7 @@ def run_from_config(
     receipt_path = run_dir / "receipt.json"
     env = os.environ.copy()
     env.update(config.get("env", {}))
+    env[_RUN_DIR_ENV] = str(run_dir)
     commands = config["commands"]
     command_results: dict[str, dict[str, Any]] = {}
     log_paths = {phase: run_dir / f"{phase}.log" for phase in _PHASES}
@@ -393,6 +510,15 @@ def run_from_config(
     if service is not None:
         _stop_service(service, command_results["start"])
 
+    ui_evidence: dict[str, Any] | None = None
+    ui_evidence_types: set[str] = set()
+    if config["boundary"] == "ui":
+        ui_evidence, ui_complete, ui_evidence_types = _collect_ui_evidence(
+            config, run_dir, root
+        )
+        if not ui_complete:
+            _append_once(failures, "ui_evidence_missing")
+
     outcome = (
         "PASS"
         if not failures
@@ -430,7 +556,9 @@ def run_from_config(
             "total": len(target_ac),
         },
         "human_intervention_count": config.get("human_intervention_count", 0),
-        "evidence_types": sorted({"command", config["boundary"], "log"}),
+        "evidence_types": sorted(
+            {"command", config["boundary"], "log", *ui_evidence_types}
+        ),
         "evidence_paths": evidence_paths,
         "evidence_sha256": evidence_sha256,
         "app_started": app_started,
@@ -444,6 +572,8 @@ def run_from_config(
         "commands": command_results,
         "failure_reasons": failures,
     }
+    if ui_evidence is not None:
+        receipt["ui_evidence"] = ui_evidence
     _write_receipt(receipt_path, receipt)
     return JourneyRunResult(0 if outcome == "PASS" else 1, receipt_path, receipt)
 
@@ -551,7 +681,97 @@ def _is_valid_receipt(payload: object, project_root: Path, receipt_path: Path) -
         return False
     if payload["outcome"] == "FAIL" and (passed != 0 or not failure_reasons):
         return False
+    if boundary == "ui":
+        if not _valid_ui_receipt(payload, project_root, receipt_path):
+            return False
+    elif "ui_evidence" in payload:
+        return False
     return _evidence_matches_receipt(payload, project_root, receipt_path)
+
+
+def _valid_ui_receipt(
+    payload: dict[str, Any], project_root: Path, receipt_path: Path
+) -> bool:
+    ui_evidence = payload.get("ui_evidence")
+    if not isinstance(ui_evidence, dict):
+        return False
+    steps = ui_evidence.get("steps")
+    if not isinstance(steps, list) or len(steps) < 2:
+        return False
+    target_ac = set(payload["target_ac"])
+    final_ac: set[str] = set()
+    step_ids: set[str] = set()
+    all_present = True
+    declared_types: set[str] = set()
+    run_dir = receipt_path.parent.resolve()
+    canonical_root = (project_root / EVIDENCE_ROOT_REL).resolve()
+    for step in steps:
+        if not isinstance(step, dict):
+            return False
+        step_id = step.get("step_id")
+        if (
+            not isinstance(step_id, str)
+            or not _ID_RE.fullmatch(step_id)
+            or step_id in step_ids
+        ):
+            return False
+        step_ids.add(step_id)
+        if not isinstance(step.get("description"), str) or not step["description"]:
+            return False
+        step_ac = step.get("target_ac")
+        if (
+            not isinstance(step_ac, list)
+            or not step_ac
+            or any(not isinstance(item, str) or not item for item in step_ac)
+            or not set(step_ac).issubset(target_ac)
+        ):
+            return False
+        if not isinstance(step.get("final"), bool):
+            return False
+        if step["final"]:
+            final_ac.update(step_ac)
+        evidence = step.get("evidence")
+        if not isinstance(evidence, list) or not evidence:
+            return False
+        for item in evidence:
+            if not isinstance(item, dict) or item.get("type") not in _UI_EVIDENCE_TYPES:
+                return False
+            declared_path = item.get("path")
+            present = item.get("present")
+            declared_hash = item.get("sha256")
+            if not isinstance(declared_path, str) or not isinstance(present, bool):
+                return False
+            path = (project_root / declared_path).resolve()
+            try:
+                path.relative_to(canonical_root)
+                path.relative_to(run_dir)
+            except ValueError:
+                return False
+            if present:
+                if (
+                    not isinstance(declared_hash, str)
+                    or path.is_symlink()
+                    or not path.is_file()
+                    or path.stat().st_size == 0
+                ):
+                    return False
+                try:
+                    actual_hash = _sha256_file(path)
+                except OSError:
+                    return False
+                if actual_hash != declared_hash:
+                    return False
+                declared_types.add(item["type"])
+            else:
+                all_present = False
+                if declared_hash is not None or path.exists():
+                    return False
+    if final_ac != target_ac:
+        return False
+    if payload["outcome"] == "PASS" and not all_present:
+        return False
+    expected_types = {"command", "log", "ui", *declared_types}
+    return set(payload["evidence_types"]) == expected_types
 
 
 def _evidence_matches_receipt(
@@ -612,7 +832,7 @@ def _evidence_matches_receipt(
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(
-        description="project-local non-UI product journey runner"
+        description="project-local product journey runner"
     )
     parser.add_argument("command", choices=["run"])
     parser.add_argument("--project-root", default=".")

--- a/skills/acceptance/SKILL.md
+++ b/skills/acceptance/SKILL.md
@@ -147,7 +147,7 @@ standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을
 ## 절차
 
 1. 입력 단위가 story 인지 epic 인지 확인한다.
-2. non-UI 핵심 journey가 검수 대상이고 `.dcness/product-journey.json` 또는 호출자가 지정한 동등한 project-local 계약이 있으면, 메인이 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `dcness-product-journey`를 실행한다. 생성된 receipt와 log 경로를 다음 prompt에 넣는다. exit 1 receipt도 gap 증거로 전달하며 mock-only/app-not-started/journey 미실행/assertion 미평가를 PASS로 바꾸지 않는다.
+2. 핵심 journey가 검수 대상이고 `.dcness/product-journey.json` 또는 호출자가 지정한 동등한 project-local 계약이 있으면, 메인이 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `dcness-product-journey`를 실행한다. 생성된 receipt와 log 경로를 다음 prompt에 넣고, UI boundary이면 단계별 screenshot/state/log 경로도 함께 넣는다. exit 1 receipt도 gap 증거로 전달하며 mock-only/app-not-started/journey 미실행/assertion 미평가/UI evidence 누락을 PASS로 바꾸지 않는다.
 3. story면 `product-acceptance:STORY_ACCEPTANCE`, epic이면 `product-acceptance:EPIC_ACCEPTANCE` 를 호출한다.
 4. `PASS`면 완료 후보로 보고한다.
 5. `FAIL`이면 자동 수정하지 않고 gap 목록과 후속 분기를 prose 로 보고한다. Cartography gap이면 affected Root Cartography, `module-architect:CARTOGRAPHY_REFRESH` 또는 `/design --revise`/system checkpoint, local-only/ignored 정책의 durable impact handoff를 포함한다.

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -231,7 +231,7 @@ story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후
 
 product-acceptance 는 read-only 라 `gh` 호출 불가다. PR 목록·검증 결과·동작 증거·UI 목업 정합 증거와 build-worker Cartography impact, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision을 메인이 prompt 에 직접 담는다. UI task 는 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 함께 넣어 목업 불일치와 화면 증거 부재를 판정할 수 있게 한다. 핵심 AC 증거가 mock-only green 이거나 대상 사용자에게 부적합한 입력/진행 동선이면 gap 이다.
 
-non-UI 핵심 journey가 마감 AC이고 project-local 계약이 있으면, 메인이 product-acceptance 호출 직전에 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `"$PLUGIN_ROOT/scripts/dcness-product-journey" run --project-root "$PROJECT_ROOT" --config <contract>`를 실행한다. 생성된 receipt와 log를 prompt에 넣는다. exit 1은 구현 gap 증거이며 mock-only, app-not-started, journey 미실행, assertion 미평가를 PASS로 세지 않는다. helper가 쓰는 영역은 ignored `.dcness-work/product-journey/`로 한정되고 product-acceptance agent는 수정하지 않는다.
+핵심 journey가 마감 AC이고 project-local 계약이 있으면, 메인이 product-acceptance 호출 직전에 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `"$PLUGIN_ROOT/scripts/dcness-product-journey" run --project-root "$PROJECT_ROOT" --config <contract>`를 실행한다. 생성된 receipt와 log를 prompt에 넣고 UI boundary이면 단계별 screenshot/state/log 경로도 함께 넣는다. exit 1은 구현 gap 증거이며 mock-only, app-not-started, journey 미실행, assertion 미평가, UI evidence 누락을 PASS로 세지 않는다. helper가 쓰는 영역은 ignored `.dcness-work/product-journey/`로 한정되고 product-acceptance agent는 수정하지 않는다.
 
 호출:
 

--- a/tests/test_outcome_scorecard.py
+++ b/tests/test_outcome_scorecard.py
@@ -354,6 +354,38 @@ class OutcomeScorecardAggregationTests(unittest.TestCase):
 
         self.assertEqual(raised.exception.unavailable, [pinned[0]])
 
+    def test_product_receipt_only_source_can_be_pinned_without_run_ledger(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            project = root / "product-only-project"
+            project.mkdir()
+            _write_product_journey_receipt(
+                project,
+                "product-only-journey",
+                outcome="PASS",
+            )
+            projects_file = root / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": [str(project)]}),
+                encoding="utf-8",
+            )
+            source_ref = "source-" + hashlib.sha256(
+                str(project.resolve()).encode("utf-8")
+            ).hexdigest()[:10]
+
+            report = build_scorecard(
+                projects_file,
+                measured_at="2026-07-11T00:00:00Z",
+                as_of="2026-07-11T00:00:00Z",
+                source_refs=[source_ref],
+                redact_paths=True,
+            )
+
+        self.assertEqual(report["product_outcome"]["numerator"], 1)
+        self.assertEqual(report["product_outcome"]["denominator"], 1)
+        self.assertEqual(report["product_outcome"]["source_project_count"], 1)
+        self.assertEqual(report["process_evidence"]["finished_runs"]["status"], "측정 불가")
+
     def test_legacy_run_replay_ignores_steps_appended_after_cutoff(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -518,6 +550,24 @@ class OutcomeScorecardDocumentTests(unittest.TestCase):
         ):
             self.assertIn(evidence, baseline)
         self.assertNotIn("/Users/dc.kim/project/youTubeGenerator", baseline)
+
+    def test_baseline_records_ui_product_journey_pilot(self) -> None:
+        baseline = (ROOT / "docs" / "internal" / "outcome-baseline.md").read_text(
+            encoding="utf-8"
+        )
+        for evidence in (
+            "UI 제품 journey pilot",
+            "source-5509daf5ed",
+            "finsight-underage-ui",
+            "AC-001",
+            "journey PASS 1/1",
+            "제품 AC 1/1",
+            "ui, screenshot, command, log",
+            "실행 중 사람 개입 0",
+            "2026-07-13T03:00:00Z",
+        ):
+            self.assertIn(evidence, baseline)
+        self.assertNotIn("/Users/dc.kim/project/finsight", baseline)
 
 
 if __name__ == "__main__":

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from harness.product_journey import (
     CONFIG_REL,
@@ -329,6 +330,62 @@ class ProductJourneyExecutionTests(unittest.TestCase):
                 run_id="ui-symlink-escape",
                 measured_at="2026-07-13T08:00:00Z",
             )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(result.receipt["outcome"], "FAIL")
+        self.assertIn("ui_evidence_missing", result.receipt["failure_reasons"])
+
+    def test_ui_evidence_hash_error_fails_closed_with_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self._base_config()
+            config["boundary"] = "ui"
+            config["commands"] = dict(config["commands"])
+            config["commands"]["journey"] = _command(
+                "import os; from pathlib import Path; "
+                "run=Path(os.environ['DCNESS_PRODUCT_JOURNEY_RUN_DIR']); "
+                "(run/'first.png').write_bytes(b'first'); "
+                "(run/'final.png').write_bytes(b'final')"
+            )
+            config["ui_evidence"] = {
+                "steps": [
+                    {
+                        "step_id": "first",
+                        "description": "첫 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": False,
+                        "evidence": [
+                            {"path": "first.png", "type": "screenshot"}
+                        ],
+                    },
+                    {
+                        "step_id": "final",
+                        "description": "최종 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": True,
+                        "evidence": [
+                            {"path": "final.png", "type": "screenshot"}
+                        ],
+                    },
+                ]
+            }
+            config_path = _write_config(root, config)
+            original_hash = __import__(
+                "harness.product_journey", fromlist=["_sha256_file"]
+            )._sha256_file
+
+            def flaky_hash(path: Path) -> str:
+                if path.name == "first.png":
+                    raise OSError("fixture evidence became unreadable")
+                return original_hash(path)
+
+            with patch("harness.product_journey._sha256_file", side_effect=flaky_hash):
+                result = run_from_config(
+                    root,
+                    config_path=config_path,
+                    run_id="ui-hash-error",
+                    measured_at="2026-07-13T08:00:00Z",
+                )
 
         self.assertEqual(result.exit_code, 1)
         self.assertEqual(result.receipt["outcome"], "FAIL")

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -1,4 +1,4 @@
-"""Project-local non-UI product journey execution contract tests."""
+"""Project-local product journey execution contract tests."""
 
 from __future__ import annotations
 
@@ -10,7 +10,12 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from harness.product_journey import CONFIG_REL, read_receipts, run_from_config
+from harness.product_journey import (
+    CONFIG_REL,
+    JourneyConfigError,
+    read_receipts,
+    run_from_config,
+)
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -165,6 +170,221 @@ class ProductJourneyExecutionTests(unittest.TestCase):
             self.assertIn(mutation["expected"], receipt["failure_reasons"])
             self.assertEqual(receipt["product_ac"]["passed"], 0)
 
+    def test_ui_journey_records_multistep_screen_state_and_log_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self._base_config()
+            config["journey_id"] = "fixture-ui-journey"
+            config["boundary"] = "ui"
+            config["commands"] = dict(config["commands"])
+            config["commands"]["journey"] = _command(
+                "import json, os; from pathlib import Path; "
+                "run=Path(os.environ['DCNESS_PRODUCT_JOURNEY_RUN_DIR']); "
+                "(run/'landing.png').write_bytes(b'fixture-png'); "
+                "(run/'onboarding-state.json').write_text(json.dumps({'consent': True})); "
+                "(run/'results.png').write_bytes(b'fixture-results-png')"
+            )
+            config["ui_evidence"] = {
+                "steps": [
+                    {
+                        "step_id": "landing",
+                        "description": "랜딩에서 무료 시작 CTA를 확인한다",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": False,
+                        "evidence": [
+                            {"path": "landing.png", "type": "screenshot"}
+                        ],
+                    },
+                    {
+                        "step_id": "onboarding",
+                        "description": "성인 생년월일과 동의를 제출한다",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": False,
+                        "evidence": [
+                            {
+                                "path": "onboarding-state.json",
+                                "type": "state",
+                            }
+                        ],
+                    },
+                    {
+                        "step_id": "results",
+                        "description": "최종 결과 화면에서 제품 AC를 확인한다",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": True,
+                        "evidence": [
+                            {"path": "results.png", "type": "screenshot"}
+                        ],
+                    },
+                ]
+            }
+            config_path = _write_config(root, config)
+
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="ui-pilot-success",
+                measured_at="2026-07-13T08:00:00Z",
+            )
+            receipt = json.loads(result.receipt_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(result.exit_code, 0)
+            self.assertEqual(receipt["outcome"], "PASS")
+            self.assertEqual(receipt["boundary"], "ui")
+            self.assertEqual(
+                receipt["evidence_types"],
+                ["command", "log", "screenshot", "state", "ui"],
+            )
+            self.assertEqual(
+                [step["step_id"] for step in receipt["ui_evidence"]["steps"]],
+                ["landing", "onboarding", "results"],
+            )
+            self.assertTrue(receipt["ui_evidence"]["steps"][-1]["final"])
+            for step in receipt["ui_evidence"]["steps"]:
+                for evidence in step["evidence"]:
+                    self.assertFalse(Path(evidence["path"]).is_absolute())
+                    self.assertRegex(evidence["sha256"], r"^[0-9a-f]{64}$")
+            self.assertEqual(len(read_receipts(root)), 1)
+
+    def test_ui_journey_missing_declared_evidence_never_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self._base_config()
+            config["boundary"] = "ui"
+            config["ui_evidence"] = {
+                "steps": [
+                    {
+                        "step_id": "start",
+                        "description": "첫 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": False,
+                        "evidence": [
+                            {"path": "missing-start.png", "type": "screenshot"}
+                        ],
+                    },
+                    {
+                        "step_id": "finish",
+                        "description": "최종 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": True,
+                        "evidence": [
+                            {"path": "missing-finish.png", "type": "screenshot"}
+                        ],
+                    },
+                ]
+            }
+            config_path = _write_config(root, config)
+
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="ui-missing-evidence",
+                measured_at="2026-07-13T08:00:00Z",
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(result.receipt["outcome"], "FAIL")
+        self.assertIn("ui_evidence_missing", result.receipt["failure_reasons"])
+        self.assertEqual(result.receipt["product_ac"]["passed"], 0)
+
+    def test_ui_evidence_symlink_escape_fails_closed_with_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self._base_config()
+            config["boundary"] = "ui"
+            config["commands"] = dict(config["commands"])
+            config["commands"]["journey"] = _command(
+                "import os; from pathlib import Path; "
+                "run=Path(os.environ['DCNESS_PRODUCT_JOURNEY_RUN_DIR']); "
+                "(run/'first.png').symlink_to('/etc/hosts'); "
+                "(run/'final.png').write_bytes(b'final')"
+            )
+            config["ui_evidence"] = {
+                "steps": [
+                    {
+                        "step_id": "first",
+                        "description": "첫 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": False,
+                        "evidence": [
+                            {"path": "first.png", "type": "screenshot"}
+                        ],
+                    },
+                    {
+                        "step_id": "final",
+                        "description": "최종 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": True,
+                        "evidence": [
+                            {"path": "final.png", "type": "screenshot"}
+                        ],
+                    },
+                ]
+            }
+            config_path = _write_config(root, config)
+
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="ui-symlink-escape",
+                measured_at="2026-07-13T08:00:00Z",
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertEqual(result.receipt["outcome"], "FAIL")
+        self.assertIn("ui_evidence_missing", result.receipt["failure_reasons"])
+
+    def test_ui_contract_requires_multistep_final_ac_coverage(self) -> None:
+        cases = {
+            "single-step": [
+                {
+                    "step_id": "only",
+                    "description": "한 단계뿐인 흐름",
+                    "target_ac": ["AC-FIXTURE-1"],
+                    "final": True,
+                    "evidence": [{"path": "only.png", "type": "screenshot"}],
+                }
+            ],
+            "no-final": [
+                {
+                    "step_id": step_id,
+                    "description": step_id,
+                    "target_ac": ["AC-FIXTURE-1"],
+                    "final": False,
+                    "evidence": [{"path": f"{step_id}.png", "type": "screenshot"}],
+                }
+                for step_id in ("first", "second")
+            ],
+            "final-misses-ac": [
+                {
+                    "step_id": "first",
+                    "description": "첫 단계",
+                    "target_ac": ["AC-FIXTURE-1", "AC-FIXTURE-2"],
+                    "final": False,
+                    "evidence": [{"path": "first.png", "type": "screenshot"}],
+                },
+                {
+                    "step_id": "finish",
+                    "description": "최종 단계",
+                    "target_ac": ["AC-FIXTURE-1"],
+                    "final": True,
+                    "evidence": [{"path": "finish.png", "type": "screenshot"}],
+                },
+            ],
+        }
+        for name, steps in cases.items():
+            with self.subTest(name=name), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                config = self._base_config()
+                config["boundary"] = "ui"
+                if name == "final-misses-ac":
+                    config["target_ac"] = ["AC-FIXTURE-1", "AC-FIXTURE-2"]
+                config["ui_evidence"] = {"steps": steps}
+                config_path = _write_config(root, config)
+
+                with self.assertRaises(JourneyConfigError):
+                    run_from_config(root, config_path=config_path, run_id=name)
+
     def test_tampered_log_invalidates_receipt_for_scorecard_consumers(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -178,6 +398,60 @@ class ProductJourneyExecutionTests(unittest.TestCase):
             self.assertEqual(len(read_receipts(root)), 1)
             journey_log = root / result.receipt["evidence_paths"]["journey"]
             journey_log.write_text("tampered\n", encoding="utf-8")
+
+            receipts = read_receipts(root)
+
+        self.assertEqual(receipts, [])
+
+    def test_tampered_ui_evidence_invalidates_receipt_for_scorecard_consumers(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            config = self._base_config()
+            config["boundary"] = "ui"
+            config["commands"] = dict(config["commands"])
+            config["commands"]["journey"] = _command(
+                "import os; from pathlib import Path; "
+                "run=Path(os.environ['DCNESS_PRODUCT_JOURNEY_RUN_DIR']); "
+                "(run/'first.png').write_bytes(b'first'); "
+                "(run/'final.png').write_bytes(b'final')"
+            )
+            config["ui_evidence"] = {
+                "steps": [
+                    {
+                        "step_id": "first",
+                        "description": "첫 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": False,
+                        "evidence": [
+                            {"path": "first.png", "type": "screenshot"}
+                        ],
+                    },
+                    {
+                        "step_id": "final",
+                        "description": "최종 화면",
+                        "target_ac": ["AC-FIXTURE-1"],
+                        "final": True,
+                        "evidence": [
+                            {"path": "final.png", "type": "screenshot"}
+                        ],
+                    },
+                ]
+            }
+            config_path = _write_config(root, config)
+            result = run_from_config(
+                root,
+                config_path=config_path,
+                run_id="ui-tamper-check",
+                measured_at="2026-07-13T08:00:00Z",
+            )
+            self.assertEqual(len(read_receipts(root)), 1)
+            ui_path = (
+                root
+                / result.receipt["ui_evidence"]["steps"][0]["evidence"][0]["path"]
+            )
+            ui_path.write_bytes(b"tampered")
 
             receipts = read_receipts(root)
 
@@ -252,6 +526,9 @@ class ProductJourneyContractDocumentTests(unittest.TestCase):
             "evidence_dir",
             "journey_exit",
             "mock_only_boundary",
+            "ui_evidence.steps",
+            "DCNESS_PRODUCT_JOURNEY_RUN_DIR",
+            "screenshot",
             ".dcness-work/product-journey",
         ):
             self.assertIn(term, contract)
@@ -262,6 +539,8 @@ class ProductJourneyContractDocumentTests(unittest.TestCase):
         self.assertIn("app_started", product_acceptance)
         self.assertIn("journey_executed", product_acceptance)
         self.assertIn("assertion", product_acceptance)
+        self.assertIn("ui_evidence.steps", product_acceptance)
+        self.assertIn("present=true", product_acceptance)
         self.assertIn("읽기 전용", product_acceptance)
         self.assertIn("사용자 repo에 복사하지", init_contract)
         self.assertIn("dcness-product-journey", init_contract)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1080

## 배경 및 문제

#1067은 외부 활성 프로젝트의 non-UI journey를 실제 앱 기동과 assertion receipt로 닫았지만, UI 다단계 흐름의 화면 상태와 screenshot을 같은 receipt에 연결할 수 없었습니다. 따라서 UI Story AC는 mock-only test나 설명만으로 product outcome PASS가 될 위험이 남아 있었습니다.

## 원인 (해당 시)

기존 runner가 `api`·`cli`·`integration` 경계와 command log만 허용했고, project-owned UI driver가 현재 run evidence directory를 알아내거나 단계별 화면 증거를 무결성 검증받을 계약이 없었습니다. 또한 process ledger가 없는 product-receipt-only source는 scorecard `--source-ref` 재현이 차단됐습니다.

## 작업내용

- 기존 `start → health → journey → cleanup` runner에 선택적 `boundary=ui`와 `ui_evidence.steps`를 추가했습니다.
- UI 단계는 최소 2개, final 단계의 전체 AC coverage, screenshot/state/log의 run-directory 경계·존재·비어 있지 않음·SHA-256을 fail-closed로 검증합니다.
- mock-only, 앱 미기동, journey 미실행, assertion 미평가, UI evidence 누락·변조·symlink escape가 제품 outcome PASS가 되지 않는 회귀 테스트를 추가했습니다.
- 유효 product receipt만 있는 source도 고정 source scorecard로 재현하되 process 축은 `측정 불가`로 유지하도록 했습니다.
- 외부 활성 프로젝트에서 실제 Next 앱과 Chromium으로 랜딩 → 온보딩 → 미성년 거부 → profile 부재 확인 AC-001 흐름을 실행해 UI journey 1/1, 제품 AC 1/1, source 1, 사람 개입 0 receipt를 남겼습니다.
- acceptance·impl-loop·product-acceptance 지침과 product journey·scorecard·deliverables SSOT를 동기화했습니다.

## 결정 근거

새 UI runner나 범용 E2E 플랫폼을 만들지 않았습니다. 기존 schema version 1과 helper를 그대로 사용하고, 프로젝트가 이미 선택한 브라우저/AppTest 도구가 `DCNESS_PRODUCT_JOURNEY_RUN_DIR`에 evidence를 쓰게 했습니다. dcNess는 실행 순서, AC 연결, receipt 무결성만 소유합니다.

## 배포 경로 검증 (plug-in 영향 시)

- plugin 본체: `harness/product_journey.py`, `harness/outcome_scorecard.py`, 기존 `scripts/dcness-product-journey` 경로로 plugin 업데이트 시 즉시 도달합니다.
- workflow/agent 계약: `skills/acceptance/SKILL.md`, `skills/impl-loop/SKILL.md`, `docs/plugin/agents/product-acceptance/product-acceptance-agent.md`를 함께 갱신했습니다.
- 사용자 SSOT: `docs/plugin/product-journey.md`, `docs/plugin/outcome-scorecard.md`, `docs/plugin/deliverables-map.md`, `docs/plugin/init-dcness.md`를 동기화했습니다.
- 사용자 repo 복사 파일은 추가하지 않았습니다. 기존 활성 프로젝트도 plugin 업데이트 후 project-local opt-in 계약만 지정하면 되며 `/init-dcness` 재실행은 필요하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없이 기존 product journey helper와 acceptance 경로를 확장했습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,948 tests PASS (commit hook 최종 실행)
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/Bandit PASS
- [x] cross-ref·public-surface·plugin-manifest·doc artifact gates PASS
- [x] 행동 eval `shorts-real-spec`, `cartography-acceptance-stale-state` — 각 1/1 PASS
- [x] 외부 활성 프로젝트 UI pilot receipt·고정 source scorecard·read-only product-acceptance 대조 PASS

## 참고

- UI pilot evidence는 외부 source 프로젝트의 ignored `.dcness-work/product-journey/ui-pilot-issue1080-20260713/`에 보존됩니다.
- 화면 evidence의 사용자 관점 충분성은 issue의 human verification 항목으로 남겨 agent가 자동 체크하지 않습니다.
