### PR TITLE
[feature] JOURNEY 검증 경계 lifecycle 추가

### DIFF
--- a/agents/product-acceptance.md
+++ b/agents/product-acceptance.md
@@ -1,9 +1,9 @@
 ---
 name: product-acceptance
 description: >
-  PRD / Epic / Story / Release 단위로 제품 검수 가능성과 완료 증거를 읽기 전용으로
-  확인하는 에이전트. 실제 지침은 docs/plugin/agents/product-acceptance/product-acceptance-agent.md 에 있다.
-tools: Read, Glob, Grep
+  PRD / Epic / Story / Release 단위로 제품 검수 가능성과 완료 증거를 확인하고,
+  선언된 제품 journey를 조건부 실행하는 write-zero 에이전트. 실제 지침은 docs/plugin/agents/product-acceptance/product-acceptance-agent.md 에 있다.
+tools: Read, Glob, Grep, Bash
 model: opus
 ---
 

--- a/docs/plugin/agents/build-worker/build-worker-agent.md
+++ b/docs/plugin/agents/build-worker/build-worker-agent.md
@@ -34,6 +34,7 @@
 - 신뢰 경계: 외부 HTTP, 파일/URL 입력, 보안, 도메인 invariant를 바꾸면 self-test가 놓친 실패 경로를 별도로 적발했는가.
 - commit 품질: task가 green이 된 뒤 [`git-spec.md#의미-단위-커밋-분할`](../../git-spec.md#의미-단위-커밋-분할)에 맞게 독립 검토 가능한 의미 단위로 로컬 커밋됐는가.
 - handoff 품질: 메인이 push/PR/merge를 소유할 수 있도록 commit sha, 검증 명령, 남은 판단 지점을 남겼는가.
+- journey handoff: `(JOURNEY)` REQ마다 프로젝트 e2e flow와 owner module/소스 영역의 journey 매니페스트를 작성하고, 실행은 acceptance에 명시적으로 인계했는가.
 - Cartography impact: 구현 중 runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after가 바뀌었는지 실제 diff와 검증 증거로 판정하고, 관련 epic/decision과 함께 refresh producer가 복구 가능한 자유 prose로 보고하는가. 특히 `stub/planned → landed`는 제품 동작·검증 증거가 있어야 한다.
 - replacement/refactor hygiene: 새 표면이 기존 구현을 대체하는 task이면 old symbol의 call site뿐 아니라 DI binding/provider, route/deep link, manifest/framework registration, resource, test/fake/fixture, suppression/deprecation까지 추적했는가. 대체된 표면은 제거하고, intentional stub/planned seam 또는 호환 경계로 보존한 표면은 이유와 owner를 보고했는가.
 - 도구 경제성: 같은 파일과 같은 명령을 반복하지 않고 읽은 내용과 편집 계획을 재사용했는가.
@@ -41,12 +42,12 @@
 ## 작업 흐름
 
 1. build-test: 계획·설계와 메인이 전달한 target GitHub issue AC snapshot 을 읽고, 이 task 의 REQ 및 테스트가 담당할 AC 를 대응시킨 뒤 테스트를 작성해 RED를 확인한다.
-2. build-impl: 허용된 코드 경로만 수정하고 GREEN을 확인한다.
-3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build/typecheck/compile 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다. 핵심 AC가 mock-only green이면 가능한 자동 동작 증거를 보강하고, 보강 불가 시 gap 으로 보고한다. 확정 목업이 있는 UI 작업은 구현 컴포넌트와 핵심 `data-node-id` 매핑을 대조하고, design:required 태스크는 `docs/design.md` 의 색·spacing·typography 토큰이 실제 앱 theme/component 상수에 반영됐는지 별도 self-check 로 보고한다. 목업 대비 의도적 차이가 있으면 이유와 영향을 보고한다. 같은 단계에서 구현 전후 diff를 읽어 affected capability, runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision을 자유 prose Cartography impact로 남긴다. 변화가 없으면 없다고 명시한다.
+2. build-impl: 허용된 코드 경로만 수정하고 GREEN을 확인한다. 담당 Story AC에 `(JOURNEY)`가 있으면 프로젝트 기존 e2e 도구로 flow 대본과 journey 매니페스트를 작성한다. 매니페스트는 `.dcness/`가 아니라 owner module/소스 영역(예: `app/.maestro/dcness-journey.json`)에 두며, 필요하면 순수 e2e 대본과 함께 setup/teardown/상태전이 스크립트를 만들고 `commands.journey.argv`에서 `bash`로 오케스트레이션한다. UI 증거는 flow가 `${DCNESS_PRODUCT_JOURNEY_RUN_DIR}` 아래에 생성하게 한다. build-worker는 디바이스가 없는 실행환경에서 이 flow를 실행하지 않는다.
+3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build/typecheck/compile 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다. `(JOURNEY)` REQ는 flow·매니페스트·필요한 오케스트레이션 산출물과 대상 AC 연결을 읽어 확인하되 실행하지 않는다. 핵심 AC가 mock-only green이면 가능한 자동 동작 증거를 보강하고, 보강 불가 시 gap 으로 보고한다. 확정 목업이 있는 UI 작업은 구현 컴포넌트와 핵심 `data-node-id` 매핑을 대조하고, design:required 태스크는 `docs/design.md` 의 색·spacing·typography 토큰이 실제 앱 theme/component 상수에 반영됐는지 별도 self-check 로 보고한다. 목업 대비 의도적 차이가 있으면 이유와 영향을 보고한다. 같은 단계에서 구현 전후 diff를 읽어 affected capability, runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision을 자유 prose Cartography impact로 남긴다. 변화가 없으면 없다고 명시한다.
    - impl 계획에 replacement/refactor/migration 신호가 있으면 old surface를 이름 검색 하나로 끝내지 않는다. call site, DI binding/provider, route/deep link, manifest/framework registration, resource, test/fake/fixture, suppression/deprecation을 전수 대조한다. 제거한 표면과 의도적으로 보존한 표면을 나누고, 보존 항목에는 이유와 owner를 남긴다. framework/runtime reachability 또는 후속 Epic의 intentional stub/planned seam 여부가 불명확하면 자동 삭제하지 않고 gap으로 보고한다.
 4. 각 phase 결과를 phase prose 파일로 남긴다.
 5. PASS 조건을 만족하면 `git status`, `git diff --check`, 필요한 `git add`, `git commit`을 실행해 task 변경을 로컬 커밋으로 닫는다. 커밋은 git-spec 의 의미 단위 커밋 분할 규칙으로 쪼개되 각 커밋은 hook을 통과하는 일관 상태여야 한다.
-6. PASS일 때만 다음 task를 위한 한 줄 요약, commit sha, 담당 target GitHub issue AC 별 충족 증거를 남긴다. build-worker 는 issue mutation 권한이 없으므로 체크박스를 직접 수정하지 않고 메인에게 증거만 인계한다.
+6. PASS일 때만 다음 task를 위한 한 줄 요약, commit sha, 담당 target GitHub issue AC 별 충족 증거를 남긴다. `(JOURNEY)`가 있으면 이 Story의 REQ 목록, flow/매니페스트 경로, acceptance 실행 인계를 함께 보고한다. build-worker 는 issue mutation 권한이 없으므로 체크박스를 직접 수정하지 않고 메인에게 증거만 인계한다.
 
 ## phase prose 경로
 
@@ -97,7 +98,8 @@
 - 자체 검증 결과가 실제 실행 증거(명령 + 종료코드)와 함께 `PASS` 또는 finding으로 남는다. 실행 불가였다면 `VALIDATION_BLOCKED` 로 보고했다.
 - green task 변경이 로컬 커밋으로 닫혔고 commit sha가 보고된다.
 - 핵심 AC별 동작 증거와 mock/stub/fake 사용 경계가 보고된다. TypeScript 등 정적 타입검사가 의미 있는 stack 에서 typecheck/compile 이 빠졌다면 품질 게이트 warning 또는 보강 필요성을 쓴다.
-- task 가 담당하는 target GitHub issue AC 와 impl task REQ 의 대응, 각 항목의 실행·관찰 증거가 보고된다. target GitHub issue AC 는 task 수용 기준의 상위 완료 계약이며, 어느 하나라도 이 task 범위에서 충족되지 않았으면 PASS 하지 않는다.
+- task 가 담당하는 target GitHub issue AC 와 impl task REQ 의 대응, 각 항목의 실행·관찰 증거가 보고된다. `(TEST)`/`(AGENT READ)`로 닫는 항목은 어느 하나라도 이 task 범위에서 충족되지 않았으면 PASS 하지 않는다. `(JOURNEY)` REQ는 build-worker의 PASS 블로커에서 제외하되, flow 대본·journey 매니페스트·필요한 setup/teardown/상태전이 스크립트를 모두 작성하고 acceptance 인계를 보고한 경우에만 예외다.
+- 담당 `(JOURNEY)` REQ마다 flow 대본과 `.dcness/` 밖 journey 매니페스트가 작성됐고 실행은 acceptance 인계로 보고됐다. 이 경로는 메인이 대신 실행하는 `VALIDATION_BLOCKED`가 아니라 build-worker `PASS` + acceptance 인계다.
 - 확정 목업이 있는 UI 작업에서는 디자인 정합(레이아웃 계층·상태·토큰 대응)과 의도적 차이가 보고된다.
 - design:required UI 작업에서는 node-id 매핑과 별개로 `docs/design.md` 토큰 적용 결과, 잔존 스캐폴딩 색 상수 여부, boilerplate 테마 잔존 금지 확인 결과가 보고된다.
 - PR 본문 초안에 close keyword가 불확실하면 메인 검토 요청을 남긴다.

--- a/docs/plugin/agents/module-architect/module-architect-agent.md
+++ b/docs/plugin/agents/module-architect/module-architect-agent.md
@@ -68,7 +68,7 @@ module-architect가 기존 표면을 새 표면으로 대체하거나 refactor/m
 - system checkpoint 필요성: 기존 모듈 경계, 도메인 invariant, storage policy, public API boundary, 기존 전역 decision 변경이 필요하면 module-architect 내부에서 임의로 큰 그림을 확정하지 않고 `SYSTEM_CHECKPOINT_REQUIRED` 로 보고하는가.
 - task-local producer/consumer wiring, 기존 경계 안의 신규 epic-scope interface 상세, 반환 형식, push/pull 같은 구현 선택의 보강만 필요하면 module-architect 자율 범위로 남기는가. 이 보강만으로 `SYSTEM_CHECKPOINT_REQUIRED`를 emit하지 않는다. 해당 결론을 emit하려면 바꿔야 하는 **기존** boundary/policy/global decision을 하나 이상 구체적으로 지목해야 하며, 지목할 수 없으면 그 결론을 쓰지 않는다. 반대로 앞 Story/task가 이미 확정한 identity key, delete namespace, 실패 시 보존 의미를 뒤 Story 때문에 바꿔야 하면 기존 domain invariant/storage policy 변경이므로 checkpoint 대상이다. 자율 보강이 필요하다는 말은 열린 gap을 둔 채 PASS한다는 뜻이 아니며, 현재 run에서 보강을 반영하고 gap이 닫힌 뒤에만 PASS한다. read-only 검토처럼 현재 run에서 보강할 수 없으면 `SPEC_GAP_FOUND`로 보고한다.
 - 구현 여지: 내부 구현을 선점하지 않고 public behavior와 invariant만 고정하는가.
-- 테스트 가능성: 수용 기준이 실행 가능한 명령 또는 `(AGENT READ)` 관찰 증거로 닫히고, 사람 판정 항목은 별도 안내로 분리되는가.
+- 테스트 가능성: 수용 기준이 실행 가능한 명령, `(AGENT READ)` 관찰 증거, 또는 실앱 실행이 필요한 AC의 `(JOURNEY)` flow로 닫히고, 사람 판정 항목은 별도 안내로 분리되는가. negative 동작 계약은 대응하는 양성 프록시 event를 REQ에 명시하며, 프록시가 없거나 관찰 창이 sub-second인 상태·순수 위치/픽셀 판정은 `(JOURNEY)`가 아니라 `사람 확인 안내`로 분리하는가.
 - 모듈 설계 원칙: 작은 공개 노출 범위, 의존 주입, 의존 차단 증거가 보이는가.
 - 모듈 스코프 입력: impl task 의 `## 사전 준비` 가 `docs/conventions.md` 와 task-specific docs 만 포함하고, 그 밖의 전역 고정 문서 목록이나 module-local delta 를 중복시키지 않는가.
 - 흐름 누적 분해: 기존 대형 파일을 건드리는 task 에서 append 대신 흐름 / 섹션 모듈 신설을 선호하고, 이번 task 가 손대는 seam 까지만 분해하는가. 기준 = [`module-design-principles.md` 단일 파일 다중 흐름 누적](../_shared/module-design-principles.md#단일-파일-다중-흐름-누적).
@@ -90,7 +90,7 @@ module-architect가 기존 표면을 새 표면으로 대체하거나 refactor/m
 9. impl task frontmatter 에는 `depends_on` 만 의존·순서 메타로 남긴다. `risk` / `engine` / `risk_reason` / `depth` 를 새로 쓰지 않는다. `/impl-loop` 구현 주체는 build-worker 하나이며, 설계 중 드러난 범위·보안·데이터·외부 의존 리스크는 엔진 선택 메타가 아니라 `SYSTEM_CHECKPOINT_REQUIRED`, `NEW_DEP_ESCALATE`, `/design` 보강, 또는 사용자 위임으로 처리한다.
 10. public contract를 만들거나 바꾸면 epic `architecture.md` 의 모듈 목록 책임/공개 인터페이스와 `docs/decisions/NNNN-slug.md` 를 갱신하고 impl 문서는 관련 module/decision 참조만 남긴다. 신규 epic-scope decision 기록은 module-architect 가 자율 처리하지만, 기존 전역 decision 변경은 `SYSTEM_CHECKPOINT_REQUIRED` 로 checkpoint 승격한다. impl 문서에 invariant/ordering/error mode/config/forbidden alternative 전문을 복제하지 않는다. 계약 전문 복제 금지는 task-specific transition·실패 책임·acceptance 생략을 뜻하지 않는다. task 내부 한정 private interface 는 사본 문제가 없으므로 `## 인터페이스` 에 남긴다.
 11. DB, 디자인 토큰, 외부 의존 같은 영향 축이 있으면 별도 증거를 남긴다. 확정 목업이 있는 UI epic 에서는 목업 미참조 설계 금지 원칙에 따라 `## 디자인 참조` 에 확정 목업 경로, 핵심 디자인 토큰(색/spacing/typography), node-id 매핑, docs/design.md 토큰 대응, 의도적 차이를 남긴다. non-UI task 는 `## 디자인 참조` 섹션을 삭제한다.
-12. 제품 REQ 는 Story AC 를 task 실행 언어로 번역하고 `(from AC-NNN)` 출처를 필수로 적는다. 어느 AC 에도 대응하지 않는 제품 REQ 를 만들지 않는다. 스키마·인터페이스 형태처럼 Story AC 로 환원되지 않는 검증만 소수 `기술 REQ` 로 두고 `(technical: 이유)`를 남긴다. 검증은 실행 가능한 명령 또는 `(AGENT READ)` 관찰 대상과 통과 조건으로 닫는다.
+12. 제품 REQ 는 Story AC 를 task 실행 언어로 번역하고 `(from AC-NNN)` 출처를 필수로 적는다. 어느 AC 에도 대응하지 않는 제품 REQ 를 만들지 않는다. 스키마·인터페이스 형태처럼 Story AC 로 환원되지 않는 검증만 소수 `기술 REQ` 로 두고 `(technical: 이유)`를 남긴다. 검증은 실행 가능한 명령, `(AGENT READ)` 관찰 대상과 통과 조건, 또는 실앱 동작이 필요한 Story AC의 `(JOURNEY)` flow로 닫는다. `(JOURNEY)`에 특정 e2e 도구를 강제하지 않고 프로젝트 기존 도구로 build-worker가 flow를 작성하게 한다. negative 동작 계약에는 양성 프록시 event를 명시하고, 프록시가 없거나 관찰 창이 sub-second인 상태·순수 위치/픽셀 판정은 REQ 밖 `사람 확인 안내`로 분리한다.
 13. 각 Story 의 `task_index: total/total` 마지막 task 에 Story AC 전항목의 종합 검증 REQ 를 둔다. 앞 task에서 개별 AC를 검증했더라도 마지막 task 전수 실행에서 생략하지 않는다. `story: 공통` task 는 제외한다.
 14. 완료 전에 구현 세부 유출, Story AC ↔ REQ 커버리지, 무출처 REQ, 마지막 task 전수 검증, Story 동작 슬라이스 증거, 고위험 shared state producer/owner/consumer/transition 완결성, Agent Operability 증거, 코드 SSOT drift 를 다시 본다.
 
@@ -114,7 +114,7 @@ module-architect가 기존 표면을 새 표면으로 대체하거나 refactor/m
 - Root 갱신 조건을 대조했고 stable route/state가 바뀌면 실제 repo-relative 경로와 관련 epic/decision만 bounded Cartography에 반영했다. 상세 Story/impl topology는 epic에 남는다.
 - 확정 목업이 있는 UI epic 은 epic architecture 또는 impl task 의 `## 디자인 참조` 에 확정 목업 경로, 핵심 디자인 토큰(색/spacing/typography), node-id 매핑, docs/design.md 토큰 대조 근거가 있고, 목업 미참조 설계 금지 원칙을 어기지 않는다.
 - cross-task contract가 있으면 module responsibility 한 줄과 decision 문서에 의미가 있고 impl 문서는 module/decision 참조만 가리킨다. 구양식 Contract Ledger / Contract References 산출물은 기존 활성 프로젝트 호환을 위해 유효하지만, 이번에 새로 쓰거나 수정하는 신규 산출물은 사본 표를 만들지 않는다.
-- 수용 기준의 검증은 실행 가능한 명령 또는 `(AGENT READ)` 관찰 증거이며, 사람 판정 항목은 REQ 에 섞이지 않는다.
+- 수용 기준의 검증은 실행 가능한 명령, `(AGENT READ)` 관찰 증거, 또는 도구 중립 `(JOURNEY)` flow이며, 사람 판정 항목은 REQ 에 섞이지 않는다. negative 동작의 양성 프록시와 sub-second·순수 시각 판정의 사람 확인 분기도 명시된다.
 - `주의사항` 의 모듈 설계 주의 또는 동등한 문구로 모듈 설계 원칙 적용 증거가 남는다.
 - owner/entrypoint 요약 또는 동등한 문구로 다음 agent 의 edit target, state owner, produced/consumed transition, validation path 증거가 남는다.
 - legacy contract sync 요청에서는 신규 진본 module/decision, 구양식 사본을 참조로 줄인 patch 위치, 남은 stale 위치를 보고한다.

--- a/docs/plugin/agents/module-architect/templates/impl-task.md
+++ b/docs/plugin/agents/module-architect/templates/impl-task.md
@@ -83,13 +83,18 @@ depends_on:             # [<NN-slug>, ...] 선행 task 순서의 단일 SSOT. se
 
 ## 수용 기준
 
-> 제품 REQ 는 Story AC 를 task 실행 언어로 번역하고 출처에 `(from AC-NNN)` 을 반드시 적는다. Story AC 로 환원되지 않는 스키마·인터페이스 형태 같은 소수 기술 계약만 `기술 REQ` + `(technical: <환원 불가 이유>)`로 구분한다. 검증은 실행 가능한 명령 또는 `(AGENT READ)` 관찰 증거로 닫고, 사람 판정 항목은 REQ 에 넣지 않는다.
+> 제품 REQ 는 Story AC 를 task 실행 언어로 번역하고 출처에 `(from AC-NNN)` 을 반드시 적는다. Story AC 로 환원되지 않는 스키마·인터페이스 형태 같은 소수 기술 계약만 `기술 REQ` + `(technical: <환원 불가 이유>)`로 구분한다. 검증은 실행 가능한 명령, `(AGENT READ)` 관찰 증거, 또는 실제 앱 실행이 필요한 `(JOURNEY)` flow로 닫고, 사람 판정 항목은 REQ 에 넣지 않는다.
 
 | REQ | 유형 | 내용 | 출처 | 검증 명령 | 통과 조건 |
 |---|---|---|---|---|---|
 | REQ-001 | Story AC |  | `(from AC-001)` | `(TEST) <command>` |  |
 | REQ-002 | Story AC |  | `(from AC-002)` | `(AGENT READ) <관찰 대상과 방법>` |  |
+| REQ-003 | Story AC | 로그인→홈 진입 | `(from AC-003)` | `(JOURNEY) <flow/매니페스트 경로>` | receipt outcome=PASS, app_started·journey_executed·assertion.passed=true, 대상 AC 전부 덮음 |
 | REQ-TECH-001 | 기술 REQ |  | `(technical: <Story AC로 환원 불가한 이유>)` | `(TEST) <command>` |  |
+
+> `(JOURNEY)`는 실제 앱/디바이스를 띄워야 하는 자동화 검증이다. build-worker 환경에서는 실행하지 않고 product-acceptance가 tip에서 실행한다. flow 대본과 journey 매니페스트는 build-worker 산출물이다. 사람 눈이 반드시 필요한 항목은 `(JOURNEY)`가 아니라 기존대로 REQ 밖 `사람 확인 안내`로 분리한다.
+>
+> negative 동작 계약은 대응하는 양성 프록시 event를 REQ 통과 조건에 명시한다. 양성 프록시가 없거나 관찰 창이 sub-second인 상태, 순수 위치·픽셀 판정은 flaky한 `(JOURNEY)`로 만들지 않고 `사람 확인 안내`로 분리한다.
 
 > `task_index: i/total` 에서 `i == total` 인 Story 마지막 task 는 해당 Story AC 전항목을 이 표에서 다시 인용하고 실제 실행·관찰하는 종합 검증 REQ 를 둔다. 앞 task 에서 검증한 항목도 마지막 task 전수 검증에서 생략하지 않는다. `story: 공통` task 에는 이 의무를 적용하지 않는다.
 

--- a/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
+++ b/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
@@ -2,7 +2,7 @@
 
 ## 목적
 
-PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 또는 실제 결과물이 수용 기준과 동작 증거로 연결됐는지 읽기 전용으로 확인한다.
+PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 또는 실제 결과물이 수용 기준과 동작 증거로 연결됐는지 확인한다. tracked 구현·설계 소스는 write-zero로 유지하되, `(JOURNEY)` REQ의 project-local 매니페스트가 있으면 tip에서 봉인된 러너를 조건부 실행해 검수 증거를 만든다.
 
 `product-acceptance` 는 기존 `impl-validator`, `architecture-validator` 를 대체하지 않는다. `impl-validator` 는 merge candidate diff 의 구현 계획 정합과 merge risk 를 보고, `architecture-validator` 는 설계 산출물 정합을 본다. 본 agent 는 제품 단위 기준 문서와 구현 증거 사이의 gap 을 본다.
 
@@ -13,6 +13,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 기준 문서: `docs/index.md`, 기능·유저 시나리오를 담은 `docs/prd.md`, Story AC·Epic 완료 기준을 담은 `docs/epics/<epic>/stories.md`, `docs/decisions/`, epic architecture/impl 문서, issue 본문 중 호출자가 제공한 경로
 - 구현 증거: PR URL, 변경 파일 목록, 테스트 결과, smoke 결과, 정적 타입검사/compile 결과, 실데이터(non-mock) 통합 테스트, UI 자동화, 화면/API/CLI 동작 설명 중 호출자가 제공한 항목
 - 제품 journey receipt: 호출자가 제공한 `receipt.json`과 단계별 log. `app_started`, `journey_executed`, assertion 평가·결과, 대상 AC, command exit, evidence sha256을 포함한다. UI boundary이면 `ui_evidence.steps`의 화면·상태·log path와 최종 단계 AC 대응도 함께 읽는다.
+- `(JOURNEY)` REQ: 대상 AC, build-worker가 작성한 project-local e2e flow와 `.dcness/` 밖 owner module/소스 영역의 journey 매니페스트 경로. receipt가 없으면 이 매니페스트를 tip에서 실행 입력으로 사용한다.
 - UI 검수 증거: UI story/epic 이면 호출자가 제공한 확정 목업 경로(`docs/design-variants/<screen-id>.html`), canvas 경로, 핵심 `data-node-id` 매핑, 구현 화면 스크린샷 또는 동등한 화면 증거 경로
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제 제품 경계 실행 여부
 - epic 구현에 대한 build-worker/impl-validator Cartography impact 보고, affected Root Cartography 좌표, tracked/local-only 문서 정책
@@ -23,6 +24,7 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 필수: 호출자가 지정한 `docs/index.md`, PRD, epic stories, issue, 또는 acceptance 기준 문서
 - 필수: 호출자가 제공한 구현 PR, 테스트 결과, smoke 결과, 변경 파일 목록
 - 상황별: `docs/architecture.md`, `docs/decisions/`, epic architecture/impl 문서, tech-review 결과
+- 상황별 (`(JOURNEY)` REQ): journey 매니페스트, 연결된 e2e flow, 필요한 setup/teardown/상태전이 스크립트
 - 상황별 (SPEC_ACCEPTANCE): [`skills/spec/spec-stories-reference.md`](../../../../skills/spec/spec-stories-reference.md) 의 Story 분할·순서 기준과 예외
 - 상황별 (SPEC_ACCEPTANCE): [`decision-completeness.md`](../../decision-completeness.md) 의 결정 범위·근거 상태·질문/위임·완료 계약
 - 참고: 기존 acceptance 결과가 있으면 이전 gap 과 재검수 증거
@@ -38,8 +40,14 @@ PRD / Epic / Story / Release 단위로 제품이 검수 가능한 상태인지, 
 - 실데이터(non-mock) 통합 테스트는 실제 parser, renderer, DB/schema, filesystem, network adapter wrapper, local fixture 같은 제품 경계를 통과해야 한다. 외부 서비스를 반드시 live 호출하라는 뜻은 아니다.
 - UI 자동화는 브라우저/앱 자동화, component interaction, screenshot/assertion, visual smoke 같은 증거를 포함한다. 사람의 수동 E2E만 요구하지 않는다.
 - mock/stub/fake 기반 unit test 는 보조 증거다. 핵심 AC가 mock-only green으로만 뒷받침되고 API/CLI/UI/통합 wiring/compile-time contract 중 어떤 실제 경계도 확인되지 않았으면 gap 이다.
-- project-local journey receipt가 있으면 `app_started=true`, `journey_executed=true`, assertion `evaluated=true`와 `passed=true`, non-mock boundary, 대상 AC 대응을 함께 확인한다. UI boundary이면 두 단계 이상의 `ui_evidence.steps`, 모든 대상 AC를 덮는 final 단계, 각 evidence의 `present=true`와 SHA-256, 실제 화면 상태 설명을 추가로 확인한다. 하나라도 빠지거나 receipt outcome이 FAIL이면 제품 outcome PASS로 판정하지 않는다. receipt와 log·screenshot은 읽기 전용으로 대조하며 검증자가 다시 실행하거나 수정하지 않는다.
+- project-local journey receipt가 있으면 `app_started=true`, `journey_executed=true`, assertion `evaluated=true`와 `passed=true`, non-mock boundary, 대상 AC 대응을 함께 확인한다. UI boundary이면 두 단계 이상의 `ui_evidence.steps`, 모든 대상 AC를 덮는 final 단계, 각 evidence의 `present=true`와 SHA-256, 실제 화면 상태 설명을 추가로 확인한다. 하나라도 빠지거나 receipt outcome이 FAIL이면 제품 outcome PASS로 판정하지 않는다. 매니페스트가 있으면 러너 호출로 receipt를 생성할 수 있고, 생성된 receipt·log·screenshot은 사후 수정하지 않는다.
 - TypeScript, typed Python, Rust, Go 처럼 정적 타입검사나 compile gate 가 의미 있는 stack 에서 typecheck/compile 증거가 전혀 없으면 품질 게이트 warning 으로 보고한다. warning 자체만으로 FAIL 을 만들지는 않지만, 그 부재 때문에 핵심 AC의 wiring/contract 동작을 증명할 수 없으면 FAIL gap 이다.
+
+### `(JOURNEY)` 실행 판정 (STORY / EPIC 공통)
+
+- 대상 AC가 `(JOURNEY)`인데 receipt가 없고 journey 매니페스트와 project-local e2e가 있으면 tip에서 `dcness-product-journey run --project-root <project-root> --config <매니페스트 경로>`를 직접 호출해 receipt를 만든 뒤 판정한다.
+- 매니페스트 또는 e2e flow가 없으면 실행할 수 없는 gap으로 보고하고 도입을 제안한다. 특정 e2e 도구 채택을 강제하지 않으며, fixable 코드 gap은 기존 routing대로 build-worker rework에 인계한다.
+- 러너가 생성하는 증거는 ignored `.dcness-work/product-journey/` 아래에만 둔다. tracked 구현·설계 소스, flow, 매니페스트를 수정하거나 receipt를 손으로 날조하지 않는다.
 
 ### UI 목업 정합 판정 (STORY / EPIC 공통)
 
@@ -103,6 +111,7 @@ story 구현 완료 직후 호출된다. 해당 story 의 수용 기준이 구�
 - 핵심 AC 의 입력/진행 동선이 대상 사용자에게 적합한 제품 언어로 닫힌다.
 - 테스트나 smoke 증거가 실제 실행 결과로 남아 있다.
 - project-local journey를 사용했다면 receipt가 Story AC와 command/log evidence를 연결하고 app_started·journey_executed·assertion 결과를 명시한다.
+- `(JOURNEY)` REQ에 receipt가 없고 매니페스트가 있으면 tip에서 직접 실행한 뒤 판정하며, 매니페스트/e2e가 없으면 실행 불가 gap과 도입 제안을 남긴다.
 - mock-only green 으로만 닫힌 핵심 AC 를 gap 으로 분리한다.
 - UI story 이면 확정 목업과 구현 화면 증거를 Read 로 열어 대조하고, 화면 증거 부재와 목업 불일치를 gap 으로 분리한다.
 - 내부 계약을 사용자가 직접 조립해야만 수행되는 핵심 흐름을 gap 으로 분리한다.
@@ -117,6 +126,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 - Epic 완료 기준과 Story AC 전항목이 하나 이상의 story/PR/test evidence 로 닫혔다.
 - story 사이의 흐름, 상태, 권한, 데이터 ownership 이 서로 어긋나지 않는다.
 - 여러 PR/story 경계를 넘는 통합 동작이 동작 증거로 닫혔다. 각 PR 의 mock-only green 이 모여 있어도 실제 사용자 흐름이 한 번도 검증되지 않았으면 cross-story gap 이다.
+- `(JOURNEY)` REQ에 receipt가 없고 매니페스트가 있으면 최종 tip에서 직접 실행한 뒤 cross-story 동작을 판정하며, 매니페스트/e2e가 없으면 실행 불가 gap과 도입 제안을 남긴다.
 - UI epic 이면 story 별 확정 목업과 최종 구현 화면 증거가 서로 이어지는지 보고, 화면 증거 부재나 cross-story 목업 불일치를 gap 으로 분리한다.
 - 여러 story 가 합쳐진 사용자 흐름이 내부 schema/payload 조립이 아니라 대상 사용자의 자연스러운 입력/진행 동선으로 이어진다.
 - 보안/권한/데이터 리스크가 새로 생겼는데 별도 후속 없이 묻히지 않았다.
@@ -141,11 +151,12 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 1. mode 와 검수 단위를 확인한다.
 2. 기준 문서에서 Story AC, Epic 완료 기준, PRD 유저 시나리오, release readiness 기준을 추출한다.
    SPEC_ACCEPTANCE이면 작업에 관련된 결정 범위와 중요한 선택의 근거 상태도 함께 추출한다.
-3. 구현 증거를 읽고 각 기준이 어떤 PR, 테스트, smoke, 정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, 화면/API/CLI 설명과 연결되는지 대조한다. EPIC_ACCEPTANCE이면 epic이 인수한 capability의 상태 before/after, affected Root 좌표, 실제 동작·검증 증거도 함께 대조한다.
-4. 대상 사용자를 식별하고 핵심 입력/진행 동선이 제품 언어인지, 내부 구현 계약을 사용자에게 떠넘기는지 대조한다.
-5. 충족된 기준, mock-only green 인 기준, 화면 증거 부재 기준, 목업 불일치 기준, 사용자 동선 부적합 기준, 증거 없는 기준을 분리한다.
-6. gap 이 있으면 기준 문서, 증거, 누락 사실, 후속 분기를 함께 쓴다.
-7. 판단에 필요한 문서나 권한이 없으면 추측하지 않고 ESCALATE한다.
+3. `(JOURNEY)` REQ별 receipt를 찾는다. receipt가 없고 매니페스트/e2e가 있으면 tip에서 `dcness-product-journey run`을 호출하고, 없으면 실행 불가 gap으로 분리한다.
+4. 구현 증거를 읽고 각 기준이 어떤 PR, 테스트, smoke, 정적 타입검사/compile, 실데이터 통합 테스트, UI 자동화, 화면/API/CLI 설명과 연결되는지 대조한다. EPIC_ACCEPTANCE이면 epic이 인수한 capability의 상태 before/after, affected Root 좌표, 실제 동작·검증 증거도 함께 대조한다.
+5. 대상 사용자를 식별하고 핵심 입력/진행 동선이 제품 언어인지, 내부 구현 계약을 사용자에게 떠넘기는지 대조한다.
+6. 충족된 기준, mock-only green 인 기준, 화면 증거 부재 기준, 목업 불일치 기준, 사용자 동선 부적합 기준, 증거 없는 기준을 분리한다.
+7. gap 이 있으면 기준 문서, 증거, 누락 사실, 후속 분기를 함께 쓴다.
+8. 판단에 필요한 문서나 권한이 없으면 추측하지 않고 ESCALATE한다.
 
 ## 완료 기준
 
@@ -160,14 +171,15 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 - gap 은 제품 기준에서 Must 인지, 후속으로 분리 가능한지 구분한다.
 - 자동으로 issue 를 만들지 않는다. gap issue 생성이 필요하면 `/to-issue` 사용자 승인 후속으로 분기만 제안한다.
 - 사람 full E2E 는 MVP acceptance 범위 밖이다. 사람 E2E 부재만으로 story acceptance 를 FAIL 로 만들지 않는다. 대신 자동 동작 증거가 핵심 AC 를 닫는지 본다.
+- `(JOURNEY)`를 직접 실행했다면 메인에는 receipt 경로, 판정, 사람 확인 잔여 목록만 반환하고 화면 dump 원본은 싣지 않는다.
 - 파일/라인/링크 근거가 없으면 추측하지 않는다.
 - EPIC_ACCEPTANCE에서 증거 없는 `landed`, 미해소 route-only refresh, system boundary backpressure가 있으면 사용자 동작 PASS만으로 전체 PASS하지 않는다.
 
 ## 권한 경계
 
-- 읽기 전용이다.
-- Bash를 쓰지 않는다.
-- 파일을 수정하지 않는다.
+- 조건부 실행 허용: `(JOURNEY)` REQ 대상 AC이고 project-local journey 매니페스트/e2e가 있으면 Bash로 `dcness-product-journey run`을 tip에서 호출해 receipt를 생성한다.
+- tracked 구현·설계 소스는 수정하지 않는다. `ALLOW_MATRIX["product-acceptance"] = ()` write-zero를 유지하며, 증거 write는 러너가 봉인한 `.dcness-work/product-journey/`에만 생성된다.
+- 특정 e2e 도구를 강제하거나 receipt·log·screenshot을 손으로 만들거나 사후 수정하지 않는다.
 - GitHub issue 생성, PR 수정, merge 같은 외부 상태 변경을 하지 않는다.
 
 ## 결론과 보고
@@ -182,6 +194,7 @@ epic 구현 완료 후 호출된다. 여러 story 가 합쳐졌을 때 Epic 완�
 - UI story/epic 이면 확정 목업 경로, 구현 화면 스크린샷 또는 화면 증거 경로, UI 목업 정합 판정 결과
 - STORY / EPIC 검수 보고에는 사용자가 지금 직접 확인할 수 있는 실행 동선(실행 명령, 화면 진입 경로 등) 안내. 호출자 제공 증거에서 확인된 동선만 쓰고, 불명이면 불명이라고 쓴다. 확인 가능한 동작이 아직 없으면 그 사실을 쓴다.
 - EPIC 검수 보고에는 epic이 인수한 capability 상태, affected Root 좌표, 상태 증거, route-only refresh 또는 system backpressure 여부를 포함한다.
+- journey를 직접 실행했으면 receipt 경로, 판정, 사람 확인 잔여 목록만 포함하고 화면 dump 원본은 메인 보고에 싣지 않는다.
 
 마지막 단락에는 `PASS`, `FAIL`, `ESCALATE` 중 하나를 쓴다.
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -70,7 +70,7 @@ Generated TDD hook 은 `scripts/dcness-tdd-hooks` 로 처리한다. dcNess 소�
 
 `docs/index.md` 의 epic/module 표와 기존 `docs/index.md` 의 진행 상태 섹션 보강은 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/aggregate_index_map.mjs`, `$PLUGIN_ROOT/scripts/ensure_docs_index_next_section.mjs`) 로 처리한다. 전역 architecture 인간용 요약은 필요할 때 `$PLUGIN_ROOT/scripts/aggregate_architecture_map.mjs` 로 `.dcness-work/reports/architecture-map.md` 에 온디맨드 생성한다. `/design` 산출물 구조 감사도 사용자 repo 에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/check_design_artifact_structure.mjs`) 로 처리한다. 활성 프로젝트에서는 이 스크립트를 현재 프로젝트 루트에서 실행한다.
 
-제품 journey runner도 사용자 repo에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-product-journey`)로 제공한다. project-local 계약 `.dcness/product-journey.json`은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다. UI journey도 같은 계약과 helper를 재사용하고 project-owned command가 단계별 화면 증거를 생성한다. 실행 receipt와 log는 기존 ignored `.dcness-work/product-journey/`에 남고 [`outcome-scorecard.md`](outcome-scorecard.md)가 집계한다. 계약과 판정 경계는 [`product-journey.md`](product-journey.md)가 소유한다.
+제품 journey runner도 사용자 repo에 복사하지 않는 plugin script (`$PLUGIN_ROOT/scripts/dcness-product-journey`)로 제공한다. project-local 계약은 owner module/소스 영역의 opt-in 매니페스트이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다. UI journey도 같은 계약과 helper를 재사용하고 project-owned command가 단계별 화면 증거를 생성한다. 실행 receipt와 log는 기존 ignored `.dcness-work/product-journey/`에 남고 [`outcome-scorecard.md`](outcome-scorecard.md)가 집계한다. 계약과 판정 경계는 [`product-journey.md`](product-journey.md)가 소유한다.
 
 ## Provider Mirror Sync
 

--- a/docs/plugin/product-journey.md
+++ b/docs/plugin/product-journey.md
@@ -13,11 +13,11 @@
 4. `cleanup`: 성공·실패와 무관하게 종료·정리한다.
 5. `evidence_dir`: command exit와 log, 대상 AC, 실행 시각을 연결하는 receipt 위치다.
 
-메인 workflow가 실행 증거를 만들고 `product-acceptance`는 receipt와 대상 Story AC를 읽기 전용으로 대조한다. 검증 agent가 구현이나 receipt를 수정하지 않는다. UI 경계도 네 command와 같은 assertion 판정을 재사용하며, helper가 브라우저를 직접 자동화하지 않는다. 프로젝트가 소유한 journey command가 화면을 조작하고 screenshot·상태 파일을 남긴다.
+module-architect가 실앱 실행이 필요한 AC를 `(JOURNEY)` REQ로 지정하고, build-worker가 project-local e2e flow와 journey 매니페스트를 작성한다. `product-acceptance`는 receipt가 없으면 tip에서 helper를 실행하고, 생성된 receipt와 대상 Story AC를 판정한다. 검증 agent는 tracked 구현·설계 소스나 receipt를 수정하지 않는다. UI 경계도 네 command와 같은 assertion 판정을 재사용하며, helper가 브라우저를 직접 자동화하지 않는다. 프로젝트가 소유한 journey command가 화면을 조작하고 screenshot·상태 파일을 남긴다.
 
 ## 프로젝트 계약
 
-기본 위치는 `.dcness/product-journey.json`이다. 다른 위치를 사용할 때는 helper의 `--config`로 명시한다.
+build-worker가 만드는 새 매니페스트는 `.dcness/` 밖 owner module/소스 영역(예: `app/.maestro/dcness-journey.json`)에 둔다. `.dcness/`는 sub-agent write 보호 영역이므로 carve-out을 만들지 않는다. 이 lifecycle에서는 helper의 `--config`로 매니페스트 경로를 명시한다. helper의 기존 기본 경로 지원은 수동으로 관리 중인 legacy 계약 호환용이며, 새 build-worker 산출물 위치가 아니다.
 
 ```json
 {
@@ -67,13 +67,19 @@
 | `assertion.source` | `journey_exit`이면 journey exit 0을 assertion PASS로 사용. `none`은 미평가 fixture이며 PASS 불가 |
 | `human_intervention_count` | 실행 중 사람이 개입한 횟수. 없으면 0 |
 | `env` | 네 단계에 공통으로 추가할 문자열 환경 변수 |
-| `commands.*.argv` | shell 문자열이 아닌 argv 배열. shell이 필요하면 프로젝트가 `bash -lc`를 명시적으로 선택 |
+| `commands.*.argv` | shell 문자열이 아닌 argv 배열. setup/teardown/상태전이 오케스트레이션이 필요하면 `commands.journey.argv`에서 `bash`와 프로젝트 스크립트 경로를 명시적으로 선택 |
 | `commands.*.timeout_sec` | 단계별 600초 이하 timeout |
 | `commands.start.mode` | 장기 실행 앱은 `service`, 종료되는 CLI 진입점은 `command` |
 | `commands.start.startup_grace_sec` | service가 조기 종료하지 않았는지 확인할 유예 시간 |
 | `evidence_dir` | `.dcness-work/product-journey/` 아래의 project-relative 위치 |
 
 start가 실패하거나 service가 유예 시간 안에 종료되면 `app_not_started`다. health가 실패하면 journey를 실행하지 않고 `journey_not_executed`로 남긴다. journey가 실행되지 않았거나 `assertion.source=none`이면 `assertion_not_evaluated`다. `mock` boundary는 모든 command가 exit 0이어도 `mock_only_boundary`이므로 PASS가 아니다. cleanup은 항상 실행하며 실패하면 전체 outcome도 FAIL이다.
+
+### `(JOURNEY)` flow 설계 경계
+
+- flow 산출물은 단일 UI yaml에 한정되지 않는다. 시드, 역할 교체, 네트워크 상태 토글처럼 전후 상태를 엮어야 하면 build-worker가 setup/teardown/상태전이 스크립트를 함께 작성하고 journey argv에서 오케스트레이션한다.
+- negative 동작 계약은 부재만 기다리지 않고 대응하는 양성 프록시 event를 REQ와 assertion에 명시한다. 양성 프록시가 없으면 자동 PASS를 만들지 않고 `사람 확인 안내`로 분리한다.
+- 관찰 창이 sub-second인 상태나 순수 위치·픽셀 판정은 flaky한 `(JOURNEY)`로 강제하지 않고 `사람 확인 안내`로 분리한다.
 
 ## UI 증거 확장
 
@@ -118,7 +124,7 @@ helper는 command 환경에 `DCNESS_PRODUCT_JOURNEY_RUN_DIR` 절대경로를 주
 ```sh
 "$PLUGIN_ROOT/scripts/dcness-product-journey" run \
   --project-root "$PROJECT_ROOT" \
-  --config .dcness/product-journey.json
+  --config app/.maestro/dcness-journey.json
 ```
 
 성공은 exit 0, 실행된 제품 gap은 exit 1, 잘못된 계약은 exit 2다. 각 run은 `evidence_dir/<run-id>/`에 단계별 log와 `receipt.json`을 남긴다. receipt는 다음 의미를 포함한다.
@@ -136,4 +142,4 @@ helper는 command 환경에 `DCNESS_PRODUCT_JOURNEY_RUN_DIR` 절대경로를 주
 
 helper와 runtime은 plugin 본체의 `scripts/dcness-product-journey`, `harness/product_journey.py`로 배포된다. 사용자 repo에 helper 사본을 복사하지 않는다. 프로젝트 계약은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다.
 
-계약을 팀과 공유해야 하면 `.dcness/product-journey.json`을 프로젝트가 명시적으로 관리한다. 실행 log와 receipt는 재생성 가능한 실측 evidence이므로 gitignore 대상 `.dcness-work/product-journey/`에 둔다.
+계약을 팀과 공유해야 하면 owner module/소스 영역의 매니페스트와 e2e flow를 프로젝트가 명시적으로 관리한다. build-worker가 이 plugin 배포물 안에서 산출물을 만들기 때문에 신규 `/init-dcness` deploy 스텝은 필요 없다. 실행 log와 receipt는 재생성 가능한 실측 evidence이므로 gitignore 대상 `.dcness-work/product-journey/`에 둔다.

--- a/docs/plugin/product-journey.md
+++ b/docs/plugin/product-journey.md
@@ -142,4 +142,4 @@ helper는 command 환경에 `DCNESS_PRODUCT_JOURNEY_RUN_DIR` 절대경로를 주
 
 helper와 runtime은 plugin 본체의 `scripts/dcness-product-journey`, `harness/product_journey.py`로 배포된다. 사용자 repo에 helper 사본을 복사하지 않는다. 프로젝트 계약은 opt-in이며 `/init-dcness`가 자동 생성하거나 덮어쓰지 않는다.
 
-계약을 팀과 공유해야 하면 owner module/소스 영역의 매니페스트와 e2e flow를 프로젝트가 명시적으로 관리한다. build-worker가 이 plugin 배포물 안에서 산출물을 만들기 때문에 신규 `/init-dcness` deploy 스텝은 필요 없다. 실행 log와 receipt는 재생성 가능한 실측 evidence이므로 gitignore 대상 `.dcness-work/product-journey/`에 둔다.
+계약을 팀과 공유해야 하면 owner module/소스 영역의 매니페스트와 e2e flow를 프로젝트가 명시적으로 관리한다. plugin에 포함된 build-worker가 활성 프로젝트의 해당 영역에 산출물을 만들기 때문에 신규 `/init-dcness` deploy 스텝은 필요 없다. 실행 log와 receipt는 재생성 가능한 실측 evidence이므로 gitignore 대상 `.dcness-work/product-journey/`에 둔다.

--- a/docs/plugin/terms.md
+++ b/docs/plugin/terms.md
@@ -42,7 +42,7 @@
 | PRD 유저 시나리오 | 기능 나열과 사용자의 정상·실패·복구 흐름을 제품 언어로 설명한다. Story 수용 기준은 두지 않는다. | `/spec` 이 시나리오를 Story 로 나누고 검증 약속을 붙인다. | [`skills/spec/spec-prd-reference.md`](../../skills/spec/spec-prd-reference.md) |
 | Epic 완료 기준 | 여러 Story 가 함께 달성해야 할 epic 단위 결과를 `[command]`/`[agent-read]` 로 정의한다. | Story 전체가 합쳐졌을 때 product-acceptance 가 통합 증거를 대조하고, GitHub issue 에서는 close 감사용 체크리스트로 materialize 된다. | [`skills/spec/spec-stories-reference.md`](../../skills/spec/spec-stories-reference.md) |
 | Story AC | `AC-NNN` Given/When/Then 으로 사용자에게 약속한 Story 단위 결과를 정의한다. 프로젝트 전역에서 ID가 불변인 검증 origin 이다. | module-architect 가 task REQ 로 번역한다. | [`skills/spec/spec-stories-reference.md`](../../skills/spec/spec-stories-reference.md) |
-| task REQ | Story AC 를 task가 실행·관찰할 검증 언어로 번역한다. 제품 REQ 는 `(from AC-NNN)`, 소수 기술 REQ 는 `(technical: 이유)`를 쓴다. | build-worker가 실행하고 validator가 출처·증거를 대조한다. | [`docs/plugin/agents/module-architect/templates/impl-task.md`](agents/module-architect/templates/impl-task.md) |
+| task REQ | Story AC 를 task가 실행·관찰할 검증 언어로 번역한다. 제품 REQ 는 `(from AC-NNN)`, 소수 기술 REQ 는 `(technical: 이유)`를 쓰며, 검증방법은 `(TEST)`·`(AGENT READ)`·실앱 자동화 `(JOURNEY)` 중 하나다. | build-worker가 `(TEST)`·`(AGENT READ)`를 실행하고 `(JOURNEY)` flow/매니페스트를 작성하며, product-acceptance가 `(JOURNEY)`를 tip에서 실행·판정한다. | [`docs/plugin/agents/module-architect/templates/impl-task.md`](agents/module-architect/templates/impl-task.md) |
 
 ## 사용 지침
 

--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -91,7 +91,6 @@ READONLY_AGENTS = {
     "impl-validator",
     "architecture-validator",
     "plan-reviewer",
-    "product-acceptance",
 }
 
 # #917 — lesson 대상 WasteFinding 패턴의 코드 SSOT.

--- a/skills/acceptance/SKILL.md
+++ b/skills/acceptance/SKILL.md
@@ -148,7 +148,7 @@ standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을
 ## 절차
 
 1. 입력 단위가 story 인지 epic 인지 확인한다.
-2. 핵심 journey가 검수 대상이면 owner module/소스 영역의 journey 매니페스트와 연결된 e2e flow 경로를 확인한다. 기존 receipt가 있으면 함께 전달하고, 없으면 product-acceptance가 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 tip에서 `dcness-product-journey run --config <매니페스트 경로>`를 실행하게 한다. UI boundary이면 단계별 screenshot/state/log 경로도 판정하되, exit 1 receipt의 mock-only/app-not-started/journey 미실행/assertion 미평가/UI evidence 누락을 PASS로 바꾸지 않는다.
+2. 핵심 journey가 검수 대상이면 owner module/소스 영역의 journey 매니페스트와 연결된 e2e flow 경로를 확인한다. 수동 관리 중인 legacy `.dcness/product-journey.json` 계약은 helper 기본 경로로 계속 호환하되 새 build-worker 산출물 위치가 아니다. 기존 receipt가 있으면 함께 전달하고, 없으면 product-acceptance가 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 tip에서 `dcness-product-journey run --config <매니페스트 경로>`를 실행하게 한다. UI boundary이면 단계별 screenshot/state/log 경로도 판정하되, exit 1 receipt의 mock-only/app-not-started/journey 미실행/assertion 미평가/UI evidence 누락을 PASS로 바꾸지 않는다.
 3. story면 `product-acceptance:STORY_ACCEPTANCE`, epic이면 `product-acceptance:EPIC_ACCEPTANCE`를 호출한다. product-acceptance가 journey를 직접 실행했다면 receipt 경로, 판정, 사람 확인 잔여 목록만 메인에 반환하고 화면 dump 원본은 싣지 않는다.
 4. `PASS`면 완료 후보로 보고한다.
 5. `FAIL`이면 자동 수정하지 않고 gap 목록과 후속 분기를 prose 로 보고한다. Cartography gap이면 affected Root Cartography, `module-architect:CARTOGRAPHY_REFRESH` 또는 `/design --revise`/system checkpoint, local-only/ignored 정책의 durable impact handoff를 포함한다.

--- a/skills/acceptance/SKILL.md
+++ b/skills/acceptance/SKILL.md
@@ -26,6 +26,7 @@ description: story 또는 epic 구현 완료 후 제품 단위 검수를 수행�
 - mock/stub/fake 를 쓴 증거라면 mock 경계와 실제로 실행된 제품 경계
 - implementation Cartography impact, affected Root Cartography 좌표, 상태 before/after 증거, 관련 epic/decision, tracked 또는 local-only/ignored 문서 정책
 - 이전 acceptance gap 이 있으면 그 결과와 재검수 대상
+- `(JOURNEY)` REQ가 있으면 build-worker가 작성한 owner module/소스 영역의 journey 매니페스트, 연결된 e2e flow, 기존 receipt 경로
 
 입력이 부족하면 추측으로 검수하지 않고 사용자에게 어떤 경로/PR/issue 가 필요한지 묻는다.
 
@@ -136,19 +137,19 @@ mode: EPIC_ACCEPTANCE
 
 ### Cartography freshness 후속
 
-standalone `/acceptance`는 tracked 구현·설계에 대해 읽기 전용을 유지하며 stale Root를 직접 수정하지 않는다. 명시된 project-local journey 계약 실행이 만드는 ignored evidence만 예외다. product-acceptance prose의 gap을 메인이 읽고 다음 producer를 명시한다.
+standalone `/acceptance`는 tracked 구현·설계에 대해 write-zero를 유지하며 stale Root를 직접 수정하지 않는다. 명시된 project-local journey 계약 실행이 만드는 ignored evidence만 예외다. product-acceptance prose의 gap을 메인이 읽고 다음 producer를 명시한다.
 
 - 영향 없음 또는 Root와 일치: 기존 완료 후보 보고를 계속한다.
 - system boundary가 유지된 route/state/as-built edge 또는 capability 상태 drift: 기존 `module-architect:CARTOGRAPHY_REFRESH`가 affected Root Cartography 좌표만 bounded refresh해야 한다고 보고한다. local-only/ignored private docs는 code PR에 강제 포함하지 않고 canonical local Root 갱신 또는 exact durable impact handoff를 다음 producer에 남긴다. durable impact handoff만으로 freshness가 해소되지는 않으므로 canonical local Root refresh 확인 전에는 PASS하지 않는다.
 - system boundary·global decision 변경: route-only refresh로 흡수하지 않고 `/design --revise` 또는 system checkpoint backpressure를 보고한다.
 
-standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을 수정하지 않는다. project-local journey 계약이 있으면 ignored `.dcness-work/product-journey/` evidence만 생성할 수 있다. direct `/impl`에서 acceptance가 생략되더라도 impl-validator 종료 경계가 최소 Cartography freshness 책임을 가진다.
+standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을 수정하지 않는다. product-acceptance가 project-local journey 계약을 실행할 때 ignored `.dcness-work/product-journey/` evidence만 생성할 수 있다. direct `/impl`에서 acceptance가 생략되더라도 impl-validator 종료 경계가 최소 Cartography freshness 책임을 가진다.
 
 ## 절차
 
 1. 입력 단위가 story 인지 epic 인지 확인한다.
-2. 핵심 journey가 검수 대상이고 `.dcness/product-journey.json` 또는 호출자가 지정한 동등한 project-local 계약이 있으면, 메인이 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `dcness-product-journey`를 실행한다. 생성된 receipt와 log 경로를 다음 prompt에 넣고, UI boundary이면 단계별 screenshot/state/log 경로도 함께 넣는다. exit 1 receipt도 gap 증거로 전달하며 mock-only/app-not-started/journey 미실행/assertion 미평가/UI evidence 누락을 PASS로 바꾸지 않는다.
-3. story면 `product-acceptance:STORY_ACCEPTANCE`, epic이면 `product-acceptance:EPIC_ACCEPTANCE` 를 호출한다.
+2. 핵심 journey가 검수 대상이면 owner module/소스 영역의 journey 매니페스트와 연결된 e2e flow 경로를 확인한다. 기존 receipt가 있으면 함께 전달하고, 없으면 product-acceptance가 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 tip에서 `dcness-product-journey run --config <매니페스트 경로>`를 실행하게 한다. UI boundary이면 단계별 screenshot/state/log 경로도 판정하되, exit 1 receipt의 mock-only/app-not-started/journey 미실행/assertion 미평가/UI evidence 누락을 PASS로 바꾸지 않는다.
+3. story면 `product-acceptance:STORY_ACCEPTANCE`, epic이면 `product-acceptance:EPIC_ACCEPTANCE`를 호출한다. product-acceptance가 journey를 직접 실행했다면 receipt 경로, 판정, 사람 확인 잔여 목록만 메인에 반환하고 화면 dump 원본은 싣지 않는다.
 4. `PASS`면 완료 후보로 보고한다.
 5. `FAIL`이면 자동 수정하지 않고 gap 목록과 후속 분기를 prose 로 보고한다. Cartography gap이면 affected Root Cartography, `module-architect:CARTOGRAPHY_REFRESH` 또는 `/design --revise`/system checkpoint, local-only/ignored 정책의 durable impact handoff를 포함한다.
 6. `ESCALATE`면 어떤 기준 문서, 구현 증거, 사용자 결정이 부족한지 보고하고 대기한다.
@@ -157,7 +158,7 @@ standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을
 ```bash
 "$PLUGIN_ROOT/scripts/dcness-product-journey" run \
   --project-root "$PROJECT_ROOT" \
-  --config .dcness/product-journey.json
+  --config app/.maestro/dcness-journey.json
 ```
 
 ```bash
@@ -169,7 +170,7 @@ standalone `/acceptance`는 producer를 직접 호출하거나 tracked 파일을
 
 ## 워크트리
 
-`/acceptance` 는 검수 skill 이므로 워크트리 자동 진입 없음. 메인이 명시된 project-local journey 계약을 실행할 때만 ignored `.dcness-work/product-journey/` evidence를 생성할 수 있다. `product-acceptance` agent는 계속 읽기 전용이며 GitHub issue 생성, 구현 코드 수정, PR 생성/머지는 수행하지 않는다.
+`/acceptance` 는 검수 skill 이므로 워크트리 자동 진입 없음. product-acceptance가 명시된 project-local journey 계약을 실행할 때만 ignored `.dcness-work/product-journey/` evidence를 생성할 수 있다. product-acceptance agent는 tracked 구현·설계에 대해 write-zero이며 GitHub issue 생성, 구현 코드 수정, PR 생성/머지는 수행하지 않는다.
 
 ## 참조
 

--- a/skills/acceptance/acceptance-routing.md
+++ b/skills/acceptance/acceptance-routing.md
@@ -42,7 +42,7 @@ flowchart TB
 | `product-acceptance:EPIC_ACCEPTANCE` `FAIL` | Epic 완료 기준·Story AC, cross-story 동작 gap, mock-only green, 화면 증거 부재, 목업 불일치, cross-story 사용자 동선 부적합, security/ops risk 를 보고하고 후속 분기를 제안한다. |
 | `ESCALATE` | 기준 문서, 구현 PR 목록, 권한, 사용자 결정 부족을 보고하고 대기한다. |
 
-Cartography freshness gap은 standalone `/acceptance`의 tracked 구현·설계 읽기 전용 경계를 유지하면서 다음 producer까지 비지 않게 한다. project-local journey 계약 실행이 만드는 ignored evidence는 이 경계를 바꾸지 않는다.
+Cartography freshness gap은 standalone `/acceptance`의 tracked 구현·설계 write-zero 경계를 유지하면서 다음 producer까지 비지 않게 한다. project-local journey 계약 실행이 ignored `.dcness-work/product-journey/`에 만드는 evidence는 이 경계를 바꾸지 않는다.
 
 | Cartography 결과 | 다음 producer |
 |---|---|
@@ -50,7 +50,7 @@ Cartography freshness gap은 standalone `/acceptance`의 tracked 구현·설계 
 | system boundary 유지 + route/state/as-built edge 또는 capability 상태 drift | `module-architect:CARTOGRAPHY_REFRESH`가 affected Root Cartography만 bounded refresh. local-only/ignored이면 canonical local refresh 또는 durable impact handoff를 보존하고 private docs를 code PR에 강제 포함하지 않음. durable impact handoff만으로 freshness가 해소되지는 않으며 canonical local Root refresh 확인 전에는 PASS 금지 |
 | system boundary·global decision 변경 | route-only patch 금지. `/design --revise` 또는 system checkpoint backpressure 보고 |
 
-standalone `/acceptance`는 이 producer를 직접 호출하지 않고 gap과 근거를 보고한다. product-acceptance는 완전한 읽기 전용이고, acceptance 메인은 명시된 journey 계약의 ignored evidence만 생성하며 tracked 구현·설계는 수정하지 않는다.
+standalone `/acceptance`는 이 producer를 직접 호출하지 않고 gap과 근거를 보고한다. product-acceptance가 receipt 없는 `(JOURNEY)` REQ의 journey 매니페스트를 tip에서 실행해 ignored evidence를 생성·판정하며, 매니페스트/e2e가 없으면 실행 불가 gap과 도입 제안을 보고한다. tracked 구현·설계는 write-zero로 유지한다.
 
 ## 깊이 차이
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -229,9 +229,9 @@ story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후
 
 최종 main 대상 PR 이 여러 story 를 닫으면 `product-acceptance:STORY_ACCEPTANCE` 를 story × N 으로 수행한 뒤, epic close 가 실제 발동되면 `product-acceptance:EPIC_ACCEPTANCE` 를 1회 수행한다. gap 수정 commit 이 생기면 이전 STORY PASS 는 stale 이므로 STORY_ACCEPTANCE 부터 다시 돌린다.
 
-product-acceptance 는 read-only 라 `gh` 호출 불가다. PR 목록·검증 결과·동작 증거·UI 목업 정합 증거와 build-worker Cartography impact, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision을 메인이 prompt 에 직접 담는다. UI task 는 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 함께 넣어 목업 불일치와 화면 증거 부재를 판정할 수 있게 한다. 핵심 AC 증거가 mock-only green 이거나 대상 사용자에게 부적합한 입력/진행 동선이면 gap 이다.
+product-acceptance 는 외부 상태 변경(`gh` issue/PR mutation, push, merge) 금지 경계라 `gh` 호출이 불가다. PR 목록·검증 결과·동작 증거·UI 목업 정합 증거와 build-worker Cartography impact, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision을 메인이 prompt 에 직접 담는다. UI task 는 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 함께 넣어 목업 불일치와 화면 증거 부재를 판정할 수 있게 한다. 핵심 AC 증거가 mock-only green 이거나 대상 사용자에게 부적합한 입력/진행 동선이면 gap 이다.
 
-핵심 journey가 마감 AC이고 project-local 계약이 있으면, 메인이 product-acceptance 호출 직전에 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `"$PLUGIN_ROOT/scripts/dcness-product-journey" run --project-root "$PROJECT_ROOT" --config <contract>`를 실행한다. 생성된 receipt와 log를 prompt에 넣고 UI boundary이면 단계별 screenshot/state/log 경로도 함께 넣는다. exit 1은 구현 gap 증거이며 mock-only, app-not-started, journey 미실행, assertion 미평가, UI evidence 누락을 PASS로 세지 않는다. helper가 쓰는 영역은 ignored `.dcness-work/product-journey/`로 한정되고 product-acceptance agent는 수정하지 않는다.
+핵심 journey가 마감 AC이면 build-worker가 인계한 `(JOURNEY)` REQ와 owner module/소스 영역의 journey 매니페스트/e2e flow 경로를 product-acceptance prompt에 넣는다. receipt가 없으면 product-acceptance가 최종 tip에서 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `"$PLUGIN_ROOT/scripts/dcness-product-journey" run --project-root "$PROJECT_ROOT" --config <contract>`를 실행한다. exit 1은 구현 gap 증거이며 mock-only, app-not-started, journey 미실행, assertion 미평가, UI evidence 누락을 PASS로 세지 않는다. helper가 쓰는 영역은 ignored `.dcness-work/product-journey/`로 한정되고 tracked 구현·설계는 write-zero로 유지한다.
 
 호출:
 

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -69,6 +69,8 @@ canvas-design 은 UI 작업의 main-owned checkpoint 이며 helper begin/end-ste
 | **product-acceptance** | `PASS` → target GitHub issue AC close audit. story×N 과 epic 대상이면 모두 PASS 필요 · `FAIL` auto-fixable gap → build-worker rework + commit append. Epic code 변경은 완료된 Sanity/impl-validator 증거를 stale 처리하고 Sanity부터 재진입, Story-only는 impl-validator 재리뷰 + acceptance 재검수(≤3) · capability 상태 drift가 route-only stale → `CARTOGRAPHY_REFRESH` + 같은 diff+갱신 Root impl-validator 재검증 + acceptance 재검수 · system boundary/global decision gap → `/design --revise`/checkpoint · `FAIL` 비자동 gap / round 초과 / `ESCALATE` → 사용자 |
 | **target GitHub issue AC close audit** | 자동 판정 가능한 AC 전항목 충족·체크 + `check_issue_body.mjs --acceptance-only --require-complete` PASS → merge · 미충족·미체크 → clean 마감 금지, 구현 보강 · human verification 잔여 → 목록 보고 후 merge 전 대기 (`blocked` 아님) |
 
+`(JOURNEY)` REQ는 PASS 블로커가 아니다. build-worker가 flow 대본, `.dcness/` 밖 journey 매니페스트, 필요한 setup/teardown/상태전이 스크립트를 작성하고 acceptance 인계를 보고하면 `PASS`로 진행한다. 이 경로는 메인 게이트 대행용 `VALIDATION_BLOCKED`와 다르다.
+
 ## retry 한도
 
 | 재시도 경로 | 한도 | 초과 시 |
@@ -90,6 +92,8 @@ story/epic close 를 실제 발동하는 PR 의 impl-validator `PASS` 후 · mer
 impl-validator 는 계획 대비 구현 정합과 merge candidate diff 위험을 검토한다. 여러 PR 이 합쳐진 story 동작과 여러 story 가 합쳐진 epic 동작의 사용자 관찰 가능 동작은 마감 product-acceptance 가 맡는다.
 
 여러 task commit 이 합쳐진 story 동작은 story PR 과 acceptance 증거를 함께 보고 판정한다. 여러 story sub-PR 이 합쳐진 epic 동작도 같은 원칙으로 product-acceptance 가 맡는다. product-acceptance 는 개별 task green 이 아니라 story/epic close 시점의 사용자 동작 전체를 검수한다.
+
+STORY/EPIC_ACCEPTANCE는 대상 AC의 `(JOURNEY)` receipt가 없고 매니페스트/e2e가 있으면 최종 tip에서 flow를 실행해 receipt를 생성·판정한다. 매니페스트/e2e가 없으면 실행 불가 gap과 도입 제안을 보고하며 특정 e2e 도구를 강제하지 않는다.
 
 Cartography freshness도 같은 close 경계의 Must다. capability 상태 drift, 미해소 route/state/as-built edge, system backpressure가 남으면 최종 clean과 merge로 진행하지 않는다. `CARTOGRAPHY_REFRESH`는 기존 module-architect의 bounded producer mode이며, local-only/ignored private docs는 code PR에 강제 포함하지 않고 canonical local refresh 또는 durable impact handoff를 보존한다. durable impact handoff만으로 freshness가 해소되지는 않으며 canonical local Root refresh 확인 전에는 최종 clean이 아니다. build-worker와 읽기 전용 validator가 docs를 직접 수정하지 않는다.
 

--- a/tests/test_agent_boundary.py
+++ b/tests/test_agent_boundary.py
@@ -269,6 +269,34 @@ class WriteAllowedAllowMatrixTests(unittest.TestCase):
             self.assertIsNotNone(reason)
             self.assertIn("write-zero", reason)
 
+    def test_product_acceptance_journey_runner_respects_write_zero(self):
+        command = (
+            "dcness-product-journey run --project-root . "
+            "--config app/.maestro/dcness-journey.json"
+        )
+        self.assertIsNone(check_bash_mutation(command))
+        self.assertEqual(extract_bash_paths(command), [])
+
+        with tempfile.TemporaryDirectory() as td:
+            cwd = Path(td)
+            for mutation in (
+                f"{command} > tracked.file",
+                "sed -i 's/x/y/' tracked.file",
+            ):
+                paths = extract_bash_paths(mutation)
+                self.assertIn("tracked.file", paths)
+                reasons = [
+                    check_write_allowed(
+                        "product-acceptance",
+                        path,
+                        cwd=cwd,
+                        shell_context=True,
+                    )
+                    for path in paths
+                ]
+                self.assertTrue(all(reasons))
+                self.assertTrue(all("write-zero" in reason for reason in reasons))
+
     def test_module_architect_new_docs_allowed(self):
         with tempfile.TemporaryDirectory() as td:
             cwd = Path(td)

--- a/tests/test_cartography_workflow_integration.py
+++ b/tests/test_cartography_workflow_integration.py
@@ -134,7 +134,8 @@ class CartographyWorkflowIntegrationTests(unittest.TestCase):
             self.assertIn("module-architect", text)
             self.assertIn("durable impact handoff", text)
             self.assertIn("/design --revise", text)
-            self.assertIn("읽기 전용", text)
+            self.assertIn("write-zero", text)
+            self.assertIn(".dcness-work/product-journey/", text)
             self.assertIn("durable impact handoff만으로 freshness가 해소되지는 않", text)
 
     def test_eval_suite_covers_all_integration_outcomes(self) -> None:

--- a/tests/test_product_acceptance_agent.py
+++ b/tests/test_product_acceptance_agent.py
@@ -33,11 +33,40 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         self.impl_loop_routing = (
             ROOT / "skills" / "impl-loop" / "impl-loop-routing.md"
         )
+        self.acceptance_skill = ROOT / "skills" / "acceptance" / "SKILL.md"
+        self.impl_loop_skill = ROOT / "skills" / "impl-loop" / "SKILL.md"
+        self.module_architect_prompt = (
+            ROOT
+            / "docs"
+            / "plugin"
+            / "agents"
+            / "module-architect"
+            / "module-architect-agent.md"
+        )
+        self.impl_task_template = (
+            ROOT
+            / "docs"
+            / "plugin"
+            / "agents"
+            / "module-architect"
+            / "templates"
+            / "impl-task.md"
+        )
+        self.build_worker_prompt = (
+            ROOT
+            / "docs"
+            / "plugin"
+            / "agents"
+            / "build-worker"
+            / "build-worker-agent.md"
+        )
+        self.product_journey = ROOT / "docs" / "plugin" / "product-journey.md"
+        self.init_dcness = ROOT / "docs" / "plugin" / "init-dcness.md"
 
     def test_agent_entrypoint_exists_and_points_to_prompt(self) -> None:
         text = self.entry.read_text(encoding="utf-8")
         self.assertRegex(text, r"(?m)^name:\s*product-acceptance$")
-        self.assertIn("tools: Read, Glob, Grep", text)
+        self.assertIn("tools: Read, Glob, Grep, Bash", text)
         self.assertIn("product-acceptance-agent.md", text)
 
     def test_prompt_defines_four_modes_and_final_enums(self) -> None:
@@ -139,9 +168,49 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         self.assertIn("여러 story 가 합쳐진 epic 동작", text)
         self.assertIn("마감 product-acceptance 가 맡는다", text)
 
-    def test_read_only_boundary_and_no_codex_route(self) -> None:
+    def test_write_zero_boundary_and_no_codex_route(self) -> None:
         self.assertEqual(ALLOW_MATRIX["product-acceptance"], ())
         self.assertNotIn("product-acceptance", ROUTABLE_VALIDATION_AGENTS)
+
+    def test_prompt_executes_declared_journey_without_modifying_tracked_sources(self) -> None:
+        text = self.prompt.read_text(encoding="utf-8")
+        for needle in (
+            "dcness-product-journey run",
+            "tracked 구현·설계 소스",
+            ".dcness-work/product-journey/",
+            "receipt 경로",
+            "사람 확인 잔여 목록",
+        ):
+            self.assertIn(needle, text)
+
+    def test_journey_taxonomy_build_handoff_and_acceptance_execution_align(self) -> None:
+        module_prompt = self.module_architect_prompt.read_text(encoding="utf-8")
+        template = self.impl_task_template.read_text(encoding="utf-8")
+        build_worker = self.build_worker_prompt.read_text(encoding="utf-8")
+        product_journey = self.product_journey.read_text(encoding="utf-8")
+        init_dcness = self.init_dcness.read_text(encoding="utf-8")
+        acceptance_skill = self.acceptance_skill.read_text(encoding="utf-8")
+        acceptance_routing = self.acceptance_routing.read_text(encoding="utf-8")
+        impl_loop_skill = self.impl_loop_skill.read_text(encoding="utf-8")
+        impl_loop_routing = self.impl_loop_routing.read_text(encoding="utf-8")
+
+        self.assertIn("(JOURNEY) <flow/매니페스트 경로>", template)
+        self.assertIn("양성 프록시", module_prompt)
+        self.assertIn("sub-second", module_prompt)
+        self.assertIn("setup/teardown/상태전이 스크립트", build_worker)
+        self.assertIn("PASS 블로커에서 제외", build_worker)
+        self.assertIn("acceptance 인계", build_worker)
+        self.assertIn("owner module/소스 영역", product_journey)
+        self.assertIn("build-worker", product_journey)
+        self.assertIn("product-acceptance", product_journey)
+        self.assertIn("owner module/소스 영역", init_dcness)
+        self.assertNotIn("project-local 계약 `.dcness/product-journey.json`", init_dcness)
+        self.assertIn("product-acceptance가", acceptance_skill)
+        self.assertIn("journey 매니페스트", acceptance_skill)
+        self.assertIn("product-acceptance가", acceptance_routing)
+        self.assertIn("journey 매니페스트", acceptance_routing)
+        self.assertIn("외부 상태 변경", impl_loop_skill)
+        self.assertIn("`(JOURNEY)` REQ는 PASS 블로커가 아니다", impl_loop_routing)
 
     def test_public_surface_contract_mentions_internal_agent(self) -> None:
         script = (ROOT / "scripts" / "check_public_surface.mjs").read_text(
@@ -157,7 +226,7 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         self.assertEqual(EXPECTED_FINAL_ENUMS["product-acceptance"], {None: "PASS"})
         self.assertIn("product-acceptance", EXPECTED_AGENT_BUDGETS)
         self.assertIn("product-acceptance", DCNESS_AGENT_NAMES)
-        self.assertIn("product-acceptance", READONLY_AGENTS)
+        self.assertNotIn("product-acceptance", READONLY_AGENTS)
         self.assertEqual(
             infer_phase("acceptance", "product-acceptance", "STORY_ACCEPTANCE"),
             "acceptance",

--- a/tests/test_product_acceptance_agent.py
+++ b/tests/test_product_acceptance_agent.py
@@ -207,6 +207,8 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         self.assertNotIn("project-local 계약 `.dcness/product-journey.json`", init_dcness)
         self.assertIn("product-acceptance가", acceptance_skill)
         self.assertIn("journey 매니페스트", acceptance_skill)
+        self.assertIn("legacy `.dcness/product-journey.json`", acceptance_skill)
+        self.assertIn("새 build-worker 산출물 위치가 아니다", acceptance_skill)
         self.assertIn("product-acceptance가", acceptance_routing)
         self.assertIn("journey 매니페스트", acceptance_routing)
         self.assertIn("외부 상태 변경", impl_loop_skill)

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -560,7 +560,7 @@ class ProductJourneyExecutionTests(unittest.TestCase):
 
 
 class ProductJourneyContractDocumentTests(unittest.TestCase):
-    def test_contract_and_main_workflows_define_execution_and_read_only_handoff(
+    def test_contract_and_workflows_define_acceptance_execution_and_write_zero_handoff(
         self,
     ) -> None:
         contract = (ROOT / "docs/plugin/product-journey.md").read_text(encoding="utf-8")
@@ -598,7 +598,9 @@ class ProductJourneyContractDocumentTests(unittest.TestCase):
         self.assertIn("assertion", product_acceptance)
         self.assertIn("ui_evidence.steps", product_acceptance)
         self.assertIn("present=true", product_acceptance)
-        self.assertIn("읽기 전용", product_acceptance)
+        self.assertIn("dcness-product-journey run", product_acceptance)
+        self.assertIn("write-zero", product_acceptance)
+        self.assertIn("tracked 구현·설계 소스", product_acceptance)
         self.assertIn("사용자 repo에 복사하지", init_contract)
         self.assertIn("dcness-product-journey", init_contract)
         self.assertIn(".dcness-work/product-journey/", deliverables)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1107

## 배경 및 문제

실앱·디바이스가 필요한 Story AC를 기존 `(TEST)`/`(AGENT READ)`만으로 표현하면 build-worker 실행환경에서 검증할 수 없거나, 마감 acceptance가 자동 journey를 재사용할 계약이 없었습니다. 설계 taxonomy부터 build-worker 산출물, product-acceptance 실행·판정까지 한 lifecycle로 연결할 필요가 있습니다.

## 원인 (해당 시)

기존 product journey runner와 receipt 판정은 존재했지만, task REQ taxonomy·flow 소유권·최종 tip 실행 책임이 각 agent/skill에 일관되게 연결되지 않았습니다.

## 작업내용

- module-architect REQ에 도구 중립 `(JOURNEY)`를 추가하고 negative 계약의 양성 프록시 및 사람 확인 분기 기준을 명시했습니다.
- build-worker가 journey를 실행하지 않고 project-local flow·매니페스트·오케스트레이션을 작성한 뒤 acceptance로 인계하도록 했습니다.
- product-acceptance에 조건부 Bash를 허용해 최종 tip에서 봉인 러너를 실행하되 tracked 구현·설계 소스 write-zero를 유지했습니다.
- acceptance/impl-loop/product-journey/init/용어 문서를 동기화하고 Bash runner 허용·redirect/sed 차단·기존 문구 회귀 테스트를 추가했습니다.

## 결정 근거

- 기존 `harness/product_journey.py`를 그대로 재사용하고 새 공개 진입점이나 e2e 도구 의존을 만들지 않았습니다.
- `ALLOW_MATRIX["product-acceptance"] = ()`와 `.dcness/` 보호를 유지하고, 러너가 만드는 ignored `.dcness-work/product-journey/` 증거만 허용했습니다.
- #1108과 겹치는 impl-loop 문서는 `(JOURNEY)` 인계·실행 문구만 수술적으로 추가하고 통합 브랜치 토폴로지는 변경하지 않았습니다.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1: `agents/product-acceptance.md`와 plugin에 포함되는 `skills/**`가 plugin 업데이트로 자동 배포됩니다.
- 경로 2: 새 복사 파일이나 workflow가 없고 runner는 기존 plugin script를 그대로 쓰므로 `/init-dcness` deploy step 추가가 필요 없습니다.
- 경로 3: 사용자 계약 SSOT인 `docs/plugin/**`를 함께 갱신해 taxonomy·소유권·실행 경계를 plugin 배포물에 포함했습니다.
- 검증: plugin manifest, public surface, cross-ref, doc path, index/design structure 게이트가 모두 통과했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 `/impl-loop`, `/acceptance`, `product-acceptance`, `dcness-product-journey` 내부 lifecycle만 확장했으며 새 public surface는 없습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증

세부 검증:

- `python3.11 -m unittest discover -s tests -v` — 1,951 tests PASS
- `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- ruff, mypy, Bandit PASS
- 행동 eval 30개 케이스: 29개 최초 PASS, 비결정적 1개 재측정 3/3 PASS

## 참고

- `harness/product_journey.py`, `harness/agent_boundary.py`, `.dcness/` 보호 패턴은 변경하지 않았습니다.
- 머지는 별도 사용자 결정 후 진행합니다.
