### PR TITLE
[feature] Codex build-worker sandbox opt-in 지원

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality
 | `DCNESS_FORCE_ENABLE` | is-active 게이트 임시 활성 (디버깅) | 미설정 | X |
 | `DCNESS_CODEX_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt timeout | validator `600`, worker `1200` | X |
 | `DCNESS_CODEX_IDLE_TIMEOUT` | `dcness-codex-worker` Codex attempt 의 stdout/prose/workspace 무진행 조기 kill timeout | `180` | X |
+| `DCNESS_CODEX_NETWORK_ACCESS` | `dcness-codex-worker` 의 `workspace-write` network opt-in (`1` / `true` / `on`; `0` / `false` / `off` 는 비활성) | 미설정 | X |
+| `DCNESS_CODEX_WRITABLE_ROOTS` | `dcness-codex-worker` 의 추가 writable roots. 플랫폼 path separator(macOS/Linux `:`)로 여러 절대경로 구분 | 미설정 | X |
 | `DCNESS_CLAUDE_TIMEOUT` | `dcness-claude-worker` Claude headless attempt timeout | `1200` | X |
 | `DCNESS_CLAUDE_IDLE_TIMEOUT` | `dcness-claude-worker` Claude attempt 의 stdout/stderr/workspace 무진행 조기 kill timeout (codex worker 와 패리티) | `180` | X |
 | `DCNESS_CODEX_MODEL` / `DCNESS_CODEX_EFFORT` | Codex headless wrapper model / reasoning effort opt-in override. 미설정 시 사용자 Codex config 상속 | 미설정 | X |

--- a/docs/plugin/hooks.md
+++ b/docs/plugin/hooks.md
@@ -207,6 +207,22 @@ PR/repo 외부 상태 변경 (`gh pr ...` / `merge_pull_request` / `push_files` 
 
 **Headless worker 정책**: [`scripts/dcness-codex-worker`](../../scripts/dcness-codex-worker) 와 [`scripts/dcness-claude-worker`](../../scripts/dcness-claude-worker) 는 성공 prose 생성 후 file-boundary 검사를 먼저 수행하고, 그 다음 changed path(`git diff`/staged diff/untracked) 중 삭제가 아닌 파일을 synthetic `Edit` payload 로 `tdd-guard.sh` 에 다시 넣는다. 중앙 `tdd-guard.sh` 가 generated hook 을 위임하므로 headless worker 도 non-TS/JS 플랫폼에서 같은 project-local **TDD 계약**을 재사용한다. 단, 이 재사용은 generated hook 파일들이 Git 에 커밋되어 해당 worktree 에 존재할 때만 성립한다. `exit 2` 는 step 성공 종료를 차단하고 위반 파일 목록을 출력한다. guard 자체 오류는 `headless-tdd-guard` fail-open event 로 기록하고 작업을 과차단하지 않는다.
 
+**Codex build-worker sandbox opt-in**: 기본 호출은 환경변수를 추가하지 않은 기존 계약 그대로 `-s workspace-write`만 전달한다. 외부 활성 프로젝트가 loopback IPC 또는 workspace 밖 build cache 쓰기를 필요로 할 때만 Claude Code 로컬 설정의 `.claude/settings.local.json` `env` 블록에 아래 값을 둘 수 있다. Bash로 spawn된 `dcness-codex-worker`가 이 값을 상속해 Codex 호출별 설정으로 변환하므로 세션마다 `export`할 필요가 없다.
+
+```json
+{
+  "env": {
+    "DCNESS_CODEX_NETWORK_ACCESS": "1",
+    "DCNESS_CODEX_WRITABLE_ROOTS": "/Users/name/.gradle:/Users/name/.konan"
+  }
+}
+```
+
+- `DCNESS_CODEX_NETWORK_ACCESS=1|true|on`은 `-c sandbox_workspace_write.network_access=true`만 추가한다. 미설정 또는 `0|false|off`는 옵션을 추가하지 않으며, 그 밖의 값은 오타로 보고 worker 시작을 거부한다.
+- `DCNESS_CODEX_WRITABLE_ROOTS`는 플랫폼 path separator(macOS/Linux `:`)로 구분한 절대경로 목록이다. wrapper가 각 원소를 JSON 호환 TOML string array로 encode한 뒤 `-c sandbox_workspace_write.writable_roots=[...]`를 추가하므로 공백·따옴표·backslash가 한 CLI 인자 안에서 보존된다.
+- 두 opt-in은 서로 독립이며 `workspace-write`를 유지한다. `danger-full-access` 전환은 제공하지 않는다.
+- 이 계약은 Codex 설정 키를 사용하는 `codex-headless` build-worker 전용이다. `claude-headless` worker는 Claude Code의 `--permission-mode acceptEdits` 경로이며 Codex sandbox 설정을 소비하지 않으므로 동일 env를 적용하지 않는다. 다른 provider로의 자동 확장은 범위 밖이다.
+
 **차단**: test 부재 시 `exit 2` + 한국어 안내. Bash write target 차단 메시지는 `TDD GUARD[Bash]` 로 시작해 어떤 target 이 matching-test enforcement 에 실패했는지 함께 표시한다. Headless worker 차단 메시지는 `[dcness-codex-worker] BLOCKED: TDD GUARD ...` 또는 `[dcness-claude-worker] BLOCKED: TDD GUARD ...` 로 시작하고 위반 파일 목록을 포함한다.
 
 ### post-agent-clear.sh

--- a/scripts/dcness-codex-worker
+++ b/scripts/dcness-codex-worker
@@ -24,10 +24,15 @@ Environment:
                          before early kill. Default: 180.
   DCNESS_CODEX_MODEL    Optional Codex model override. Default: inherit user config.
   DCNESS_CODEX_EFFORT   Optional reasoning effort override. Default: inherit user config.
+  DCNESS_CODEX_NETWORK_ACCESS  Opt in to workspace-write network access with
+                         1, true, or on. Unset/0/false/off keeps the default.
+  DCNESS_CODEX_WRITABLE_ROOTS  Optional path-separator-delimited list of
+                         additional workspace-write writable roots.
 
-The wrapper runs Codex in workspace-write mode. Model and effort overrides are
-only passed when the matching environment variables are set:
-  codex [-m "$DCNESS_CODEX_MODEL"] [-c "model_reasoning_effort=$DCNESS_CODEX_EFFORT"] exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE"
+The wrapper always runs Codex in workspace-write mode. Model, effort, network,
+and writable-root overrides are only passed when the matching environment
+variables opt in. It never offers danger-full-access:
+  codex [-m "$DCNESS_CODEX_MODEL"] [-c "model_reasoning_effort=$DCNESS_CODEX_EFFORT"] [-c sandbox_workspace_write.network_access=true] [-c 'sandbox_workspace_write.writable_roots=[...]'] exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE"
 
 On success it validates changed paths against dcNess agent_boundary, reuses
 tdd-guard matching-test enforcement for Codex-changed implementation files, and stores:
@@ -78,6 +83,8 @@ CODEX_TIMEOUT="${DCNESS_CODEX_TIMEOUT:-1200}"
 CODEX_IDLE_TIMEOUT="${DCNESS_CODEX_IDLE_TIMEOUT:-180}"
 CODEX_MODEL="${DCNESS_CODEX_MODEL:-}"
 CODEX_EFFORT="${DCNESS_CODEX_EFFORT:-}"
+CODEX_NETWORK_ACCESS="${DCNESS_CODEX_NETWORK_ACCESS:-}"
+CODEX_WRITABLE_ROOTS="${DCNESS_CODEX_WRITABLE_ROOTS:-}"
 
 abs_path() {
   case "$1" in
@@ -164,6 +171,34 @@ if ! command -v codex >/dev/null 2>&1; then
   exit 127
 fi
 
+CODEX_NETWORK_CONFIG=""
+case "$CODEX_NETWORK_ACCESS" in
+  '') ;;
+  1|true|on)
+    CODEX_NETWORK_CONFIG="sandbox_workspace_write.network_access=true"
+    ;;
+  0|false|off) ;;
+  *)
+    echo "[dcness-codex-worker] DCNESS_CODEX_NETWORK_ACCESS must be one of 1/true/on or 0/false/off: $CODEX_NETWORK_ACCESS" >&2
+    exit 2
+    ;;
+esac
+
+CODEX_WRITABLE_ROOTS_CONFIG=""
+if [ -n "$CODEX_WRITABLE_ROOTS" ]; then
+  if ! CODEX_WRITABLE_ROOTS_TOML="$(python3 -c '
+import json
+import os
+
+roots = [root for root in os.environ["DCNESS_CODEX_WRITABLE_ROOTS"].split(os.pathsep) if root]
+print(json.dumps(roots, ensure_ascii=False))
+')"; then
+    echo "[dcness-codex-worker] failed to encode DCNESS_CODEX_WRITABLE_ROOTS as a TOML string array" >&2
+    exit 2
+  fi
+  CODEX_WRITABLE_ROOTS_CONFIG="sandbox_workspace_write.writable_roots=$CODEX_WRITABLE_ROOTS_TOML"
+fi
+
 cd "$PROJECT_ROOT"
 
 dcness_resolve_headless_context "dcness-codex-worker" "$PROJECT_ROOT" "$SCRIPT_DIR"
@@ -229,6 +264,12 @@ if [ -n "$CODEX_MODEL" ]; then
 fi
 if [ -n "$CODEX_EFFORT" ]; then
   CODEX_CMD+=( -c "model_reasoning_effort=$CODEX_EFFORT" )
+fi
+if [ -n "$CODEX_NETWORK_CONFIG" ]; then
+  CODEX_CMD+=( -c "$CODEX_NETWORK_CONFIG" )
+fi
+if [ -n "$CODEX_WRITABLE_ROOTS_CONFIG" ]; then
+  CODEX_CMD+=( -c "$CODEX_WRITABLE_ROOTS_CONFIG" )
 fi
 CODEX_ARGS=(exec -C "$PROJECT_ROOT" -s workspace-write --output-last-message "$TMP_PROSE" -)
 

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -1,6 +1,7 @@
 """Smoke tests for the Codex validator wrapper."""
 from __future__ import annotations
 
+import json
 import os
 import re
 import subprocess
@@ -583,6 +584,175 @@ class CodexValidatorWrapperTests(unittest.TestCase):
 
 
 class CodexWorkerWrapperTests(unittest.TestCase):
+    def _capture_worker_args(
+        self,
+        *,
+        network_access: str | None = None,
+        writable_roots: list[str] | None = None,
+    ) -> tuple[list[str], str]:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt_file = tmp / "prompt.md"
+            prompt_file.write_text("Implement the task.\n", encoding="utf-8")
+            args_capture = tmp / "codex-args.txt"
+            prose_capture = tmp / "captured-prose.md"
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            codex = bin_dir / "codex"
+            codex.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = "--help" ]; then
+                      echo "Usage: codex [OPTIONS]"
+                      echo "  -a, --ask-for-approval <APPROVAL_POLICY>"
+                      exit 0
+                    fi
+                    printf '%s\\n' "$@" > "$ARGS_CAPTURE"
+                    out=""
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --output-last-message)
+                          out="$2"
+                          shift 2
+                          ;;
+                        *)
+                          shift
+                          ;;
+                      esac
+                    done
+                    cat >/dev/null
+                    printf 'Worker prose\\n\\nPASS\\n' > "$out"
+                    """
+                ),
+                encoding="utf-8",
+            )
+            codex.chmod(0o755)
+
+            helper = tmp / "dcness-helper"
+            helper.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    while [ "$#" -gt 0 ]; do
+                      case "$1" in
+                        --prose-file)
+                          cp "$2" "$PROSE_CAPTURE"
+                          exit 0
+                          ;;
+                      esac
+                      shift
+                    done
+                    exit 1
+                    """
+                ),
+                encoding="utf-8",
+            )
+            helper.chmod(0o755)
+
+            env = os.environ.copy()
+            for key in (
+                "DCNESS_CODEX_EFFORT",
+                "DCNESS_CODEX_MODEL",
+                "DCNESS_CODEX_NETWORK_ACCESS",
+                "DCNESS_CODEX_WRITABLE_ROOTS",
+            ):
+                env.pop(key, None)
+            env.update(
+                {
+                    "ARGS_CAPTURE": str(args_capture),
+                    "DCNESS_RUN_ID": "run-sandbox1",
+                    "DCNESS_SESSION_ID": "sid-worker-sandbox",
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    "PROSE_CAPTURE": str(prose_capture),
+                }
+            )
+            if network_access is not None:
+                env["DCNESS_CODEX_NETWORK_ACCESS"] = network_access
+            if writable_roots is not None:
+                env["DCNESS_CODEX_WRITABLE_ROOTS"] = os.pathsep.join(writable_roots)
+
+            result = subprocess.run(
+                [
+                    str(WORKER),
+                    "build-worker",
+                    "--prompt-file",
+                    str(prompt_file),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            return args_capture.read_text(encoding="utf-8").splitlines(), str(project)
+
+    def test_worker_default_sandbox_args_remain_workspace_write_only(self) -> None:
+        for network_access in (None, "0", "false", "off"):
+            with self.subTest(network_access=network_access):
+                args, project = self._capture_worker_args(
+                    network_access=network_access,
+                )
+
+                self.assertEqual(
+                    args[:7],
+                    [
+                        "-a",
+                        "never",
+                        "exec",
+                        "-C",
+                        project,
+                        "-s",
+                        "workspace-write",
+                    ],
+                )
+                self.assertEqual(args[7], "--output-last-message")
+                self.assertTrue(args[8])
+                self.assertEqual(args[9:], ["-"])
+                self.assertNotIn("-c", args)
+
+    def test_worker_adds_only_opted_in_sandbox_config_with_toml_escaping(self) -> None:
+        writable_roots = [
+            "/tmp/gradle cache",
+            '/tmp/quoted"cache',
+            "/tmp/back\\slash",
+        ]
+
+        args, project = self._capture_worker_args(
+            network_access="true",
+            writable_roots=writable_roots,
+        )
+
+        self.assertEqual(
+            args[:11],
+            [
+                "-a",
+                "never",
+                "-c",
+                "sandbox_workspace_write.network_access=true",
+                "-c",
+                "sandbox_workspace_write.writable_roots="
+                + json.dumps(writable_roots, ensure_ascii=False),
+                "exec",
+                "-C",
+                project,
+                "-s",
+                "workspace-write",
+            ],
+        )
+        self.assertEqual(args[11], "--output-last-message")
+        self.assertTrue(args[12])
+        self.assertEqual(args[13:], ["-"])
+
     def test_worker_embeds_agent_docs_writes_workspace_and_stores_prose(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -584,12 +584,12 @@ class CodexValidatorWrapperTests(unittest.TestCase):
 
 
 class CodexWorkerWrapperTests(unittest.TestCase):
-    def _capture_worker_args(
+    def _run_worker_for_args(
         self,
         *,
         network_access: str | None = None,
         writable_roots: list[str] | None = None,
-    ) -> tuple[list[str], str]:
+    ) -> tuple[subprocess.CompletedProcess[str], list[str], str]:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)
             project = tmp / "project"
@@ -693,8 +693,25 @@ class CodexWorkerWrapperTests(unittest.TestCase):
                 text=True,
             )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
-            return args_capture.read_text(encoding="utf-8").splitlines(), str(project)
+            args = (
+                args_capture.read_text(encoding="utf-8").splitlines()
+                if args_capture.exists()
+                else []
+            )
+            return result, args, str(project)
+
+    def _capture_worker_args(
+        self,
+        *,
+        network_access: str | None = None,
+        writable_roots: list[str] | None = None,
+    ) -> tuple[list[str], str]:
+        result, args, project = self._run_worker_for_args(
+            network_access=network_access,
+            writable_roots=writable_roots,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return args, project
 
     def test_worker_default_sandbox_args_remain_workspace_write_only(self) -> None:
         for network_access in (None, "0", "false", "off"):
@@ -752,6 +769,54 @@ class CodexWorkerWrapperTests(unittest.TestCase):
         self.assertEqual(args[11], "--output-last-message")
         self.assertTrue(args[12])
         self.assertEqual(args[13:], ["-"])
+
+    def test_worker_sandbox_opt_ins_are_independent(self) -> None:
+        writable_roots = ["/tmp/gradle cache"]
+        cases = (
+            (
+                "network-only",
+                "on",
+                None,
+                ["sandbox_workspace_write.network_access=true"],
+            ),
+            (
+                "roots-only",
+                None,
+                writable_roots,
+                [
+                    "sandbox_workspace_write.writable_roots="
+                    + json.dumps(writable_roots, ensure_ascii=False)
+                ],
+            ),
+        )
+
+        for name, network_access, roots, expected_configs in cases:
+            with self.subTest(name=name):
+                args, _project = self._capture_worker_args(
+                    network_access=network_access,
+                    writable_roots=roots,
+                )
+                actual_configs = [
+                    args[index + 1]
+                    for index, arg in enumerate(args)
+                    if arg == "-c"
+                ]
+                self.assertEqual(actual_configs, expected_configs)
+                self.assertEqual(args.count("-c"), 1)
+                self.assertIn("workspace-write", args)
+
+    def test_worker_rejects_invalid_network_access_before_codex(self) -> None:
+        result, args, _project = self._run_worker_for_args(
+            network_access="enabled",
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertEqual(args, [])
+        self.assertIn(
+            "DCNESS_CODEX_NETWORK_ACCESS must be one of "
+            "1/true/on or 0/false/off: enabled",
+            result.stderr,
+        )
 
     def test_worker_embeds_agent_docs_writes_workspace_and_stores_prose(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1105

## 배경 및 문제

- Codex headless build-worker가 항상 기본 `workspace-write` sandbox로 실행되어, loopback IPC와 workspace 밖 build cache 쓰기가 필요한 Gradle 계열 외부 활성 프로젝트를 자체 검증하지 못했습니다.

## 원인 (해당 시)

- 기존 wrapper는 `-s workspace-write`만 고정 전달했고, Codex가 제공하는 `sandbox_workspace_write.network_access`와 `sandbox_workspace_write.writable_roots`를 프로젝트별로 opt-in할 전달 경로가 없었습니다.

## 작업내용

- `DCNESS_CODEX_NETWORK_ACCESS=1|true|on`일 때만 Codex network access 설정을 추가하고, 미설정 또는 `0|false|off`는 기존 인자를 그대로 유지합니다.
- `DCNESS_CODEX_WRITABLE_ROOTS`의 path-separator 목록을 JSON 호환 TOML string array로 encode해 추가 writable roots로 전달합니다.
- 기본/비활성 호출의 완전한 인자 회귀, 잘못된 network 값의 `exit 2`, 두 opt-in의 독립 동작, 공백·따옴표·backslash가 포함된 writable roots escape를 worker 단위 테스트로 고정했습니다.
- `CLAUDE.md` 환경변수 표와 `docs/plugin/hooks.md` headless worker 정책에 설정법, 안전 경계, `claude-headless` 미적용 결론을 동기화했습니다.

## 결정 근거

- Codex 공식 configuration reference의 `sandbox_workspace_write.network_access`와 `sandbox_workspace_write.writable_roots` 계약을 사용해 `workspace-write`를 유지했습니다.
- `danger-full-access`는 제공하지 않고 필요한 network/root 권한만 독립 opt-in으로 열었습니다.
- `claude-headless`는 Codex sandbox 설정이 아닌 Claude Code `--permission-mode acceptEdits` 경로이므로 신규 env를 적용하지 않았습니다.

## 배포 경로 검증 (plug-in 영향 시)

- wrapper는 plugin root의 `scripts/dcness-codex-worker`에서 직접 실행되므로 plugin update/release artifact로 외부 활성 프로젝트에 도달합니다. 사용자 프로젝트에 복사하는 `/init-dcness` inventory 변경은 필요하지 않습니다.
- 외부 사용자 계약은 plugin 배포 문서인 `docs/plugin/hooks.md`에 반영했습니다. 기존 사용자는 plugin update 후 프로젝트별 `.claude/settings.local.json` `env` opt-in만 추가하면 됩니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 build-worker wrapper의 선택형 환경변수 계약만 확장하며 public skill/command/agent/gate는 추가하지 않습니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,955 tests PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/Bandit PASS
- [x] `node scripts/check_cross_refs.mjs` — PASS
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] `node scripts/check_plugin_manifest.mjs` — PASS
- [x] `node scripts/aggregate_index_map.mjs --check` — PASS
- [x] `node scripts/check_design_artifact_structure.mjs` — PASS
- [x] `python3.11 evals/guard_efficacy.py` — 39/39 PASS
- [x] `bash -n scripts/dcness-codex-worker` 및 `git diff --check` — PASS

## 참고

- 실제 외부 활성 Android 프로젝트에서 Gradle build/test가 headless worker 안에서 GREEN인지 확인하는 항목은 이슈의 human verification으로 남깁니다.
