### PR TITLE
[docs] release 0.23.0 — story PR stack·Codex sandbox opt-in·marketplace 경량화·UI journey·release preflight

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — Claude Code와 Codex를 제품 개발 루프에 묶고 순서 게이트, 역할 경계, TDD guard, 검증 가능한 작업 기록을 제공하는 agent workflow harness. release 브랜치의 경량 runtime artifact 배포.",
-    "version": "0.22.1"
+    "version": "0.23.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "Claude Code와 Codex를 Git/PR/CI 흐름 안에서 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 묶는 agent workflow harness. (한국어 사용자 대상)",
   "author": {
     "name": "alruminum",

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.22.1","measured_at":"2026-07-14","unit_tests":{"passed":1946,"total":1946},"guard":{"passed":39,"total":39},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.23.0","measured_at":"2026-07-14","unit_tests":{"passed":1963,"total":1963},"guard":{"passed":39,"total":39},"source_project_count":2} -->
 
-현재 공개 snapshot은 **v0.22.1, 2026-07-14 측정**이다. 숫자마다 분모와 source 수를
+현재 공개 snapshot은 **v0.23.0, 2026-07-14 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,946/1,946 PASS, 결정적 guard 39/39 PASS | test 1,946, guard case 39 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,963/1,963 PASS, 결정적 guard 39/39 PASS | test 1,963, guard case 39 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -6,18 +6,40 @@
 
 ## Unreleased
 
-- **`/impl-loop` story stack topology 전환 — breaking migration (#1108, PR #1111)** — 다중
-  story 구현에서 long-lived 통합 브랜치와 `**Base Branch:**` marker를 폐기하고, PR 생성
-  시 story branch stack을 유지한 뒤 merge gate가 열린 시점에 `main`으로 리타겟·리베이스한다.
-  플러그인 업데이트 시 marker가 남은 in-flight epic은 `pr-trailer`와 issue 생성이 fail-fast하므로,
-  marker를 제거하고 `dcness-story-runner next-action`의 `pr_base`에 따라 story branch를
-  재구성한 뒤 계속해야 한다. 기존 진행 branch는 자동 변환하지 않는다.
-- **marketplace artifact 경량화 (#1102)** — clean install/update가 `release` ref를 직접 소비하도록
-  marketplace source를 현행 GitHub source 계약으로 복구하고, candidate·release sync가 하나의
-  artifact manifest를 공유한다. 격리 install 기준 self 전용 파일을 제거한 payload는
-  549파일·5,159,235 bytes·102,346 LOC에서 191파일·2,139,171 bytes·43,138 LOC로 줄었으며,
-  SessionStart additionalContext는 별도 지표(2,068 bytes, 약 517 token)로 유지해 package 감소를
-  prompt 감소로 주장하지 않는다.
+_(현재 없음)_
+
+---
+
+## v0.23.0 (2026-07-14)
+
+**커밋 범위**: `v0.22.0..v0.23.0` (머지 PR 7개, #1101 · #1103 · #1104 · #1109 · #1110 · #1111 · #1114)
+**핵심 변경**: **`/impl-loop` multi-story 토폴로지를 통합 브랜치에서 story PR stack 으로 바꾼 breaking 릴리즈** 이면서, **Codex headless build-worker 의 sandbox 경계를 프로젝트별 opt-in + 사용자 승인 복구로 열고**, marketplace 배포 artifact 를 경량화하고, 제품 outcome 증거 사슬을 UI journey 까지 확장하고, 릴리즈 운영을 단일 preflight 도구로 자동화한 minor 릴리즈. (1) 다중 story 구현이 long-lived 통합 브랜치·`Base Branch` marker 를 폐기하고 story branch stack 을 유지하다 merge 직전에만 `main` 으로 리타겟·rebase, (2) Codex `workspace-write` 의 network/writable-root 를 env opt-in 으로 열고 sandbox 거부를 감지→승인→1회 재시도로 복구, (3) marketplace clean install/update 가 `release` ref 를 직접 소비하도록 배포 artifact 를 단일 manifest 로 경량화(549→191 files), (4) product journey runner 에 UI 화면 증거(`boundary=ui`)와 `(JOURNEY)` 검증 경계 lifecycle 을 추가, (5) 릴리즈 전 evidence 축을 고정 순서로 한 번에 수집하는 `scripts/release_preflight.py` 운영 자동화와 공개 evidence 비식별화·문구 정정.
+
+### 무엇이 바뀌나
+
+1. **`/impl-loop` story PR stack 전환 — breaking migration** ([#1111](https://github.com/Daeguk-Sun/dcNess/pull/1111) Closes [#1108](https://github.com/Daeguk-Sun/dcNess/issues/1108)) — multi-story 흐름이 long-lived 통합 브랜치와 자동 merge 를 전제해 "사용자만 merge 를 승인한다" 는 운영 원칙 및 story 별 독립 PR 검증과 충돌하던 문제를 해소. story 1 은 `main`, 이후 story 는 직전 story branch 를 base 로 하는 stack 정보를 runner 가 산출하고, non-default base PR 의 finalize 를 fail-fast 로 차단하며, merge 직전에만 `main` 리타겟·rebase 및 downstream restack 을 수행한다. PR base 조회 실패도 fail-closed 로 처리하고 peer lock 이후 merge 직전 base 를 재검증한다. 자동 merge 를 제거하고 조건부 QA PR·stack-tip 대비 Code Validation/Sanity·story close acceptance 규칙을 동기화했으며, `Base Branch` marker 를 폐기했다. **마이그레이션**: 플러그인 업데이트 시 marker 가 남은 in-flight epic 은 `pr-trailer` 와 issue 생성이 fail-fast 하므로, marker 를 제거하고 `dcness-story-runner next-action` 의 `pr_base` 에 따라 story branch 를 재구성한 뒤 계속해야 한다. 기존 진행 branch 는 자동 변환하지 않는다.
+
+2. **Codex build-worker sandbox opt-in + 사용자 승인 복구** ([#1110](https://github.com/Daeguk-Sun/dcNess/pull/1110) Closes [#1105](https://github.com/Daeguk-Sun/dcNess/issues/1105), [#1114](https://github.com/Daeguk-Sun/dcNess/pull/1114) Closes [#1113](https://github.com/Daeguk-Sun/dcNess/issues/1113)) — Codex headless build-worker 가 항상 기본 `workspace-write` sandbox 로 실행돼 loopback IPC·workspace 밖 build cache 쓰기가 필요한 Gradle 계열 외부 활성 프로젝트를 자체 검증하지 못하던 문제를 해소. `DCNESS_CODEX_NETWORK_ACCESS=1|true|on` 일 때만 network access 를, `DCNESS_CODEX_WRITABLE_ROOTS` 의 path-separator 목록으로 추가 writable roots 를 opt-in 전달한다(`danger-full-access` 미제공, 미설정·`off` 는 기존 인자 유지). 이어서 sandbox 거부를 일반 검증 실패와 구분해, `VALIDATION_BLOCKED` prose 를 제외한 Codex raw log 에서 실제 SocketException/sandbox write signature 만 permission receipt·ledger event 로 기록하고, `dcness-codex-permission` helper 가 이번 실행만 허용/프로젝트 저장(`.claude/settings.local.json` 보존 병합)/거부를 처리한 뒤 승인한 env 만 Codex worker 재시도 1회에 전달한다.
+
+3. **marketplace artifact 경량화 + install/update 정합** ([#1103](https://github.com/Daeguk-Sun/dcNess/pull/1103) Closes [#1102](https://github.com/Daeguk-Sun/dcNess/issues/1102)) — 기존 `source: "./"` 설치가 저장소 전체 checkout 을 cache 에 복사해 사용자가 소비하지 않는 테스트·평가·내부 문서·self CI 도구까지 배포하던 문제를 해소. `scripts/release_artifact.json` 을 단일 include/exclude·필수 runtime·허용 cache metadata 계약으로 추가하고, marketplace source 를 GitHub `release` ref 로 전환해 candidate·release sync 가 하나의 artifact manifest 를 공유한다. 격리 install 기준 self 전용 파일을 제거한 payload 는 549파일·5,159,235 bytes·102,346 LOC 에서 191파일·2,139,171 bytes·43,138 LOC 로 줄었으며, Claude Code 2.1.170 으로 clean install 과 이전→새 명시 버전 update 를 모두 격리 검증했다. SessionStart additionalContext 는 별도 지표(2,068 bytes, 약 517 token)로 유지해 package 감소를 prompt 감소로 주장하지 않는다.
+
+4. **UI journey 실행 증거 pilot + `(JOURNEY)` 검증 경계 lifecycle** ([#1104](https://github.com/Daeguk-Sun/dcNess/pull/1104) Closes [#1080](https://github.com/Daeguk-Sun/dcNess/issues/1080), [#1109](https://github.com/Daeguk-Sun/dcNess/pull/1109) Closes [#1107](https://github.com/Daeguk-Sun/dcNess/issues/1107)) — 기존 product journey runner 가 `api`·`cli`·`integration` 경계만 허용해 UI 다단계 흐름의 화면 상태·screenshot 을 receipt 에 연결하지 못하던 문제를 해소. runner 에 선택적 `boundary=ui` 와 `ui_evidence.steps` 를 추가해 UI 단계 최소 2개·final 단계 전체 AC coverage·screenshot/state/log 의 run-directory 경계·존재·SHA-256 을 fail-closed 로 검증하고, mock-only·앱 미기동·evidence 변조·symlink escape 가 제품 outcome PASS 가 되지 않게 했다. 이어서 module-architect REQ 에 도구 중립 `(JOURNEY)` taxonomy 를 추가하고, build-worker 는 flow·매니페스트만 작성한 뒤 product-acceptance 가 조건부 Bash 로 봉인 러너를 실행하는 lifecycle(설계 taxonomy→build-worker 산출물→acceptance 실행·판정)을 연결했다.
+
+5. **릴리즈 운영 자동화(preflight) + 공개 evidence 비식별화·문구 정정** ([#1114](https://github.com/Daeguk-Sun/dcNess/pull/1114) 내 [#1088](https://github.com/Daeguk-Sun/dcNess/issues/1088), [#1101](https://github.com/Daeguk-Sun/dcNess/pull/1101) Closes [#1064](https://github.com/Daeguk-Sun/dcNess/issues/1064)) — 릴리즈 전 evidence 축(guard·핵심 행동 eval·judge calibration·제품 outcome·agent effectiveness·경량화 결정·공개 evidence·bundle 소비 smoke)을 감사 가능한 고정 순서로 한 번에 수집하는 `scripts/release_preflight.py` 와 harness 실험 러너(`evals/harness_experiment.py`), loop_diagnose 진단 보강을 추가했다. 함께, benchmark snapshot 측정일과 prose 불일치를 교정하고 cross-session 값을 unmeasured(null) 의미로 정정했으며, sanitizer/validator 의 host-home 탐지가 macOS `/Users` 뿐 아니라 Linux `/home` 경로도 `<HOME>` 으로 치환·거부하도록 강화했다.
+
+### 자기개선 점검
+
+- Sense/Diagnose: 이번 릴리즈 diff 가 order gate·headless worker(Codex sandbox)·boundary·TDD 인접 영역과 story-runner·product journey·release artifact 를 건드려 결정적 guard-efficacy 를 재실행 — **39/39 PASS**, 회귀 없음. 전체 unittest 도 재실행해 공개 snapshot 수치를 실측 동기화했다. 각 머지 PR 은 개별 CI(pytest·static-quality·public-surface·cross-ref·index-map·doc-sync)와 guard-efficacy 39/39 를 통과했고, #1104·#1109·#1111 은 행동 eval(30/30 등)을 개별 실행했다.
+- Decide: 소멸 후보 없음. follow-up 없음. (marketplace artifact·release preflight 로 배포 경계·릴리즈 절차를 오히려 단순화했다.)
+- Verify: 7개 머지 PR 각각 CI PASS. story PR stack runner·Codex sandbox opt-in/permission·release artifact·UI journey·(JOURNEY) lifecycle·release preflight 신규/회귀 테스트 통과. LLM 기반 핵심 행동 eval 은 사용자 지시 minor 배포라 릴리즈 시점 재실행은 생략(advisory)하고 각 PR 개별 실행 결과로 갈음했다.
+
+### 사용자 영향
+
+- **`claude plugin update dcness@dcness` 로 자동 반영** — `harness/**`·`hooks/**`·`scripts/**`·`skills/**`·`agents/**`·`docs/plugin/**` 변경. marketplace 는 이제 경량 `release` ref artifact 를 소비한다.
+- **`/impl-loop` 로 multi-story/epic 을 도는 프로젝트 (breaking)** — 통합 브랜치·`Base Branch` marker 가 폐기되고 story PR stack 으로 바뀐다. marker 가 남은 in-flight epic 은 marker 제거 + `dcness-story-runner next-action` 의 `pr_base` 기준 story branch 재구성 후 계속해야 하며, 자동 변환은 없다.
+- **Codex headless build-worker(Gradle 등) 사용 프로젝트** — `.claude/settings.local.json` 의 `env` 에 `DCNESS_CODEX_NETWORK_ACCESS`/`DCNESS_CODEX_WRITABLE_ROOTS` opt-in 을 추가하면 loopback IPC·workspace 밖 build cache 쓰기가 필요한 검증을 headless 로 수행할 수 있고, sandbox 거부 시 승인→1회 재시도 복구 여정이 제공된다.
+- **marketplace 설치/업데이트 사용자** — 설치 cache 가 저장소 전체 checkout 이 아니라 경량 `release` ref artifact(v0.23.0 릴리즈 smoke 실측 194파일·약 2.23MB·45,019 LOC)를 소비한다. 소비하지 않던 테스트·평가·내부 문서·self CI 도구가 더는 배포되지 않는다.
+- **`/acceptance`·`/impl-loop` 로 제품 검수하는 프로젝트** — UI 다단계 흐름의 화면 증거(`boundary=ui`)와 `(JOURNEY)` 검증 경계가 연결돼, mock-only/설명만으로 UI Story AC 가 제품 outcome PASS 되던 경로가 차단된다.
 
 ---
 

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -7,15 +7,15 @@
 
 ## 현재 공개 Evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.22.1","measured_at":"2026-07-14","unit_tests":{"passed":1946,"total":1946},"guard":{"passed":39,"total":39},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.23.0","measured_at":"2026-07-14","unit_tests":{"passed":1963,"total":1963},"guard":{"passed":39,"total":39},"source_project_count":2} -->
 
-현재 plugin version은 **v0.22.1**, 측정일은 **2026-07-14**이다. 아래 표의 최대
+현재 plugin version은 **v0.23.0**, 측정일은 **2026-07-14**이다. 아래 표의 최대
 source 프로젝트 수는 2이며, 영역별 실제 source와 denominator는 각 행에 다시 적는다.
 process, Agent effectiveness, product outcome, 비용을 합산한 단일 성공 점수는 만들지 않는다.
 
 | evidence 영역 | 관측값 | denominator | source 수 | 재현 명령 | 한계 |
 |---|---|---:|---:|---|---|
-| 하네스 정의·기계적 guard | unittest 1,946/1,946 PASS; guard fixture 39/39 PASS | test 1,946; guard 39 | dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 테스트와 fixture 계약의 과정 evidence다. 보안 증명·제품 성공률이 아니다 |
+| 하네스 정의·기계적 guard | unittest 1,963/1,963 PASS; guard fixture 39/39 PASS | test 1,963; guard 39 | dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 테스트와 fixture 계약의 과정 evidence다. 보안 증명·제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 | 실측 fixture 1 | `printf '{"version":1,"projects":[]}' > /tmp/dcness-empty-projects.json && python3.11 harness/outcome_scorecard.py --projects-file /tmp/dcness-empty-projects.json --agent-effectiveness-record evals/agent-effectiveness/cartography-sanity-real.json --measured-at 2026-07-12T15:17:58Z --json` | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1)이다. downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 측정 불가다. 1차 거부→계약 개선→2차 채택 경위와 host metadata를 비식별화한 trace, 세션 ID·SHA-256·capture/rebuild 명령 provenance가 [`outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)에 공개된다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished 26/28; PR merge 7/7; validator verdict 33/26 finished run | candidate run 28; measurable PR 7; finished run 26 | 외부 활성 프로젝트 2 | [`outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 두 source-ref 고정 명령 | merge·validator FAIL은 제품 성공률이 아니다. 선택한 legacy ledger의 guard와 regression은 측정 불가 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS; 제품 AC 1/1 | journey 1; AC 1 | 외부 활성 프로젝트 1 | [`outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 CLI/filesystem pilot이다. UI·다른 제품·공개 우위로 일반화할 수 없다 |


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 플러그인 버전 릴리즈(0.22.1 → 0.23.0) 버전 파일 + 릴리즈 노트 + 공개 evidence snapshot 반영 PR. 개별 이슈는 v0.22.0..v0.23.0 범위의 7개 머지 PR 에서 이미 close 됨.

## 배경 및 문제

v0.22.0 이후 머지된 7개 PR(#1101 · #1103 · #1104 · #1109 · #1110 · #1111 · #1114 — impl-loop story PR stack breaking 전환, Codex sandbox opt-in·승인 복구, marketplace artifact 경량화, UI journey·(JOURNEY) lifecycle, release preflight 운영 자동화·evidence 비식별화)을 사용자에게 도달시키려면 플러그인 버전을 올려 release 브랜치로 배포해야 한다. 태그만으로는 사용자에게 도달하지 않는다. 직전 0.22.1 은 #1102 안에서 patch 로 올렸으나 태그·릴리즈되지 않은 상태였다.

## 원인 (해당 시)

-

## 작업내용

- `.claude-plugin/plugin.json` `version` 0.22.1 → 0.23.0
- `.claude-plugin/marketplace.json` `metadata.version` 0.22.1 → 0.23.0
- `docs/internal/release-notes.md` v0.23.0 항목 추가 (7개 PR 을 5개 테마로 그룹화 + 자기개선 점검 + 사용자 영향), Unreleased 비움
- `README.md` · `docs/plugin/benchmark.md` public-evidence snapshot 을 v0.23.0 · unittest 1,963/1,963 · guard 39/39 · 2026-07-14 로 실측 동기화

## 결정 근거

- 7개 PR 은 기능 추가·버그픽스 혼합이며 `/impl-loop` story PR stack 전환(#1108/#1111)이라는 breaking change 를 포함한다. pre-1.0(0.x) 규약과 사용자 지시(마이너 bump)에 따라 minor bump(0.23.0)로 담고, 마이그레이션 절차를 릴리즈 노트에 명시했다.
- 릴리즈 노트는 PR 단위 나열 대신 테마별 그룹으로 사용자 영향 중심 정리.

## 배포 경로 검증 (plug-in 영향 시)

N/A — 버전 파일 + docs/internal 릴리즈 노트 + 공개 evidence snapshot 만 변경. 실제 기능 배포는 이미 머지된 7개 PR 이 담당하며, 본 PR 머지 시 release-sync.yml CI 가 release 브랜치를 자동 갱신해 사용자에게 도달시킨다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public surface 없음.

## Test Plan

- [x] 전체 unittest 1,963/1,963 PASS (python3.11 unittest discover)
- [x] 결정적 guard-efficacy eval 39/39 PASS (회귀 없음)
- [x] public-evidence PASS — version=0.23.0, tests=1,963/1,963, guard=39/39, measured_at=2026-07-14
- [x] release_artifact smoke PASS — 194 files · 2,227,648 bytes · SessionStart 2,068 bytes(약 517 token)
- [x] plugin-manifest PASS — dcness@0.23.0
- [x] cross-ref PASS — dead link / anchor / 옛 명칭 / 고아 0건
- [x] doc-sync(index-map · design-artifact) PASS

## 참고

- 릴리즈 절차 SSOT: `docs/internal/plugin-release.md`
- LLM 기반 핵심 행동 eval 은 사용자 지시 minor 배포라 릴리즈 시점 재실행 생략(advisory) — 각 머지 PR 에서 개별 실행됨(#1104·#1109·#1111 행동 eval 등).
