### PR TITLE
[feature] 정책 수명주기 inventory와 baseline 확정

### DIFF
--- a/docs/internal/outcome-baseline.md
+++ b/docs/internal/outcome-baseline.md
@@ -92,6 +92,7 @@ receipt는 `landing` → `onboarding` → `underage-rejection` → final `profil
 
 - Cartography freshness에서 얻을 수 있는 것: 현재 SSOT·runtime entrypoint·capability owner 후보, affected route의 stale 여부와 갱신·재검증 기록.
 - Codebase Sanity에서 얻을 수 있는 것: 감사 code revision, 실제 scope, 명령·warning·coverage 근거, dead-code 분류와 unknown.
+- #1089 cleanup 전 repository-size·compatibility snapshot은 [`policy-sunset-inventory.md`](policy-sunset-inventory.md)에 별도 고정한다.
 - 아직 측정할 수 없는 것: 첫 올바른 대상 선택 정확도와 시간, 불필요한 read/tool 양, 오경로, 영향 범위 누락, context 기인 validator 재작업, cross-session 복구 성공의 paired before/after.
 
 기능 또는 receipt가 존재한다는 사실은 마지막 항목들의 개선 증거가 아니다. 후속 trial이 생길 때까지 `측정 불가`를 실패나 개선으로 추정하지 않는다.

--- a/docs/internal/policy-sunset-baseline.json
+++ b/docs/internal/policy-sunset-baseline.json
@@ -1,0 +1,65 @@
+{
+  "definitions": {
+    "code_loc": "*.py under harness/, scripts/, and evals/",
+    "compatibility_candidates": "inventory entries classified 제거 가능 or 한시적 호환 필요",
+    "large_files": "major text files with logical LOC >= threshold",
+    "major_text_suffixes": [
+      ".js",
+      ".json",
+      ".md",
+      ".mjs",
+      ".py",
+      ".sh",
+      ".toml",
+      ".yaml",
+      ".yml"
+    ],
+    "test_functions": "Python AST FunctionDef/AsyncFunctionDef names starting test_",
+    "test_loc": "*.py under tests/",
+    "tracked_files": "git ls-tree -r --name-only <revision>"
+  },
+  "inventory": {
+    "by_area": {
+      "design": 6,
+      "install-path": 5,
+      "lifecycle": 5,
+      "routing": 5,
+      "run-ledger": 8
+    },
+    "by_classification": {
+      "제거 가능": 4,
+      "한시적 호환 필요": 11,
+      "현재 실사용": 14
+    },
+    "by_follow_up_issue": {
+      "1093": 6,
+      "1094": 8,
+      "1095": 5,
+      "1096": 5,
+      "1097": 5
+    },
+    "compatibility_candidates": 15,
+    "entries_total": 29
+  },
+  "metrics": {
+    "code_and_test_loc": 69865,
+    "code_loc": 29190,
+    "files_ge_1000_loc": 18,
+    "files_ge_500_loc": 56,
+    "major_text_files": 519,
+    "major_text_loc": 104856,
+    "revision": "b676140bcffdaa5843ce59198ecef4f997efddc9",
+    "test_functions": 1943,
+    "test_loc": 40675,
+    "tracked_files": 560
+  },
+  "purpose": "#1089 cleanup before/after comparison baseline",
+  "schema_version": 1,
+  "unit_suite": {
+    "command": "python3.11 -m unittest discover -s tests -v < /dev/null",
+    "elapsed_seconds": 118.693,
+    "exit_code": 0,
+    "failure_tail": "",
+    "tree_mode": "detached_git_worktree"
+  }
+}

--- a/docs/internal/policy-sunset-inventory.json
+++ b/docs/internal/policy-sunset-inventory.json
@@ -1,0 +1,443 @@
+{
+  "schema_version": 1,
+  "snapshot_revision": "b676140bcffdaa5843ce59198ecef4f997efddc9",
+  "classification_enum": [
+    "현재 실사용",
+    "제거 가능",
+    "한시적 호환 필요"
+  ],
+  "entries": [
+    {
+      "id": "DES-001",
+      "area": "design",
+      "policy_slice": "module responsibility와 decision link 기반 현행 설계 authoring",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1093,
+      "current_ssot": ["docs/plugin/deliverables-map.md#설계-산출물"],
+      "implementation": ["docs/plugin/agents/module-architect/module-architect-agent.md", "docs/plugin/agents/system-architect/templates/epic-architecture.md"],
+      "tests_fixtures": ["tests/test_contract_pointer_model.py", "tests/fixtures/architecture-cartography"],
+      "docs_distribution": ["skills/design/SKILL.md", "docs/plugin/agents/_shared/module-design-principles.md"],
+      "consumer_evidence": "신규 template과 design workflow가 모듈 목록·decision 참조를 생성하고 관련 회귀 테스트가 이를 진본으로 검증한다.",
+      "compatibility": null
+    },
+    {
+      "id": "DES-002",
+      "area": "design",
+      "policy_slice": "legacy contract sync authoring mode와 전용 sweep report",
+      "classification": "제거 가능",
+      "follow_up_issue": 1093,
+      "current_ssot": ["docs/plugin/deliverables-map.md#설계-산출물"],
+      "implementation": ["docs/plugin/agents/module-architect/module-architect-agent.md#legacy-contract-sync", "docs/plugin/agents/module-architect/templates/contract-sweep-report.md"],
+      "tests_fixtures": ["tests/test_contract_pointer_model.py", "tests/test_design_surface.py"],
+      "docs_distribution": ["agents/module-architect.md", "docs/plugin/agents/module-architect/references/contract-amendment.md"],
+      "consumer_evidence": "현행 /design 진입은 epic-batch·revision·Cartography refresh만 사용하며 legacy sync를 호출하는 runtime route나 생성기가 저장소에 없다.",
+      "compatibility": null
+    },
+    {
+      "id": "DES-003",
+      "area": "design",
+      "policy_slice": "legacy Contract Ledger·References·frontmatter warning reader와 deprecated --contract flag",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1093,
+      "current_ssot": ["docs/plugin/deliverables-map.md#설계-산출물"],
+      "implementation": ["scripts/check_design_artifact_structure.mjs:auditArchitecture", "scripts/check_design_artifact_structure.mjs:auditArtifact"],
+      "tests_fixtures": ["tests/test_design_artifact_audit.py"],
+      "docs_distribution": ["docs/plugin/hooks.md", "docs/plugin/init-dcness.md"],
+      "consumer_evidence": "2026-07-14 등록 프로젝트 익명 집계에서 2/5 프로젝트, 72개 문서가 legacy design marker를 보유한다.",
+      "compatibility": {
+        "consumer_or_format": "기존 활성 프로젝트의 Contract Ledger, Contract References, contract frontmatter, Flow Ownership Map 문서",
+        "reason": "doc-sync audit가 기존 문서를 실패시키지 않고 경고로 분류해야 migration 전 프로젝트가 계속 검증된다.",
+        "removal_trigger": "등록 프로젝트의 legacy design marker가 0이 되고 --contract 호출자가 없음을 재조사한 뒤 reader 지원 종료를 명시한다.",
+        "verification": "node scripts/check_design_artifact_structure.mjs --root <legacy-project> --json 및 tests.test_design_artifact_audit"
+      }
+    },
+    {
+      "id": "DES-004",
+      "area": "design",
+      "policy_slice": "architecture map의 legacy Contract Ledger·Decisions table reader",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1093,
+      "current_ssot": ["docs/plugin/deliverables-map.md#cartography"],
+      "implementation": ["scripts/aggregate_architecture_map.mjs:parseEpicArchitecture"],
+      "tests_fixtures": ["tests/test_architecture_map_aggregate.py:test_generates_report_from_epic_architecture_tables"],
+      "docs_distribution": ["docs/plugin/deliverables-map.md", "docs/plugin/init-dcness.md"],
+      "consumer_evidence": "DES-003과 동일한 두 활성 프로젝트의 기존 architecture 문서를 온디맨드 map이 읽는다.",
+      "compatibility": {
+        "consumer_or_format": "## Contract Ledger와 표 형식 ## Decisions가 있는 기존 epic architecture.md",
+        "reason": "migration 전 global map에서 기존 capability와 decision 연결을 잃지 않아야 한다.",
+        "removal_trigger": "기존 architecture 문서를 module list·docs/decisions 형식으로 migration하고 legacy parser 적중이 0임을 확인한다.",
+        "verification": "node scripts/aggregate_architecture_map.mjs --root <legacy-project> --stdout 및 tests.test_architecture_map_aggregate"
+      }
+    },
+    {
+      "id": "DES-005",
+      "area": "design",
+      "policy_slice": "architecture validator와 design routing의 legacy artifact leniency",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1093,
+      "current_ssot": ["docs/plugin/agents/architecture-validator/architecture-validator-agent.md"],
+      "implementation": ["skills/design/design-routing.md", "codex/skills/dcness-architecture-validator/SKILL.md"],
+      "tests_fixtures": ["tests/test_surface_docs_sync.py", "tests/test_contract_pointer_model.py"],
+      "docs_distribution": ["docs/plugin/agents/architecture-validator/references/finding-examples.md", "docs/plugin/agents/module-architect/references/contract-amendment.md"],
+      "consumer_evidence": "기존 설계 문서가 남은 2개 활성 프로젝트에서 형식 잔존만으로 false FAIL하지 않게 하는 reader-side 계약이다.",
+      "compatibility": {
+        "consumer_or_format": "legacy Contract Ledger/References를 포함하지만 현행 module/decision과 충돌하지 않는 설계 pack",
+        "reason": "구양식 존재 자체를 Must finding으로 승격하면 migration되지 않은 활성 프로젝트의 설계 개정이 차단된다.",
+        "removal_trigger": "legacy 문서 migration 완료 후 validator fixture와 실제 프로젝트에서 leniency 없이 같은 판정이 나옴을 확인한다.",
+        "verification": "python3.11 -m unittest tests.test_contract_pointer_model tests.test_surface_docs_sync -v"
+      }
+    },
+    {
+      "id": "DES-006",
+      "area": "design",
+      "policy_slice": "release artifact --contract 옵션의 동명이의 검색 적중",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1093,
+      "current_ssot": ["docs/internal/plugin-release.md"],
+      "implementation": ["scripts/release_artifact.py"],
+      "tests_fixtures": ["tests/test_release_artifact.py"],
+      "docs_distribution": ["docs/internal/release-notes.md"],
+      "consumer_evidence": "release_artifact의 contract는 legacy design row key가 아니라 배포 artifact 계약 파일이며 snapshot/build 검증에서 현재 사용된다.",
+      "compatibility": null
+    },
+    {
+      "id": "RUN-001",
+      "area": "run-ledger",
+      "policy_slice": "canonical ledger.jsonl event writer와 receipt 무결성",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/loop-procedure.md#ledger"],
+      "implementation": ["harness/ledger.py:append_event", "harness/ledger.py:append_step_completed"],
+      "tests_fixtures": ["tests/test_ledger.py", "tests/test_session_state.py"],
+      "docs_distribution": ["docs/plugin/hooks.md", "skills/impl-loop/SKILL.md"],
+      "consumer_evidence": "등록 프로젝트 집계에서 ledger.jsonl 30개가 존재하고 .steps.jsonl은 0개이며 현재 writer는 ledger.jsonl만 생성한다.",
+      "compatibility": null
+    },
+    {
+      "id": "RUN-002",
+      "area": "run-ledger",
+      "policy_slice": "legacy .steps.jsonl reader와 mixed-upgrade merge",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/loop-procedure.md#ledger"],
+      "implementation": ["harness/ledger.py:legacy_steps_path", "harness/ledger.py:_read_events_paths"],
+      "tests_fixtures": ["tests/test_ledger.py", "tests/test_run_review.py"],
+      "docs_distribution": ["docs/plugin/benchmark.md", "scripts/check_cross_refs.mjs"],
+      "consumer_evidence": "활성 프로젝트에는 .steps.jsonl이 없지만 plugin cache와 과거 checkout의 persisted run을 run-review가 읽는 지원 형식으로 코드와 fixture가 명시한다.",
+      "compatibility": {
+        "consumer_or_format": "ledger.jsonl 도입 전 .steps.jsonl 및 업데이트 중 두 파일이 공존하는 mixed run",
+        "reason": "과거 run review와 plugin update 도중 occurrence·prose receipt 순서를 보존한다.",
+        "removal_trigger": "지원 보존 기간을 정하고 cache/보관 run을 migration한 뒤 .steps.jsonl 표본과 실제 호출이 0임을 확인한다.",
+        "verification": "python3.11 -m unittest tests.test_ledger tests.test_run_review -v"
+      }
+    },
+    {
+      "id": "RUN-003",
+      "area": "run-ledger",
+      "policy_slice": "옛 step row 필드명 prose_file·prose_excerpt·must_fix·enum 유지",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/loop-procedure.md#ledger"],
+      "implementation": ["harness/ledger.py:build_receipt", "harness/run_review.py:parse_steps"],
+      "tests_fixtures": ["tests/test_ledger.py", "tests/test_benchmark_aggregate.py", "tests/test_outcome_scorecard.py"],
+      "docs_distribution": ["docs/plugin/benchmark.md", "docs/plugin/outcome-scorecard.md"],
+      "consumer_evidence": "run-review·benchmark·outcome 집계가 현재 receipt와 legacy row를 같은 field vocabulary로 소비한다.",
+      "compatibility": {
+        "consumer_or_format": "legacy step rows와 현행 step_completed receipt의 공통 필드명",
+        "reason": "저장 데이터와 집계 consumer를 동시에 migration하지 않고 이름을 바꾸면 과거 evidence가 누락된다.",
+        "removal_trigger": "canonical receipt schema와 migration tool을 확정하고 모든 reader가 새 필드를 사용한 뒤 legacy fixture를 별도 archive reader로 격리한다.",
+        "verification": "python3.11 -m unittest tests.test_ledger tests.test_benchmark_aggregate tests.test_outcome_scorecard -v"
+      }
+    },
+    {
+      "id": "RUN-004",
+      "area": "run-ledger",
+      "policy_slice": "malformed·partial ledger, invalid receipt, tombstone 안전 처리",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/hooks.md#상태-저장"],
+      "implementation": ["harness/ledger.py:_read_jsonl", "harness/ledger.py:_drop_invalid_primary_steps", "harness/session_state.py"],
+      "tests_fixtures": ["tests/test_ledger.py", "tests/test_session_state.py", "tests/test_state_cleanup.py"],
+      "docs_distribution": ["docs/plugin/loop-procedure.md"],
+      "consumer_evidence": "현재 append-only writer도 crash/partial write와 worktree cleanup을 겪을 수 있어 legacy 여부와 무관한 손상 안전 경계다.",
+      "compatibility": null
+    },
+    {
+      "id": "RUN-005",
+      "area": "run-ledger",
+      "policy_slice": "legacy validator agent-name alias",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/agents/impl-validator/impl-validator-agent.md"],
+      "implementation": ["harness/agent_names.py:LEGACY_AGENT_ALIASES", "harness/run_review.py:LEGACY_AGENT_ALIASES"],
+      "tests_fixtures": ["tests/test_run_review.py", "tests/test_agent_boundary.py"],
+      "docs_distribution": ["docs/plugin/loop-procedure.md"],
+      "consumer_evidence": "과거 trace의 dcness:validator 이름과 file-boundary 정규화를 run-review가 복구하도록 issue #383의 persisted trace 소비 근거가 남아 있다.",
+      "compatibility": {
+        "consumer_or_format": "0.2.16 시기 validator agent 이름을 가진 persisted trace",
+        "reason": "과거 run review와 boundary attribution을 impl-validator로 정규화한다.",
+        "removal_trigger": "지원 기간 이전 trace를 migration/archive하고 validator alias 적중 telemetry가 0임을 확인한다.",
+        "verification": "python3.11 -m unittest tests.test_run_review tests.test_agent_boundary -v"
+      }
+    },
+    {
+      "id": "RUN-006",
+      "area": "run-ledger",
+      "policy_slice": "harness.session_state의 historical private-name re-export",
+      "classification": "제거 가능",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/loop-procedure.md"],
+      "implementation": ["harness/session_state.py:_CLI_REEXPORT_NAMES", "harness/session_state.py:__getattr__"],
+      "tests_fixtures": ["tests/test_session_state.py", "tests/test_parallel_wave.py"],
+      "docs_distribution": ["scripts/dcness-helper"],
+      "consumer_evidence": "session_state_cli의 sibling handler import는 현재 parser가 사용한다. 반면 harness.session_state에서 private helper를 다시 노출하는 경로는 저장소 테스트 import 외 runtime 호출자가 검색되지 않는다.",
+      "compatibility": null
+    },
+    {
+      "id": "RUN-007",
+      "area": "run-ledger",
+      "policy_slice": "hook staging 실패 시 run-dir prose 탐색",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/loop-procedure.md#자유서술-방식"],
+      "implementation": ["harness/session_state_cli_finalize.py:_find_prose_fallback"],
+      "tests_fixtures": ["tests/test_session_state.py", "tests/test_hooks.py"],
+      "docs_distribution": ["docs/plugin/hooks.md"],
+      "consumer_evidence": "현재 hook auto-stage 자체가 best-effort이므로 hook failure 뒤 이미 기록된 prose를 회수하는 runtime 복구 경로다.",
+      "compatibility": null
+    },
+    {
+      "id": "RUN-008",
+      "area": "run-ledger",
+      "policy_slice": "prose-only PROSE_LOGGED와 legacy stored verdict 집계",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1094,
+      "current_ssot": ["docs/plugin/loop-procedure.md#자유서술-방식"],
+      "implementation": ["harness/run_review.py:_resolved_verdict", "harness/benchmark_aggregate.py:_step_verdict", "harness/outcome_scorecard.py"],
+      "tests_fixtures": ["tests/test_run_review.py", "tests/test_benchmark_aggregate.py", "tests/test_outcome_scorecard.py"],
+      "docs_distribution": ["docs/plugin/benchmark.md", "docs/plugin/outcome-scorecard.md"],
+      "consumer_evidence": "현행 ledger는 PROSE_LOGGED sentinel과 prose 결론을 쓰지만 legacy .steps.jsonl은 LGTM·CHANGES_REQUESTED 등 stored verdict를 보유한다.",
+      "compatibility": {
+        "consumer_or_format": "legacy stored verdict enum과 현행 prose-only sentinel이 섞인 run evidence",
+        "reason": "과거 FAIL 비율과 waste 분석에서 prose 재파싱 오판으로 verdict가 뒤집히지 않게 한다.",
+        "removal_trigger": "legacy row를 canonical prose verdict로 migration하고 old verdict 표본이 지원 범위에서 0임을 확인한다.",
+        "verification": "python3.11 -m unittest tests.test_run_review tests.test_benchmark_aggregate tests.test_outcome_scorecard -v"
+      }
+    },
+    {
+      "id": "ROUTE-001",
+      "area": "routing",
+      "policy_slice": "schema v3 role-split routes와 headless-chain 기본값",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1095,
+      "current_ssot": ["docs/plugin/init-dcness.md#provider-routing"],
+      "implementation": ["harness/agent_routing.py:enable_role_split_routing", "scripts/dcness-implementation-chain"],
+      "tests_fixtures": ["tests/test_agent_routing.py", "tests/test_provider_chain.py"],
+      "docs_distribution": ["commands/init-dcness.md", "skills/impl-loop/SKILL.md"],
+      "consumer_evidence": "로컬 routing.json은 version=3과 routes/implementation_routes를 사용하고 init의 추천 preset이 이 형식을 쓴다.",
+      "compatibility": null
+    },
+    {
+      "id": "ROUTE-002",
+      "area": "routing",
+      "policy_slice": "routing schema version 1·2와 retired agent key 수용",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1095,
+      "current_ssot": ["docs/plugin/init-dcness.md#provider-routing"],
+      "implementation": ["harness/agent_routing.py:SUPPORTED_CONFIG_VERSIONS", "harness/agent_routing.py:load_routing"],
+      "tests_fixtures": ["tests/test_agent_routing.py"],
+      "docs_distribution": ["commands/init-dcness.md"],
+      "consumer_evidence": "2026-07-14 local version=3 config에도 retired code-validator·pr-reviewer·test-engineer keys가 남아 persisted config migration 필요가 실재한다.",
+      "compatibility": {
+        "consumer_or_format": "routing.json schema 1·2와 schema 3 안의 retired agent route keys",
+        "reason": "plugin update가 기존 local config를 조용히 삭제하지 않고 doctor/migration 대상으로 식별해야 한다.",
+        "removal_trigger": "등록 config를 current agent key로 migration하고 schema/retired-key scan이 0인 뒤 지원 버전을 축소한다.",
+        "verification": "python3.11 -m harness.session_state routing doctor 및 python3.11 -m unittest tests.test_agent_routing -v"
+      }
+    },
+    {
+      "id": "ROUTE-003",
+      "area": "routing",
+      "policy_slice": "legacy codex-first preset과 enable/disable CLI",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1095,
+      "current_ssot": ["docs/plugin/init-dcness.md#provider-routing"],
+      "implementation": ["harness/agent_routing.py:enable_codex_implementation", "harness/session_state_cli.py:_cli_routing", "scripts/dcness-implementation-chain"],
+      "tests_fixtures": ["tests/test_agent_routing.py", "tests/test_provider_chain.py"],
+      "docs_distribution": ["commands/init-dcness.md", "docs/plugin/loop-procedure.md"],
+      "consumer_evidence": "현재 조사 config는 codex-first를 쓰지 않지만 과거 opt-in 프로젝트가 저장한 implementation route 값의 지원 경계로 문서와 parser가 유지한다.",
+      "compatibility": {
+        "consumer_or_format": "implementation_routes.build-worker=codex-first인 기존 local routing config",
+        "reason": "headless-chain 도입 전 explicit opt-in의 Codex→Claude-main 의미를 migration 전 보존한다.",
+        "removal_trigger": "등록 routing config에서 codex-first가 0이고 custom 사용자를 headless-chain 또는 claude로 migration한 뒤 CLI를 제거한다.",
+        "verification": "python3.11 -m harness.session_state routing status 및 python3.11 -m unittest tests.test_agent_routing tests.test_provider_chain -v"
+      }
+    },
+    {
+      "id": "ROUTE-004",
+      "area": "routing",
+      "policy_slice": "VALID_PROVIDERS backward-compatible export",
+      "classification": "제거 가능",
+      "follow_up_issue": 1095,
+      "current_ssot": ["docs/plugin/init-dcness.md#provider-routing"],
+      "implementation": ["harness/agent_routing.py:VALID_PROVIDERS"],
+      "tests_fixtures": ["tests/test_agent_routing.py"],
+      "docs_distribution": ["commands/init-dcness.md"],
+      "consumer_evidence": "repository-wide symbol search에서 정의·__all__ 외 import/call site가 없고 local JSON은 symbol export를 소비하지 않는다.",
+      "compatibility": null
+    },
+    {
+      "id": "ROUTE-005",
+      "area": "routing",
+      "policy_slice": "workspace 변경 전 provider 실패만 다음 provider로 넘기는 safety fallback",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1095,
+      "current_ssot": ["docs/plugin/loop-procedure.md#provider-routing"],
+      "implementation": ["scripts/dcness-implementation-chain"],
+      "tests_fixtures": ["tests/test_provider_chain.py"],
+      "docs_distribution": ["docs/plugin/loop-procedure.md", "skills/impl-loop/SKILL.md"],
+      "consumer_evidence": "현행 headless-chain의 CLI/auth/timeout 복구 계약이며 workspace mutation 뒤에는 fallback하지 않는 안전 불변조건이 테스트된다.",
+      "compatibility": null
+    },
+    {
+      "id": "INST-001",
+      "area": "install-path",
+      "policy_slice": "project-local generated Claude/Codex TDD hook contract",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1096,
+      "current_ssot": ["docs/plugin/init-dcness.md#generated-tdd-hooks"],
+      "implementation": ["harness/tdd_hooks.py:ensure_generated_hooks", "harness/tdd_hooks.py:run_generated_hook"],
+      "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_tdd_guard.py"],
+      "docs_distribution": ["commands/init-dcness.md", "hooks/tdd-guard.sh"],
+      "consumer_evidence": "등록 프로젝트 1개는 5/5 generated 파일을 보유하고 current impl preflight가 committed project-local hook을 요구한다.",
+      "compatibility": null
+    },
+    {
+      "id": "INST-002",
+      "area": "install-path",
+      "policy_slice": "partial generated install에서 central TDD guard를 유지하는 fallback",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1096,
+      "current_ssot": ["docs/plugin/hooks.md#tdd-guard"],
+      "implementation": ["hooks/tdd-guard.sh:delegate_generated_project_hook"],
+      "tests_fixtures": ["tests/test_tdd_guard.py", "tests/test_generated_tdd_hooks.py"],
+      "docs_distribution": ["commands/init-dcness.md", "docs/plugin/init-dcness.md"],
+      "consumer_evidence": "등록 5개 프로젝트의 generated install 보유량이 0/5, 2/5, 5/5, 0/5, 1/5라 partial state가 현재 실재한다.",
+      "compatibility": null
+    },
+    {
+      "id": "INST-003",
+      "area": "install-path",
+      "policy_slice": "generated hook의 explicit root→Claude root→cache→in-place root 탐색",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1096,
+      "current_ssot": ["docs/plugin/init-dcness.md#실행-위치"],
+      "implementation": ["harness/tdd_hooks.py:_generated_hook_text", "scripts/hooks/commit-msg", "scripts/hooks/pre-push"],
+      "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_git_hook_guard_telemetry.py"],
+      "docs_distribution": ["commands/init-dcness.md", "docs/plugin/hooks.md"],
+      "consumer_evidence": "plugin cache 실행, dcness self in-place 실행, Claude hook env, headless env가 서로 다른 root 신호를 제공하는 현행 배포 topology다.",
+      "compatibility": null
+    },
+    {
+      "id": "INST-004",
+      "area": "install-path",
+      "policy_slice": "design-variants/ legacy path prefix의 validation-only 탐지",
+      "classification": "제거 가능",
+      "follow_up_issue": 1096,
+      "current_ssot": ["docs/plugin/deliverables-map.md#design-variants"],
+      "implementation": ["scripts/check_doc_path_integrity.mjs:LEGACY_PATH_PREFIXES"],
+      "tests_fixtures": ["tests/test_doc_path_integrity.py"],
+      "docs_distribution": ["docs/plugin/init-dcness.md"],
+      "consumer_evidence": "등록 프로젝트 익명 조사에서 docs/design-variants/를 제외한 legacy design-variants/ 참조가 0건이다.",
+      "compatibility": null
+    },
+    {
+      "id": "INST-005",
+      "area": "install-path",
+      "policy_slice": "linked worktree의 common git hooks path와 primary worktree 상태 해석",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1096,
+      "current_ssot": ["docs/plugin/hooks.md#worktree"],
+      "implementation": ["harness/session_state.py:primary_worktree_root", "harness/tdd_hooks.py:generated_files_git_state", "scripts/hooks/post-checkout"],
+      "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_session_state.py", "tests/test_hook_wrapper_exit.py"],
+      "docs_distribution": ["commands/init-dcness.md", "docs/plugin/loop-procedure.md"],
+      "consumer_evidence": "현행 impl/design workflow가 linked worktree를 사용하며 common-dir hook과 primary local receipt를 구분해야 한다.",
+      "compatibility": null
+    },
+    {
+      "id": "LIFE-001",
+      "area": "lifecycle",
+      "policy_slice": "typed Story AC와 issue acceptance checklist 현행 writer",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1097,
+      "current_ssot": ["skills/spec/spec-stories-reference.md", "docs/plugin/git-spec.md#이슈-완료-규칙"],
+      "implementation": ["scripts/create_epic_story_issues.sh", "scripts/check_issue_body.mjs"],
+      "tests_fixtures": ["tests/test_spec_story_slice.py", "tests/test_issue_body_validation.py", "tests/test_create_epic_story_issues.py"],
+      "docs_distribution": ["docs/plugin/issue-lifecycle.md", "commands/init-dcness.md"],
+      "consumer_evidence": "신규 story/issue 생성기는 [command]/[agent-read] 기준만 체크박스로 materialize하고 close audit가 이를 검사한다.",
+      "compatibility": null
+    },
+    {
+      "id": "LIFE-002",
+      "area": "lifecycle",
+      "policy_slice": "Story AC가 없는 stories.md와 완료 시 확인 가능한 동작 reader",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1097,
+      "current_ssot": ["skills/spec/spec-stories-reference.md#구버전-호환성"],
+      "implementation": ["scripts/report_ac_coverage.mjs:buildCoverageReport", "docs/plugin/agents/product-acceptance/product-acceptance-agent.md"],
+      "tests_fixtures": ["tests/test_spec_story_slice.py", "tests/test_acceptance_contract_hierarchy.py"],
+      "docs_distribution": ["docs/plugin/git-spec.md", "docs/plugin/agents/architecture-validator/architecture-validator-agent.md"],
+      "consumer_evidence": "등록 프로젝트 3곳의 stories.md 8개 모두 Story AC heading이 없는 구양식으로 조사됐다.",
+      "compatibility": {
+        "consumer_or_format": "Story AC 없이 As a/I want/So that 또는 완료 시 확인 가능한 동작을 쓰는 기존 stories.md",
+        "reason": "소급 추론으로 AC 의미를 바꾸거나 기존 설계/acceptance를 false fail하지 않게 한다.",
+        "removal_trigger": "등록 프로젝트 stories를 typed AC로 migration하고 legacy story scan이 0인 뒤 reader 지원 종료를 선언한다.",
+        "verification": "node scripts/report_ac_coverage.mjs --stories <legacy-stories> --impl-dir <impl> 및 python3.11 -m unittest tests.test_spec_story_slice -v"
+      }
+    },
+    {
+      "id": "LIFE-003",
+      "area": "lifecycle",
+      "policy_slice": "acceptance checklist가 없는 legacy issue의 close audit pass",
+      "classification": "한시적 호환 필요",
+      "follow_up_issue": 1097,
+      "current_ssot": ["docs/plugin/git-spec.md#이슈-완료-규칙"],
+      "implementation": ["scripts/check_issue_body.mjs:validateIssueBody"],
+      "tests_fixtures": ["tests/test_issue_body_validation.py"],
+      "docs_distribution": ["docs/plugin/issue-lifecycle.md"],
+      "consumer_evidence": "typed acceptance checklist 도입 전 생성된 GitHub issue는 checklist 자체가 없는 지원 대상 형식이며 checker가 legacy/no AC를 명시적으로 판정한다.",
+      "compatibility": {
+        "consumer_or_format": "Acceptance criteria checklist가 없는 도입 이전 GitHub issue body",
+        "reason": "기존 issue를 의미 추론으로 자동 체크하거나 영구 close 불가 상태로 만들지 않는다.",
+        "removal_trigger": "열린 legacy issue를 typed checklist로 migration하거나 지원 종료 목록으로 닫고 no-AC close 호출이 0임을 확인한다.",
+        "verification": "node scripts/check_issue_body.mjs --body-file <legacy-body> --acceptance-only --require-complete 및 tests.test_issue_body_validation"
+      }
+    },
+    {
+      "id": "LIFE-004",
+      "area": "lifecycle",
+      "policy_slice": "사람 판정 항목의 checkbox 금지와 agent 자동 체크 금지",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1097,
+      "current_ssot": ["docs/plugin/git-spec.md#이슈-완료-규칙"],
+      "implementation": ["scripts/check_issue_body.mjs:validateIssueBody"],
+      "tests_fixtures": ["tests/test_issue_body_validation.py"],
+      "docs_distribution": ["docs/plugin/issue-lifecycle.md", "skills/acceptance/SKILL.md"],
+      "consumer_evidence": "현재 close 안전 계약으로 사람 확인을 자동 완료하지 못하게 하며 legacy 여부와 무관하다.",
+      "compatibility": null
+    },
+    {
+      "id": "LIFE-005",
+      "area": "lifecycle",
+      "policy_slice": "Story AC→REQ coverage의 advisory-only 판정",
+      "classification": "현재 실사용",
+      "follow_up_issue": 1097,
+      "current_ssot": ["skills/design/SKILL.md#mechanical-pre-final-checks"],
+      "implementation": ["scripts/report_ac_coverage.mjs"],
+      "tests_fixtures": ["tests/test_acceptance_contract_hierarchy.py", "tests/test_spec_story_slice.py"],
+      "docs_distribution": ["docs/plugin/agents/architecture-validator/architecture-validator-agent.md"],
+      "consumer_evidence": "현행 typed AC에서도 command output을 validator 관찰 증거로 쓰고 형식만으로 hard fail하지 않는 자율성 계약이다.",
+      "compatibility": null
+    }
+  ]
+}

--- a/docs/internal/policy-sunset-inventory.json
+++ b/docs/internal/policy-sunset-inventory.json
@@ -358,7 +358,7 @@
       "classification": "현재 실사용",
       "follow_up_issue": 1096,
       "current_ssot": ["docs/plugin/hooks.md#worktree"],
-      "implementation": ["harness/session_state.py:primary_worktree_root", "harness/tdd_hooks.py:generated_files_git_state", "scripts/hooks/post-checkout"],
+      "implementation": ["harness/session_state.py:_resolve_state_root_for_cwd", "harness/tdd_hooks.py:generated_files_git_state", "scripts/hooks/post-checkout"],
       "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_session_state.py", "tests/test_hook_wrapper_exit.py"],
       "docs_distribution": ["commands/init-dcness.md", "docs/plugin/loop-procedure.md"],
       "consumer_evidence": "현행 impl/design workflow가 linked worktree를 사용하며 common-dir hook과 primary local receipt를 구분해야 한다.",

--- a/docs/internal/policy-sunset-inventory.md
+++ b/docs/internal/policy-sunset-inventory.md
@@ -1,0 +1,170 @@
+# 정책 수명주기 inventory와 cleanup baseline
+
+> #1089의 cleanup 전 snapshot이다. 측정 revision은 `b676140bcffdaa5843ce59198ecef4f997efddc9`이며, 분류 근거는 2026-07-14 KST의 저장소와 등록 활성 프로젝트 read-only 조사다. 이 문서는 제거 작업을 수행하지 않는다.
+
+## 재현 명령과 산출물
+
+한 명령이 Git tracked tree의 크기 지표, inventory schema·분류·후속 이슈 전수 배정, 전체 unit suite 실행시간을 함께 출력한다. untracked receipt와 현재 working copy의 새 파일은 revision 지표에 들어가지 않는다. suite도 지정 revision의 임시 detached worktree에서 실행해 dirty working tree를 격리한다.
+
+```sh
+python3.11 scripts/policy_cleanup_baseline.py \
+  --revision b676140bcffdaa5843ce59198ecef4f997efddc9 \
+  --inventory docs/internal/policy-sunset-inventory.json \
+  --run-unit-suite
+```
+
+- 측정 구현: [`scripts/policy_cleanup_baseline.py`](../../scripts/policy_cleanup_baseline.py)
+- 정책 slice 원장: [`policy-sunset-inventory.json`](policy-sunset-inventory.json)
+- 고정 출력: [`policy-sunset-baseline.json`](policy-sunset-baseline.json)
+
+`major text`는 `.py`, `.mjs`, `.js`, `.sh`, `.md`, `.json`, `.yml`, `.yaml`, `.toml`이다. `code LOC`는 `harness/`, `scripts/`, `evals/` 아래 Python이고 `test LOC`는 `tests/` 아래 Python이다. test 함수는 Python AST에서 이름이 `test_`로 시작하는 함수·메서드를 센다. 대형 파일 수는 major text의 논리 LOC가 각각 500·1,000 이상인 파일 수다. compatibility 후보는 `제거 가능`과 `한시적 호환 필요` slice의 합이며 `현재 실사용`은 분모에는 남지만 감량 후보로 세지 않는다.
+
+| 지표 | cleanup 전 값 |
+|---|---:|
+| tracked file | 560 |
+| major text file / LOC | 519 / 104,856 |
+| code LOC | 29,190 |
+| test LOC | 40,675 |
+| code + test LOC | 69,865 |
+| 500 / 1,000 LOC 이상 major text | 56 / 18 |
+| test 함수 | 1,943 |
+| 전체 unit suite | exit 0 / 118.693초 / detached clean tree |
+| inventory entry / compatibility 후보 | 29 / 15 |
+
+실행시간은 같은 명령의 wall-clock 비교값이며 하드 성능 gate가 아니다. revision, Python 3.11, 동일 명령을 함께 기록하고 후속 #1099에서 다시 잰다.
+
+## 분류 계약
+
+| 분류 | 판단 기준 | baseline 수 |
+|---|---|---:|
+| `현재 실사용` | 현행 writer·runtime safety·배포 topology가 직접 소비하며 오래됐다는 이유로 제거할 수 없음 | 14 |
+| `제거 가능` | repo call/import와 활성 소비자 증거가 없고 현행 writer가 만들지 않는 surface | 4 |
+| `한시적 호환 필요` | persisted 형식이나 실제 활성 프로젝트가 소비하며 대상·이유·제거 trigger·확인 방법이 모두 있음 | 11 |
+
+영역별 29개는 design 6, run/ledger 8, routing 5, install/path 5, lifecycle 5다. 각 entry는 현행 SSOT, 구현, test/fixture, 문서·배포, 소비자 증거를 모두 가진다. 키워드가 같아도 release artifact의 `--contract`처럼 의미가 다른 적중은 `현재 실사용`으로 명시해 false positive를 버리지 않고 분류했다.
+
+### 활성 소비자 snapshot
+
+등록 파일 `~/.claude/plugins/data/dcness-dcness/projects.json`의 경로는 문서에 공개하지 않고 registry 순번으로만 조사했다.
+
+| 관찰 영역 | 2026-07-14 read-only 결과 | inventory 영향 |
+|---|---|---|
+| legacy design artifact | 5개 중 2개 프로젝트, marker 포함 문서 72개 | `DES-003`~`DES-005` 한시 호환 |
+| persisted run | `ledger.jsonl` 30개, `.steps.jsonl` 0개 | `RUN-001` 현행; 과거/cache 형식인 `RUN-002`는 종료 trigger 필요 |
+| routing config | schema 3이지만 retired `code-validator`, `pr-reviewer`, `test-engineer` key 잔존 | `ROUTE-002` migration 대상 실재 |
+| generated install | 프로젝트별 5개 대상 파일 보유량 `0/5, 2/5, 5/5, 0/5, 1/5` | partial install fallback인 `INST-002` 현행 |
+| stories | 3개 프로젝트의 `stories.md` 8개가 모두 Story AC heading 없는 구양식 | `LIFE-002` 한시 호환 |
+| legacy `design-variants/` prefix | 등록 프로젝트 0건 | `INST-004` 제거 가능 |
+
+절대경로·프로젝트명은 근거가 아니라 민감한 host 정보라 기록하지 않았다. 후속 이슈는 같은 registry 순번과 해당 이슈의 확인 명령으로 재조사한다.
+
+## 한시적 호환 4요소 감사
+
+아래 11개 모두 대상, 유지 이유, 제거 trigger, 확인 방법을 가진다. 명령 전문과 trace path는 machine inventory에 있다.
+
+| ID | 소비자 또는 대상 형식 | 유지 이유 | 제거 trigger | 확인 방법 |
+|---|---|---|---|---|
+| DES-003 | 기존 Ledger/References/frontmatter/Flow Map 문서 | doc-sync false fail 방지 | 활성 marker 0 + `--contract` 호출자 0 | design artifact audit + fixture |
+| DES-004 | legacy Ledger·Decisions table architecture | 기존 capability/decision map 보존 | 문서 migration + parser 적중 0 | architecture map + fixture |
+| DES-005 | legacy artifact를 가진 설계 pack | 존재만으로 validator Must 방지 | migration 뒤 leniency 없이 판정 동일 | contract pointer/docs sync tests |
+| RUN-002 | `.steps.jsonl`과 mixed-upgrade run | 과거 review와 occurrence 순서 보존 | 보존기간 확정·migration·표본 0 | ledger/run-review tests |
+| RUN-003 | 옛 row와 현행 receipt 공통 필드명 | reader 동시 migration 전 evidence 보존 | canonical receipt migration 완료 | ledger/benchmark/outcome tests |
+| RUN-005 | `validator` 이름의 persisted trace | attribution과 boundary 복구 | archive migration + alias 적중 0 | run-review/boundary tests |
+| RUN-008 | legacy stored verdict + prose sentinel | 과거 FAIL 비율 오판 방지 | verdict migration + old 표본 0 | run-review/aggregate tests |
+| ROUTE-002 | schema 1·2와 retired route keys | local config를 조용히 폐기하지 않음 | config migration + scan 0 | routing doctor + tests |
+| ROUTE-003 | `codex-first` 저장값 | 과거 explicit opt-in 의미 보존 | registered config 사용 0 + migration | routing status/provider-chain tests |
+| LIFE-002 | Story AC 없는 stories | 소급 의미 추론·false fail 방지 | typed AC migration + scan 0 | AC coverage + fixture |
+| LIFE-003 | checklist 없는 legacy issue | false close·영구 close 불가 방지 | 열린 issue migration/지원 종료 | issue close audit + fixture |
+
+종료 날짜를 근거 없이 임의 지정하지 않았다. trigger를 만족하지 못한 채 reader를 제거하는 것은 #1089 안전 경계를 위반한다.
+
+## 500줄 이상 major text 책임 감사
+
+단순 분할은 개선으로 세지 않는다. 각 파일의 현재 책임, 중복·legacy 비중, 실제 감량 후보를 읽었다. `후속/판정`이 #1098인 항목도 앞선 정책 이슈가 제거한 branch·fixture를 입력으로 받을 뿐, 크기만으로 쪼개지 않는다.
+
+| 파일 | LOC | 현재 책임 | 중복·legacy 관찰 | 후속/판정 |
+|---|---:|---|---|---|
+| `PROGRESS.md` | 556 | self 진행 기록 | 누적 이력이며 runtime 아님 | #1098 입력 제외; 분할 무효 |
+| `commands/init-dcness.md` | 512 | 활성화·재실행·제거 orchestration | install 설명이 사용자 SSOT와 일부 반복 | #1096에서 배포 계약 단위 감량 |
+| `docs/archive/change_rationale_history.md` | 2,633 | 과거 결정 archive | legacy 비중 높지만 실행 surface 아님 | #1098에서 archive 보존정책 없이는 삭제 금지 |
+| `docs/archive/conveyor-design.md` | 684 | 폐기 설계 archive | 현행 loop와 중복 가능 | #1098 후보, 단 runtime 감량으로 계산 X |
+| `docs/archive/document_update_record.md` | 1,777 | 과거 변경 archive | Git history와 중복 | #1098 후보, 별도 archive 근거 필요 |
+| `docs/archive/status-json-mutate-pattern.md` | 553 | 폐기 status JSON 참고 | 현행 prose-only와 legacy 비중 높음 | #1098 후보, 외부 링크 감사 후 |
+| `docs/internal/marketplace-artifact-baseline.json` | 658 | release artifact inventory | generated data, 책임 중복 없음 | 유지; 분할 무효 |
+| `docs/internal/release-notes.md` | 2,184 | 릴리즈 이력 | GitHub PR history와 일부 중복 | #1098 후보지만 release SSOT 보존 필요 |
+| `docs/plugin/loop-procedure.md` | 504 | loop mechanics SSOT | run/routing 호환 설명이 누적 | #1094·#1095 뒤 문구 삭제, 단순 분할 금지 |
+| `evals/agent_effectiveness_measure.py` | 734 | paired trace 측정 | policy compatibility와 무관 | 현행; #1098 크기만으로 선택 금지 |
+| `evals/calibrate_judge.py` | 542 | eval judge 보정 | compatibility와 무관 | 현행 |
+| `evals/guard_efficacy.py` | 781 | hard safety 결정적 eval | 안전 invariant | 현행, 감량 이유로 제거 금지 |
+| `evals/harness_experiment.py` | 590 | experiment runner | compatibility와 무관 | 현행 |
+| `harness/agent_boundary.py` | 1,596 | file/external-state 권한 경계 | alias fixture 일부, 핵심 safety 다수 | #1094 alias 후 #1098; 안전 invariant 보존 |
+| `harness/agent_effectiveness.py` | 690 | effectiveness record 검증 | compatibility와 무관 | 현행 |
+| `harness/benchmark_aggregate.py` | 500 | run verdict·waste 집계 | legacy verdict 분기 포함 | #1094 `RUN-008`, 이후 #1098 |
+| `harness/chain_view.py` | 531 | run chain view | run reader와 assertion 중복 가능 | #1094 결과 후 #1098 |
+| `harness/codex_sandbox_permission.py` | 594 | Codex 제한 승인 receipt | 현행 safety | 유지 |
+| `harness/guard_telemetry.py` | 657 | guard hit telemetry | compatibility와 무관 | 현행 |
+| `harness/hooks.py` | 1,671 | order/state hook 집약 | 여러 세대 enum·run assertion 포함 | #1094 후 #1098; order guard 보존 |
+| `harness/ledger.py` | 642 | canonical + legacy run reader | legacy/mixed/field 호환 비중 큼 | #1094 핵심 감량 후보 |
+| `harness/outcome_scorecard.py` | 739 | process·effectiveness·outcome 집계 | legacy verdict 소비 중복 | #1094 뒤 #1098 |
+| `harness/parallel_wave.py` | 948 | peer claim/wave 상태 | 현행 concurrency safety | 유지 |
+| `harness/product_journey.py` | 864 | 제품 journey runner | compatibility와 무관 | 현행 |
+| `harness/run_review.py` | 1,853 | persisted run 분석·waste report | legacy name/verdict/prose 비중 큼 | #1094 핵심, 이후 #1098 |
+| `harness/session_state.py` | 2,190 | run lifecycle/state owner | legacy lane·path와 다세대 state 책임 | #1094 핵심, 단순 분할 무효 |
+| `harness/session_state_cli.py` | 1,488 | CLI dispatch·routing | historical private re-export와 legacy route CLI | #1094 `RUN-006` + #1095 |
+| `harness/session_state_cli_finalize.py` | 595 | end-step/finalize/prose receipt | prose fallback과 old field 설명 | #1094 |
+| `harness/session_state_status.py` | 501 | status/diagnostic view | state reader assertion과 중복 가능 | #1094 뒤 #1098 |
+| `harness/story_runner.py` | 509 | story stack state | 현행 lifecycle | #1097 reader 정리 뒤 #1098 |
+| `harness/tdd_hooks.py` | 1,356 | generated hook 생성·status·self-test | install 상태별 분기 큼, 실제 partial 소비자 존재 | #1096; 단순 분할 금지 |
+| `scripts/github_project_lifecycle.mjs` | 1,444 | GitHub Project state lifecycle | legacy story reader와 직접 무관 | 현행; #1098 크기만으로 선택 금지 |
+| `scripts/loop_diagnose.py` | 884 | cross-project 진단 | compatibility와 무관 | 현행 |
+| `templates/design-variants/_lib/canvas.js` | 618 | static mockup canvas runtime | policy legacy와 무관 | 현행 |
+| `tests/test_agent_boundary.py` | 2,642 | 권한 경계 회귀 | legacy alias assertion 일부, safety fixture 다수 | #1094 후 #1098 중복 assertion 검토 |
+| `tests/test_agent_effectiveness.py` | 591 | effectiveness schema | compatibility와 무관 | 현행 |
+| `tests/test_benchmark_aggregate.py` | 565 | aggregate verdict 회귀 | legacy verdict fixture 포함 | #1094 후 #1098 |
+| `tests/test_chain_view.py` | 522 | chain view 회귀 | run fixture 중복 가능 | #1094 후 #1098 |
+| `tests/test_codex_sandbox_permission.py` | 564 | sandbox 승인 경계 | 현행 safety | 유지 |
+| `tests/test_codex_validator_wrapper.py` | 1,522 | Codex wrapper/prose/boundary | 여러 wrapper fixture 중복 가능 | #1096 후 #1098, sandbox safety 보존 |
+| `tests/test_design_surface.py` | 578 | design prompt/template sync | legacy authoring 부정 assertion 포함 | #1093 후 #1098 |
+| `tests/test_generated_tdd_hooks.py` | 771 | generated install matrix | partial/install fixture가 실사용 | #1096 후 중복 fixture만 #1098 |
+| `tests/test_github_project_lifecycle.py` | 1,544 | project lifecycle 스크립트 | compatibility와 무관 | 현행; #1098 크기만으로 선택 금지 |
+| `tests/test_hooks.py` | 3,582 | order/state/hook 통합 회귀 | run·alias·fallback assertion 세대 다수 | #1094·#1096 뒤 #1098 핵심 |
+| `tests/test_ledger.py` | 598 | ledger current/legacy/mixed/corrupt | compatibility fixture 비중 큼 | #1094 핵심; 4개 안전 시나리오 보존 |
+| `tests/test_loop_diagnose.py` | 645 | cross-project 진단 | compatibility와 무관 | 현행 |
+| `tests/test_multisession_smoke.py` | 647 | 동시 run smoke | 현행 concurrency safety | 유지 |
+| `tests/test_outcome_scorecard.py` | 574 | outcome aggregation | legacy verdict fixture 일부 | #1094 후 #1098 |
+| `tests/test_parallel_wave.py` | 978 | wave/merge lock | 현행 concurrency safety | 유지 |
+| `tests/test_product_journey.py` | 610 | journey runner | compatibility와 무관 | 현행 |
+| `tests/test_provider_chain.py` | 1,466 | provider chain 상태전이 | codex-first fixture와 현행 safety fallback 혼재 | #1095 핵심, mutation-after-failure 보존 |
+| `tests/test_run_review.py` | 1,622 | run review current/legacy 분석 | legacy alias/verdict/.steps fixture 비중 큼 | #1094 핵심, 이후 #1098 |
+| `tests/test_session_state.py` | 3,533 | state/CLI/run lifecycle | private re-export·legacy state fixture와 현행 safety 혼재 | #1094 핵심, 이후 #1098 |
+| `tests/test_story_runner.py` | 545 | story runner lifecycle | 현행 stack fixture | #1097 뒤 #1098 |
+| `tests/test_surface_docs_sync.py` | 1,005 | agent/docs/Codex mirror sync | legacy design leniency 문자열 assertion 포함 | #1093 후 #1098 |
+| `tests/test_tdd_guard.py` | 816 | central/generated TDD guard | partial install fallback fixture가 실사용 | #1096 후 #1098, TDD invariant 보존 |
+
+실제 감량 우선순위는 `ledger/run_review/session_state`와 대응 테스트의 다세대 persisted 형식, provider-chain의 `codex-first`, design legacy authoring·reader, install partial-state 증거다. archive·release data·safety eval·concurrency·journey 파일은 크기만으로 선택하지 않는다.
+
+## 후속 범위 완전성
+
+| 후속 | inventory 입력 | 책임 |
+|---|---|---|
+| #1093 | DES-001~006 | design authoring·reader·warning·validator·배포 |
+| #1094 | RUN-001~008 | ledger/prose/alias/verdict/session state |
+| #1095 | ROUTE-001~005 | schema/preset/export/provider fallback |
+| #1096 | INST-001~005 | generated hook/partial install/root/path/worktree |
+| #1097 | LIFE-001~005 | current writer/legacy stories/no-AC issue/human/advisory |
+| #1098 | 위 500줄 이상 감사의 정책 제거 후 중복 책임 | 단순 분할이 아닌 assertion/helper 통합 |
+| #1099 | baseline JSON과 29개 원장 전항목 | 동일 정의 재측정·전체 gate·부모 close audit |
+
+machine validator 결과는 29/29 entry가 정확히 하나의 #1093~#1097에 배정되고 중복 ID가 없으며, 11/11 한시 호환 entry가 4요소를 갖춘다. 대형 파일 56/56도 표에서 유지·정책 cleanup·#1098 검토 중 하나로 판정했다. 어느 범위에도 속하지 않은 후보는 없다.
+
+## Codebase Sanity receipt
+
+- revision: `b676140bcffdaa5843ce59198ecef4f997efddc9`
+- semantic scope: full tracked repository의 policy compatibility와 500줄 이상 major text; archive와 external active-project 절대경로는 read-only·비식별 집계
+- 기계 증거: baseline command exit 0, full unit suite exit 0, 118.693초, detached clean tree
+- coverage: `UNKNOWN` — repository에 full-suite coverage 도구·리포트가 없어 test 수나 green으로 추정하지 않음
+- 분류: removable 4, temporary compatibility 11, current 14; unknown 0
+- replacement hygiene: 현행 writer와 legacy reader를 분리했고 새 writer가 legacy 형식을 생성한다고 판정한 항목은 없음
+- warning 경계: legacy marker 자체는 warning/후속 입력이며 소비자 증거 없이 dead code로 승격하지 않음
+
+새 public command·agent·mode·workflow·상설 hard gate는 만들지 않았다. baseline 스크립트는 #1092/#1099 비교용 내부 one-shot 도구이며 plugin 배포 inventory와 `/init-dcness`에 포함하지 않는다.

--- a/docs/internal/policy-sunset-inventory.md
+++ b/docs/internal/policy-sunset-inventory.md
@@ -17,6 +17,8 @@ python3.11 scripts/policy_cleanup_baseline.py \
 - 정책 slice 원장: [`policy-sunset-inventory.json`](policy-sunset-inventory.json)
 - 고정 출력: [`policy-sunset-baseline.json`](policy-sunset-baseline.json)
 
+측정 구현은 dcNess self에서만 쓰는 일회성 내부 도구다. `scripts/release_artifact.json`의 제외 계약에 고정되어 marketplace release payload에 들어가지 않으며, `init-dcness`도 외부 프로젝트에 복사하지 않는다.
+
 `major text`는 `.py`, `.mjs`, `.js`, `.sh`, `.md`, `.json`, `.yml`, `.yaml`, `.toml`이다. `code LOC`는 `harness/`, `scripts/`, `evals/` 아래 Python이고 `test LOC`는 `tests/` 아래 Python이다. test 함수는 Python AST에서 이름이 `test_`로 시작하는 함수·메서드를 센다. 대형 파일 수는 major text의 논리 LOC가 각각 500·1,000 이상인 파일 수다. compatibility 후보는 `제거 가능`과 `한시적 호환 필요` slice의 합이며 `현재 실사용`은 분모에는 남지만 감량 후보로 세지 않는다.
 
 | 지표 | cleanup 전 값 |

--- a/scripts/policy_cleanup_baseline.py
+++ b/scripts/policy_cleanup_baseline.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Measure the one-shot #1089 policy-cleanup baseline at a Git revision.
+
+This is an internal comparison tool, not a CI gate or public plug-in command.
+It reads the tracked Git tree so untracked receipts and working-copy files cannot
+silently change the baseline.  The optional unit-suite timing must run at the
+checked-out revision because tests execute from the working tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import subprocess  # nosec B404 - argv-only internal git and Python commands
+import sys
+import tempfile
+import time
+from collections import Counter
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+MAJOR_TEXT_SUFFIXES = frozenset(
+    {".py", ".mjs", ".js", ".sh", ".md", ".json", ".yml", ".yaml", ".toml"}
+)
+CODE_ROOTS = frozenset({"harness", "scripts", "evals"})
+CLASSIFICATIONS = ("현재 실사용", "제거 가능", "한시적 호환 필요")
+AREA_TO_FOLLOW_UP = {
+    "design": 1093,
+    "run-ledger": 1094,
+    "routing": 1095,
+    "install-path": 1096,
+    "lifecycle": 1097,
+}
+TRACE_LIST_FIELDS = (
+    "current_ssot",
+    "implementation",
+    "tests_fixtures",
+    "docs_distribution",
+)
+COMPATIBILITY_FIELDS = (
+    "consumer_or_format",
+    "reason",
+    "removal_trigger",
+    "verification",
+)
+
+
+def _run_git(repo_root: Path, *args: str) -> bytes:
+    return subprocess.run(  # nosec B603, B607
+        ["git", *args],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    ).stdout
+
+
+def _tracked_paths(repo_root: Path, revision: str) -> list[str]:
+    output = _run_git(repo_root, "ls-tree", "-r", "--name-only", "-z", revision)
+    return sorted(
+        item.decode("utf-8")
+        for item in output.split(b"\0")
+        if item
+    )
+
+
+def _blob(repo_root: Path, revision: str, path: str) -> bytes:
+    return _run_git(repo_root, "show", f"{revision}:{path}")
+
+
+def _line_count(content: bytes) -> int:
+    if not content:
+        return 0
+    return content.count(b"\n") + (0 if content.endswith(b"\n") else 1)
+
+
+def _is_major_text(path: str) -> bool:
+    return Path(path).suffix.lower() in MAJOR_TEXT_SUFFIXES
+
+
+def _is_code(path: str) -> bool:
+    parts = Path(path).parts
+    return bool(parts) and parts[0] in CODE_ROOTS and Path(path).suffix == ".py"
+
+
+def _is_test(path: str) -> bool:
+    parts = Path(path).parts
+    return bool(parts) and parts[0] == "tests" and Path(path).suffix == ".py"
+
+
+def _count_test_functions(source: bytes, path: str) -> int:
+    tree = ast.parse(source.decode("utf-8"), filename=path)
+    return sum(
+        1
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name.startswith("test_")
+    )
+
+
+def measure_revision(repo_root: Path, revision: str) -> dict[str, Any]:
+    """Return stable size/count metrics for one tracked Git tree."""
+    root = repo_root.resolve()
+    resolved_revision = _run_git(root, "rev-parse", revision).decode().strip()
+    paths = _tracked_paths(root, resolved_revision)
+    major_text_loc = 0
+    code_loc = 0
+    test_loc = 0
+    test_functions = 0
+    major_text_lines: list[int] = []
+
+    for path in paths:
+        major = _is_major_text(path)
+        code = _is_code(path)
+        test = _is_test(path)
+        if not (major or code or test):
+            continue
+        content = _blob(root, resolved_revision, path)
+        line_count = _line_count(content)
+        if major:
+            major_text_loc += line_count
+            major_text_lines.append(line_count)
+        if code:
+            code_loc += line_count
+        if test:
+            test_loc += line_count
+            test_functions += _count_test_functions(content, path)
+
+    return {
+        "revision": resolved_revision,
+        "tracked_files": len(paths),
+        "major_text_files": len(major_text_lines),
+        "major_text_loc": major_text_loc,
+        "code_loc": code_loc,
+        "test_loc": test_loc,
+        "code_and_test_loc": code_loc + test_loc,
+        "files_ge_500_loc": sum(lines >= 500 for lines in major_text_lines),
+        "files_ge_1000_loc": sum(lines >= 1000 for lines in major_text_lines),
+        "test_functions": test_functions,
+    }
+
+
+def _require_nonempty_string(entry_id: str, entry: dict[str, Any], field: str) -> None:
+    value = entry.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{entry_id}: {field} must be a non-empty string")
+
+
+def _require_trace_lists(entry_id: str, entry: dict[str, Any]) -> None:
+    for field in TRACE_LIST_FIELDS:
+        value = entry.get(field)
+        if (
+            not isinstance(value, list)
+            or not value
+            or any(not isinstance(item, str) or not item.strip() for item in value)
+        ):
+            raise ValueError(f"{entry_id}: {field} must be a non-empty string list")
+
+
+def summarize_inventory(entries: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Validate inventory coverage and return comparison counts."""
+    seen: set[str] = set()
+    by_classification: Counter[str] = Counter()
+    by_area: Counter[str] = Counter()
+    by_follow_up_issue: Counter[str] = Counter()
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ValueError("inventory entries must be JSON objects")
+        entry_id = entry.get("id")
+        if not isinstance(entry_id, str) or not entry_id.strip():
+            raise ValueError("inventory id must be a non-empty string")
+        if entry_id in seen:
+            raise ValueError(f"duplicate inventory id: {entry_id}")
+        seen.add(entry_id)
+
+        _require_nonempty_string(entry_id, entry, "policy_slice")
+        _require_nonempty_string(entry_id, entry, "consumer_evidence")
+        _require_trace_lists(entry_id, entry)
+
+        area = entry.get("area")
+        if area not in AREA_TO_FOLLOW_UP:
+            raise ValueError(f"{entry_id}: unknown area: {area!r}")
+        expected_issue = AREA_TO_FOLLOW_UP[area]
+        if entry.get("follow_up_issue") != expected_issue:
+            raise ValueError(
+                f"{entry_id}: follow_up_issue must be {expected_issue} for area={area}"
+            )
+
+        classification = entry.get("classification")
+        if classification not in CLASSIFICATIONS:
+            raise ValueError(
+                f"{entry_id}: classification must be one of {CLASSIFICATIONS}"
+            )
+
+        compatibility = entry.get("compatibility")
+        if classification == "한시적 호환 필요":
+            if not isinstance(compatibility, dict):
+                raise ValueError(f"{entry_id}: compatibility evidence is required")
+            for field in COMPATIBILITY_FIELDS:
+                _require_nonempty_string(entry_id, compatibility, field)
+        elif compatibility not in (None, {}):
+            raise ValueError(
+                f"{entry_id}: compatibility evidence is only valid for 한시적 호환 필요"
+            )
+
+        by_classification[classification] += 1
+        by_area[area] += 1
+        by_follow_up_issue[str(expected_issue)] += 1
+
+    return {
+        "entries_total": len(entries),
+        "compatibility_candidates": (
+            by_classification["제거 가능"]
+            + by_classification["한시적 호환 필요"]
+        ),
+        "by_classification": {
+            name: by_classification[name] for name in CLASSIFICATIONS
+        },
+        "by_area": dict(sorted(by_area.items())),
+        "by_follow_up_issue": dict(sorted(by_follow_up_issue.items())),
+    }
+
+
+def load_inventory(path: Path) -> list[dict[str, Any]]:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or data.get("schema_version") != 1:
+        raise ValueError("inventory schema_version must be 1")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("inventory entries must be a list")
+    return entries
+
+
+def run_unit_suite(repo_root: Path, revision: str) -> dict[str, Any]:
+    command = [sys.executable, "-m", "unittest", "discover", "-s", "tests", "-v"]
+    command_display = [
+        Path(sys.executable).name,
+        "-m",
+        "unittest",
+        "discover",
+        "-s",
+        "tests",
+        "-v",
+    ]
+    with tempfile.TemporaryDirectory(prefix="dcness-policy-baseline-") as tmp:
+        checkout = Path(tmp) / "tree"
+        worktree_command = [
+            "git",
+            "-c",
+            "core.hooksPath=/dev/null",
+            "worktree",
+            "add",
+            "--detach",
+            str(checkout),
+            revision,
+        ]
+        subprocess.run(  # nosec B603, B607
+            worktree_command,
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+        try:
+            started = time.perf_counter()
+            completed = subprocess.run(  # nosec B603
+                command,
+                cwd=checkout,
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            )
+            elapsed_seconds = round(time.perf_counter() - started, 3)
+        finally:
+            subprocess.run(  # nosec B603, B607
+                [
+                    "git",
+                    "-c",
+                    "core.hooksPath=/dev/null",
+                    "worktree",
+                    "remove",
+                    "--force",
+                    str(checkout),
+                ],
+                cwd=repo_root,
+                check=True,
+                capture_output=True,
+            )
+    return {
+        "command": " ".join(command_display) + " < /dev/null",
+        "tree_mode": "detached_git_worktree",
+        "exit_code": completed.returncode,
+        "elapsed_seconds": elapsed_seconds,
+        "failure_tail": completed.stderr[-4000:] if completed.returncode else "",
+    }
+
+
+def build_report(
+    repo_root: Path,
+    revision: str,
+    inventory_path: Path,
+    *,
+    include_unit_suite: bool,
+) -> dict[str, Any]:
+    metrics = measure_revision(repo_root, revision)
+    entries = load_inventory(inventory_path)
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "purpose": "#1089 cleanup before/after comparison baseline",
+        "definitions": {
+            "tracked_files": "git ls-tree -r --name-only <revision>",
+            "major_text_suffixes": sorted(MAJOR_TEXT_SUFFIXES),
+            "code_loc": "*.py under harness/, scripts/, and evals/",
+            "test_loc": "*.py under tests/",
+            "test_functions": "Python AST FunctionDef/AsyncFunctionDef names starting test_",
+            "large_files": "major text files with logical LOC >= threshold",
+            "compatibility_candidates": "inventory entries classified 제거 가능 or 한시적 호환 필요",
+        },
+        "metrics": metrics,
+        "inventory": summarize_inventory(entries),
+    }
+    if include_unit_suite:
+        report["unit_suite"] = run_unit_suite(repo_root, metrics["revision"])
+    return report
+
+
+def parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--revision", default="HEAD")
+    parser.add_argument(
+        "--inventory",
+        type=Path,
+        default=Path("docs/internal/policy-sunset-inventory.json"),
+    )
+    parser.add_argument("--run-unit-suite", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    inventory_path = args.inventory
+    if not inventory_path.is_absolute():
+        inventory_path = repo_root / inventory_path
+    report = build_report(
+        repo_root,
+        args.revision,
+        inventory_path,
+        include_unit_suite=args.run_unit_suite,
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True))
+    return int(report.get("unit_suite", {}).get("exit_code", 0) != 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release_artifact.json
+++ b/scripts/release_artifact.json
@@ -25,6 +25,7 @@
     "scripts/check_static_quality.sh",
     "scripts/hooks/cc-pre-commit.sh",
     "scripts/launchd",
+    "scripts/policy_cleanup_baseline.py",
     "scripts/release_preflight.py",
     "scripts/release_artifact.json",
     "scripts/release_artifact.py",

--- a/tests/test_policy_cleanup_baseline.py
+++ b/tests/test_policy_cleanup_baseline.py
@@ -1,0 +1,181 @@
+"""Tests for the one-shot policy cleanup baseline measurement."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "policy_cleanup_baseline.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("policy_cleanup_baseline", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(*args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+class PolicyCleanupBaselineTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = load_module()
+
+    def test_measure_revision_uses_tracked_tree_and_stable_metric_definitions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            run("git", "init", "-q", cwd=repo)
+            run("git", "config", "user.name", "Test", cwd=repo)
+            run("git", "config", "user.email", "test@example.com", cwd=repo)
+
+            files = {
+                "README.md": "# Sample\n",
+                "harness/core.py": "def current():\n    return True\n",
+                "scripts/helper.py": "print('ok')\n",
+                "evals/probe.py": "VALUE = 1\n",
+                "tests/test_core.py": (
+                    "def test_one():\n    pass\n\n"
+                    "class TestCore:\n"
+                    "    def test_two(self):\n        pass\n"
+                ),
+                "data/sample.jsonl": "{}\n",
+            }
+            for rel, content in files.items():
+                path = repo / rel
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            run("git", "add", ".", cwd=repo)
+            run("git", "commit", "-qm", "fixture", cwd=repo)
+
+            (repo / "untracked.py").write_text("def test_not_counted(): pass\n")
+            result = self.module.measure_revision(repo, "HEAD")
+
+        self.assertEqual(result["tracked_files"], 6)
+        self.assertEqual(result["major_text_files"], 5)
+        self.assertEqual(result["major_text_loc"], 11)
+        self.assertEqual(result["code_loc"], 4)
+        self.assertEqual(result["test_loc"], 6)
+        self.assertEqual(result["test_functions"], 2)
+        self.assertEqual(result["files_ge_500_loc"], 0)
+        self.assertEqual(result["files_ge_1000_loc"], 0)
+
+    def test_inventory_summary_requires_classification_mapping_and_compat_evidence(self) -> None:
+        entries = [
+            {
+                "id": "DES-001",
+                "area": "design",
+                "policy_slice": "legacy reader",
+                "classification": "한시적 호환 필요",
+                "follow_up_issue": 1093,
+                "current_ssot": ["docs/current.md"],
+                "implementation": ["scripts/reader.mjs"],
+                "tests_fixtures": ["tests/test_reader.py"],
+                "docs_distribution": ["docs/plugin/design.md"],
+                "consumer_evidence": "active-project survey found legacy documents",
+                "compatibility": {
+                    "consumer_or_format": "legacy Contract Ledger documents",
+                    "reason": "existing documents must remain readable",
+                    "removal_trigger": "all registered projects migrate",
+                    "verification": "run the compatibility fixture",
+                },
+            },
+            {
+                "id": "RUN-001",
+                "area": "run-ledger",
+                "policy_slice": "canonical writer",
+                "classification": "현재 실사용",
+                "follow_up_issue": 1094,
+                "current_ssot": ["docs/current.md"],
+                "implementation": ["harness/ledger.py"],
+                "tests_fixtures": ["tests/test_ledger.py"],
+                "docs_distribution": ["docs/plugin/loop-procedure.md"],
+                "consumer_evidence": "current runs contain ledger.jsonl",
+                "compatibility": None,
+            },
+        ]
+
+        summary = self.module.summarize_inventory(entries)
+
+        self.assertEqual(summary["entries_total"], 2)
+        self.assertEqual(summary["compatibility_candidates"], 1)
+        self.assertEqual(summary["by_classification"]["현재 실사용"], 1)
+        self.assertEqual(summary["by_classification"]["한시적 호환 필요"], 1)
+        self.assertEqual(summary["by_follow_up_issue"], {"1093": 1, "1094": 1})
+
+        broken = json.loads(json.dumps(entries))
+        del broken[0]["compatibility"]["removal_trigger"]
+        with self.assertRaisesRegex(ValueError, "removal_trigger"):
+            self.module.summarize_inventory(broken)
+
+    def test_inventory_rejects_duplicate_ids_and_wrong_follow_up_scope(self) -> None:
+        entry = {
+            "id": "ROUTE-001",
+            "area": "routing",
+            "policy_slice": "route",
+            "classification": "제거 가능",
+            "follow_up_issue": 1094,
+            "current_ssot": ["docs/current.md"],
+            "implementation": ["harness/agent_routing.py"],
+            "tests_fixtures": ["tests/test_agent_routing.py"],
+            "docs_distribution": ["docs/plugin/init-dcness.md"],
+            "consumer_evidence": "no active config uses the preset",
+            "compatibility": None,
+        }
+
+        with self.assertRaisesRegex(ValueError, "follow_up_issue"):
+            self.module.summarize_inventory([entry])
+
+        entry["follow_up_issue"] = 1095
+        with self.assertRaisesRegex(ValueError, "duplicate inventory id"):
+            self.module.summarize_inventory([entry, dict(entry)])
+
+    def test_unit_suite_runs_the_requested_revision_not_dirty_working_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp)
+            run("git", "init", "-q", cwd=repo)
+            run("git", "config", "user.name", "Test", cwd=repo)
+            run("git", "config", "user.email", "test@example.com", cwd=repo)
+            test_path = repo / "tests" / "test_clean_tree.py"
+            test_path.parent.mkdir(parents=True)
+            test_path.write_text(
+                "import unittest\n\n"
+                "class CleanTreeTests(unittest.TestCase):\n"
+                "    def test_committed_tree(self):\n"
+                "        self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+            run("git", "add", ".", cwd=repo)
+            run("git", "commit", "-qm", "fixture", cwd=repo)
+            revision = run("git", "rev-parse", "HEAD", cwd=repo).stdout.strip()
+
+            test_path.write_text(
+                "import unittest\n\n"
+                "class DirtyTreeTests(unittest.TestCase):\n"
+                "    def test_dirty_tree(self):\n"
+                "        self.fail('dirty working tree leaked into baseline')\n",
+                encoding="utf-8",
+            )
+            result = self.module.run_unit_suite(repo, revision)
+
+        self.assertEqual(result["exit_code"], 0)
+        self.assertEqual(result["tree_mode"], "detached_git_worktree")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -59,6 +59,7 @@ class ReleaseArtifactContractTests(unittest.TestCase):
                 "scripts/check_public_surface.mjs",
                 "scripts/hooks/cc-pre-commit.sh",
                 "scripts/launchd",
+                "scripts/policy_cleanup_baseline.py",
                 "scripts/release_artifact.json",
                 "scripts/release_artifact.py",
                 "scripts/setup_branch_protection.mjs",


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1092
Part of #1089

## 배경 및 문제

#1089 cleanup을 시작하기 전에 현재 정책 SSOT에서 구현·테스트·fixture·문서·배포·소비자까지 이어지는 inventory와 동일 revision 비교 baseline이 필요합니다. 키워드 검색만으로는 현행 safety fallback과 제거 가능한 legacy surface를 구분할 수 없었습니다.

## 원인 (해당 시)

정책 교체 뒤 이전 writer·reader·fixture·문서의 종료 조건을 한 단위로 추적하는 원장이 없고, 저장소 크기·전체 suite 시간·compatibility 후보를 같은 정의로 다시 측정하는 도구가 없었습니다.

## 작업내용

- `b676140` tracked tree 기준 29개 정책 slice를 `현재 실사용` 14, `제거 가능` 4, `한시적 호환 필요` 11로 분류했습니다.
- 한시적 호환 11개에 소비자/형식, 유지 이유, 제거 trigger, 확인 방법을 모두 기록했습니다.
- tracked files, text/code/test LOC, 500·1,000줄 이상 파일, test 함수, 전체 suite 시간, compatibility 후보를 한 명령으로 재현하는 내부 baseline 도구와 회귀 테스트를 추가했습니다.
- 500줄 이상 major text 56개의 책임·중복 계약·legacy 비중을 검토하고 #1093~#1099 후속 범위에 누락 없이 연결했습니다.

## 결정 근거

- suite는 dirty working tree가 아니라 지정 revision의 detached clean worktree에서 실행해 revision 계약을 보장합니다.
- compatibility 후보 수는 `제거 가능 + 한시적 호환 필요`로 정의하고 현행 safety path는 감량 분자에서 제외했습니다.
- 실제 활성 프로젝트는 registry 순번으로만 집계해 host 절대경로와 프로젝트명을 기록하지 않았습니다.
- inventory freshness를 강제하는 새 상설 gate는 만들지 않았습니다.

## 배포 경로 검증 (plug-in 영향 시)

dcness self cleanup 조사와 내부 #1092/#1099 비교 도구입니다. `scripts/release_artifact.json`에서 self-only baseline 스크립트를 명시적으로 제외하고 release artifact 테스트·smoke로 고정했으며, `init-dcness`도 외부 프로젝트에 복사하지 않습니다. agent/command/hook 배포 surface는 바꾸지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/mode/workflow/hard gate가 없습니다. `scripts/policy_cleanup_baseline.py`는 internal one-shot comparison tool입니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_policy_cleanup_baseline -v`
- [x] `python3.11 -m unittest tests.test_release_artifact tests.test_policy_cleanup_baseline`
- [x] `python3.11 scripts/release_artifact.py smoke --repo-root . --ref HEAD`
- [x] pre-commit full suite — 1,967 tests PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] baseline reproducibility diff (unit runtime 제외) PASS
- [x] cross-ref, public-surface, doc-sync, design-artifact, doc-path, plugin-manifest PASS

## 참고

- baseline revision: `b676140bcffdaa5843ce59198ecef4f997efddc9`
- baseline: tracked 560, major text 519/104,856 LOC, code+test 69,865 LOC, 500+/1,000+ 56/18, test 함수 1,943, clean revision suite 118.693초, compatibility 후보 15
- Codebase Sanity coverage: `UNKNOWN` — coverage 도구·리포트가 없어 green test count로 추정하지 않음
