### PR TITLE
[feature] eval flaky 후보 표면화 — 정답률 흔들리는 케이스 marker + 자동 후보 표

### DIFF
--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -16,7 +16,7 @@
 | 슬롯 | 질문 | 현재 담당 |
 |---|---|---|
 | Sense | 어떤 신호를 보나 | `/run-review`, benchmark/fleet 집계, 프로젝트-로컬 `.claude/loop-lessons/` 활성 lesson, `evals/guard_efficacy.py`, `evals/run.sh`, 가드 발화 텔레메트리 후보 [#875](https://github.com/alruminum/dcNess/issues/875), 재발·낭비 집계 후보 [#876](https://github.com/alruminum/dcNess/issues/876), judge 보정 후보 [#894](https://github.com/alruminum/dcNess/issues/894) |
-| Diagnose | 여러 신호를 어떻게 우선순위화하나 | 기존 `/run-review`가 내부 `scripts/loop_diagnose.py`를 호출한다. 활성 프로젝트 whitelist의 cross-project 신호를 종합해 판단 가치가 가장 큰 한 건만 사용자 언어로 보여주며, 별도 공개 command는 없다. guard telemetry는 `dcness-helper guard-telemetry`와 같은 기본 90일 스캔창(`--since-days`)으로 본다. 활성 lesson은 프로젝트별 Sense 항목으로 표시하고, 같은 lesson 패턴이 복수 프로젝트에서 활성화되면 중앙 RULE 후보로 올린다. |
+| Diagnose | 여러 신호를 어떻게 우선순위화하나 | 기존 `/run-review`가 내부 `scripts/loop_diagnose.py`를 호출한다. 활성 프로젝트 whitelist의 cross-project 신호를 종합해 판단 가치가 가장 큰 한 건만 사용자 언어로 보여주며, 별도 공개 command는 없다. guard telemetry는 `dcness-helper guard-telemetry`와 같은 기본 90일 스캔창(`--since-days`)으로 본다. eval 케이스는 정답률이 만점이면 노후 후보, min_runs 이상 시도에서 일부만 통과하면 flaky 후보로 같은 후보 표에 자동으로 올려, 사람이 리포트를 직접 치지 않아도 흔들리는 케이스가 표면화되게 한다. 활성 lesson은 프로젝트별 Sense 항목으로 표시하고, 같은 lesson 패턴이 복수 프로젝트에서 활성화되면 중앙 RULE 후보로 올린다. |
 | Decide | 무엇을 바꾸나 | 추가 전 제거 검토를 먼저 한다. 새 룰·hook·CI를 추가하기 전에 기존 룰 삭제, 문구 축약, SSOT 파생 생성으로 같은 효과를 낼 수 있는지 확인한다. 첫 사례는 개수 하드코딩 제거 [#877](https://github.com/alruminum/dcNess/issues/877)이다. |
 | Act | 실제 변경은 어디서 하나 | 일반 dcNess 변경 절차대로 branch → PR → merge를 탄다. PR 본문에 Sense 근거, Diagnose 판단, Decide 이유, Verify 계획을 짧게 적는다. |
 | Verify | 개선이 먹혔는지 어떻게 보나 | 변경 성격별로 결정적 eval, 행동 eval, 다음 Sense 주기 재측정을 분리한다. |

--- a/evals/README.md
+++ b/evals/README.md
@@ -71,8 +71,11 @@ Verify 슬롯을 사람이 도는 릴리즈 전 권고다.
 이 이벤트에는 pass/fail 뿐 아니라 블라인드 검수와 judge 호출 2회를 기준으로 한
 `llm_turns`, 보고서/judge 출력 길이, 추정 출력 token 이 함께 기록된다.
 `dcness-helper guard-telemetry` 는 이 이벤트를 읽어 최근 window 에서 장기간 만점인
-케이스를 **노후 후보**로 표시하고 평균 turn/token effort 를 함께 보여준다. 이 표시는
-케이스 삭제나 비활성화를 자동 실행하지 않는다.
+케이스를 **노후 후보**로, 정답률이 흔들리는(min_runs 이상 시도에서 일부만 통과한)
+케이스를 **flaky 후보**로 표시하고 평균 turn/token effort 를 함께 보여준다. 두 표시는
+상호배타이며(만점=노후, 부분 통과=flaky, 전패=회귀), 케이스 삭제나 비활성화를 자동
+실행하지 않는다. flaky 후보는 `scripts/loop_diagnose.py`(스케줄 sweep·`/run-review`)의
+자동 후보 표에도 노후 후보와 함께 올라오므로 사람이 리포트를 직접 치지 않아도 표면화된다.
 기본 산출 위치인 `.metrics/evals/**` 는 자동 집계 대상이다. `EVAL_OUTPUT_DIR` 를 repo 밖으로
 지정한 경우에는 `dcness-helper guard-telemetry --base-dir <EVAL_OUTPUT_DIR>` 로 그 산출물을 직접 본다.
 

--- a/harness/guard_telemetry.py
+++ b/harness/guard_telemetry.py
@@ -469,6 +469,7 @@ def collect_eval_summary(
             row["estimated_output_tokens"] / attempts if attempts else 0.0
         )
         row["saturation_candidate"] = attempts >= min_runs and attempts == passes
+        row["flaky_candidate"] = attempts >= min_runs and 0 < passes < attempts
     return {
         "saturation_days": saturation_days,
         "saturation_min_runs": saturation_min_runs,
@@ -517,7 +518,12 @@ def format_telemetry_report(
         if isinstance(cases, dict) and cases:
             for case, row_any in sorted(cases.items()):
                 row = row_any if isinstance(row_any, dict) else {}
-                marker = "노후 후보" if row.get("saturation_candidate") else "active"
+                if row.get("saturation_candidate"):
+                    marker = "노후 후보"
+                elif row.get("flaky_candidate"):
+                    marker = "flaky 후보"
+                else:
+                    marker = "active"
                 attempts = int(row.get("attempts") or 0)
                 passes = int(row.get("passes") or 0)
                 accuracy = float(row.get("accuracy") or 0.0)

--- a/scripts/loop_diagnose.py
+++ b/scripts/loop_diagnose.py
@@ -358,12 +358,15 @@ def _collect_self_evals(repo_root: Path, args: argparse.Namespace) -> dict[str, 
     if isinstance(cases, dict):
         for case, raw in sorted(cases.items()):
             row = raw if isinstance(raw, dict) else {}
-            if not row.get("saturation_candidate"):
+            saturation = bool(row.get("saturation_candidate"))
+            flaky = bool(row.get("flaky_candidate"))
+            if not (saturation or flaky):
                 continue
             attempts = int(row.get("attempts") or 0)
             passes = int(row.get("passes") or 0)
             accuracy = float(row.get("accuracy") or 0.0)
-            detail = f"{passes}/{attempts} pass, accuracy={accuracy:.0%}"
+            kind_label = "flaky" if flaky else "saturation"
+            detail = f"{kind_label}: {passes}/{attempts} pass, accuracy={accuracy:.0%}"
             last = row.get("last_ts") if isinstance(row.get("last_ts"), str) else None
             candidates.append(
                 _candidate(

--- a/tests/test_guard_telemetry.py
+++ b/tests/test_guard_telemetry.py
@@ -261,6 +261,7 @@ class EvalSummaryTests(unittest.TestCase):
             self.assertEqual(row["passes"], 0)
             self.assertEqual(row["failure_stages"]["report"], 1)
             self.assertFalse(row["saturation_candidate"])
+            self.assertFalse(row["flaky_candidate"])
 
     def test_all_pass_eval_case_is_saturation_candidate(self) -> None:
         with TemporaryDirectory() as td:
@@ -285,6 +286,29 @@ class EvalSummaryTests(unittest.TestCase):
             self.assertEqual(row["passes"], 2)
             self.assertEqual(row["accuracy"], 1.0)
             self.assertTrue(row["saturation_candidate"])
+            self.assertFalse(row["flaky_candidate"])
+
+    def test_partial_pass_eval_case_is_flaky_candidate(self) -> None:
+        with TemporaryDirectory() as td:
+            root = Path(td)
+            for passed in (True, True, False):
+                record_eval_case_result(
+                    "flow-ownership-entrypoint-bad",
+                    passed=passed,
+                    cwd=root,
+                )
+
+            summary = collect_eval_summary(
+                cwd=root,
+                saturation_days=30,
+                saturation_min_runs=3,
+            )
+
+            row = summary["cases"]["flow-ownership-entrypoint-bad"]
+            self.assertEqual(row["attempts"], 3)
+            self.assertEqual(row["passes"], 2)
+            self.assertTrue(row["flaky_candidate"])
+            self.assertFalse(row["saturation_candidate"])
 
     def test_any_recent_fail_prevents_saturation_candidate(self) -> None:
         with TemporaryDirectory() as td:
@@ -392,6 +416,32 @@ class ReportFormatTests(unittest.TestCase):
 
         self.assertIn("scan window: 7d", report)
         self.assertIn("관측 부족", report)
+
+    def test_report_marks_flaky_candidate(self) -> None:
+        guard_summary = {"idle_days": 30, "guards": {}}
+        eval_summary = {
+            "saturation_days": 30,
+            "saturation_min_runs": 3,
+            "cases": {
+                "flow-ownership-entrypoint-bad": {
+                    "attempts": 3,
+                    "passes": 2,
+                    "accuracy": 2 / 3,
+                    "avg_llm_turns": 2.0,
+                    "avg_estimated_output_tokens": 60.0,
+                    "last_ts": "2026-07-05T00:00:00Z",
+                    "saturation_candidate": False,
+                    "flaky_candidate": True,
+                    "failure_stages": {},
+                }
+            },
+            "token_estimate_basis": "utf8_bytes/4_lower_bound",
+        }
+
+        report = format_telemetry_report(guard_summary, eval_summary)
+
+        self.assertIn("flaky 후보", report)
+        self.assertIn("2/3", report)
 
 
 if __name__ == "__main__":

--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -408,6 +408,40 @@ class LoopDiagnoseTests(unittest.TestCase):
             self.assertIn("eval:headless-prose-quality", result.stdout)
             self.assertIn("judge 보정은 자동 수집하지 않습니다", result.stdout)
 
+    def test_eval_flaky_candidate_from_self_metrics(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            repo_root = tmp / "dcness"
+            repo_root.mkdir()
+            projects_file = tmp / "projects.json"
+            projects_file.write_text(
+                json.dumps({"version": 1, "projects": []}),
+                encoding="utf-8",
+            )
+            _write_jsonl(
+                repo_root / ".metrics" / "evals" / "run-1" / "guard-telemetry.jsonl",
+                [
+                    {
+                        "kind": "eval_case_result",
+                        "case": "flow-ownership-entrypoint-bad",
+                        "passed": True,
+                        "ts": "2026-07-05T00:00:00Z",
+                    },
+                    {
+                        "kind": "eval_case_result",
+                        "case": "flow-ownership-entrypoint-bad",
+                        "passed": False,
+                        "ts": "2026-07-05T01:00:00Z",
+                    },
+                ],
+            )
+
+            result = self._run(repo_root, projects_file)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("eval:flow-ownership-entrypoint-bad", result.stdout)
+            self.assertIn("flaky", result.stdout)
+
     def test_active_lessons_are_sense_candidates_and_cross_project_rule_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             tmp = Path(td)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1122

## 배경 및 문제

LLM 행동 eval 에서 입력·지침이 같아도 실행마다 판정이 흔들리는 케이스(flaky)를 표면화하는 경로가 없었다. `collect_eval_summary` 는 정답률(`accuracy`)을 계산하고도 리포트 marker 트리거는 `saturation_candidate`(장기 만점) 하나뿐이라, `flow-ownership-entrypoint-bad: 7/10 (70%)` 같은 명백한 flaky 가 `active` 로 묻혔다. 나아가 자동 표면화 경로인 `scripts/loop_diagnose.py:361` 이 `saturation_candidate` 만 통과시켜, sweep digest·`/run-review` 에서도 flaky 는 탈락했다. 사람이 리포트를 직접 쳐서 정답률 숫자를 눈으로 골라야 하는 상태였다.

## 원인 (해당 시)

-

## 작업내용

- `harness/guard_telemetry.py`: `collect_eval_summary` 에 `flaky_candidate` 파생 추가 — `attempts >= min_runs and 0 < passes < attempts` (saturation 의 대칭). 만점=노후, 부분 통과=flaky, 전패=회귀로 상호배타.
- `format_telemetry_report` marker 에 `flaky 후보` 추가 (기존 `노후 후보`/`active` 사이).
- `scripts/loop_diagnose.py`: 자동 후보 필터를 `saturation_candidate or flaky_candidate` 로 확장하고 `detail` 에 유형(flaky/saturation)을 표시 → sweep digest·`/run-review` 에 사람 개입 없이 표면화.
- 문서: `evals/README.md`, `docs/internal/self-improvement-loop.md`.

## 결정 근거

- 최소 구현 범위(케이스 단위 정답률 기반). 기대 단위(어느 기대 ID 가 흔들리는지)는 telemetry 스키마·`run.sh` 파싱을 건드려야 해 별도 follow-up 으로 분리(#1122 본문).
- 자동 재실행 채택(cherry-pick)·자동 케이스 수정은 배제 — `agent_effectiveness_measure.py` 원칙 + self-improvement-loop 의 "표면화까지, 결정은 사람" 유지. 표시만 추가.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 운영 도구 변경. `evals/`(self QA)·`harness/guard_telemetry.py`·`scripts/loop_diagnose.py` 는 plug-in 배포물이 아니며, `agents/**`·`commands/**`·`hooks/**`·init-dcness 복사 파일·`docs/plugin` SSOT 변경 없음. 문서도 `evals/README.md`·`docs/internal/**` 로 self 전용.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. 기존 `dcness-helper guard-telemetry` 리포트와 `loop_diagnose` 자동 후보 표에 marker 를 추가한 확장.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 — `tests/test_guard_telemetry.py`(flaky 파생·경계·marker), `tests/test_loop_diagnose.py`(자동 표면화) 신규 테스트를 RED 확인 후 GREEN. 전체 `python3.11 -m unittest discover -s tests` 1974개 OK.
- [x] 회귀 검증 — 두 모듈 + 전체 suite 통과. 실데이터 `scripts/dcness-helper guard-telemetry` 로 `7/10 (70%) → flaky 후보`, 만점 `→ 노후 후보` 상호배타 확인.

## 참고

-
