### PR TITLE
[feature] 활성화 hook 경로 호환 분기 정리

### DIFF
--- a/commands/init-dcness.md
+++ b/commands/init-dcness.md
@@ -412,7 +412,7 @@ custom 은 기존 세부 기능을 유지하되 이미 결정 가능한 항목�
 
 - CI workflow: GitHub remote 가 없거나 `.github/workflows/` 를 쓸 수 없으면 묻지 않고 skip 이유를 남긴다. 가능하면 `git-naming-validation.yml`, `pr-body-validation.yml`, `doc-path-integrity.yml`, `doc-sync.yml`, `github-project-lifecycle.yml` 을 각각 선택할 수 있다.
 - docs seed: 이미 존재하는 파일은 묻지 않는다. 단 기존 `docs/index.md` 에 진행 상태 섹션이 없으면 append 보강한다. 루트 `architecture.md` 가 있으면 `docs/architecture.md` 생성 질문을 생략하고 `root architecture.md 감지로 docs/architecture.md skip` 을 남긴다.
-- design seed: UI 프로젝트 여부가 불명확할 때만 묻는다. `docs/design.md` 는 부재 시 [`docs/plugin/design.md`](../docs/plugin/design.md) 기준 minimal template 생성 여부를 선택한다. `docs/design-variants/` 는 사용자가 명시 선택한 경우에만 설치한다. draft 는 `docs/design-variants/drafts/` 에 두고 gitignore 한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 custom design seed 를 재실행하거나 아래 파일들을 `docs/design-variants/` 로 복사해 재배포한다.
+- design seed: UI 프로젝트 여부가 불명확할 때만 묻는다. `docs/design.md` 는 부재 시 [`docs/plugin/design.md`](../docs/plugin/design.md) 기준 minimal template 생성 여부를 선택한다. `docs/design-variants/` 는 사용자가 명시 선택한 경우에만 설치한다. draft 는 `docs/design-variants/drafts/` 에 두고 gitignore 한다.
 - Provider routing: 추천 role-split 으로 복귀하려면 `enable-role-split-routing` 을 선택한다. all-codex validation 을 원하면 `enable-codex-validation`, Claude 검증 복귀를 원하면 `disable-codex-validation` 을 명시 선택한다.
 - Implementation routing: 지원값과 migration 순서는 [`docs/plugin/init-dcness.md#provider-routing`](../docs/plugin/init-dcness.md#provider-routing)을 따르고, Claude-only는 `set-implementation build-worker claude`를 사용한다.
 - GitHub Project lifecycle: custom 에서만 진행한다. 세부 계약은 [`docs/plugin/github-project.md`](../docs/plugin/github-project.md) 와 [`docs/plugin/issue-lifecycle.md`](../docs/plugin/issue-lifecycle.md) 가 SSOT 다.

--- a/docs/internal/policy-sunset-inventory.json
+++ b/docs/internal/policy-sunset-inventory.json
@@ -307,6 +307,13 @@
       "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_tdd_guard.py"],
       "docs_distribution": ["commands/init-dcness.md", "hooks/tdd-guard.sh"],
       "consumer_evidence": "등록 프로젝트 1개는 5/5 generated 파일을 보유하고 current impl preflight가 committed project-local hook을 요구한다.",
+      "support_contract": {
+        "installation_states": "fresh init, idempotent re-run, plugin update 후 재생성, CC+Codex 5/5 complete generated install",
+        "supported_versions": "v0.12.0+에서 generated hook 계약 지원; v0.19.0+에서 in-place·linked-worktree Git 도달성 판정 지원",
+        "retention_reason": "현행 writer·self-test·impl preflight가 이 계약을 직접 사용하고 완전 설치 활성 프로젝트가 실재한다.",
+        "removal_trigger": "대체 project-local TDD 계약과 migration이 승인되고 등록 프로젝트의 generated file·runtime hit가 0이 된 뒤",
+        "verification": "python3.11 -m unittest tests.test_generated_tdd_hooks tests.test_hooks -v; scripts/dcness-tdd-hooks status/ensure"
+      },
       "compatibility": null
     },
     {
@@ -320,6 +327,13 @@
       "tests_fixtures": ["tests/test_tdd_guard.py", "tests/test_generated_tdd_hooks.py"],
       "docs_distribution": ["commands/init-dcness.md", "docs/plugin/init-dcness.md"],
       "consumer_evidence": "등록 5개 프로젝트의 generated install 보유량이 0/5, 2/5, 5/5, 0/5, 1/5라 partial state가 현재 실재한다.",
+      "support_contract": {
+        "installation_states": "generated file 0/5·1/5·2/5 partial state, plugin update 중간 상태, project-local hook 미생성 project",
+        "supported_versions": "v0.12.0+의 generated/central 공존 계약; 현재 v0.23.0 partial install 지원",
+        "retention_reason": "등록 활성 프로젝트 5곳 중 4곳이 partial state이며 generated hook이 없는 TS/JS 경로의 TDD safety를 중앙 fallback이 유지한다.",
+        "removal_trigger": "지원 대상 활성 프로젝트가 모두 5/5로 migration되고 plugin update 중간 상태에서도 동등한 TDD safety가 보장된 뒤",
+        "verification": "python3.11 -m unittest tests.test_generated_tdd_hooks tests.test_tdd_guard tests.test_hooks -v; scripts/dcness-tdd-hooks status"
+      },
       "compatibility": null
     },
     {
@@ -333,19 +347,33 @@
       "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_git_hook_guard_telemetry.py"],
       "docs_distribution": ["commands/init-dcness.md", "docs/plugin/hooks.md"],
       "consumer_evidence": "plugin cache 실행, dcness self in-place 실행, Claude hook env, headless env가 서로 다른 root 신호를 제공하는 현행 배포 topology다.",
+      "support_contract": {
+        "installation_states": "DCNESS_TDD_PLUGIN_ROOT explicit self-test/headless, CLAUDE_PLUGIN_ROOT interactive hook, plugin cache native/git hook, dcNess self repo-local top-level",
+        "supported_versions": "thin shim v0.2.2+; post-checkout/pre-push v0.2.6+; generated hook root resolver v0.12.0+",
+        "retention_reason": "Claude hook, native git hook, headless worker, self repo가 root env를 서로 다르게 제공하며 현재 cache v0.23.0과 repo-local 개발 모두가 소비한다.",
+        "removal_trigger": "모든 지원 실행 환경이 검증된 active plugin root 단일 신호를 제공하고 self repo·cache fallback fixture hit가 0이 된 뒤",
+        "verification": "python3.11 -m unittest tests.test_generated_tdd_hooks tests.test_git_hook_guard_telemetry tests.test_hook_wrapper_exit -v"
+      },
       "compatibility": null
     },
     {
       "id": "INST-004",
       "area": "install-path",
       "policy_slice": "design-variants/ legacy path prefix의 validation-only 탐지",
-      "classification": "제거 가능",
+      "classification": "퇴역 완료",
       "follow_up_issue": 1096,
       "current_ssot": ["docs/plugin/deliverables-map.md#design-variants"],
-      "implementation": ["scripts/check_doc_path_integrity.mjs:LEGACY_PATH_PREFIXES"],
-      "tests_fixtures": ["tests/test_doc_path_integrity.py"],
-      "docs_distribution": ["docs/plugin/init-dcness.md"],
-      "consumer_evidence": "등록 프로젝트 익명 조사에서 docs/design-variants/를 제외한 legacy design-variants/ 참조가 0건이다.",
+      "implementation": ["scripts/check_doc_path_integrity.mjs:LEGACY_PATH_PREFIXES (removed)"],
+      "tests_fixtures": ["tests/test_canvas_design_workflow.py", "tests/test_policy_cleanup_baseline.py"],
+      "docs_distribution": ["commands/init-dcness.md", "docs/plugin/init-dcness.md"],
+      "consumer_evidence": "2026-07-14 등록 프로젝트 5곳 익명 조사에서 legacy design-variants/ 디렉터리·markdown 참조가 모두 0건이었다. canonical docs/design-variants/ 디렉터리는 1곳에 존재했고 current generator는 canonical path만 쓴다.",
+      "support_contract": {
+        "installation_states": "v0.11.0~v0.23.0의 validation-only legacy root 탐지; 등록 프로젝트 legacy directory·reference 0",
+        "supported_versions": "legacy 탐지는 v0.11.0~v0.23.0; 이 변경 이후 미지원",
+        "retention_reason": "유지 사유 없음; current generator·docs·TDD skip은 docs/design-variants/ canonical path만 사용한다.",
+        "removal_trigger": "등록 프로젝트 legacy directory 0 그리고 markdown reference 0으로 2026-07-14 충족",
+        "verification": "! rg 'LEGACY_PATH_PREFIXES' scripts/check_doc_path_integrity.mjs && ! rg '(^|[^/])design-variants/' commands docs/plugin; python3.11 -m unittest tests.test_canvas_design_workflow tests.test_doc_path_integrity tests.test_policy_cleanup_baseline -v"
+      },
       "compatibility": null
     },
     {
@@ -359,6 +387,13 @@
       "tests_fixtures": ["tests/test_generated_tdd_hooks.py", "tests/test_session_state.py", "tests/test_hook_wrapper_exit.py"],
       "docs_distribution": ["commands/init-dcness.md", "docs/plugin/loop-procedure.md"],
       "consumer_evidence": "현행 impl/design workflow가 linked worktree를 사용하며 common-dir hook과 primary local receipt를 구분해야 한다.",
+      "support_contract": {
+        "installation_states": "primary worktree, linked worktree, common git hooks path, committed/uncommitted/missing generated files, primary-worktree receipt",
+        "supported_versions": "v0.19.0+ current in-place·linked-worktree generated-file reachability contract",
+        "retention_reason": "현행 impl/design workflow가 linked worktree를 사용하며 common hook와 worktree-local generated file, primary receipt를 구분해야 오차단·미차단을 피한다.",
+        "removal_trigger": "worktree 격리 workflow가 종료되거나 Git hook·state root가 단일 표준 경로로 대체되고 등록 프로젝트 migration이 완료된 뒤",
+        "verification": "python3.11 -m unittest tests.test_generated_tdd_hooks tests.test_hooks tests.test_session_state tests.test_hook_wrapper_exit -v"
+      },
       "compatibility": null
     },
     {

--- a/docs/internal/policy-sunset-inventory.md
+++ b/docs/internal/policy-sunset-inventory.md
@@ -176,6 +176,22 @@ PY
 | ROUTE-004 | 저장 형식과 무관한 Python export; repo caller 0 | backward-compatible 이름만 남은 read surface | 완료 — export·`__all__`·assertion 제거 | `rg 'VALID_PROVIDERS' harness scripts`와 `tests.test_policy_cleanup_baseline` |
 | ROUTE-005 | schema v3 `headless-chain`; implementation runtime | pre-mutation 실패만 복구하고 mutation 후 자동 덮어쓰기를 막는 현행 safety | 동등한 mutation 감지·중단 보장으로 chain을 대체할 때 | `python3.11 -m unittest tests.test_provider_chain -v` |
 
+### #1096 설치·hook·경로 cleanup 상태 전이
+
+`INST-004`의 루트 `design-variants/` prefix는 v0.11.0에서 canonical `docs/design-variants/`로 이동할 때 stale reference를 잡던 validation-only 경로였다. 2026-07-14 등록 프로젝트 5곳을 비식별 재조사한 결과 legacy directory와 markdown reference가 모두 0건이었고, current generator·TDD skip·배포 inventory는 canonical path만 쓴다. 따라서 `LEGACY_PATH_PREFIXES`, 구 migration 안내, 존재 예상 test를 함께 제거하고 `퇴역 완료`로 전이한다. 전체 compatibility 후보는 11개에서 10개, install/path 후보는 1개에서 0개로 감소한다.
+
+나머지 경로는 단순히 오래됐다는 이유로 제거하지 않는다. generated hook은 v0.12.0+의 현행 계약이고, v0.19.0+의 in-place·linked-worktree 도달성 판정과 함께 쓴다. git thin shim의 repo-local·`CLAUDE_PLUGIN_ROOT`·cache 탐색은 v0.2.2+ self/external 실행 topology를, central TDD fallback은 현재 partial generated install을 보호한다.
+
+| ID | 소비 설치 상태·지원 버전 | #1096 판정·유지 이유 | 제거 trigger | 확인 명령·fixture |
+|---|---|---|---|---|
+| INST-001 | fresh init, re-run, plugin update, 5/5 generated install; v0.12.0+, Git 도달성은 v0.19.0+ | 현재 writer·self-test·impl preflight와 5/5 활성 소비자가 있어 유지 | 대체 계약 migration 후 generated file·runtime hit 0 | `tests.test_generated_tdd_hooks`, `dcness-tdd-hooks status/ensure` |
+| INST-002 | 0/5·1/5·2/5 partial, update 중간 상태; v0.12.0+ | 5곳 중 4곳이 partial이며 generated hook 없는 TS/JS TDD safety를 보호해 유지 | 전항 5/5 migration + update 중간 safety 대체 | `tests.test_generated_tdd_hooks`, `tests.test_tdd_guard`, `tests.test_hooks` |
+| INST-003 | explicit headless/self-test, Claude env, plugin cache, dcNess self repo-local; thin shim v0.2.2+, generated resolver v0.12.0+ | 실행 surface별 root 신호가 달라 유지 | 검증된 active root 단일 신호 전환 + self/cache hit 0 | `tests.test_generated_tdd_hooks`, `tests.test_git_hook_guard_telemetry`, `tests.test_hook_wrapper_exit` |
+| INST-004 | v0.11.0~v0.23.0 validation-only legacy prefix; 디렉터리·reference 0 | 퇴역 완료; canonical generator는 `docs/design-variants/`만 쓰며 소비자 없음 | 2026-07-14 등록 프로젝트 directory 0 + reference 0으로 충족 | `rg 'LEGACY_PATH_PREFIXES'`, canvas/doc-path/policy inventory tests |
+| INST-005 | primary/linked worktree, common hooks, generated commit state, primary receipt; v0.19.0+ | 현행 impl/design worktree의 오차단·미차단 방지로 유지 | worktree workflow 종료 또는 Git hook/state root 단일화 + migration | `tests.test_hooks`, `tests.test_session_state`, `tests.test_hook_wrapper_exit` |
+
+배포 경로는 두 가지다. `harness/**`, `hooks/**`, `scripts/**`, `commands/**`, `docs/plugin/**`는 plugin 본체와 release artifact를 통해 다음 plugin update 시 활성 프로젝트에 도달한다. 선택형 `doc-path-integrity.yml`은 `Daeguk-Sun/dcNess/.github/actions/doc-path-integrity@main`의 현행 script를 호출하므로 legacy prefix 제거를 위한 workflow 재배포는 필요 없다. git thin shim 내용이 바뀌는 후속 변경만 `/init-dcness` 재실행이 필요하며, 이 변경은 shim과 generated file 바이트를 바꾸지 않는다.
+
 ### 활성 소비자 snapshot
 
 등록 파일 `~/.claude/plugins/data/dcness-dcness/projects.json`의 경로는 문서에 공개하지 않고 registry 순번으로만 조사했다.
@@ -187,7 +203,7 @@ PY
 | routing config | schema 3이지만 retired `code-validator`, `pr-reviewer`, `test-engineer` key 잔존 | `ROUTE-002` migration 대상 실재 |
 | generated install | 프로젝트별 5개 대상 파일 보유량 `0/5, 2/5, 5/5, 0/5, 1/5` | partial install fallback인 `INST-002` 현행 |
 | stories | 3개 프로젝트의 `stories.md` 8개가 모두 Story AC heading 없는 구양식 | `LIFE-002` 한시 호환 |
-| legacy `design-variants/` prefix | 등록 프로젝트 0건 | `INST-004` 제거 가능 |
+| legacy `design-variants/` prefix | 등록 프로젝트 directory·markdown reference 모두 0건 | `INST-004` 제거 trigger 충족·퇴역 완료 |
 
 절대경로·프로젝트명은 근거가 아니라 민감한 host 정보라 기록하지 않았다. 후속 이슈는 같은 registry 순번과 해당 이슈의 확인 명령으로 재조사한다.
 

--- a/docs/internal/policy-sunset-inventory.md
+++ b/docs/internal/policy-sunset-inventory.md
@@ -209,7 +209,7 @@ PY
 
 ## 한시적 호환 4요소 감사
 
-아래 11개 모두 대상, 유지 이유, 제거 trigger, 확인 방법을 가진다. 명령 전문과 trace path는 machine inventory에 있다.
+아래 10개 모두 대상, 유지 이유, 제거 trigger, 확인 방법을 가진다. 명령 전문과 trace path는 machine inventory에 있다.
 
 | ID | 소비자 또는 대상 형식 | 유지 이유 | 제거 trigger | 확인 방법 |
 |---|---|---|---|---|
@@ -221,7 +221,6 @@ PY
 | RUN-005 | `validator` 이름의 persisted trace | attribution과 boundary 복구 | archive migration + alias 적중 0 | run-review/boundary tests |
 | RUN-008 | legacy stored verdict + prose sentinel | 과거 FAIL 비율 오판 방지 | verdict migration + old 표본 0 | run-review/aggregate tests |
 | ROUTE-002 | schema 1·2와 retired route keys | local config를 조용히 폐기하지 않음 | config migration + scan 0 | routing doctor + tests |
-| ROUTE-003 | `codex-first` 저장값 | 과거 explicit opt-in 의미 보존 | registered config 사용 0 + migration | routing status/provider-chain tests |
 | LIFE-002 | Story AC 없는 stories | 소급 의미 추론·false fail 방지 | typed AC migration + scan 0 | AC coverage + fixture |
 | LIFE-003 | checklist 없는 legacy issue | false close·영구 close 불가 방지 | 열린 issue migration/지원 종료 | issue close audit + fixture |
 

--- a/docs/plugin/init-dcness.md
+++ b/docs/plugin/init-dcness.md
@@ -203,7 +203,7 @@ node "$PLUGIN_ROOT/scripts/github_project_lifecycle.mjs" bootstrap \
 | 선택형 `.github/workflows/*.yml` 갱신 | 예 | workflow 파일은 사용자 repo 에 배포된 사본이다. 기존 epic 또는 module docs 가 있는 프로젝트는 doc-sync 채택 직후 index 집계기를 1회 실행해야 한다. 전역 architecture 요약은 온디맨드다. |
 | Provider routing preset/custom 변경 | 예 | 기존 활성 프로젝트도 plugin 공용 local data 를 갱신해야 한다. 추천 preset 은 `dcness-helper routing enable-role-split-routing` 뒤 `dcness-helper routing doctor` 로 적용·검증하고, custom은 [Provider Routing](#provider-routing)의 현행 값만 사용한다. Native Codex skill 등록/fallback 용 `$CODEX_HOME/skills` 도 최신화된다. |
 | Project lifecycle 좌표 저장/변경 | 예 | repo variables 와 선택형 workflow 를 갱신해야 한다. |
-| docs/design + docs/design-variants seed 추가 | 예 | 부재 파일 seed 는 사용자 repo 에 직접 생성된다. draft 는 `docs/design-variants/drafts/` 에 두고 `.gitignore` 로 무시하되 `drafts/.gitkeep` 으로 디렉터리를 보존한다. 기존 활성 프로젝트가 과거 루트 `design-variants/` seed 만 갖고 있으면 `/init-dcness` custom design seed 를 재실행하거나 `templates/design-variants/{.gitignore,canvas.html,_lib/*,drafts/.gitkeep}` 를 `docs/design-variants/` 로 복사한다. |
+| docs/design + docs/design-variants seed 추가 | 예 | 부재 파일 seed 는 사용자 repo 에 직접 생성된다. draft 는 `docs/design-variants/drafts/` 에 두고 `.gitignore` 로 무시하되 `drafts/.gitkeep` 으로 디렉터리를 보존한다. |
 | TDD Guard 정책 갱신 | 아니오 | 중앙 fallback 과 self-test 본체는 plug-in update 로 갱신된다. project-local generated hook 이 없는 기존 프로젝트는 `/init-dcness` 또는 `/impl` 진입 시 생성 제안을 다시 받을 수 있다. |
 
 ## Auto PR Scope

--- a/scripts/check_doc_path_integrity.mjs
+++ b/scripts/check_doc_path_integrity.mjs
@@ -51,13 +51,6 @@ const PATH_PREFIXES = [
   'tests/',
 ];
 
-// Canonical canvas SSOT moved to docs/design-variants/. Keep the legacy root
-// prefix as a validation-only path so stale docs fail instead of becoming
-// invisible to this checker.
-const LEGACY_PATH_PREFIXES = [
-  'design-variants/',
-];
-
 const OPTIONAL_SEED_PATHS = new Set([
   '.dcness-work/',
   'docs/tech-review.md',
@@ -191,9 +184,7 @@ function shouldIgnoreCandidate(value) {
 
 function looksLikeRepoPath(value) {
   if (ROOT_FILES.has(value)) return true;
-  return [...PATH_PREFIXES, ...LEGACY_PATH_PREFIXES].some((prefix) =>
-    value.startsWith(prefix),
-  );
+  return PATH_PREFIXES.some((prefix) => value.startsWith(prefix));
 }
 
 function isSeedPlaceholderPath(value) {

--- a/tests/test_canvas_design_workflow.py
+++ b/tests/test_canvas_design_workflow.py
@@ -280,15 +280,16 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
         self.assertIn("docs/design-variants/drafts/", self.designer)
         self.assertNotIn("design-variants/<screen>-v<N>.html", self.designer)
 
-    def test_init_dcness_deploys_docs_design_variants_seed_and_redeploy_notice(
+    def test_init_dcness_deploys_canonical_docs_design_variants_seed(
         self,
     ) -> None:
         for text in (self.init_skill, self.init_ref):
             with self.subTest(doc=text[:30]):
                 self.assertIn("docs/design-variants/", text)
                 self.assertIn("docs/design-variants/drafts/", text)
-                self.assertIn("canvas.html", text)
-                self.assertIn("기존 활성 프로젝트", text)
+                self.assertNotIn("과거 루트 `design-variants/`", text)
+        self.assertIn("canvas.html", self.init_skill)
+        self.assertIn("templates/design-variants/**", self.init_ref)
         self.assertNotIn('TARGET="$PROJECT_ROOT/design-variants/$FILE"', self.init_skill)
         self.assertTrue((ROOT / "templates" / "design-variants" / ".gitignore").is_file())
         self.assertTrue(
@@ -297,8 +298,8 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
 
     def test_support_gates_treat_docs_design_variants_as_canonical_path(self) -> None:
         self.assertIn("'docs/design-variants/'", self.doc_path_integrity)
-        self.assertIn("LEGACY_PATH_PREFIXES", self.doc_path_integrity)
-        self.assertIn("'design-variants/'", self.doc_path_integrity)
+        self.assertNotIn("LEGACY_PATH_PREFIXES", self.doc_path_integrity)
+        self.assertNotIn("\n  'design-variants/',", self.doc_path_integrity)
 
         self.assertIn("*/docs/design-variants/*", self.tdd_guard)
         self.assertNotIn("*/design-variants/*) allow", self.tdd_guard)

--- a/tests/test_policy_cleanup_baseline.py
+++ b/tests/test_policy_cleanup_baseline.py
@@ -162,8 +162,26 @@ class PolicyCleanupBaselineTests(unittest.TestCase):
         doc_path_source = (
             ROOT / "scripts" / "check_doc_path_integrity.mjs"
         ).read_text(encoding="utf-8")
+        inventory_doc = (
+            ROOT / "docs" / "internal" / "policy-sunset-inventory.md"
+        ).read_text(encoding="utf-8")
+        compatibility_audit = inventory_doc.split("## 한시적 호환 4요소 감사", 1)[1].split(
+            "## 500줄 이상 major text 책임 감사", 1
+        )[0]
+        documented_compatibility = {
+            row.split("|")[1].strip()
+            for row in compatibility_audit.splitlines()
+            if row.startswith("| ") and not row.startswith("| ID ")
+        }
+        expected_compatibility = {
+            entry["id"]
+            for entry in entries
+            if entry["classification"] == "한시적 호환 필요"
+        }
         self.assertEqual(by_id["INST-004"]["classification"], "퇴역 완료")
         self.assertNotIn("LEGACY_PATH_PREFIXES", doc_path_source)
+        self.assertEqual(documented_compatibility, expected_compatibility)
+        self.assertIn(f"아래 {len(expected_compatibility)}개", compatibility_audit)
 
     def test_unit_suite_runs_the_requested_revision_not_dirty_working_tree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_policy_cleanup_baseline.py
+++ b/tests/test_policy_cleanup_baseline.py
@@ -159,6 +159,12 @@ class PolicyCleanupBaselineTests(unittest.TestCase):
         self.assertNotIn("codex-first", routing_source)
         self.assertNotIn("VALID_PROVIDERS", routing_source)
 
+        doc_path_source = (
+            ROOT / "scripts" / "check_doc_path_integrity.mjs"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(by_id["INST-004"]["classification"], "퇴역 완료")
+        self.assertNotIn("LEGACY_PATH_PREFIXES", doc_path_source)
+
     def test_unit_suite_runs_the_requested_revision_not_dirty_working_tree(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1096
Part of #1089

## 배경 및 문제

- 상위 Epic #1089의 install/path 정책 후보 중 소비자가 사라진 legacy 루트 `design-variants/` validation 분기를 퇴역해야 합니다.
- 선행 inventory #1092와 routing/run-ledger/lifecycle 정리 #1093~#1095가 완료된 상태에서, 현재 사용 중인 generated hook·중앙 fallback·root 탐색·linked worktree 안전장치와 제거 가능한 경로를 구분할 근거가 필요했습니다.

## 원인 (해당 시)

- canonical seed가 `docs/design-variants/`로 이동한 뒤에도 stale reference 탐지용 `LEGACY_PATH_PREFIXES`와 구 migration 안내가 남아 있었습니다.

## 작업내용

- install/path 후보 5개에 소비 설치 상태, 지원 버전, 유지 사유, 제거 trigger, 확인 명령을 기록했습니다.
- 등록 활성 프로젝트 조사에서 directory·markdown reference가 모두 0인 `INST-004`를 `퇴역 완료`로 전이했습니다.
- `scripts/check_doc_path_integrity.mjs`의 legacy root prefix와 init 문서의 구 migration 안내를 함께 제거했습니다.
- canonical path 및 inventory 퇴역 상태를 고정하는 회귀 테스트를 갱신했습니다.

## 결정 근거

- generated hook과 central fallback은 등록 프로젝트의 5/5 및 partial 설치가 모두 실재해 유지했습니다.
- Claude/Codex root 탐색과 linked worktree 분기는 현재 실행 topology가 직접 소비하므로 종료 조건만 명시하고 보존했습니다.
- `design-variants/` legacy root는 v0.11.0~v0.23.0 validation-only 호환이었고 현재 소비자가 0이라 구현·테스트·문서를 같은 PR에서 제거했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `scripts/check_doc_path_integrity.mjs`, `commands/**`, `docs/plugin/**` 변경은 plugin 본체와 release artifact를 통해 다음 plugin update에 전달됩니다.
- 선택형 `doc-path-integrity.yml`은 `Daeguk-Sun/dcNess/.github/actions/doc-path-integrity@main`을 호출하므로 workflow 사본 재배포 없이 새 checker를 사용합니다.
- git thin shim과 generated hook 바이트는 변경하지 않아 이 PR만을 위한 `/init-dcness` 재실행은 필요 없습니다.
- 커밋된 HEAD에서 `release_artifact.py smoke`가 193 files, 2,222,899 bytes로 PASS했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — public surface를 추가하지 않고 소비자 없는 validation 분기를 제거했습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 — `python3.11 -m unittest discover -s tests -q` 1,971 tests PASS
- [x] 회귀 검증 — install matrix fresh 5/5, repair 4/5→5/5, byte-identical re-run, plugin-cache deny, partial central fallback deny, linked worktree committed PASS
- [x] Claude+Codex generated hook·project-local 우선·central fallback·pre-commit/commit-msg/pre-push 관련 565 tests PASS
- [x] static quality ruff/mypy/Bandit PASS, guard efficacy 39/39 PASS
- [x] doc-path/public-surface/cross-ref/index/design-artifact/plugin-manifest/release-artifact gates PASS

## 참고

- 선행: #1092, #1093, #1094, #1095 완료
- 후행: #1097; 통합 검증 #1098; Epic 마감 #1099
