### PR TITLE
[feature] eval run.sh (case, run) 셀 병렬 실행 — wall-clock 단축

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,7 @@ PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality
 | 이름 | 용도 | 기본값 | 필수 |
 |---|---|---|---|
 | `EVAL_RUNS` / `EVAL_MODEL` / `EVAL_OUTPUT_DIR` / `EVAL_RELEASE_CHECK` / `EVAL_STRICT_CASES` | `evals/run.sh` 행동 eval — 반복 수 / 모델 / 산출물 위치 / 릴리즈 N/N 모드 / 핵심 케이스 목록 | `1` / `sonnet` / `.metrics/evals/run-*` / `0` / 핵심 2케이스 | X |
+| `EVAL_PARALLEL` | `evals/run.sh` 행동 eval 의 동시 실행 `(case, run)` 셀 상한. `1` = 직렬(회귀 안전판). headless `claude -p` quota 는 메인 세션과 공유하므로 보수적 값 유지 | `4` | X |
 | `DCNESS_FORCE_ENABLE` | is-active 게이트 임시 활성 (디버깅) | 미설정 | X |
 | `DCNESS_CODEX_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt timeout | validator `600`, worker `1200` | X |
 | `DCNESS_CODEX_IDLE_TIMEOUT` | `dcness-codex-worker` Codex attempt 의 stdout/prose/workspace 무진행 조기 kill timeout | `180` | X |

--- a/evals/README.md
+++ b/evals/README.md
@@ -37,6 +37,7 @@ EVAL_RUNS=3 bash evals/run.sh        # 케이스당 3회 반복 (릴리즈 전 �
 EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh  # 핵심 실사고 케이스 N/N 확인
 EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonnet)
 EVAL_OUTPUT_DIR=/tmp/dcness-evals bash evals/run.sh # 산출물 저장 위치 지정
+EVAL_PARALLEL=8 bash evals/run.sh    # (case, run) 셀을 최대 8개까지 병렬 실행 (기본 4, 1=직렬 안전판)
 
 # judge 보정 — blind report 생성 후 사람이 versioned golden을 작성·확인한다
 python3 evals/calibrate_judge.py .metrics/evals/run-YYYYMMDDTHHMMSSZ-PID --expect-golden-version example-human-v1 --expect-subset-version example-subset-v1
@@ -45,6 +46,12 @@ python3 evals/calibrate_judge.py /tmp/dcness-evals --golden /tmp/dcness-evals/ju
 # 저장된 core 후보 — owner 확인 전에는 의도적으로 exit 2
 python3 evals/calibrate_judge.py evals/calibration/core-incidents-v1 --golden evals/golden/core-incidents-v1.json --expect-golden-version core-incidents-v1-human-v1 --expect-subset-version core-incidents-v1
 ```
+
+`run.sh` 는 `(case, run)` 셀이 서로 독립인 점을 이용해 셀 단위로 병렬 실행한다. 셀 내부의
+report→judge 순서만 유지하고, 동시 셀 상한은 `EVAL_PARALLEL`(기본 4)로 조절한다.
+`EVAL_PARALLEL=1` 은 셀을 하나씩 도는 직렬 실행이며 병렬화 회귀가 의심될 때의 안전판이다.
+headless `claude -p` quota 는 메인 세션과 공유되므로 상한은 보수적으로 둔다. 집계는 shell
+카운터가 아니라 셀별 marker 파일로 하므로 병렬/직렬 pass·fail 판정은 동일하다.
 
 `guard_efficacy.py` 는 범주별 pass/fail count 를 출력한다. `provider-agnostic-order-gate`
 와 `provider-agnostic-tdd` 범주는 Claude Agent hook 이 아닌 `begin-step`/headless worker

--- a/evals/run.sh
+++ b/evals/run.sh
@@ -2,86 +2,28 @@
 # 행동 eval 러너 — 언제/어떻게/채점 원리는 evals/README.md 가 진본.
 #
 # 사용:
-#   bash evals/run.sh                 # 전 케이스 1회씩
+#   bash evals/run.sh                 # 전 케이스 1회씩 (셀 병렬 — 기본 EVAL_PARALLEL=4)
 #   EVAL_RUNS=3 bash evals/run.sh     # 케이스당 3회 (릴리즈 전 권장)
 #   EVAL_MODEL=opus bash evals/run.sh # 모델 변경 (기본 sonnet)
 #   EVAL_CASES="case-a case-b" bash evals/run.sh # 선택 케이스만 실행
+#   EVAL_PARALLEL=1 bash evals/run.sh # 직렬 실행 (병렬화 회귀 안전판 — 기본은 4 셀 병렬)
+#
+# (case, run_index) 셀은 서로 독립이므로 셀 단위로 병렬 실행한다. 셀 내부의 report→judge
+# 순서만 유지하고, 케이스 간·run 간에는 순서 의존이 없다. macOS 기본 bash 3.2 는 `wait -n`
+# 을 지원하지 않으므로 이식성을 위해 `xargs -P` 로 동시 셀 상한을 건다. 셀 워커는 자기
+# 자신을 `__worker` 모드로 재호출한 프로세스이며, 결과는 shell 변수가 아니라 marker 파일로
+# 집계한다 (서브셸이 부모 카운터를 못 갱신하는 문제 회피).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-RUNS="${EVAL_RUNS:-1}"
-MODEL="${EVAL_MODEL:-sonnet}"
-OUTPUT_DIR="${EVAL_OUTPUT_DIR:-$ROOT/.metrics/evals/run-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
-RELEASE_CHECK="${EVAL_RELEASE_CHECK:-0}"
-STRICT_CASES="${EVAL_STRICT_CASES:-shorts-real-spec headless-prose-quality}"
-CASE_FILTER="${EVAL_CASES:-}"
-
-command -v claude >/dev/null 2>&1 || { echo "[eval] claude CLI 가 필요하다"; exit 2; }
-
-case_is_available() {
-  local needle="$1"
-  local available_dir
-  for available_dir in "$ROOT"/evals/cases/*/; do
-    [ "$(basename "$available_dir")" = "$needle" ] && return 0
-  done
-  return 1
-}
-
-if [ -n "$CASE_FILTER" ]; then
-  selected_count=0
-  for selected_case in $CASE_FILTER; do
-    selected_count=$((selected_count + 1))
-    case_is_available "$selected_case" || {
-      echo "[eval] 선택 케이스 없음: $selected_case" >&2
-      exit 2
-    }
-  done
-  [ "$selected_count" -gt 0 ] || {
-    echo "[eval] 선택 케이스가 비어 있음" >&2
-    exit 2
-  }
-fi
-
-overall_fail=0
-mkdir -p "$OUTPUT_DIR"
-echo "[eval] output: $OUTPUT_DIR"
-
-# Report agent에는 지침을 읽을 최소 snapshot만 노출한다. repo 전체를 --add-dir로 주면
-# evals/golden/**의 사람 판정과 이유를 탐색할 수 있어 blind report가 오염된다.
-instruction_root="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-instructions-XXXXXX")"
-sandbox=""
-cleanup() {
-  [ -z "$sandbox" ] || rm -rf -- "$sandbox"
-  rm -rf -- "$instruction_root"
-}
-trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-cp -R "$ROOT/docs" "$ROOT/skills" "$ROOT/agents" "$instruction_root/"
-
-is_strict_case() {
-  local needle="$1"
-  local item
-  for item in $STRICT_CASES; do
-    [ "$item" = "$needle" ] && return 0
-  done
-  return 1
-}
-
-is_selected_case() {
-  local needle="$1"
-  local item
-  [ -z "$CASE_FILTER" ] && return 0
-  for item in $CASE_FILTER; do
-    [ "$item" = "$needle" ] && return 0
-  done
-  return 1
-}
 
 byte_len() {
   LC_ALL=C printf '%s' "$1" | wc -c | tr -d ' '
 }
 
+# telemetry 기록 — case_name/i/RUNS/MODEL/OUTPUT_DIR 는 호출자(run_cell)의 local 을
+# dynamic scope 로 참조한다. 병렬 append 는 harness.guard_telemetry 가 O_APPEND 라인
+# 단위로 원자적이며, 빈 파일 첫 기록 시 telemetry_epoch 가 중복될 수 있으나 무해하다.
 record_eval_result() {
   local passed_flag="$1"
   local failure_stage="$2"
@@ -130,48 +72,53 @@ record_eval_result() {
     --base-dir "$OUTPUT_DIR" >/dev/null 2>&1 || true
 }
 
-for case_dir in "$ROOT"/evals/cases/*/; do
-  case_name="$(basename "$case_dir")"
-  is_selected_case "$case_name" || continue
-  case_path="${case_dir%/}"
-  case_output="$OUTPUT_DIR/$case_name"
-  mkdir -p "$case_output"
+# 셀 워커 — 하나의 (case, run_index) 셀을 처리한다: 블라인드 검수(report) → 채점(judge)
+# → verdict 파싱 → telemetry 기록 → PASS/FAIL marker. 진행 로그는 인터리빙 방지를 위해
+# 자기 로그 파일에만 쓰고, 부모가 케이스 순서대로 다시 출력한다. 어떤 결과에서도 exit 0.
+run_cell() {
+  local spec="$1"
+  local case_name run_index total_runs model output_dir instruction_root sandbox
+  local prompt_file expected_file case_output marker_file log_file
+  {
+    IFS= read -r case_name
+    IFS= read -r run_index
+    IFS= read -r total_runs
+    IFS= read -r model
+    IFS= read -r output_dir
+    IFS= read -r instruction_root
+    IFS= read -r sandbox
+    IFS= read -r prompt_file
+    IFS= read -r expected_file
+    IFS= read -r case_output
+    IFS= read -r marker_file
+    IFS= read -r log_file
+  } < "$spec"
 
-  for f in prompt.md expected.md; do
-    [ -f "$case_path/$f" ] || { echo "[eval] $case_name: $f 없음 — skip"; overall_fail=1; continue 2; }
-  done
+  # record_eval_result 가 참조하는 이름들을 셀 컨텍스트로 고정한다 (dynamic scope).
+  local i="$run_index" RUNS="$total_runs" MODEL="$model" OUTPUT_DIR="$output_dir"
+  local prompt expected report grade report_file judge_file
+  prompt="$(cat "$prompt_file")"
+  expected="$(cat "$expected_file")"
+  report_file="$case_output/run-$run_index-report.md"
+  judge_file="$case_output/run-$run_index-judge.md"
+  : > "$log_file"
 
-  # 블라인드 보장 — fixture 만 sandbox 로 복사 (정답표/프롬프트 제외). sandbox 이름은
-  # 케이스명을 포함하지 않는다 — 검수 agent 가 repo 의 정답표 경로를 역추적하지 못하게.
-  sandbox="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-XXXXXX")"
-  for f in "$case_path"/*; do
-    base="$(basename "$f")"
-    case "$base" in prompt.md | expected.md) continue ;; esac
-    cp -R "$f" "$sandbox/"
-  done
+  # 하네스 무주입 격리 (#1073) — --safe-mode 가 CLAUDE.md·skills·hooks·MCP·user settings
+  # customization 을 전부 끄고(OAuth 인증은 유지), --tools 가 도구 schema 를 제한한다.
+  # 검수자는 격리된 instruction snapshot의 agent 지침을 Read 하고 일부 케이스는
+  # {{CASE_DIR}} fixture 를 파일명 없이 열거(Glob)해야 하므로 --tools Read Glob +
+  # --add-dir "$instruction_root"(지침) + --add-dir "$sandbox"(fixture)만 유지한다.
+  # (--bare 는 OAuth/keychain 을 못 읽어 "Not logged in" 이라 쓰지 않는다.)
+  if ! report="$(cd "$instruction_root" && claude -p "$prompt" --model "$MODEL" --safe-mode --tools Read Glob --add-dir "$instruction_root" --add-dir "$sandbox" 2>/dev/null)"; then
+    echo "[eval] $case_name run $run_index: 검수 실행 실패" >> "$log_file"
+    record_eval_result "failed" "report" "" "" 1 0 0 0
+    printf 'FAIL\n' > "$marker_file"
+    return 0
+  fi
+  printf '%s\n' "$report" > "$report_file"
 
-  prompt="$(sed -e "s|{{REPO_ROOT}}|$instruction_root|g" -e "s|{{CASE_DIR}}|$sandbox|g" "$case_path/prompt.md")"
-  expected="$(cat "$case_path/expected.md")"
-  pass=0
-
-  for ((i = 1; i <= RUNS; i++)); do
-    report_file="$case_output/run-$i-report.md"
-    judge_file="$case_output/run-$i-judge.md"
-
-    # 하네스 무주입 격리 (#1073) — --safe-mode 가 CLAUDE.md·skills·hooks·MCP·user settings
-    # customization 을 전부 끄고(OAuth 인증은 유지), --tools 가 도구 schema 를 제한한다.
-    # 검수자는 격리된 instruction snapshot의 agent 지침을 Read 하고 일부 케이스는
-    # {{CASE_DIR}} fixture 를 파일명 없이 열거(Glob)해야 하므로 --tools Read Glob +
-    # --add-dir "$instruction_root"(지침) + --add-dir "$sandbox"(fixture)만 유지한다.
-    # (--bare 는 OAuth/keychain 을 못 읽어 "Not logged in" 이라 쓰지 않는다.)
-    if ! report="$(cd "$instruction_root" && claude -p "$prompt" --model "$MODEL" --safe-mode --tools Read Glob --add-dir "$instruction_root" --add-dir "$sandbox" 2>/dev/null)"; then
-      echo "[eval] $case_name run $i: 검수 실행 실패"
-      record_eval_result "failed" "report" "" "" 1 0 0 0
-      continue
-    fi
-    printf '%s\n' "$report" > "$report_file"
-
-    judge_prompt="너는 채점자다. 아래 [검수 보고]가 [정답표]의 각 기대를 충족하는지만 판정한다.
+  local judge_prompt
+  judge_prompt="너는 채점자다. 아래 [검수 보고]가 [정답표]의 각 기대를 충족하는지만 판정한다.
 - MUST 기대: 그 취지의 결함이 보고 어딘가에서 지적되면 충족.
 - MUST_NOT 기대: 보고가 그 취지의 결함을 지적하지 않으면 충족. 다른 이유의 결함 지적은 무관하다.
 - PASS / FAIL / ESCALATE 같은 최소 결론 enum 요구는 rigid schema 요구가 아니다. status JSON, marker, fixed table, fixed schema, exact template 같은 출력 구조 강제만 rigid schema 요구로 본다.
@@ -183,47 +130,228 @@ $expected
 [검수 보고]
 $report"
 
-    # 채점자는 정답표+보고가 프롬프트에 인라인 — repo 접근 0 필요. --safe-mode + --tools ""
-    # 로 customization·도구를 전부 끈다. baseline 실측 43,455 → ~1,857.
-    # (--allowedTools "" 는 permission 만 비우고 tool schema 는 남으므로 쓰지 않는다.)
-    if ! grade="$(cd "$instruction_root" && claude -p "$judge_prompt" --model "$MODEL" --safe-mode --tools "" 2>/dev/null)"; then
-      echo "[eval] $case_name run $i: 채점 실행 실패"
-      report_chars="${#report}"
-      report_bytes="$(byte_len "$report")"
-      estimated_output_tokens=$(((report_bytes + 3) / 4))
-      record_eval_result "failed" "judge" "$report_file" "" 2 "$report_chars" 0 "$estimated_output_tokens"
-      continue
-    fi
-    printf '%s\n' "$grade" > "$judge_file"
-
+  # 채점자는 정답표+보고가 프롬프트에 인라인 — repo 접근 0 필요. --safe-mode + --tools ""
+  # 로 customization·도구를 전부 끈다. baseline 실측 43,455 → ~1,857.
+  # (--allowedTools "" 는 permission 만 비우고 tool schema 는 남으므로 쓰지 않는다.)
+  if ! grade="$(cd "$instruction_root" && claude -p "$judge_prompt" --model "$MODEL" --safe-mode --tools "" 2>/dev/null)"; then
+    echo "[eval] $case_name run $run_index: 채점 실행 실패" >> "$log_file"
+    local report_chars report_bytes estimated_output_tokens
     report_chars="${#report}"
-    judge_chars="${#grade}"
     report_bytes="$(byte_len "$report")"
-    judge_bytes="$(byte_len "$grade")"
-    estimated_output_tokens=$(((report_bytes + judge_bytes + 3) / 4))
-    llm_turns=2
+    estimated_output_tokens=$(((report_bytes + 3) / 4))
+    record_eval_result "failed" "judge" "$report_file" "" 2 "$report_chars" 0 "$estimated_output_tokens"
+    printf 'FAIL\n' > "$marker_file"
+    return 0
+  fi
+  printf '%s\n' "$grade" > "$judge_file"
 
-    verdict="$(printf '%s\n' "$grade" | grep -E '^RESULT: (PASS|FAIL)$' | tail -1 || true)"
-    if [ "$verdict" = "RESULT: PASS" ]; then
-      pass=$((pass + 1))
-      echo "[eval] $case_name run $i: 정답"
-      record_eval_result "passed" "" "$report_file" "$judge_file" "$llm_turns" "$report_chars" "$judge_chars" "$estimated_output_tokens"
-    else
-      echo "[eval] $case_name run $i: 오답"
-      printf '%s\n' "$grade" | grep -E "^(OK|MISS) " || true
-      record_eval_result "failed" "" "$report_file" "$judge_file" "$llm_turns" "$report_chars" "$judge_chars" "$estimated_output_tokens"
-    fi
+  local report_chars judge_chars report_bytes judge_bytes estimated_output_tokens llm_turns verdict
+  report_chars="${#report}"
+  judge_chars="${#grade}"
+  report_bytes="$(byte_len "$report")"
+  judge_bytes="$(byte_len "$grade")"
+  estimated_output_tokens=$(((report_bytes + judge_bytes + 3) / 4))
+  llm_turns=2
+
+  verdict="$(printf '%s\n' "$grade" | grep -E '^RESULT: (PASS|FAIL)$' | tail -1 || true)"
+  if [ "$verdict" = "RESULT: PASS" ]; then
+    echo "[eval] $case_name run $run_index: 정답" >> "$log_file"
+    record_eval_result "passed" "" "$report_file" "$judge_file" "$llm_turns" "$report_chars" "$judge_chars" "$estimated_output_tokens"
+    printf 'PASS\n' > "$marker_file"
+  else
+    echo "[eval] $case_name run $run_index: 오답" >> "$log_file"
+    printf '%s\n' "$grade" | grep -E "^(OK|MISS) " >> "$log_file" || true
+    record_eval_result "failed" "" "$report_file" "$judge_file" "$llm_turns" "$report_chars" "$judge_chars" "$estimated_output_tokens"
+    printf 'FAIL\n' > "$marker_file"
+  fi
+  return 0
+}
+
+# 셀 워커 재진입 — xargs 가 `bash run.sh __worker <spec>` 로 각 셀을 호출한다.
+if [ "${1:-}" = "__worker" ]; then
+  run_cell "$2"
+  exit 0
+fi
+
+# =========================== main (부모 오케스트레이터) ===========================
+RUNS="${EVAL_RUNS:-1}"
+MODEL="${EVAL_MODEL:-sonnet}"
+OUTPUT_DIR="${EVAL_OUTPUT_DIR:-$ROOT/.metrics/evals/run-$(date -u +%Y%m%dT%H%M%SZ)-$$}"
+RELEASE_CHECK="${EVAL_RELEASE_CHECK:-0}"
+STRICT_CASES="${EVAL_STRICT_CASES:-shorts-real-spec headless-prose-quality}"
+CASE_FILTER="${EVAL_CASES:-}"
+PARALLEL="${EVAL_PARALLEL:-4}"
+SELF="$ROOT/evals/run.sh"
+
+command -v claude >/dev/null 2>&1 || { echo "[eval] claude CLI 가 필요하다"; exit 2; }
+
+case "$PARALLEL" in
+  '' | *[!0-9]*)
+    echo "[eval] EVAL_PARALLEL 은 양의 정수여야 한다: '$PARALLEL'" >&2
+    exit 2
+    ;;
+esac
+if [ "$PARALLEL" -lt 1 ]; then
+  echo "[eval] EVAL_PARALLEL 은 1 이상이어야 한다: '$PARALLEL'" >&2
+  exit 2
+fi
+
+case_is_available() {
+  local needle="$1"
+  local available_dir
+  for available_dir in "$ROOT"/evals/cases/*/; do
+    [ "$(basename "$available_dir")" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+if [ -n "$CASE_FILTER" ]; then
+  selected_count=0
+  for selected_case in $CASE_FILTER; do
+    selected_count=$((selected_count + 1))
+    case_is_available "$selected_case" || {
+      echo "[eval] 선택 케이스 없음: $selected_case" >&2
+      exit 2
+    }
+  done
+  [ "$selected_count" -gt 0 ] || {
+    echo "[eval] 선택 케이스가 비어 있음" >&2
+    exit 2
+  }
+fi
+
+is_strict_case() {
+  local needle="$1"
+  local item
+  for item in $STRICT_CASES; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+is_selected_case() {
+  local needle="$1"
+  local item
+  [ -z "$CASE_FILTER" ] && return 0
+  for item in $CASE_FILTER; do
+    [ "$item" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+overall_fail=0
+mkdir -p "$OUTPUT_DIR"
+echo "[eval] output: $OUTPUT_DIR"
+
+# Report agent에는 지침을 읽을 최소 snapshot만 노출한다. repo 전체를 --add-dir로 주면
+# evals/golden/**의 사람 판정과 이유를 탐색할 수 있어 blind report가 오염된다.
+instruction_root="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-instructions-XXXXXX")"
+# 셀 spec / marker / 로그 / sandbox 를 한 작업 디렉터리에 모아 trap 으로 일괄 정리한다.
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/dcness-eval-work-XXXXXX")"
+mkdir -p "$WORK/specs" "$WORK/markers" "$WORK/logs" "$WORK/sandboxes"
+cleanup() {
+  rm -rf -- "$WORK"
+  rm -rf -- "$instruction_root"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+cp -R "$ROOT/docs" "$ROOT/skills" "$ROOT/agents" "$instruction_root/"
+
+# --- 준비 단계: 케이스별 sandbox·프롬프트 렌더링 후 (case, run) 셀 worklist 생성 ---
+cases_ordered=()
+cell_spec_list="$WORK/cell-spec-list"
+: > "$cell_spec_list"
+
+for case_dir in "$ROOT"/evals/cases/*/; do
+  case_name="$(basename "$case_dir")"
+  is_selected_case "$case_name" || continue
+  case_path="${case_dir%/}"
+  case_output="$OUTPUT_DIR/$case_name"
+  mkdir -p "$case_output"
+
+  missing=0
+  for f in prompt.md expected.md; do
+    [ -f "$case_path/$f" ] || {
+      echo "[eval] $case_name: $f 없음 — skip"
+      overall_fail=1
+      missing=1
+      break
+    }
+  done
+  [ "$missing" -eq 0 ] || continue
+
+  # 블라인드 보장 — fixture 만 sandbox 로 복사 (정답표/프롬프트 제외). sandbox 이름은
+  # 케이스명을 포함하지 않는다 — 검수 agent 가 repo 의 정답표 경로를 역추적하지 못하게.
+  # 케이스당 1회 생성해 그 케이스의 모든 run 이 공유 읽기(eval 중 read-only)한다.
+  sandbox="$(mktemp -d "$WORK/sandboxes/sb.XXXXXX")"
+  for f in "$case_path"/*; do
+    base="$(basename "$f")"
+    case "$base" in prompt.md | expected.md) continue ;; esac
+    cp -R "$f" "$sandbox/"
   done
 
-  rm -rf "$sandbox"
-  sandbox=""
-  echo "[eval] $case_name — 정답 $pass/$RUNS"
-  [ "$pass" -gt 0 ] || overall_fail=1
-  if [ "$RELEASE_CHECK" = "1" ] && is_strict_case "$case_name" && [ "$pass" -ne "$RUNS" ]; then
-    echo "[eval] $case_name — 릴리즈 체크 실패: 핵심 실사고 케이스는 $RUNS/$RUNS 필요"
-    overall_fail=1
-  fi
+  prompt="$(sed -e "s|{{REPO_ROOT}}|$instruction_root|g" -e "s|{{CASE_DIR}}|$sandbox|g" "$case_path/prompt.md")"
+  prompt_file="$WORK/specs/$case_name.prompt"
+  expected_file="$WORK/specs/$case_name.expected"
+  printf '%s' "$prompt" > "$prompt_file"
+  cp "$case_path/expected.md" "$expected_file"
+  cases_ordered+=("$case_name")
+
+  for ((i = 1; i <= RUNS; i++)); do
+    spec="$WORK/specs/${case_name}__run${i}.spec"
+    marker="$WORK/markers/${case_name}__run${i}.marker"
+    log_file="$WORK/logs/${case_name}__run${i}.log"
+    {
+      printf '%s\n' "$case_name"
+      printf '%s\n' "$i"
+      printf '%s\n' "$RUNS"
+      printf '%s\n' "$MODEL"
+      printf '%s\n' "$OUTPUT_DIR"
+      printf '%s\n' "$instruction_root"
+      printf '%s\n' "$sandbox"
+      printf '%s\n' "$prompt_file"
+      printf '%s\n' "$expected_file"
+      printf '%s\n' "$case_output"
+      printf '%s\n' "$marker"
+      printf '%s\n' "$log_file"
+    } > "$spec"
+    printf '%s\n' "$spec" >> "$cell_spec_list"
+  done
 done
+
+# --- 실행 단계: 셀을 EVAL_PARALLEL 상한으로 병렬 실행 (=1 이면 직렬 안전판) ---
+if [ -s "$cell_spec_list" ]; then
+  echo "[eval] 셀 실행 — 병렬도 $PARALLEL"
+  set +e
+  tr '\n' '\0' < "$cell_spec_list" | xargs -0 -P "$PARALLEL" -n1 bash "$SELF" __worker
+  dispatch_rc=$?
+  set -e
+  if [ "$dispatch_rc" -ne 0 ]; then
+    echo "[eval] 경고: 일부 셀 워커가 비정상 종료 (rc=$dispatch_rc) — marker 기준으로 집계" >&2
+  fi
+fi
+
+# --- 집계 단계: 케이스별 pass/RUNS 를 marker 로 재현하고 로그를 순서대로 출력 ---
+if [ "${#cases_ordered[@]}" -gt 0 ]; then
+  for case_name in "${cases_ordered[@]}"; do
+    pass=0
+    for ((i = 1; i <= RUNS; i++)); do
+      log_file="$WORK/logs/${case_name}__run${i}.log"
+      [ -f "$log_file" ] && cat "$log_file"
+      marker="$WORK/markers/${case_name}__run${i}.marker"
+      if [ -f "$marker" ] && [ "$(cat "$marker")" = "PASS" ]; then
+        pass=$((pass + 1))
+      fi
+    done
+    echo "[eval] $case_name — 정답 $pass/$RUNS"
+    [ "$pass" -gt 0 ] || overall_fail=1
+    if [ "$RELEASE_CHECK" = "1" ] && is_strict_case "$case_name" && [ "$pass" -ne "$RUNS" ]; then
+      echo "[eval] $case_name — 릴리즈 체크 실패: 핵심 실사고 케이스는 $RUNS/$RUNS 필요"
+      overall_fail=1
+    fi
+  done
+fi
 
 if [ "$overall_fail" -ne 0 ]; then
   echo "[eval] FAIL — 정답 0회 케이스 존재. 방금 바꾼 지침이 보호를 깨먹었는지 확인할 것 (evals/README.md)."

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -585,12 +585,14 @@ class EvalsHarnessContractTests(unittest.TestCase):
             )
 
     def test_parallel_and_serial_agree_on_pass_fail(self) -> None:
-        """같은 케이스 집합에서 병렬/직렬 pass·fail 집계가 동일해야 한다 (#1120 MUST)."""
+        """병렬/직렬 pass·fail 집계 동일 + EVAL_RELEASE_CHECK strict N/N 판정 불변 (#1120 MUST)."""
         cases = "headless-prose-quality shorts-real-spec story-slice-skeleton"
 
         def summary(stdout: str) -> list[str]:
             return sorted(
-                line for line in stdout.splitlines() if re.search(r"— 정답 \d+/\d+", line)
+                line
+                for line in stdout.splitlines()
+                if re.search(r"— 정답 \d+/\d+", line) or "릴리즈 체크 실패" in line
             )
 
         for verdict, expected_rc in (("PASS", 0), ("FAIL", 1)):
@@ -599,9 +601,12 @@ class EvalsHarnessContractTests(unittest.TestCase):
                 bin_dir = tmp / "bin"
                 bin_dir.mkdir()
                 self._write_fake_claude(bin_dir, self._verdict_fake(verdict))
+                # RELEASE_CHECK=1 + 선택 케이스를 전부 strict 로 둬 N/N 판정 경로까지 태운다.
                 base_env = {
                     "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
                     "EVAL_CASES": cases,
+                    "EVAL_STRICT_CASES": cases,
+                    "EVAL_RELEASE_CHECK": "1",
                     "EVAL_RUNS": "2",
                 }
                 serial = self._run_eval(

--- a/tests/test_evals_harness.py
+++ b/tests/test_evals_harness.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import stat
 import subprocess
 import unittest
@@ -472,6 +473,210 @@ class EvalsHarnessContractTests(unittest.TestCase):
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, run_sh)
+
+    # ------------------------------------------------------------------
+    # #1120 — (case, run) 셀 단위 병렬 실행. 셀 내부 report→judge 순서만 유지.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _write_fake_claude(bin_dir: Path, body_lines: list[str]) -> Path:
+        fake_claude = bin_dir / "claude"
+        fake_claude.write_text("\n".join(body_lines), encoding="utf-8")
+        fake_claude.chmod(fake_claude.stat().st_mode | stat.S_IEXEC)
+        return fake_claude
+
+    @staticmethod
+    def _verdict_fake(verdict: str) -> list[str]:
+        """검수는 report, 채점은 고정 verdict 를 돌려주는 deterministic fake."""
+        return [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            "prompt=''",
+            'while [ "$#" -gt 0 ]; do',
+            '  case "$1" in -p) shift; prompt="$1" ;; esac',
+            "  shift || true",
+            "done",
+            "if printf '%s' \"$prompt\" | grep -q '\\[정답표\\]'; then",
+            f"  printf 'OK FAKE\\nRESULT: {verdict}\\n'",
+            "else",
+            "  printf 'blind report with concrete evidence\\n'",
+            "fi",
+        ]
+
+    def _run_eval(self, env_overrides: dict, timeout: int = 90):
+        env = os.environ.copy()
+        env.update({k: str(v) for k, v in env_overrides.items()})
+        return subprocess.run(
+            ["bash", str(EVALS / "run.sh")],
+            cwd=str(ROOT),
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+
+    def test_runner_runs_cells_in_parallel_but_serial_valve_stays_serial(self) -> None:
+        """EVAL_PARALLEL>1 이면 셀이 실제로 겹쳐 돌고, EVAL_PARALLEL=1 은 겹치지 않는다."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            conc_dir = tmp / "conc"
+            bin_dir.mkdir()
+            conc_dir.mkdir()
+            # 셀마다 진입 시 동시 실행 수를 원자적으로(mkdir 락) 세고 최대치를 기록한다.
+            self._write_fake_claude(
+                bin_dir,
+                [
+                    "#!/usr/bin/env bash",
+                    "prompt=''",
+                    'while [ "$#" -gt 0 ]; do',
+                    '  case "$1" in -p) shift; prompt="$1" ;; esac',
+                    "  shift || true",
+                    "done",
+                    'LOCK="$CONC_DIR/lock"',
+                    'COUNT="$CONC_DIR/count"',
+                    'MAXC="$CONC_DIR/max"',
+                    'while ! mkdir "$LOCK" 2>/dev/null; do :; done',
+                    'n=$(( $(cat "$COUNT" 2>/dev/null || echo 0) + 1 ))',
+                    'echo "$n" > "$COUNT"',
+                    'm=$(cat "$MAXC" 2>/dev/null || echo 0)',
+                    'if [ "$n" -gt "$m" ]; then echo "$n" > "$MAXC"; fi',
+                    'rmdir "$LOCK"',
+                    "sleep 0.3",
+                    'while ! mkdir "$LOCK" 2>/dev/null; do :; done',
+                    'echo "$(( $(cat "$COUNT" 2>/dev/null || echo 1) - 1 ))" > "$COUNT"',
+                    'rmdir "$LOCK"',
+                    "if printf '%s' \"$prompt\" | grep -q '\\[정답표\\]'; then",
+                    "  printf 'RESULT: PASS\\n'",
+                    "else",
+                    "  printf 'blind report\\n'",
+                    "fi",
+                ],
+            )
+
+            def run_and_measure(parallel: int) -> int:
+                (conc_dir / "count").write_text("0", encoding="utf-8")
+                (conc_dir / "max").write_text("0", encoding="utf-8")
+                env = os.environ.copy()
+                env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+                env["CONC_DIR"] = str(conc_dir)
+                env["EVAL_CASES"] = "headless-prose-quality"
+                env["EVAL_RUNS"] = "4"
+                env["EVAL_PARALLEL"] = str(parallel)
+                env["EVAL_OUTPUT_DIR"] = str(tmp / f"out-{parallel}")
+                result = subprocess.run(
+                    ["bash", str(EVALS / "run.sh")],
+                    cwd=str(ROOT),
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    timeout=90,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+                return int((conc_dir / "max").read_text(encoding="utf-8").strip())
+
+            parallel_max = run_and_measure(4)
+            serial_max = run_and_measure(1)
+            self.assertGreaterEqual(
+                parallel_max, 2, f"EVAL_PARALLEL=4 인데 셀이 겹치지 않음 (max={parallel_max})"
+            )
+            self.assertEqual(
+                serial_max, 1, f"EVAL_PARALLEL=1 인데 셀이 겹침 (max={serial_max})"
+            )
+
+    def test_parallel_and_serial_agree_on_pass_fail(self) -> None:
+        """같은 케이스 집합에서 병렬/직렬 pass·fail 집계가 동일해야 한다 (#1120 MUST)."""
+        cases = "headless-prose-quality shorts-real-spec story-slice-skeleton"
+
+        def summary(stdout: str) -> list[str]:
+            return sorted(
+                line for line in stdout.splitlines() if re.search(r"— 정답 \d+/\d+", line)
+            )
+
+        for verdict, expected_rc in (("PASS", 0), ("FAIL", 1)):
+            with self.subTest(verdict=verdict), TemporaryDirectory() as td:
+                tmp = Path(td)
+                bin_dir = tmp / "bin"
+                bin_dir.mkdir()
+                self._write_fake_claude(bin_dir, self._verdict_fake(verdict))
+                base_env = {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "EVAL_CASES": cases,
+                    "EVAL_RUNS": "2",
+                }
+                serial = self._run_eval(
+                    {**base_env, "EVAL_PARALLEL": "1", "EVAL_OUTPUT_DIR": str(tmp / "s")}
+                )
+                parallel = self._run_eval(
+                    {**base_env, "EVAL_PARALLEL": "8", "EVAL_OUTPUT_DIR": str(tmp / "p")}
+                )
+                self.assertEqual(serial.returncode, expected_rc, serial.stdout + serial.stderr)
+                self.assertEqual(parallel.returncode, expected_rc, parallel.stdout + parallel.stderr)
+                self.assertEqual(
+                    summary(serial.stdout),
+                    summary(parallel.stdout),
+                    f"serial vs parallel 집계 불일치\nS:{serial.stdout}\nP:{parallel.stdout}",
+                )
+
+    def test_parallel_telemetry_lines_all_valid_json(self) -> None:
+        """병렬 실행 후 guard-telemetry.jsonl 전 라인이 valid JSON 이어야 한다 (#1120 MUST)."""
+        with TemporaryDirectory() as td:
+            tmp = Path(td)
+            bin_dir = tmp / "bin"
+            out_dir = tmp / "out"
+            bin_dir.mkdir()
+            self._write_fake_claude(bin_dir, self._verdict_fake("PASS"))
+            result = self._run_eval(
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                    "EVAL_RUNS": "2",
+                    "EVAL_PARALLEL": "8",
+                    "EVAL_OUTPUT_DIR": str(out_dir),
+                }
+            )
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            telemetry = out_dir / "guard-telemetry.jsonl"
+            self.assertTrue(telemetry.is_file())
+            epoch_count = 0
+            for line in telemetry.read_text(encoding="utf-8").splitlines():
+                if not line.strip():
+                    continue
+                obj = json.loads(line)  # 깨진 라인이면 여기서 실패
+                if obj.get("kind") == "telemetry_epoch":
+                    epoch_count += 1
+            # epoch 중복은 무해 — 존재만 확인하고 깨진 라인이 없음을 위에서 강제한다.
+            self.assertGreaterEqual(epoch_count, 1)
+
+    def test_runner_rejects_invalid_parallel_without_llm_call(self) -> None:
+        for value in ("0", "abc", "-1", "  "):
+            with self.subTest(value=value), TemporaryDirectory() as td:
+                tmp = Path(td)
+                bin_dir = tmp / "bin"
+                bin_dir.mkdir()
+                marker = tmp / "claude-called"
+                self._write_fake_claude(
+                    bin_dir,
+                    ["#!/usr/bin/env bash", f"touch {marker}", "exit 0"],
+                )
+                result = self._run_eval(
+                    {
+                        "PATH": f"{bin_dir}{os.pathsep}{os.environ['PATH']}",
+                        "EVAL_PARALLEL": value,
+                        "EVAL_OUTPUT_DIR": str(tmp / "out"),
+                    },
+                    timeout=30,
+                )
+                self.assertEqual(result.returncode, 2, result.stderr + result.stdout)
+                self.assertIn("EVAL_PARALLEL", result.stderr)
+                self.assertFalse(marker.exists())
+
+    def test_eval_parallel_is_documented(self) -> None:
+        run_sh = (EVALS / "run.sh").read_text(encoding="utf-8")
+        readme = (EVALS / "README.md").read_text(encoding="utf-8")
+        claude_md = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+        for label, text in (("run.sh", run_sh), ("README", readme), ("CLAUDE.md", claude_md)):
+            with self.subTest(doc=label):
+                self.assertIn("EVAL_PARALLEL", text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1120

## 배경 및 문제

LLM 행동 eval 러너 `evals/run.sh` 는 30개 케이스 × `EVAL_RUNS` 반복 × (검수+채점 2회 `claude -p`) 를 **완전 직렬**로 돌아 wall-clock 이 길다. `RUNS=1` → 60회, `EVAL_RUNS=3`(릴리즈 전 권장) → 180회의 순차 `claude -p` 호출이 지배 비용이다. 셀(case × run) 은 서로 독립이므로 직렬로 돌 이유가 없다.

## 원인 (해당 시)

-

## 작업내용

- `evals/run.sh` 를 **(case, run) 셀 단위 병렬 실행**으로 리팩터:
  - **준비 단계** — 케이스별 sandbox(케이스명 미포함 opaque, 케이스당 1회·read-only 공유) 생성 + prompt 렌더링 후 셀 worklist 생성.
  - **실행 단계** — 셀 워커(`bash run.sh __worker <spec>` 자기 재호출)를 `xargs -0 -P "$EVAL_PARALLEL" -n1` 로 병렬 실행. 셀 내부 report→judge 순서만 유지.
  - **집계 단계** — shell 카운터(서브셸이 부모 변수 못 갱신)를 버리고 **셀별 marker 파일**로 pass/RUNS·overall_fail·release check 를 재현. 진행 로그는 셀별 파일에 써서 인터리빙을 막고 부모가 케이스 순서대로 출력.
- **`EVAL_PARALLEL` 환경변수 신설** — 동시 셀 상한. 기본 `4`, `=1` 은 직렬 실행(병렬화 회귀 안전판). 양의 정수 검증(불량 값 → exit 2, claude 무호출).
- 테스트 추가(`tests/test_evals_harness.py`): 셀 실제 병렬성/직렬 안전판(mkdir-lock max-concurrency), 병렬·직렬 pass·fail 판정 동치, telemetry 전 라인 valid JSON, invalid `EVAL_PARALLEL` 거부, 문서 정합.
- 문서 정합: `CLAUDE.md` 환경변수 표 + `evals/README.md` 실행 예시·의미 설명 + `run.sh` 헤더 주석.

## 결정 근거

- **동시성 메커니즘 = `xargs -P`** — macOS 기본 bash 3.2 는 `wait -n`(4.3+) 미지원. 이식성 위해 `xargs -P` 스로틀 채택(`#!/usr/bin/env bash` 유지).
- **worker 자기 재호출** — `export -f` 의 bash 3.2 이식성 리스크·argv 멀티라인 quoting 문제를 피하려 셀 입력을 스칼라/경로만 담은 spec 파일로 전달하고 `run.sh __worker <spec>` 로 재진입. `record_eval_result` 는 dynamic scope 로 셀 컨텍스트를 그대로 재사용.
- **marker 파일 집계** — 서브셸이 부모 shell 카운터를 못 갱신하므로 파일시스템 marker 로 집계. bash 3.2 `declare -A` 미지원도 회피. 집계 로직이 병렬도와 무관 → 병렬/직렬 판정 동치 보장.
- **telemetry O_APPEND 무변경** — `harness/guard_telemetry.py` 는 라인 단위 O_APPEND write 라 병렬 append 에도 각 라인이 온전. 빈 파일 첫 기록 시 `telemetry_epoch` 만 중복될 수 있으나 무해(테스트로 전 라인 valid JSON 확인).
- **기본값 4** — 이슈가 `=1` 을 "회귀 안전판"으로 규정 → 기본은 병렬. headless `claude -p` quota 는 메인 세션과 공유하므로 보수적 상한 유지.

### wall-clock 실측 (SHOULD)

30 케이스·`RUNS=1`·per-call 0.5s fake claude(하네스가 통제하는 동시성 효과만 격리한 결정적 재현):

| EVAL_PARALLEL | wall-clock | speedup |
|---|---|---|
| 1 (직렬) | 34.1s | 1.0x |
| 4 (기본) | 9.7s | 3.5x |
| 8 | 5.5s | 6.2x |

## 배포 경로 검증 (plug-in 영향 시)

N/A — `evals/` 는 dcness self QA 도구(`evals/README.md`: "plug-in 배포물이 아니다")로 외부 활성 프로젝트에 배포되지 않는다(배포 경로 1/2/3 해당 없음). `CLAUDE.md` 환경변수 표 갱신만 self 문서 정합 대상이며 사용자 환경 도달 경로 없음.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public skill/command/agent/gate 없음. `EVAL_PARALLEL` 은 self QA 도구의 내부 환경변수이며 공개 진입점 표면을 늘리지 않는다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과 — `python3.11 -m unittest discover -s tests` → 1979 OK, `tests.test_evals_harness` 21건 OK
- [x] 회귀 검증 — 기존 eval 하네스 계약 테스트 유지, `bash -n` 파싱 PASS, `node scripts/check_cross_refs.mjs` PASS
- [x] 병렬/직렬 판정 동치 + telemetry 무결성 + invalid EVAL_PARALLEL 거부 + wall-clock 실측

## 참고

-
