### PR TITLE
[feature] legacy acceptance reader 경계 정리

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@
 3. **branch → PR → regular merge** (직접 `main` push 금지). CI PASS 후 메인이 즉시 머지 — *사용자 수동 승인 대기 X*.
 4. **종료 시 ExitWorktree** — squash 흡수 검사 후 자동 `keep`/`remove` ([`docs/plugin/loop-procedure.md` worktree 분기](docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정)).
 
-GitHub issue 를 대상으로 하는 dcness self 구현은 진입 때 읽은 본문을 target GitHub issue AC snapshot 으로 보관하고, 항목별 구현·검증 증거를 대조한다. close 전 자동 판정 가능한 AC 를 모두 충족·체크한 body 가 `node scripts/check_issue_body.mjs --body-file <issue-body.md> --acceptance-only --require-complete` 를 통과해야 한다. 미충족·미체크 상태로 clean 마감하거나 merge하지 않는다. 사람 확인이 남으면 agent 가 체크하지 않고 `human verification 대기`로 보고한다.
+GitHub issue 를 대상으로 하는 dcness self 구현은 진입 때 읽은 본문을 target GitHub issue AC snapshot 으로 보관하고, 항목별 구현·검증 증거를 대조한다. close 전 자동 판정 가능한 typed AC 를 모두 충족·체크한 body 가 `node scripts/check_issue_body.mjs --body-file <issue-body.md> --acceptance-only --require-complete` 의 정확한 `PASS`를 받아야 한다. 검증 주체 미기재 legacy AC 와 no-AC body의 exit 0 `REVIEW`는 자동 close 권한이 아니며 agent가 의미를 추론·체크·재분류하지 않는다. 미충족·미체크 상태로 clean 마감하거나 merge하지 않고, legacy `REVIEW` 또는 사람 확인이 남으면 `human verification 대기`로 보고한다.
 
 ## 게이트 요약
 

--- a/docs/internal/policy-sunset-inventory.json
+++ b/docs/internal/policy-sunset-inventory.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "baseline_revision": "b676140bcffdaa5843ce59198ecef4f997efddc9",
-  "last_transition_issue": 1094,
+  "last_transition_issue": 1097,
   "classification_enum": [
     "현재 실사용",
     "제거 가능",
@@ -407,6 +407,13 @@
       "tests_fixtures": ["tests/test_spec_story_slice.py", "tests/test_issue_body_validation.py", "tests/test_create_epic_story_issues.py"],
       "docs_distribution": ["docs/plugin/issue-lifecycle.md", "commands/init-dcness.md"],
       "consumer_evidence": "신규 story/issue 생성기는 [command]/[agent-read] 기준만 체크박스로 materialize하고 close audit가 이를 검사한다.",
+      "lifecycle_evidence": {
+        "introduced": "typed Story AC·issue checklist writer는 2026-07-11 commit de38edc/555ede9에서 도입",
+        "actual_consumer": "spec stories template, create_epic_story_issues.sh, to-issue template와 신규 issue pre-create/close audit",
+        "support_reason": "신규 작성이 agent가 판정 가능한 두 유형과 별도 human verification만 생성하게 하는 현행 계약",
+        "removal_trigger": "대체 acceptance schema와 writer/reader migration이 별도로 승인될 때",
+        "verification": "python3.11 -m unittest tests.test_create_epic_story_issues tests.test_issue_body_validation tests.test_spec_story_slice -v"
+      },
       "compatibility": null
     },
     {
@@ -419,7 +426,14 @@
       "implementation": ["scripts/report_ac_coverage.mjs:buildCoverageReport", "docs/plugin/agents/product-acceptance/product-acceptance-agent.md"],
       "tests_fixtures": ["tests/test_spec_story_slice.py", "tests/test_acceptance_contract_hierarchy.py"],
       "docs_distribution": ["docs/plugin/git-spec.md", "docs/plugin/agents/architecture-validator/architecture-validator-agent.md"],
-      "consumer_evidence": "등록 프로젝트 3곳의 stories.md 8개 모두 Story AC heading이 없는 구양식으로 조사됐다.",
+      "consumer_evidence": "2026-07-14 재조사에서 등록 프로젝트 3곳의 stories.md 10개가 모두 Story AC 없는 구양식이며 생성일 확인 범위는 2026-05-24~2026-07-03이다.",
+      "lifecycle_evidence": {
+        "introduced": "legacy stories format은 typed Story AC 도입(2026-07-11) 이전 작성본이며 확인 가능한 생성일은 2026-05-24~2026-07-03",
+        "actual_consumer": "등록 프로젝트 3/5의 stories.md 10개를 report_ac_coverage와 product-acceptance가 read-only로 소비",
+        "support_reason": "typed AC가 없는 기존 설계와 acceptance를 migration 없이 false fail하거나 coverage PASS로 오인하지 않게 함",
+        "removal_trigger": "등록 프로젝트 stories를 typed AC로 migration하고 legacy story scan이 0인 뒤 지원 종료 선언",
+        "verification": "node scripts/report_ac_coverage.mjs --stories <legacy-stories> --impl-dir <impl> 및 python3.11 -m unittest tests.test_acceptance_contract_hierarchy tests.test_spec_story_slice -v"
+      },
       "compatibility": {
         "consumer_or_format": "Story AC 없이 As a/I want/So that 또는 완료 시 확인 가능한 동작을 쓰는 기존 stories.md",
         "reason": "소급 추론으로 AC 의미를 바꾸거나 기존 설계/acceptance를 false fail하지 않게 한다.",
@@ -430,18 +444,30 @@
     {
       "id": "LIFE-003",
       "area": "lifecycle",
-      "policy_slice": "acceptance checklist가 없는 legacy issue의 close audit pass",
+      "policy_slice": "acceptance checklist가 없거나 검증 주체 미기재인 legacy issue REVIEW reader",
       "classification": "한시적 호환 필요",
       "follow_up_issue": 1097,
       "current_ssot": ["docs/plugin/git-spec.md#이슈-완료-규칙"],
       "implementation": ["scripts/check_issue_body.mjs:validateIssueBody"],
       "tests_fixtures": ["tests/test_issue_body_validation.py"],
       "docs_distribution": ["docs/plugin/issue-lifecycle.md"],
-      "consumer_evidence": "typed acceptance checklist 도입 전 생성된 GitHub issue는 checklist 자체가 없는 지원 대상 형식이며 checker가 legacy/no AC를 명시적으로 판정한다.",
+      "consumer_evidence": "2026-07-14 등록 프로젝트 open issue 비식별 조사에서 2026-06-05~2026-06-21 생성된 legacy issue 14개가 남아 있다. 검증 주체 미기재 checklist 8개, no-AC 6개이며 무분류 항목 중 5개는 사람 판단 가능성이 있다.",
+      "lifecycle_evidence": {
+        "introduced": "지원 body는 typed checklist 도입(2026-07-11) 전인 2026-06-05~2026-06-21에 생성; 기존 자동 PASS reader는 2026-07-11 commit 297b611에서 도입",
+        "actual_consumer": "등록 프로젝트 1/5의 open legacy issue 14개(무분류 AC 8, no-AC 6)가 향후 close audit 대상",
+        "support_reason": "본문을 migration 없이 읽되 의미 불명확·사람 판정 항목을 agent가 자동 완료하거나 영구 close 불가로 만들지 않음",
+        "removal_trigger": "open legacy issue가 typed checklist로 migration되거나 human-confirmed close되어 unclassified/no-AC scan이 0이 된 뒤",
+        "verification": "node scripts/check_issue_body.mjs --body-file <legacy-body> --acceptance-only --require-complete 및 python3.11 -m unittest tests.test_issue_body_validation -v"
+      },
+      "retired_surface": {
+        "old_behavior": "legacy/no AC와 checked unclassified AC를 PASS로 출력하고 impl skills가 무분류 AC를 두 자동 유형으로 재분류·본문 반영",
+        "removed_in": "#1097에서 REVIEW/human verification 경계로 교체하고 agent inference writer 지침 삭제",
+        "verification": "legacy fixture는 exit 0 REVIEW·PASS 부재, typed fixture만 PASS; impl/impl-loop 부정 문자열 회귀 테스트"
+      },
       "compatibility": {
-        "consumer_or_format": "Acceptance criteria checklist가 없는 도입 이전 GitHub issue body",
-        "reason": "기존 issue를 의미 추론으로 자동 체크하거나 영구 close 불가 상태로 만들지 않는다.",
-        "removal_trigger": "열린 legacy issue를 typed checklist로 migration하거나 지원 종료 목록으로 닫고 no-AC close 호출이 0임을 확인한다.",
+        "consumer_or_format": "Acceptance criteria가 없거나 checklist에 [command]/[agent-read]가 없는 도입 이전 GitHub issue body",
+        "reason": "기존 issue를 읽는 동안 agent 자동 close는 막고 명시적 사람 확인으로 migration 없는 close를 허용한다.",
+        "removal_trigger": "열린 legacy issue를 typed checklist로 migration하거나 human-confirmed close하고 unclassified/no-AC scan이 0임을 확인한다.",
         "verification": "node scripts/check_issue_body.mjs --body-file <legacy-body> --acceptance-only --require-complete 및 tests.test_issue_body_validation"
       }
     },
@@ -456,6 +482,13 @@
       "tests_fixtures": ["tests/test_issue_body_validation.py"],
       "docs_distribution": ["docs/plugin/issue-lifecycle.md", "skills/acceptance/SKILL.md"],
       "consumer_evidence": "현재 close 안전 계약으로 사람 확인을 자동 완료하지 못하게 하며 legacy 여부와 무관하다.",
+      "lifecycle_evidence": {
+        "introduced": "typed human-verification 분리는 2026-07-11 commit 555ede9에서 도입",
+        "actual_consumer": "신규 Issue Brief·Story issue와 impl/impl-loop close 경계 전부",
+        "support_reason": "시각·취향·운영 승인 같은 사람 판단을 agent-verifiable checkbox와 분리하는 현행 안전 계약",
+        "removal_trigger": "동등하게 사람 판정을 자동 완료하지 않는 대체 close 계약이 승인될 때",
+        "verification": "python3.11 -m unittest tests.test_issue_body_validation tests.test_acceptance_contract_hierarchy -v"
+      },
       "compatibility": null
     },
     {
@@ -469,6 +502,13 @@
       "tests_fixtures": ["tests/test_acceptance_contract_hierarchy.py", "tests/test_spec_story_slice.py"],
       "docs_distribution": ["docs/plugin/agents/architecture-validator/architecture-validator-agent.md"],
       "consumer_evidence": "현행 typed AC에서도 command output을 validator 관찰 증거로 쓰고 형식만으로 hard fail하지 않는 자율성 계약이다.",
+      "lifecycle_evidence": {
+        "introduced": "Story AC→REQ advisory reporter는 2026-07-11 commit de38edc에서 도입",
+        "actual_consumer": "design mechanical pre-final check와 architecture-validator가 typed stories/impl을 함께 읽을 때 사용",
+        "support_reason": "형식 출력만으로 hard fail하지 않고 실제 산출물 읽기 판정을 보존하는 현행 자율성 계약",
+        "removal_trigger": "동등한 Story AC→REQ trace reader가 architecture validation에 통합될 때",
+        "verification": "python3.11 -m unittest tests.test_acceptance_contract_hierarchy tests.test_spec_story_slice -v"
+      },
       "compatibility": null
     }
   ]

--- a/docs/internal/policy-sunset-inventory.md
+++ b/docs/internal/policy-sunset-inventory.md
@@ -202,10 +202,29 @@ PY
 | persisted run | `ledger.jsonl` 30개, `.steps.jsonl` 0개 | `RUN-001` 현행; 과거/cache 형식인 `RUN-002`는 종료 trigger 필요 |
 | routing config | schema 3이지만 retired `code-validator`, `pr-reviewer`, `test-engineer` key 잔존 | `ROUTE-002` migration 대상 실재 |
 | generated install | 프로젝트별 5개 대상 파일 보유량 `0/5, 2/5, 5/5, 0/5, 1/5` | partial install fallback인 `INST-002` 현행 |
-| stories | 3개 프로젝트의 `stories.md` 8개가 모두 Story AC heading 없는 구양식 | `LIFE-002` 한시 호환 |
+| stories | 3개 프로젝트의 `stories.md` 10개가 모두 Story AC 없는 구양식 | `LIFE-002` 한시 호환 |
+| open issue acceptance | 1개 프로젝트의 open issue 14개: 검증 주체 미기재 8, no-AC 6; 무분류 중 사람 판단 가능 항목 5 | `LIFE-003` REVIEW reader 한시 호환 |
 | legacy `design-variants/` prefix | 등록 프로젝트 directory·markdown reference 모두 0건 | `INST-004` 제거 trigger 충족·퇴역 완료 |
 
 절대경로·프로젝트명은 근거가 아니라 민감한 host 정보라 기록하지 않았다. 후속 이슈는 같은 registry 순번과 해당 이슈의 확인 명령으로 재조사한다.
+
+### #1097 story·issue acceptance cleanup 상태 전이
+
+신규 writer와 legacy reader를 분리해 조사했다. typed Story AC·issue checklist는 2026-07-11 도입됐고 신규 생성기는 `[command]`/`[agent-read]`만 checklist로 만든다. 반면 등록 프로젝트에는 2026-05-24~2026-07-03에 생성된 legacy stories 10개와 2026-06-05~2026-06-21에 생성된 open legacy issue 14개가 남아 reader 제거 trigger를 충족하지 못했다.
+
+`LIFE-003` reader는 유지하되 자동 close 신호만 퇴역했다. 기존 `PASS — legacy/no AC`와 checked unclassified AC의 일반 `PASS`, impl/impl-loop의 무분류 AC 자동 재분류·본문 반영 지침을 제거했다. 이제 legacy body는 exit 0 `REVIEW`로 읽혀 migration 없는 접근은 유지하지만 agent 자동 close 권한을 주지 않는다. typed 전항목 완료 body만 `PASS`이며, legacy 의미·사람 판단은 agent가 추론·체크·재분류하지 않고 human verification으로 넘긴다.
+
+| ID | 생성 시기·실제 소비자 | 지원 이유 | 제거 trigger | 확인 fixture |
+|---|---|---|---|---|
+| LIFE-001 | 2026-07-11 도입; spec template, story issue generator, to-issue, pre-create/close audit | 신규 작성이 typed agent-verifiable checklist만 생성하는 현행 계약 | 대체 schema와 writer/reader migration 승인 | create-issue, issue-body, spec-story tests |
+| LIFE-002 | 확인 가능 2026-05-24~2026-07-03; 3/5 프로젝트 stories 10개 | 기존 설계·acceptance를 false fail하거나 coverage PASS로 오인하지 않음 | typed migration 뒤 legacy scan 0 | AC coverage와 product-acceptance fixture |
+| LIFE-003 | 2026-06-05~2026-06-21; open issue 14개(무분류 8, no-AC 6) | migration 없이 읽되 사람·불명확 의미의 agent 자동 close를 차단 | typed migration 또는 human-confirmed close 뒤 scan 0 | issue-body typed PASS / legacy REVIEW fixture |
+| LIFE-004 | 2026-07-11 도입; 모든 신규 issue와 close workflow | 사람 판단을 agent-verifiable checkbox에서 분리 | 동등한 human safety 계약 승인 | issue human-verification fixture |
+| LIFE-005 | 2026-07-11 도입; design pre-final과 architecture-validator | 실제 문서 읽기 판정을 형식 hard fail로 대체하지 않음 | 동등한 trace reader 통합 | AC coverage advisory fixture |
+
+compatibility 후보는 `LIFE-002`와 `LIFE-003` 두 개로 유지된다. 둘 다 활성 소비자가 0이 아니므로 감소시키지 않았으며, 대신 `LIFE-003` 안의 자동 PASS·agent inference writer surface만 구현·테스트·skill·SSOT에서 함께 제거했다. 신규 public command·agent·mode·gate는 만들지 않았고 변경은 plugin 본체 `scripts/**`, `skills/**`, `docs/plugin/**`를 통해 다음 plugin update에 도달한다. `/init-dcness`가 복사하는 generated file은 바뀌지 않는다.
+
+비식별 fixture 재생 결과 legacy stories는 `10/10 REVIEW`, completed-copy open legacy issue는 `14/14 REVIEW`였고 `PASS`·실패는 각각 0건이었다. lifecycle script+test diff(`check_issue_body`, `report_ac_coverage`, 대응 두 test)는 31줄 추가·32줄 삭제로 1 LOC 순감이다. 전체 compatibility 후보는 10개, lifecycle 후보는 2개로 유지되며 감소 불가 근거는 위 `LIFE-002`·`LIFE-003` 활성 소비자 수다.
 
 ## 한시적 호환 4요소 감사
 
@@ -222,7 +241,7 @@ PY
 | RUN-008 | legacy stored verdict + prose sentinel | 과거 FAIL 비율 오판 방지 | verdict migration + old 표본 0 | run-review/aggregate tests |
 | ROUTE-002 | schema 1·2와 retired route keys | local config를 조용히 폐기하지 않음 | config migration + scan 0 | routing doctor + tests |
 | LIFE-002 | Story AC 없는 stories | 소급 의미 추론·false fail 방지 | typed AC migration + scan 0 | AC coverage + fixture |
-| LIFE-003 | checklist 없는 legacy issue | false close·영구 close 불가 방지 | 열린 issue migration/지원 종료 | issue close audit + fixture |
+| LIFE-003 | checklist 없거나 검증 주체 미기재인 legacy issue | migration 없는 read + agent false close 방지 | typed migration/human-confirmed close + scan 0 | typed PASS·legacy REVIEW close fixture |
 
 종료 날짜를 근거 없이 임의 지정하지 않았다. trigger를 만족하지 못한 채 reader를 제거하는 것은 #1089 안전 경계를 위반한다.
 

--- a/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
+++ b/docs/plugin/agents/product-acceptance/product-acceptance-agent.md
@@ -107,7 +107,7 @@ story 구현 완료 직후 호출된다. 해당 story 의 수용 기준이 구�
 - stories.md 또는 story issue 의 Story AC 전항목과 그 AC 에서 파생된 REQ 가 구현 파일, 테스트, smoke 증거 중 하나 이상과 연결된다.
 - 핵심 AC 가 동작 증거와 연결된다.
 - Story 마지막 task 가 Story AC 전항목을 실제 실행·관찰한 증거를 대조한다.
-- Story AC 가 없는 구양식에서 `완료 시 확인 가능한 동작` 줄이 있으면, 그 동작이 실제 동작 증거로 닫혔는지 하위호환 기준으로 대조한다.
+- Story AC 가 없는 구양식에서 `완료 시 확인 가능한 동작` 줄이 있으면, 그 동작이 실제 동작 증거로 닫혔는지 하위호환 기준으로 대조한다. 검증 주체나 의미가 불명확하면 typed Story AC를 합성하지 않고 불명확성을 그대로 보고한다.
 - 핵심 AC 의 입력/진행 동선이 대상 사용자에게 적합한 제품 언어로 닫힌다.
 - 테스트나 smoke 증거가 실제 실행 결과로 남아 있다.
 - project-local journey를 사용했다면 receipt가 Story AC와 command/log evidence를 연결하고 app_started·journey_executed·assertion 결과를 명시한다.

--- a/docs/plugin/git-spec.md
+++ b/docs/plugin/git-spec.md
@@ -230,7 +230,7 @@ task 는 별도 GitHub 이슈를 만들지 않는다. build-worker 의 local com
 
 ## 이슈 완료 규칙
 
-`Closes` 가 발동할 target issue 는 plan이나 Story AC 와 별개의 **target GitHub issue AC** 마감 계약을 가진다. 구현 경로는 plan ∪ target GitHub issue AC 를 충족해야 하며, close 직전 자동 판정 가능한 체크박스를 모두 check 한 body 가 `check_issue_body.mjs --acceptance-only --require-complete` 를 통과해야 한다. 미충족·미체크 AC 가 있으면 PR 을 clean 으로 마감하거나 merge 하지 않는다. 사람 판정 항목은 agent 가 체크하지 않고 human verification 대기로 보고한다.
+`Closes` 가 발동할 target issue 는 plan이나 Story AC 와 별개의 **target GitHub issue AC** 마감 계약을 가진다. 구현 경로는 plan ∪ target GitHub issue AC 를 충족해야 하며, close 직전 자동 판정 가능한 typed 체크박스를 모두 check 한 body 가 `check_issue_body.mjs --acceptance-only --require-complete` 의 정확한 `PASS`를 받아야 한다. 미충족·미체크 AC 가 있으면 PR 을 clean 으로 마감하거나 merge 하지 않는다. 검증 주체 미기재 또는 no-AC legacy body의 exit 0 `REVIEW`는 자동 close 권한이 아니며, agent가 의미를 추론·체크·재분류하지 않고 human verification 대기로 보고한다.
 
 ### Story 완료
 

--- a/docs/plugin/issue-lifecycle.md
+++ b/docs/plugin/issue-lifecycle.md
@@ -51,7 +51,9 @@ gh issue create --title "<title>" --body-file <brief.md> --label "<IssueType>"
 
 `scripts/check_issue_body.mjs` 가 실패하면 `gh issue create` 를 실행하지 않는다. 실제 issue 생성 preflight 는 `--labels` 를 함께 넘겨 label 계약까지 검증하고, 본문 초안만 점검할 때만 `--body-only` 를 명시한다. GitHub issue 생성·등록은 직접 `gh issue create` 대신 `/to-issue` 를 기본 경로로 사용한다 (작업 흐름 중 자발적으로 남기는 후속 이슈 포함). `/to-issue` 외 대화나 agent workflow 가 issue 를 생성하는 경우에도 같은 pre-create validation 을 통과하고 IssueType 라벨을 붙여야 한다.
 
-`--require-complete` 는 새 CI hard gate 가 아니라 close 직전 메인이 같은 validator 를 재사용하는 로컬 감사 옵션이다. `--acceptance-only` 와 함께 쓰면 Issue Brief 와 Story/Epic issue body 에 공통으로 적용되며, target GitHub issue AC 에 미체크 항목이 하나라도 있으면 실패한다. close 감사는 Acceptance criteria 와 human verification 의 bold field·Markdown heading 섹션을 모두 인식하고, `-`·`*`·`+` 체크박스 불릿을 같은 checklist 문법으로 집계한다. 신규 issue 의 `[command]`/`[agent-read]` 분류는 pre-create 에서 강제하고, 이미 존재하는 무분류 legacy AC 는 close 감사에서 소급 태깅하지 않는다. legacy 사람 판정 항목은 사용자가 직접 체크한 뒤에만 전항목 완료가 된다. Acceptance criteria 섹션 자체가 없는 구양식 issue 는 `legacy/no AC` 로 보고하며, 존재하지 않는 체크리스트를 소급 생성하지 않는다.
+`--require-complete` 는 새 CI hard gate 가 아니라 close 직전 메인이 같은 validator 를 재사용하는 로컬 감사 옵션이다. `--acceptance-only` 와 함께 쓰면 Issue Brief 와 Story/Epic issue body 에 공통으로 적용되며, target GitHub issue AC 에 미체크 항목이 하나라도 있으면 실패한다. close 감사는 Acceptance criteria 와 human verification 의 bold field·Markdown heading 섹션을 모두 인식하고, `-`·`*`·`+` 체크박스 불릿을 같은 checklist 문법으로 집계한다.
+
+reader 결과는 한 경계에서 해석한다. 전항목이 `[command]`/`[agent-read]` 인 현행 body만 정확한 `PASS`로 자동 close를 허용한다. 검증 주체 미기재 AC 또는 Acceptance criteria가 없는 구양식 body는 exit 0의 `REVIEW`로 읽어 기존 issue를 migration 없이 열어둘 수 있게 하지만, 이 결과는 자동 close 권한이 아니다. agent는 legacy 항목을 추론·체크·재분류하지 않고 `human verification 대기`로 보고한다. 사용자가 의미와 완료를 명시적으로 확인하면 body를 소급 변환하지 않고 그 확인을 close 근거로 사용할 수 있다. 신규 writer는 계속 typed checklist만 생성하며, 실제 미체크 항목이나 현행 typed 일반론 AC는 실패한다.
 
 ## Issue/label Status lifecycle
 
@@ -102,7 +104,7 @@ Project 미러까지 원하면 `--owner` / `--project` 를 명시하거나 repo 
 
 ### PR merge 후처리 — close + label cleanup
 
-close 를 발동하는 PR 의 CI와 최종 review 증거가 확정된 뒤, merge 전 메인은 진입 preflight 에서 한 번 읽어 보관한 target GitHub issue AC snapshot 과 구현·검증 증거를 완료 후보 issue 별로 전수 대조한다. task/story 진행 중 issue 를 다시 조회하거나 수정하지 않는다. story-close acceptance verdict에서 자동 판정 및 `(JOURNEY)`로 충족된 AC는 메인이 체크하고 `사람 확인 안내`는 미체크로 둔다. 이 체크박스 write는 issue별 close 경계에서 한 번 수행한다. 갱신 body 는 각각 다음 명령이 PASS 해야 한다.
+close 를 발동하는 PR 의 CI와 최종 review 증거가 확정된 뒤, merge 전 메인은 진입 preflight 에서 한 번 읽어 보관한 target GitHub issue AC snapshot 과 구현·검증 증거를 완료 후보 issue 별로 전수 대조한다. task/story 진행 중 issue 를 다시 조회하거나 수정하지 않는다. story-close acceptance verdict에서 자동 판정 및 `(JOURNEY)`로 충족된 typed AC만 메인이 체크하고 `사람 확인 안내`는 미체크로 둔다. 이 체크박스 write는 issue별 close 경계에서 한 번 수행한다. 갱신 body 는 각각 다음 명령으로 감사한다.
 
 ```bash
 node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
@@ -111,7 +113,7 @@ node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
   --require-complete
 ```
 
-사람 판정 항목이 기존 AC 체크박스에 남아 있으면 agent 가 체크하지 않는다. 자동 항목을 모두 충족·체크한 뒤 잔여 human verification 목록을 보고 merge 전에 정지한다. 이는 구현 실패인 `blocked` 가 아니라 `human verification 대기`다.
+정확한 `PASS`면 typed 자동 항목의 close 감사가 끝난다. `REVIEW`면 legacy reader가 본문을 성공적으로 읽은 것이며 close 완료 신호가 아니다. 사람 판정·검증 주체 미기재·no-AC 항목은 agent가 체크하거나 재분류하지 않고 잔여 human verification 목록을 보고 merge 전에 정지한다. 이는 구현 실패인 `blocked`가 아니라 `human verification 대기`다.
 
 default branch 로 PR merge 가 끝난 뒤 GitHub closing reference 가 issue close 를 발동한다. 후처리 경로는 PR body 또는 GitHub closing issue reference 에서 완료 후보 issue 를 찾고, `in-progress` label 을 제거한다. Project 좌표가 설정된 repo 에서는 label 제거 뒤에 Project item `Status=Done` 이동을 best-effort 로 1회 시도한다. 보드 미러 실패는 warning 으로만 보고하고 label cleanup 성공을 실패로 바꾸지 않는다.
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -385,7 +385,7 @@ end-run 안전망 (`session_state.py`) 이 자동으로 `finalize-run --auto-rev
 2. step enum 이 해당 skill `## Loop` 의 advance/expected_steps 와 정합
 3. git 안전 가드: `git status --porcelain` 에 `.env` / `secrets.*` / `credentials.*` 없음 · unstaged + untracked ≤ 10 · submodule 변경 없음
 
-이 공통 매트릭스는 issue close 계약을 대체하지 않는다. `/impl-loop` 이 target GitHub issue 를 닫는 경우 [`impl-loop-routing.md`](../../skills/impl-loop/impl-loop-routing.md)의 clean 판정에 따라 AC 전항목 충족·체크와 `require-complete` PASS 까지 추가로 만족해야 clean 이다.
+이 공통 매트릭스는 issue close 계약을 대체하지 않는다. `/impl-loop` 이 target GitHub issue 를 닫는 경우 [`impl-loop-routing.md`](../../skills/impl-loop/impl-loop-routing.md)의 clean 판정에 따라 typed AC 전항목 충족·체크와 `require-complete`의 정확한 `PASS`까지 추가로 만족해야 clean 이다. legacy `REVIEW`는 human verification 대기다.
 
 **verify-only 예외 (`/impl-loop`)**: `impl-validator:VERIFY_ONLY` prose 가 `PASS`이고 prose 안에 검증 명령 exit 0 + `git status --porcelain` 변경 0 증거가 있으면, step 1개 + PR 0개도 clean 이다. 이 예외에서는 `pr-create.sh` 를 호출하지 않는다.
 

--- a/scripts/check_issue_body.mjs
+++ b/scripts/check_issue_body.mjs
@@ -205,10 +205,12 @@ export function validateIssueBody({
         `acceptance criterion must declare [command] or [agent-read]: ${criterion.text}`,
       );
     }
-    if (GENERIC_ACCEPTANCE.test(criterion.statement)) {
+    if ((!acceptanceOnly || criterion.verificationClass) && GENERIC_ACCEPTANCE.test(criterion.statement)) {
       failures.push(`generic acceptance criterion is not verifiable: ${criterion.statement}`);
     }
   }
+
+  const unclassifiedCriteria = acceptanceCriteria.filter((item) => !item.verificationClass);
 
   const humanVerification = parseNamedSection(
     text,
@@ -232,6 +234,7 @@ export function validateIssueBody({
     priority: priority || null,
     issueTypeLabels,
     acceptanceCriteria,
+    unclassifiedCriteria,
     uncheckedCriteria,
   };
 }
@@ -264,7 +267,9 @@ async function main() {
   if (result.ok) {
     if (args['acceptance-only']) {
       if (result.acceptanceCriteria.length === 0) {
-        console.log('[issue-body] PASS — legacy/no AC issue; no acceptance checklist to close');
+        console.log('[issue-body] REVIEW — legacy/no AC issue; readable without migration, automatic close is not authorized');
+      } else if (result.unclassifiedCriteria.length > 0) {
+        console.log(`[issue-body] REVIEW — legacy/unclassified AC (${result.unclassifiedCriteria.length}); automatic close is not authorized`);
       } else {
         console.log(`[issue-body] PASS — acceptance criteria complete (${result.acceptanceCriteria.length})`);
       }

--- a/scripts/report_ac_coverage.mjs
+++ b/scripts/report_ac_coverage.mjs
@@ -150,7 +150,7 @@ export function buildCoverageReport({ storyData, implData, implDir }) {
   );
   if (allAcceptance.length === 0) {
     return [
-      '[ac-coverage] Legacy stories format — no Story AC found.',
+      '[ac-coverage] REVIEW — Legacy stories format; no Story AC found.',
       '[ac-coverage] Existing artifacts remain valid; no retroactive conversion is required.',
     ].join('\n');
   }

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -51,7 +51,7 @@ UI 작업이면 구현 전 **UI 기준 확보 분기**를 먼저 본다. 내부 
 ## Pre-flight
 
 1. `docs/epics/**/stories.md` 상단의 `**GitHub Epic Issue:** [#N]` 또는 `미등록 (사유: …)` 를 확인한다. 없으면 STOP.
-2. parent epic/story issue 본문을 진입 preflight 에서 한 번 read 하고 target GitHub issue AC snapshot 을 만든다. task 자체는 GitHub issue 가 아니라 impl 파일 + task commit 으로 추적한다. snapshot 은 task/story 진행 전체에서 재사용하며 반복 issue 조회를 추가하지 않는다. 검증 주체가 없는 legacy AC 는 `[command]`/`[agent-read]` 로 분류하고, 일반론 AC 는 snapshot 에서 구체화해 구현 계약으로 쓴다. body 반영은 close 경계의 1회 write 에 포함하며, 사용자 판단 없이는 구체화할 수 없으면 추측하지 않는다.
+2. parent epic/story issue 본문을 진입 preflight 에서 한 번 read 하고 target GitHub issue AC snapshot 을 만든다. task 자체는 GitHub issue 가 아니라 impl 파일 + task commit 으로 추적한다. snapshot 은 task/story 진행 전체에서 재사용하며 반복 issue 조회를 추가하지 않는다. 검증 주체 미기재 legacy AC 는 기존 의미를 보존하며 agent 가 `[command]`/`[agent-read]` 로 추론·체크·재분류하지 않는다. 사람 판단인지 불명확한 항목과 no-AC issue 는 close audit의 `REVIEW` 결과를 따라 human verification 대기로 보낸다. 현행 typed 일반론 AC 는 snapshot 에서 구체화해 구현 계약으로 쓰되 사용자 판단 없이는 구체화하지 않는다.
 3. task 가 이미 머지됐는지 `git log --grep <task-slug>` 와 task tail 로 확인한다.
 4. `begin-run impl --design-doc <task impl 문서>` 로 설계 문서를 기록한다. 이 값은 build-worker gate, boundary pre-flight, impl-validator review 근거다.
 5. `boundary-suggestions --impl-plan <task>` 로 `### 수정 허용` 경로가 `ALLOW_MATRIX ∪ .dcness/boundary.json` 으로 커버되는지 확인한다. 미커버 경로는 사람 승인 후 boundary override 가 필요하다.
@@ -225,7 +225,7 @@ node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
   --require-complete
 ```
 
-미충족·미체크 target GitHub issue AC 가 하나라도 있으면 clean 마감과 merge 를 금지한다. 기존 이슈 체크박스에 사람 판정 항목이 남아 있으면 agent 는 자동 항목만 충족·체크하고 잔여 human verification 목록을 보고 정지한다. 이는 자동 구현 실패인 `blocked` 가 아니라 `human verification 대기`다.
+미충족·미체크 typed target GitHub issue AC 가 하나라도 있으면 clean 마감과 merge 를 금지한다. close audit의 정확한 `PASS`만 자동 close 경로를 열며 exit 0의 legacy `REVIEW`는 failure가 아니라 human verification 대기 신호다. 사람 판정·검증 주체 미기재·no-AC 항목은 agent 가 체크하거나 재분류하지 않고 잔여 human verification 목록을 보고 merge 전에 정지한다.
 
 `impl-validator:CODEBASE_SANITY FAIL`이면 finding의 affected surface를 build-worker rework로 넘기고 Sanity부터 재감사한다. 일반 `impl-validator FAIL`의 story-local FAIL은 해당 story PR 브랜치에 append하고 downstream story/QA branch를 restack한다. story PR 이 2개 이상인 run의 cross-cutting FAIL은 QA PR이 흡수한다. 단일 story PR은 해당 PR branch에 append한다. 어느 경로든 코드가 바뀌면 Sanity와 merge-review 증거가 stale이며 같은 finding을 줄 단위 점 패치로 반복하지 않는다. cycle 한도는 routing 문서가 소유한다.
 
@@ -297,7 +297,7 @@ PR이 아직 열린 stack 상태면 `PR <#NNN> open · base <branch>`로 표시�
 - Epic close이면 현재 code revision을 덮는 `.dcness-work/codebase-sanity/` receipt와 `impl-validator:CODEBASE_SANITY` PASS.
 - 필요한 product-acceptance PASS.
 - build-worker Cartography impact가 affected Root Cartography 및 관련 epic/decision과 대조됐고 route-only stale 또는 system backpressure가 남지 않음.
-- target issue 가 있으면 자동 판정 가능한 AC 전항목 충족·체크 + `require-complete` PASS.
+- target issue 가 있으면 자동 판정 가능한 typed AC 전항목 충족·체크 + `require-complete`의 정확한 `PASS`; legacy `REVIEW`면 human verification 완료.
 
 이 중 하나라도 없는데 clean 이라고 쓰면 false-clean → blocked.
 

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -51,8 +51,8 @@ flowchart TB
   ACC -->|아니오| MERGE[사용자 승인 → main 리타겟·리베이스·merge]
   ACC -->|예| PA[product-acceptance story x N + epic]
   PA -->|PASS| AC[Target GitHub issue AC close audit]
-  AC -->|require-complete PASS| MERGE
-  AC -.->|미충족·미체크| USER
+  AC -->|typed require-complete PASS| MERGE
+  AC -.->|legacy REVIEW 또는 미충족·미체크| USER
   PA -->|FAIL auto-fixable + Epic code 변경| CSFIX
   PA -->|FAIL auto-fixable + Story-only| RETRY
   PA -->|capability 상태 drift route-only| CR
@@ -75,7 +75,7 @@ canvas-design 은 UI 작업의 main-owned checkpoint 이며 helper begin/end-ste
 | **impl-validator** | stack tip vs main diff `PASS` → close 발동 여부 확인 · `FAIL`(`[spec-gap]` 또는 `[quality-gap]`) → 메인 root-cause 수정. 단일 story는 해당 PR append, story PR 이 2개 이상이면 story-local FAIL은 해당 story PR 브랜치 append + downstream restack, cross-cutting FAIL은 QA PR 흡수 + 재리뷰(≤3) · `ESCALATE` → 사용자 |
 | **Cartography freshness** | build-worker Cartography impact + merge candidate diff + affected Root Cartography + 관련 epic/decision이 `영향 없음 또는 Root와 일치` → 기존 경로 · route/state/as-built edge stale → `module-architect:CARTOGRAPHY_REFRESH` bounded refresh + impl-validator 재검증 · system boundary/global decision 변경 → `/design --revise` 또는 system checkpoint backpressure |
 | **product-acceptance** | 최종 tip에서 story×N + epic을 per-story verdict로 판정. `PASS` → target GitHub issue AC close audit. 1-story fix는 본 PR append, N-story tracked cross-cutting fix/flow 보정은 QA PR 흡수 · Epic code 변경은 완료된 Sanity/impl-validator 증거를 stale 처리하고 Sanity부터 재진입, Story-only는 impl-validator 재리뷰 + acceptance 재검수(≤3) · capability 상태 drift가 route-only stale → `CARTOGRAPHY_REFRESH` + 같은 diff+갱신 Root impl-validator 재검증 + acceptance 재검수 · system boundary/global decision gap → `/design --revise`/checkpoint · `FAIL` 비자동 gap / round 초과 / `ESCALATE` → 사용자 |
-| **target GitHub issue AC close audit** | 메인이 acceptance verdict로 자동/`(JOURNEY)` AC를 체크하고 `사람 확인 안내`는 미체크 유지. `check_issue_body.mjs --acceptance-only --require-complete` PASS → 사용자 merge 승인 대기 · 미충족·미체크 → clean 마감 금지, 구현 보강 · human verification 잔여 → 목록 보고 후 merge 전 대기 (`blocked` 아님) |
+| **target GitHub issue AC close audit** | 메인이 acceptance verdict로 자동/`(JOURNEY)` typed AC만 체크하고 `사람 확인 안내`는 미체크 유지. `check_issue_body.mjs --acceptance-only --require-complete`의 정확한 `PASS` → 사용자 merge 승인 대기 · legacy `REVIEW` → human verification 대기 · 미충족·미체크 → clean 마감 금지, 구현 보강 (`blocked` 아님) |
 
 loop의 자동 merge 금지: 사용자가 유일한 merge gate다. 승인 뒤에만 대상 PR을 base=`main`으로 리타겟·리베이스하고 merge helper를 호출한다.
 
@@ -121,7 +121,7 @@ auto-fixable gap: PRD 유저 시나리오 / Story AC 미충족, 검수 증거 �
 - task clean = build-worker PASS + phase prose 3개 + local commit sha + clean status + story-runner mark.
 - story boundary clean = 해당 story의 모든 task completed + story PR 생성 + merge 없이 다음 branch를 직전 story branch에서 재분기.
 - integrated review clean = 모든 target task completed + 모든 story PR 경계 처리 + stack tip 확정 + Epic close이면 현재 code revision의 `impl-validator:CODEBASE_SANITY` PASS와 receipt + 일반 impl-validator PASS.
-- close 발동 clean = integrated review clean + 필요한 product-acceptance PASS + target GitHub issue AC 전항목 충족·체크 + `require-complete` PASS.
+- close 발동 automatic clean = integrated review clean + 필요한 product-acceptance PASS + typed target GitHub issue AC 전항목 충족·체크 + `require-complete`의 정확한 `PASS`. legacy `REVIEW`는 human verification 뒤에만 진행한다.
 - verify-only clean = 검증 명령 exit 0 + 변경 0 + validator PASS.
 
 false-clean 의심 시 blocked. 예: phase prose 부재, commit sha 부재, 검증 미실행, impl-validator PASS 부재, acceptance PASS 부재, target GitHub issue AC 미충족·미체크, PR/merge 흔적 부재. 단, 자동 항목은 모두 끝났고 사람 판정만 남은 `human verification 대기`는 blocked 로 뭉뚱그리지 않는다.

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -46,7 +46,7 @@ UI 기준: 시각 구조 불변 — 목업 없이 구현
 - 이 repo 의 실제 lint/build/test 명령, PR helper, hook 존재 여부를 확인한다.
 - GitHub issue 번호가 대상이면 구현 실행 전 [`issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#issuelabel-status-lifecycle)에 따라 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 Project `Status=In progress` 도 best-effort 로 미러한다.
 
-GitHub issue 가 대상이면 이 진입 preflight 에서 한 번 읽은 본문을 run 전체의 **target GitHub issue AC** snapshot 으로 재사용한다. 각 AC 에 구현 범위와 검증 증거를 대응시키고, task/commit/validator 단계마다 issue 를 반복 조회하지 않는다. `[command]` 는 명령과 종료코드, `[agent-read]` 는 읽은 산출물·diff·계약과 관찰 사실로 판정한다. 검증 주체 표기가 없는 기존 AC 도 같은 두 부류로 분류해 다룬다. `구현이 완료된다`나 `정상 동작한다` 같은 일반론은 snapshot 에서 구체적인 관측 조건으로 교체해 구현 계약으로 쓰고, issue body 반영은 close 경계의 1회 write 에 포함한다. 구체화에 사용자 판단이 필요하면 추측하지 않는다.
+GitHub issue 가 대상이면 이 진입 preflight 에서 한 번 읽은 본문을 run 전체의 **target GitHub issue AC** snapshot 으로 재사용한다. 각 AC 에 구현 범위와 검증 증거를 대응시키고, task/commit/validator 단계마다 issue 를 반복 조회하지 않는다. `[command]` 는 명령과 종료코드, `[agent-read]` 는 읽은 산출물·diff·계약과 관찰 사실로 판정한다. 검증 주체 미기재 legacy AC 는 기존 의미를 보존하며 agent 가 `[command]`/`[agent-read]` 로 추론·체크·재분류하지 않는다. 사람 판단인지 불명확한 항목과 no-AC issue 는 close audit의 `REVIEW` 결과를 따라 human verification 대기로 보낸다. 현행 typed AC 의 `구현이 완료된다`나 `정상 동작한다` 같은 일반론은 snapshot 에서 구체적인 관측 조건으로 교체해 구현 계약으로 쓰되 사용자 판단 없이는 구체화하지 않는다.
 
 ## Step 0.2 — 파일 경계 override 후보 확인
 
@@ -114,7 +114,7 @@ UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 �
 - **커밋**: green 변경은 독립 검토 가능한 단위 commit 으로 닫는다.
 - **UI**: 확정 목업이 있으면 레이아웃·상태·`design:required` 토큰 정합을 대조하고 보고한다.
 - **Cartography impact**: 구현 결과에서 runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision의 변화 여부를 자유 prose로 남긴다. 영향이 없으면 `영향 없음`과 대조한 Root 좌표를 명시한다.
-- **target issue AC**: 대상 GitHub issue 가 있으면 target GitHub issue AC 전항목 충족과 자동 판정 가능한 체크박스 전부 check 가 공통 종료 조건이다. 하나라도 미충족·미체크면 `require-complete` 감사가 실패하므로 clean 마감, `Closes` PR 머지, 완료 보고를 금지한다. 이 계약은 계획 파일 유무와 무관하다.
+- **target issue AC**: 대상 GitHub issue 가 있으면 typed target GitHub issue AC 전항목 충족과 자동 판정 가능한 체크박스 전부 check가 공통 자동 종료 조건이다. 하나라도 미충족·미체크면 `require-complete` 감사가 실패하므로 clean 마감, `Closes` PR 머지, 완료 보고를 금지한다. legacy `REVIEW`는 human verification 대기이며 이 계약은 계획 파일 유무와 무관하다.
 
 ### Cartography freshness boundary
 
@@ -160,7 +160,7 @@ standalone acceptance가 생략 가능한 direct `/impl`에서는 이 `impl-vali
    - dcNess plugin 배포물 변경이면 PR body 에 배포 경로 검증을 적는다.
 8. CI / merge policy
    - PR 생성 후 CI 를 확인한다.
-   - CI green 과 최종 review 증거가 확정된 뒤, target issue 를 `Closes` 하는 PR 경계에서 메인이 보관한 AC 증거를 전수 대조한다. `Closes` 대상이 여러 개면 issue 별로 모두 수행한다. 자동 판정 가능한 항목을 모두 충족한 뒤 이슈 본문 체크박스 write 를 issue 별 close 경계에서 한 번 수행하고, 같은 body 를 `node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" --body-file <issue-body.md> --acceptance-only --require-complete` 로 감사한다. 진행 중에는 issue mutation 을 하지 않는다.
+   - CI green 과 최종 review 증거가 확정된 뒤, target issue 를 `Closes` 하는 PR 경계에서 메인이 보관한 AC 증거를 전수 대조한다. `Closes` 대상이 여러 개면 issue 별로 모두 수행한다. 자동 판정 가능한 typed 항목을 모두 충족한 뒤 이슈 본문 체크박스 write 를 issue 별 close 경계에서 한 번 수행하고, 같은 body 를 `node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" --body-file <issue-body.md> --acceptance-only --require-complete` 로 감사한다. 정확한 `PASS`만 자동 close 경로를 열며, exit 0의 legacy `REVIEW`는 failure가 아니라 human verification 대기 신호다. 진행 중에는 issue mutation 을 하지 않는다.
    - 머지는 host repo 정책을 따른다. 사용자 승인 대기 정책 repo 에서는 임의 머지하지 않는다.
 
 최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, 격리 `impl-validator`, 단위 commit/PR, CI, false-clean 방지다. TDD 게이트는 삭제하지 않는다.

--- a/skills/impl/impl-routing.md
+++ b/skills/impl/impl-routing.md
@@ -67,7 +67,7 @@ UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 �
 
 일반 `/impl` 도 `impl-validator` 를 호출한다. direct 에 대상 issue 가 있으면 계획 파일이 없어도 spec 렌즈를 켜고 **target GitHub issue AC** 를 대조한다. design-doc 경로의 spec 기준은 plan ∪ target GitHub issue AC 이며, 대상 issue 가 없는 direct 만 quality 렌즈로 검토한다. 최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, 격리 `impl-validator`, 단위 commit/PR, CI, false-clean 방지다.
 
-대상 issue 가 있는 경로는 target GitHub issue AC 전항목 충족과 자동 판정 가능한 체크박스 전부 check 후 `check_issue_body.mjs --acceptance-only --require-complete` PASS 까지가 clean 조건이다. 미충족·미체크 AC 가 남으면 clean 마감과 close 발동을 금지한다. agent 가 체크할 수 없는 human verification 은 목록을 보고 merge 전에 정지하며, 이 대기 상태를 `blocked` 로 분류하지 않는다.
+대상 issue 가 있는 경로는 typed target GitHub issue AC 전항목 충족과 자동 판정 가능한 체크박스 전부 check 후 `check_issue_body.mjs --acceptance-only --require-complete`의 정확한 `PASS`까지가 자동 clean 조건이다. 미충족·미체크 typed AC가 남으면 clean 마감과 close 발동을 금지한다. legacy `REVIEW`와 agent가 체크할 수 없는 human verification은 목록을 보고 merge 전에 정지하며, 이 대기 상태를 `blocked`로 분류하지 않는다.
 
 ## high-risk warn-don't-block
 

--- a/skills/spec/spec-stories-reference.md
+++ b/skills/spec/spec-stories-reference.md
@@ -98,4 +98,4 @@ milestone: vNN
 
 기존 외부 활성 프로젝트의 옛 양식 stories.md 와 PRD AC 는 그대로 허용한다. 새 작성 시만 Story AC 양식을 적용하며 기존 산출물을 소급 변환하지 않는다. read 시 parser 는 `As a / I want / So that` 매치만 의무로 본다.
 
-Story AC 가 없거나 `**완료 시 확인 가능한 동작**:` 줄을 쓰는 기존 stories.md 도 그대로 허용한다. `scripts/report_ac_coverage.mjs` 는 이런 파일을 legacy 로 보고하고 변환이나 실패를 강제하지 않는다.
+Story AC 가 없거나 `**완료 시 확인 가능한 동작**:` 줄을 쓰는 기존 stories.md 도 그대로 허용한다. `scripts/report_ac_coverage.mjs` 는 이런 파일을 exit 0의 `REVIEW`로 보고하고 변환이나 실패를 강제하지 않으며, `REVIEW`를 typed AC coverage PASS로 해석하지 않는다.

--- a/tests/test_acceptance_contract_hierarchy.py
+++ b/tests/test_acceptance_contract_hierarchy.py
@@ -252,7 +252,8 @@ class AcceptanceCoverageReporterTests(unittest.TestCase):
         result = _run_report(legacy, {})
 
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("Legacy stories format", result.stdout)
+        self.assertIn("REVIEW — Legacy stories format", result.stdout)
+        self.assertNotIn("PASS", result.stdout)
         self.assertIn("no retroactive conversion", result.stdout)
 
     def test_duplicate_ac_declaration_inside_one_story_is_reported(self) -> None:

--- a/tests/test_issue_body_validation.py
+++ b/tests/test_issue_body_validation.py
@@ -179,16 +179,6 @@ class IssueBodyValidationTests(unittest.TestCase):
 
         self.assertEqual(0, result.returncode, result.stderr)
 
-    def test_close_preflight_rejects_unchecked_acceptance_criteria(self) -> None:
-        result = run_validator(
-            VALID_BODY,
-            "--acceptance-only",
-            "--require-complete",
-        )
-
-        self.assertEqual(1, result.returncode)
-        self.assertIn("unchecked acceptance criteria", result.stderr)
-
     def test_close_audit_rejects_unchecked_heading_acceptance_criteria(self) -> None:
         body = textwrap.dedent(
             """
@@ -224,23 +214,11 @@ class IssueBodyValidationTests(unittest.TestCase):
         self.assertEqual(1, result.returncode)
         self.assertIn("unchecked acceptance criteria remain: 1", result.stderr)
 
-    def test_close_preflight_accepts_checked_acceptance_criteria(self) -> None:
-        body = VALID_BODY.replace("- [ ]", "- [x]")
-
-        result = run_validator(
-            body,
-            "--acceptance-only",
-            "--require-complete",
-        )
-
-        self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("PASS", result.stdout)
-
-    def test_close_audit_accepts_checked_legacy_unclassified_criteria(self) -> None:
+    def test_close_audit_routes_checked_legacy_unclassified_criteria_to_review(self) -> None:
         legacy_body = textwrap.dedent(
             """
             **Acceptance criteria:**
-            - [x] 기존 자동 검증 결과를 확인한다.
+            - [x] 정상 동작한다.
             - [x] 사용자가 최종 시각 결과를 확인한다.
             """
         ).strip()
@@ -252,9 +230,10 @@ class IssueBodyValidationTests(unittest.TestCase):
         )
 
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("acceptance criteria complete (2)", result.stdout)
+        self.assertIn("REVIEW — legacy/unclassified", result.stdout)
+        self.assertNotIn("PASS", result.stdout)
 
-    def test_close_audit_allows_legacy_issue_without_acceptance_section(self) -> None:
+    def test_close_audit_routes_legacy_issue_without_acceptance_section_to_review(self) -> None:
         legacy_story_body = textwrap.dedent(
             """
             **As a** user,
@@ -272,7 +251,8 @@ class IssueBodyValidationTests(unittest.TestCase):
         )
 
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("legacy/no AC", result.stdout)
+        self.assertIn("REVIEW — legacy/no AC", result.stdout)
+        self.assertNotIn("PASS", result.stdout)
 
     def test_acceptance_criterion_requires_agent_verification_class(self) -> None:
         body = VALID_BODY.replace(
@@ -327,7 +307,8 @@ class IssueBodyValidationTests(unittest.TestCase):
         )
 
         self.assertEqual(0, result.returncode, result.stderr)
-        self.assertIn("acceptance criteria complete (2)", result.stdout)
+        self.assertIn("PASS — acceptance criteria complete (2)", result.stdout)
+        self.assertNotIn("REVIEW", result.stdout)
 
     def test_story_human_verification_checkbox_is_rejected(self) -> None:
         story_body = textwrap.dedent(
@@ -381,6 +362,18 @@ class IssueBodyValidationDocsTests(unittest.TestCase):
         self.assertIn("gh issue create", text)
         self.assertIn("GitHub UI", text)
         self.assertIn("hard gate", text)
+        self.assertIn("REVIEW", text)
+        self.assertIn("자동 close 권한이 아니다", text)
+
+        for relative in ("skills/impl/SKILL.md", "skills/impl-loop/SKILL.md"):
+            skill = (ROOT / relative).read_text(encoding="utf-8")
+            self.assertIn("검증 주체 미기재 legacy AC", skill, relative)
+            self.assertIn("추론·체크·재분류하지 않는다", skill, relative)
+            self.assertNotIn(
+                "검증 주체가 없는 legacy AC 는 `[command]`/`[agent-read]` 로 분류",
+                skill,
+                relative,
+            )
 
     def test_workflow_router_mentions_non_to_issue_agent_creation_still_validates(self) -> None:
         text = (ROOT / "docs" / "plugin" / "workflow-router.md").read_text(

--- a/tests/test_issue_body_validation.py
+++ b/tests/test_issue_body_validation.py
@@ -365,7 +365,7 @@ class IssueBodyValidationDocsTests(unittest.TestCase):
         self.assertIn("REVIEW", text)
         self.assertIn("자동 close 권한이 아니다", text)
 
-        for relative in ("skills/impl/SKILL.md", "skills/impl-loop/SKILL.md"):
+        for relative in ("CLAUDE.md", "skills/impl/SKILL.md", "skills/impl-loop/SKILL.md"):
             skill = (ROOT / relative).read_text(encoding="utf-8")
             self.assertIn("검증 주체 미기재 legacy AC", skill, relative)
             self.assertIn("추론·체크·재분류하지 않는다", skill, relative)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1097
Part of #1089

## 배경 및 문제

- #1092가 고정한 policy inventory를 기준으로 #1093~#1096 선행 cleanup이 설계·run·routing·install/path 순서로 끝났고, lifecycle 구간인 #1097이 남아 있었습니다.
- 기존 close reader는 Acceptance criteria가 없거나 검증 주체가 없는 legacy issue도 `PASS`로 출력했고, impl 지침은 무분류 AC를 agent가 두 자동 유형으로 추론·재분류하도록 해 false close와 사람 판단 대리 위험이 있었습니다.
- 후속 #1098은 assertion/large-file 감량, #1099는 최종 계측·epic 감사를 담당하므로 이 PR은 story·issue acceptance reader 경계에만 한정합니다.

## 원인 (해당 시)

- typed writer 도입 뒤에도 legacy 호환 reader의 성공적인 읽기(exit 0)와 자동 close 권한(`PASS`)이 같은 신호로 표현됐습니다.
- 실제 활성 legacy 소비자와 제거 trigger가 lifecycle 후보별로 충분히 기록되지 않아, 안전한 호환 유지와 제거 가능한 자동화 surface를 분리하기 어려웠습니다.

## 작업내용

- 전항목이 `[command]`/`[agent-read]`인 typed body만 정확한 `PASS`를 내고, no-AC 또는 검증 주체 미기재 legacy body는 exit 0 `REVIEW`를 내도록 close reader를 분리했습니다.
- legacy AC를 agent가 추론·체크·재분류하지 않고 human verification으로 넘기도록 impl/impl-loop와 lifecycle SSOT를 동기화했습니다.
- dcness self 작업 SSOT인 `CLAUDE.md`도 정확한 `PASS`만 자동 close로 해석하도록 동기화했습니다.
- legacy Story AC coverage도 `REVIEW`로 명시해 현행 typed coverage `PASS`로 오인하지 않게 했습니다.
- 등록 프로젝트 비식별 조사 결과(legacy stories 10개, open legacy issue 14개), 생성 시기, 실제 소비자, 유지 이유, 제거 trigger, 확인 fixture를 LIFE-001~005에 기록했습니다.
- 기존 자동 PASS·agent inference surface를 구현·테스트·skill·문서에서 함께 제거하고 typed PASS / legacy REVIEW 회귀 fixture를 추가했습니다.

## 결정 근거

- 실제 활성 소비자가 남은 LIFE-002·LIFE-003 reader 자체를 제거하면 migration 없는 false fail이 생기므로 호환 후보 2개는 유지했습니다.
- 대신 성공적으로 읽었다는 의미와 자동 close 가능하다는 의미를 `REVIEW`/`PASS`로 분리해 false close만 제거했습니다.
- legacy stories 10/10과 completed-copy legacy issue 14/14가 `REVIEW`, `PASS` 0, 실패 0으로 재생됐습니다.
- lifecycle script+test diff는 31줄 추가·32줄 삭제로 1 LOC 순감이며 신규 public surface는 없습니다.

## 배포 경로 검증 (plug-in 영향 시)

- 변경은 plugin 본체의 `scripts/**`, `skills/**`, `docs/plugin/**`에 반영되며 다음 plugin update/release artifact에 포함됩니다.
- `/init-dcness`가 복사하는 generated 파일은 변경하지 않았습니다.
- `python3.11 scripts/release_artifact.py smoke --repo-root . --ref HEAD` 통과: 193 files, `release_artifact_smoke=PASS`.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 lifecycle reader와 기존 impl/spec 지침의 신호 경계만 정리했으며 신규 public skill/command/agent/gate가 없습니다.

## Test Plan

- [x] TDD red 확인: 기존 legacy fixture가 `PASS`, `REVIEW` 부재, no-inference 문서 계약 부재로 실패
- [x] `python3.11 -m unittest tests.test_issue_body_validation tests.test_acceptance_contract_hierarchy tests.test_policy_cleanup_baseline -v` (42 tests)
- [x] 관련 생성·spec·acceptance·distribution 회귀 (104 tests)
- [x] `python3.11 -m unittest discover -s tests -q` (rebased HEAD, 1975 tests)
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `node scripts/check_cross_refs.mjs`
- [x] `node scripts/check_public_surface.mjs`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] `node scripts/check_plugin_manifest.mjs`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `python3.11 evals/guard_efficacy.py` (39/39)
- [x] `python3.11 scripts/release_artifact.py smoke --repo-root . --ref HEAD`

## 참고

- 상위 epic: #1089
- 선행 baseline/cleanup: #1092 / PR #1116, #1093 / PR #1117, #1094 / PR #1119, #1095 / PR #1121, #1096 / PR #1124
- 후속 경계: #1098, #1099
- merge는 수행하지 않고 사용자 승인 대기 상태로 둡니다.
