### PR TITLE
[docs] decision-completeness-ungrounded flaky 처분 fixed 기록

### DIFF
--- a/docs/internal/loop-decisions.jsonl
+++ b/docs/internal/loop-decisions.jsonl
@@ -5,3 +5,4 @@
 {"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "eval:flow-ownership-owner-good", "note": "negative-guard 회귀 감시 유지; 포화 지속 시 다음 주기 은퇴 재검토.", "ref": "#931"}
 {"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "eval:story-slice-partfirst", "note": "negative-guard 회귀 감시 유지; 포화 지속 시 다음 주기 은퇴 재검토.", "ref": "#931"}
 {"decided_at": "2026-07-05T13:29:24Z", "decision": "hold", "key": "eval:story-slice-skeleton", "note": "negative-guard 회귀 감시 유지; 포화 지속 시 다음 주기 은퇴 재검토.", "ref": "#931"}
+{"decided_at": "2026-07-14T07:31:34Z", "decision": "fixed", "key": "eval:decision-completeness-ungrounded", "note": "HEAD 재측정 18/18(100%), 전부 GAP-1(30일 삭제=구현 기본값) 정확 포착 후 FAIL·judge 정채점. 케이스 정당(expected 불변). 역사 50%(4/8)는 케이스 생성 7e0a6da(7/12 14:48)와 근거 지침 4d4256e(7/12 14:59) 사이 pre-fix 표본이 /tmp 누적에 섞인 오염 — 둘 다 PR #1076(#1065 pilot). agent 결함이었으나 4d4256e 로 이미 해소. 형제 grounded(#1128, 과대판정)는 여전히 OPEN.", "ref": "#1129"}


### PR DESCRIPTION
## 관련 이슈 번호

Part of #1129

## 배경 및 문제

우산 #1129 의 🔴 심각 티어 7개 케이스 중 첫 진단 대상 `decision-completeness-ungrounded`(역사 스냅샷 50%, 4/8)를 현재 지침 기준으로 재측정·원인 확정했다. #1129 규범상 flaky 후보는 gate 통과와 무관하게 처분(record-decision)을 남겨야 한다.

## 원인 (해당 시)

- 현재 HEAD 재측정 **18/18 (100%)** — 전 회차 report 가 `GAP-1`(증빙 30일 자동 삭제 = 파일 저장 모듈 구현 기본값 → 근거 없는 가정)을 정확히 포착하고 `FAIL`, judge 도 E1/E2/E3 정확 채점. 맞는 이유로 통과.
- 케이스 정당(`prd.md:23` 은 목표 `:11`·7년 이력 `:22` 와 충돌하는 실제 근거 없는 가정). `expected.md`·fixture 불변.
- 역사 50%(4/8) 원인 = **pre-fix 표본 오염**. 케이스 생성 `7e0a6da`(7/12 14:48)와 이를 잡는 근거 지침 `4d4256e`(7/12 14:59, 11분 뒤)가 **둘 다 PR #1076**(#1065 pilot). 개발 iteration 초기(지침 前) 실패 표본이 `/tmp` 누적에 섞여 정답률을 끌어내림.
- 층 분류: **agent 결함이었으나 `4d4256e` 로 이미 해소**. 신규 버그 이슈 대상 아님. 형제 케이스 grounded(#1128, 과대판정)는 여전히 OPEN — grounding 축의 false-negative 방향은 해결, false-positive 방향은 미해결.

## 작업내용

- `docs/internal/loop-decisions.jsonl` 에 `eval:decision-completeness-ungrounded → fixed` (ref #1129) append.

## 결정 근거

- #1129 진단 방법론 step 4/5 + evals/README.md "실패·재실행 처리 규범": 최초 MISS 를 버리지 않고 EVAL_RUNS 를 높여 측정, flaky 후보는 record-decision 처분 필수.
- 현재 결함이 없어 agent/judge 지침 수정·신규 이슈 불필요 → 처분은 `fixed`.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 운영 작업 (진단 원장 기록, 외부 배포물 미변경).

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A.

## Test Plan

- [x] 회귀 검증 — 원장 append-only, 기존 7줄 불변. `EVAL_CASES=decision-completeness-ungrounded EVAL_RUNS=6/12` 두 회 18/18.