### PR TITLE
[feature] persisted run fixture 책임 통합

### DIFF
--- a/docs/internal/policy-sunset-inventory.md
+++ b/docs/internal/policy-sunset-inventory.md
@@ -247,17 +247,18 @@ compatibility 후보는 `LIFE-002`와 `LIFE-003` 두 개로 유지된다. 둘 �
 
 ## 500줄 이상 major text 책임 감사
 
-단순 분할은 개선으로 세지 않는다. 각 파일의 현재 책임, 중복·legacy 비중, 실제 감량 후보를 읽었다. `후속/판정`이 #1098인 항목도 앞선 정책 이슈가 제거한 branch·fixture를 입력으로 받을 뿐, 크기만으로 쪼개지 않는다.
+단순 분할은 개선으로 세지 않는다. `265e538`에서 58개 전부를 다시 읽고 현재 책임, 중복·legacy 비중, 실제 감량 후보를 갱신했다. `후속/판정`이 #1098인 항목도 앞선 정책 이슈가 제거한 branch·fixture를 입력으로 받을 뿐, 크기만으로 쪼개지 않는다.
 
 | 파일 | LOC | 현재 책임 | 중복·legacy 관찰 | 후속/판정 |
 |---|---:|---|---|---|
 | `PROGRESS.md` | 556 | self 진행 기록 | 누적 이력이며 runtime 아님 | #1098 입력 제외; 분할 무효 |
-| `commands/init-dcness.md` | 512 | 활성화·재실행·제거 orchestration | install 설명이 사용자 SSOT와 일부 반복 | #1096에서 배포 계약 단위 감량 |
+| `commands/init-dcness.md` | 513 | 활성화·재실행·제거 orchestration | install 설명이 사용자 SSOT와 일부 반복 | #1096에서 배포 계약 단위 감량 |
 | `docs/archive/change_rationale_history.md` | 2,633 | 과거 결정 archive | legacy 비중 높지만 실행 surface 아님 | #1098에서 archive 보존정책 없이는 삭제 금지 |
 | `docs/archive/conveyor-design.md` | 684 | 폐기 설계 archive | 현행 loop와 중복 가능 | #1098 후보, 단 runtime 감량으로 계산 X |
 | `docs/archive/document_update_record.md` | 1,777 | 과거 변경 archive | Git history와 중복 | #1098 후보, 별도 archive 근거 필요 |
 | `docs/archive/status-json-mutate-pattern.md` | 553 | 폐기 status JSON 참고 | 현행 prose-only와 legacy 비중 높음 | #1098 후보, 외부 링크 감사 후 |
 | `docs/internal/marketplace-artifact-baseline.json` | 658 | release artifact inventory | generated data, 책임 중복 없음 | 유지; 분할 무효 |
+| `docs/internal/policy-sunset-inventory.json` | 515 | 정책 slice machine inventory | markdown 감사와 표현은 겹치지만 machine validation 입력 | 유지; #1099 재측정 입력 |
 | `docs/internal/release-notes.md` | 2,184 | 릴리즈 이력 | GitHub PR history와 일부 중복 | #1098 후보지만 release SSOT 보존 필요 |
 | `docs/plugin/loop-procedure.md` | 504 | loop mechanics SSOT | run/routing 호환 설명이 누적 | #1094·#1095 뒤 문구 삭제, 단순 분할 금지 |
 | `evals/agent_effectiveness_measure.py` | 734 | paired trace 측정 | policy compatibility와 무관 | 현행; #1098 크기만으로 선택 금지 |
@@ -269,7 +270,7 @@ compatibility 후보는 `LIFE-002`와 `LIFE-003` 두 개로 유지된다. 둘 �
 | `harness/benchmark_aggregate.py` | 500 | run verdict·waste 집계 | legacy verdict 분기 포함 | #1094 `RUN-008`, 이후 #1098 |
 | `harness/chain_view.py` | 531 | run chain view | run reader와 assertion 중복 가능 | #1094 결과 후 #1098 |
 | `harness/codex_sandbox_permission.py` | 594 | Codex 제한 승인 receipt | 현행 safety | 유지 |
-| `harness/guard_telemetry.py` | 657 | guard hit telemetry | compatibility와 무관 | 현행 |
+| `harness/guard_telemetry.py` | 663 | guard hit telemetry | compatibility와 무관 | 현행 |
 | `harness/hooks.py` | 1,671 | order/state hook 집약 | 여러 세대 enum·run assertion 포함 | #1094 후 #1098; order guard 보존 |
 | `harness/ledger.py` | 642 | canonical + legacy run reader | legacy/mixed/field 호환 비중 큼 | #1094 핵심 감량 후보 |
 | `harness/outcome_scorecard.py` | 739 | process·effectiveness·outcome 집계 | legacy verdict 소비 중복 | #1094 뒤 #1098 |
@@ -283,32 +284,41 @@ compatibility 후보는 `LIFE-002`와 `LIFE-003` 두 개로 유지된다. 둘 �
 | `harness/story_runner.py` | 509 | story stack state | 현행 lifecycle | #1097 reader 정리 뒤 #1098 |
 | `harness/tdd_hooks.py` | 1,356 | generated hook 생성·status·self-test | install 상태별 분기 큼, 실제 partial 소비자 존재 | #1096; 단순 분할 금지 |
 | `scripts/github_project_lifecycle.mjs` | 1,444 | GitHub Project state lifecycle | legacy story reader와 직접 무관 | 현행; #1098 크기만으로 선택 금지 |
-| `scripts/loop_diagnose.py` | 884 | cross-project 진단 | compatibility와 무관 | 현행 |
+| `scripts/loop_diagnose.py` | 887 | cross-project 진단 | compatibility와 무관 | 현행 |
 | `templates/design-variants/_lib/canvas.js` | 618 | static mockup canvas runtime | policy legacy와 무관 | 현행 |
 | `tests/test_agent_boundary.py` | 2,642 | 권한 경계 회귀 | legacy alias assertion 일부, safety fixture 다수 | #1094 후 #1098 중복 assertion 검토 |
 | `tests/test_agent_effectiveness.py` | 591 | effectiveness schema | compatibility와 무관 | 현행 |
-| `tests/test_benchmark_aggregate.py` | 565 | aggregate verdict 회귀 | legacy verdict fixture 포함 | #1094 후 #1098 |
+| `tests/test_benchmark_aggregate.py` | 528 | aggregate verdict 회귀 | local current/legacy fixture writer를 #1098 공통 helper로 통합; verdict assertions 유지 | #1098 fixture 책임 감량 완료 |
 | `tests/test_chain_view.py` | 522 | chain view 회귀 | run fixture 중복 가능 | #1094 후 #1098 |
 | `tests/test_codex_sandbox_permission.py` | 564 | sandbox 승인 경계 | 현행 safety | 유지 |
 | `tests/test_codex_validator_wrapper.py` | 1,522 | Codex wrapper/prose/boundary | 여러 wrapper fixture 중복 가능 | #1096 후 #1098, sandbox safety 보존 |
 | `tests/test_design_surface.py` | 578 | design prompt/template sync | legacy authoring 부정 assertion 포함 | #1093 후 #1098 |
+| `tests/test_evals_harness.py` | 688 | eval runner 격리·병렬·release strict 회귀 | policy compatibility와 무관 | 현행; 크기만으로 선택 금지 |
 | `tests/test_generated_tdd_hooks.py` | 771 | generated install matrix | partial/install fixture가 실사용 | #1096 후 중복 fixture만 #1098 |
 | `tests/test_github_project_lifecycle.py` | 1,544 | project lifecycle 스크립트 | compatibility와 무관 | 현행; #1098 크기만으로 선택 금지 |
 | `tests/test_hooks.py` | 3,582 | order/state/hook 통합 회귀 | run·alias·fallback assertion 세대 다수 | #1094·#1096 뒤 #1098 핵심 |
 | `tests/test_ledger.py` | 600 | ledger current/legacy/mixed/corrupt | compatibility fixture 비중 큼 | #1094 핵심; 4개 안전 시나리오 보존 |
-| `tests/test_loop_diagnose.py` | 645 | cross-project 진단 | compatibility와 무관 | 현행 |
+| `tests/test_loop_diagnose.py` | 679 | cross-project 진단 | compatibility와 무관 | 현행 |
 | `tests/test_multisession_smoke.py` | 647 | 동시 run smoke | 현행 concurrency safety | 유지 |
 | `tests/test_outcome_scorecard.py` | 574 | outcome aggregation | legacy verdict fixture 일부 | #1094 후 #1098 |
 | `tests/test_parallel_wave.py` | 978 | wave/merge lock | 현행 concurrency safety | 유지 |
 | `tests/test_product_journey.py` | 610 | journey runner | compatibility와 무관 | 현행 |
 | `tests/test_provider_chain.py` | 1,466 | provider chain 상태전이 | 현행 provider 성공·변경 전 실패·변경 후 실패 안전 경계 | #1095에서 legacy route 제거, safety fallback 보존 |
-| `tests/test_run_review.py` | 1,622 | run review current/legacy 분석 | legacy alias/verdict/.steps fixture 비중 큼 | #1094 핵심, 이후 #1098 |
+| `tests/test_run_review.py` | 1,590 | run review current/legacy 분석 | local persisted-run writer를 #1098에서 공통 helper로 통합; reader별 assertion은 유지 | #1098 fixture 책임 감량 완료 |
 | `tests/test_session_state.py` | 3,510 | state/CLI/run lifecycle | private re-export fixture는 #1094에서 canonical owner import로 전환; persisted safety fixture 유지 | #1094 완료 뒤 #1098 |
 | `tests/test_story_runner.py` | 545 | story runner lifecycle | 현행 stack fixture | #1097 뒤 #1098 |
 | `tests/test_surface_docs_sync.py` | 1,005 | agent/docs/Codex mirror sync | legacy design leniency 문자열 assertion 포함 | #1093 후 #1098 |
 | `tests/test_tdd_guard.py` | 816 | central/generated TDD guard | partial install fallback fixture가 실사용 | #1096 후 #1098, TDD invariant 보존 |
 
 실제 감량 우선순위는 `ledger/run_review/session_state`와 대응 테스트의 다세대 persisted 형식, provider routing의 소비자 없는 preset/export, design legacy authoring·reader, install partial-state 증거다. archive·release data·safety eval·concurrency·journey 파일은 크기만으로 선택하지 않는다.
+
+## #1098 persisted-run fixture 책임 통합
+
+#1094/PR #1119는 canonical `ledger.jsonl` writer와 실제 표본이 남은 legacy `.steps.jsonl` reader를 구분해 보존했다. 그 뒤 call/import scan에서 제품 호출자가 아닌 `tests/test_run_review.py`, `tests/test_benchmark_aggregate.py`, `tests/test_design_run_records.py`가 같은 run 경로 생성, prose 절대경로 치환, SHA-256 receipt 작성을 세 번 구현하고, legacy row writer도 두 번 구현한 사실을 확인했다. 크기 자체가 아니라 선행 정책 퇴역 결과와 3개 reader의 동일 persisted contract가 cleanup 근거다.
+
+5개 로컬 fixture writer를 `tests/run_fixtures.py`의 canonical/legacy helper 2개로 통합했다. run review의 current·legacy·mixed·invalid receipt, fleet verdict 집계, design durable record 시나리오와 각 assertion은 그대로 두어 검증 범위를 줄이지 않았다. helper 책임 수는 5→2, code+test LOC는 70,710→70,689로 21줄 순감하며 단순 파일 분할은 없다. 새 public surface와 제품 동작 변경도 없다.
+
+Safety invariant는 영향 경로를 달리해 보존한다. persisted state 관련 369개와 전체 1,980개 unit test가 통과했고, order gate·file/external-state boundary·TDD guard·install path는 각각 hooks, agent-boundary, tdd-guard, generated-hook 전체 회귀와 guard-efficacy 39/39로 확인했다. static quality, 문서·public-surface·manifest, release artifact smoke도 통과했으며 최종 명령은 #1098 PR Test Plan과 issue close audit에 남긴다.
 
 ## 후속 범위 완전성
 
@@ -322,7 +332,7 @@ compatibility 후보는 `LIFE-002`와 `LIFE-003` 두 개로 유지된다. 둘 �
 | #1098 | 위 500줄 이상 감사의 정책 제거 후 중복 책임 | 단순 분할이 아닌 assertion/helper 통합 |
 | #1099 | baseline JSON과 29개 원장 전항목 | 동일 정의 재측정·전체 gate·부모 close audit |
 
-machine validator 결과는 29/29 entry가 정확히 하나의 #1093~#1097에 배정되고 중복 ID가 없으며, 11/11 한시 호환 entry가 4요소를 갖춘다. 대형 파일 56/56도 표에서 유지·정책 cleanup·#1098 검토 중 하나로 판정했다. 어느 범위에도 속하지 않은 후보는 없다.
+machine validator 결과는 29/29 entry가 정확히 하나의 #1093~#1097에 배정되고 중복 ID가 없으며, 현재 남은 10/10 한시 호환 entry가 4요소를 갖춘다. `265e538`의 대형 파일 58/58도 표에서 유지·정책 cleanup·#1098 검토 중 하나로 판정했다. 어느 범위에도 속하지 않은 후보는 없다.
 
 ## Codebase Sanity receipt
 

--- a/tests/run_fixtures.py
+++ b/tests/run_fixtures.py
@@ -1,0 +1,69 @@
+"""Shared persisted-run fixtures for reader and aggregate tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+from harness import ledger
+
+
+RunRow = Mapping[str, Any]
+
+
+def _run_dir(root: Path, sid: str, rid: str) -> Path:
+    path = root / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _write_jsonl(path: Path, rows: Iterable[RunRow]) -> None:
+    path.write_text(
+        "".join(json.dumps(dict(row), ensure_ascii=False) + "\n" for row in rows),
+        encoding="utf-8",
+    )
+
+
+def make_legacy_run_dir(
+    root: Path,
+    sid: str,
+    rid: str,
+    rows: Iterable[RunRow],
+    prose_files: Mapping[str, str] | None = None,
+) -> Path:
+    """Write a legacy ``.steps.jsonl`` run fixture."""
+    path = _run_dir(root, sid, rid)
+    _write_jsonl(path / ".steps.jsonl", rows)
+    for filename, content in (prose_files or {}).items():
+        (path / filename).write_text(content, encoding="utf-8")
+    return path
+
+
+def make_ledger_run_dir(
+    root: Path,
+    sid: str,
+    rid: str,
+    events: Iterable[RunRow],
+    prose_files: Mapping[str, str] | None = None,
+) -> Path:
+    """Write a canonical ledger fixture with valid prose receipts."""
+    path = _run_dir(root, sid, rid)
+    prose_by_name: dict[str, tuple[Path, str]] = {}
+    for filename, content in (prose_files or {}).items():
+        prose_path = path / filename
+        prose_path.write_text(content, encoding="utf-8")
+        prose_by_name[filename] = (prose_path, content)
+
+    normalized_events: list[dict[str, Any]] = []
+    for event in events:
+        record = dict(event)
+        prose_file = record.get("prose_file")
+        if isinstance(prose_file, str) and prose_file in prose_by_name:
+            prose_path, content = prose_by_name[prose_file]
+            record["prose_file"] = str(prose_path)
+            record.setdefault("sha256", ledger.sha256_text(content))
+        normalized_events.append(record)
+    _write_jsonl(path / "ledger.jsonl", normalized_events)
+    return path

--- a/tests/test_benchmark_aggregate.py
+++ b/tests/test_benchmark_aggregate.py
@@ -4,7 +4,6 @@ run_review.py (run 1개) 위의 fleet 레이어. fixture 는 정식 ledger.jsonl
 (sha256 receipt 자동) 로 만들어 production reader 와 동형으로 검증한다.
 """
 
-import json
 import sys
 import tempfile
 import unittest
@@ -14,52 +13,16 @@ from typing import Optional
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
 
-from harness import ledger  # noqa: E402
 from harness.benchmark_aggregate import (  # noqa: E402
     aggregate_runs,
     aggregate_sessions,
     render_markdown,
     main,
 )
-
-
-def _make_run_dir_ledger(tmp: Path, sid: str, rid: str, events: list,
-                          prose_files: Optional[dict] = None) -> Path:
-    """ledger.jsonl 기반 run_dir fixture (sha256 receipt 자동 — reader drop 회피).
-
-    test_run_review.py 의 동명 헬퍼와 동일 규약. prose_file 은 파일명으로 참조하면
-    절대경로로 치환 + sha256 receipt 가 채워진다.
-    """
-    run_dir = tmp / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
-    run_dir.mkdir(parents=True, exist_ok=True)
-    prose_by_name: dict = {}
-    for filename, content in (prose_files or {}).items():
-        prose_path = run_dir / filename
-        prose_path.write_text(content, encoding="utf-8")
-        prose_by_name[filename] = (prose_path, content)
-    with open(run_dir / "ledger.jsonl", "w", encoding="utf-8") as f:
-        for e in events:
-            rec = dict(e)
-            prose_file = rec.get("prose_file")
-            if isinstance(prose_file, str) and prose_file in prose_by_name:
-                prose_path, content = prose_by_name[prose_file]
-                rec["prose_file"] = str(prose_path)
-                rec.setdefault("sha256", ledger.sha256_text(content))
-            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
-    return run_dir
-
-
-def _make_run_dir_steps(tmp: Path, sid: str, rid: str, rows: list) -> Path:
-    """legacy .steps.jsonl 기반 run_dir fixture (receipt 무검증 경로).
-
-    prose 부재 + enum 에 실제 verdict 저장된 옛 row 의 폴백 집계를 검증하기 위함.
-    """
-    run_dir = tmp / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
-    run_dir.mkdir(parents=True, exist_ok=True)
-    with open(run_dir / ".steps.jsonl", "w", encoding="utf-8") as f:
-        for r in rows:
-            f.write(json.dumps(r, ensure_ascii=False) + "\n")
-    return run_dir
+from tests.run_fixtures import (  # noqa: E402
+    make_ledger_run_dir as _make_run_dir_ledger,
+    make_legacy_run_dir as _make_run_dir_steps,
+)
 
 
 def _step(agent: str, prose_name: str, *, enum: str = "PROSE_LOGGED",

--- a/tests/test_design_run_records.py
+++ b/tests/test_design_run_records.py
@@ -1,13 +1,11 @@
 """Design run durable record tests (#833)."""
 from __future__ import annotations
 
-import json
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
-from harness import ledger
 from harness.design_run_records import (
     DESIGN_RUN_RECORD_REL,
     build_design_record,
@@ -16,26 +14,7 @@ from harness.design_run_records import (
     design_record_path,
     write_design_record,
 )
-
-
-def _make_run_dir(tmp: Path, sid: str, rid: str, events: list[dict], prose: dict) -> Path:
-    run_dir = tmp / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
-    run_dir.mkdir(parents=True, exist_ok=True)
-    prose_paths: dict[str, tuple[Path, str]] = {}
-    for name, text in prose.items():
-        p = run_dir / name
-        p.write_text(text, encoding="utf-8")
-        prose_paths[name] = (p, text)
-    with (run_dir / "ledger.jsonl").open("w", encoding="utf-8") as f:
-        for event in events:
-            rec = dict(event)
-            pf = rec.get("prose_file")
-            if isinstance(pf, str) and pf in prose_paths:
-                p, text = prose_paths[pf]
-                rec["prose_file"] = str(p)
-                rec.setdefault("sha256", ledger.sha256_text(text))
-            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
-    return run_dir
+from tests.run_fixtures import make_ledger_run_dir as _make_run_dir
 
 
 def _step(agent: str, filename: str, ts: str, *, provider: str | None = None) -> dict:

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -7,7 +7,6 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Optional
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -15,6 +14,10 @@ sys.path.insert(0, str(REPO_ROOT))
 from harness import ledger  # noqa: E402
 from harness import run_review as run_review_module  # noqa: E402
 from harness.session_state import record_fail_open_event  # noqa: E402
+from tests.run_fixtures import (  # noqa: E402
+    make_ledger_run_dir as _make_run_dir_ledger,
+    make_legacy_run_dir as _make_run_dir,
+)
 from harness.run_review import (  # noqa: E402
     RunReport, StepRecord, WasteFinding, build_report, detect_wastes, detect_notes,
     parse_steps, render_report, list_runs, find_run_dir,
@@ -51,41 +54,6 @@ class ActiveWastePatternSsotTests(unittest.TestCase):
 
         self.assertEqual(dynamic_pattern_lines, [])
         self.assertEqual(ACTIVE_WASTE_PATTERNS, frozenset(emitted))
-
-
-def _make_run_dir(tmp: Path, sid: str, rid: str, step_records: list[dict],
-                    prose_files: Optional[dict[str, str]] = None) -> Path:
-    run_dir = tmp / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
-    run_dir.mkdir(parents=True, exist_ok=True)
-    jsonl = run_dir / ".steps.jsonl"
-    with open(jsonl, "w", encoding="utf-8") as f:
-        for r in step_records:
-            f.write(json.dumps(r, ensure_ascii=False) + "\n")
-    for filename, content in (prose_files or {}).items():
-        (run_dir / filename).write_text(content, encoding="utf-8")
-    return run_dir
-
-
-def _make_run_dir_ledger(tmp: Path, sid: str, rid: str, events: list[dict],
-                          prose_files: Optional[dict[str, str]] = None) -> Path:
-    """이슈 #587 — ledger.jsonl (event stream) 기반 run_dir fixture."""
-    run_dir = tmp / ".claude" / "harness-state" / ".sessions" / sid / "runs" / rid
-    run_dir.mkdir(parents=True, exist_ok=True)
-    prose_by_name: dict[str, tuple[Path, str]] = {}
-    for filename, content in (prose_files or {}).items():
-        prose_path = run_dir / filename
-        prose_path.write_text(content, encoding="utf-8")
-        prose_by_name[filename] = (prose_path, content)
-    with open(run_dir / "ledger.jsonl", "w", encoding="utf-8") as f:
-        for e in events:
-            rec = dict(e)
-            prose_file = rec.get("prose_file")
-            if isinstance(prose_file, str) and prose_file in prose_by_name:
-                prose_path, content = prose_by_name[prose_file]
-                rec["prose_file"] = str(prose_path)
-                rec.setdefault("sha256", ledger.sha256_text(content))
-            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
-    return run_dir
 
 
 class ParseStepsTests(unittest.TestCase):


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1098
Part of #1089

## 배경 및 문제

- #1092/PR #1116의 대형 파일 감사와 #1093~#1097/PR #1117·#1119·#1121·#1124·#1130의 정책 퇴역 뒤, 실제 code+test 총량과 Agent read surface를 줄이는 후속 cleanup이 필요했습니다.
- #1094/PR #1119는 현재 `ledger.jsonl`과 실제 persisted sample이 남은 legacy `.steps.jsonl` reader를 보존했지만, 그 계약을 만드는 테스트 fixture writer가 여러 파일에 중복돼 있었습니다.

## 원인 (해당 시)

- `test_run_review`, `test_benchmark_aggregate`, `test_design_run_records`가 같은 run path, prose 절대경로 치환, SHA-256 receipt 규약을 각각 구현했고 legacy row writer도 두 파일에 중복됐습니다.
- reader별 assertion은 의미가 달랐지만 fixture 생성 책임까지 파일별로 소유해, 같은 persisted contract를 이해하려면 5개 helper를 반복해서 읽어야 했습니다.

## 작업내용

- canonical `ledger.jsonl`과 legacy `.steps.jsonl` fixture writer를 `tests/run_fixtures.py`의 2개 helper로 통합했습니다.
- run review의 current/legacy/mixed/invalid receipt, fleet verdict 집계, design durable record 시나리오와 assertion은 그대로 유지했습니다.
- 최신 기준 500줄 이상 major text 58개 전부의 현재 책임·중복 계약·legacy 비중·safety invariant를 다시 감사하고 #1098 감량 근거를 기록했습니다.
- fixture writer 책임은 5→2, code+test LOC는 70,710→70,689로 21줄 순감했습니다. 단순 파일 분할은 없습니다.

## 결정 근거

- 크기가 아니라 #1094의 writer/reader 보존 근거와 동일 call/import/test contract를 기준으로 cleanup 대상을 골랐습니다.
- 제품 reader·writer와 public surface는 바꾸지 않고 test-only fixture 생성 책임만 통합해 기능 변경 위험을 피했습니다.
- tracked file은 공통 helper 1개가 늘지만 중복 책임 3개와 code+test LOC가 순감하며, 각 소비 test의 독립 assertion은 남습니다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — `tests/**`와 dcness self용 `docs/internal/**`만 변경합니다. release artifact smoke는 193 files로 PASS했고 plugin 본체·`/init-dcness` 복사 파일·외부 활성 프로젝트 runtime은 바뀌지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public skill/command/agent/mode/gate가 없습니다.

## Test Plan

- [x] TDD RED: canonical fixture module 도입 전 `tests.test_run_review`가 `ModuleNotFoundError`로 실패
- [x] persisted-state 관련 369 tests PASS
- [x] 전체 unit suite 1,980 tests PASS; pre-commit hook에서도 1,980 tests PASS
- [x] Ruff, mypy, Bandit static quality PASS
- [x] guard-efficacy 39/39 PASS
- [x] cross-ref, public-surface, index/doc-sync, design-artifact, plugin-manifest, doc-path PASS
- [x] release artifact smoke PASS
- [x] cleanup baseline: code 29,449 + test 41,240 = 70,689 LOC, 500+/1,000+ 58/18, test 함수 1,960

## 참고

- cleanup 시작 revision: `265e53852b64400e946df15f1a22d56a384797cf`
- 최종 재베이스 base: `50fdfa8`
- 선행: #1092 / PR #1116, #1093 / PR #1117, #1094 / PR #1119, #1095 / PR #1121, #1096 / PR #1124, #1097 / PR #1130
- 후속 통합 측정과 상위 epic close audit: #1099
