### PR TITLE
[issue-1155] run-review enum 오파싱을 수정합니다.

### DIFF
--- a/harness/run_review.py
+++ b/harness/run_review.py
@@ -568,8 +568,8 @@ def _parse_iso(ts: str) -> Optional[datetime]:
 
 
 # issue #383 B4 — prose 본문 결론 enum 추출.
-# agents/impl-validator.md 의 결론 + 권장 다음 단계 등: "prose 마지막 단락에 결론 (PASS / FAIL / ESCALATE)".
-# 마지막 N줄에서 단어 단위 매칭 — 부정문 (예: "FAIL 없음", "0 FAIL") 회피를 위해
+# 명시적인 `결론:` 라인은 위치와 무관하게 우선하고, 구형 prose 호환을 위해 마지막
+# N줄 단어 매칭을 fallback 한다. 부정문 (예: "FAIL 없음", "PASS 불가") 회피를 위해
 # 같은 줄에 부정 마커가 있으면 skip.
 _CONCLUSION_ENUMS: tuple[tuple[str, re.Pattern[str]], ...] = (
     # 현행 agents/*.md 결론 enum. 구체적 enum을 일반 enum보다 먼저 매칭한다.
@@ -593,8 +593,14 @@ _STANDALONE_CONCLUSIONS: frozenset[str] = frozenset({
     "IMPLEMENTATION_ESCALATE", "SYSTEM_CHECKPOINT_REQUIRED", "NEW_DEP_ESCALATE",
     "UX_FLOW_READY", "UX_FLOW_PATCHED", "UX_REFINE_READY", "UX_FLOW_ESCALATE",
 })
+_CONCLUSION_LABELS = frozenset(label for label, _pattern in _CONCLUSION_ENUMS)
+_EXPLICIT_CONCLUSION_RE = re.compile(
+    r"^\s*(?:[-*+]\s+)?(?:#{1,6}\s+)?(?:\*\*)?결론(?:\*\*)?\s*[:：]"
+    r"\s*(?:\*\*)?\s*(?P<enum>[A-Z][A-Z_]*)\b",
+    re.IGNORECASE,
+)
 _NEGATION_RE = re.compile(
-    r"(없|미발견|아님|아니|불필요|"           # 한글 부정
+    r"(없|미발견|아님|아니|불필요|불가능|불가|불충분|못|"  # 한글 부정
     r"\bno\b|\bnot\b|\bzero\b|\b0\s*\b|"     # 영어 부정
     r"없음)",
     re.IGNORECASE,
@@ -639,17 +645,26 @@ def _prose_final_verdict_is_fail(prose: str) -> bool:
 
 
 def _extract_conclusion_enum(prose: str) -> str:
-    """prose 본문 끝 ~15줄에서 positive 결론 enum 추출.
+    """prose 에서 positive 결론 enum 추출.
 
     매칭 룰:
-    - 끝 15줄 (마지막 단락 가정)
-    - 결론 enum 단어 매칭 + 같은 줄 부정 마커 부재
+    - 문서 전체에서 `결론:` 바로 뒤의 enum 우선 (여러 개면 마지막 라인)
+    - 명시 라인이 없으면 끝 15줄 (마지막 단락 가정)
+    - fallback 결론 enum은 같은 줄에 부정 마커가 있으면 제외
     - 구체적 worker enum > PASS > FAIL > ESCALATE 우선순위
     - 다 매칭 실패 시 빈 문자열 반환 (= 호출자가 helper sentinel 그대로 표시)
     """
     if not prose:
         return ""
     lines = prose.splitlines()
+    explicit_matches = [
+        match for line in lines if (match := _EXPLICIT_CONCLUSION_RE.match(line))
+    ]
+    for match in reversed(explicit_matches):
+        label = match.group("enum").upper()
+        if label in _CONCLUSION_LABELS:
+            return label
+
     tail = lines[-15:] if len(lines) > 15 else lines
     for label, pattern in _CONCLUSION_ENUMS:
         for line in tail:

--- a/tests/test_run_review.py
+++ b/tests/test_run_review.py
@@ -332,6 +332,26 @@ class WasteDetectionTests(unittest.TestCase):
         wastes = detect_wastes(steps)
         self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
 
+    def test_must_fix_ghost_korean_negated_pass_keeps_earlier_fail(self):
+        # #1155 — 아래쪽 "PASS 불가"는 pass 결론이 아니라 부정된 incidental 언급이다.
+        # conclusion_enum 이 PASS 로 오파싱된 방어 상황에서도 상단 FAIL을 찾아 GHOST를 막는다.
+        prose = (
+            "검증 결과.\n결론: **FAIL** (Cartography drift 미해소)\n\n"
+            "## Cartography freshness 렌즈 — MUST FIX\n"
+            "route-only drift를 해소해야 한다.\n\n"
+            "현재 완료 기준상 PASS 불가."
+        )
+        steps = [
+            StepRecord(idx=0, ts="t1", agent="impl-validator", mode=None,
+                       enum="PROSE_LOGGED", must_fix=True, conclusion_enum="PASS",
+                       prose_excerpt="", prose_full=prose),
+            StepRecord(idx=1, ts="t2", agent="module-architect", mode="CARTOGRAPHY_REFRESH",
+                       enum="PROSE_LOGGED", must_fix=False,
+                       conclusion_enum="CARTOGRAPHY_REFRESHED", prose_excerpt="fixed"),
+        ]
+        wastes = detect_wastes(steps)
+        self.assertFalse(any(w.pattern == "MUST_FIX_GHOST" for w in wastes))
+
     def test_must_fix_ghost_mixed_conclusion_line_fail_wins(self):
         # #771 — 혼합 결론줄 "PASS / FAIL 중 FAIL" 도 fail 우선 → GHOST 아님.
         steps = [
@@ -1081,10 +1101,47 @@ class ConclusionEnumExtractionTests(unittest.TestCase):
         prose = "검증 결과.\n\nspec mismatch 발견 — FAIL 판정."
         self.assertEqual(_extract_conclusion_enum(prose), "FAIL")
 
+    def test_explicit_top_conclusion_drives_step_and_run_final_enum(self):
+        # #1155 실측: 상단 결론 FAIL 뒤 20줄 이상의 근거에 incidental PASS가 있어도
+        # 명시 결론이 step enum과 run 최종 enum을 함께 지배해야 한다.
+        prose = "\n".join([
+            "# Product acceptance",
+            "결론: **FAIL** (코드 결함 아님 · journey 미실행)",
+            "",
+            "## 검증 근거",
+            *[f"근거 {idx}" for idx in range(1, 18)],
+            "비루팅 에뮬 환경의 제한 안에서는 fixture 검사가 PASS.",
+            "실제 journey 실행 증거는 없다.",
+        ])
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            run_dir = _make_run_dir_ledger(
+                tmp,
+                "sid_1155",
+                "rid_1155",
+                [{
+                    "event": "step_completed",
+                    "ts": "2026-07-15T10:15:00+00:00",
+                    "agent": "product-acceptance", "mode": "STORY_ACCEPTANCE",
+                    "enum": "PROSE_LOGGED", "must_fix": False,
+                    "prose_excerpt": "결론: **FAIL**", "prose_file": "product-acceptance.md",
+                }],
+                {"product-acceptance.md": prose},
+            )
+            report = build_report(run_dir, repo_path=tmp)
+
+        self.assertEqual(report.steps[0].conclusion_enum, "FAIL")
+        self.assertEqual(report.final_enum, "FAIL")
+
     def test_negation_skipped_for_pass_fail(self):
         # "FAIL 없음" 부정문은 매칭 X
         prose = "검토 완료.\n\n모든 항목 통과 — FAIL 없음."
         self.assertNotEqual(_extract_conclusion_enum(prose), "FAIL")
+
+    def test_korean_negated_pass_variants_are_not_conclusions(self):
+        for phrase in ("PASS 불가", "PASS 불가능", "PASS 불충분", "PASS 못 함"):
+            with self.subTest(phrase=phrase):
+                self.assertEqual(_extract_conclusion_enum(f"완료 기준상 {phrase}."), "")
 
     def test_empty_prose_returns_empty(self):
         self.assertEqual(_extract_conclusion_enum(""), "")


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1155

## 배경 및 문제

run-review가 prose 상단의 명시적 `결론: **FAIL**`을 tail-only scan으로 놓치고, 하단 근거의 incidental `PASS`를 step 및 run 최종 enum으로 표시했습니다. 이 오파싱 때문에 정상적인 FAIL→보정 흐름에도 HIGH `MUST_FIX_GHOST`가 발생했습니다.

## 원인 (해당 시)

- `_extract_conclusion_enum`이 마지막 15줄만 검사하고 `PASS`를 `FAIL`보다 먼저 탐색해 상단 명시 결론보다 하단 incidental 표현을 우선했습니다.
- GHOST 방어선의 공용 부정 정규식이 `PASS 불가`, `불가능`, `불충분`, `못`을 인식하지 못했습니다.
- 명시 결론줄 전체에 부정 검사를 적용하면 `결론: FAIL (코드 결함 아님 …)`의 설명까지 결론 부정으로 오인할 수 있었습니다.

## 작업내용

- 문서 전체에서 `결론:` 바로 뒤의 enum을 구조적으로 추출하고, 여러 명시 결론이 있으면 마지막 명시 결론을 우선하도록 변경했습니다.
- 명시 결론이 없는 기존 prose를 위해 마지막 15줄 fallback을 유지했습니다.
- 한국어 부정 표현 `불가`, `불가능`, `불충분`, `못`을 fallback 및 GHOST 방어에 반영했습니다.
- 상단 FAIL이 step/run 최종 enum을 지배하는 통합 회귀와 허위 `MUST_FIX_GHOST` 방지 회귀를 추가했습니다.

## 결정 근거

- 문서 전체를 무차별 enum scan하지 않고 명시적인 `결론:` 계약만 전역 우선하여 incidental 단어의 영향 범위를 차단했습니다.
- `결론:` 뒤 첫 enum 토큰만 읽어 뒤 설명의 `아님`이 명시 결론을 취소하지 않게 했습니다.
- 기존 tail fallback을 보존해 명시 prefix가 없는 과거 run 리포트의 호환성을 유지했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `harness/run_review.py`는 `scripts/release_artifact.json`의 release allowlist에 포함되어 plugin 업데이트 시 사용자 환경에 직접 배포됩니다.
- `/init-dcness`가 사용자 프로젝트로 복사하는 파일은 아니므로 init deploy inventory 변경은 필요 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 `/run-review` 내부 parser 수정이며 신규 public surface가 없습니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_run_review -v < /dev/null` — 81 PASS
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,143 PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/Bandit PASS
- [x] `node scripts/check_plugin_manifest.mjs` — PASS
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] `node scripts/check_cross_refs.mjs` — PASS
- [x] pre-commit hook — 1,143 PASS

## 참고

- TDD red 확인: 상단 명시 FAIL 회귀는 기존 코드에서 `PASS != FAIL`, 한국어 `PASS 불가` GHOST 회귀는 기존 코드에서 허위 finding으로 각각 실패했습니다.
