### PR TITLE
[issue-1158] 동일 plugin version artifact 불변성 강제

### DIFF
--- a/.github/workflows/release-sync.yml
+++ b/.github/workflows/release-sync.yml
@@ -2,7 +2,8 @@ name: release sync
 
 on:
   push:
-    branches: [main]
+    tags:
+      - 'v*.*.*'
 
 concurrency:
   group: release-sync
@@ -18,11 +19,23 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
+        with:
+          python-version: '3.11'
+      - name: setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: '20'
+      - name: validate version manifests
+        run: node scripts/check_plugin_manifest.mjs
+      - name: test exact tagged source
+        run: python3 -m unittest discover -s tests -v < /dev/null
       - name: configure git
         run: |
           git config user.name "release-sync-bot"
           git config user.email "release-sync@dcness.local"
-      - name: run sync
+      - name: publish immutable release artifact
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run: bash scripts/sync_release.sh --yes
+        run: bash scripts/sync_release.sh --tag "$GITHUB_REF_NAME" --yes

--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -30,8 +30,8 @@
 따른다.
 
 release artifact의 단일 positive allowlist SSOT는 [`scripts/release_artifact.json`](../../scripts/release_artifact.json)이다.
-[`scripts/release_artifact.py`](../../scripts/release_artifact.py)의 candidate 생성과
-[`scripts/sync_release.sh`](../../scripts/sync_release.sh)의 release branch 정리가 이 파일만 소비한다.
+[`scripts/release_artifact.py`](../../scripts/release_artifact.py)의 candidate 생성·manifest digest·smoke와
+[`scripts/sync_release.sh`](../../scripts/sync_release.sh)의 immutable tag publish가 이 파일만 소비한다.
 `include_paths`는 제품 콘텐츠와 runtime만 선택하고, `product_python`은 배포되는 모든 Python
 파일을 공개 hook·command·skill 또는 외부 사용자용 CLI 계약과 1:1로 분류한다. 포함 디렉터리
 아래에 새 Python 파일이 추가돼도 `product_python`에 제품 소비자를 명시하지 않으면 artifact
@@ -43,14 +43,25 @@ transport/runtime metadata는 GitHub source update용 `.git`, 활성 사용 표�
 않는다. payload footprint는 이 metadata를 제외해 candidate와 비교하고, 실제 cache disk
 footprint를 보고할 때는 metadata 크기를 별도로 병기한다.
 
+공개 version은 `v{version}` tag, tag가 가리키는 tested source SHA, `snapshot`의
+`manifest_sha256`과 1:1로 대응한다. `release` artifact commit의 parent가 그 source SHA이므로 별도
+registry나 provenance 저장소 없이 관계를 확인할 수 있다. 같은 version의 기존 release와 candidate의
+source SHA 또는 digest가 다르면 release branch를 checkout하거나 push하기 전에 실패한다. 이미 배포한
+version의 tag를 이동·재사용하지 않으며 `sync_release.sh`도 tag ref를 만들거나 수정하지 않는다.
+
 `release`는 사람이 작업하는 외부 프로젝트 브랜치 예외가 아니다. dcNess self의
 `sync_release.sh`가 공식 저장소 원격(`Daeguk-Sun/dcNess`, 이전 redirect `alruminum/dcNess`)에
-push할 때만 pre-push naming gate에서 기계 생성 배포 ref로 인정한다. positive allowlist artifact
-생성이나 제품 Python inventory 검증이 실패하면 sync는 push 전에 fail-closed 한다.
+push할 때만 pre-push naming gate에서 기계 생성 배포 ref로 인정한다. workflow는 `main` push가 아니라
+새 `vMAJOR.MINOR.PATCH` tag에서만 실행하며, exact tag source의 전체 unit suite를 통과한 뒤 publish한다.
+positive allowlist build, 제품 Python inventory, version/tag/source/digest 정합, clean install/update smoke 중
+하나라도 실패하면 release ref는 이전 상태로 보존된다.
 
 ```sh
 # 현재 ref의 비파괴 candidate + runtime smoke + footprint/context 분리 측정
 python3 scripts/release_artifact.py smoke --repo-root . --ref HEAD
+
+# publish 경계에서는 sync가 직전 release artifact를 --previous-root로 넘겨
+# clean install과 직전 version update의 source SHA / bundle digest 정합까지 검사
 
 # 같은 revision의 저장소 Python과 release Python을 분리 측정
 python3 scripts/release_artifact.py measure --repo-root . --ref HEAD
@@ -102,28 +113,40 @@ worktree·checkout을 나눠도 상한이 분리되지 않는다. `--ledger`는 
 - Verify: [`evals/core-incident-subset.json`](../../evals/core-incident-subset.json)의 핵심 행동 eval은 `bash evals/run-core.sh`에서 N/N 통과해야 한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 사람 golden 보정 입력으로 남기고, report digest·golden/subset version이 맞는지 확인한다.
 
 ```sh
-# 1. 브랜치 생성 — 브랜치명 버전은 . 대신 _ (0.13.0 → 0_13_0).
-#    docs/{desc} 네이밍 게이트가 . 을 거부한다. (커밋 제목·태그·버전 파일은 . 유지)
-git checkout -b docs/release_0_13_0_{설명} main
+# 1. version bump 브랜치 생성 — 브랜치명 버전은 . 대신 _ (0.25.0 → 0_25_0).
+git checkout -b docs/release_0_25_0_{설명} main
 
-# 2. 버전 올리기
+# 2. 두 manifest의 version을 같은 새 값으로 올리기
 #    .claude-plugin/plugin.json     "version" 필드
 #    .claude-plugin/marketplace.json "metadata.version" 필드
+node scripts/check_plugin_manifest.mjs
 
-# 3. 커밋
+# 3. commit → PR → 전체 required CI PASS → regular merge
 git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
 git commit -m "[docs] release {버전} — {설명}"
-
-# 4. PR 생성 → CI PASS → merge
-git push -u origin docs/release_0_13_0_{설명}
+git push -u origin docs/release_0_25_0_{설명}
 gh pr create --title "[docs] release {버전} — {설명}" ...
-gh pr merge {번호} --merge
 
-# 5. main pull 후 태그 박기
-git checkout main && git pull
-git tag v{버전} && git push origin v{버전}
+# 4. merge된 exact source에서 full preflight PASS 확인
+git checkout main
+git pull --ff-only origin main
+python3.11 scripts/release_preflight.py
 
-# 6. 사용자 업데이트 가이드 출력
+# 5. 새 immutable tag 생성·push — 기존 tag 재사용/이동 및 force push 금지
+VERSION=$(python3 -c 'import json; print(json.load(open(".claude-plugin/plugin.json"))["version"])')
+TAG="v${VERSION}"
+SOURCE_SHA=$(git rev-parse HEAD)
+git tag "$TAG" "$SOURCE_SHA"
+git push origin "refs/tags/$TAG"
+
+# 6. exact tag unit suite → clean install/update smoke → release publish workflow 확인
+RUN_ID=$(gh run list --workflow=release-sync.yml --commit "$SOURCE_SHA" --limit 1 --json databaseId --jq '.[0].databaseId')
+gh run watch "$RUN_ID" --exit-status
+# workflow log의 verify-release JSON에서 아래 네 값이 일치해야 한다.
+# source_sha == clean_install.source_sha == previous_version_update.source_sha
+# bundle_digest == clean_install.bundle_digest == previous_version_update.bundle_digest
+
+# 7. 사용자 업데이트 가이드 출력
 echo "---"
 echo "v{버전} 업데이트 가이드"
 echo ""
@@ -132,16 +155,11 @@ echo ""
 echo "문제 발생 시:"
 echo "  claude plugin uninstall dcness@dcness && claude plugin install dcness@dcness"
 echo "---"
-
-# 7. release 브랜치 배포 정합 확인 (사용자 배포물 — 수동 sync 불필요)
-#    사용자가 받는 배포물은 main/tag 가 아니라 release 브랜치다(dcness self 경로 제외 사본).
-#    release-sync.yml CI 가 main push 마다 sync_release.sh 를 자동 실행해 release 브랜치를 갱신하므로
-#    수동 실행은 불필요하다. 단, 태그만으로는 사용자에게 도달하지 않으니 아래로 정합을 확인한다.
-gh run list --workflow=release-sync.yml --limit 1                   # merge sha 발화 success 확인
-git show origin/release:.claude-plugin/plugin.json | grep version   # release 브랜치 = v{버전} 정합
 ```
 
-> **완료 기준은 3단 정합**: `main` plugin.json · `v{버전}` 태그 · `release` 브랜치 plugin.json 이 모두 같은 버전이어야 사용자에게 도달한 것이다. 태그만 박고 끝내면 배포 미도달을 완료로 착각할 수 있다.
+> **완료 기준은 4단 정합**: `main` manifest version · immutable `v{version}` tag · release commit
+> parent의 tested source SHA · release bundle digest가 1:1이어야 한다. workflow의 clean install과 직전
+> version update가 같은 source SHA와 digest를 보고해야 사용자에게 도달한 것으로 본다.
 
 ## 4. 릴리즈 후 사용자 검증 방법
 

--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -12,6 +12,7 @@ import io
 import json
 import os
 from pathlib import Path, PurePosixPath
+import re
 import shutil
 # All subprocess calls below use fixed argv and never enable shell execution.
 import subprocess  # nosec B404
@@ -266,6 +267,194 @@ def compare(expected: Path, actual: Path, contract: Contract) -> tuple[bool, lis
     return not details, details
 
 
+SEMVER_RE = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+RELEASE_TAG_RE = re.compile(r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+
+
+def _json_object(path: Path, *, label: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ArtifactError(f"cannot read {label}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ArtifactError(f"{label} must contain a JSON object")
+    return payload
+
+
+def _git_file(repo_root: Path, ref: str, relative: str) -> str:
+    result = subprocess.run(  # nosec B603
+        [_executable("git"), "-C", str(repo_root), "show", f"{ref}:{relative}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise ArtifactError(
+            f"cannot read {relative} at {ref}: {result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _git_commit(repo_root: Path, ref: str) -> str:
+    result = subprocess.run(  # nosec B603
+        [_executable("git"), "-C", str(repo_root), "rev-parse", "--verify", f"{ref}^{{commit}}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise ArtifactError(f"cannot resolve commit {ref}: {result.stderr.strip()}")
+    return result.stdout.strip()
+
+
+def _plugin_version(root: Path) -> str:
+    payload = _json_object(root / ".claude-plugin" / "plugin.json", label="plugin manifest")
+    version = payload.get("version")
+    if not isinstance(version, str) or SEMVER_RE.fullmatch(version) is None:
+        raise ArtifactError(f"plugin version must be strict semver: {version!r}")
+    return version
+
+
+def _marketplace_version(repo_root: Path, ref: str) -> str:
+    try:
+        payload = json.loads(_git_file(repo_root, ref, ".claude-plugin/marketplace.json"))
+        version = payload["metadata"]["version"]
+    except (json.JSONDecodeError, KeyError, TypeError) as exc:
+        raise ArtifactError("marketplace metadata.version is missing or invalid") from exc
+    if not isinstance(version, str) or SEMVER_RE.fullmatch(version) is None:
+        raise ArtifactError(f"marketplace version must be strict semver: {version!r}")
+    return version
+
+
+def _semver_tuple(version: str) -> tuple[int, int, int]:
+    match = SEMVER_RE.fullmatch(version)
+    if match is None:
+        raise ArtifactError(f"version must be strict semver: {version!r}")
+    major, minor, patch = match.groups()
+    return int(major), int(minor), int(patch)
+
+
+def _install_payload(bundle: Path, destination: Path, contract: Contract) -> None:
+    destination.mkdir(parents=True, exist_ok=True)
+    preserved = set(contract.allowed_cache_metadata)
+    for child in destination.iterdir():
+        if child.name in preserved:
+            continue
+        if child.is_dir() and not child.is_symlink():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
+    shutil.copytree(bundle, destination, dirs_exist_ok=True)
+
+
+def _install_cohort_report(
+    candidate: Path,
+    published: Path | None,
+    source_sha: str,
+    contract: Contract,
+    temp_root: Path,
+) -> dict[str, Any]:
+    candidate_digest = snapshot(candidate, contract)["manifest_sha256"]
+    clean_cache = temp_root / "clean-cache"
+    _install_payload(candidate, clean_cache, contract)
+    clean_digest = snapshot(clean_cache, contract)["manifest_sha256"]
+    clean_report = {"source_sha": source_sha, "bundle_digest": clean_digest}
+    update_report: dict[str, str] | None = None
+    if published is not None:
+        update_cache = temp_root / "update-cache"
+        _install_payload(published, update_cache, contract)
+        _install_payload(candidate, update_cache, contract)
+        update_digest = snapshot(update_cache, contract)["manifest_sha256"]
+        update_report = {"source_sha": source_sha, "bundle_digest": update_digest}
+    if clean_digest != candidate_digest or (
+        update_report is not None and update_report["bundle_digest"] != candidate_digest
+    ):
+        raise ArtifactError("clean install and previous-version update cohort digest mismatch")
+    return {
+        "bundle_digest": candidate_digest,
+        "clean_install": clean_report,
+        "previous_version_update": update_report,
+    }
+
+
+def verify_release(
+    repo_root: Path,
+    tag: str,
+    candidate: Path,
+    published: Path | None,
+    published_source_sha: str | None,
+    contract: Contract,
+) -> dict[str, Any]:
+    tag_match = RELEASE_TAG_RE.fullmatch(tag)
+    if tag_match is None:
+        raise ArtifactError(f"release tag must match vMAJOR.MINOR.PATCH: {tag!r}")
+    version = ".".join(tag_match.groups())
+    tag_ref = f"refs/tags/{tag}"
+    source_sha = _git_commit(repo_root, tag_ref)
+    candidate_version = _plugin_version(candidate)
+    marketplace_version = _marketplace_version(repo_root, tag_ref)
+    if candidate_version != version or marketplace_version != version:
+        raise ArtifactError(
+            "tag, plugin, and marketplace versions must match: "
+            f"tag={version}, plugin={candidate_version}, marketplace={marketplace_version}"
+        )
+
+    with tempfile.TemporaryDirectory(prefix="dcness-release-verify-") as tmp:
+        temp_root = Path(tmp)
+        expected = temp_root / "tag-candidate"
+        build(repo_root, tag_ref, expected, contract)
+        matched, details = compare(expected, candidate, contract)
+        if not matched:
+            raise ArtifactError(
+                "candidate bundle does not match immutable tag source:\n" + "\n".join(details)
+            )
+
+        candidate_digest = snapshot(candidate, contract)["manifest_sha256"]
+        previous_version: str | None = None
+        previous_digest: str | None = None
+        action = "publish"
+        if published is not None:
+            if not published_source_sha:
+                raise ArtifactError("published source SHA is required with a published bundle")
+            resolved_published_source = _git_commit(repo_root, published_source_sha)
+            if resolved_published_source != published_source_sha:
+                raise ArtifactError("published source SHA must be a full commit SHA")
+            previous_version = _plugin_version(published)
+            previous_digest = snapshot(published, contract)["manifest_sha256"]
+            if candidate_version == previous_version:
+                if candidate_digest != previous_digest:
+                    raise ArtifactError(
+                        f"existing version {candidate_version} has a different bundle digest"
+                    )
+                if source_sha != published_source_sha:
+                    raise ArtifactError(
+                        f"existing version {candidate_version} has a different source SHA"
+                    )
+                action = "already_published"
+            elif _semver_tuple(candidate_version) <= _semver_tuple(previous_version):
+                raise ArtifactError(
+                    f"release version must increase: published={previous_version}, candidate={candidate_version}"
+                )
+
+        cohorts = _install_cohort_report(
+            candidate, published, source_sha, contract, temp_root
+        )
+
+    return {
+        "action": action,
+        "tag": tag,
+        "version": candidate_version,
+        "source_sha": source_sha,
+        "bundle_digest": candidate_digest,
+        "previous_version": previous_version,
+        "previous_bundle_digest": previous_digest,
+        "clean_install": cohorts["clean_install"],
+        "previous_version_update": cohorts["previous_version_update"],
+    }
+
+
 def _executable(name: str) -> str:
     resolved = shutil.which(name)
     if resolved is None:
@@ -510,7 +699,9 @@ def _verify_external_runtime(bundle: Path, temp_root: Path) -> dict[str, int]:
     }
 
 
-def smoke(repo_root: Path, ref: str, contract: Contract) -> dict[str, int]:
+def smoke(
+    repo_root: Path, ref: str, contract: Contract, previous_root: Path | None = None
+) -> dict[str, Any]:
     with tempfile.TemporaryDirectory(prefix="dcness-release-smoke-") as tmp:
         temp_root = Path(tmp)
         bundle = temp_root / "bundle"
@@ -520,11 +711,19 @@ def smoke(repo_root: Path, ref: str, contract: Contract) -> dict[str, int]:
         _verify_agent_surface(bundle, repo_root / "scripts" / "check_public_surface.mjs")
         runtime = _verify_external_runtime(bundle, temp_root)
         artifact = snapshot(bundle, contract)
+        source_sha = _git_commit(repo_root, ref)
+        cohorts = _install_cohort_report(
+            bundle, previous_root, source_sha, contract, temp_root
+        )
         context_bytes = runtime["session_start_additional_context_bytes"]
         return {
             "file_count": artifact["file_count"],
             "byte_size": artifact["byte_size"],
             "text_loc": artifact["text_loc"],
+            "source_sha": source_sha,
+            "bundle_digest": cohorts["bundle_digest"],
+            "clean_install": cohorts["clean_install"],
+            "previous_version_update": cohorts["previous_version_update"],
             "session_start_additional_context_bytes": context_bytes,
             "session_start_token_approx": (context_bytes + 3) // 4,
             "agent_instruction_reads": runtime["agent_instruction_reads"],
@@ -570,7 +769,16 @@ def parser() -> argparse.ArgumentParser:
     smoke_parser = subparsers.add_parser("smoke")
     smoke_parser.add_argument("--repo-root", type=_path, required=True)
     smoke_parser.add_argument("--ref", required=True)
+    smoke_parser.add_argument("--previous-root", type=_path)
     add_contract(smoke_parser)
+
+    verify_release_parser = subparsers.add_parser("verify-release")
+    verify_release_parser.add_argument("--repo-root", type=_path, required=True)
+    verify_release_parser.add_argument("--tag", required=True)
+    verify_release_parser.add_argument("--candidate", type=_path, required=True)
+    verify_release_parser.add_argument("--published", type=_path)
+    verify_release_parser.add_argument("--published-source-sha")
+    add_contract(verify_release_parser)
     return root
 
 
@@ -598,9 +806,24 @@ def main(argv: list[str] | None = None) -> int:
                 )
             )
         elif args.command == "smoke":
-            result = smoke(args.repo_root, args.ref, contract)
+            result = smoke(args.repo_root, args.ref, contract, args.previous_root)
             print("release_artifact_smoke=PASS")
             print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+        elif args.command == "verify-release":
+            print(
+                json.dumps(
+                    verify_release(
+                        args.repo_root,
+                        args.tag,
+                        args.candidate,
+                        args.published,
+                        args.published_source_sha,
+                        contract,
+                    ),
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+            )
         return 0
     except (ArtifactError, OSError, subprocess.SubprocessError) as exc:
         print(f"release_artifact=FAIL: {exc}", file=sys.stderr)

--- a/scripts/sync_release.sh
+++ b/scripts/sync_release.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# sync_release.sh — main → release 동기화
-# positive allowlist artifact만 release 브랜치에 기록해 repo-only 신규 파일의 유입을 막는다.
+# sync_release.sh — immutable version tag → release artifact publish
+# positive allowlist artifact만 release 브랜치에 기록하고 같은 version의 재발행을 차단한다.
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "$REPO_ROOT"
@@ -40,11 +40,32 @@ cleanup() {
 trap cleanup EXIT
 
 YES_MODE=0
-for arg in "$@"; do
-    if [ "$arg" = "--yes" ] || [ "$arg" = "-y" ]; then
-        YES_MODE=1
-    fi
+TAG=""
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --yes|-y)
+            YES_MODE=1
+            shift
+            ;;
+        --tag)
+            if [ "$#" -lt 2 ]; then
+                echo "ERROR: --tag requires vMAJOR.MINOR.PATCH." >&2
+                exit 2
+            fi
+            TAG="$2"
+            shift 2
+            ;;
+        *)
+            echo "ERROR: unknown argument: $1" >&2
+            exit 2
+            ;;
+    esac
 done
+
+if [ -z "$TAG" ]; then
+    echo "ERROR: release publish requires --tag vMAJOR.MINOR.PATCH." >&2
+    exit 2
+fi
 
 confirm() {
     local prompt="$1"
@@ -56,62 +77,104 @@ confirm() {
     [ "$ans" = "yes" ]
 }
 
-# 위험 경고: release 위 직접 commit 체크
-git_with_token fetch origin --quiet
-if git show-ref --verify --quiet refs/remotes/origin/release; then
-    DIVERGED=$(git log origin/release ^origin/main --oneline 2>/dev/null | wc -l | tr -d ' ')
-    if [ "$DIVERGED" -gt 0 ]; then
-        echo "⚠ WARNING: origin/release 에 origin/main 에 없는 commit ${DIVERGED}개 발견."
-        echo "  force-push 하면 이 commit 들이 사라집니다."
-        if ! confirm "계속하려면 'yes' 입력"; then
-            echo "중단."
-            exit 1
-        fi
-    fi
-fi
+git_with_token fetch origin --quiet --tags
 
-MAIN_SHA=$(git rev-parse origin/main)
-SHORT_SHA=${MAIN_SHA:0:7}
-
-echo "→ release 브랜치를 origin/main@${SHORT_SHA} 기반으로 reset..."
-if git show-ref --verify --quiet refs/heads/release; then
-    git checkout release 2>/dev/null
-    git reset --hard origin/main
-else
-    git checkout -b release origin/main
-fi
-
-echo "→ positive allowlist artifact 생성..."
-ARTIFACT_BUILDER="$REPO_ROOT/scripts/release_artifact.py"
-TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/dcness-release-sync.XXXXXX")
-ARTIFACT_DIR="$TEMP_ROOT/artifact"
-if ! python3 "$ARTIFACT_BUILDER" build \
-    --repo-root "$REPO_ROOT" \
-    --ref "$MAIN_SHA" \
-    --output "$ARTIFACT_DIR"; then
-    echo "ERROR: positive allowlist artifact 생성에 실패해 release sync를 중단합니다." >&2
+TAG_REF="refs/tags/${TAG}"
+if ! git show-ref --verify --quiet "$TAG_REF"; then
+    echo "ERROR: immutable release tag not found: ${TAG}" >&2
     exit 1
 fi
 
+LOCAL_TAG_OBJECT=$(git rev-parse "$TAG_REF")
+REMOTE_TAG_OBJECT=$(git_with_token ls-remote origin "$TAG_REF" | awk 'NR == 1 {print $1}')
+if [ -z "$REMOTE_TAG_OBJECT" ] || [ "$LOCAL_TAG_OBJECT" != "$REMOTE_TAG_OBJECT" ]; then
+    echo "ERROR: local and origin tag objects differ for ${TAG}." >&2
+    exit 1
+fi
+
+SOURCE_SHA=$(git rev-parse "${TAG_REF}^{commit}")
+SHORT_SHA=${SOURCE_SHA:0:7}
+if ! git merge-base --is-ancestor "$SOURCE_SHA" origin/main; then
+    echo "ERROR: ${TAG} source ${SHORT_SHA} is not a tested origin/main commit." >&2
+    exit 1
+fi
+
+ARTIFACT_BUILDER="$REPO_ROOT/scripts/release_artifact.py"
+TEMP_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/dcness-release-sync.XXXXXX")
+ARTIFACT_DIR="$TEMP_ROOT/artifact"
+echo "→ ${TAG}@${SHORT_SHA} positive allowlist artifact 생성..."
+if ! python3 "$ARTIFACT_BUILDER" build \
+    --repo-root "$REPO_ROOT" \
+    --ref "$TAG_REF" \
+    --output "$ARTIFACT_DIR"; then
+    echo "ERROR: positive allowlist artifact 생성에 실패해 release publish를 중단합니다." >&2
+    exit 1
+fi
+
+PUBLISHED_RELEASE_SHA=$(printf '0%.0s' {1..40})
+VERIFY_ARGS=(
+    verify-release
+    --repo-root "$REPO_ROOT"
+    --tag "$TAG"
+    --candidate "$ARTIFACT_DIR"
+)
+if git show-ref --verify --quiet refs/remotes/origin/release; then
+    PUBLISHED_RELEASE_SHA=$(git rev-parse origin/release)
+    PUBLISHED_SOURCE_SHA=$(git rev-parse origin/release^)
+    PUBLISHED_DIR="$TEMP_ROOT/published"
+    mkdir -p "$PUBLISHED_DIR"
+    git archive --format=tar origin/release | tar -xf - -C "$PUBLISHED_DIR"
+    VERIFY_ARGS+=(
+        --published "$PUBLISHED_DIR"
+        --published-source-sha "$PUBLISHED_SOURCE_SHA"
+    )
+fi
+
+if [ -n "${PUBLISHED_DIR:-}" ]; then
+    SMOKE_ARGS=(
+        smoke
+        --repo-root "$REPO_ROOT"
+        --ref "$TAG_REF"
+        --previous-root "$PUBLISHED_DIR"
+    )
+    if ! python3 "$ARTIFACT_BUILDER" "${SMOKE_ARGS[@]}"; then
+        echo "ERROR: clean install/update release smoke에 실패해 publish하지 않습니다." >&2
+        exit 1
+    fi
+fi
+
+if ! VERIFY_JSON=$(python3 "$ARTIFACT_BUILDER" "${VERIFY_ARGS[@]}"); then
+    echo "ERROR: version/tag/source/bundle consistency 검증에 실패해 publish하지 않습니다." >&2
+    exit 1
+fi
+printf '%s\n' "$VERIFY_JSON"
+ACTION=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["action"])' "$VERIFY_JSON")
+VERSION=$(python3 -c 'import json,sys; print(json.loads(sys.argv[1])["version"])' "$VERIFY_JSON")
+if [ "$ACTION" = "already_published" ]; then
+    echo "→ ${TAG} artifact는 이미 동일 source SHA와 bundle digest로 배포됨 — 변경 없음."
+    exit 0
+fi
+
+if ! confirm "${TAG}@${SHORT_SHA} artifact를 release 브랜치에 publish"; then
+    echo "publish 생략."
+    exit 0
+fi
+
+echo "→ release 브랜치를 ${TAG}@${SHORT_SHA} tested source 기반으로 작성..."
+git checkout -B release "$SOURCE_SHA" 2>/dev/null
 git rm -r --quiet -- .
 cp -R "$ARTIFACT_DIR/." "$REPO_ROOT/"
 git add -u
 (cd "$ARTIFACT_DIR" && find . -type f -print0) \
     | git add --pathspec-from-file=- --pathspec-file-nul
-echo "  allowlist artifact 반영 완료"
 
 if git diff --cached --quiet; then
-    echo "→ 변경 없음 — commit 생략."
-else
-    git commit -m "[docs] release sync from main@${SHORT_SHA}"
-    echo "→ commit: [docs] release sync from main@${SHORT_SHA}"
+    echo "ERROR: new version ${VERSION} did not create a release artifact commit." >&2
+    exit 1
 fi
 
-echo ""
-if ! confirm "release 브랜치를 origin 에 force-with-lease push"; then
-    echo "push 생략. 로컬 release 브랜치만 갱신됨."
-    exit 0
-fi
-
-git_with_token push --force-with-lease origin release
-echo "✓ release 브랜치 sync 완료 — main@${SHORT_SHA}"
+git commit -m "[docs] release ${VERSION} from ${TAG}@${SHORT_SHA}"
+git_with_token push \
+    "--force-with-lease=refs/heads/release:${PUBLISHED_RELEASE_SHA}" \
+    origin HEAD:refs/heads/release
+echo "✓ release publish 완료 — ${TAG}@${SHORT_SHA}"

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -483,12 +483,30 @@ class ReleaseArtifactContractTests(unittest.TestCase):
 
         self.assertGreater(semver(plugin["version"]), semver(baseline["plugin_version"]))
 
-    def test_sync_release_has_no_second_exclude_list_or_hook_bypass(self) -> None:
+    def test_release_workflow_is_tag_only_and_tests_the_exact_source_before_publish(self) -> None:
+        workflow = (ROOT / ".github/workflows/release-sync.yml").read_text(encoding="utf-8")
+
+        self.assertIn("tags:", workflow)
+        self.assertIn("'v*.*.*'", workflow)
+        self.assertNotIn("branches: [main]", workflow)
+        self.assertIn("python3 -m unittest discover -s tests -v", workflow)
+        self.assertIn('bash scripts/sync_release.sh --tag "$GITHUB_REF_NAME" --yes', workflow)
+        self.assertLess(
+            workflow.index("python3 -m unittest discover -s tests -v"),
+            workflow.index("bash scripts/sync_release.sh"),
+        )
+
+    def test_sync_release_has_no_second_exclude_list_tag_mutation_or_hook_bypass(self) -> None:
         script = (ROOT / "scripts/sync_release.sh").read_text(encoding="utf-8")
 
         self.assertIn("scripts/release_artifact.py", script)
         self.assertIn('"$ARTIFACT_BUILDER" build', script)
-        self.assertIn('git commit -m "[docs] release sync from main@', script)
+        self.assertIn("verify-release", script)
+        self.assertIn('"$ARTIFACT_BUILDER" "${VERIFY_ARGS[@]}"', script)
+        self.assertIn("--previous-root", script)
+        self.assertIn('"$ARTIFACT_BUILDER" "${SMOKE_ARGS[@]}"', script)
+        self.assertIn("--tag", script)
+        self.assertNotIn("git tag", script)
         self.assertNotIn("EXCLUDE_PATHS=(", script)
         self.assertNotIn("excluded-paths", script)
         self.assertNotIn("--no-verify", script)
@@ -502,7 +520,7 @@ class ReleaseArtifactContractTests(unittest.TestCase):
                 "node",
                 str(ROOT / "scripts/check_git_naming.mjs"),
                 "--title",
-                "[docs] release sync from main@abcdef0",
+                "[docs] release 1.2.3 from v1.2.3@abcdef0",
             ],
             cwd=ROOT,
             check=True,
@@ -572,11 +590,13 @@ class ReleaseArtifactContractTests(unittest.TestCase):
             )
             subprocess.run(["git", "-C", repo, "add", "."], check=True)
             subprocess.run(["git", "-C", repo, "commit", "-qm", "fixture"], check=True)
+            subprocess.run(["git", "-C", repo, "tag", "v1.0.0"], check=True)
             subprocess.run(["git", "-C", repo, "remote", "add", "origin", str(remote)], check=True)
             subprocess.run(["git", "-C", repo, "push", "-q", "-u", "origin", "main"], check=True)
+            subprocess.run(["git", "-C", repo, "push", "-q", "origin", "v1.0.0"], check=True)
 
             result = subprocess.run(
-                ["bash", "scripts/sync_release.sh", "--yes"],
+                ["bash", "scripts/sync_release.sh", "--tag", "v1.0.0", "--yes"],
                 cwd=repo,
                 env={**os.environ, "PATH": f"{fake_bin}:{os.environ['PATH']}"},
                 check=False,
@@ -586,7 +606,10 @@ class ReleaseArtifactContractTests(unittest.TestCase):
             )
 
             self.assertNotEqual(result.returncode, 0)
-            self.assertIn("positive allowlist artifact 생성에 실패해 release sync를 중단합니다", result.stderr)
+            self.assertIn(
+                "positive allowlist artifact 생성에 실패해 release publish를 중단합니다",
+                result.stderr,
+            )
             remote_release = subprocess.run(
                 ["git", "--git-dir", str(remote), "show-ref", "--verify", "refs/heads/release"],
                 check=False,
@@ -594,6 +617,59 @@ class ReleaseArtifactContractTests(unittest.TestCase):
                 text=True,
             )
             self.assertNotEqual(remote_release.returncode, 0)
+
+    def test_main_push_style_sync_invocation_leaves_release_ref_and_tree_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp) / "repo"
+            (repo / "scripts").mkdir(parents=True)
+            shutil.copy2(ROOT / "scripts/sync_release.sh", repo / "scripts/sync_release.sh")
+            (repo / "product.txt").write_text("published\n", encoding="utf-8")
+            subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+            subprocess.run(["git", "-C", repo, "config", "user.name", "test"], check=True)
+            subprocess.run(
+                ["git", "-C", repo, "config", "user.email", "test@example.com"], check=True
+            )
+            subprocess.run(["git", "-C", repo, "add", "."], check=True)
+            subprocess.run(["git", "-C", repo, "commit", "-qm", "published"], check=True)
+            subprocess.run(["git", "-C", repo, "branch", "release"], check=True)
+            refs_before = subprocess.run(
+                ["git", "-C", repo, "show-ref"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            tree_before = subprocess.run(
+                ["git", "-C", repo, "rev-parse", "release^{tree}"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            result = subprocess.run(
+                ["bash", "scripts/sync_release.sh", "--yes"],
+                cwd=repo,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("release publish requires --tag", result.stderr)
+            refs_after = subprocess.run(
+                ["git", "-C", repo, "show-ref"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            tree_after = subprocess.run(
+                ["git", "-C", repo, "rev-parse", "release^{tree}"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(refs_after, refs_before)
+            self.assertEqual(tree_after, tree_before)
 
     def test_sync_release_publishes_only_the_positive_allowlist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -607,14 +683,23 @@ class ReleaseArtifactContractTests(unittest.TestCase):
                 json.dumps(
                     {
                         "schema_version": 2,
-                        "include_paths": ["product.txt"],
+                        "include_paths": [".claude-plugin/plugin.json", "product.txt"],
                         "product_python": {},
                         "allowed_cache_metadata": [".git", ".in_use"],
                         "allowed_cache_metadata_globs": [],
-                        "required_runtime_paths": ["product.txt"],
+                        "required_runtime_paths": [".claude-plugin/plugin.json", "product.txt"],
                         "forbidden_product_imports": ["evals", "tests"],
                     }
                 ),
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin").mkdir()
+            (repo / ".claude-plugin/plugin.json").write_text(
+                json.dumps({"name": "dcness", "version": "1.0.0"}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin/marketplace.json").write_text(
+                json.dumps({"metadata": {"version": "1.0.0"}}) + "\n",
                 encoding="utf-8",
             )
             (repo / "product.txt").write_text("product\n", encoding="utf-8")
@@ -628,11 +713,19 @@ class ReleaseArtifactContractTests(unittest.TestCase):
             )
             subprocess.run(["git", "-C", repo, "add", "."], check=True)
             subprocess.run(["git", "-C", repo, "commit", "-qm", "fixture"], check=True)
+            source_sha = subprocess.run(
+                ["git", "-C", repo, "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(["git", "-C", repo, "tag", "v1.0.0"], check=True)
             subprocess.run(["git", "-C", repo, "remote", "add", "origin", str(remote)], check=True)
             subprocess.run(["git", "-C", repo, "push", "-q", "-u", "origin", "main"], check=True)
+            subprocess.run(["git", "-C", repo, "push", "-q", "origin", "v1.0.0"], check=True)
 
             result = subprocess.run(
-                ["bash", "scripts/sync_release.sh", "--yes"],
+                ["bash", "scripts/sync_release.sh", "--tag", "v1.0.0", "--yes"],
                 cwd=repo,
                 check=False,
                 capture_output=True,
@@ -647,7 +740,21 @@ class ReleaseArtifactContractTests(unittest.TestCase):
                 capture_output=True,
                 text=True,
             ).stdout.splitlines()
-            self.assertEqual(released, ["product.txt"])
+            self.assertEqual(released, [".claude-plugin/plugin.json", "product.txt"])
+            released_parent = subprocess.run(
+                ["git", "--git-dir", str(remote), "rev-parse", "release^"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(released_parent, source_sha)
+            remote_tag = subprocess.run(
+                ["git", "--git-dir", str(remote), "rev-parse", "v1.0.0^{}"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(remote_tag, source_sha)
             self.assertEqual(
                 subprocess.run(
                     ["git", "-C", repo, "branch", "--show-current"],
@@ -656,6 +763,255 @@ class ReleaseArtifactContractTests(unittest.TestCase):
                     text=True,
                 ).stdout.strip(),
                 "main",
+            )
+
+    def test_verify_release_rejects_same_version_digest_drift_without_mutating_refs(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            contract_path = root / "contract.json"
+            published = root / "published"
+            candidate = root / "candidate"
+            (repo / ".claude-plugin").mkdir(parents=True)
+            subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+            subprocess.run(["git", "-C", repo, "config", "user.name", "test"], check=True)
+            subprocess.run(
+                ["git", "-C", repo, "config", "user.email", "test@example.com"], check=True
+            )
+            contract_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "include_paths": [".claude-plugin/plugin.json", "product.txt"],
+                        "product_python": {},
+                        "allowed_cache_metadata": [".git", ".in_use"],
+                        "allowed_cache_metadata_globs": [],
+                        "required_runtime_paths": [".claude-plugin/plugin.json", "product.txt"],
+                        "forbidden_product_imports": ["evals", "tests"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin/plugin.json").write_text(
+                json.dumps({"name": "dcness", "version": "1.0.0"}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin/marketplace.json").write_text(
+                json.dumps({"metadata": {"version": "1.0.0"}}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / "product.txt").write_text("published\n", encoding="utf-8")
+            subprocess.run(["git", "-C", repo, "add", "."], check=True)
+            subprocess.run(["git", "-C", repo, "commit", "-qm", "published"], check=True)
+            published_source = subprocess.run(
+                ["git", "-C", repo, "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(["git", "-C", repo, "tag", "v1.0.0"], check=True)
+            subprocess.run(["git", "-C", repo, "branch", "release"], check=True)
+            _run(
+                "build",
+                "--repo-root",
+                str(repo),
+                "--ref",
+                "HEAD",
+                "--output",
+                str(published),
+                "--contract",
+                str(contract_path),
+            )
+
+            (repo / "product.txt").write_text("drifted\n", encoding="utf-8")
+            subprocess.run(["git", "-C", repo, "add", "."], check=True)
+            subprocess.run(["git", "-C", repo, "commit", "-qm", "drift"], check=True)
+            subprocess.run(["git", "-C", repo, "tag", "-f", "v1.0.0"], check=True)
+            _run(
+                "build",
+                "--repo-root",
+                str(repo),
+                "--ref",
+                "HEAD",
+                "--output",
+                str(candidate),
+                "--contract",
+                str(contract_path),
+            )
+            refs_before = subprocess.run(
+                ["git", "-C", repo, "show-ref"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+
+            failed = _run(
+                "verify-release",
+                "--repo-root",
+                str(repo),
+                "--tag",
+                "v1.0.0",
+                "--candidate",
+                str(candidate),
+                "--published",
+                str(published),
+                "--published-source-sha",
+                published_source,
+                "--contract",
+                str(contract_path),
+                check=False,
+            )
+
+            self.assertNotEqual(failed.returncode, 0)
+            self.assertIn("existing version 1.0.0 has a different bundle digest", failed.stderr)
+            refs_after = subprocess.run(
+                ["git", "-C", repo, "show-ref"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout
+            self.assertEqual(refs_after, refs_before)
+
+    def test_verify_release_reports_new_version_cohorts_and_rejects_version_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            repo = root / "repo"
+            contract_path = root / "contract.json"
+            published = root / "published"
+            candidate = root / "candidate"
+            (repo / ".claude-plugin").mkdir(parents=True)
+            (repo / "product").mkdir()
+            subprocess.run(["git", "init", "-q", "-b", "main", repo], check=True)
+            subprocess.run(["git", "-C", repo, "config", "user.name", "test"], check=True)
+            subprocess.run(
+                ["git", "-C", repo, "config", "user.email", "test@example.com"], check=True
+            )
+            contract_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "include_paths": [".claude-plugin/plugin.json", "product"],
+                        "product_python": {},
+                        "allowed_cache_metadata": [".git", ".in_use"],
+                        "allowed_cache_metadata_globs": [],
+                        "required_runtime_paths": [".claude-plugin/plugin.json", "product"],
+                        "forbidden_product_imports": ["evals", "tests"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin/plugin.json").write_text(
+                json.dumps({"name": "dcness", "version": "1.0.0"}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin/marketplace.json").write_text(
+                json.dumps({"metadata": {"version": "1.0.0"}}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / "product/runtime.txt").write_text("old\n", encoding="utf-8")
+            (repo / "product/removed.txt").write_text("remove on update\n", encoding="utf-8")
+            subprocess.run(["git", "-C", repo, "add", "."], check=True)
+            subprocess.run(["git", "-C", repo, "commit", "-qm", "v1"], check=True)
+            published_source = subprocess.run(
+                ["git", "-C", repo, "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(["git", "-C", repo, "tag", "v1.0.0"], check=True)
+            _run(
+                "build",
+                "--repo-root",
+                str(repo),
+                "--ref",
+                "HEAD",
+                "--output",
+                str(published),
+                "--contract",
+                str(contract_path),
+            )
+
+            (repo / ".claude-plugin/plugin.json").write_text(
+                json.dumps({"name": "dcness", "version": "1.1.0"}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / ".claude-plugin/marketplace.json").write_text(
+                json.dumps({"metadata": {"version": "1.1.0"}}) + "\n",
+                encoding="utf-8",
+            )
+            (repo / "product/runtime.txt").write_text("new\n", encoding="utf-8")
+            (repo / "product/removed.txt").unlink()
+            subprocess.run(["git", "-C", repo, "add", "-A"], check=True)
+            subprocess.run(["git", "-C", repo, "commit", "-qm", "v1.1"], check=True)
+            source_sha = subprocess.run(
+                ["git", "-C", repo, "rev-parse", "HEAD"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            subprocess.run(["git", "-C", repo, "tag", "v1.1.0"], check=True)
+            _run(
+                "build",
+                "--repo-root",
+                str(repo),
+                "--ref",
+                "HEAD",
+                "--output",
+                str(candidate),
+                "--contract",
+                str(contract_path),
+            )
+
+            result = _run(
+                "verify-release",
+                "--repo-root",
+                str(repo),
+                "--tag",
+                "v1.1.0",
+                "--candidate",
+                str(candidate),
+                "--published",
+                str(published),
+                "--published-source-sha",
+                published_source,
+                "--contract",
+                str(contract_path),
+            )
+            report = json.loads(result.stdout)
+
+            self.assertEqual(report["action"], "publish")
+            self.assertEqual(report["source_sha"], source_sha)
+            self.assertEqual(report["version"], "1.1.0")
+            self.assertEqual(
+                report["clean_install"],
+                {
+                    "source_sha": source_sha,
+                    "bundle_digest": report["bundle_digest"],
+                },
+            )
+            self.assertEqual(report["previous_version_update"], report["clean_install"])
+
+            subprocess.run(["git", "-C", repo, "tag", "v1.2.0"], check=True)
+            version_mismatch = _run(
+                "verify-release",
+                "--repo-root",
+                str(repo),
+                "--tag",
+                "v1.2.0",
+                "--candidate",
+                str(candidate),
+                "--published",
+                str(published),
+                "--published-source-sha",
+                published_source,
+                "--contract",
+                str(contract_path),
+                check=False,
+            )
+            self.assertNotEqual(version_mismatch.returncode, 0)
+            self.assertIn(
+                "tag, plugin, and marketplace versions must match",
+                version_mismatch.stderr,
             )
 
     def test_distributed_markdown_links_do_not_target_excluded_paths(self) -> None:
@@ -734,6 +1090,15 @@ class ReleaseArtifactContractTests(unittest.TestCase):
             )
         self.assertEqual(smoke_metrics["file_count"], direct["file_count"])
         self.assertEqual(smoke_metrics["byte_size"], direct["byte_size"])
+        self.assertEqual(smoke_metrics["bundle_digest"], direct["manifest_sha256"])
+        self.assertEqual(
+            smoke_metrics["clean_install"],
+            {
+                "source_sha": smoke_metrics["source_sha"],
+                "bundle_digest": smoke_metrics["bundle_digest"],
+            },
+        )
+        self.assertIsNone(smoke_metrics["previous_version_update"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1158

## 배경 및 문제

`release-sync.yml`이 모든 `main` push에서 `release` branch를 다시 만들었기 때문에 plugin version이 바뀌지 않아도 사용자별 설치 시점에 따라 같은 version의 서로 다른 artifact를 받을 수 있었습니다.

## 원인 (해당 시)

release publish 기준이 immutable version tag가 아니라 mutable `origin/main`이었고, 기존 release artifact의 version·source SHA·bundle digest와 candidate를 publish 전에 대조하는 경계가 없었습니다.

## 작업내용

- workflow trigger를 `main` push에서 strict version tag로 전환하고 exact tagged source에서 전체 unit suite를 먼저 실행합니다.
- 기존 allowlist builder와 snapshot manifest를 재사용해 tag, 두 version manifest, tested source SHA, bundle digest의 1:1 정합을 검증합니다.
- 같은 version의 source/digest drift를 release checkout·push 전에 차단하고 explicit force-with-lease로 publish race를 막습니다.
- 기존 runtime smoke에 직전 release artifact update cohort를 추가해 clean install/update가 같은 source SHA와 digest를 보고하도록 했습니다.
- release runbook을 version bump → PR/CI → full preflight → immutable tag → install/update smoke 순서로 갱신했습니다.

## 결정 근거

release artifact commit의 parent를 tested source SHA로 유지하고 기존 `snapshot.manifest_sha256`를 digest로 사용하면 별도 registry나 provenance 상태 저장소 없이 version/tag/source/digest 관계를 감사할 수 있습니다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcNess self release 운영 경로 변경입니다. 변경한 workflow, release builder/sync, 내부 runbook은 plugin artifact에 포함되지 않으며 기존 `scripts/release_artifact.json`이 사용자 배포 payload의 단일 SSOT로 유지됩니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 공개 skill/command/agent/gate 추가 없음. `verify-release`는 artifact에서 제외되는 기존 내부 builder의 publish 전용 subcommand입니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_release_artifact tests.test_release_preflight -v < /dev/null`
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,147 tests PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] `bash -n scripts/sync_release.sh` 및 `git diff --check`
- [x] plugin-manifest, public-surface, cross-ref, index-map, design-artifact gate PASS

## 참고

- 이 PR은 version을 재발행하거나 기존 tag를 이동하지 않습니다. 다음 release는 새 version/tag에서 수행합니다.
