### PR TITLE
[feature] release preflight 행동 예산 제한

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -92,10 +92,20 @@ Sense→Diagnose→Decide→Act→Verify 루프를 따른다. 메인 agent가 �
 python3.11 scripts/release_preflight.py
 ```
 
-이 명령은 guard efficacy, 핵심 행동 eval, 검증된 golden 기준 judge calibration, 최신 제품
-결과, 실제 Agent 작업 효율 record, 최근 하네스 경량화 결정, 공개 evidence 생성·검사,
+이 명령은 guard efficacy, 핵심 행동 eval, 검증된 golden 기준 judge calibration, 과거 관측
+제품 outcome snapshot, 실제 Agent 작업 효율 record, 최근 하네스 경량화 결정, 공개 evidence 생성·검사,
 release bundle 소비 smoke를 독립 축으로 실행한다. bundle 소비 smoke와 2026-08 실측은 이
 도구가 재구현하지 않고 기존 산출물·검증기를 조합한다.
+
+기본 핵심 행동 eval은 manifest의 두 case를 각 1회 실행한다. 최초 MISS는 release FAIL로
+고정되며 후속 PASS로 되돌리지 않는다. 원인 분류가 필요할 때 `--diagnose-core-misses`를 사용하면
+실패 case만 case당 최대 2회, 초기 실행을 포함한 자동 총 4 trial 안에서 추가 실행하고 모든
+report·judge trace를 보존한다. 4회를 넘는 표본은 사용자 승인 아래 수동 진단으로만 수집하며
+이미 실패한 release 판정을 바꾸지 않는다.
+
+`product_outcome_snapshot` 축의 `SNAPSHOT COLLECTED`는 기존 scorecard command가 종료코드 0으로
+raw historical ratio·`측정 불가`·한계를 수집했다는 의미다. 현재 revision의 제품 성공률이나
+제품 PASS 판정이 아니다.
 
 하네스 실험의 월 trial ledger는 checkout 내부가 아니라 operator-wide
 `~/.claude/plugins/data/dcness-dcness/harness-experiments/trial-ledger.jsonl`를 사용하므로
@@ -110,7 +120,7 @@ worktree·checkout을 나눠도 상한이 분리되지 않는다. `--ledger`는 
   - 이미 판단한 후보는 `record-decision` 으로 `docs/internal/loop-decisions.jsonl` 에 남긴다. 다음 리포트에서 `fixed`/`rejected` 는 `--hide-decided` 로 숨길 수 있고, `hold` 는 계속 표시된다.
   - 장기 무발화 guard는 바로 제거하지 않고 **소멸 후보**로만 기록한다. 실제 제거는 별도 issue/PR에서 Decide→Act→Verify를 탄다.
 - Decide: 추가 전 제거 검토를 먼저 한다. 소멸 후보나 follow-up이 있으면 릴리즈 노트 `Unreleased`의 자기개선 점검 기록에 적고, 후보가 없으면 `소멸 후보 없음`이라고 적는다. 추적이 길어질 항목은 별도 GitHub issue로 분리한다.
-- Verify: [`evals/core-incident-subset.json`](../../evals/core-incident-subset.json)의 핵심 행동 eval은 `bash evals/run-core.sh`에서 N/N 통과해야 한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 사람 golden 보정 입력으로 남기고, report digest·golden/subset version이 맞는지 확인한다.
+- Verify: [`evals/core-incident-subset.json`](../../evals/core-incident-subset.json)의 핵심 행동 eval은 기본 각 1회에서 모두 통과해야 한다. 최초 MISS가 있으면 release FAIL을 유지한 채 필요한 경우에만 bounded 추가 진단으로 원인을 분류한다. judge 판정이 의심스러우면 저장된 `run-<N>-report.md`와 `run-<N>-judge.md`를 사람 golden 보정 입력으로 남기고, report digest·golden/subset version이 맞는지 확인한다.
 
 ```sh
 # 1. version bump 브랜치 생성 — 브랜치명 버전은 . 대신 _ (0.25.0 → 0_25_0).

--- a/docs/internal/self-improvement-loop.md
+++ b/docs/internal/self-improvement-loop.md
@@ -129,7 +129,7 @@ Verify는 하나의 PASS로 뭉개지 않는다.
 |---|---|---|
 | hook/function/order/TDD guard 변경 | `python3 evals/guard_efficacy.py` | fixture 계약의 재현만 본다. 실제 agent 행동은 보지 않는다. |
 | agent·skill 행동 판단 변경 | `bash evals/run.sh` | LLM 실행이라 흔들림이 있다. judge 신뢰성은 [#894](https://github.com/alruminum/dcNess/issues/894) 보정 대상이다. |
-| 릴리즈 전 핵심 실사고 회귀 | `EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh` | `shorts-real-spec`, `headless-prose-quality`는 N/N 통과가 기준이다. |
+| 릴리즈 전 핵심 실사고 회귀 | `python3.11 scripts/release_preflight.py` | 기본은 core 두 case를 각 1회 실행한다. 최초 MISS는 release FAIL로 고정하며, 원인 분류가 필요하면 `--diagnose-core-misses`로 실패 case만 자동 총 4 trial 안에서 추가 진단한다. |
 | 재발·낭비·비용 신호 | 다음 Sense 주기 재측정 | evals 밖 운영 신호라 즉시 증명할 수 없다. |
 
 `evals/run.sh`는 블라인드 검수 보고와 judge 채점 결과를 `.metrics/evals/` 아래 또는

--- a/evals/README.md
+++ b/evals/README.md
@@ -33,8 +33,9 @@ python3 evals/guard_efficacy.py --json # 범주별 pass/fail JSON
 
 bash evals/run.sh                    # 전 케이스 1회씩
 bash evals/run-core.sh               # versioned 핵심 실사고 subset만 1회씩
-EVAL_RUNS=3 bash evals/run.sh        # 케이스당 3회 반복 (릴리즈 전 권장)
-EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh  # 핵심 실사고 케이스 N/N 확인
+python3.11 scripts/release_preflight.py  # 릴리즈 기본: core 두 case를 각 1회
+python3.11 scripts/release_preflight.py --diagnose-core-misses  # MISS case만 총 4 trial 안에서 추가 진단
+EVAL_RUNS=3 bash evals/run.sh        # 사용자 승인 아래 수동 진단 표본 수집
 EVAL_MODEL=opus bash evals/run.sh    # 검수/채점 모델 변경 (기본 sonnet)
 EVAL_OUTPUT_DIR=/tmp/dcness-evals bash evals/run.sh # 산출물 저장 위치 지정
 EVAL_PARALLEL=8 bash evals/run.sh    # (case, run) 셀을 최대 8개까지 병렬 실행 (기본 4, 1=직렬 안전판)
@@ -63,7 +64,12 @@ headless `claude -p` quota 는 메인 세션과 공유되므로 상한은 보수
 `shorts-real-spec`, `headless-prose-quality`다. 첫 케이스는 실제 제품 순서 사고를, 두 번째는
 근거 없는 headless PASS와 rigid output 회귀를 함께 잡는다. 나머지는 전체 suite의 합성 대조군,
 cartography 확장 회귀, 또는 중복 축으로 유지하되 개인 릴리즈 기본 calibration 비용에서는 뺀다.
-`bash evals/run-core.sh`는 manifest에서 case 목록을 읽고 N/N을 요구한다. 이 기준은 새 CI 게이트가 아니라
+`bash evals/run-core.sh`는 manifest에서 case 목록을 읽고 지정된 실행 수의 N/N을 요구한다.
+릴리즈 preflight는 외부 `EVAL_RUNS` 값과 무관하게 두 case를 각 1회 실행한다. 최초 MISS가 있으면
+릴리즈 FAIL을 즉시 고정하고 기본 실행은 추가 표본을 자동 수집하지 않는다. 원인 분류가 필요한
+operator가 `--diagnose-core-misses`를 선택한 경우에만 실패한 case를 case당 최대 2회 추가 실행하되,
+초기 2회를 포함한 자동 행동 trial 총량은 4회를 넘지 않는다. 추가 진단이 모두 PASS여도 고정된
+release FAIL은 바뀌지 않는다. 이 기준은 새 CI 게이트가 아니라
 [`docs/internal/self-improvement-loop.md`](../docs/internal/self-improvement-loop.md)의
 Verify 슬롯을 사람이 도는 릴리즈 전 권고다.
 저장된 v1 사람 확인 후보와 report/judge 대조 순서는
@@ -89,10 +95,11 @@ dcNess source checkout의 repo-only `scripts/loop_diagnose.py`는 기본
 적용한다.
 
 단발 실패를 뒤이은 재실행 PASS로 덮어 "통과"로 닫지 않는다. 재실행은 flaky 여부를 판별하는
-수단이지 통과 표본을 고르는 수단이 아니다. 판정이 흔들리면 최초 MISS를 결과 집합에서 버리지 않은
-채 `EVAL_RUNS`를 높여 추가 표본을 모으고, 최초 MISS까지 합산한 전체 정답률(`k/N`)을 측정한다.
-일부만 통과하면 결과를 flaky로 보고한다. 방금 변경한 diff의 회귀가 아니라는 근거가 있더라도 해당
-flaky 신호 자체를 없던 것으로 취급하지 않는다.
+수단이지 통과 표본을 고르는 수단이 아니다. 릴리즈 자동 경로는 위 4 trial 상한 안에서 최초 MISS와
+추가 진단의 report·judge trace를 모두 보존한다. 그보다 많은 표본은 사용자 승인 아래
+`EVAL_RUNS`를 높인 수동 진단으로만 모으며, 최초 MISS까지 합산한 전체 정답률(`k/N`)을 측정한다.
+수동 진단 역시 이미 실패한 release 판정을 바꾸지 않는다. 일부만 통과하면 결과를 flaky로 보고한다.
+방금 변경한 diff의 회귀가 아니라는 근거가 있더라도 해당 flaky 신호 자체를 없던 것으로 취급하지 않는다.
 
 flaky로 확정한 후보는 gate 통과 여부와 무관하게 처분을 남긴다. [#1123](https://github.com/alruminum/dcNess/pull/1123)의
 flaky 후보 자동 표면화를 거쳐 `scripts/loop_diagnose.py record-decision`으로 `fixed`·`hold`·`rejected`

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -17,12 +17,17 @@ EXPECTED_AXES = [
     "guard",
     "core_behavior",
     "judge_calibration",
-    "product_outcome",
+    "product_outcome_snapshot",
     "agent_effectiveness",
     "lightweight_decision",
     "public_evidence",
     "bundle_consumer",
 ]
+MAX_AUTOMATED_BEHAVIOR_TRIALS = 4
+MAX_DIAGNOSTIC_RUNS_PER_CASE = 2
+PRODUCT_OUTCOME_INTERPRETATION = (
+    "snapshot_collection_only_not_current_product_success"
+)
 
 
 class PreflightError(RuntimeError):
@@ -45,10 +50,33 @@ def _latest_lightweight_record() -> Path:
     return ROOT / "evals" / "lean-ablation" / "tool-repeat-lesson-metadata.json"
 
 
+def _core_behavior_cases() -> list[str]:
+    manifest = ROOT / "evals" / "core-incident-subset.json"
+    try:
+        payload = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PreflightError(f"core_behavior_manifest_unreadable: {exc}") from exc
+    selected = payload.get("selected_cases") if isinstance(payload, dict) else None
+    if not isinstance(selected, list):
+        raise PreflightError("core_behavior_selected_cases_must_be_array")
+    cases = [item.get("case") for item in selected if isinstance(item, dict)]
+    if (
+        not cases
+        or len(cases) != len(selected)
+        or not all(isinstance(case, str) and case for case in cases)
+        or len(set(cases)) != len(cases)
+    ):
+        raise PreflightError("core_behavior_cases_must_be_unique_nonempty_strings")
+    if len(cases) > MAX_AUTOMATED_BEHAVIOR_TRIALS:
+        raise PreflightError("core_behavior_cases_exceed_automatic_trial_budget")
+    return cases
+
+
 def _default_steps(output_dir: Path) -> list[dict[str, Any]]:
     python = sys.executable
     effectiveness_record = _latest_agent_effectiveness_record()
     lightweight_record = _latest_lightweight_record()
+    behavior_cases = _core_behavior_cases()
     product_scorecard = [
         python,
         str(ROOT / "harness" / "outcome_scorecard.py"),
@@ -77,8 +105,13 @@ def _default_steps(output_dir: Path) -> list[dict[str, Any]]:
         {
             "id": "core_behavior",
             "command": ["bash", str(ROOT / "evals" / "run-core.sh")],
+            "diagnostic_command": ["bash", str(ROOT / "evals" / "run.sh")],
+            "behavior_cases": behavior_cases,
             "required": True,
-            "env": {"EVAL_OUTPUT_DIR": str(output_dir / "core-behavior")},
+            "env": {
+                "EVAL_OUTPUT_DIR": str(output_dir / "core-behavior" / "initial"),
+                "EVAL_RUNS": "1",
+            },
         },
         {
             "id": "judge_calibration",
@@ -96,9 +129,13 @@ def _default_steps(output_dir: Path) -> list[dict[str, Any]]:
             "required": True,
         },
         {
-            "id": "product_outcome",
+            "id": "product_outcome_snapshot",
             "command": product_scorecard,
             "required": True,
+            "description": (
+                "Collect the raw historical product outcome scorecard snapshot; "
+                "command success is not a current product success verdict."
+            ),
         },
         {
             "id": "agent_effectiveness",
@@ -171,10 +208,40 @@ def _validate_steps(steps: list[dict[str, Any]]) -> None:
             for key, value in env.items()
         ):
             raise PreflightError(f"{step['id']}_env_must_be_string_object")
+        behavior_cases = step.get("behavior_cases")
+        diagnostic_command = step.get("diagnostic_command")
+        if behavior_cases is None and diagnostic_command is None:
+            continue
+        if step["id"] != "core_behavior":
+            raise PreflightError("behavior_diagnostics_only_allowed_for_core_behavior")
+        if (
+            not isinstance(behavior_cases, list)
+            or not behavior_cases
+            or not all(isinstance(case, str) and case for case in behavior_cases)
+            or len(set(behavior_cases)) != len(behavior_cases)
+        ):
+            raise PreflightError("core_behavior_cases_must_be_unique_nonempty_strings")
+        if len(behavior_cases) > MAX_AUTOMATED_BEHAVIOR_TRIALS:
+            raise PreflightError("core_behavior_cases_exceed_automatic_trial_budget")
+        if (
+            not isinstance(diagnostic_command, list)
+            or not diagnostic_command
+            or not all(
+                isinstance(item, str) and item for item in diagnostic_command
+            )
+        ):
+            raise PreflightError("core_behavior_diagnostic_command_must_be_string_array")
+        if env.get("EVAL_RUNS") != "1":
+            raise PreflightError("core_behavior_initial_eval_runs_must_be_one")
 
 
 def _run_step(
-    step: dict[str, Any], *, index: int, output_dir: Path, timeout: int
+    step: dict[str, Any],
+    *,
+    index: int,
+    output_dir: Path,
+    timeout: int,
+    stem_suffix: str = "",
 ) -> dict[str, Any]:
     env = os.environ.copy()
     env.update(step.get("env", {}))
@@ -201,12 +268,12 @@ def _run_step(
         stderr = exc.stderr if isinstance(exc.stderr, str) else ""
         stderr += f"\npreflight step timed out after {timeout}s"
     finished = datetime.datetime.now(datetime.timezone.utc)
-    stem = f"{index:02d}-{step['id']}"
+    stem = f"{index:02d}-{step['id']}{stem_suffix}"
     stdout_path = output_dir / f"{stem}.stdout.log"
     stderr_path = output_dir / f"{stem}.stderr.log"
     stdout_path.write_text(stdout, encoding="utf-8")
     stderr_path.write_text(stderr, encoding="utf-8")
-    return {
+    row = {
         "id": step["id"],
         "required": step["required"],
         "status": "PASS" if returncode == 0 else "FAIL",
@@ -215,6 +282,96 @@ def _run_step(
         "duration_seconds": round((finished - started).total_seconds(), 3),
         "stdout_log": str(stdout_path),
         "stderr_log": str(stderr_path),
+    }
+    if description := step.get("description"):
+        row["description"] = description
+    if step["id"] == "product_outcome_snapshot":
+        row.update(
+            {
+                "snapshot_collection_succeeded": returncode == 0,
+                "interpretation": PRODUCT_OUTCOME_INTERPRETATION,
+            }
+        )
+    return row
+
+
+def _judge_passed(output_dir: Path, case: str, run_index: int = 1) -> bool:
+    judge_path = output_dir / case / f"run-{run_index}-judge.md"
+    try:
+        lines = judge_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return False
+    return any(line.strip() == "RESULT: PASS" for line in lines)
+
+
+def _attach_behavior_trials(
+    step: dict[str, Any],
+    result: dict[str, Any],
+    *,
+    diagnose_core_misses: bool,
+    index: int,
+    output_dir: Path,
+    timeout: int,
+) -> None:
+    cases = step.get("behavior_cases")
+    if not isinstance(cases, list):
+        return
+    initial_output = Path(step["env"]["EVAL_OUTPUT_DIR"])
+    initial_failed = [case for case in cases if not _judge_passed(initial_output, case)]
+    initial_trial_count = len(cases)
+    diagnostic_runs = 0
+    diagnostic_trial_count = 0
+    diagnostic_output: Path | None = None
+    diagnostic_result: dict[str, Any] | None = None
+
+    remaining_budget = MAX_AUTOMATED_BEHAVIOR_TRIALS - initial_trial_count
+    if diagnose_core_misses and initial_failed and remaining_budget > 0:
+        diagnostic_runs = min(
+            MAX_DIAGNOSTIC_RUNS_PER_CASE,
+            remaining_budget // len(initial_failed),
+        )
+        if diagnostic_runs > 0:
+            diagnostic_output = initial_output.parent / "diagnostic"
+            diagnostic_step = {
+                "id": "core_behavior_diagnostic",
+                "command": step["diagnostic_command"],
+                "required": False,
+                "env": {
+                    **step.get("env", {}),
+                    "EVAL_CASES": " ".join(initial_failed),
+                    "EVAL_STRICT_CASES": " ".join(initial_failed),
+                    "EVAL_RELEASE_CHECK": "1",
+                    "EVAL_RUNS": str(diagnostic_runs),
+                    "EVAL_OUTPUT_DIR": str(diagnostic_output),
+                },
+            }
+            diagnostic_result = _run_step(
+                diagnostic_step,
+                index=index,
+                output_dir=output_dir,
+                timeout=timeout,
+                stem_suffix="-diagnostic",
+            )
+            diagnostic_trial_count = len(initial_failed) * diagnostic_runs
+
+    release_failure_latched = result["status"] != "PASS" or bool(initial_failed)
+    if release_failure_latched:
+        result["status"] = "FAIL"
+    result["behavior_trials"] = {
+        "automatic_trial_limit": MAX_AUTOMATED_BEHAVIOR_TRIALS,
+        "initial_trial_count": initial_trial_count,
+        "initial_output_dir": str(initial_output),
+        "initial_failed_cases": initial_failed,
+        "diagnostic_requested": diagnose_core_misses,
+        "diagnostic_cases": initial_failed if diagnostic_trial_count else [],
+        "diagnostic_runs_per_case": diagnostic_runs,
+        "diagnostic_trial_count": diagnostic_trial_count,
+        "diagnostic_output_dir": (
+            str(diagnostic_output) if diagnostic_output is not None else None
+        ),
+        "diagnostic_command_result": diagnostic_result,
+        "total_trial_count": initial_trial_count + diagnostic_trial_count,
+        "release_failure_latched": release_failure_latched,
     }
 
 
@@ -229,12 +386,43 @@ def _render_markdown(report: dict[str, Any]) -> str:
         "|---|---|---:|---|",
     ]
     for step in report["steps"]:
+        display_status = step["status"]
+        if step["id"] == "product_outcome_snapshot":
+            display_status = (
+                "SNAPSHOT COLLECTED"
+                if step["snapshot_collection_succeeded"]
+                else "SNAPSHOT COLLECTION FAILED"
+            )
         lines.append(
-            f"| {step['id']} | {step['status']} | {step['returncode']} | "
+            f"| {step['id']} | {display_status} | {step['returncode']} | "
             f"`{step['stdout_log']}` |"
+        )
+    core = next((step for step in report["steps"] if step["id"] == "core_behavior"), None)
+    if core and "behavior_trials" in core:
+        trials = core["behavior_trials"]
+        lines.extend(
+            [
+                "",
+                (
+                    "- 행동 eval 자동 trial: "
+                    f"`{trials['total_trial_count']}/{trials['automatic_trial_limit']}` "
+                    f"(초기 `{trials['initial_trial_count']}`, "
+                    f"추가 진단 `{trials['diagnostic_trial_count']}`)"
+                ),
+                (
+                    "- 최초 MISS release FAIL 고정: "
+                    f"`{'YES' if trials['release_failure_latched'] else 'NO'}`"
+                ),
+            ]
         )
     lines.extend(
         [
+            "",
+            (
+                "`product_outcome_snapshot`의 command 성공은 기존 scorecard의 raw historical "
+                "ratio·`측정 불가`·한계를 snapshot으로 수집했다는 뜻이며, 현재 제품 성공률이나 "
+                "제품 PASS 판정이 아닙니다."
+            ),
             "",
             (
                 "사람 개입은 저장된 evidence 사이의 불일치나 새 사람 판정이 "
@@ -250,10 +438,21 @@ def run(args: argparse.Namespace) -> dict[str, Any]:
     output_dir.mkdir(parents=True, exist_ok=True)
     steps = _load_config(args.config.resolve() if args.config else None, output_dir)
     _validate_steps(steps)
-    results = [
-        _run_step(step, index=index, output_dir=output_dir, timeout=args.timeout)
-        for index, step in enumerate(steps, start=1)
-    ]
+    results = []
+    for index, step in enumerate(steps, start=1):
+        result = _run_step(
+            step, index=index, output_dir=output_dir, timeout=args.timeout
+        )
+        if step["id"] == "core_behavior":
+            _attach_behavior_trials(
+                step,
+                result,
+                diagnose_core_misses=args.diagnose_core_misses,
+                index=index,
+                output_dir=output_dir,
+                timeout=args.timeout,
+            )
+        results.append(result)
     failed_required = [
         row["id"] for row in results if row["required"] and row["status"] != "PASS"
     ]
@@ -284,6 +483,14 @@ def main(argv: list[str] | None = None) -> int:
         default=ROOT / ".metrics" / "release-preflight" / timestamp,
     )
     parser.add_argument("--timeout", type=int, default=3600)
+    parser.add_argument(
+        "--diagnose-core-misses",
+        action="store_true",
+        help=(
+            "After an initial core MISS, use the remaining automatic four-trial "
+            "budget for failed-case diagnosis without changing the release FAIL."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
     try:

--- a/scripts/release_preflight.py
+++ b/scripts/release_preflight.py
@@ -301,7 +301,12 @@ def _judge_passed(output_dir: Path, case: str, run_index: int = 1) -> bool:
         lines = judge_path.read_text(encoding="utf-8").splitlines()
     except OSError:
         return False
-    return any(line.strip() == "RESULT: PASS" for line in lines)
+    verdicts = [
+        line.strip()
+        for line in lines
+        if line.strip() in {"RESULT: PASS", "RESULT: FAIL"}
+    ]
+    return bool(verdicts) and verdicts[-1] == "RESULT: PASS"
 
 
 def _attach_behavior_trials(

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -17,7 +17,7 @@ EXPECTED_AXES = [
     "guard",
     "core_behavior",
     "judge_calibration",
-    "product_outcome",
+    "product_outcome_snapshot",
     "agent_effectiveness",
     "lightweight_decision",
     "public_evidence",
@@ -56,23 +56,109 @@ class ReleasePreflightTests(unittest.TestCase):
         )
         return config, tmp / "order.txt"
 
+    def _behavior_fixture(
+        self, tmp: Path, *, outcomes: dict[str, list[str]]
+    ) -> tuple[Path, Path]:
+        behavior = tmp / "behavior.py"
+        behavior.write_text(
+            "import json, os, pathlib, sys\n"
+            "mode=sys.argv[1]\n"
+            "cases=os.environ.get('EVAL_CASES', 'case-a case-b').split()\n"
+            "runs=int(os.environ.get('EVAL_RUNS', '1'))\n"
+            "output=pathlib.Path(os.environ['EVAL_OUTPUT_DIR'])\n"
+            "state_path=pathlib.Path(os.environ['BEHAVIOR_STATE_FILE'])\n"
+            "trace_path=pathlib.Path(os.environ['BEHAVIOR_TRACE_FILE'])\n"
+            "outcomes=json.loads(os.environ['BEHAVIOR_OUTCOMES'])\n"
+            "state=json.loads(state_path.read_text()) if state_path.exists() else {}\n"
+            "failed=False\n"
+            "for case in cases:\n"
+            "    case_dir=output / case\n"
+            "    case_dir.mkdir(parents=True, exist_ok=True)\n"
+            "    for run in range(1, runs + 1):\n"
+            "        index=state.get(case, 0)\n"
+            "        result=outcomes[case][min(index, len(outcomes[case]) - 1)]\n"
+            "        state[case]=index + 1\n"
+            "        (case_dir / f'run-{run}-report.md').write_text(f'{mode} {case} report {index + 1}\\n')\n"
+            "        (case_dir / f'run-{run}-judge.md').write_text(f'RESULT: {result}\\n')\n"
+            "        with trace_path.open('a') as trace:\n"
+            "            trace.write(f'{mode} {case} {result} {case_dir}\\n')\n"
+            "        failed = failed or result != 'PASS'\n"
+            "state_path.write_text(json.dumps(state))\n"
+            "raise SystemExit(1 if failed else 0)\n",
+            encoding="utf-8",
+        )
+        generic = tmp / "step.py"
+        generic.write_text(
+            "import pathlib, sys\n"
+            "pathlib.Path(sys.argv[2]).open('a').write(sys.argv[1] + '\\n')\n",
+            encoding="utf-8",
+        )
+        order = tmp / "order.txt"
+        shared_env = {
+            "BEHAVIOR_STATE_FILE": str(tmp / "behavior-state.json"),
+            "BEHAVIOR_TRACE_FILE": str(tmp / "behavior-trace.txt"),
+            "BEHAVIOR_OUTCOMES": json.dumps(outcomes),
+            "EVAL_CASES": "case-a case-b",
+            "EVAL_RUNS": "1",
+            "EVAL_OUTPUT_DIR": str(tmp / "output" / "core-behavior" / "initial"),
+        }
+        steps = []
+        for axis in EXPECTED_AXES:
+            if axis == "core_behavior":
+                steps.append(
+                    {
+                        "id": axis,
+                        "command": [sys.executable, str(behavior), "initial"],
+                        "diagnostic_command": [
+                            sys.executable,
+                            str(behavior),
+                            "diagnostic",
+                        ],
+                        "behavior_cases": ["case-a", "case-b"],
+                        "required": True,
+                        "env": shared_env,
+                    }
+                )
+            else:
+                steps.append(
+                    {
+                        "id": axis,
+                        "command": [sys.executable, str(generic), axis, str(order)],
+                        "required": True,
+                    }
+                )
+        config = tmp / "config.json"
+        config.write_text(
+            json.dumps({"schema_version": 1, "steps": steps}), encoding="utf-8"
+        )
+        return config, tmp / "behavior-trace.txt"
+
     def _run(
-        self, tmp: Path, *, failing: str = ""
+        self,
+        tmp: Path,
+        *,
+        failing: str = "",
+        config: Path | None = None,
+        diagnose_core_misses: bool = False,
     ) -> subprocess.CompletedProcess[str]:
-        config, order = self._fixture(tmp)
+        fixture_config, order = self._fixture(tmp) if config is None else (config, None)
         env = os.environ.copy()
-        env["PREFLIGHT_ORDER_FILE"] = str(order)
+        if order is not None:
+            env["PREFLIGHT_ORDER_FILE"] = str(order)
         env["PREFLIGHT_FAIL"] = failing
+        command = [
+            sys.executable,
+            str(SCRIPT),
+            "--config",
+            str(fixture_config),
+            "--output-dir",
+            str(tmp / "output"),
+            "--json",
+        ]
+        if diagnose_core_misses:
+            command.append("--diagnose-core-misses")
         return subprocess.run(
-            [
-                sys.executable,
-                str(SCRIPT),
-                "--config",
-                str(config),
-                "--output-dir",
-                str(tmp / "output"),
-                "--json",
-            ],
+            command,
             cwd=ROOT,
             env=env,
             text=True,
@@ -95,6 +181,19 @@ class ReleasePreflightTests(unittest.TestCase):
                 (tmp / "order.txt").read_text(encoding="utf-8").splitlines(),
                 EXPECTED_AXES,
             )
+
+            product = next(
+                step
+                for step in report["steps"]
+                if step["id"] == "product_outcome_snapshot"
+            )
+            self.assertTrue(product["snapshot_collection_succeeded"])
+            self.assertIn("not_current_product_success", product["interpretation"])
+            markdown = (tmp / "output" / "report.md").read_text(encoding="utf-8")
+            self.assertIn(
+                "| product_outcome_snapshot | SNAPSHOT COLLECTED |", markdown
+            )
+            self.assertNotIn("| product_outcome_snapshot | PASS |", markdown)
 
     def test_failure_is_reported_but_later_independent_axes_still_run(self) -> None:
         with tempfile.TemporaryDirectory() as td:
@@ -129,11 +228,114 @@ class ReleasePreflightTests(unittest.TestCase):
         spec.loader.exec_module(module)
         with tempfile.TemporaryDirectory() as td:
             steps = {step["id"]: step for step in module._default_steps(Path(td))}
-        product = steps["product_outcome"]["command"]
+        product = steps["product_outcome_snapshot"]["command"]
         effectiveness = steps["agent_effectiveness"]["command"]
         self.assertNotEqual(product, effectiveness)
         self.assertNotIn("--agent-effectiveness-record", product)
         self.assertIn("--projects-file", effectiveness)
+        core = steps["core_behavior"]
+        self.assertEqual(core["env"]["EVAL_RUNS"], "1")
+        self.assertEqual(core["behavior_cases"], ["shorts-real-spec", "headless-prose-quality"])
+        self.assertTrue(core["diagnostic_command"][-1].endswith("evals/run.sh"))
+
+    def test_core_success_runs_each_case_once(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            config, trace = self._behavior_fixture(
+                tmp,
+                outcomes={"case-a": ["PASS"], "case-b": ["PASS"]},
+            )
+
+            result = self._run(tmp, config=config)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            report = json.loads(result.stdout)
+            core = next(step for step in report["steps"] if step["id"] == "core_behavior")
+            behavior = core["behavior_trials"]
+            self.assertEqual(behavior["initial_trial_count"], 2)
+            self.assertEqual(behavior["diagnostic_trial_count"], 0)
+            self.assertEqual(
+                [line.split()[:3] for line in trace.read_text(encoding="utf-8").splitlines()],
+                [
+                    ["initial", "case-a", "PASS"],
+                    ["initial", "case-b", "PASS"],
+                ],
+            )
+
+    def test_initial_miss_latches_release_failure_and_preserves_all_four_trials(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            config, trace = self._behavior_fixture(
+                tmp,
+                outcomes={"case-a": ["FAIL", "PASS", "PASS"], "case-b": ["PASS"]},
+            )
+
+            result = self._run(
+                tmp, config=config, diagnose_core_misses=True
+            )
+
+            self.assertEqual(result.returncode, 1, result.stderr)
+            report = json.loads(result.stdout)
+            self.assertFalse(report["releasable"])
+            self.assertEqual(report["failed_required"], ["core_behavior"])
+            core = next(step for step in report["steps"] if step["id"] == "core_behavior")
+            behavior = core["behavior_trials"]
+            self.assertEqual(behavior["initial_failed_cases"], ["case-a"])
+            self.assertTrue(behavior["release_failure_latched"])
+            self.assertEqual(behavior["diagnostic_runs_per_case"], 2)
+            self.assertEqual(behavior["total_trial_count"], 4)
+            self.assertEqual(core["status"], "FAIL")
+            traces = trace.read_text(encoding="utf-8").splitlines()
+            self.assertEqual(
+                [line.split()[:3] for line in traces],
+                [
+                    ["initial", "case-a", "FAIL"],
+                    ["initial", "case-b", "PASS"],
+                    ["diagnostic", "case-a", "PASS"],
+                    ["diagnostic", "case-a", "PASS"],
+                ],
+            )
+            artifacts = list((tmp / "output" / "core-behavior").rglob("run-*-*.md"))
+            self.assertEqual(len(artifacts), 8)
+
+    def test_two_initial_misses_share_the_remaining_two_trial_budget(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            config, trace = self._behavior_fixture(
+                tmp,
+                outcomes={"case-a": ["FAIL", "PASS"], "case-b": ["FAIL", "PASS"]},
+            )
+
+            result = self._run(tmp, config=config, diagnose_core_misses=True)
+
+            self.assertEqual(result.returncode, 1, result.stderr)
+            report = json.loads(result.stdout)
+            core = next(step for step in report["steps"] if step["id"] == "core_behavior")
+            behavior = core["behavior_trials"]
+            self.assertEqual(behavior["initial_failed_cases"], ["case-a", "case-b"])
+            self.assertEqual(behavior["diagnostic_runs_per_case"], 1)
+            self.assertEqual(behavior["total_trial_count"], 4)
+            self.assertEqual(len(trace.read_text(encoding="utf-8").splitlines()), 4)
+
+    def test_initial_miss_does_not_rerun_without_diagnostic_request(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            config, trace = self._behavior_fixture(
+                tmp,
+                outcomes={"case-a": ["FAIL", "PASS"], "case-b": ["PASS"]},
+            )
+
+            result = self._run(tmp, config=config)
+
+            self.assertEqual(result.returncode, 1, result.stderr)
+            report = json.loads(result.stdout)
+            core = next(step for step in report["steps"] if step["id"] == "core_behavior")
+            behavior = core["behavior_trials"]
+            self.assertEqual(behavior["total_trial_count"], 2)
+            self.assertEqual(behavior["diagnostic_trial_count"], 0)
+            self.assertEqual(len(trace.read_text(encoding="utf-8").splitlines()), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_preflight.py
+++ b/tests/test_release_preflight.py
@@ -262,6 +262,23 @@ class ReleasePreflightTests(unittest.TestCase):
                 ],
             )
 
+    def test_core_judge_uses_the_final_result_line_like_eval_runner(self) -> None:
+        spec = importlib.util.spec_from_file_location("release_preflight", SCRIPT)
+        module = importlib.util.module_from_spec(spec)
+        assert spec.loader is not None
+        spec.loader.exec_module(module)
+        with tempfile.TemporaryDirectory() as td:
+            output = Path(td)
+            case_dir = output / "case-a"
+            case_dir.mkdir()
+            judge = case_dir / "run-1-judge.md"
+
+            judge.write_text("RESULT: PASS\nRESULT: FAIL\n", encoding="utf-8")
+            self.assertFalse(module._judge_passed(output, "case-a"))
+
+            judge.write_text("RESULT: FAIL\nRESULT: PASS\n", encoding="utf-8")
+            self.assertTrue(module._judge_passed(output, "case-a"))
+
     def test_initial_miss_latches_release_failure_and_preserves_all_four_trials(
         self,
     ) -> None:


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1157

## 배경 및 문제

기존 release preflight는 호출 환경의 `EVAL_RUNS`를 그대로 상속할 수 있어 기본 행동 eval 비용이 릴리즈당 4 trial을 넘을 수 있었습니다. 또한 `product_outcome` 축은 scorecard snapshot 수집 명령의 종료코드 0을 제품 결과 PASS처럼 보이게 했습니다.

## 원인 (해당 시)

- core 행동 eval을 일반 command step으로만 실행해 최초 MISS와 후속 진단의 판정 관계 및 trial budget을 표현하지 않았습니다.
- product outcome scorecard 실행 성공과 scorecard가 담은 과거 관측값의 의미를 preflight report에서 분리하지 않았습니다.

## 작업내용

- 기본 core subset 실행을 기존 두 case 각 1회로 고정했습니다.
- 최초 MISS를 release FAIL로 고정하고, `--diagnose-core-misses`에서 실패 case만 case당 최대 2회·자동 총 4 trial 안에서 추가 실행하도록 했습니다.
- 초기 실행과 추가 진단의 report/judge 경로, trial 수, 최초 실패 case, FAIL 고정 여부를 JSON/Markdown report에 남깁니다.
- judge trace에 결과 줄이 여러 개면 기존 eval runner와 동일하게 마지막 `RESULT`를 최종 판정으로 사용합니다.
- 축 이름을 `product_outcome_snapshot`으로 바꾸고 `SNAPSHOT COLLECTED`가 raw historical scorecard 수집 성공일 뿐 현재 제품 성공률/PASS가 아님을 명시했습니다.
- release/eval 운영 문서와 deterministic fixture 회귀 테스트를 갱신했습니다.

## 결정 근거

- 기존 `evals/run-core.sh`, `evals/run.sh`, `EVAL_RUNS`, report/judge artifact, `outcome_scorecard.py`를 그대로 조합했습니다.
- 원인 분류가 필요할 때만 명시 옵션으로 추가 진단을 실행해 기본 성공 경로 비용을 2 trial로 유지했습니다.
- 새 freshness selector, 상태 taxonomy, 공개 entrypoint는 추가하지 않았습니다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcNess self 릴리즈 운영 도구와 내부 운영 문서 변경입니다. plug-in payload 및 `/init-dcness` 배포 inventory 변경이 없습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 내부 `scripts/release_preflight.py`의 선택 옵션만 확장했으며 public skill/command/agent/gate를 추가하지 않았습니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_release_preflight -v < /dev/null` — 8 tests PASS
- [x] `python3.11 -m unittest discover -s tests < /dev/null` — 1152 tests PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/Bandit PASS
- [x] `node scripts/check_cross_refs.mjs` — PASS
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] `node scripts/aggregate_index_map.mjs --check` — PASS
- [x] `node scripts/check_design_artifact_structure.mjs` — PASS
- [x] `python3.11 scripts/release_artifact.py smoke --repo-root . --ref HEAD` — PASS

## 참고

- 자동 행동 trial budget: 기본 2, 실패 진단 포함 최대 4
- 추가 진단 PASS는 최초 MISS로 고정된 release FAIL을 되돌리지 않습니다.
