### PR TITLE
[docs] release 0.25.0 — release artifact 불변성 + preflight 행동 예산·judge verdict 정합

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — Claude Code와 Codex를 제품 개발 루프에 묶고 순서 게이트, 역할 경계, TDD guard, 검증 가능한 작업 기록을 제공하는 agent workflow harness. release 브랜치의 경량 runtime artifact 배포.",
-    "version": "0.24.0"
+    "version": "0.25.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Claude Code와 Codex를 Git/PR/CI 흐름 안에서 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 묶는 agent workflow harness. (한국어 사용자 대상)",
   "author": {
     "name": "alruminum",

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.23.0","measured_at":"2026-07-15","unit_tests":{"passed":1131,"total":1131},"guard":{"passed":48,"total":48},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.25.0","measured_at":"2026-07-16","unit_tests":{"passed":1152,"total":1152},"guard":{"passed":48,"total":48},"source_project_count":2} -->
 
-현재 공개 snapshot은 **v0.23.0, 2026-07-15 측정**이다. 숫자마다 분모와 source 수를
+현재 공개 snapshot은 **v0.25.0, 2026-07-16 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,131/1,131 PASS, 결정적 guard 48/48 PASS | test 1,131, guard case 48 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,152/1,152 PASS, 결정적 guard 48/48 PASS | test 1,152, guard case 48 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -8,6 +8,30 @@
 
 ---
 
+## v0.25.0 (2026-07-16)
+
+**커밋 범위**: `v0.24.0..v0.25.0` (머지 PR 2개, [#1166](https://github.com/Daeguk-Sun/dcNess/pull/1166) · [#1167](https://github.com/Daeguk-Sun/dcNess/pull/1167))
+**핵심 변경**: **dcNess 자신의 release publish 경계를 tag-only immutable 파이프라인으로 굳히고, 릴리즈 전 preflight 의 행동 예산·judge verdict 파싱을 정합화한** minor 릴리즈. 배포되는 외부 활성 프로젝트 runtime 동작 변화는 없으며, 공개 evidence snapshot 을 현재 revision 실측으로 갱신했다. (1) 같은 plugin version 의 release artifact 불변성을 tag/version/source SHA/bundle digest 4단 정합으로 강제하고 main-push sync 를 제거해 새 `vX.Y.Z` 태그에서만 publish, (2) release preflight 의 핵심 행동 eval 기본 실행을 case 별 1회로 고정해 최초 MISS 를 release FAIL 로 유지하고 judge 최종 verdict 파싱을 eval runner 와 일치시켰다. **v0.25.0 은 이 tag-only immutable publish 파이프라인을 처음 실제로 통과하는 릴리즈다.**
+
+### 무엇이 바뀌나
+
+1. **release artifact 불변성 강제 — tag-only immutable publish** ([#1166](https://github.com/Daeguk-Sun/dcNess/pull/1166) Closes [#1158](https://github.com/Daeguk-Sun/dcNess/issues/1158)) — release publish 가 `main` push 로 트리거돼 이미 배포한 version 의 artifact 가 tag 이동·재빌드로 조용히 바뀔 수 있던 문제를 해소. `sync_release.sh` 가 tag·manifest version·release commit parent 의 tested source SHA·release bundle digest 를 1:1 로 검증하고 같은 version 의 기존 release 와 candidate 의 source SHA/digest 가 다르면 checkout·push 전에 실패하도록 했다. `release-sync.yml` 은 `main` push 가 아니라 새 `vMAJOR.MINOR.PATCH` 태그에서만 실행하며, exact tag source 의 전체 unit suite 와 clean install/update smoke 를 통과한 뒤에만 publish 한다. clean install/update cohort 회귀 테스트와 release runbook 을 함께 갱신했다.
+
+2. **release preflight 행동 예산 + core judge 최종 verdict 정합** ([#1167](https://github.com/Daeguk-Sun/dcNess/pull/1167) Closes [#1157](https://github.com/Daeguk-Sun/dcNess/issues/1157)) — preflight 의 핵심 행동 eval 이 실행 표본 수를 고정하지 않고 judge verdict 파싱이 eval runner 와 달라 판정이 흔들리던 문제를 해소. 기본 실행을 case 별 1회로 고정하고 최초 MISS 를 release FAIL 로 유지하며, 선택형 실패 진단만 자동 4 trial 상한 안에서 실행하되 전체 report·judge trace 를 보존한다. product outcome 축을 현재 성공률이 아니라 historical snapshot 수집 의미로 명확화하고, preflight 가 eval runner 와 동일하게 문서 마지막 `RESULT` 줄을 judge 최종 verdict 로 사용하도록 맞춰(중복 `RESULT` 순서 회귀 테스트 추가) 파싱 불일치를 제거했다.
+
+### 자기개선 점검
+
+- Sense/Diagnose: 이번 릴리즈 diff 가 release publish 경계(`sync_release.sh`·`release-sync.yml`)와 preflight/judge 파싱을 건드려 결정적 guard-efficacy 를 재실행 — **48/48 PASS**, 회귀 없음. 전체 unittest 도 재실행해 공개 수치를 실측 동기화 — **1,152/1,152 PASS**. 두 머지 PR 은 각각 개별 CI(pytest·static-quality·public-surface·cross-ref·index-map·doc-sync·plugin-manifest·pr-body)를 통과했다.
+- Decide: 소멸 후보 없음. follow-up 없음.
+- Verify: release artifact 불변성·preflight 행동 예산·core judge verdict 신규/회귀 테스트 통과. 공개 evidence snapshot(README·`docs/plugin/benchmark.md`)을 v0.25.0 / 2026-07-16 실측(unit 1,152/1,152 · guard 48/48)으로 갱신했고 `node scripts/check_public_evidence.mjs` 로 문서 marker 와 실측 대조를 검증한다.
+
+### 사용자 영향
+
+- **`claude plugin update dcness@dcness` 로 자동 반영** — 이번 릴리즈의 실질 변경은 dcNess self 의 release publish 불변성과 preflight 판정이라 외부 활성 프로젝트 runtime 동작 변화는 없다. 배포물에서는 공개 evidence snapshot(README·benchmark)과 version bump 만 반영된다.
+- **marketplace 설치/업데이트 사용자** — v0.25.0 부터 release 는 새 `vX.Y.Z` 태그에서만 publish 되고, 이미 배포한 version 의 tag 는 이동·재사용하지 않는다. 태그·version·tested source SHA·bundle digest 4단 정합이 맞아야 사용자에게 도달한 것으로 본다.
+
+---
+
 ## v0.24.0 (2026-07-16)
 
 **커밋 범위**: `v0.23.0..v0.24.0` (머지 PR 27개)

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -4,13 +4,13 @@
 
 ## 현재 공개 evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.23.0","measured_at":"2026-07-15","unit_tests":{"passed":1131,"total":1131},"guard":{"passed":48,"total":48},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.25.0","measured_at":"2026-07-16","unit_tests":{"passed":1152,"total":1152},"guard":{"passed":48,"total":48},"source_project_count":2} -->
 
-현재 plugin version은 **v0.23.0**, 측정일은 **2026-07-15**다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
+현재 plugin version은 **v0.25.0**, 측정일은 **2026-07-16**다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
 
 | evidence | 관측값 | 재현 명령 | 한계 |
 |---|---:|---|---|
-| 전체 unit 계약 | 1,131/1,131 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
+| 전체 unit 계약 | 1,152/1,152 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
 | guard fixture | 48/48 PASS | `python3.11 evals/guard_efficacy.py --json` | deterministic payload의 allow/block/exit/stdout 계약 |
 | 공개 snapshot drift | README/benchmark 일치 | `node scripts/check_public_evidence.mjs` | 위 두 명령 결과와 문서 marker만 대조 |
 


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: v0.25.0 릴리즈 운영 PR — 버전 bump + 공개 evidence 실측 갱신 (대응 이슈 없음, 릴리즈 콘텐츠는 이미 머지된 #1158·#1157)

## 배경 및 문제

- v0.24.0(2026-07-16 09:06 태그) 이후 main 에 5개 커밋이 머지됐다 — release artifact 불변성 강제([#1158](https://github.com/Daeguk-Sun/dcNess/issues/1158) · [#1166](https://github.com/Daeguk-Sun/dcNess/pull/1166)), release preflight 행동 예산 + core judge 최종 verdict 정합([#1157](https://github.com/Daeguk-Sun/dcNess/issues/1157) · [#1167](https://github.com/Daeguk-Sun/dcNess/pull/1167)).
- 이 변경을 tag-only immutable publish 파이프라인의 **첫 실 릴리즈**로 태그·배포하려면 두 manifest version 을 0.25.0 으로 올리고, 공개 evidence snapshot 이 v0.23.0/1,131 에 머물러 있어(v0.24.0 때 미갱신) 현재 revision 실측으로 갱신해야 한다.

## 원인 (해당 시)

-

## 작업내용

- `.claude-plugin/plugin.json` · `.claude-plugin/marketplace.json` version `0.24.0` → `0.25.0`.
- `README.md` · `docs/plugin/benchmark.md` 의 `public-evidence-snapshot` marker 와 prose·표를 현재 revision 실측으로 갱신 — plugin_version `0.25.0`, measured_at `2026-07-16`, unit `1,152/1,152`, guard `48/48`.
- `docs/internal/release-notes.md` 에 v0.25.0 섹션 추가 (커밋 범위 · 무엇이 바뀌나 2건 · 자기개선 점검 · 사용자 영향).

## 결정 근거

- 공개 evidence 는 `check_public_evidence.mjs` 가 marker 를 실측과 대조하는 계약이다. 실측(전체 unittest 1,152/1,152 PASS, guard 48/48 PASS)을 **먼저 측정한 뒤** marker 를 그 값으로 갱신했다.
- Superpowers·OMC scorecard 는 quick 모드 규칙에 따라 갱신 대상이 아니며 2026-07-15 역사적 기준으로만 남긴다.

## 배포 경로 검증 (plug-in 영향 시)

- 배포물 중 갱신되는 것은 **공개 evidence 문서(README·`docs/plugin/benchmark.md`)와 version manifest** 뿐이다. 새 runtime 기능·hook·command·agent 변화가 없어 **외부 활성 프로젝트의 runtime 동작 변화는 없다** (v0.25.0 실질 변경은 dcNess self 의 release publish 불변성·preflight 판정).
- 사용자 도달 경로: v0.25.0 태그 push → `release-sync.yml`(tag `v*.*.*` 트리거) → exact-tag unit + clean install/update smoke → `Daeguk-Sun/dcNess` `release` 브랜치 immutable publish → marketplace 소비.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public surface 없음.

## Test Plan

- [x] `node scripts/check_plugin_manifest.mjs` PASS — dcness@0.25.0
- [x] `node scripts/check_public_evidence.mjs` PASS — version=0.25.0, tests=1152/1152, guard=48/48, measured_at=2026-07-16
- [x] `node scripts/check_cross_refs.mjs` PASS — dead link/anchor/옛 명칭/고아 0건
- [x] 전체 unittest 1,152/1,152 PASS + 결정적 guard 48/48 PASS 실측

## 참고

- v0.25.0 은 tag-only immutable publish 파이프라인([#1158](https://github.com/Daeguk-Sun/dcNess/issues/1158))을 처음 실제로 통과하는 릴리즈다. 머지 후 main 에서 `python3.11 scripts/release_preflight.py` full 확인 → `v0.25.0` 태그 생성·push 로 배포한다 (태그 push 는 사용자 확인 후 진행).
