### PR TITLE
[feature] story 순서 판정 계약 테스트 리팩터

### DIFF
--- a/tests/test_spec_story_slice.py
+++ b/tests/test_spec_story_slice.py
@@ -2,6 +2,9 @@
 
 /spec 의 story 분할·순서 기준과 SPEC_ACCEPTANCE 검수 축이
 "사용자 검증 가능한 동작 증분 / 얇은 골격 우선" 원칙을 유지하는지 회귀로 보존한다.
+
+이 정적 테스트는 이름 붙은 판정 축과 적용 순서가 지침에 남아 있는지만 보장한다.
+문장 전문이나 agent 의 실제 판정 행동은 고정하지 않으며, 행동 보장은 핵심 eval 이 담당한다.
 """
 from __future__ import annotations
 
@@ -10,6 +13,49 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+STORY_ORDER_AXIS_MARKERS = {
+    "thin_walking_skeleton": ("walking skeleton", "최소 동선"),
+    "boundary_closure_not_feature_completion": (
+        "PRD 기능",
+        "최종 사용자 가치 경계",
+        "순서 결함",
+    ),
+    "delayed_first_boundary_crossing": ("뒤 Story", "마지막 Story", "순서 결함"),
+    "no_invented_impossibility": (
+        "기술적 의존 순서",
+        "불가능 사유",
+        "만들어내지 않는다",
+    ),
+}
+
+PRODUCT_SEQUENCE_AXIS_MARKERS = {
+    "final_boundary_and_first_reach": ("최종 사용자 가치 경계", "최초 Story"),
+    "walking_skeleton_guard": (
+        "첫 Story",
+        "walking skeleton",
+        "기능 완성도",
+        "별도 gap",
+    ),
+    "delayed_sequence_defect": ("Story 2 이후", "마지막 Story", "sequence defect"),
+    "no_invented_impossibility": ("불가능 사유", "지어내지 않는다"),
+}
+
+VALIDATOR_SEQUENCE_AXIS_MARKERS = {
+    "final_boundary_and_first_reach": ("최종 사용자 가치 경계", "최초 Story"),
+    "walking_skeleton_guard": ("walking skeleton", "기능 완성도", "coverage gap"),
+    "delayed_sequence_defect": ("Story 2 이후", "불가능 사유", "순서 결함"),
+}
+
+
+def contract_block(text: str, start_marker: str, end_marker: str) -> str:
+    """Return one static contract block without coupling tests to its prose."""
+    if start_marker not in text:
+        raise AssertionError(f"contract start marker missing: {start_marker}")
+    remainder = text.split(start_marker, 1)[1]
+    if end_marker not in remainder:
+        raise AssertionError(f"contract end marker missing: {end_marker}")
+    return remainder.split(end_marker, 1)[0]
 
 
 class SpecStorySliceContractTests(unittest.TestCase):
@@ -41,6 +87,16 @@ class SpecStorySliceContractTests(unittest.TestCase):
             ROOT / "docs" / "plugin" / "agents" / "_shared" / "module-design-principles.md"
         ).read_text(encoding="utf-8")
 
+    def assert_axis_markers(
+        self,
+        text: str,
+        axes: dict[str, tuple[str, ...]],
+    ) -> None:
+        for axis, markers in axes.items():
+            for marker in markers:
+                with self.subTest(axis=axis, marker=marker):
+                    self.assertIn(marker, text)
+
     def test_stories_reference_requires_behavior_increment_split(self) -> None:
         for needle in (
             "## Story 분할 기준 — 사용자 검증 가능한 동작 증분",
@@ -56,20 +112,12 @@ class SpecStorySliceContractTests(unittest.TestCase):
                 self.assertIn(needle, self.stories_reference)
 
     def test_stories_reference_requires_walking_skeleton_ordering(self) -> None:
-        for needle in (
+        story_order_contract = contract_block(
+            self.stories_reference,
             "## Story 순서 기준 — 얇은 골격 우선",
-            "walking skeleton",
-            "입력에서 결과까지 한 줄로 통과하는 최소 동선",
-            "골격 위에 확인 가능한 증분을 쌓는다",
-            "마지막 Story 까지 밀리는 순서(부품을 다 만든 뒤에야 처음 동작)는 그대로 두지 않는다",
-            "첫 Story가 최종 사용자 가치 경계까지 닫히지 않으면",
-            "뒤 Story가 마지막 Story가 아니어도 순서 결함",
-            "기술적 의존 순서를 검수자가 불가능 사유로 만들어내지 않는다",
-            "PRD 기능 일부가 후속 Story에 남아 있어도 첫 Story의 최소 동선이 최종 사용자 가치 경계를 통과하면 순서 결함이 아니다",
-            "후속 기능의 누락·AC coverage는 순서 축과 별개의 gap",
-        ):
-            with self.subTest(needle=needle):
-                self.assertIn(needle, self.stories_reference)
+            "## Template",
+        )
+        self.assert_axis_markers(story_order_contract, STORY_ORDER_AXIS_MARKERS)
 
     def test_stories_reference_template_has_story_acceptance_criteria(self) -> None:
         for needle in (
@@ -103,28 +151,12 @@ class SpecStorySliceContractTests(unittest.TestCase):
     def test_product_acceptance_spec_mode_tracks_first_core_e2e_closure(
         self,
     ) -> None:
-        for needle in (
-            "순서 판단 단일 규칙",
-            "최종 경계와 최초 도달 위치",
-            "Sequence defect 유지",
-            "정상 walking skeleton 우선 보호",
-            "최종 사용자 가치 경계를 실제 통과하는 최초 Story를 표시한다",
-            "순서 축의 최초 닫힘은 모든 PRD 기능의 완성이 아니라 최소 동선이 최종 사용자 가치 경계를 실제 통과한 시점이다",
-            "첫 Story AC가 최종 사용자 가치 경계를 실제 통과하면 순서 판정을 끝낸다",
-            "후속 기능의 누락이나 AC coverage는 별도 gap으로 평가한다",
-            "최종 사용자 가치 경계의 최초 통과를 후속 Story로 지연하면",
-            "Story AC 또는 동작 증거 부족과 별개의 sequence defect",
-            "Story AC가 없더라도 PRD 목표·유저 시나리오, Epic 완료 기준, Story 목적·영향 모듈이 Story별 제품 경계를 드러내면 지연 근거로 사용한다",
-            "sequence defect 판정은 Story AC 충족 여부와 독립적으로 먼저 수행한다",
-            "최초 닫힘 위치가 Story 2 이후다",
-            "후속 Story가 마지막 Story인지 여부와 무관하게",
-            "완전한 흐름에 필요한 기능을 순서대로 구현한다는 설명은 명시된 불가능 사유가 아니다",
-            "지연을 입증하는 Story 순서·제품 경계 근거가 없으면",
-            "Story AC 또는 동작 증거 부족만 보고하고 sequence defect를 추측하지 않는다",
-            "export·upload·publish·download·delivery",
-        ):
-            with self.subTest(needle=needle):
-                self.assertIn(needle, self.product_acceptance)
+        sequence_contract = contract_block(
+            self.product_acceptance,
+            "- **순서 판단 단일 규칙**:",
+            "### STORY_ACCEPTANCE",
+        )
+        self.assert_axis_markers(sequence_contract, PRODUCT_SEQUENCE_AXIS_MARKERS)
 
         self.assertEqual(self.product_acceptance.count("순서 판단 단일 규칙"), 1)
         self.assertNotIn(
@@ -140,19 +172,23 @@ class SpecStorySliceContractTests(unittest.TestCase):
             self.product_acceptance.index("Sequence defect 유지"),
         )
 
-        for guidance in (
-            self.architecture_validator,
-            self.codex_architecture_validator,
+        for guidance, start_marker, end_marker in (
+            (
+                self.architecture_validator,
+                "- 구현 순서:",
+                "- 시스템 경계 변경 신호:",
+            ),
+            (
+                self.codex_architecture_validator,
+                "- epic architecture 의 Story/모듈 구현 순서",
+                "- Agent Operability evidence",
+            ),
         ):
-            for needle in (
-                "첫 Story가 최소 기능으로 최종 사용자 가치 경계까지 실제 도달하면",
-                "정상 walking skeleton",
-                "기능 완성도 부족을 제품 경계 미도달로 바꾸어 해석하지 않는다",
-                "후속 기능의 누락은 별도 coverage gap",
-                "Story 2 이후에서 처음 닫히면 명세에 기록된 불가능 사유가 없는 한 순서 결함",
-            ):
-                with self.subTest(guidance=guidance[:40], needle=needle):
-                    self.assertIn(needle, guidance)
+            sequence_guidance = contract_block(guidance, start_marker, end_marker)
+            self.assert_axis_markers(
+                sequence_guidance,
+                VALIDATOR_SEQUENCE_AXIS_MARKERS,
+            )
 
     def test_product_acceptance_report_includes_user_runnable_path(self) -> None:
         self.assertIn(
@@ -185,25 +221,27 @@ class SpecStorySliceContractTests(unittest.TestCase):
         self.assertIn("AC-NNN", git_spec)
 
     def test_spec_acceptance_axes_keep_documented_exceptions(self) -> None:
-        for needle in (
-            "어느 후행 Story 에서 그 동작이 확인되는지 명시했으면 gap 이 아니다",
-            "더 이른 얇은 end-to-end 검증이 불가능한 사유를 명시하면 warning",
-            "첫 Story가 최소 기능으로 최종 사용자 가치 경계까지 실제 도달하면 이후 기능 풍부화는 정상 walking skeleton",
-        ):
-            with self.subTest(needle=needle):
-                self.assertIn(needle, self.product_acceptance)
+        exception_axes = {
+            "documented_component_story": ("후행 Story", "gap 이 아니다"),
+            "documented_impossibility": ("불가능한 사유", "warning"),
+            "normal_walking_skeleton": (
+                "첫 Story",
+                "walking skeleton",
+                "sequence defect가 아니다",
+            ),
+        }
+        self.assert_axis_markers(self.product_acceptance, exception_axes)
 
     def test_spec_acceptance_ordering_gap_not_retracted_or_reframed(self) -> None:
         """순서 gap 을 하위 동작·의존 순서로 철회하거나, 사유를 지어내거나,
         형식/export 프레이밍으로 덮는 razor-thin 경계 흔들림을 회귀로 차단한다 (#1139)."""
-        for needle in (
-            "앞 Story의 하위 동작이나 합리적인 의존 순서로 철회하지 않는다",
-            "불가능 사유를 검수자가 지어내지 않는다",
-            "형식 gap이나 제품 경계 모호성으로 대체·흡수하지 않는다",
-            "sequence defect로 보고하고 PASS하지 않는다",
-        ):
-            with self.subTest(needle=needle):
-                self.assertIn(needle, self.product_acceptance)
+        rejection_axes = {
+            "dependency_does_not_retract": ("하위 동작", "의존 순서", "철회"),
+            "no_invented_impossibility": ("불가능 사유", "지어내지 않는다"),
+            "not_reframed_as_format_gap": ("형식 gap", "제품 경계 모호성", "대체·흡수"),
+            "defect_must_not_pass": ("sequence defect", "PASS하지 않는다"),
+        }
+        self.assert_axis_markers(self.product_acceptance, rejection_axes)
 
     def test_product_acceptance_reads_stories_reference_for_spec_mode(self) -> None:
         self.assertIn(

--- a/tests/test_spec_story_slice.py
+++ b/tests/test_spec_story_slice.py
@@ -168,8 +168,8 @@ class SpecStorySliceContractTests(unittest.TestCase):
             self.product_acceptance,
         )
         self.assertLess(
-            self.product_acceptance.index("정상 walking skeleton 우선 보호"),
-            self.product_acceptance.index("Sequence defect 유지"),
+            sequence_contract.index("정상 walking skeleton 우선 보호"),
+            sequence_contract.index("Sequence defect 유지"),
         )
 
         for guidance, start_marker, end_marker in (
@@ -241,7 +241,12 @@ class SpecStorySliceContractTests(unittest.TestCase):
             "not_reframed_as_format_gap": ("형식 gap", "제품 경계 모호성", "대체·흡수"),
             "defect_must_not_pass": ("sequence defect", "PASS하지 않는다"),
         }
-        self.assert_axis_markers(self.product_acceptance, rejection_axes)
+        sequence_contract = contract_block(
+            self.product_acceptance,
+            "- **순서 판단 단일 규칙**:",
+            "### STORY_ACCEPTANCE",
+        )
+        self.assert_axis_markers(sequence_contract, rejection_axes)
 
     def test_product_acceptance_reads_stories_reference_for_spec_mode(self) -> None:
         self.assertIn(


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1177

## 배경 및 문제

- #1175 회귀 방지 테스트가 순서 판정 지침의 긴 문장 전문을 needle로 고정해, 의미를 보존한 문구 개선도 테스트 실패로 만들었습니다.
- 정적 문자열 검사가 실제 agent 판정 행동까지 보장하는 것처럼 읽힐 수 있었고, architecture-validator 검사는 전체 문서의 우연한 용어 중복으로 규칙 block 삭제를 놓칠 여지도 있었습니다.

## 원인 (해당 시)

- 판정 축과 구조 대신 현재 문장 표현을 직접 계약으로 삼았습니다.
- marker가 어떤 의미 축을 담당하는지 이름이 없었고, 일부 mirror 검사는 해당 `구현 순서` block이 아닌 파일 전체를 검색했습니다.

## 작업내용

- 장문 needle을 `boundary_closure_not_feature_completion`, `walking_skeleton_guard`, `delayed_sequence_defect`, `no_invented_impossibility` 등 이름 붙은 축별 최소 marker로 교체했습니다.
- Story 순서 section, product-acceptance 단일 규칙 block, Claude/Codex architecture-validator의 구현 순서 block을 각각 잘라 그 범위 안에서 marker를 검사합니다.
- walking skeleton 보호 제목이 sequence defect 유지 제목보다 앞선다는 구조 순서 검사는 유지했습니다.
- 테스트 머리말에 정적 검사는 축의 존재·순서만 보장하고 실제 판정 행동은 핵심 eval이 담당한다고 명시했습니다.

## 결정 근거

- 별도 parser 모듈, 환경변수 override, 신규 테스트 메서드를 만들지 않고 기존 테스트 메서드를 리팩터해 변경 범위와 공개 test-count drift를 피했습니다.
- 의미 보존 재서술은 in-memory 변형본으로 통과시키고, product 규칙 및 Claude mirror block 삭제는 같은 테스트를 실제 실행해 non-zero exit로 탐지력을 확인했습니다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self의 테스트 코드 한 파일만 변경하며 플러그인 배포물, `/init-dcness` 복사 파일, 사용자 SSOT는 바꾸지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface가 없습니다.

## Test Plan

- [x] 현행 장문 needle에서 의미 보존 재서술 변형이 실패하는 RED 확인
- [x] `python3.11 -m unittest tests.test_spec_story_slice -v` — 16/16 PASS
- [x] 의미 보존 재서술 변형본으로 `test_stories_reference_requires_walking_skeleton_ordering` 실행 — PASS
- [x] product-acceptance 순서 규칙 block 삭제 변형본으로 `test_product_acceptance_spec_mode_tracks_first_core_e2e_closure` 실행 — 의도대로 exit 1
- [x] Claude architecture-validator 구현 순서 block 삭제 변형본으로 동일 계약 테스트 실행 — 의도대로 exit 1
- [x] `EVAL_CASES=shorts-real-spec EVAL_STRICT_CASES=shorts-real-spec EVAL_RUNS=3 EVAL_RELEASE_CHECK=1 bash evals/run.sh` — 3/3 PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh` — ruff/mypy/Bandit PASS
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,167 tests PASS
- [x] pre-commit hook — 1,167 tests PASS

## 참고

- 순서 판정 지침과 eval case/expected는 변경하지 않았습니다.
- 테스트 메서드 수가 유지돼 public evidence snapshot의 1,167개 분모도 그대로입니다.
