### PR TITLE
[issue-1190] impl 착수 속도 개선

### DIFF
--- a/docs/plugin/agents/build-worker/build-worker-agent.md
+++ b/docs/plugin/agents/build-worker/build-worker-agent.md
@@ -2,17 +2,18 @@
 
 ## 목적
 
-`/impl-loop` 단일 구현 엔진으로 한 impl task의 테스트 작성, 구현, 자체 검증, 로컬 커밋을 한 호출 안에서 끝낸다. 같은 agent를 내부 `JOURNEY_ENV_PREFLIGHT`와 `JOURNEY_CONVERGENCE` mode로 재사용해 자동 `(JOURNEY)`의 실행환경과 final tip 하네스도 수렴시킨다. 신규 agent나 공개 진입점을 만들지 않으며, 비용을 줄이되 검증 증거와 커밋 가능 상태를 생략하지 않는다.
+`/impl-loop` 단일 구현 엔진으로 한 impl task의 조건부 `JOURNEY_ENV_PREFLIGHT`, 테스트 작성, 구현, 자체 검증, 로컬 커밋을 한 호출 안에서 끝낸다. 같은 agent를 completed 이후 `JOURNEY_CONVERGENCE` mode로 재사용해 자동 `(JOURNEY)`의 final tip 하네스도 수렴시킨다. 신규 agent나 공개 진입점을 만들지 않으며, 비용을 줄이되 검증 증거와 커밋 가능 상태를 생략하지 않는다.
 
 ## 입력
 
 - impl 계획 파일 경로
 - 메인이 진입 preflight 에서 확보한 대상 issue 와 target GitHub issue AC snapshot
 - task slug
-- RUN_ID와 helper 정보
+- wrapper가 주입한 canonical run directory와 phase prose 절대경로
+- wrapper가 `.dcness/tdd-hooks.json`에서 생성한 project-local TDD contract
 - 재시도라면 실패 맥락
 - 이전 task 요약이 있으면 참고한다.
-- 내부 mode가 있으면 `JOURNEY_ENV_PREFLIGHT` 또는 `JOURNEY_CONVERGENCE`, story의 `(JOURNEY)` 선언, `acceptance_environment`, `harness_paths`, 현재 run의 `journey_deferred` 목록, final stack tip
+- 기본 task 호출이면 story의 `(JOURNEY)` 선언, `acceptance_environment`, `harness_paths`; 내부 mode가 있으면 `JOURNEY_CONVERGENCE`, 현재 run의 `journey_deferred` 목록, final stack tip
 
 ## 먼저 읽을 문서
 
@@ -42,20 +43,21 @@
 
 ## 작업 흐름
 
-1. build-test: 계획·설계와 메인이 전달한 target GitHub issue AC snapshot 을 읽고, 이 task 의 REQ 및 테스트가 담당할 AC 를 대응시킨 뒤 테스트를 작성해 RED를 확인한다.
-2. build-impl: 허용된 코드 경로만 수정하고 GREEN을 확인한다. 담당 Story AC에 `(JOURNEY)`가 있으면 프로젝트 기존 e2e 도구로 flow 대본과 journey 매니페스트를 작성한다. 매니페스트는 `.dcness/`가 아니라 owner module/소스 영역(예: `app/.maestro/dcness-journey.json`)에 두며, impl task가 선언한 `acceptance_environment`와 `harness_paths`를 materialize한다. 필요하면 순수 e2e 대본과 함께 setup/teardown/상태전이 스크립트를 만들고 `commands.journey.argv`에서 `bash`로 오케스트레이션한다. UI 증거는 flow가 `${DCNESS_PRODUCT_JOURNEY_RUN_DIR}` 아래에 생성하게 한다. task 구현 호출에서는 뒤의 final tip 수렴보다 먼저 부분 journey를 실행해 결과를 확정하지 않는다.
-3. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build/typecheck/compile 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다. `(JOURNEY)` REQ는 flow·매니페스트·필요한 오케스트레이션 산출물, 환경·배관 선언과 대상 AC 연결을 읽어 final tip 수렴 호출에 인계한다. 핵심 AC가 mock-only green이면 가능한 자동 동작 증거를 보강하고, 보강 불가 시 gap 으로 보고한다. 확정 목업이 있는 UI 작업은 구현 컴포넌트와 핵심 `data-node-id` 매핑을 대조하고, design:required 태스크는 `docs/design.md` 의 색·spacing·typography 토큰이 실제 앱 theme/component 상수에 반영됐는지 별도 self-check 로 보고한다. 목업 대비 의도적 차이가 있으면 이유와 영향을 보고한다. 같은 단계에서 구현 전후 diff를 읽어 affected capability, runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision을 자유 prose Cartography impact로 남긴다. 변화가 없으면 없다고 명시한다.
+1. journey-env-preflight: impl task를 먼저 읽고 자동 `(JOURNEY)`가 있으면 아래 `JOURNEY_ENV_PREFLIGHT`를 같은 기본 worker 호출 안에서 source read/edit보다 먼저 한 번 수행한다. 없으면 no-op이다.
+2. build-test: 계획·설계와 메인이 전달한 target GitHub issue AC snapshot 을 읽고, 이 task 의 REQ 및 테스트가 담당할 AC 를 대응시킨 뒤 테스트를 작성해 RED를 확인한다. wrapper가 project-local TDD contract를 주입했으면 구현 source마다 그 계약의 matching test를 source edit 전에 만든다. 다른 basename의 넓은 feature test만으로 matching-test 계약을 충족했다고 간주하지 않는다.
+3. build-impl: 허용된 코드 경로만 수정하고 GREEN을 확인한다. 담당 Story AC에 `(JOURNEY)`가 있으면 프로젝트 기존 e2e 도구로 flow 대본과 journey 매니페스트를 작성한다. 매니페스트는 `.dcness/`가 아니라 owner module/소스 영역(예: `app/.maestro/dcness-journey.json`)에 두며, impl task가 선언한 `acceptance_environment`와 `harness_paths`를 materialize한다. 필요하면 순수 e2e 대본과 함께 setup/teardown/상태전이 스크립트를 만들고 `commands.journey.argv`에서 `bash`로 오케스트레이션한다. UI 증거는 flow가 `${DCNESS_PRODUCT_JOURNEY_RUN_DIR}` 아래에 생성하게 한다. task 구현 호출에서는 뒤의 final tip 수렴보다 먼저 부분 journey를 실행해 결과를 확정하지 않는다.
+4. build-validate: 계획, 코드, 계약, lint 또는 프로젝트 표준 검증을 확인한다. 테스트/lint/build/typecheck/compile 게이트는 명령을 실제로 실행해 종료코드 기반으로 판정한다. `(JOURNEY)` REQ는 flow·매니페스트·필요한 오케스트레이션 산출물, 환경·배관 선언과 대상 AC 연결을 읽어 final tip 수렴 호출에 인계한다. 핵심 AC가 mock-only green이면 가능한 자동 동작 증거를 보강하고, 보강 불가 시 gap 으로 보고한다. 확정 목업이 있는 UI 작업은 구현 컴포넌트와 핵심 `data-node-id` 매핑을 대조하고, design:required 태스크는 `docs/design.md` 의 색·spacing·typography 토큰이 실제 앱 theme/component 상수에 반영됐는지 별도 self-check 로 보고한다. 목업 대비 의도적 차이가 있으면 이유와 영향을 보고한다. 같은 단계에서 구현 전후 diff를 읽어 affected capability, runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision을 자유 prose Cartography impact로 남긴다. 변화가 없으면 없다고 명시한다.
    - impl 계획에 replacement/refactor/migration 신호가 있으면 old surface를 이름 검색 하나로 끝내지 않는다. call site, DI binding/provider, route/deep link, manifest/framework registration, resource, test/fake/fixture, suppression/deprecation을 전수 대조한다. 제거한 표면과 의도적으로 보존한 표면을 나누고, 보존 항목에는 이유와 owner를 남긴다. framework/runtime reachability 또는 후속 Epic의 intentional stub/planned seam 여부가 불명확하면 자동 삭제하지 않고 gap으로 보고한다.
-4. 각 phase 결과를 phase prose 파일로 남긴다.
-5. PASS 조건을 만족하면 `git status`, `git diff --check`, 필요한 `git add`, `git commit`을 실행해 task 변경을 로컬 커밋으로 닫는다. 커밋은 git-spec 의 의미 단위 커밋 분할 규칙으로 쪼개되 각 커밋은 hook을 통과하는 일관 상태여야 한다.
-6. PASS일 때만 다음 task를 위한 한 줄 요약, commit sha, 담당 target GitHub issue AC 별 충족 증거를 남긴다. `(JOURNEY)`가 있으면 이 Story의 REQ 목록, flow/매니페스트, `acceptance_environment`, `harness_paths`, 수렴·acceptance 실행 인계를 함께 보고한다. build-worker 는 issue mutation 권한이 없으므로 체크박스를 직접 수정하지 않고 메인에게 증거만 인계한다.
+5. 각 phase 결과를 phase prose 파일로 남긴다.
+6. PASS 조건을 만족하면 `git status`, `git diff --check`, 필요한 `git add`, `git commit`을 실행해 task 변경을 로컬 커밋으로 닫는다. 커밋은 git-spec 의 의미 단위 커밋 분할 규칙으로 쪼개되 각 커밋은 hook을 통과하는 일관 상태여야 한다.
+7. PASS일 때만 다음 task를 위한 한 줄 요약, commit sha, 담당 target GitHub issue AC 별 충족 증거를 남긴다. `(JOURNEY)`가 있으면 이 Story의 REQ 목록, flow/매니페스트, `acceptance_environment`, `harness_paths`, 수렴·acceptance 실행 인계를 함께 보고한다. build-worker 는 issue mutation 권한이 없으므로 체크박스를 직접 수정하지 않고 메인에게 증거만 인계한다.
 
 ### `JOURNEY_ENV_PREFLIGHT`
 
-- `/impl-loop` run preflight 직후, 구현 task 시작 전에 자동 `(JOURNEY)`가 하나라도 있을 때만 1회 호출한다. journey 미선언 run과 `acceptance_environment.automation=human_verification`만 있는 run은 비발동이다.
+- `/impl-loop` 기본 one-shot worker가 impl task를 읽은 직후, source read/edit 전에 자동 `(JOURNEY)`가 하나라도 있을 때만 내부 phase로 1회 수행한다. 별도 main turn, provider fork, outer lifecycle step을 만들지 않는다. journey 미선언 run과 `acceptance_environment.automation=human_verification`만 있는 run은 비발동이다.
 - main 컨텍스트가 아니라 build-worker가 실제 실행될 동일 provider·sandbox의 worker 실행 컨텍스트에서 `requirements[].probe`를 수행한다. mobile은 device/emulator+`adb` socket, web은 browser/driver, CLI는 기동 service+writable fixture, API는 provisioned tenant처럼 해당 runtime 의존에 실제로 도달하는지 본다.
 - 확실한 미충족이라도 `requirements[].prepare`로 emulator boot, container/service 기동, socket 노출 같은 자동 준비가 가능하면 질문 없이 먼저 준비하고 다시 probe한다. 검출이 불확실하면 차단하지 않고 그 불확실성을 보고한 `PASS`로 task 구현에 진행해 수렴 호출이 흡수하게 한다.
-- 확실한 미충족이고 자동 준비가 불가능할 때만 근거와 함께 `IMPLEMENTATION_ESCALATE`를 보고한다. main이 host에서 대신 probe하거나 journey를 실행해 worker substrate 부재를 숨기지 않는다. 이 mode는 tracked file을 수정하거나 commit하지 않는다.
+- 확실한 미충족이고 자동 준비가 불가능할 때만 근거와 함께 `IMPLEMENTATION_ESCALATE`를 보고한다. main이 host에서 대신 probe하거나 journey를 실행해 worker substrate 부재를 숨기지 않는다. 이 phase는 tracked file을 수정하거나 commit하지 않는다.
 
 ### `JOURNEY_CONVERGENCE`
 
@@ -68,12 +70,12 @@
 
 ## phase prose 경로
 
-- 메인이 전달한 `<run_dir>`는 `.claude/harness-state/.sessions/<sid>/runs/<run-id>` 경로이며, phase prose를 실제로 쓰는 디렉토리도 이 경로다.
-- phase prose는 worker 내부 test/impl/validate 증거다. outer Agent 호출의 `step_started`/`step_completed` receipt가 아니며, phase마다 outer `begin-step`/`end-step`을 호출하거나 phase 파일을 outer completion으로 append하지 않는다. foreground Claude outer lifecycle은 hook, headless outer lifecycle은 wrapper가 1쌍만 소유한다.
+- headless wrapper가 prompt에 넣은 `canonical run directory` 절대경로가 phase prose의 유일한 기록 위치다. linked worktree 안의 상대 `.claude/harness-state`를 다시 계산하지 않는다.
+- phase prose는 worker 내부 test/impl/validate 증거다. outer Agent 호출의 `step_started`/`step_completed` receipt가 아니며, phase마다 outer `begin-step`/`end-step`을 호출하거나 phase 파일을 outer completion으로 append하지 않는다. foreground Claude outer lifecycle은 hook이 소유한다. `/impl-loop` headless outer lifecycle은 implementation chain이 provider fork 전 `step_started`, worker wrapper가 최종 prose의 `step_completed`를 각각 정확히 한 번 소유한다.
 - `phases/<RUN_ID>/` 같은 별도 worktree 경로를 만들거나 보고하지 않는다.
 - `build-test.md`, `build-impl.md`, `build-validate.md`를 쓴 뒤 `ls <run_dir>/build-test.md <run_dir>/build-impl.md <run_dir>/build-validate.md`로 3개 실존을 확인한다.
 - impl-validator finding 대응 등 별도 polish 기록이 필요하면 `build-polish.md`도 같은 `<run_dir>`에만 쓴다. 이 파일은 선택 기록이며 clean 게이트의 필수 3개에는 포함하지 않는다.
-- 하나라도 없으면 PASS를 내지 말고 즉시 재기록하거나 `TESTS_FAIL`/`IMPLEMENTATION_ESCALATE`로 보고한다.
+- 하나라도 없으면 PASS를 내지 말고 즉시 재기록하거나 `TESTS_FAIL`/`IMPLEMENTATION_ESCALATE`로 보고한다. chain-owned 실행은 wrapper도 PASS terminal receipt 전에 같은 세 파일을 검사하고 `phase_evidence`로 차단한다. source read/edit 전 환경 미충족을 보고하는 `IMPLEMENTATION_ESCALATE` 같은 non-PASS receipt에는 이 clean 게이트를 적용하지 않는다.
 
 ## 로컬 커밋 소유
 
@@ -118,7 +120,7 @@
 - 핵심 AC별 동작 증거와 mock/stub/fake 사용 경계가 보고된다. TypeScript 등 정적 타입검사가 의미 있는 stack 에서 typecheck/compile 이 빠졌다면 품질 게이트 warning 또는 보강 필요성을 쓴다.
 - task 가 담당하는 target GitHub issue AC 와 impl task REQ 의 대응, 각 항목의 실행·관찰 증거가 보고된다. `(TEST)`/`(AGENT READ)`로 닫는 항목은 어느 하나라도 이 task 범위에서 충족되지 않았으면 PASS 하지 않는다. task 구현 mode의 `(JOURNEY)` REQ는 PASS 블로커에서 제외하되, flow 대본·journey 매니페스트·필요한 setup/teardown/상태전이 스크립트와 환경·배관 선언을 모두 작성하고 final tip 수렴 및 acceptance 인계를 보고한 경우에만 예외다.
 - 담당 `(JOURNEY)` REQ마다 flow 대본과 `.dcness/` 밖 journey 매니페스트가 작성됐고 수렴 대상이면 `JOURNEY_CONVERGENCE`와 sealed acceptance 실행에 인계됐다. `journey_deferred`이면 현재 run의 수렴·sealed 실행 비대상과 human verification/follow-up 인계를 보고한다. 메인이 대신 실행하는 `VALIDATION_BLOCKED` 경로와 다르며, 최종 clean에는 수렴 대상 journey의 별도 PASS가 필요하다.
-- `JOURNEY_ENV_PREFLIGHT`는 ready 또는 검출 불확실 진행 근거를 보고했거나, 확실한 미충족·자동 준비 불가를 `IMPLEMENTATION_ESCALATE`로 보고했다. `JOURNEY_CONVERGENCE` PASS면 final tip 실행 결과, iteration별 실패 서명·수정·진행 여부, 최종 commit sha가 남는다.
+- 자동 journey가 있으면 내부 `JOURNEY_ENV_PREFLIGHT`가 ready 또는 검출 불확실 진행 근거를 보고했거나, 확실한 미충족·자동 준비 불가를 `IMPLEMENTATION_ESCALATE`로 보고했다. `JOURNEY_CONVERGENCE` PASS면 final tip 실행 결과, iteration별 실패 서명·수정·진행 여부, 최종 commit sha가 남는다.
 - 확정 목업이 있는 UI 작업에서는 디자인 정합(레이아웃 계층·상태·토큰 대응)과 의도적 차이가 보고된다.
 - design:required UI 작업에서는 node-id 매핑과 별개로 `docs/design.md` 토큰 적용 결과, 잔존 스캐폴딩 색 상수 여부, boilerplate 테마 잔존 금지 확인 결과가 보고된다.
 - PR 본문 초안에 close keyword가 불확실하면 메인 검토 요청을 남긴다.
@@ -140,7 +142,7 @@
 
 ## 결론과 보고
 
-마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `VALIDATION_BLOCKED`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `PASS` 포함 모든 구현 결과에는 Cartography impact의 의미 축과 refresh 필요 여부를 자유 prose로 남긴다. `JOURNEY_ENV_PREFLIGHT` PASS에는 ready/자동 준비 완료/검출 불확실 진행 중 하나와 probe 근거를, `JOURNEY_CONVERGENCE` 결과에는 iteration·실패 서명·수정·commit 증거를 포함한다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다. `VALIDATION_BLOCKED`에는 메인이 대신 실행할 검증 명령 목록을 함께 쓰되, worker substrate 부재는 host 대행으로 우회하지 않는다.
+마지막 단락에 `PASS`, `SPEC_GAP_FOUND`, `TESTS_FAIL`, `VALIDATION_BLOCKED`, `IMPLEMENTATION_ESCALATE` 중 하나를 쓴다. `PASS` 포함 모든 구현 결과에는 Cartography impact의 의미 축과 refresh 필요 여부를 자유 prose로 남긴다. 자동 journey가 있으면 내부 `JOURNEY_ENV_PREFLIGHT`의 ready/자동 준비 완료/검출불확실 진행 중 하나와 probe 근거를 같은 task 결과에 포함하고, `JOURNEY_CONVERGENCE` 결과에는 iteration·실패 서명·수정·commit 증거를 포함한다. `SPEC_GAP_FOUND`에는 small, medium, large 중 분량 메타를 함께 쓴다. `VALIDATION_BLOCKED`에는 메인이 대신 실행할 검증 명령 목록을 함께 쓰되, worker substrate 부재는 host 대행으로 우회하지 않는다.
 
 ## 템플릿과 참고 문서
 

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -63,13 +63,13 @@ echo "[<entry>] run started: $RUN_ID"
 
 `--acceptance-required` — story/epic 마감 task 처럼 `impl-validator` 뒤 inline `product-acceptance` 를 거쳐야 run 이 정상 종료되는 경우에만 기록한다. Stop hook 은 이 marker 가 있는 `entry_point=impl` run 에서 `impl-validator` 를 종료 agent 로 취급하지 않고 product-acceptance 진입 turn 을 재발화한다. 중간 task / `--no-acceptance` run / verify-only run 은 이 플래그를 주지 않는다. chain 의 다음 task 진입은 `next-task --acceptance-required` 로 동일 기록한다.
 
-> `/impl-loop` 의 **chain 모드(N task)** 는 자기 run 을 갖지 않는 driver 다 — `impl-task-loop × N` 이므로 각 task 가 독립 `begin-run impl` … `end-run` run 1개씩 (N task = N run = N review.md). **single 모드(1 task)** 는 `impl` entry_point 로 run 1개. 자세히 = [`/impl-loop`](../../skills/impl-loop/SKILL.md).
+> `/impl-loop` driver 자체는 run을 갖지 않는다. single/chain 모두 implementation chain이 task마다 독립 `begin-run impl`과 terminal receipt를 만들며, merge candidate `impl-validator` 통합 review는 모든 target task가 completed 된 뒤 1회 수행한다. 자세한 시작은 [`/impl-loop`](../../skills/impl-loop/SKILL.md), 마감은 [`impl-loop-finish.md`](../../skills/impl-loop/impl-loop-finish.md)가 소유한다.
 
 ---
 
 ## Step 1 — TaskCreate
 
-해당 skill 의 `## Loop` 의 `task_list` 필드대로 일괄 등록. **단 `/impl-loop` chain 모드 아래의 `impl` run 은 TaskCreate skip** — task 리스트는 impl-loop skill 이 진행 뷰로 일괄 관리한다 ([진행 뷰](../../skills/impl-loop/SKILL.md#진행-뷰-task-리스트)). impl run 은 이미 생성된 sub-step task 를 TaskUpdate 만 한다.
+해당 skill 의 `## Loop` 의 `task_list` 필드대로 일괄 등록한다. **단 `/impl-loop`는 이 절을 적용하지 않는다.** story runner state와 implementation chain의 lifecycle receipt가 진행 진본이므로 worker 시작 전에 `TaskCreate`/`TaskUpdate`를 만들지 않는다.
 
 ```
 TaskCreate("<agent>: <mode 또는 짧은 설명>")
@@ -99,7 +99,7 @@ Agent tool input을 만들기 **전** [`agent-prompt-slots.md`](templates/agent-
 
 active run(`entry_point=design|impl|ux`)의 mode 없는 foreground Claude Agent는 PreToolUse가 순서/호출 적합성을 검사하고 correlation intent만 둔다. sibling PreToolUse hook이 deny하면 `SubagentStart`가 발화하지 않으므로 `step_started`도 없다. 실제 spawn 뒤 `SubagentStart`가 `tool_use_id`와 `agent_id`를 current step에 묶고, `PostToolUse Agent`는 `status=completed`인 비어 있지 않은 최종 prose만 `<run_dir>/<agent>.md`에 저장해 `step_completed` receipt를 만든다. `async_launched`, Agent 실패, 빈 prose는 `step_completed`를 만들지 않으며 시작된 foreground step은 `step_aborted` 진단으로 닫힌다. 같은 lifecycle payload 재전달은 멱등이고 identity가 current step과 다르면 prose/receipt append 전에 거부한다.
 
-modeful Claude Agent는 공개 Agent tool field로 mode를 안정 전달할 수 없으므로 Agent 호출 전에 `begin-step <agent> <mode>`를 명시한다. `SubagentStart`가 그 step에 spawn identity를 bind하고 성공 `PostToolUse`가 완료를 기록하므로 메인의 별도 `end-step`은 없다. Codex/Claude headless wrapper는 기존처럼 자기 경로의 `begin-step`/`end-step` 소유권을 유지한다.
+modeful Claude Agent는 공개 Agent tool field로 mode를 안정 전달할 수 없으므로 Agent 호출 전에 `begin-step <agent> <mode>`를 명시한다. `SubagentStart`가 그 step에 spawn identity를 bind하고 성공 `PostToolUse`가 완료를 기록하므로 메인의 별도 `end-step`은 없다. `/impl-loop` headless build-worker는 implementation chain이 provider fork 전에 `begin-step`을 정확히 한 번 기록하고 worker wrapper가 성공 `end-step`을 기록한다. 메인이 둘 중 어느 것도 선행 호출하지 않는다.
 
 이 순서 검사는 `entry_point=design|impl|ux` 에 공통이다. 정상 `/design` 은 `begin-run design` 로 시작하며 같은 lifecycle 검사를 탄다.
 
@@ -126,7 +126,7 @@ fi
 
 Codex wrapper 는 설치된 `dcness-<agent>/SKILL.md` 내용을 prompt 에 직접 포함한 뒤 `codex exec -C "$PROJECT_ROOT" -s read-only` 로 실행한다. 마지막 응답은 `/tmp` prose 파일에 받은 뒤 `dcness-helper end-step <agent> --provider codex-headless --prose-file ...` 로 저장한다. 따라서 Codex 분기 경로에서는 메인이 별도 `end-step` 을 한 번 더 부르지 않는다. Claude Agent의 완료는 PostToolUse lifecycle hook이, Codex wrapper의 완료는 wrapper가 소유하며 둘 다 메인이 prose를 읽어 집계한다. wrapper가 end-step까지 수행해도 counter 소유자는 메인이다. `DCNESS_CODEX_MODEL` 을 설정하면 wrapper 가 `-m` 모델 override 를, `DCNESS_CODEX_EFFORT` 를 설정하면 `-c model_reasoning_effort=...` override 를 전달한다. 둘 다 미설정이면 사용자 Codex config 를 그대로 상속하며, dcNess 는 특정 Codex 모델명을 하드코딩하지 않는다. 분기 config 파일명은 `routing.json` 이고 repo 파일이 아니라 `~/.claude/plugins/data/dcness-dcness/routing.json` 에 있으며, validation 비활성/미설정 기본값은 Claude 다.
 
-**implementation provider 분기 (headless-chain 기본)**: `build-worker` 는 호출 직전 provider 를 resolve 한다.
+**implementation provider 분기 (headless-chain 기본)**: `/impl-loop` 메인은 provider resolve·state init·previous-task reset·run/step lifecycle을 각각 호출하지 않는다. feature worktree에서 implementation chain 한 호출이 순서대로 소유한다.
 
 ```bash
 PLUGIN_ROOT=""
@@ -136,33 +136,18 @@ else
   PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
 fi
 [ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
-HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
-
-PROVIDER=$("$HELPER" routing resolve <agent>)
-if [ "$PROVIDER" = "claude" ]; then
-  # mode가 있으면 Agent 전에 "$HELPER" begin-step <agent> <MODE>
-  Agent(subagent_type="<agent>", ...)
-else
-  rc=0
-  # /impl-loop는 이 Bash tool 호출을 run_in_background=true로 발행하고
-  # workspace/raw log 진행을 polling한다.
-  "$PLUGIN_ROOT/scripts/dcness-implementation-chain" <agent> [MODE] \
-    --provider "$PROVIDER" \
-    --provider-provenance routing \
-    --chain-state .dcness-work/story-run.json \
-    --prompt-file "$PROMPT_FILE" || rc=$?
-  if [ "$rc" -eq 75 ]; then
-    # mode가 있으면 Agent 전에 "$HELPER" begin-step <agent> <MODE>
-    Agent(subagent_type="<agent>", ...)
-  elif [ "$rc" -ne 0 ]; then
-    exit "$rc"
-  fi
-fi
+"$PLUGIN_ROOT/scripts/dcness-implementation-chain" build-worker \
+  --chain-state .dcness-work/story-run.json \
+  --init-path <impl-task-1> \
+  --init-path <impl-task-N> \
+  --prompt-file "$PROMPT_FILE"
 ```
 
-`dcness-implementation-chain` 은 `headless-chain`(Codex headless → Claude headless → Claude main), `claude-headless`, `claude` 를 같은 routing config 로 실행한다. Headless wrapper 가 성공하면 마지막 응답을 저장하고 `end-step` 까지 수행한다. Codex headless worker 도 `DCNESS_CODEX_MODEL` / `DCNESS_CODEX_EFFORT` 가 설정된 경우에만 같은 override 를 전달하고, 미설정 시 사용자 Codex config 를 상속한다. workspace 변경 전 실패한 경우에만 다음 provider 로 넘어간다. workspace/HEAD 변경 뒤 `timeout`·`idle_timeout`·`empty_output`·`boundary_violation`·`tdd_guard`는 기존 diff를 보존하고 같은 provider/같은 workspace에서 기본 2회 bounded continuation하며 mutation-time guard를 다시 실행한다. 단, failure receipt에 `permission_required`가 함께 있으면 같은 권한으로 반복해도 해결되지 않으므로 첫 실패에서 사용자 승인 경로로 멈춘다. 복구 불가 category나 한도 소진은 자동 폴백·revert 없이 중단한다. 기본 total/idle timeout은 두 headless worker 모두 3000초/900초이며 호출 자체는 background로 실행해 foreground Bash timeout과 분리한다. chain 이 Claude main 에 도달하면 `FALLBACK_TO_CLAUDE_MAIN` 과 exit 75 를 반환하므로 메인이 기존 Agent 경로를 실행하고 성공 receipt는 PostToolUse lifecycle hook이 `provider=claude-main`으로 기록한다. raw headless session log 는 run 디렉터리의 `headless-logs/` 파일로 보존한다. 단, `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 와 active run scan 이 모두 실패하면 wrapper 는 telemetry 미귀속 상태를 경고하고 provider 실행을 계속하며, raw log 와 최종 prose 를 `.dcness-work/headless-logs/unattributed/` 에 남긴다. 이 degraded 경로에서는 `end-step` 기록 실패가 provider exit code 를 덮지 않는다. Claude headless wrapper 는 자식 `claude -p` 실행 전 부모 세션 식별 env 를 제거하되, `DCNESS_SESSION_ID` / `DCNESS_RUN_ID` 는 유지해 run 기록을 이어간다. Headless build-worker 가 `VALIDATION_BLOCKED` 를 보고하면 `ledger.jsonl` 에 `blocked` event 와 `category=headless_validation_blocked` 가 추가로 남으므로, 검증 명령 권한 문제 빈도는 `run-review` 또는 ledger 조회로 확인한다. Codex raw log가 좁은 sandbox 거부 signature와 일치하면 wrapper가 post-run boundary/TDD guard보다 먼저 `permission_required` receipt와 ledger evidence를 생성한다. guard도 실패한 경우 primary guard category와 permission receipt를 모두 보존한다. 이 경우 다음 호출 판단은 [`impl-loop-routing.md`](../../skills/impl-loop/impl-loop-routing.md)의 사용자 승인·Codex 1회 제한 재시도 경로를 따르며, 일반 메인 검증 대행이나 provider fallback으로 우회하지 않는다.
+`dcness-implementation-chain` 은 worktree/default-branch 검사를 state mutation보다 먼저 수행하고, story state·previous tasks·현재 task run·`step_started`를 한 번만 준비한 뒤 provider를 fork한다. wrapper는 `.dcness/tdd-hooks.json`을 scan 없이 prompt 계약으로 변환하고 canonical primary run directory 및 phase prose 절대경로를 주입한다. Codex에는 그 exact run directory만 추가 writable root로 연다. PASS 전 wrapper가 phase prose 3개, task boundary, post-run TDD guard를 검사한다. source mutation 전 환경 미충족 같은 routed non-PASS 결론은 phase prose clean 게이트로 재시도하지 않고 원래 terminal receipt를 보존한다.
 
-`/impl-loop`는 task 1개 single 모드도 `dcness-story-runner init`으로 one-task state를 만들고, single/chain 모드 모두 `--chain-state`를 넘겨 provider capability cache를 활성화한다. story-runner state의 `chain_id`가 수명 진본이며 cache sidecar는 같은 state 디렉터리의 `provider-failure-cache/<chain_id>.json`이다. 새 chain/reinit은 새 `chain_id`를 받고, 완료 chain은 cache를 소비하지 않으며 archive/force init 시 기존 sidecar를 무효화한다. state의 `project_root`가 현재 project/worktree와 다르면 실행을 거부한다. `/impl-loop`가 아닌 single `/impl`과 다른 project/worktree는 cache를 공유하지 않는다. sidecar update는 file lock과 atomic replace를 사용해 같은 chain의 동시 접근에도 JSON을 손상시키지 않는다.
+chain은 `headless-chain`(Codex headless → Claude headless → Claude main), `claude-headless`, `claude` 를 같은 routing config 로 실행한다. workspace 변경 전 실패만 다음 provider로 넘어간다. workspace/HEAD 변경 뒤 `timeout`·`idle_timeout`·`empty_output`·`boundary_violation`·`tdd_guard`·`phase_evidence`는 기존 diff를 보존하고 같은 provider/같은 workspace에서 기본 2회 bounded continuation한다. permission receipt가 있으면 첫 실패에서 사용자 승인 경로로 멈춘다. 복구 불가 category나 한도 소진은 자동 폴백·revert 없이 중단한다.
+
+`/impl-loop`는 single/chain 모두 implementation chain에 `--chain-state`와 전체 `--init-path`를 넘긴다. chain이 missing state를 story runner로 한 번 초기화하고, 같은 task 목록·project root 재호출은 기존 state를 재사용한다. state의 `chain_id`가 수명 진본이며 cache sidecar는 같은 state 디렉터리의 `provider-failure-cache/<chain_id>.json`이다. 완료 chain은 cache를 소비하지 않으며 archive/force init 시 기존 sidecar를 무효화한다. state의 `project_root`가 현재 project/worktree와 다르면 provider fork 전에 거부한다.
 
 worker가 `DCNESS_PROVIDER_FAILURE_FILE` 내부 JSON으로 전달하는 failure category 중 `cli_missing`, `auth_unavailable`, `config_unavailable`만 같은 chain에서 재시도 가치가 없는 cacheable capability 실패다. `timeout`, `idle_timeout`, `empty_output`, `boundary_violation`, `tdd_guard`, `interrupt`, `network_transient`, 그 밖의 `provider_error`와 agent의 구현/검증 결론은 cache하지 않는다. chain은 workspace/HEAD 불변을 다시 확인한 뒤에만 cache를 기록한다. cache hit 진단에는 provider, category, 최초 실패 `first_raw_log`, `scope=chain:<chain_id>`와 현재 skip log가 남는다.
 
@@ -172,7 +157,7 @@ worker가 `DCNESS_PROVIDER_FAILURE_FILE` 내부 JSON으로 전달하는 failure 
 
 **MUST.** 호출 직전 해당 `agent.md` 의 "입력" / "호출자가 prompt 로 전달하는 정보" 항목 read 후 prompt 작성 (형식 자유, 정보 명시 의무). prompt 에는 **(1) 읽을 SSOT 문서 포인터 (agent 가 자체 read 할 경로) (2) 대상 단위 (어떤 task / Story / 모듈) (3) 그 호출에 특유한 제약·주의 (4) 산출 경로·번호 규약·write 경계** 만 담는다.
 
-**호출 직전 self-check (#780).** `/impl`·`/impl-loop`·`/design`·`/ux` action loop는 Agent tool input을 쓰기 전에 정적 템플릿을 직접 읽고 아래 3가지를 확인한다. (a) 대상+읽을 진본이 슬롯 1에 있는가, (b) 슬롯 2가 동적 lifecycle context와 충돌하지 않는가, (c) 슬롯 3이 방법 처방이 아니라 이 호출 특유의 미기록 제약·신호만 담는가. 코드 hook은 prompt 내용을 판정하거나 차단하지 않는다.
+**호출 직전 self-check (#780).** `/impl`·`/design`·`/ux` action loop가 Agent tool input을 쓸 때와 `/impl-loop`가 GREEN 이후 validator/acceptance Agent를 호출할 때 정적 템플릿을 읽고 아래 3가지를 확인한다. worker 시작 prompt는 `/impl-loop`의 slim prompt 계약이 소유하므로 이 후기 템플릿을 preflight로 읽지 않는다. (a) 대상+읽을 진본이 슬롯 1에 있는가, (b) 슬롯 2가 동적 lifecycle context와 충돌하지 않는가, (c) 슬롯 3이 방법 처방이 아니라 이 호출 특유의 미기록 제약·신호만 담는가. 코드 hook은 prompt 내용을 판정하거나 차단하지 않는다.
 
 - ❌ **이미 SSOT 문서에 기록된 결정의 사본을 prompt 에 재기입 금지** — 합의 스택·계약·설계 결정은 agent 가 자기 "먼저 읽을 문서" 규약대로 SSOT 문서를 직접 읽어 획득한다. 같은 결정이 prompt 와 문서 두 곳에 살면 진본이 둘이 되어, 한쪽만 갱신될 때 어느 쪽이 맞는지 모르는 drift 가 생긴다 (dcNess 가 본래 막으려는 사본 drift 를 절차 자신이 유발).
 - ❌ **agent 본업을 "뭐뭐 해라"로 절차 재지시 금지** — 판단 축·작업 흐름·완료 기준은 각 `agent.md` 가 소유한다. 메인은 컨텍스트·제약·사실관계만 넘기고 *어떻게 할지* 는 agent 가 정한다 (아래 [finding 수용 원칙](#finding-수용-원칙-점-패치-금지-근본-수정) 의 relay 와 동형 — "해법 메커니즘은 메인이 처방하지 말 것").
@@ -186,7 +171,7 @@ worker가 `DCNESS_PROVIDER_FAILURE_FILE` 내부 JSON으로 전달하는 failure 
 - 슬롯 1 ↔ 4요소 (1)(2)(4), 슬롯 2 ↔ worktree MUST(아래), 슬롯 3 ↔ 4요소 (3) + 미기록 결정 예외. 4요소를 줄인 게 아니라 *담는 칸* 을 고정한 것이다.
 - `이 호출 특유` 칸이 방법 처방을 막는 가드다 — 채울 게 없으면 비우고, 채워도 "무엇" 까지만 적는다.
 - **진본 충실 시 수렴**: module-architect 산출물(impl task 파일)이 인터페이스·수용기준 통과조건·테스트 스켈레톤·Scope 까지 담으면, 호출은 포인터+worktree(+미기록 사실 한 줄)로 수렴한다. agent 본업(RED·lint·결론 형식)이나 진본 사본(AC 통과조건·Scope·인터페이스 시그니처)을 prompt 에 다시 적으면 슬림 포인터 규약 위반이다 — 진본이 진본임을 prompt 가 명시하면서 그 사본을 욱여넣는 자기모순.
-- direct 기본 경로(메인 직접 구현)는 sub-agent 호출 자체가 없어 본 슬롯 대상이 아니다. 슬롯이 적용되는 곳은 *sub-agent 에 prompt 가 나가는* 경로다 (`/impl-loop` build-worker · design 의 설계 agent 호출).
+- direct 기본 경로(메인 직접 구현)는 sub-agent 호출 자체가 없어 본 슬롯 대상이 아니다. 슬롯이 적용되는 곳은 *sub-agent 에 prompt 가 나가는* 경로다. `/impl-loop` build-worker 시작은 별도 slim prompt 계약이고, 본 슬롯은 GREEN 이후 validator/acceptance 호출에 적용된다.
 
 **worktree 활성 시 worktree 절대 경로 전달 — MUST**: foreground Claude Agent는 SubagentStart hook, headless worker는 wrapper가 worktree 절대경로를 첫 prompt에 직접 넣는다. main repo abs path 사용 금지 — 머지 전 옛 코드 read 로 false positive가 난다. hook/wrapper가 동적 경로를 전달하므로 메인이 Bash stdout을 다시 prompt로 relay하지 않는다.
 
@@ -205,7 +190,7 @@ worker가 `DCNESS_PROVIDER_FAILURE_FILE` 내부 JSON으로 전달하는 failure 
 평가: PASS / REDO_SAME / REDO_BACK / REDO_DIFF — <사유>
 ```
 
-- `<task-id>` = step 이름 (`/impl-loop` chain 모드 아래선 진행 뷰 sub-step task — [진행 뷰](../../skills/impl-loop/SKILL.md#진행-뷰-task-리스트))
+- `<task-id>` = step 이름. `/impl-loop` build-worker는 Task UI가 아니라 story runner state와 ledger receipt를 사용한다.
 - `▎` 글자 (U+258E) 그대로 — 사용자 인식 패턴
 - 5줄 미만 / 12줄 초과 = 룰 위반
 
@@ -262,15 +247,15 @@ REDO 판단 신호: 결과가 질문에 제대로 답하지 못함 / 같은 tool
 | impl-validator 재리뷰 | `begin-step impl-validator retry` | `impl-validator-retry.md` |
 | `/design` epic batch | `begin-step module-architect epic-batch` | `module-architect-epic-batch.md` |
 
-headless/wrapper 재호출은 별도 begin/end-step 1쌍이 필요하다. Claude Agent 재호출은 mode가 있을 때만 명시적 begin-step을 다시 열고, mode 없는 foreground 경로는 lifecycle hook이 occurrence를 관리한다. `--prose-file` 명시적 전달은 wrapper/helper override로 허용한다.
+headless wrapper의 동일-provider bounded recovery는 같은 active outer step 안에서 이어지고, 최종 성공 wrapper가 대응 `end-step`을 한 번 기록한다. terminal 실패 뒤 별도 rework launch를 열 때만 implementation chain이 새 outer `begin-step`을 만든다. 메인은 어느 경우에도 lifecycle 호출을 추가하지 않는다. Claude Agent 재호출은 mode가 있을 때만 명시적 begin-step을 다시 열고, mode 없는 foreground 경로는 lifecycle hook이 occurrence를 관리한다. `--prose-file` 명시적 전달은 wrapper/helper override로 허용한다.
 
 **안티패턴** (begin/end-step 쌍 누락): ❌ build-worker local commit 후 git status 확인 → end-step skip / ❌ FAIL 후 build-worker rework 호출 시 begin/end-step 미포함 / ❌ end-step 보류 중 다음 step 진입으로 망각 / ❌ task 간 보고 작성 후 begin-step 재호출 누락.
 
 ### build-worker phase prose (`/impl-loop` Hybrid A 한정)
 
-build-worker 는 한 sub-agent 호출(= 메인 outer step) 안에서 3 phase (test → impl → validate) 를 직렬 진행하며 phase prose (`build-test.md` / `build-impl.md` / `build-validate.md`) 를 *자체 Write* 한다. phase prose는 inner 작업 증거이지 outer Agent lifecycle receipt가 아니다. worker가 phase마다 outer `begin-step`/`end-step`을 다시 호출하거나 phase prose를 outer completion으로 append하면 중복 기록이다. outer Claude Agent는 SubagentStart/PostToolUse가 1쌍으로 기록하고, headless worker는 wrapper가 outer begin/end-step 1쌍을 소유한다. phase 분할·각 phase 책임·검증 항목 풀스펙 = [`agents/build-worker.md`](../../agents/build-worker.md) + [`skills/impl-loop/SKILL.md`](../../skills/impl-loop/SKILL.md).
+build-worker 는 한 sub-agent 호출(= 메인 outer step) 안에서 3 phase (test → impl → validate) 를 직렬 진행하며 phase prose (`build-test.md` / `build-impl.md` / `build-validate.md`) 를 *자체 Write* 한다. phase prose는 inner 작업 증거이지 outer Agent lifecycle receipt가 아니다. worker가 phase마다 outer `begin-step`/`end-step`을 다시 호출하거나 phase prose를 outer completion으로 append하면 중복 기록이다. outer Claude Agent는 SubagentStart/PostToolUse가 1쌍으로 기록하고, headless worker는 chain `step_started` + wrapper `step_completed` 한 쌍으로 기록한다. phase 분할·각 phase 책임·검증 항목 풀스펙은 [`build-worker-agent.md`](agents/build-worker/build-worker-agent.md)가 소유한다.
 
-phase prose 실제 기록 디렉토리 = `dcness-helper run-dir` 이 출력하는 harness-state run_dir (`.claude/harness-state/.sessions/<sid>/runs/<run-id>`). worktree 안 `phases/<RUN_ID>/` 는 현행 규약이 아니다. build-worker 는 phase prose 3개를 쓴 뒤 `ls <run_dir>/build-test.md <run_dir>/build-impl.md <run_dir>/build-validate.md` 로 실존을 확인하고, 부재 시 PASS 를 내지 않는다.
+phase prose 실제 기록 디렉토리 = wrapper가 prompt에 주입하는 canonical absolute run directory (`.claude/harness-state/.sessions/<sid>/runs/<run-id>`). linked worktree 안에서 같은 상대경로를 다시 계산하거나 `phases/<RUN_ID>/`를 만들지 않는다. build-worker 는 PASS 전에 phase prose 3개를 쓴 뒤 실존을 확인하고, chain-owned wrapper도 PASS terminal receipt 전에 다시 검사한다.
 
 선택적 polish/retry 기록이 필요하면 `build-polish.md` 도 같은 run_dir 에만 둔다. clean 게이트가 요구하는 필수 phase prose 는 `build-test.md` / `build-impl.md` / `build-validate.md` 3개다.
 
@@ -302,9 +287,9 @@ Claude Agent 와 Codex wrapper 모두 메인이 집계한다. Codex wrapper 는 
 
 ```
 TaskUpdate(<기존 task>, in_progress)   # 신규 TaskCreate 금지
-"$HELPER" begin-step <agent> <mode>    # modeful Claude/headless만 명시
+"$HELPER" begin-step <agent> <mode>    # modeful Claude만 메인이 명시
 Agent(...)                              # mode 없음: begin/end 모두 lifecycle hook 소유
-# headless wrapper만 end-step, foreground Claude Agent는 PostToolUse가 완료
+# headless는 chain begin + wrapper end, foreground Claude Agent는 PostToolUse가 완료
 TaskUpdate(<기존 task>, completed)
 ```
 
@@ -475,7 +460,7 @@ review 리포트의 must-fix / waste finding / per-Agent metric 즉시 인지 + 
 
 **자동 기록 event** (코드 경로):
 - `run_started` (begin-run) — entry_point / issue_num / design_doc(기록 시)
-- `step_started` (SubagentStart 또는 wrapper `begin-step`) — agent / mode + Claude Agent면 tool_use_id / agent_id
+- `step_started` (SubagentStart 또는 implementation chain `begin-step`) — agent / mode + Claude Agent면 tool_use_id / agent_id
 - `step_aborted` (PostToolUseFailure·빈 prose·비완료 상태 복구) — false completion 없이 시작된 step을 닫는 진단 event
 - `step_completed` (성공 PostToolUse 또는 wrapper `end-step`) — = **receipt**: agent / mode / enum / prose_excerpt / must_fix / prose_file / sha256 / evidence_paths / next_action(hint), Claude Agent면 tool_use_id / agent_id
 - `run_finished` (end-run)

--- a/evals/impl-fast-start-metadata.json
+++ b/evals/impl-fast-start-metadata.json
@@ -1,0 +1,154 @@
+{
+  "schema_version": 1,
+  "issue": 1190,
+  "measured_at": "2026-07-24",
+  "source_project": "Daeguk-Sun/alrimjang",
+  "runtime": {
+    "claude_code": "2.1.215",
+    "model": "claude-sonnet-5",
+    "effort": "medium",
+    "provider": "claude-main"
+  },
+  "fixture": {
+    "id": "alrimjang-fast-start-probe",
+    "ab_commit": "fc092581f121faa391bbee354df4be0f8232bb04",
+    "loop_commit": "6f35f3d3eaa669c54ddf729fcf0b248bd31ee822",
+    "contract_sha256": "78df5e03e1f9b4e812aa2722c77dbee3b6674edf81e6aa9304d52f873577628d",
+    "product_ac": "The first RED test asserts outer trim plus collapsed internal whitespace."
+  },
+  "impl_main_direct": [
+    {
+      "session_id": "34c930f7-307f-4572-91d3-16ffbf3c1c34",
+      "trace_sha256": "9115a26bf763730f837538ada15eb615787941016f0eedbc11328829ba8b623e",
+      "time_to_first_edit_seconds": 9.964,
+      "blocking_assistant_requests": 2,
+      "all_total_input_tokens": 175125,
+      "all_output_tokens": 696,
+      "product_ac_passed": true
+    },
+    {
+      "session_id": "768c1a54-ebc0-4d3c-8e9a-7981ad129731",
+      "trace_sha256": "3c5e21a573c4099ecac139b92f11ca2260a1ef46bef3bbaa9a4d6f194d8e7245",
+      "time_to_first_edit_seconds": 12.616,
+      "blocking_assistant_requests": 2,
+      "all_total_input_tokens": 175400,
+      "all_output_tokens": 677,
+      "product_ac_passed": true
+    },
+    {
+      "session_id": "fc0b16d3-7037-494b-8f32-b74154433386",
+      "trace_sha256": "fe0f6da791ad46d96e4d0f5365c2fc59efbd6a272857805c2135a07783f190bd",
+      "time_to_first_edit_seconds": 8.627,
+      "blocking_assistant_requests": 2,
+      "all_total_input_tokens": 175078,
+      "all_output_tokens": 715,
+      "product_ac_passed": true
+    }
+  ],
+  "impl_fresh_executor": {
+    "prompt_fields": [
+      "target",
+      "confirmed_choice",
+      "scope",
+      "test",
+      "ssot_pointer"
+    ],
+    "excluded_prompt_context": [
+      "past_transcript",
+      "review_procedure",
+      "close_procedure"
+    ],
+    "trials": [
+      {
+        "session_id": "213280ca-b64c-43f8-94f3-e7d6d7096cc9",
+        "trace_sha256": "6a75354fac7b6c0bc1686f2bc6556c007307f874ce1f990507c91e63f6850dca",
+        "time_to_first_edit_seconds": 17.527,
+        "blocking_assistant_requests": 2,
+        "all_total_input_tokens": 221690,
+        "all_output_tokens": 170,
+        "product_ac_passed": true
+      },
+      {
+        "session_id": "7c84c41a-2735-495e-9065-1119814c6a73",
+        "trace_sha256": "70a237b165d8413d4f694af35b6765e7b7dfa1c3d4ced0c1d1132c06b6ea247a",
+        "time_to_first_edit_seconds": 18.513,
+        "blocking_assistant_requests": 1,
+        "all_total_input_tokens": 154086,
+        "all_output_tokens": 744,
+        "product_ac_passed": true
+      },
+      {
+        "session_id": "9b460da8-5866-45ef-bb22-b817e8d2eff7",
+        "trace_sha256": "27235bd9ad57f52babd9a3c45a71de81f1a3c56c73e56886dde394ed0f650d02",
+        "time_to_first_edit_seconds": 18.272,
+        "blocking_assistant_requests": 2,
+        "all_total_input_tokens": 219431,
+        "all_output_tokens": 130,
+        "product_ac_passed": true
+      }
+    ]
+  },
+  "ab_decision": {
+    "main_direct_median_first_edit_seconds": 9.964,
+    "fresh_executor_median_first_edit_seconds": 18.272,
+    "quality_regressed": false,
+    "default": "main-direct",
+    "conditional_fresh_executor": false,
+    "reason": "Fresh execution was accurate but slower and used more median all-executor input."
+  },
+  "impl_loop_real_forks": [
+    {
+      "session_id": "1eded949-7d58-4d2a-bd23-c0c6d7229514",
+      "run_id": "run-2584b584",
+      "trace_sha256": "753c3987d238b7378cd0e719caedcf777acdecf89c573e976acd4fdd99227433",
+      "request_start": "2026-07-24T03:22:52.442000+00:00",
+      "step_started": "2026-07-24T03:23:03+00:00",
+      "log_birth": "2026-07-24T03:23:03.996685+00:00",
+      "process_fork": "2026-07-24T03:23:03.997939+00:00",
+      "seconds_to_fork": 11.556,
+      "provider_pid": 12655,
+      "provider_log_sha256": "274caacbec974ce4b176cc6c87d6f192fe6243ba90c1ca1ba7ba42697d74fbb4"
+    },
+    {
+      "session_id": "448774a3-e818-4add-b989-54db0f217cbe",
+      "run_id": "run-180b6c44",
+      "trace_sha256": "5c140a5c6fbc8f71e4f42eead2c09c927782f3bb70ea3196e55350d8bbc11bec",
+      "request_start": "2026-07-24T03:23:43.094000+00:00",
+      "step_started": "2026-07-24T03:24:00+00:00",
+      "log_birth": "2026-07-24T03:24:01.052070+00:00",
+      "process_fork": "2026-07-24T03:24:01.053597+00:00",
+      "seconds_to_fork": 17.96,
+      "provider_pid": 14276,
+      "provider_log_sha256": "5bd16c274ab850996d8dc78cacc3812a38ff78824cc7849a46ff9ac100eb3b1c"
+    },
+    {
+      "session_id": "ce8081c9-a254-44b9-a39e-9db237d4e301",
+      "run_id": "run-d3d3d3a4",
+      "trace_sha256": "fd9f2a3f1a6ec3fcd18ed7f4728f0fe9381d42dfb8686a58b8807475133cba72",
+      "request_start": "2026-07-24T03:24:20.225000+00:00",
+      "step_started": "2026-07-24T03:24:30+00:00",
+      "log_birth": "2026-07-24T03:24:31.277577+00:00",
+      "process_fork": "2026-07-24T03:24:31.279156+00:00",
+      "seconds_to_fork": 11.054,
+      "provider_pid": 15431,
+      "provider_log_sha256": "fcfdc94f448b3a116839a74aad83d7ab053e813a12a31141c00060c25c758e2a"
+    }
+  ],
+  "terminal_receipt_evidence": {
+    "scope": "isolated integration replay because non-interactive Claude print mode terminates background jobs after returning the launch receipt",
+    "tests": [
+      "tests.test_impl_loop_launch.ImplLoopLaunchTests.test_one_call_initializes_in_worktree_and_starts_step_before_provider",
+      "tests.test_impl_loop_launch.ImplLoopLaunchTests.test_completed_current_run_is_idempotent_without_second_provider_fork",
+      "tests.test_impl_loop_launch.ImplLoopLaunchTests.test_missing_canonical_phase_prose_recovers_without_duplicate_step"
+    ],
+    "required_ledger": [
+      "run_started",
+      "step_started",
+      "step_completed"
+    ]
+  },
+  "measurement": {
+    "tool": "scripts/measure_main_turns.py",
+    "claim_boundary": "Repeated frozen-fixture screening supports only the /impl ownership decision and the measured external /impl-loop fork boundary; it is not provider or model superiority evidence."
+  }
+}

--- a/harness/provider_failure_cache.py
+++ b/harness/provider_failure_cache.py
@@ -31,6 +31,7 @@ NON_CACHEABLE_CATEGORIES = frozenset(
         "empty_output",
         "boundary_violation",
         "tdd_guard",
+        "phase_evidence",
         "interrupt",
         "network_transient",
         "provider_error",

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -259,6 +259,7 @@ def _cli_next_task(args: Any) -> int:
         return 1
 
     entry_point = getattr(args, "entry_point", "impl") or "impl"
+    issue_num = getattr(args, "issue_num", None)
     design_doc = getattr(args, "design_doc", None)
     acceptance_required = bool(getattr(args, "acceptance_required", False))
     if acceptance_required and entry_point != "impl":
@@ -296,7 +297,7 @@ def _cli_next_task(args: Any) -> int:
     try:
         transition(
             sid, "run_started", run_id=new_rid, entry_point=entry_point,
-            issue_num=None, design_doc=design_doc,
+            issue_num=issue_num, design_doc=design_doc,
             acceptance_required=acceptance_required,
         )
     except Exception as exc:
@@ -780,6 +781,7 @@ def _build_arg_parser() -> Any:
         "--design-doc", default=None, dest="design_doc",
         help="다음 task 가 참조하는 머지된 설계 문서 경로 (begin-run --design-doc 동일)",
     )
+    p_nt.add_argument("--issue-num", type=int, default=None)
     p_nt.add_argument(
         "--acceptance-required", action="store_true",
         help="다음 task 가 story/epic 마감 acceptance 대상임을 기록 (#722)",

--- a/harness/story_runner.py
+++ b/harness/story_runner.py
@@ -215,6 +215,9 @@ def build_state(
         "updated_at": _now_iso(),
         "scope": resolved_scope,
         "project_root": str(root),
+        "setup": {
+            "previous_tasks_reset": False,
+        },
         "tasks": tasks,
     }
 
@@ -373,6 +376,15 @@ def next_task(state: dict[str, Any]) -> dict[str, Any] | None:
     if action.get("action") == "task":
         return action.get("task")
     return None
+
+
+def task_requires_acceptance(state: dict[str, Any], ref: str) -> bool:
+    """Return whether *ref* is the final task that hands off to loop acceptance."""
+    tasks = state.get("tasks", [])
+    if not isinstance(tasks, list) or not tasks:
+        return False
+    task = find_task(state, ref)
+    return task is tasks[-1]
 
 
 def next_action(state: dict[str, Any]) -> dict[str, Any]:

--- a/harness/tdd_hooks.py
+++ b/harness/tdd_hooks.py
@@ -295,6 +295,43 @@ def _load_project_contract_config(project_root: Path) -> Optional[dict[str, Any]
     return _normalize_contract_config(config)
 
 
+def format_prompt_guidance(
+    project_root: Path,
+    config_path: Optional[Path] = None,
+) -> str:
+    """Render the generated TDD contract without scanning project sources."""
+    root = project_root.resolve()
+    path = (config_path or root / CONFIG_REL).resolve()
+    if not path.is_file():
+        return ""
+    config = _normalize_contract_config(_read_json(path, strict=True))
+    roots = ", ".join(_string_list(config, "source_roots"))
+    extensions = ", ".join(_string_list(config, "impl_exts"))
+    templates = _string_list(config, TEST_CANDIDATE_TEMPLATES_KEY)
+    globs = _string_list(config, TEST_FILE_GLOBS_KEY)
+    lines = [
+        "Project-local generated TDD guard is active.",
+        f"Implementation scope: source roots [{roots}], extensions [{extensions}].",
+        (
+            "For every implementation file in that scope, create a substantive "
+            "matching test before writing the implementation file."
+        ),
+        (
+            "A broad feature test with a different basename does not satisfy this "
+            "matching test contract."
+        ),
+    ]
+    if templates:
+        lines.append("Configured matching-test templates:")
+        lines.extend(f"- {template}" for template in templates)
+    if globs:
+        lines.append(f"Recognized test-file globs: {', '.join(globs)}")
+    lines.append(
+        f"Use `{TDD_EXEMPT_DISPLAY}` only when a matching test is genuinely inapplicable."
+    )
+    return "\n".join(lines)
+
+
 def _iter_project_files(root: Path, suffixes: tuple[str, ...]) -> Iterable[Path]:
     for path in root.rglob("*"):
         rel_parts = path.relative_to(root).parts
@@ -1315,6 +1352,21 @@ def _cmd_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_guidance(args: argparse.Namespace) -> int:
+    config_path = Path(args.config) if args.config else None
+    try:
+        guidance = format_prompt_guidance(
+            Path(args.project_root),
+            config_path=config_path,
+        )
+    except JsonConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    if guidance:
+        print(guidance)
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="dcness-tdd-hooks",
@@ -1346,6 +1398,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_status.add_argument("--project-root", default=".")
     p_status.add_argument("--json", action="store_true")
     p_status.set_defaults(func=_cmd_status)
+
+    p_guidance = sub.add_parser(
+        "guidance",
+        help="render the project-local TDD contract for a headless worker",
+    )
+    p_guidance.add_argument("--project-root", required=True)
+    p_guidance.add_argument("--config", default="")
+    p_guidance.set_defaults(func=_cmd_guidance)
     return parser
 
 

--- a/scripts/dcness-claude-worker
+++ b/scripts/dcness-claude-worker
@@ -159,6 +159,16 @@ cd "$PROJECT_ROOT"
 
 dcness_resolve_headless_context "dcness-claude-worker" "$PROJECT_ROOT" "$SCRIPT_DIR"
 
+TDD_PROMPT_GUIDANCE="$(
+  PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 -m harness.tdd_hooks guidance --project-root "$PROJECT_ROOT"
+)"
+TDD_GUIDANCE_RC=$?
+if [ "$TDD_GUIDANCE_RC" -ne 0 ]; then
+  echo "[dcness-claude-worker] invalid project-local TDD contract" >&2
+  exit "$TDD_GUIDANCE_RC"
+fi
+
 git_status_without_harness_state() {
   git -C "$PROJECT_ROOT" status --porcelain=v1 -uall 2>/dev/null \
     | sed '/^.. \.claude\/harness-state\//d' \
@@ -240,6 +250,19 @@ fi
   echo "project/worktree root: $PROJECT_ROOT"
   echo "session id: ${DCNESS_SESSION_ID:-UNATTRIBUTED}"
   echo "run id: ${DCNESS_RUN_ID:-UNATTRIBUTED}"
+  if [ -n "$CANONICAL_RUN_DIR" ]; then
+    echo "canonical run directory: $CANONICAL_RUN_DIR"
+    echo "required phase prose:"
+    echo "- $CANONICAL_RUN_DIR/build-test.md"
+    echo "- $CANONICAL_RUN_DIR/build-impl.md"
+    echo "- $CANONICAL_RUN_DIR/build-validate.md"
+  fi
+  if [ -n "$TDD_PROMPT_GUIDANCE" ]; then
+    echo
+    echo "----- BEGIN PROJECT TDD CONTRACT -----"
+    printf '%s\n' "$TDD_PROMPT_GUIDANCE"
+    echo "----- END PROJECT TDD CONTRACT -----"
+  fi
   echo
   echo "You are executing this dcNess implementation worker step through Claude headless."
   echo "Run with hooks and plugins enabled; do not use safe-mode, bare mode, or hook-skipping modes."
@@ -271,6 +294,9 @@ fi
 } > "$TMP_PROMPT"
 
 CLAUDE_CMD=(claude -p --permission-mode acceptEdits --output-format text)
+if [ -n "$CANONICAL_RUN_DIR" ]; then
+  CLAUDE_CMD+=(--add-dir "$CANONICAL_RUN_DIR")
+fi
 
 run_claude_once() {
   python3 -c '
@@ -279,6 +305,7 @@ import signal
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 
 timeout = int(sys.argv[1])
 idle_timeout = int(sys.argv[2])
@@ -381,6 +408,12 @@ with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") 
         stderr=raw,
         env=child_env,
         start_new_session=True,
+    )
+    raw.write(
+        (
+            f"PROCESS_FORK: pid={proc.pid} "
+            f"started_at={datetime.now(timezone.utc).isoformat()}\n"
+        ).encode("utf-8", "replace")
     )
     raw.flush()
     started = time.monotonic()
@@ -648,6 +681,25 @@ if [ "$TDD_RC" -eq 1 ]; then
   echo "[dcness-claude-worker] BLOCKED: TDD GUARD failed for Claude-changed implementation files." >&2
   echo "[dcness-claude-worker] raw log: $RAW_LOG" >&2
   printf '%s\n' "$TDD_PROBLEMS" >&2
+  exit 1
+fi
+
+MISSING_PHASE_PROSE=""
+if [ "${DCNESS_PHASE_EVIDENCE_REQUIRED:-0}" = "1" ] \
+  && [ "$AGENT" = "build-worker" ] \
+  && [ -z "$MODE" ] \
+  && dcness_build_outcome_requires_phase_prose "$SCRIPT_DIR" "$TMP_PROSE"; then
+  MISSING_PHASE_PROSE="$(dcness_missing_build_phase_prose)"
+fi
+if [ -n "$MISSING_PHASE_PROSE" ]; then
+  {
+    echo
+    echo "----- REQUIRED PHASE PROSE MISSING -----"
+    printf '%s\n' "$MISSING_PHASE_PROSE"
+  } >> "$RAW_LOG"
+  emit_provider_failure 1 phase_evidence
+  echo "[dcness-claude-worker] BLOCKED: required build-worker phase prose is missing from the canonical run directory." >&2
+  printf '%s\n' "$MISSING_PHASE_PROSE" >&2
   exit 1
 fi
 

--- a/scripts/dcness-codex-worker
+++ b/scripts/dcness-codex-worker
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Run a dcNess implementation worker through Codex and store prose via
-# dcness-helper end-step. The caller still owns begin-step and fallback policy.
+# dcness-helper end-step. The implementation chain owns begin-step and fallback.
 
 set -uo pipefail
 
@@ -184,24 +184,42 @@ case "$CODEX_NETWORK_ACCESS" in
     ;;
 esac
 
+cd "$PROJECT_ROOT"
+
+dcness_resolve_headless_context "dcness-codex-worker" "$PROJECT_ROOT" "$SCRIPT_DIR"
+
+TDD_PROMPT_GUIDANCE="$(
+  PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 -m harness.tdd_hooks guidance --project-root "$PROJECT_ROOT"
+)"
+TDD_GUIDANCE_RC=$?
+if [ "$TDD_GUIDANCE_RC" -ne 0 ]; then
+  echo "[dcness-codex-worker] invalid project-local TDD contract" >&2
+  exit "$TDD_GUIDANCE_RC"
+fi
+
 CODEX_WRITABLE_ROOTS_CONFIG=""
-if [ -n "$CODEX_WRITABLE_ROOTS" ]; then
+if [ -n "$CODEX_WRITABLE_ROOTS" ] || [ -n "$CANONICAL_RUN_DIR" ]; then
+  export DCNESS_CANONICAL_RUN_DIR="$CANONICAL_RUN_DIR"
   if ! CODEX_WRITABLE_ROOTS_TOML="$(python3 -c '
 import json
 import os
 
-roots = [root for root in os.environ["DCNESS_CODEX_WRITABLE_ROOTS"].split(os.pathsep) if root]
+roots = [
+    root
+    for root in os.environ.get("DCNESS_CODEX_WRITABLE_ROOTS", "").split(os.pathsep)
+    if root
+]
+canonical = os.environ.get("DCNESS_CANONICAL_RUN_DIR", "")
+if canonical and canonical not in roots:
+    roots.append(canonical)
 print(json.dumps(roots, ensure_ascii=False))
 ')"; then
-    echo "[dcness-codex-worker] failed to encode DCNESS_CODEX_WRITABLE_ROOTS as a TOML string array" >&2
+    echo "[dcness-codex-worker] failed to encode writable roots as a TOML string array" >&2
     exit 2
   fi
   CODEX_WRITABLE_ROOTS_CONFIG="sandbox_workspace_write.writable_roots=$CODEX_WRITABLE_ROOTS_TOML"
 fi
-
-cd "$PROJECT_ROOT"
-
-dcness_resolve_headless_context "dcness-codex-worker" "$PROJECT_ROOT" "$SCRIPT_DIR"
 
 git_status_without_harness_state() {
   git -C "$PROJECT_ROOT" status --porcelain=v1 -uall 2>/dev/null \
@@ -288,6 +306,19 @@ fi
   echo "project/worktree root: $PROJECT_ROOT"
   echo "session id: ${DCNESS_SESSION_ID:-UNATTRIBUTED}"
   echo "run id: ${DCNESS_RUN_ID:-UNATTRIBUTED}"
+  if [ -n "$CANONICAL_RUN_DIR" ]; then
+    echo "canonical run directory: $CANONICAL_RUN_DIR"
+    echo "required phase prose:"
+    echo "- $CANONICAL_RUN_DIR/build-test.md"
+    echo "- $CANONICAL_RUN_DIR/build-impl.md"
+    echo "- $CANONICAL_RUN_DIR/build-validate.md"
+  fi
+  if [ -n "$TDD_PROMPT_GUIDANCE" ]; then
+    echo
+    echo "----- BEGIN PROJECT TDD CONTRACT -----"
+    printf '%s\n' "$TDD_PROMPT_GUIDANCE"
+    echo "----- END PROJECT TDD CONTRACT -----"
+  fi
   echo
   echo "You are executing this dcNess implementation worker step through Codex headless."
   echo "You may edit files in the project/worktree only within the embedded agent boundary."
@@ -342,6 +373,7 @@ import signal
 import subprocess
 import sys
 import time
+from datetime import datetime, timezone
 
 timeout = int(sys.argv[1])
 idle_timeout = int(sys.argv[2])
@@ -409,6 +441,13 @@ with open(prompt, "rb") as stdin, open(log, "ab") as raw:
         stderr=subprocess.STDOUT,
         start_new_session=True,
     )
+    raw.write(
+        (
+            f"PROCESS_FORK: pid={proc.pid} "
+            f"started_at={datetime.now(timezone.utc).isoformat()}\n"
+        ).encode("utf-8", "replace")
+    )
+    raw.flush()
     started = time.monotonic()
     deadline = started + timeout
     last_progress = started
@@ -700,6 +739,25 @@ if [ "$TDD_RC" -eq 1 ]; then
   echo "[dcness-codex-worker] BLOCKED: TDD GUARD failed for Codex-changed implementation files." >&2
   echo "[dcness-codex-worker] raw log: $RAW_LOG" >&2
   printf '%s\n' "$TDD_PROBLEMS" >&2
+  exit 1
+fi
+
+MISSING_PHASE_PROSE=""
+if [ "${DCNESS_PHASE_EVIDENCE_REQUIRED:-0}" = "1" ] \
+  && [ "$AGENT" = "build-worker" ] \
+  && [ -z "$MODE" ] \
+  && dcness_build_outcome_requires_phase_prose "$SCRIPT_DIR" "$TMP_PROSE"; then
+  MISSING_PHASE_PROSE="$(dcness_missing_build_phase_prose)"
+fi
+if [ -n "$MISSING_PHASE_PROSE" ]; then
+  {
+    echo
+    echo "----- REQUIRED PHASE PROSE MISSING -----"
+    printf '%s\n' "$MISSING_PHASE_PROSE"
+  } >> "$RAW_LOG"
+  emit_provider_failure 1 phase_evidence
+  echo "[dcness-codex-worker] BLOCKED: required build-worker phase prose is missing from the canonical run directory." >&2
+  printf '%s\n' "$MISSING_PHASE_PROSE" >&2
   exit 1
 fi
 

--- a/scripts/dcness-implementation-chain
+++ b/scripts/dcness-implementation-chain
@@ -11,7 +11,7 @@ set -uo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  dcness-implementation-chain <agent> [MODE] --prompt-file <file> [--provider <provider>] [--provider-provenance <routing|explicit>] [--chain-state <file>] [--project-root <dir>]
+  dcness-implementation-chain <agent> [MODE] --prompt-file <file> [--provider <provider>] [--provider-provenance <routing|explicit>] [--chain-state <file>] [--init-path <impl-path>]... [--project-root <dir>]
 
 Agents:
   build-worker
@@ -25,7 +25,12 @@ Options:
   --prompt-file, -p   File containing the caller prompt.
   --provider          Override local implementation routing.
   --provider-provenance  Provider origin. Explicit selections bypass chain cache.
-  --chain-state       Active story-runner state. Enables impl-loop chain cache.
+  --chain-state       Story-runner state. Enables lifecycle setup and chain cache.
+  --init-path         Impl task path used to initialize a missing chain state.
+                      Repeat for a multi-task chain. Existing matching state is reused.
+  --issue-num         Target GitHub issue number recorded on an auto-created run.
+  --acceptance-required  Enable acceptance on the final chain task only.
+                         Requires --chain-state.
   --project-root, -C  Repository root. Default: git rev-parse --show-toplevel.
   --helper            dcness-helper path. Default: sibling script.
   --help, -h          Show this help.
@@ -79,7 +84,17 @@ PROVIDER=""
 PROVIDER_ARG_SEEN=0
 PROVIDER_PROVENANCE=""
 CHAIN_STATE=""
+INIT_PATHS=()
+ISSUE_NUM=""
+ACCEPTANCE_REQUIRED=0
 RECOVERY_LIMIT="${DCNESS_IMPLEMENTATION_RECOVERY_LIMIT:-2}"
+
+# Claude Code's background Bash job is not always a direct child of the main
+# process registered by SessionStart. Preserve its explicit session identity so
+# the chain can create the first run before an active-run fallback exists.
+if [ -z "${DCNESS_SESSION_ID:-}" ] && [ -n "${CLAUDE_CODE_SESSION_ID:-}" ]; then
+  export DCNESS_SESSION_ID="$CLAUDE_CODE_SESSION_ID"
+fi
 
 abs_path() {
   case "$1" in
@@ -106,6 +121,18 @@ while [ $# -gt 0 ]; do
     --chain-state)
       CHAIN_STATE="${2:-}"
       shift 2
+      ;;
+    --init-path)
+      INIT_PATHS+=("${2:-}")
+      shift 2
+      ;;
+    --issue-num)
+      ISSUE_NUM="${2:-}"
+      shift 2
+      ;;
+    --acceptance-required)
+      ACCEPTANCE_REQUIRED=1
+      shift
       ;;
     --project-root|-C)
       PROJECT_ROOT="${2:-}"
@@ -140,14 +167,26 @@ if [ ! -d "$PROJECT_ROOT" ]; then
   echo "[dcness-implementation-chain] project root not found: $PROJECT_ROOT" >&2
   exit 2
 fi
-PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd)"
+PROJECT_ROOT="$(cd "$PROJECT_ROOT" && pwd -P)"
 HELPER="$(abs_path "$HELPER")"
 if [ -n "$CHAIN_STATE" ]; then
   CHAIN_STATE="$(abs_path "$CHAIN_STATE")"
-  if [ ! -f "$CHAIN_STATE" ]; then
+  if [ ! -f "$CHAIN_STATE" ] && [ "${#INIT_PATHS[@]}" -eq 0 ]; then
     echo "[dcness-implementation-chain] chain state not found: $CHAIN_STATE" >&2
     exit 2
   fi
+fi
+if [ "${#INIT_PATHS[@]}" -gt 0 ] && [ -z "$CHAIN_STATE" ]; then
+  echo "[dcness-implementation-chain] --init-path requires --chain-state" >&2
+  exit 2
+fi
+if [ "$ACCEPTANCE_REQUIRED" -eq 1 ] && [ -z "$CHAIN_STATE" ]; then
+  echo "[dcness-implementation-chain] --acceptance-required requires --chain-state" >&2
+  exit 2
+fi
+if [ -n "$ISSUE_NUM" ] && [[ ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[dcness-implementation-chain] --issue-num must be a positive integer: $ISSUE_NUM" >&2
+  exit 2
 fi
 
 if [ -z "$PROVIDER_PROVENANCE" ]; then
@@ -184,7 +223,334 @@ esac
 
 cd "$PROJECT_ROOT"
 
+prepare_chain_state() {
+  local git_root=""
+  local current_branch=""
+  local default_branch=""
+  local plan_rc=0
+  local setup_required=""
+
+  [ -n "$CHAIN_STATE" ] || return 0
+
+  git_root="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)"
+  if [ -z "$git_root" ] || [ "$(cd "$git_root" && pwd -P)" != "$PROJECT_ROOT" ]; then
+    echo "[dcness-implementation-chain] project root is not a git worktree root: $PROJECT_ROOT" >&2
+    return 2
+  fi
+
+  if [ "${#INIT_PATHS[@]}" -gt 0 ]; then
+    if [ "$(pwd -P)" != "$PROJECT_ROOT" ]; then
+      echo "[dcness-implementation-chain] initial launch must run from its project/worktree root: $PROJECT_ROOT" >&2
+      return 2
+    fi
+    current_branch="$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)"
+    default_branch="$(
+      git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
+        | sed 's#^[^/]*/##' || true
+    )"
+    if [ -z "$default_branch" ]; then
+      case "$current_branch" in
+        main|master) default_branch="$current_branch" ;;
+      esac
+    fi
+    if [ -n "$default_branch" ] && [ "$current_branch" = "$default_branch" ]; then
+      echo "[dcness-implementation-chain] refusing default branch initial launch: $current_branch; enter an isolated feature worktree first." >&2
+      return 2
+    fi
+
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$PROJECT_ROOT" "$CHAIN_STATE" "${INIT_PATHS[@]}" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.story_runner import build_state, load_state
+
+project_root = Path(sys.argv[1]).resolve()
+state_path = Path(sys.argv[2]).resolve()
+paths = sys.argv[3:]
+expected = build_state(paths, cwd=project_root)
+if not state_path.exists():
+    raise SystemExit(0)
+actual = load_state(state_path)
+expected_paths = [task["path"] for task in expected["tasks"]]
+actual_paths = [task.get("path") for task in actual.get("tasks", [])]
+if Path(str(actual.get("project_root", ""))).resolve() != project_root:
+    raise SystemExit(
+        "existing chain state belongs to a different project/worktree: "
+        f"{actual.get('project_root')}"
+    )
+if actual_paths != expected_paths:
+    raise SystemExit(
+        "existing chain state task list differs from --init-path input: "
+        f"state={actual_paths} input={expected_paths}"
+    )
+PY
+    plan_rc=$?
+    if [ "$plan_rc" -ne 0 ]; then
+      return "$plan_rc"
+    fi
+
+    if [ ! -f "$CHAIN_STATE" ]; then
+      PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+        python3 -m harness.story_runner init \
+          --state "$CHAIN_STATE" \
+          --cwd "$PROJECT_ROOT" \
+          "${INIT_PATHS[@]}" >/dev/null || return $?
+    fi
+  fi
+
+  setup_required="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$CHAIN_STATE" "$PROJECT_ROOT" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.story_runner import load_state
+
+state = load_state(Path(sys.argv[1]))
+project_root = Path(sys.argv[2]).resolve()
+recorded_root = Path(str(state.get("project_root", ""))).resolve()
+if recorded_root != project_root:
+    raise SystemExit(
+        f"chain state project_root mismatch: state={recorded_root} current={project_root}"
+    )
+print("0" if state.get("setup", {}).get("previous_tasks_reset") is True else "1")
+PY
+  )" || return $?
+
+  if [ "$setup_required" = "1" ]; then
+    "$HELPER" prev-tasks-reset >/dev/null || return $?
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$CHAIN_STATE" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.story_runner import load_state, save_state
+
+path = Path(sys.argv[1])
+state = load_state(path)
+state.setdefault("setup", {})["previous_tasks_reset"] = True
+save_state(path, state)
+PY
+  fi
+}
+
+current_chain_task_path() {
+  [ -n "$CHAIN_STATE" ] || return 0
+  PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 - "$CHAIN_STATE" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.story_runner import load_state, next_action
+
+action = next_action(load_state(Path(sys.argv[1])))
+if action.get("action") != "task":
+    raise SystemExit(
+        "chain has no runnable task: "
+        f"action={action.get('action')} note={action.get('note', '')}"
+    )
+print(action["task"]["path"])
+PY
+}
+
+ensure_chain_run() {
+  local sid=""
+  local rid=""
+  local run_action=""
+  local transition_output=""
+  local begin_args=()
+  local next_args=()
+  local current_acceptance_required=0
+
+  [ -n "$CHAIN_STATE" ] || return 0
+  if [ "$ACCEPTANCE_REQUIRED" -eq 1 ]; then
+    current_acceptance_required="$(
+      PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+        python3 - "$CHAIN_STATE" "$CURRENT_CHAIN_TASK" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.story_runner import load_state, task_requires_acceptance
+
+state = load_state(Path(sys.argv[1]))
+print("1" if task_requires_acceptance(state, sys.argv[2]) else "0")
+PY
+    )" || return $?
+  fi
+  sid="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 -c 'from harness.session_state import auto_detect_session_id; print(auto_detect_session_id())'
+  )"
+  [ -n "$sid" ] || return 0
+  rid="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 -c 'from harness.session_state import auto_detect_run_id; print(auto_detect_run_id())'
+  )"
+  run_action="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$sid" "$rid" "$PROJECT_ROOT" "$CHAIN_STATE" "$CURRENT_CHAIN_TASK" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.session_state import read_live
+from harness.story_runner import load_state
+
+sid, rid, root_text, state_text, current_text = sys.argv[1:6]
+if not rid:
+    print("new")
+    raise SystemExit(0)
+
+root = Path(root_text).resolve()
+current = (root / current_text).resolve()
+live = read_live(sid)
+slot = live.get("active_runs", {}).get(rid) if live else None
+if not isinstance(slot, dict):
+    print("new")
+    raise SystemExit(0)
+
+design_text = str(slot.get("design_doc") or "")
+design = Path(design_text).resolve() if design_text else None
+if slot.get("entry_point") == "impl" and design == current:
+    print("reuse")
+    raise SystemExit(0)
+
+state = load_state(Path(state_text))
+completed = {
+    (root / str(task["path"])).resolve()
+    for task in state.get("tasks", [])
+    if task.get("status") == "completed"
+}
+if slot.get("entry_point") == "impl" and design in completed:
+    print("next")
+else:
+    print("new")
+PY
+  )" || return $?
+
+  if [ "$run_action" = "next" ]; then
+    next_args=(next-task --entry-point impl --design-doc "$CURRENT_CHAIN_TASK")
+    if [ -n "$ISSUE_NUM" ]; then
+      next_args+=(--issue-num "$ISSUE_NUM")
+    fi
+    if [ "$current_acceptance_required" -eq 1 ]; then
+      next_args+=(--acceptance-required)
+    fi
+    transition_output="$(
+      DCNESS_SESSION_ID="$sid" DCNESS_RUN_ID="$rid" \
+        "$HELPER" "${next_args[@]}"
+    )" || return $?
+    rid="$(printf '%s\n' "$transition_output" | sed -n 's/^\[new\] run_id: //p' | tail -1)"
+    if [ -z "$rid" ]; then
+      echo "[dcness-implementation-chain] next-task did not return a run id" >&2
+      return 1
+    fi
+  elif [ "$run_action" = "new" ]; then
+    begin_args=(begin-run impl --design-doc "$CURRENT_CHAIN_TASK")
+    if [ -n "$ISSUE_NUM" ]; then
+      begin_args+=(--issue-num "$ISSUE_NUM")
+    fi
+    if [ "$current_acceptance_required" -eq 1 ]; then
+      begin_args+=(--acceptance-required)
+    fi
+    rid="$("$HELPER" "${begin_args[@]}")" || return $?
+  elif [ "$run_action" != "reuse" ]; then
+    echo "[dcness-implementation-chain] invalid run preparation action: $run_action" >&2
+    return 1
+  fi
+  export DCNESS_SESSION_ID="$sid"
+  export DCNESS_RUN_ID="$rid"
+}
+
+ensure_chain_step() {
+  local state=""
+
+  [ -n "$CHAIN_STATE" ] || return 0
+  [ -n "$RESOLVED_SID" ] && [ -n "$RESOLVED_RID" ] || return 0
+  state="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$RESOLVED_SID" "$RESOLVED_RID" "$AGENT" "$MODE" <<'PY'
+import sys
+from harness import ledger
+
+sid, rid, agent, mode = sys.argv[1:5]
+events = ledger.read_events(sid, rid)
+last_terminal = -1
+last_started = -1
+started = None
+for index, event in enumerate(events):
+    if event.get("event") == "step_started":
+        last_started = index
+        started = event
+    elif event.get("event") in {
+        "step_completed",
+        "step_aborted",
+        "run_blocked",
+        "run_finished",
+    }:
+        last_terminal = index
+if last_started > last_terminal and started is not None:
+    if started.get("agent") == agent and (started.get("mode") or "") == mode:
+        print("active")
+    else:
+        print(
+            "conflict:"
+            f"{started.get('agent')}:{started.get('mode') or ''}"
+        )
+else:
+    terminal = events[last_terminal] if last_terminal >= 0 else None
+    if (
+        last_started >= 0
+        and last_terminal > last_started
+        and terminal is not None
+        and terminal.get("event") == "step_completed"
+        and terminal.get("agent") == agent
+        and (terminal.get("mode") or "") == mode
+    ):
+        print("completed")
+    else:
+        print("missing")
+PY
+  )" || return $?
+  case "$state" in
+    active)
+      return 0
+      ;;
+    missing)
+      if [ -n "$MODE" ]; then
+        "$HELPER" begin-step "$AGENT" "$MODE" >/dev/null
+      else
+        "$HELPER" begin-step "$AGENT" >/dev/null
+      fi
+      return $?
+      ;;
+    completed)
+      echo "[dcness-implementation-chain] ALREADY_COMPLETED: current run already has a terminal build-worker receipt; mark the story task before launching the next task." >&2
+      return 10
+      ;;
+    conflict:*)
+      echo "[dcness-implementation-chain] active lifecycle step conflicts with launch: $state" >&2
+      return 2
+      ;;
+    *)
+      echo "[dcness-implementation-chain] could not determine lifecycle step state: $state" >&2
+      return 2
+      ;;
+  esac
+}
+
+prepare_chain_state || exit $?
+CURRENT_CHAIN_TASK="$(current_chain_task_path)" || exit $?
+ensure_chain_run || exit $?
 dcness_resolve_headless_context "dcness-implementation-chain" "$PROJECT_ROOT" "$SCRIPT_DIR"
+ensure_chain_step
+STEP_RC=$?
+if [ "$STEP_RC" -eq 10 ]; then
+  exit 0
+fi
+if [ "$STEP_RC" -ne 0 ]; then
+  exit "$STEP_RC"
+fi
 
 git_status_without_harness_state() {
   git -C "$PROJECT_ROOT" status --porcelain=v1 -uall 2>/dev/null \
@@ -318,7 +684,7 @@ fi
 
 recovery_eligible() {
   case "$1" in
-    timeout|idle_timeout|empty_output|boundary_violation|tdd_guard) return 0 ;;
+    timeout|idle_timeout|empty_output|boundary_violation|tdd_guard|phase_evidence) return 0 ;;
     *) return 1 ;;
   esac
 }
@@ -430,6 +796,7 @@ run_headless_stage() {
 
     DCNESS_MUTATION_BASE_HEAD="$stage_initial_head" \
       DCNESS_RECOVERY_OWNER=implementation-chain \
+      DCNESS_PHASE_EVIDENCE_REQUIRED="$([ -n "$CHAIN_STATE" ] && printf 1 || printf 0)" \
       DCNESS_PROVIDER_FAILURE_FILE="$failure_file" \
       "${cmd[@]}" >> "$log" 2>&1
     rc=$?

--- a/scripts/lib/headless_context.sh
+++ b/scripts/lib/headless_context.sh
@@ -12,6 +12,7 @@ dcness_resolve_headless_context() {
   DCNESS_HEADLESS_CONTEXT_DIAGNOSTIC=""
   RESOLVED_SID=""
   RESOLVED_RID=""
+  CANONICAL_RUN_DIR=""
 
   err_file="$(mktemp "${TMPDIR:-/tmp}/dcness-headless-context.XXXXXX")"
   context="$(
@@ -44,20 +45,22 @@ $context
 EOF
     export DCNESS_SESSION_ID="$RESOLVED_SID"
     export DCNESS_RUN_ID="$RESOLVED_RID"
-    RAW_LOG_DIR="$(
+    CANONICAL_RUN_DIR="$(
       PYTHONPATH="$script_dir/.." python3 - "$RESOLVED_SID" "$RESOLVED_RID" <<'PY'
 import sys
 from harness.session_state import run_dir
 
-print(run_dir(sys.argv[1], sys.argv[2]) / "headless-logs")
+print(run_dir(sys.argv[1], sys.argv[2]))
 PY
     )"
+    RAW_LOG_DIR="$CANONICAL_RUN_DIR/headless-logs"
   else
     DCNESS_HEADLESS_CONTEXT_DEGRADED=1
     unset DCNESS_SESSION_ID
     unset DCNESS_RUN_ID
     DCNESS_SESSION_ID=""
     DCNESS_RUN_ID=""
+    CANONICAL_RUN_DIR=""
     RAW_LOG_DIR="$project_root/.dcness-work/headless-logs/unattributed"
     echo "[$prefix] WARN: sid/rid unresolved; continuing degraded/unattributed. fallback log dir: $RAW_LOG_DIR" >&2
     if [ -n "$DCNESS_HEADLESS_CONTEXT_DIAGNOSTIC" ]; then
@@ -66,6 +69,7 @@ PY
   fi
 
   export DCNESS_HEADLESS_CONTEXT_DEGRADED
+  export CANONICAL_RUN_DIR
   mkdir -p "$RAW_LOG_DIR"
 }
 
@@ -98,6 +102,47 @@ dcness_append_final_prose_to_raw_log() {
     echo "----- $label / FINAL PROSE -----"
     cat "$prose_file" 2>/dev/null || true
   } >> "$raw_log"
+}
+
+dcness_missing_build_phase_prose() {
+  local phase=""
+
+  [ -n "${CANONICAL_RUN_DIR:-}" ] || return 0
+  for phase in build-test.md build-impl.md build-validate.md; do
+    if [ ! -s "$CANONICAL_RUN_DIR/$phase" ]; then
+      printf '%s\n' "$CANONICAL_RUN_DIR/$phase"
+    fi
+  done
+}
+
+dcness_build_outcome_requires_phase_prose() {
+  local script_dir="$1"
+  local prose_file="$2"
+  local conclusion=""
+
+  conclusion="$(
+    PYTHONPATH="$script_dir/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$prose_file" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.run_review import _extract_conclusion_enum
+
+print(
+    _extract_conclusion_enum(
+        Path(sys.argv[1]).read_text(encoding="utf-8", errors="replace")
+    )
+)
+PY
+  )" || return 0
+
+  # Canonical phase prose is a clean/PASS invariant. Routed non-PASS outcomes
+  # such as a pre-implementation environment escalation must still reach the
+  # main orchestrator as their original terminal receipt.
+  case "$conclusion" in
+    PASS|"") return 0 ;;
+    *) return 1 ;;
+  esac
 }
 
 dcness_record_end_step() {

--- a/scripts/measure_main_turns.py
+++ b/scripts/measure_main_turns.py
@@ -8,6 +8,9 @@
 - Hybrid A 목표: 메인 turn/task ~30 (~85-90% 감소). gate = Step 3 프로토타입.
 - 동일 frozen 1-task baseline/variant 1+1에서 request/tool/wall-clock/token과
   제품 AC/MUST-FIX/regression/사람 개입을 함께 묶는 paired screening.
+- 각 디렉터리에 같은 수의 JSONL을 두면 request→첫 Edit/Write 시간,
+  첫 edit 전 main blocking request, main/전체 executor token, 정확성을 같은
+  정의로 반복 비교한다. fresh executor edit는 parent tool event에서도 찾는다.
 
 JSONL 위치: `~/.claude/projects/<project-id>/<session-id>.jsonl` (Claude Code 가 자동 기록).
 한 줄 = 한 event. 메인 assistant turn = `type=assistant` + `message.role=assistant`.
@@ -28,6 +31,8 @@ Tool histogram 은 tool_use block 의 `name` 빈도. Agent 호출은 `name=Task`
     python3 scripts/measure_main_turns.py <directory>     # 모든 *.jsonl 일괄
     python3 scripts/measure_main_turns.py baseline.jsonl \
       --paired-with variant.jsonl --outcomes outcomes.json --json
+    python3 scripts/measure_main_turns.py baseline-trials/ \
+      --paired-with fresh-trials/ --outcomes repeated-outcomes.json --json
 
 예시 (jajang impl 1-task 세션 측정):
     python3 scripts/measure_main_turns.py \\
@@ -41,10 +46,19 @@ import argparse
 import collections
 import json
 import re
+import statistics
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
+
+
+_TOKEN_FIELDS = (
+    "input_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
+    "output_tokens",
+)
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -56,17 +70,97 @@ def _parse_timestamp(value: Any) -> datetime | None:
         return None
 
 
+def _is_direct_user_request(content: Any) -> bool:
+    if isinstance(content, str):
+        return True
+    if not isinstance(content, list):
+        return False
+    has_text = any(
+        isinstance(block, dict) and block.get("type") == "text"
+        for block in content
+    )
+    has_tool_result = any(
+        isinstance(block, dict) and block.get("type") == "tool_result"
+        for block in content
+    )
+    return has_text and not has_tool_result
+
+
+def _update_token_max(target: dict[str, Any], usage: Any) -> None:
+    if not isinstance(usage, dict):
+        return
+    for field in _TOKEN_FIELDS:
+        target[field] = max(target[field], int(usage.get(field) or 0))
+
+
+def _result_observation(
+    event: dict[str, Any],
+    line_number: int,
+    result_usage: dict[str, Any],
+    result_duration_seconds: float | None,
+    result_line_number: int | None,
+) -> tuple[dict[str, Any], float | None, int | None]:
+    usage = event.get("usage")
+    if isinstance(usage, dict):
+        result_usage = usage
+    duration_ms = event.get("duration_ms")
+    if isinstance(duration_ms, (int, float)) and duration_ms >= 0:
+        duration_seconds = float(duration_ms) / 1000
+        if (
+            result_duration_seconds is None
+            or duration_seconds > result_duration_seconds
+        ):
+            result_duration_seconds = duration_seconds
+            result_line_number = line_number
+    return result_usage, result_duration_seconds, result_line_number
+
+
+def _first_edit_observation(
+    content: list[Any],
+    timestamp: datetime | None,
+    line_number: int,
+    parent_tool_use_id: Any,
+) -> dict[str, Any] | None:
+    if timestamp is None:
+        return None
+    for block in content:
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "tool_use"
+            and block.get("name") in {"Edit", "Write", "NotebookEdit"}
+        ):
+            tool_input = block.get("input") or {}
+            return {
+                "timestamp": timestamp.isoformat(),
+                "line": line_number,
+                "tool": block.get("name"),
+                "path": tool_input.get("file_path") or tool_input.get("path") or "",
+                "executor": (
+                    "main" if parent_tool_use_id in (None, "") else "fresh"
+                ),
+            }
+    return None
+
+
 def parse_session(path: Path) -> dict:
     """JSONL 한 파일 분석. 결과 dict 반환."""
     requests: dict[str, dict[str, Any]] = {}
+    all_requests: dict[str, dict[str, int]] = {}
     tool_hist: collections.Counter = collections.Counter()
     agent_invocations: list[str] = []
     seen_tool_uses: set[str] = set()
     timestamps: list[datetime] = []
+    first_timestamp_line: int | None = None
     models: set[str] = set()
     effort_levels: set[str] = set()
     providers: set[str] = set()
     result_duration_seconds: float | None = None
+    result_usage: dict[str, Any] = {}
+    result_line_number: int | None = None
+    start_evidence: dict[str, Any] | None = None
+    first_edit_evidence: dict[str, Any] | None = None
+    first_edit_request_key: str | None = None
+    request_first_seen: dict[str, datetime] = {}
 
     with path.open() as f:
         for line_number, line in enumerate(f, start=1):
@@ -76,17 +170,38 @@ def parse_session(path: Path) -> dict:
                 continue
             timestamp = _parse_timestamp(d.get("timestamp"))
             if timestamp is not None:
+                if not timestamps:
+                    first_timestamp_line = line_number
                 timestamps.append(timestamp)
+            message = d.get("message") or {}
+            user_content = message.get("content")
+            if (
+                start_evidence is None
+                and d.get("type") == "user"
+                and d.get("parent_tool_use_id") in (None, "")
+                and timestamp is not None
+                and _is_direct_user_request(user_content)
+                and d.get("isSynthetic") is not True
+            ):
+                start_evidence = {
+                    "timestamp": timestamp.isoformat(),
+                    "line": line_number,
+                    "kind": "root_user_request",
+                }
             if d.get("type") == "result":
-                duration_ms = d.get("duration_ms")
-                if isinstance(duration_ms, (int, float)) and duration_ms >= 0:
-                    result_duration_seconds = float(duration_ms) / 1000
+                (
+                    result_usage,
+                    result_duration_seconds,
+                    result_line_number,
+                ) = _result_observation(
+                    d,
+                    line_number,
+                    result_usage,
+                    result_duration_seconds,
+                    result_line_number,
+                )
                 continue
             if d.get("type") != "assistant":
-                continue
-            # stream-json forwards sub-agent assistant events with their parent Agent
-            # tool id. They are useful end-to-end evidence but are not main requests.
-            if d.get("parent_tool_use_id") not in (None, ""):
                 continue
             msg = d.get("message") or {}
             if msg.get("role") != "assistant":
@@ -96,6 +211,37 @@ def parse_session(path: Path) -> dict:
                 continue
 
             request_key = d.get("request_id") or msg.get("id") or f"line-{line_number}"
+            parent_tool_use_id = d.get("parent_tool_use_id")
+            all_request_key = f"{parent_tool_use_id or 'root'}:{request_key}"
+            all_request = all_requests.setdefault(
+                all_request_key,
+                {
+                    "input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "output_tokens": 0,
+                },
+            )
+            usage = msg.get("usage") or d.get("usage") or {}
+            _update_token_max(all_request, usage)
+
+            if first_edit_evidence is None:
+                first_edit_evidence = _first_edit_observation(
+                    content,
+                    timestamp,
+                    line_number,
+                    parent_tool_use_id,
+                )
+                if first_edit_evidence is not None:
+                    first_edit_request_key = str(request_key)
+
+            # stream-json forwards fresh-executor assistant events with their parent
+            # Agent tool id. Their edit/token evidence is end-to-end, but they are
+            # not counted as main assistant requests.
+            if parent_tool_use_id not in (None, ""):
+                continue
+            if timestamp is not None:
+                request_first_seen.setdefault(str(request_key), timestamp)
             request = requests.setdefault(
                 str(request_key),
                 {
@@ -108,17 +254,7 @@ def parse_session(path: Path) -> dict:
                     "output_tokens": 0,
                 },
             )
-            usage = msg.get("usage") or d.get("usage") or {}
-            if isinstance(usage, dict):
-                for field in (
-                    "input_tokens",
-                    "cache_creation_input_tokens",
-                    "cache_read_input_tokens",
-                    "output_tokens",
-                ):
-                    request[field] = max(
-                        request[field], int(usage.get(field) or 0)
-                    )
+            _update_token_max(request, usage)
             model = msg.get("model") or d.get("model")
             if isinstance(model, str) and model:
                 models.add(model)
@@ -172,9 +308,76 @@ def parse_session(path: Path) -> dict:
     total_input_tokens = (
         input_tokens + cache_creation_input_tokens + cache_read_input_tokens
     )
-    wall_clock = result_duration_seconds or 0.0
-    if result_duration_seconds is None and timestamps:
-        wall_clock = max((max(timestamps) - min(timestamps)).total_seconds(), 0.0)
+    all_input_tokens = sum(row["input_tokens"] for row in all_requests.values())
+    all_cache_creation_input_tokens = sum(
+        row["cache_creation_input_tokens"] for row in all_requests.values()
+    )
+    all_cache_read_input_tokens = sum(
+        row["cache_read_input_tokens"] for row in all_requests.values()
+    )
+    all_total_input_tokens = (
+        all_input_tokens
+        + all_cache_creation_input_tokens
+        + all_cache_read_input_tokens
+    )
+    all_output_tokens = sum(row["output_tokens"] for row in all_requests.values())
+    if result_usage:
+        result_total_input = sum(
+            int(result_usage.get(field) or 0)
+            for field in (
+                "input_tokens",
+                "cache_creation_input_tokens",
+                "cache_read_input_tokens",
+            )
+        )
+        all_total_input_tokens = max(all_total_input_tokens, result_total_input)
+        all_output_tokens = max(
+            all_output_tokens,
+            int(result_usage.get("output_tokens") or 0),
+        )
+    if (
+        start_evidence is None
+        and result_duration_seconds is not None
+        and timestamps
+    ):
+        derived = max(timestamps) - timedelta(seconds=result_duration_seconds)
+        earliest = min(timestamps)
+        fallback_start = min(derived, earliest)
+        start_evidence = {
+            "timestamp": fallback_start.isoformat(),
+            "line": (
+                result_line_number
+                if fallback_start == derived
+                else first_timestamp_line
+            ),
+            "kind": (
+                "result_duration_derived_process_start"
+                if fallback_start == derived
+                else "earliest_timed_event"
+            ),
+        }
+    time_to_first_edit_seconds: float | None = None
+    blocking_assistant_requests_before_first_edit: int | None = None
+    if start_evidence is not None and first_edit_evidence is not None:
+        parsed_start = _parse_timestamp(start_evidence["timestamp"])
+        edit_at = _parse_timestamp(first_edit_evidence["timestamp"])
+        if (
+            parsed_start is not None
+            and edit_at is not None
+            and edit_at >= parsed_start
+        ):
+            time_to_first_edit_seconds = (edit_at - parsed_start).total_seconds()
+            blocking_assistant_requests_before_first_edit = sum(
+                request_key != first_edit_request_key
+                and parsed_start <= request_at < edit_at
+                for request_key, request_at in request_first_seen.items()
+            )
+    observed_wall_clock = (
+        max((max(timestamps) - min(timestamps)).total_seconds(), 0.0)
+        if timestamps
+        else 0.0
+    )
+    wall_clock = max(result_duration_seconds or 0.0, observed_wall_clock)
     return {
         "session": path.name,
         "path": str(path),
@@ -186,6 +389,14 @@ def parse_session(path: Path) -> dict:
         "cache_read_input_tokens": cache_read_input_tokens,
         "total_input_tokens": total_input_tokens,
         "output_tokens": output_tokens,
+        "all_total_input_tokens": all_total_input_tokens,
+        "all_output_tokens": all_output_tokens,
+        "time_to_first_edit_seconds": time_to_first_edit_seconds,
+        "blocking_assistant_requests_before_first_edit": (
+            blocking_assistant_requests_before_first_edit
+        ),
+        "start_evidence": start_evidence,
+        "first_edit_evidence": first_edit_evidence,
         "models": sorted(models),
         "effort_levels": sorted(effort_levels),
         "providers": sorted(providers),
@@ -271,14 +482,20 @@ def build_paired_screening(
         "main_assistant_requests",
         "tool_calls",
         "wall_clock_seconds",
+        "time_to_first_edit_seconds",
+        "blocking_assistant_requests_before_first_edit",
         "input_tokens",
         "cache_creation_input_tokens",
         "cache_read_input_tokens",
         "total_input_tokens",
         "output_tokens",
+        "all_total_input_tokens",
+        "all_output_tokens",
     )
     delta = {
-        name: round(float(variant.get(name, 0)) - float(baseline.get(name, 0)), 6)
+        name: round(
+            float(variant.get(name) or 0) - float(baseline.get(name) or 0), 6
+        )
         for name in metric_names
     }
     for name in (
@@ -289,6 +506,9 @@ def build_paired_screening(
         "cache_read_input_tokens",
         "total_input_tokens",
         "output_tokens",
+        "blocking_assistant_requests_before_first_edit",
+        "all_total_input_tokens",
+        "all_output_tokens",
     ):
         delta[name] = int(delta[name])
     return {
@@ -299,6 +519,170 @@ def build_paired_screening(
         "claim_boundary": (
             "single frozen 1-task baseline/variant 1+1 screening; "
             "not statistical or public superiority evidence"
+        ),
+    }
+
+
+def _metric_summary(values: list[float]) -> dict[str, float]:
+    return {
+        "min": round(min(values), 6),
+        "median": round(statistics.median(values), 6),
+        "mean": round(statistics.fmean(values), 6),
+        "max": round(max(values), 6),
+    }
+
+
+def build_repeated_screening(
+    baselines: list[dict[str, Any]],
+    variants: list[dict[str, Any]],
+    outcomes: dict[str, Any],
+) -> dict[str, Any]:
+    """Compare repeated main-direct and slim fresh-executor frozen trials."""
+    if len(baselines) != len(variants) or len(baselines) < 2:
+        raise ValueError(
+            "repeated screening requires equal baseline/variant counts of at least 2"
+        )
+    if not isinstance(outcomes, dict):
+        raise ValueError("outcomes must be an object")
+    fixture = outcomes.get("fixture")
+    if (
+        not isinstance(fixture, dict)
+        or not fixture.get("id")
+        or not isinstance(fixture.get("sha256"), str)
+        or not re.fullmatch(r"[0-9a-f]{64}", fixture["sha256"])
+    ):
+        raise ValueError("fixture.id and fixture.sha256 are required")
+    outcomes_trials = outcomes.get("trials")
+    if not isinstance(outcomes_trials, dict):
+        raise ValueError("trials must be an object")
+
+    joined: dict[str, list[dict[str, Any]]] = {"baseline": [], "variant": []}
+    runtime_identity: dict[str, str] | None = None
+    for label, metrics_rows in (
+        ("baseline", baselines),
+        ("variant", variants),
+    ):
+        quality_rows = outcomes_trials.get(label)
+        if not isinstance(quality_rows, list) or len(quality_rows) != len(metrics_rows):
+            raise ValueError(
+                f"{label} outcomes must be a list matching its trace count"
+            )
+        for index, (metrics, quality_raw) in enumerate(
+            zip(metrics_rows, quality_rows, strict=True),
+            start=1,
+        ):
+            quality = _validated_trial_outcome(
+                quality_raw, f"{label}[{index - 1}]"
+            )
+            if metrics.get("time_to_first_edit_seconds") is None:
+                raise ValueError(
+                    f"{label}[{index - 1}] has no root-user to first-edit evidence"
+                )
+            if (
+                metrics.get("blocking_assistant_requests_before_first_edit")
+                is None
+            ):
+                raise ValueError(
+                    f"{label}[{index - 1}] has no blocking-turn evidence"
+                )
+            if runtime_identity is None:
+                runtime_identity = quality["runtime"]
+            elif quality["runtime"] != runtime_identity:
+                raise ValueError(
+                    "all repeated trials must use the same model/effort/provider"
+                )
+            joined[label].append(
+                {
+                    "variant": label,
+                    "trial": index,
+                    **metrics,
+                    **quality,
+                }
+            )
+
+    metric_names = (
+        "time_to_first_edit_seconds",
+        "blocking_assistant_requests_before_first_edit",
+        "main_assistant_requests",
+        "total_input_tokens",
+        "output_tokens",
+        "all_total_input_tokens",
+        "all_output_tokens",
+    )
+    summaries: dict[str, dict[str, dict[str, float]]] = {}
+    for label, rows in joined.items():
+        summaries[label] = {
+            metric: _metric_summary([float(row[metric]) for row in rows])
+            for metric in metric_names
+        }
+        passed = sum(row["product_ac"]["passed"] for row in rows)
+        total = sum(row["product_ac"]["total"] for row in rows)
+        summaries[label]["product_ac"] = {
+            "passed": float(passed),
+            "total": float(total),
+            "rate": round(passed / total, 6) if total else 0.0,
+        }
+
+    baseline_quality = {
+        field: sum(row[field] for row in joined["baseline"])
+        for field in _QUALITY_FIELDS[1:]
+    }
+    variant_quality = {
+        field: sum(row[field] for row in joined["variant"])
+        for field in _QUALITY_FIELDS[1:]
+    }
+    quality_regressed = (
+        summaries["variant"]["product_ac"]["total"]
+        != summaries["baseline"]["product_ac"]["total"]
+        or summaries["variant"]["product_ac"]["passed"]
+        < summaries["baseline"]["product_ac"]["passed"]
+        or any(
+            variant_quality[field] > baseline_quality[field]
+            for field in _QUALITY_FIELDS[1:]
+        )
+    )
+    baseline_edit = summaries["baseline"]["time_to_first_edit_seconds"]["median"]
+    variant_edit = summaries["variant"]["time_to_first_edit_seconds"]["median"]
+    baseline_blocking = summaries["baseline"][
+        "blocking_assistant_requests_before_first_edit"
+    ]["median"]
+    variant_blocking = summaries["variant"][
+        "blocking_assistant_requests_before_first_edit"
+    ]["median"]
+    enough_trials = len(baselines) >= 3
+    materially_faster = variant_edit <= baseline_edit * 0.8
+    no_more_blocking = variant_blocking <= baseline_blocking
+    conditional_candidate = (
+        enough_trials
+        and not quality_regressed
+        and materially_faster
+        and no_more_blocking
+    )
+    return {
+        "fixture": fixture,
+        "runtime": runtime_identity,
+        "trial_count_per_variant": len(baselines),
+        "trials": joined,
+        "summary": summaries,
+        "quality_regressed": quality_regressed,
+        "adoption": {
+            "default": "main-direct",
+            "conditional_fresh_executor": conditional_candidate,
+            "decision": (
+                "fresh executor is a narrow conditional candidate"
+                if conditional_candidate
+                else "retain main-direct; fresh executor evidence is insufficient"
+            ),
+            "threshold": (
+                "at least 3 paired trials, no quality regression, "
+                "fresh median time-to-first-edit at least 20% lower, "
+                "and no higher median blocking-turn count"
+            ),
+        },
+        "claim_boundary": (
+            "repeated frozen-fixture screening with identical declared runtime; "
+            "supports only this narrow routing decision, not default or public "
+            "provider/model superiority"
         ),
     }
 
@@ -315,6 +699,15 @@ def format_text(r: dict) -> str:
         f"{r['cache_read_input_tokens']} / {r['total_input_tokens']}"
     )
     lines.append(f"  output tokens           : {r['output_tokens']}")
+    lines.append(
+        "  request→first edit / blocking requests: "
+        f"{r['time_to_first_edit_seconds']}s / "
+        f"{r['blocking_assistant_requests_before_first_edit']}"
+    )
+    lines.append(
+        "  all-executor input/output tokens: "
+        f"{r['all_total_input_tokens']} / {r['all_output_tokens']}"
+    )
     lines.append(f"  model / effort / provider: {r['models']} / {r['effort_levels']} / {r['providers']}")
     lines.append(f"  total assistant turns : {r['total_turns']}")
     lines.append(f"    - tool turns        : {r['tool_turns']}")
@@ -329,6 +722,14 @@ def format_text(r: dict) -> str:
         for name, n in r["tool_histogram"].items():
             lines.append(f"    - {name}: {n}")
     return "\n".join(lines)
+
+
+def _session_files(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(path.glob("*.jsonl"))
+    if path.is_file():
+        return [path]
+    return []
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -354,11 +755,13 @@ def main(argv: list[str] | None = None) -> int:
 
     p = Path(args.path).expanduser()
     if args.paired_with:
-        if not p.is_file():
+        baseline_files = _session_files(p)
+        if not baseline_files:
             print(f"ERROR: baseline not found: {p}", file=sys.stderr)
             return 2
         variant_path = Path(args.paired_with).expanduser()
-        if not variant_path.is_file():
+        variant_files = _session_files(variant_path)
+        if not variant_files:
             print(f"ERROR: variant not found: {variant_path}", file=sys.stderr)
             return 2
         if not args.outcomes:
@@ -366,24 +769,26 @@ def main(argv: list[str] | None = None) -> int:
             return 2
         try:
             outcomes = json.loads(Path(args.outcomes).read_text(encoding="utf-8"))
-            paired = build_paired_screening(
-                parse_session(p), parse_session(variant_path), outcomes
-            )
+            if len(baseline_files) == len(variant_files) == 1:
+                paired = build_paired_screening(
+                    parse_session(baseline_files[0]),
+                    parse_session(variant_files[0]),
+                    outcomes,
+                )
+            else:
+                paired = build_repeated_screening(
+                    [parse_session(path) for path in baseline_files],
+                    [parse_session(path) for path in variant_files],
+                    outcomes,
+                )
         except (OSError, json.JSONDecodeError, ValueError) as exc:
             print(f"ERROR: paired screening invalid: {exc}", file=sys.stderr)
             return 2
         print(json.dumps(paired, ensure_ascii=False, indent=2))
         return 0
-    if p.is_dir():
-        files = sorted(p.glob("*.jsonl"))
-    elif p.is_file():
-        files = [p]
-    else:
-        print(f"ERROR: not found: {p}", file=sys.stderr)
-        return 2
-
+    files = _session_files(p)
     if not files:
-        print(f"ERROR: no *.jsonl in {p}", file=sys.stderr)
+        print(f"ERROR: not found: {p}", file=sys.stderr)
         return 2
 
     results = [parse_session(f) for f in files]

--- a/skills/acceptance/SKILL.md
+++ b/skills/acceptance/SKILL.md
@@ -9,7 +9,7 @@ description: story 또는 epic 구현 완료 후 제품 단위 검수를 수행�
 
 > 🔴 **분기 규칙 SSOT** — `product-acceptance` 결론(`PASS` / `FAIL` / `ESCALATE`) → 다음 행동은 [`acceptance-routing.md`](acceptance-routing.md) 가 본 skill 의 단일 진본이다. 본 파일은 입력 정형화와 진행 절차만 담는다. 용어·공개 진입점·분기 표현을 수정하거나 리뷰할 때만 [`terms.md`](../../docs/plugin/terms.md) 를 확인한다.
 
-> `/impl-loop` 는 story/epic 마감 task 의 머지 *전* 에 같은 `product-acceptance` agent 로 inline 검수를 돈다 — 그 경로의 결론→다음(gap 수정 루프 포함)은 [`impl-loop-routing.md` 마감 acceptance 분기](../impl-loop/impl-loop-routing.md#마감-acceptance-분기) 가 소유하고, 본 skill 의 prompt 규약(아래 Story/Epic Acceptance 호출 형식)만 재사용한다.
+> `/impl-loop` 는 story/epic 마감 task 의 머지 *전* 에 같은 `product-acceptance` agent 로 inline 검수를 돈다 — 그 경로의 결론→다음(gap 수정 루프 포함)은 [`impl-loop-finish.md` product acceptance](../impl-loop/impl-loop-finish.md#product-acceptance) 가 소유하고, 본 skill 의 prompt 규약(아래 Story/Epic Acceptance 호출 형식)만 재사용한다.
 
 ## Inputs
 

--- a/skills/acceptance/acceptance-routing.md
+++ b/skills/acceptance/acceptance-routing.md
@@ -111,7 +111,7 @@ acceptance gap issue 는 제품 검수 후속이다. 이미 기준 문서와 구
 
 `FAIL` 은 끝이 아니라 다음 작업 단위로 돌아가기 위한 보고다.
 
-- 자동 수정하지 않는다. (standalone `/acceptance` 한정 — `/impl-loop` 의 story/epic 마감 inline 검수는 마감 PR 이 아직 열려 있어 auto-fixable gap 의 수정 루프를 돌며, 그 결론→다음은 [`impl-loop-routing.md` 마감 acceptance 분기](../impl-loop/impl-loop-routing.md#마감-acceptance-분기) 가 소유한다.)
+- 자동 수정하지 않는다. (standalone `/acceptance` 한정 — `/impl-loop` 의 story/epic 마감 inline 검수는 마감 PR 이 아직 열려 있어 auto-fixable gap 의 수정 루프를 돌며, 그 결론→다음은 [`impl-loop-finish.md` product acceptance](../impl-loop/impl-loop-finish.md#product-acceptance) 가 소유한다.)
 - 자동 issue 생성하지 않는다.
 - 사용자 승인 없이 GitHub issue 를 만들지 않는다.
 - gap 은 기준 문서, 구현 증거, 누락 사실, 후속 분기를 포함한다.

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -1,129 +1,85 @@
 ---
 name: impl-loop
-description: Story/공통 impl task 파일(SDD 설계도)을 받아 단일 build-worker headless runner 로 구현한다. task 1개(single) 또는 여러 개(chain/story/epic) 를 처리하며, build-worker 가 task 별 로컬 커밋까지 소유하고, 모든 대상 task 구현 후 merge candidate diff 를 impl-validator 가 1회 통합 리뷰한다. push/PR/merge 는 메인만 수행한다. 사용자가 "/impl-loop <task>", "이 deep task 구현", "전부 구현", "task 다 돌려", "epic 전체 구현", "끝까지 구현", "/design 후 자동"처럼 impl task 경로/목록/story/epic 을 명시할 때 사용한다. 일반 구현·버그픽스·한 줄 수정은 기본 진입점 `/impl`.
+description: Story/공통 impl task 파일을 받아 build-worker로 구현하는 runner. worktree 이후 run/state/step/provider launch를 기존 implementation chain 한 호출로 준비한다. task 1개 또는 story/epic chain을 처리하고, 모든 구현이 끝난 뒤에만 통합 review·acceptance·PR 마감 진본을 읽는다. 일반 구현은 /impl.
 ---
 
-# Impl Loop Skill — story/epic build-worker runner
+# Impl Loop — one-shot worker start
 
-> 본 스킬 = `/design` 이 만든 SDD story/epic 설계도(`docs/epics/**/impl/NN-*.md`)를 단일 구현 엔진 `build-worker` headless runner 로 처리한다. 일반 구현 요청은 [`/impl`](../impl/SKILL.md) 이 맡는다.
+`/impl-loop`는 `docs/epics/**/impl/NN-*.md`를 단일 구현 엔진 `build-worker`로 처리한다. 일반 버그픽스·한 줄 수정·설계 문서 없는 구현은 [`/impl`](../impl/SKILL.md)로 간다.
 
-> 🔴 **분기 규칙 SSOT** — build-worker 결론 → 다음 호출 / retry 한도 / acceptance gap 처리는 [`impl-loop-routing.md`](impl-loop-routing.md) 가 본 skill 의 단일 진본. 본 파일은 진행 절차만 담는다.
+```text
+target/AC snapshot → worktree → implementation-chain 한 호출 → worker
+```
 
-## Loop
+구현 전 메인은 provider resolve, `prev-tasks-reset`, `begin-run`, `begin-step`, prompt-slot 문서 확인을 따로 수행하지 않는다. 기존 `dcness-implementation-chain`이 story runner와 helper를 호출해 한 번에 소유한다.
 
-- **loop**: `impl-task-loop` (UI 감지 시 `impl-ui-design-loop`)
-- **entry_point**: `impl`
-- **implementation**: `build-worker` 하나. `build-worker` 는 test + impl + self-validate + task local commit 을 수행한다.
-- **review**: 모든 대상 task 와 `journey_deferred`가 아닌 자동 `(JOURNEY)` 수렴이 completed 된 뒤 merge candidate diff 를 대상으로 `impl-validator` 1회 통합 리뷰. Epic close를 발동하는 최종 candidate만 그 앞에서 `impl-validator:CODEBASE_SANITY`를 1회 수행한다.
-- **main-owned**: push / PR 생성 / PR merge / issue mutation 은 메인 전담. 최초 PR은 acceptance·AC close audit·tree-preserving consolidate 뒤에만 만든다.
-- **state**: `dcness-story-runner` 가 chain identity, task 순서, task commit 상태만 저장하고 story PR/run 종결은 task 에서 계산한다. provider capability failure는 chain identity를 키로 둔 sidecar에 보존한다.
-- **분기 규칙**: [`impl-loop-routing.md`](impl-loop-routing.md)
+모든 task가 completed 되기 전에는 validator provider, Cartography freshness, CODEBASE_SANITY, product acceptance, close audit, PR/merge 상세를 읽지 않는다. 그 경계에서만 [`impl-loop-finish.md`](impl-loop-finish.md)를 읽는다. worker 실패 분기가 실제로 생겼을 때만 [`impl-loop-routing.md`](impl-loop-routing.md)를 읽는다.
 
-UI expected_steps 의 `canvas-design` 은 진행 뷰용 main-owned checkpoint 이며 helper begin/end-step 비대상이다. draft가 필요할 때 ledger에 기록되는 실제 mode 없는 foreground designer step은 lifecycle hook이 소유한다.
+## 입력과 소유권
 
-## Inputs
+- 입력: impl task 1개, task 목록, glob 또는 epic impl 디렉터리
+- 구현: `build-worker` 하나가 test → impl → self-validate → task local commit 수행
+- 상태: `dcness-story-runner`가 chain identity, 정렬된 task, commit/status를 저장
+- 외부 상태: push, PR, merge, issue mutation은 메인만 수행
+- merge: 자동 merge 금지, 사용자가 유일한 merge gate
 
-- deep task 경로 (필수): 단일 task, task list, glob, 또는 epic impl 디렉터리.
-- 이슈 번호 (있으면): parent epic/story 본문과 target GitHub issue AC read 에 사용한다.
-- 선택 `--retry-limit N`: task 당 자동 재시도 한도. 기본 3.
-- 선택 `--no-acceptance`: story/epic 마감 acceptance 비활성. 미지정 시 기본 ON.
-
-## 비대상
-
-- 일반 구현 / 버그픽스 / 한 줄 수정 / 설계 문서 없는 작은 구현 → `/impl`
-- spec / design 단계 → `/spec` (PRD) 또는 `/design` (설계)
-- deep task 부재 → 기본 진입점 `/impl`
-
-## UI 작업 시 canvas-design 선두
-
-UI 작업이면 구현 전 **UI 기준 확보 분기**를 먼저 본다. 내부 [`canvas-design`](../canvas-design/SKILL.md) 은 main-owned checkpoint 이며 helper begin/end-step 비대상이다. 기준 있음 / 신규 시각 구조 + 기준 없음 / 시각 구조 불변을 판정하고, 필요한 경우 mode 없는 foreground designer Agent를 lifecycle hook 경로로 호출해 draft 생성 → 사용자 PICK → 확정본 승격 → `docs/design-variants/canvas.html` frame 등록을 수행한다.
-
-반환값은 `docs/design-variants/<screen-id>.html` 확정 목업 경로와 핵심 node-id 매핑이다. `build-worker` 는 그 경로를 디자인 정합 기준으로 읽고, 레이아웃 계층·상태·토큰·의도적 차이를 보고한다. 사용자 PICK 은 draft 생성 시 canvas-design 내부 조건부 절차이며 chain sub-step 으로 세지 않는다.
-
-## 워크트리와 story stack
-
-진입 시 worktree 격리를 기본으로 사용한다. 자세한 mechanics 는 [`loop-procedure.md`](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정)를 따른다.
-
-### Story branch base
-
-단일 story worktree는 `main`에서 시작한다. 다중 story는 첫 story를 `main`, 다음 story를 직전 story 브랜치에서 재분기한다. PR 생성 시 stack base를 유지하고 merge 승인 시점에만 main으로 리타겟·리베이스한다. mechanics는 [`loop-procedure.md` story 브랜치 스택](../../docs/plugin/loop-procedure.md#story-브랜치-스택), naming/trailer는 [`git-spec.md` story 브랜치 스택](../../docs/plugin/git-spec.md#story-브랜치-스택)이 진본이다.
+같은 story 값은 path 정렬 결과에서 한 연속 block이어야 한다. 다중 story는 `story1(base=main) → story2(base=story1)` branch stack이며, 다음 story는 직전 story 브랜치에서 재분기한다.
 
 ## Fast start
 
-1. `docs/epics/**/stories.md` 상단의 `**GitHub Epic Issue:** [#N]` 또는 `미등록 (사유: …)` 를 확인한다. 없으면 STOP.
-2. parent epic/story issue 본문을 진입 preflight 에서 한 번 read 하고 target GitHub issue AC snapshot 을 만든다. task 자체는 GitHub issue 가 아니라 impl 파일 + task commit 으로 추적한다. snapshot 은 task/story 진행 전체에서 재사용하며 반복 issue 조회를 추가하지 않는다. AC가 없거나 검증 주체가 미기재됐으면 close 전에 현행 typed AC로 갱신하고, agent가 의미를 임의 추론해 체크·재분류하지 않는다. 현행 typed 일반론 AC 는 snapshot 에서 구체화해 구현 계약으로 쓰되 사용자 판단 없이는 구체화하지 않는다.
-3. task 가 이미 머지됐는지 `git log --grep <task-slug>` 와 task tail 로 확인한다.
-4. `begin-run impl --design-doc <task impl 문서>` 로 설계 문서를 한 번 기록한다. 이 run-level 값에서 `### 수정 허용` 경로를 mutation-time guard가 재사용한다.
-5. task 목록에서 `(JOURNEY)` 선언과 `acceptance_environment`를 수집한다. journey 미선언 run과 `automation=human_verification`만 있는 run은 추가 호출 없이 no-op이다. 자동 journey가 있으면 구현 전에 `begin-step build-worker JOURNEY_ENV_PREFLIGHT`를 열어 실제 worker 실행 컨텍스트에서 probe·자동 준비를 1회 수행한다. 준비 완료 또는 검출 불확실은 `PASS`로 task 구현에 진행하고, 확실한 미충족 + 자동 준비 불가만 사용자에게 환경 먼저 준비 / 구현만 진행하고 journey 검수 분리 중 하나를 1회 확인한다. 분리를 선택하면 해당 `journey_id`를 현재 run의 `journey_deferred` 목록으로 진행 뷰와 이후 모든 build-worker·impl-validator·product-acceptance prompt에 보존한다. 해당 journey는 수렴·sealed acceptance·종료 조건의 수렴 PASS Must 비대상이며 human verification/follow-up으로 남고, 그 AC가 속한 story/epic issue는 닫지 않으며 PR body에 `Closes`를 붙이지 않는다. 다른 자동 journey는 정상 진행한다.
+### 1. 최소 snapshot
 
-전체 repo boundary scan, generated TDD 설치 health, provider별 preview는 task 시작 전에 실행하지 않는다. hard boundary와 TDD는 실제 mutation-time/post-run guard에서 검사하며, 같은 plan/config/tree를 task·retry·provider마다 다시 preflight하지 않는다.
+warm handoff나 사용자 입력이 exact task path·AC snapshot pointer·slim prompt와
+feature worktree 상태를 이미 확정했으면 이 snapshot을 다시 `ls`/`find`/`cat`하지
+않는다. one-shot launch가 첫 tool call이다. worktree/default-branch 정합은 chain이
+mutation 전에 검증한다.
 
-첫 진행 이정표는 task/AC snapshot과 worktree가 준비되는 즉시 `착수: <task> · worker 시작`으로 남긴다. 이후 `진행: RED/첫 edit 확인`, `진행: 구현·검증 green`, `진행: 통합 review 시작`처럼 사용자에게 의미 있는 변화만 알리고 helper PASS/no-op은 진행 성과처럼 echo하지 않는다.
+1. `stories.md`의 parent epic/story issue pointer를 확인한다.
+2. 대상 issue 본문을 한 번 읽어 target GitHub issue AC snapshot을 보관한다. 진행 중 재조회하지 않는다.
+3. AC가 없거나 검증 주체가 없으면 close 때 현행 typed AC로 갱신한다. 의미를 임의 추론해 체크하거나 재분류하지 않는다.
+4. task가 이미 머지됐는지만 `git log --grep <task-slug>`로 확인한다.
 
-## 질문 budget과 자율 복구
+전체 repo scan, generated TDD 설치 health, provider preview, branch naming SSOT, 후기 validator/Cartography/close 문서는 worker 전에 읽지 않는다.
 
-관련 코드 선택, scope bullet의 기계적 오타, 설계 문서가 이미 허용한 비표준 경로, timeout/idle timeout/empty prose, post-run TDD·soft boundary 실패, 일반 test/lint 실패는 묻지 않는다. wrapper가 같은 provider와 같은 workspace에서 변경분을 보존한 채 bounded continuation/rework를 수행하고 guard를 다시 검사한다.
+### 2. worktree가 첫 mutation보다 먼저
 
-제품 의미가 달라지는 선택, repo 밖 접근·새 dependency/secret·보안/데이터 파괴 등 새 권한, hard boundary 변경, 자동 복구 한도 소진, merge 승인만 사용자에게 묻는다. hard boundary 자동 확대, `.dcness/boundary.json` 자동 작성, `tdd-exempt` 자동 삽입, provider 간 dirty diff 인계는 금지한다.
+- 사용자가 “워크트리 없이”라고 하지 않았으면 즉시 `EnterWorktree`를 사용한다.
+- story branch는 main 또는 직전 story branch를 base로 만든다.
+- worktree 진입 뒤 task pointer와 test seam만 다시 잡는다.
+- `.dcness-work` state, `begin-run`, issue lifecycle mutation은 worktree 진입 전 실행하지 않는다.
+- canvas-design의 seed·draft·확정본 mutation도 worktree 안에서만 수행한다.
 
-반복 가능한 provider 실행·상태 보존·복구 prompt·guard 재검사는 `dcness-implementation-chain`과 story runner가 소유한다. 메인이 task마다 같은 명령/판정을 재작성하지 않으며, 새 side script를 늘리기 전에 기존 runner를 확장하고 대체된 helper·분기·문서는 함께 삭제한다.
+첫 메시지는 다음 한 줄이면 충분하다.
 
-## TaskCreate / TaskUpdate
+```text
+착수: <task> · worker 시작
+```
 
-본 skill 의 모든 step 은 Claude Code 의 **TaskCreate / TaskUpdate 호출과 한 묶음**이다. 자율 skip 금지.
+### 3. UI checkpoint와 slim prompt
 
-WHY: lifecycle hook/helper는 run state를, TaskCreate/TaskUpdate는 사용자가 직접 보는 진행 표시를 소유한다. 둘은 중복이 아니라 보완 관계다.
+UI 기준은 task/handoff에 드러난 정보만 3분기한다. 확정 목업·사용자 이미지가 있으면
+그 pointer를 slim prompt로 넘기고, 시각 구조 불변이면 그대로 진행한다. 신규 시각
+구조인데 기준이 없을 때만 main-owned `canvas-design` checkpoint를 열어 사용자
+PICK 뒤 `docs/design-variants/<screen-id>.html` 확정본 승격을 마친다. `canvas-design`은
+helper begin/end-step 비대상이며 mode 없는 foreground designer Agent의
+SubagentStart/PostToolUse lifecycle hook만 사용한다. 이 조건을 알아내려고 별도 UI
+전수조사를 하지 않는다.
 
-**중대 차단 안티패턴**: "begin-step 으로 트래킹 충분하다 자율 판단해서 TaskCreate skip" — 사용자 진행 상태가 보이지 않아 회귀한다.
+prompt에는 다음만 둔다.
 
-호출 시점:
+- 현재 impl task path
+- target issue AC snapshot pointer
+- 확정된 사용자 선택이 있으면 그 선택 한 줄
+- 진본에 없는 scope/test 제약
 
-- 진입 직후 task list 생성.
-- 각 step 전환 때 `TaskUpdate(status=in_progress | completed)`. `in_progress`와 mode 없는 foreground Claude Agent 호출이 서로 결과 의존성이 없으면 같은 assistant turn의 독립 tool batch로 발행한다.
-- 종료 직전 헤더와 sub-step 전부 completed.
+과거 transcript, review/close 절차, provider 설명, worktree 경로, `[PREVIOUS_TASKS]`를 복사하지 않는다. wrapper가 worktree와 이전 task 요약을 동적으로 합성한다. 구현 방법·assert 방식·알고리즘을 처방하지 않는다.
 
-retry 시 기존 sub-step 을 재활용하고 신규 TaskCreate 를 만들지 않는다.
+### 4. one-shot launch
 
-## Sub-agent prompt 작성 checkpoint (#780)
-
-`build-worker` / `impl-validator` / `product-acceptance` 호출 전, Agent tool input을 쓰기 전에 [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md)를 직접 읽고 3슬롯을 점검한다. 정적 원칙은 `begin-step` stdout relay가 아니다. foreground Claude Agent의 worktree와 `[PREVIOUS_TASKS]`는 SubagentStart hook이, headless build-worker는 wrapper가 첫 prompt에 직접 넣는다.
-
-- **대상 + 읽을 진본**: impl 파일 경로, preflight 에서 확보한 parent epic/story target GitHub issue AC snapshot, merge candidate diff, build-worker Cartography impact 자유 prose, affected Root Cartography 좌표, 관련 epic/decision 같은 SSOT 포인터만 둔다.
-- **리뷰 대상 전달 우선순위**: build-worker task 결과처럼 검토 대상이 커밋으로 존재하면 커밋 id와 변경 파일 목록을 선행 전달하고, validator가 `git show` / `git diff` / `git log`로 커밋 진본을 직접 펼치게 한다. 호출자는 별도 diff 파일을 덤프하지 않는다. 커밋이 없는 uncommitted local diff일 때만 diff 파일 전달을 폴백으로 사용한다.
-- **worktree**: foreground Claude Agent는 SubagentStart hook, headless는 wrapper가 worktree 절대경로를 동적으로 넣는다. 메인은 Bash stdout을 prompt로 재전달하지 않는다.
-- **이 호출 특유**: 재호출 finding, wave-plan 신호, 검증 대행 결과처럼 진본에 아직 없는 신호만 둔다.
-- agent 본업의 구현 방식, 테스트 assert 방식, 알고리즘 같은 방법 처방은 prompt 에 넣지 않는다.
-
-## impl 파일 사전 read 의무 (MUST — module-architect 7 원칙 + cost-aware #436)
-
-진입 시 `build-worker` 가 impl 파일의 `## 사전 준비` 섹션을 따라 다음 파일을 read 한다. **통째 read 금지** — `CLAUDE.md` 의 cost-aware 행동 (#402) 과 맞춘다. 200 line 초과 doc 은 grep + offset/limit 부분 read 를 사용한다.
-
-| 항목 | read 범위 |
-|---|---|
-| `docs/architecture.md` | 200 line 초과 시 본 task 관련 섹션만 grep + offset read. 100 line 이하면 통째 OK |
-| `docs/decisions/` | 본 task 영향 decision 만 read. 부재 시 silent skip |
-| `docs/prd.md` | 본 task 의 Story 항목 섹션만. 통째 read 금지 |
-| 의존 task 머지 PR | `gh pr view <num> --json body --jq '.body' | head -20` |
-| 형제 PR 환기 | `gh pr list --search "[epic<N>]" --state merged --limit 10 --json title,url` |
-| 의존 모듈 (수정 X 영역) | grep + 시그니처만 read. 예: `grep "^export" path/to/file.ts | head -10` |
-| 의존 모듈 (수정 영역) | 통째 read OK |
-
-메인 직접 read 는 **진입 분기 판단 최소**만 수행한다. 메인이 통째 read 하지 말 것. agent prompt 에 경로를 넣으면 build-worker 가 위 룰로 자체 read 한다.
-
-## build-worker 실행
-
-1. `journey_deferred`가 아닌 자동 `(JOURNEY)`가 있으면 task loop보다 먼저 같은 provider·sandbox 설정의 `JOURNEY_ENV_PREFLIGHT` mode를 호출한다. 이 호출은 tracked write/commit 없이 worker 실행 컨텍스트의 runtime 도달성을 판정한다. main host probe나 product-acceptance 실행으로 대행하지 않는다.
-2. `dcness-helper prev-tasks-reset` 은 chain 첫 task 또는 single 모드에서 build-worker 호출 전에 1회 실행한다. chain 2번째+ task 는 직전 task 산출을 hook/wrapper가 `[PREVIOUS_TASKS]`로 직접 넣으므로 reset하지 않는다.
-3. implementation provider를 먼저 resolve한다. 기본 provider는 `headless-chain`이다. routing 결과는 provenance=`routing`, 사용자가 직접 고른 override는 provenance=`explicit`으로 보존한다. headless provider면 wrapper 소유권을 위해 `begin-step build-worker`로 열고, mode 없는 foreground Claude Agent면 명시적 begin/end-step 없이 lifecycle hook에 맡긴다. modeful Claude Agent는 `begin-step build-worker <MODE>`를 유지한다.
-4. `/impl-loop`는 `dcness-implementation-chain build-worker --provider <provider> --provider-provenance <routing|explicit> --chain-state .dcness-work/story-run.json --prompt-file <file>`을 Bash tool의 `run_in_background: true`로 실행하고, foreground tool timeout에 종속되지 않게 workspace/raw log 진행을 polling한다. task 1개 single `/impl-loop`도 진입 직후 one-task story-runner state를 초기화하고 `--chain-state`로 넘긴다. prompt 에는 target GitHub issue AC snapshot 을 진본 포인터로 포함한다. 성공 경로는 마지막 응답 저장과 `end-step build-worker` 까지 수행한다. `/impl-loop`가 아닌 single `/impl`만 `--chain-state`를 생략하고 provider failure cache를 사용하지 않는다.
-   기본 routing 호출은 `--provider-provenance routing`, 사용자가 고른 override는 `--provider-provenance explicit`으로 넘겨 cache 적용 여부와 선택 출처를 섞지 않는다.
-5. build-worker 는 test → impl → self-validate 를 한 task 안에서 수행하고, gates 가 green 이면 로컬 task commit 을 만든다.
-   - `task_index: total/total` 인 Story 마지막 task 는 impl 문서의 종합 검증 REQ 로 해당 Story AC 전항목을 다시 실행·관찰한다. 앞 task 의 PASS 를 대신 재사용하지 않는다. 마지막 task 에 전수 검증 REQ 가 없으면 구현 완료로 간주하지 않고 `SPEC_GAP_FOUND` 로 설계 보강을 요청한다.
-6. task local commit 은 [`git-spec.md#의미-단위-커밋-분할`](../../docs/plugin/git-spec.md#의미-단위-커밋-분할)을 따른다. build-worker 는 한 task 안에서도 독립 검토 가능한 의미 단위로 쪼개되, 각 커밋은 hook 을 통과할 수 있는 일관 상태여야 한다.
-7. build-worker 는 `git status`, `git diff`, `git diff --check`, `git add`, `git commit`, `git rev-parse HEAD` 만 사용할 수 있다. `git push`, `gh pr create`, `gh pr merge`, `gh issue` mutation 은 금지다.
-8. build-worker report 에 commit sha, 검증 명령, clean status 가 없으면 task clean 으로 보지 않는다.
-
-provider wrapper:
+첫 task는 아래 명령 하나를 Bash `run_in_background: true`로 실행한다. shell 안에
+`nohup`, `&`, `disown`, redirect, `sleep`/polling을 덧붙이지 않고
+`.dcness-work`를 미리 만들지 않는다. `--init-path`는 전체 대상 task에 대해
+반복한다. provider를 미리 resolve하지 않는다.
 
 ```bash
 PLUGIN_ROOT=""
@@ -135,233 +91,81 @@ fi
 [ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
 HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
 
-if [ -n "${DCNESS_IMPLEMENTATION_PROVIDER:-}" ]; then
-  PROVIDER="$DCNESS_IMPLEMENTATION_PROVIDER"
-  PROVIDER_PROVENANCE="explicit"
-else
-  PROVIDER=$("$HELPER" routing resolve build-worker)
-  PROVIDER_PROVENANCE="routing"
-fi
-PROMPT_FILE="<prompt-file>"
-# 이 Bash tool 호출 자체를 `run_in_background: true` 로 발행한다.
 "$PLUGIN_ROOT/scripts/dcness-implementation-chain" build-worker \
-  --provider "$PROVIDER" \
-  --provider-provenance "$PROVIDER_PROVENANCE" \
   --chain-state .dcness-work/story-run.json \
-  --prompt-file "$PROMPT_FILE"
+  --init-path <impl-task-1> \
+  --init-path <impl-task-N> \
+  --prompt-file <slim-prompt> \
+  --issue-num <target-issue> \
+  --acceptance-required
 ```
 
-최초 resolve한 plugin root/helper 절대경로를 이후 독립 Bash 호출에 literal로 넣는다. 위 변수는 한 Bash 프로세스 안의 예시일 뿐 호출 간 지속 상태가 아니다.
+사용자가 provider를 직접 골랐을 때만 `--provider <provider> --provider-provenance explicit`을 추가한다. 기본 호출은 chain 내부 routing이며 provider option을 생략한다.
 
-phase prose:
+이 한 호출의 소유권은 다음과 같다.
 
-- build-worker 는 `build-test.md`, `build-impl.md`, `build-validate.md` phase prose 를 남긴다.
-- 이 세 파일은 worker 내부 phase 증거이며 outer Agent lifecycle receipt가 아니다. phase별 outer begin/end-step을 추가하거나 phase 파일을 outer completion으로 중복 append하지 않는다.
-- `build-{test,impl,validate}.md` 3개 실존 확인은 false-clean 방지 닻이다.
-- phase prose 부재 또는 worker/validator 흔적 없이 clean 표기 = false-clean → blocked.
+- chain: feature worktree 여부를 state mutation 전에 검사
+- story runner: state를 올바른 worktree에서 정확히 한 번 초기화
+- chain: chain 최초 1회만 previous tasks 초기화
+- chain/helper: 현재 task의 `begin-run impl --design-doc`를 필요할 때 정확히 한 번 생성
+- chain/helper: `--acceptance-required`를 chain의 마지막 task run에만 기록
+- chain/helper: completed 이전 task run이 있으면 다음 호출 안에서 닫고 현재 task run을 정확히 한 번 생성
+- chain: 같은 run의 `begin-step build-worker`를 provider fork 전에 정확히 한 번 기록
+- chain: provider resolve·fallback·same-workspace recovery
+- worker wrapper: 마지막 prose와 대응 `step_completed` terminal receipt
 
-검증 대행:
+같은 state와 같은 `--init-path` 재호출은 task 목록·project root가 일치할 때 기존 state를 재사용하고 중복 초기화하지 않는다. default branch에서 초기 launch하거나 state의 project root가 다르면 provider fork 전에 실패한다.
+background task notification의 최종 exit code가 실행 진본이다. exit 0이면 stage 중간
+stderr나 partial output에 provider 실패가 보여도 fallback을 포함한 chain이 terminal
+prose를 기록한 것이므로 재호출하지 않는다. 최신 prose가 `PASS`일 때만 mark하고,
+`TESTS_FAIL`·`SPEC_GAP_FOUND`·`VALIDATION_BLOCKED`·`IMPLEMENTATION_ESCALATE`는
+[`impl-loop-routing.md`](impl-loop-routing.md)대로 처리한다. 같은 current run에 이미
+`step_completed`가 있으면 chain 재호출도 provider를 다시 fork하지 않는 성공 no-op이다.
 
-- build-worker 가 `VALIDATION_BLOCKED` 를 보고하면 먼저 같은 run ledger의 최신 `codex_sandbox_permission_required` event가 가리키는 `codex-sandbox-permission-*.json` receipt와 `permission_required` 상태를 확인한다. 이 receipt는 Codex wrapper가 자유 prose와 raw log의 좁은 sandbox signature를 post-run boundary/TDD guard 종료보다 먼저 읽어 생성하며 agent 출력 JSON/marker가 아니다. guard도 실패했다면 permission receipt와 `worker_boundary` 또는 `tdd_guard` 실패가 함께 남고, 어느 한쪽이 다른 신호를 지우지 않는다.
-- permission receipt가 없을 때만 기존 경로대로 메인이 같은 worktree cwd에서 worker가 남긴 검증 명령을 직접 실행한다. assertion/compile/test 실패, 일반 `Permission denied`, Codex CLI/auth/timeout 실패에는 receipt가 생기지 않는다. permission receipt가 있으면 implementation chain은 같은 권한으로 해결 불가능한 guard 실패를 bounded continuation으로 반복하거나 dirty workspace를 다른 provider에 넘기지 않고 즉시 사용자 승인 경로로 멈춘다.
-- `permission_required`이면 메인은 사용자에게 승인 전에 다음 사실을 한 번 설명한다: 필요한 capability, `network_access`가 loopback 전용이 아니라 Codex workspace-write의 **outbound network** 전체 허용이라는 범위, 제안 writable root 절대경로와 로그 근거, `workspace-write` 유지, `danger-full-access` 미사용. 선택지는 **이번 실행에만 허용 / 이 프로젝트에 저장 / 거부** 세 가지다.
-- 사용자가 선택하면 `"$PLUGIN_ROOT/scripts/dcness-codex-permission" retry --receipt <receipt> --decision once|project|deny --prompt-file "$PROMPT_FILE" --project-root "$PROJECT_ROOT" --helper "$HELPER"`를 실행한다. `once`는 승인 env를 해당 Codex worker 프로세스에만 전달하고 설정 파일을 쓰지 않는다. `project`는 기존 최상위/`env` 키를 보존해 `.claude/settings.local.json`에 승인한 키만 병합하고 현재 재시도에도 같은 env를 명시적으로 전달한다.
-- permission retry는 provider chain이 아니라 Codex build-worker를 직접 `-s workspace-write`로 한 번만 재호출한다. malformed settings, 사용자 `deny`, 안전한 root 추론 실패, 승인 후 같은 거부 반복은 설정·권한을 더 바꾸지 않고 `VALIDATION_BLOCKED`를 유지한다. 이 상태에서 host 직접 검증, 다른 provider, `danger-full-access`로 우회하지 않고 증거와 남은 선택지를 사용자에게 보고한다.
-- permission retry는 chain capability cache를 우회한다. 사용자 명시 provider 호출도 provenance=`explicit`으로 cache를 우회하며, 우회 실행 성공 시 해당 provider의 오래된 entry를 무효화한다.
-- 검증 미실행 상태로 commit/push/PR 진행 금지.
+### 5. worker task loop
 
-## story/epic runner task 단일 상태 (#1019, #1041)
+- worker는 impl 파일의 `## 사전 준비` pointer만 따라 focused read한다.
+- 200 line 초과 문서는 관련 section만 `rg` + offset read하고, 수정하지 않는 모듈은 signature만 읽는다. 메인은 worker 대신 문서를 통째로 읽지 않는다.
+- task local commit과 실제 검증 명령·exit code·clean status가 report에 있어야 PASS다.
+- Story 마지막 task는 Story AC 전항목을 종합 검증한다. 종합 REQ가 없으면 `SPEC_GAP_FOUND`다.
+- 기본 build-worker는 task를 읽은 직후 자동 `(JOURNEY)` 선언을 감지하고, 같은
+  worker context에서 source read/edit보다 먼저 `JOURNEY_ENV_PREFLIGHT`를 내부
+  phase로 한 번 수행한다. journey 미선언은 no-op이며 별도 main/provider launch를
+  만들지 않는다.
 
-`/impl-loop` 은 single/chain 모드를 가리지 않고 진행을 자연어로 암기하지 않는다. task 1개 single 모드도 진입 직후 `dcness-story-runner plan/init` 으로 one-task state를 만들고, 여러 task의 story/epic 모드도 같은 runner가 impl task 목록을 path 순으로 정렬한다. 정렬 결과에서 같은 frontmatter `story` 값(숫자 story 와 `공통` 모두)이 둘 이상의 비연속 block 으로 재등장하면 `plan/init` 은 관련 task 경로를 보고하고 fail-fast 한다. `init` 은 이 검증을 기존 state 의 아카이브·교체보다 먼저 수행해 실패 시 state 를 변경하지 않는다. story 간 의존성을 표현할 수 있는 path 순서를 runner 가 임의로 재정렬하지 않으며, 각 story 가 한 연속 block 인 입력은 기존 순서를 그대로 보존한다. state file에는 chain 수명 식별자인 `chain_id`와 각 task의 `pending / running / completed / error / blocked`, `attempts / commit / provider / note`만 저장한다. story/run status와 PR 번호는 저장하지 않는다.
-
-provider capability cache는 `.dcness-work/provider-failure-cache/<chain_id>.json` sidecar다. `cli_missing`, `auth_unavailable`, `config_unavailable`만 cacheable하며 `timeout`, `idle_timeout`, `empty_output`, `boundary_violation`, `tdd_guard`, `interrupt`, `network_transient`, 일반 `provider_error`, agent 결론은 cache하지 않는다. workspace/HEAD 변경 뒤 recoverable category는 같은 provider/같은 workspace에서 기본 2회 bounded continuation하고 매번 boundary/TDD guard를 재검사한다. 단, 같은 실패 receipt에 `permission_required`가 함께 있으면 새 권한 없이는 self-recovery할 수 없으므로 반복하지 않는다. 복구 불가 category나 한도 소진은 diff를 보존하고 중단하며 다른 provider로 fallback하지 않는다. cache hit는 provider/category/최초 `first_raw_log`/`scope=chain:<chain_id>`를 남긴다. 새 chain·다른 project/worktree·완료/reinit chain은 cache를 이어받지 않고, 동시 access는 lock+atomic replace로 보호한다.
-
-실행 단위는 **task commit** 과 **story PR** 이다. build-worker가 각 task local commit을 만든 뒤 mark 성공에만 next-action을 실행하는 한 Bash 호출로 `dcness-story-runner mark ... && dcness-story-runner next-action ...`을 묶는다. `&&` 계약 때문에 mark 실패 시 next-action은 실행되지 않는다. `error` / `blocked` 는 서로 다른 task 상태로 기록하고 `--note <사유>` 를 반드시 남긴다.
-
-`next-action` 의 파생 결과만 다음 행동을 정한다.
-
-- `action=task`: 미완 task 를 build-worker 로 실행한다.
-- `action=story-pr`: 직전 story 의 task commit 이 모두 완료됐다. 응답의 `story`와 `pr_base`로 PR base 메타와 story branch tip을 봉인하되 원격 PR은 아직 만들지 않는다. `next_branch_base`가 가리키는 직전 story 브랜치에서 재분기한 뒤 `next_task`를 시작한다.
-- `action=done`: 모든 task commit 이 완료됐다. `final_story`와 `pr_base`의 마지막 story branch tip을 봉인하고 `stack_tip` vs main merge candidate를 확정한다. `journey_deferred`를 제외한 수렴 대상만 다음 호출로 보내며, 최초 PR cut은 필요한 수렴·review·acceptance·AC audit·consolidate 뒤다.
-- `action=error` / `action=blocked`: 해당 task 의 note 를 근거로 retry 또는 사용자 위임한다.
-
-task 가 모두 completed 면 run 은 PR 생성·머지 여부와 무관하게 종결된 것이다. 다음 `init` 은 기존 state 를 `story-run.completed-<UTC>.json` 으로 자동 보관하고 `--force` 없이 새 run 을 시작한다.
+성공 뒤 task commit을 mark하고 `next-action`을 같은 Bash 호출로 묶는다.
 
 ```bash
-"<PLUGIN_ROOT_ABS>/scripts/dcness-story-runner" plan <impl-glob-or-dir>
-"<PLUGIN_ROOT_ABS>/scripts/dcness-story-runner" init --state .dcness-work/story-run.json <impl-glob-or-dir>
-"<PLUGIN_ROOT_ABS>/scripts/dcness-story-runner" mark --state .dcness-work/story-run.json --task <id> --status completed --commit <sha> && \
-  "<PLUGIN_ROOT_ABS>/scripts/dcness-story-runner" next-action --state .dcness-work/story-run.json
+"$PLUGIN_ROOT/scripts/dcness-story-runner" mark \
+  --state .dcness-work/story-run.json \
+  --task <id> --status completed --commit <sha> &&
+"$PLUGIN_ROOT/scripts/dcness-story-runner" next-action \
+  --state .dcness-work/story-run.json
 ```
 
-`<PLUGIN_ROOT_ABS>`는 진입 시 최초 resolve한 literal 절대경로다. `$PLUGIN_ROOT` shell 변수가 독립 Bash tool 호출 사이에 지속된다고 가정하지 않는다. `dcness-helper`의 self-location은 이미 발견된 executable 내부 root 해소일 뿐 executable 발견 경로가 아니다.
+- `action=task`: 다음 task용 slim prompt로 chain을 다시 호출한다. 기존 state이므로 `--init-path`는 생략하며, chain이 이전 run 종료와 새 run 시작을 같은 호출 안에서 처리한다.
+- `action=story-pr`: 직전 story tip/base를 봉인하고 PR 없이 다음 story branch를 만든다.
+- `action=done`: worker loop를 끝내고 GREEN 이후 진본으로 이동한다.
+- `action=error|blocked`: 그때만 routing 문서를 읽어 bounded recovery 또는 사용자 결정을 수행한다.
 
-완료 state 는 `story-run.completed-<UTC>.json` 으로 보관한다. 이 state file 은 직렬 chain driver 전용이며, 메인이 path glob 를 다시 정렬하거나 frontmatter 를 재해석하지 않는다.
+진행 메시지는 `진행: RED/첫 edit 확인`, `진행: 구현·검증 green`, `진행: 통합 review 시작`처럼 사용자에게 의미 있는 변화만 남긴다. helper PASS/no-op과 polling 자체를 성과처럼 반복 출력하지 않는다.
 
-story branch / PR 경계:
+## 질문 budget과 안전
 
-- 단일 story run: `final_story` branch 1개를 base=`main`으로 봉인한다. review/acceptance/AC audit/consolidate 뒤 PR 1개를 처음 만든다.
-- 다중 story/epic run: story branch를 `story1(base=main) → story2(base=story1) → …`로 쌓는다. `action=story-pr`마다 현재 tip과 base를 봉인하고 다음 branch는 **직전 story 브랜치에서 재분기**한다. 원격 story PR은 아직 만들지 않는다.
-- 마지막 `action=done`: `stack_tip` vs main을 최종 candidate로 삼는다. tracked cross-cutting 보정이 생기면 stack tip 기반 QA branch가 흡수하고, 변경이 없으면 빈 QA branch/PR을 만들지 않는다. 모든 PR은 clean cut 경계에서 한 번에 만든다.
-- loop의 자동 merge 금지: 사용자가 유일한 merge gate다. 승인 전 `$PLUGIN_ROOT/scripts/pr-finalize.sh` 호출은 금지한다.
+관련 코드 선택, scope 오타, 일반 test/lint 실패, timeout/empty prose, 같은 workspace recovery는 묻지 않는다. 제품 의미·새 권한·hard boundary·데이터 파괴·복구 한도 소진·merge 승인만 묻는다.
 
-dry preview echo:
+- hard boundary 자동 확대, `tdd-exempt`, provider 간 dirty diff 인계 금지
+- build-worker의 push/PR/merge/issue mutation 금지
+- TDD와 mutation-time boundary guard 유지
+- 새 side script보다 기존 chain/runner 확장 우선
+- 대체한 helper·분기·문서·테스트는 함께 삭제하고 옛 호출을 `rg`로 확인
 
-```text
-전체: K task commit · S story PR · tracked 마감 보정이 있으면 QA PR 1개
-stack: story1(base=main) → story2(base=story1) → … → QA(조건부)
-acceptance 경계: story #<M>…#<N> · epic #<E>   ← 각 main 리타겟/merge 전 검수 대상 (기본 ON, --no-acceptance 시 생략)
-```
+## GREEN 이후
 
-issue close 가 실제 발동되는 story PR 또는 epic 마감 PR 을 포함한 chain 은 task 수와 무관하게 계획 표 echo + `진행할까요? (Y/n)` 1회 확인 후 진입한다. 확인 응답 전에는 task1 또는 story PR merge 준비로 진입하지 않는다. 구현 완료 뒤 각 story PR 의 main 리타겟 직전에 1회 확인한다. yolo 모드에서는 생략한다.
-
-## Story PR / integrated review / merge
-
-story 의 target task 가 completed 될 때마다 메인은 story branch tip과 base만 봉인한다. 다중 story run 은 local branch stack을 먼저 완성하고, `impl-validator review 출력은 merge candidate 경계에서 1회`만 수행한다. 단일 story는 story→main candidate diff, 다중 story/epic은 **스택 tip vs main** diff를 넘긴다. QA branch가 있으면 그 branch가 stack tip이다. 모든 Story/PR마다 full-repo semantic audit을 강제하지 않으며, repo-wide Codebase Sanity cadence는 Epic당 최종 clean candidate 1회가 기본이다.
-
-정상 순서:
-
-1. 한 story 의 build-worker task commit 들과 `git status --porcelain` clean 을 확인한다. runner의 `pr_base`와 story branch tip을 기록한 뒤, 다중 story/epic이면 `next_branch_base`가 가리키는 직전 story branch에서 다음 story branch를 만든다. 자동 merge 금지다.
-2. 모든 target task가 completed 되면 `journey_deferred`가 아닌 자동 `(JOURNEY)`가 있는 final stack tip에서 `begin-step build-worker JOURNEY_CONVERGENCE`로 fresh context 수렴 호출을 연다. 첫 실행 PASS면 1회로 끝내고, 실패하면 실행·관찰·배관 수정·재실행을 수행한다. 단일 story tracked 수정은 해당 story branch에 둔다. N-story 수렴의 story-local production 수정은 해당 story branch에 commit하고 downstream branch를 restack하며, cross-cutting production 수정과 tracked flow/manifest 보정은 QA branch에 둔다.
-3. 수렴 호출이 발동했다면 `JOURNEY_CONVERGENCE` PASS 뒤, 수렴 대상이 없어 비발동했다면 바로 final tip에서 통합 test/E2E 증거를 확정한다. 수렴이 production code를 바꾸면 재현 테스트 RED→GREEN과 의미 단위 commit이 있어야 한다. 설계·AC 충돌, 수렴 한도 초과는 분기 규칙대로 중단한다.
-4. Epic close를 발동할 최종 stack tip에서 메인이 repo의 실제 test/lint/build/typecheck/coverage 명령을 발견·실행하고 code revision 또는 tree identity, 명령별 exit code, warning, coverage 도구·리포트 유무를 수집한다. coverage 도구가 없으면 `UNKNOWN`이며 test count로 추정하지 않는다. 작은 단일-module repo는 전체 repo, 큰 repo는 affected module과 affected dependency cone을 semantic scope로 잡고 cheap global signals를 함께 남긴다.
-5. `begin-step impl-validator CODEBASE_SANITY`로 `impl-validator:CODEBASE_SANITY`를 연다. 같은 read-only impl-validator에 final merge candidate, task별 build-worker 보고, 수렴 증거, 수집한 기계적 증거, scope, Cartography 상태를 전달한다. finding이면 build-worker rework로 코드를 고친 뒤 수렴과 Sanity를 새 revision에서 재감사한다. PASS이면 `SANITY_RECEIPT_DIR="$("$HELPER" sanity-receipt-dir --project-root "$PROJECT_ROOT")"`로 persistent primary-worktree 경로를 구해 prose의 최소 의미를 `$SANITY_RECEIPT_DIR/<tree-identity>.md` local receipt로 보존한다. helper는 linked worktree의 `git --git-common-dir`을 기준으로 primary worktree의 `.dcness-work/codebase-sanity/`를 반환하므로 `ExitWorktree`가 임시 worktree를 제거해도 receipt가 남는다. local-only/ignored 정책이면 code PR에 포함하지 않는다.
-6. mode 없는 foreground `impl-validator`는 lifecycle hook 경로로 열고, build-worker provider의 반대편으로 review provider를 resolve 한다. 최종 stack tip 커밋 id와 변경 파일 목록을 선행 전달해 일반 merge-review mode가 커밋 진본을 직접 펼치게 하고, task별 build-worker Cartography impact, affected Root Cartography 좌표, 관련 epic/decision을 plan ∪ target GitHub issue AC와 함께 리뷰한다. `(JOURNEY)`가 있으면 선언된 각 `target_ac` ↔ flow의 실제 assertion 대조를 고정 항목으로 수행한다. Story-only close는 Step 4~5 없이 이 단계로 바로 온다.
-7. 영향 없음 또는 Root와 일치하면 기존 경로를 계속한다. system boundary는 유지되지만 route/state/as-built edge가 stale이면 메인이 기존 `module-architect:CARTOGRAPHY_REFRESH`를 호출해 affected Root 좌표만 bounded refresh하고 같은 diff+갱신 Root로 impl-validator 재검증한다. system boundary·global decision 변경이면 route-only patch로 흡수하지 않고 `/design --revise` 또는 system checkpoint backpressure에서 멈춘다.
-8. 일반 merge review `PASS` 후 close를 발동할 final tip에서 `product-acceptance`의 `STORY_ACCEPTANCE` × N을 story별로 판정하고, epic close 시 `EPIC_ACCEPTANCE`를 수행한다. `journey_deferred`가 담당하는 story는 close candidate에서 제외해 sealed journey 실행을 발동하지 않고 human verification/follow-up으로 보고한다. build-worker 수렴 PASS는 나머지 journey의 sealed 실행과 final tip cross-story 스위프를 대체하지 않는다.
-9. product-acceptance PASS 뒤 close를 발동할 `target GitHub issue AC close audit`을 수행하고 자동 typed AC 전항목을 close 경계에서 한 번 갱신·감사한다. `journey_deferred` target AC가 있는 story/epic은 close audit을 발동하지 않는다. checklist 밖 사람 항목은 미체크로 둔 별도 merge gate로 보존하며, 자동 audit PASS 뒤 clean cut은 계속한다.
-10. close audit 뒤 수렴 iteration 노이즈가 있을 때만 **커밋 consolidate**를 수행해 독립 검토 가능한 의미 단위로 재구성한다. 작업 전후 `git rev-parse <tip>^{tree}`가 같아 최종 tree 불변임을 확인하며, 이미 의미 단위면 no-op이다. tree가 바뀌면 기존 Sanity·review·acceptance·AC 증거를 stale 처리하고 수렴 이후부터 다시 수행한다.
-11. consolidate가 끝난 clean branch stack에서 repo git-spec의 push + `gh pr create` 절차로 **PR 생성**을 처음 수행한다. task commit으로 이미 clean인 branch에 새 commit을 요구하는 `scripts/pr-create.sh`는 이 경계에 사용하지 않는다. 단일 story close candidate는 acceptance PASS·AC close audit 뒤 최초 PR 1개를 cut한다. `journey_deferred` production-only candidate는 review와 consolidate 뒤 close 없이 PR을 cut한다. 다중 story는 봉인한 base로 story PR과 조건부 QA PR을 clean 상태에서 cut해 수렴 노이즈가 열린 PR에 append되지 않게 한다.
-12. 숫자 story close candidate PR body에는 `Closes #story`를 두고, QA PR 유무를 확정한 마지막 merge 대상 PR body에만 `Closes #epic`을 둔다. `journey_deferred` target AC가 있는 production-only PR에는 `Closes`를 붙이지 않고 `Part of`와 `Document-Exception-PR-Close: journey deferred human verification/follow-up` 사유로 연결한다. 그 외 story/QA PR에는 epic `Closes`가 남지 않았는지 확인한다.
-13. PR 이후 CI 실패가 rerun이나 외부 인프라 복구만으로 해소돼 tree가 같으면 acceptance verdict와 tree-identity Sanity receipt는 유효하다. tracked code나 harness를 수정하면 기존 증거를 stale 처리하고 수렴·검증·acceptance·audit·consolidate 뒤 PR에 새 commit을 반영한다.
-14. 사용자가 merge를 승인할 때 story PR을 순서대로 base=`main`으로 리타겟·리베이스한다. checklist 밖 사람 항목이 남아 있으면 먼저 `human verification 대기`로 멈춘다. 현재 story tip이 바뀌면 아직 열린 downstream branch를 새 tip 위에 순서대로 restack하고 `--force-with-lease`로 갱신한다. restack 충돌 해결로 최종 tree가 달라지면 기존 review/acceptance 증거를 stale 처리하고 통합 review부터 다시 수행한다. 각 PR은 해당 story acceptance verdict와 AC close audit을 확인한 뒤 `$PLUGIN_ROOT/scripts/pr-finalize.sh`를 호출한다. QA PR이 있으면 마지막에 같은 절차로 merge한다.
-
-### QA 산출물 배치
-
-- **1-story**: branch 1개 = PR 1개다. 수렴/review/acceptance가 찾은 fix와 tracked flow/manifest 보정은 PR cut 전 해당 story branch에 반영한다. 별도 QA PR은 만들지 않는다.
-- **N-story**: 최종 stack tip에서 수렴과 sealed acceptance를 실행해 story별 verdict를 만든다. story-local production 수정은 해당 story branch에 commit하고 downstream branch를 restack한다. cross-cutting production 수정과 tracked flow/manifest 보정은 마지막 story branch 기반 **QA branch/PR**이 흡수한다. tracked 변경이 없으면 빈 QA PR을 만들지 않는다.
-- receipt/log/screenshot은 ignored `.dcness-work/product-journey/`에만 두고 어떤 PR에도 commit하지 않는다. acceptance 보고에는 receipt 경로만 참조한다.
-- impl-validator의 story-local FAIL은 해당 story PR 브랜치에 commit하고 downstream branch를 restack한다. story PR 이 2개 이상인 run의 cross-cutting FAIL은 QA branch가 흡수하며 모든 PR은 재검증·consolidate 뒤 cut한다.
-
-Epic 마감의 고정 순서는 `JOURNEY_CONVERGENCE → impl-validator:CODEBASE_SANITY → impl-validator:merge review → 필요 시 CARTOGRAPHY_REFRESH → 같은 diff+갱신 Root impl-validator 재검증 → product-acceptance → close audit → commit consolidate → PR cut → 사용자 merge gate`다. Sanity PASS 이후 어떤 단계에서든 코드가 다시 바뀌면 기존 Sanity와 일반 impl-validator 증거를 모두 stale 처리하고 새 기계적 증거를 수집해 수렴과 Sanity부터 재진입한다. Cartography 문서만 bounded refresh되고 code tree가 같거나 consolidate가 tree identity를 보존하면 Sanity receipt는 그대로 유효하지만 일반 impl-validator는 같은 diff와 갱신 Root를 재검증한다.
-
-Sanity receipt에는 rigid JSON/marker 없이 code revision/tree identity, 실제 scope, 명령·exit/warning, coverage 값 또는 `UNKNOWN` 근거, dead-code 후보별 `removable`/`intentional stub`/`planned seam`/`framework-reachable`/`unknown`, example/scaffold·duplicate path·stale suppression/deprecation·convention drift·code-smell, clean 여부와 남은 finding/rework surface를 보존한다. receipt는 canonical Root refresh 완료 증거나 다음 `/design`의 affected capability/entrypoint 현재 코드 대조를 대신하지 않는다. `ExitWorktree` 전에 위 persistent 경로에 receipt가 실존하는지 확인한다.
-
-`CARTOGRAPHY_REFRESH`는 새 agent나 공개 진입점이 아니라 기존 bounded module-architect write 계약을 구현 종료 경계에서 재사용하는 workflow mode다. tracked docs는 현재 branch/PR 정책으로 반영한다. local-only/ignored private docs는 code PR에 강제 포함하지 않고 canonical local Root를 갱신하거나 exact affected 좌표·상태 증거·다음 producer를 durable impact handoff로 보존한다. durable impact handoff만으로 freshness가 해소되지는 않으며 canonical local Root refresh 확인 전에는 최종 clean이 아니다. build-worker와 읽기 전용 impl-validator는 docs write를 떠안지 않는다.
-
-producer 호출은 `begin-step module-architect CARTOGRAPHY_REFRESH`로 열고, module-architect prose를 `end-step module-architect CARTOGRAPHY_REFRESH --prose-file <cartography-refresh-prose>`로 기록한다. `PASS` 뒤에만 같은 merge candidate diff와 갱신 Root로 mode 없는 foreground `impl-validator` lifecycle hook 재검증을 열고, `SYSTEM_CHECKPOINT_REQUIRED`이면 Root patch 없이 `/design --revise` 또는 system checkpoint backpressure로 보낸다.
-
-close 를 발동할 각 PR candidate 는 product-acceptance 와 impl-validator PASS 만으로 clean 이 아니다. 최종 acceptance verdict가 확정되면 최초 PR cut 전에 메인이 `Closes` 대상 story/epic issue의 target GitHub issue AC를 대조한다. verdict가 자동 판정 또는 `(JOURNEY)`로 충족했다고 판정한 AC만 체크하고, `사람 확인 안내`는 미체크로 둔다. 그 뒤 이슈 본문 write를 issue별 close 경계에서 한 번 수행한다. 진행 중 task/story 경계에서는 issue mutation이나 재조회를 추가하지 않는다. 각 최종 body는 다음 감사가 PASS 해야 한다.
-
-```bash
-node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
-  --body-file <issue-body.md> \
-  --acceptance-only \
-  --require-complete
-```
-
-미충족·미체크 typed target GitHub issue AC 가 하나라도 있으면 clean 마감과 merge 를 금지한다. close audit의 정확한 `PASS`만 close 경로를 연다. AC 부재·검증 주체 미기재 항목은 실패하며 body를 현행 typed AC로 갱신하기 전 merge를 정지한다. 사람 판정은 checklist와 분리한 human verification 목록으로 보고한다.
-
-`impl-validator:CODEBASE_SANITY FAIL`이면 finding의 affected surface를 build-worker rework로 넘기고 수렴·Sanity부터 재감사한다. 일반 `impl-validator FAIL`의 story-local FAIL은 해당 story PR 브랜치에 commit하고 downstream story/QA branch를 restack한다. story PR 이 2개 이상인 run의 cross-cutting FAIL은 QA branch가 흡수한다. 단일 story는 해당 branch에 commit한다. 어느 경로든 코드가 바뀌면 수렴·Sanity·merge-review 증거가 stale이며 같은 finding을 줄 단위 점 패치로 반복하지 않는다. cycle 한도는 routing 문서가 소유한다.
-
-review provider resolve:
-
-```bash
-IMPLEMENTATION_PROVIDER="${DCNESS_IMPLEMENTATION_PROVIDER:-headless-chain}"
-REVIEW_PROVIDER=$("$HELPER" routing resolve impl-validator --implementation-provider "$IMPLEMENTATION_PROVIDER")
-```
-
-`routing.json` 에 `impl-validator` 가 명시되어 있으면 그 값이 우선한다. 명시값이 없으면 headless-chain build-worker 의 리뷰는 Claude, claude-headless/claude build-worker 의 리뷰는 Codex 가능 시 Codex·불가 시 Claude 다.
-
-## 마감 acceptance
-
-story/epic 마감마다 제품 검수(`product-acceptance`)를 끼워 **PASS 후에만 마감 PR 을 머지**한다. 기본 ON — `--no-acceptance` 또는 "검수 없이" 발화 시에만 생략한다. 자동 merge 금지이며 사용자가 유일한 merge gate다.
-
-다중 story는 최종 stack tip에서 `product-acceptance:STORY_ACCEPTANCE`를 story × N으로 수행해 story별 acceptance verdict를 만든 뒤, epic close가 실제 발동되면 `product-acceptance:EPIC_ACCEPTANCE`를 1회 수행한다. merge 순서에서 각 PR의 코드가 이 tip verdict와 동일함을 확인하고 해당 verdict를 story-close gate에 사용한다. gap 수정 commit이 생기면 이전 STORY PASS는 stale이므로 STORY_ACCEPTANCE부터 다시 돌린다.
-
-product-acceptance 는 외부 상태 변경(`gh` issue/PR mutation, push, merge) 금지 경계라 `gh` 호출이 불가다. 아직 PR을 만들지 않은 branch stack/base 메타·final tip commit·검증 결과·동작 증거·UI 목업 정합 증거와 build-worker Cartography impact, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision, 현재 run의 `journey_deferred` 목록을 메인이 prompt 에 직접 담는다. UI task 는 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 함께 넣어 목업 불일치와 화면 증거 부재를 판정할 수 있게 한다. 핵심 AC 증거가 mock-only green 이거나 대상 사용자에게 부적합한 입력/진행 동선이면 gap 이다.
-
-핵심 journey가 마감 AC이면 build-worker가 인계한 `(JOURNEY)` REQ, `JOURNEY_CONVERGENCE` 증거와 owner module/소스 영역의 journey 매니페스트/e2e flow 경로를 product-acceptance prompt에 넣는다. `journey_deferred`가 아닌 journey는 수렴 receipt를 acceptance 판정에 재사용하지 않고 product-acceptance가 최종 tip에서 [`product-journey.md`](../../docs/plugin/product-journey.md)에 따라 `"$PLUGIN_ROOT/scripts/dcness-product-journey" run --project-root "$PROJECT_ROOT" --config <contract>`를 다시 실행해 sealed receipt를 만든다. deferred journey는 sealed 실행 비발동이며 PASS/close 증거로 세지 않고 human verification/follow-up으로 남긴다. exit 1은 구현 gap 증거이며 mock-only, app-not-started, journey 미실행, assertion 미평가, UI evidence 누락을 PASS로 세지 않는다. helper가 쓰는 영역은 ignored `.dcness-work/product-journey/`로 한정되고 tracked 구현·설계는 write-zero로 유지한다. receipt는 어떤 PR에도 commit하지 않고 경로만 acceptance 보고에 남긴다.
-
-호출(modeful foreground Claude Agent; 완료는 PostToolUse가 기록하므로 별도 end-step 없음):
-
-```text
-begin-step product-acceptance STORY_ACCEPTANCE
-Agent(subagent_type="product-acceptance")  # current explicit mode=STORY_ACCEPTANCE
-begin-step product-acceptance EPIC_ACCEPTANCE
-Agent(subagent_type="product-acceptance")  # current explicit mode=EPIC_ACCEPTANCE
-```
-
-`PASS` → target GitHub issue AC close audit 로 진행한다. `FAIL` → auto-fixable gap 은 build-worker rework 로 수정한다. 코드 수정이면 Epic close run은 `JOURNEY_CONVERGENCE`와 Sanity부터 재진입하고, Story-only run은 수렴·impl-validator 재리뷰 후 acceptance를 재검수한다. capability 상태 drift가 route-only stale이면 `module-architect:CARTOGRAPHY_REFRESH` → 같은 diff+갱신 Root impl-validator 재검증 → acceptance 재검수 순서로 닫는다. system boundary/global decision gap이면 `/design --revise` 또는 system checkpoint backpressure로 보낸다. `ESCALATE` → 사용자 위임. acceptance FAIL, Cartography freshness 미해소, AC close audit 미해소 상태로 최초 PR cut이나 `pr-finalize.sh`를 강행하지 않는다.
-
-## 진행 뷰 task 리스트
-
-진행 뷰는 [`harness/chain_view.py`](../../harness/chain_view.py) helper 가 산출한다. 입력은 task list JSON `{tasks:[{name, engine:"build-worker", closes?}], current}` 이며, UI task 는 `engine:"ui-build-worker"` 로 표현한다. 그 외 변종은 `substeps:[...]` 명시 라벨을 사용한다. 구현 주체 enum 을 늘리지 않는다.
-
-sub-step:
-
-- 기본 task: `build-worker` → `impl-validator`
-- UI task: `canvas-design` → `build-worker` → `impl-validator`
-- story close: `build-worker:JOURNEY_CONVERGENCE`(조건부) → `impl-validator` → `product-acceptance`
-- epic close: `build-worker:JOURNEY_CONVERGENCE`(조건부) → `impl-validator:CODEBASE_SANITY` → `impl-validator` → `product-acceptance:STORY` → `product-acceptance:EPIC`
-
-완료 task 는 한 줄, 현재 task 만 sub-step 펼침, 예정 task 는 대기 줄이다. 총 task 수 기준 redraw strategy 는 ≤10 full / 11~20 partial / >20 minimal 이다.
-
-## review 출력 재정의 (#446)
-
-chain 안에서는 매 task 전수 review.md 출력을 하지 않는다. 메인 컨텍스트 출력 = 5줄 요약이며 자유 형식 단축 금지.
-
-```text
-[task<i> · <slug>] <clean|error|blocked>
-build-worker: N tests RED→GREEN · M files +X -Y · validate PASS|FAIL · commit <sha>
-finding: <PASS 시 "없음" / FAIL·NICE TO HAVE 시 1-2 문장>
-PR <#NNN> open · base <branch> · closes #<MMM>
-next: <다음 task slug 진입 | story-pr | integrated-review | 정지 사유>
-```
-
-PR cut 전에는 `PR pending · acceptance/AC audit/consolidate 선행`으로, cut 뒤 열린 stack은 `PR <#NNN> open · base <branch>`로 표시한다. close 발동 PR은 acceptance 줄을 PR 상태 줄 앞에 추가한다. 디스크의 `<run_dir>/review.md`는 원본 그대로 저장한다.
-
-## 종료 조건
-
-전체 완료 후 메인은 처리 N/N, task commit sha, story PR URL, 조건부 QA PR URL, stack tip, impl-validator round, acceptance 결과, target GitHub issue AC close audit 결과를 보고한다. clean 판정 전에는 다음 흔적을 확인한다.
-
-- build-worker phase prose 3개.
-- build-worker local commit sha.
-- `dcness-story-runner` state mark.
-- `journey_deferred`가 아닌 수렴 대상 자동 journey가 있으면 worker 실행 컨텍스트의 `JOURNEY_ENV_PREFLIGHT` 증거와 final tip `JOURNEY_CONVERGENCE` PASS. deferred journey는 종료 조건의 수렴 PASS Must 비대상이다.
-- merge candidate impl-validator PASS.
-- Epic close이면 현재 code revision을 덮는 `.dcness-work/codebase-sanity/` receipt와 `impl-validator:CODEBASE_SANITY` PASS.
-- 필요한 product-acceptance PASS.
-- build-worker Cartography impact가 affected Root Cartography 및 관련 epic/decision과 대조됐고 route-only stale 또는 system backpressure가 남지 않음.
-- target issue 가 있으면 자동 판정 가능한 typed AC 전항목 충족·체크 + `require-complete`의 정확한 `PASS`.
-- 수렴 노이즈가 있으면 tree identity 불변 commit consolidate, 이미 의미 단위면 no-op 근거, 그 뒤 최초 PR URL.
-- 자동 판정할 수 없는 사람 확인 항목이 남으면 `human verification 대기`로 보고하고 merge 전에 정지한다.
-- `journey_deferred` production-only PR은 해당 story/epic issue를 닫지 않고 `Closes` 미부착, human verification/follow-up과 남은 target AC를 보고한다.
-
-이 중 하나라도 없는데 clean 이라고 쓰면 false-clean → blocked.
-
-전체 완료 보고 뒤 메인이 이슈 등록, cleanup, 측정 같은 자율 작업으로 이어갈 때는 진입 전 `dcness-helper post-task-begin --reason "<사유>"` 를 호출한다. 이 marker 는 task ROI 측정 분리를 위한 #472 계약이다.
-
-## 안티패턴
-
-- task N 개를 한 build-worker 호출에 묶어 한 번에 처리.
-- task commit/mark 전 다음 task 진입.
-- build-worker 가 push / PR 생성 / merge / issue mutation 수행.
-- main 컨텍스트가 worker 대신 env probe나 journey 수렴 실행을 떠안기.
-- acceptance·AC close audit 전에 최초 story/QA PR을 만들거나 수렴 iteration commit을 열린 PR에 누적하기.
-- story PR을 건너뛰고 epic 구현을 단일 PR로 묶기.
-- story PR을 사용자 승인 없이 자동 merge하거나 merge 전 main 리타겟·리베이스를 생략하기.
-- 모든 구현 뒤 impl-validator 통합 리뷰 없이 stack PR을 머지하기.
-- story/epic close 발동 PR 에서 acceptance 생략 또는 FAIL 미해소 상태로 `$PLUGIN_ROOT/scripts/pr-finalize.sh` 강행.
-- TaskCreate / TaskUpdate skip.
-- chain 전체 완료 후 자율 작업 (이슈 등록 / cleanup / 분석) 진입 시 `post-task-begin` marker 누락.
+모든 target task가 completed 된 뒤에만 [`impl-loop-finish.md`](impl-loop-finish.md)를 읽어 통합 review, journey convergence, Cartography, acceptance, AC close audit, consolidate, PR cut을 수행한다.
 
 ## 참조
 
-- 분기 규칙: [`impl-loop-routing.md`](impl-loop-routing.md)
-- 기본 구현 진입점: [`/impl`](../impl/SKILL.md)
-- loop mechanics: [`loop-procedure.md`](../../docs/plugin/loop-procedure.md)
-- branch / commit / PR: [`git-spec.md`](../../docs/plugin/git-spec.md)
-- build-worker: [`build-worker.md`](../../agents/build-worker.md)
-- impl-validator: [`impl-validator.md`](../../agents/impl-validator.md)
-- product acceptance: [`/acceptance`](../acceptance/SKILL.md)
+- 실패·retry 분기(필요할 때만): [`impl-loop-routing.md`](impl-loop-routing.md)
+- completed 이후 마감(필요할 때만): [`impl-loop-finish.md`](impl-loop-finish.md)
+- worker 계약: [`build-worker-agent.md`](../../docs/plugin/agents/build-worker/build-worker-agent.md)

--- a/skills/impl-loop/impl-loop-finish.md
+++ b/skills/impl-loop/impl-loop-finish.md
@@ -1,0 +1,119 @@
+# `/impl-loop` completed 이후 마감
+
+이 문서는 모든 target task가 local commit으로 completed 된 뒤에만 읽는다. worker 시작 preflight가 아니다.
+
+## merge candidate와 review 입력
+
+- 단일 story는 story branch vs main, 다중 story는 최종 stack tip vs main을 merge candidate로 고정한다.
+- task별 commit, 검증 명령, phase prose, build-worker Cartography impact, affected Root Cartography, 관련 epic/decision, target GitHub issue AC snapshot을 수집한다.
+- review 대상이 commit이면 commit id와 변경 파일 목록을 선행한다. uncommitted diff일 때만 diff 파일을 쓴다.
+- [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md)는 validator/acceptance 호출 직전에만 읽는다.
+
+## Story PR / integrated review / merge
+
+마감 순서는 다음과 같다.
+
+1. 자동 journey가 있으면 final tip에서 fresh context `JOURNEY_CONVERGENCE`
+2. Epic close이면 `impl-validator:CODEBASE_SANITY`
+3. merge candidate `impl-validator` 통합 review
+4. 필요하면 `module-architect:CARTOGRAPHY_REFRESH`와 impl-validator 재검증
+5. `product-acceptance`
+6. target GitHub issue AC close audit
+7. tree-preserving 커밋 consolidate
+8. 최초 PR 생성
+9. 별도 merge gate
+
+`JOURNEY_CONVERGENCE → impl-validator:CODEBASE_SANITY → product-acceptance → target GitHub issue AC close audit → 커밋 consolidate → PR 생성` 순서를 바꾸지 않는다. 최종 tree가 불변이면 review/acceptance 증거를 유지하고, 의미 단위 commit이 이미 clean하면 consolidate는 no-op이다. 최초 PR은 이 순서가 끝난 뒤에만 만든다.
+
+### journey
+
+- `journey_deferred`가 아닌 자동 journey만 `JOURNEY_CONVERGENCE`를 실행한다.
+- 첫 실행 PASS면 끝내고, 실패하면 실행 → 관찰 → 배관 수정 → 재실행한다.
+- story-local production 수정은 해당 story branch에 commit하고 downstream branch를 restack한다.
+- 다중 story의 cross-cutting production 수정과 tracked flow/manifest 보정은 QA branch가 소유한다.
+- `journey_deferred`는 수렴·sealed journey 실행 비발동이며 종료 조건의 수렴 PASS Must 비대상이다. 해당 issue에 `Closes`를 붙이지 않는다.
+- 같은 실패 서명이 수정 뒤 반복되는 무진행은 3회, 전체 iteration은 12회가 상한이다. device 유실·재부팅은 1회만 자동 재준비한다.
+- 서로 다른 실패가 이전 실패를 고친 뒤 순차 노출되면 무진행으로 세지 않는다. 전체 iteration 12회가 실패 서명과 별개인 실질 runaway 가드다.
+- 상한 소진 시 커밋을 보존하고 `수렴 재개 / production만 착지하고 journey 분리 / run 폐기` 중 사용자 처분을 받는다. production만 착지하면 human verification/follow-up으로 남기고 issue를 닫지 않는다.
+
+### CODEBASE_SANITY
+
+Epic당 최종 clean candidate 1회만 affected dependency cone을 `impl-validator:CODEBASE_SANITY`로 감사한다. 모든 Story/PR마다 반복하지 않는다.
+
+- code revision/tree identity와 실제 lint/build/test/typecheck 명령·exit·warning을 기록한다.
+- coverage 도구가 없으면 `UNKNOWN`으로 기록한다.
+- dead code, stale registration, duplicate/example/scaffold, suppression/deprecation, convention drift를 분류한다.
+- receipt는 primary worktree의 `.dcness-work/codebase-sanity/`에 보존한다.
+- receipt 경로는 `dcness-helper sanity-receipt-dir --project-root "$PROJECT_ROOT"`로 계산한다.
+- finding은 build-worker rework로 수정하고 journey convergence와 Sanity부터 재진입한다.
+
+코드가 바뀌면 기존 Sanity와 merge review 증거는 stale이다. Cartography 문서만 bounded refresh되고 code tree가 같으면 Sanity receipt는 유지할 수 있으나 merge review는 갱신 Root로 다시 수행한다.
+
+### 격리 review
+
+구현 provider의 반대 진영을 기본 review provider로 resolve한다. validator는 read-only다. MUST FIX가 있으면 최대 3회 root-cause 수정하고 관련 gate를 재실행한다. build-worker rework가 코드나 harness를 바꾸면 필요한 earlier evidence부터 다시 수집한다.
+
+`impl-validator review 출력은 merge candidate 경계에서 1회`가 기본이다. 모든 task마다 full review를 반복하지 않는다.
+
+## Cartography freshness
+
+build-worker Cartography impact와 affected Root Cartography를 merge candidate 및 관련 epic/decision과 대조한다.
+
+- 영향 없음/일치: 계속한다.
+- capability 상태 drift 또는 route/state/as-built edge stale: `begin-step module-architect CARTOGRAPHY_REFRESH`로 bounded producer를 열고 `end-step module-architect CARTOGRAPHY_REFRESH --prose-file <path>`로 기록한 뒤 같은 diff+갱신 Root를 impl-validator 재검증한다.
+- system boundary/global decision 변경: `/design --revise` 또는 system checkpoint로 보낸다.
+
+durable impact handoff만으로 freshness가 해소되지는 않는다. canonical Root refresh와 impl-validator 재검증 없이 최종 clean으로 보고하지 않는다.
+local-only/ignored Root는 code PR에 강제 포함하지 않고 canonical local Root에서 갱신한다.
+
+## product acceptance
+
+story/epic 마감마다 read-only `product-acceptance`를 수행한다. product-acceptance는 외부 상태 변경(`gh` issue/PR mutation, push, merge)을 하지 않는다. UI면 확정 목업 경로, 구현 화면 스크린샷, 화면 증거를 포함해 화면 증거 부재와 목업 불일치를 판정한다. 자동 journey는 final tip에서 `dcness-product-journey`를 다시 실행한 sealed receipt로 판정한다. mock-only, app-not-started, assertion 미평가, UI evidence 누락은 PASS가 아니다.
+
+impl-validator는 계획 대비 구현 정합과 merge candidate diff 위험을 맡는다. 여러 PR이 합쳐진 story 동작과 여러 story가 합쳐진 epic 동작의 사용자 관찰 가능 동작은 마감 product-acceptance가 맡는다.
+
+acceptance gap 수정으로 code가 바뀌면 convergence/Sanity/review 증거를 stale 처리하고 다시 진입한다. route-only Cartography stale이면 refresh → impl-validator 재검증 → acceptance 재검수 순서로 닫는다.
+
+auto-fixable gap은 PRD/Story AC 미충족, 검수 증거 부족, smoke 실패, mock-only green/동작 증거 부족, 화면 증거 부재, 구현으로 닫히는 목업 불일치, 사용자 동선 부적합/내부 계약 노출이다. 설계 결함, 범위 재정의, 사용자/UX 선택, 보안·권한·데이터 위험은 비자동 gap으로 사용자에게 넘긴다.
+
+## 마감 복구 한도
+
+| 경로 | 한도 | 초과 시 |
+|---|---|---|
+| Codebase Sanity `FAIL` → build-worker rework → 재감사 | 3 | 사용자 위임 |
+| impl-validator `FAIL` → root-cause 수정 → 재리뷰 | 3 | 사용자 위임 |
+| product-acceptance auto-fixable gap → rework → 재검수 | 3 | 사용자 위임 |
+
+같은 영역 finding이 반복되면 줄 단위 점 패치가 아니라 root cause를 재검토한다. 비자동 acceptance gap, 설계·AC 충돌, `ESCALATE`는 사용자에게 넘긴다.
+
+## target GitHub issue AC close audit
+
+진입 때 보관한 snapshot을 구현·명령·validator·acceptance 증거와 대조한다. 자동 판정 가능한 typed 항목만 충족 증거가 있을 때 체크하고, issue body write는 close 경계에서 issue별 한 번만 수행한다.
+
+```bash
+node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
+  --body-file <issue-body.md> \
+  --acceptance-only \
+  --require-complete
+```
+
+미충족·미체크 typed AC, acceptance FAIL, Cartography freshness 미해소가 있으면 최초 PR이나 merge를 금지한다. 사람 판정은 체크하지 않고 `human verification 대기`로 보고한다.
+
+## PR stack과 merge
+
+- commit 경계에서 [`git-spec.md`](../../docs/plugin/git-spec.md)를 읽고 의미 단위를 맞춘다. hook을 우회하지 않는다.
+- `action=story-pr`마다 봉인한 story branch/base를 그대로 사용한다.
+- 단일 story는 PR 1개다. 다중 story는 story PR stack과 실제 tracked cross-cutting fix가 있을 때만 QA PR을 만든다.
+- PR body에는 story별 `Closes`, 필요한 epic close trailer, 검증, 배포 경로를 기록한다.
+- 사람 확인이 남으면 최초 PR 생성 뒤 `human verification 대기`로 멈추고 별도 merge gate로 보존한다. 이 대기는 blocked가 아니다.
+- 사용자가 유일한 merge gate다. 자동 merge 금지다.
+- 승인 뒤 story 순서대로 base를 main으로 리타겟하고 최신 main 위로 rebase한다. tree가 바뀌면 review/acceptance/AC audit을 다시 수행한다.
+- 각 PR의 review·acceptance·AC audit과 사용자 승인이 확인된 뒤에만 `$PLUGIN_ROOT/scripts/pr-finalize.sh`를 호출한다.
+
+## 종료
+
+처리 N/N, task commit, story/QA PR URL, final tip, review round, acceptance, Cartography freshness, target issue AC close audit, human verification 잔여를 보고한다. phase prose 3개·commit·state mark·필수 review/acceptance/audit 중 하나라도 없으면 clean으로 보고하지 않는다.
+
+PR/merge handoff 전에는 story worktree를 유지한다. 종료 시점에만 [`loop-procedure.md` worktree 분기](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정)를 읽고, 커밋 흡수와 clean 상태가 모두 증명된 worktree만 `ExitWorktree(action="remove")`하며 dirty/unmerged worktree는 `ExitWorktree(action="keep")`한다.
+
+완료 뒤 별도 자율 작업으로 이어갈 때만 `dcness-helper post-task-begin --reason <사유>`를 호출해 task ROI와 분리한다. 이 #472 marker는 worker 시작 preflight가 아니다.

--- a/skills/impl-loop/impl-loop-routing.md
+++ b/skills/impl-loop/impl-loop-routing.md
@@ -1,7 +1,7 @@
 # impl-loop 분기 규칙 SSOT
 
 > **Status**: ACTIVE
-> **Scope**: `/impl-loop` skill 전용. 단일 구현 엔진 `build-worker`, merge candidate reviewer `impl-validator`, inline `product-acceptance` 의 결론 → 다음 호출 + retry 한도 + escalate 처리를 정한다. 진행 절차는 [`SKILL.md`](SKILL.md).
+> **Scope**: `/impl-loop` worker 시작부터 모든 task completed 전까지의 실패·복구·다음 task 분기를 정한다. completed 이후 review·acceptance·PR 분기는 [`impl-loop-finish.md`](impl-loop-finish.md)가 소유한다. 진행 절차는 [`SKILL.md`](SKILL.md).
 
 ## 읽는 법
 
@@ -13,12 +13,9 @@ agent 는 prose 마지막 단락에 결론과 사유를 적는다. 메인 Claude
 
 ```mermaid
 flowchart TB
-  START[run preflight] --> AUTO{자동 JOURNEY 선언?}
-  AUTO -->|아니오 / human_verification| BW
-  AUTO -->|예| ENV[build-worker JOURNEY_ENV_PREFLIGHT]
-  ENV -->|PASS ready / 검출 불확실| BW[build-worker task]
-  ENV -->|확실한 미충족 + 자동 준비 불가| ENVUSER[사용자 처분 1회]
-  ENVUSER -->|환경 준비| ENV
+  START[one-shot chain launch] --> BW[build-worker: task read → conditional JOURNEY_ENV_PREFLIGHT → TDD]
+  BW -->|preflight 확실한 미충족 + 자동 준비 불가| ENVUSER[사용자 처분 1회]
+  ENVUSER -->|환경 준비| BW
   ENVUSER -->|구현만 + journey 분리| DEFER[journey_deferred 기록]
   DEFER --> BW
   BW -->|PASS + local commit sha| MARK[dcness-story-runner mark completed]
@@ -37,52 +34,13 @@ flowchart TB
   NEXT -->|story-pr| SPR[story tip + stack base 봉인 · PR 없음]
   SPR --> REBRANCH[직전 story 브랜치에서 재분기]
   REBRANCH --> BW
-  NEXT -->|done + final_story| FPR[마지막 branch + stack tip 확정 · PR 없음]
-  FPR --> JQ{수렴 대상 자동 JOURNEY?}
-  JQ -->|아니오| EPIC{Epic close?}
-  JQ -->|예| JC[build-worker JOURNEY_CONVERGENCE]
-  JC -->|PASS| EPIC
-  JC -->|SPEC_GAP_FOUND| DESIGN
-  JC -.->|무진행 / 총 iteration 상한| USER
-  EPIC -->|아니오| IV[impl-validator stack tip vs main review 1회]
-  EPIC -->|예| CS[impl-validator CODEBASE_SANITY]
-  CS -->|PASS| IV
-  CS -->|FAIL quality-gap| CSFIX[build-worker rework]
-  CS -.->|ESCALATE| USER
-  CSFIX --> CS
-  IV -->|PASS + 영향 없음 또는 Root와 일치| ACC{close 발동?}
-  IV -->|route/state/as-built edge stale| CR[module-architect CARTOGRAPHY_REFRESH]
-  CR -->|bounded refresh| IV
-  CR -->|SYSTEM_CHECKPOINT_REQUIRED| DESIGN
-  IV -->|system boundary/global decision 변경| DESIGN["/design --revise 또는 system checkpoint backpressure"]
-  IV -->|FAIL| FIX[메인 root-cause 수정 + commit append]
-  FIX -->|Epic code 변경| CS
-  FIX -->|Story-only| IV
-  ACC -->|아니오| CONSOLIDATE[tree-preserving commit consolidate]
-  ACC -->|예| PA[product-acceptance story x N + epic]
-  PA -->|PASS| AC[Target GitHub issue AC close audit]
-  AC -->|typed require-complete PASS| CONSOLIDATE
-  CONSOLIDATE --> PRCUT[clean stack에서 최초 story / QA PR cut]
-  PRCUT --> HUMAN{사람 확인 안내 남음?}
-  HUMAN -->|아니오| MERGE[사용자 승인 → main 리타겟·리베이스·merge]
-  HUMAN -.->|예 · human verification 대기| USER
-  AC -.->|typed AC 미충족·미체크| USER
-  PA -->|FAIL auto-fixable| JCFIX[build-worker rework]
-  JCFIX --> JCRETRY{수렴 대상 자동 JOURNEY?}
-  JCRETRY -->|예| JC
-  JCRETRY -->|아니오| EPIC
-  PA -->|capability 상태 drift route-only| CR
-  PA -->|system boundary/global decision gap| DESIGN
+  NEXT -->|done + final_story| FINISH[impl-loop-finish lazy-load]
   BW -.->|IMPLEMENTATION_ESCALATE| USER((사용자))
-  IV -.->|ESCALATE| USER
-  PA -.->|ESCALATE / round 초과 / 비자동 gap| USER
   ENVUSER -.->|처분 보류| USER
   REWORK -.-> USER
 ```
 
-canvas-design 은 UI 작업의 main-owned checkpoint 이며 helper begin/end-step 비대상이다. draft가 필요할 때 mode 없는 foreground designer Agent는 lifecycle hook 경로로 연다. `canvas-design PASS` 뒤에는 같은 `build-worker` 경로로 들어간다.
-
-`JOURNEY_ENV_PREFLIGHT`와 `JOURNEY_CONVERGENCE`는 기존 build-worker의 내부 mode다. 신규 agent나 신규 공개 진입점이 아니며, journey 미선언 run에는 두 mode 모두 비발동이다.
+`JOURNEY_ENV_PREFLIGHT`는 기본 build-worker 호출 안의 내부 phase다. 신규 agent, mode, outer lifecycle step, 공개 진입점을 만들지 않으며 journey 미선언 run에는 비발동이다. completed 이후 `JOURNEY_CONVERGENCE` 계약은 마감 진본에서만 읽는다.
 
 env 확실 미충족 + 자동 준비 불가에서 사용자가 검수 분리를 선택하면 메인은 해당 `journey_id`를 현재 run의 `journey_deferred` 목록으로 진행 뷰와 이후 agent prompt에 보존한다. 이는 manifest의 설계 선언을 바꾸는 값이 아니다. 해당 journey는 현재 run에서 `JOURNEY_CONVERGENCE 비발동`, `product-acceptance sealed journey 실행 비발동`, `종료 조건의 수렴 PASS Must 비대상`이며 human verification/follow-up으로 남는다. 그 target AC가 속한 story/epic은 close candidate가 아니므로 AC close audit을 발동하지 않고 PR body에 `Closes`를 붙이지 않는다. 다른 수렴 대상 journey는 그대로 진행한다.
 
@@ -90,21 +48,12 @@ env 확실 미충족 + 자동 준비 불가에서 사용자가 검수 분리를 
 
 | step | 결론 → 다음 |
 |---|---|
-| **build-worker:`JOURNEY_ENV_PREFLIGHT`** | 자동 `(JOURNEY)`가 있을 때 구현 전 1회, main이 아니라 실제 worker 실행 컨텍스트에서 probe · 충족 또는 자동 준비 성공 → `PASS` 후 task loop · 검출 불확실 → 불확실 근거를 남긴 `PASS` 후 task loop · 확실한 미충족 + 자동 준비 불가 → 구현 전에 사용자에게 환경 먼저 준비 / 구현만 진행하고 journey 검수 분리 중 하나를 1회 확인 · 분리 선택 → 해당 journey를 run-local `journey_deferred`로 보존하고 수렴·sealed acceptance·close 경계에서 제외. journey 미선언과 설계상 `human_verification`은 mode 자체가 비발동 |
+| **build-worker 내부 `JOURNEY_ENV_PREFLIGHT`** | 자동 `(JOURNEY)`가 있을 때 기본 worker가 task를 읽은 직후 source read/edit 전 1회, main이 아니라 실제 worker 실행 컨텍스트에서 probe · 충족 또는 자동 준비 성공 → 같은 호출의 task TDD · 검출 불확실 → 불확실 근거를 남기고 같은 호출의 task TDD · 확실한 미충족 + 자동 준비 불가 → 구현 전에 사용자에게 환경 먼저 준비 / 구현만 진행하고 journey 검수 분리 중 하나를 1회 확인 · 분리 선택 → 해당 journey를 run-local `journey_deferred`로 보존하고 수렴·sealed acceptance·close 경계에서 제외. journey 미선언과 설계상 `human_verification`만 있으면 phase 비발동 |
 | **build-worker** | `PASS` + local commit sha + clean status → `dcness-story-runner mark --status completed --commit <sha>` 후 `next-action` · `TESTS_FAIL` → build-worker rework(≤3) · `SPEC_GAP_FOUND` → design-doc 보강 또는 사용자 위임 · `VALIDATION_BLOCKED` + `permission_required` → outbound network 범위·제안 root·근거·`workspace-write` 유지·`danger-full-access` 미사용을 설명하고 사용자에게 이번 실행에만 허용/이 프로젝트에 저장/거부 선택 요청. 승인하면 Codex만 1회 제한 재시도, 거부·malformed settings·안전한 root 없음·반복 sandbox 거부면 권한 확대/host 직접 검증/다른 provider 우회 없이 사용자 위임 · permission receipt 없음 → 메인이 같은 worktree cwd에서 worker 검증 명령 실행, exit 0이면 PASS와 동일, 실패면 build-worker rework(≤3), 메인도 실행 불가면 사용자 위임 · `IMPLEMENTATION_ESCALATE` → 사용자 |
-| **headless execution recovery** | mutation 뒤 `timeout` / `idle_timeout` / `empty_output` / `boundary_violation` / `tdd_guard` → 같은 provider + 같은 workspace bounded continuation, 기존 diff 보존, mutation-time guard 재검사(기본 ≤2) · hard boundary 자동 확대 / `tdd-exempt` 자동 삽입 / dirty cross-provider fallback 금지 · 한도 소진 또는 제품 의미·새 권한 필요 → 사용자 |
-| **dcness-story-runner `next-action`** | `task` → 다음 task build-worker · `story-pr` → 응답의 `pr_base`와 직전 story tip만 봉인하고 PR 없이 `next_branch_base`의 직전 story 브랜치에서 재분기 · `done` → `final_story` tip과 `stack_tip` vs main candidate를 확정하고 조건부 journey 수렴으로 진행 · `blocked` / `error` → task note를 근거로 retry 한도 내 재시도 또는 사용자 위임 |
-| **build-worker:`JOURNEY_CONVERGENCE`** | 모든 task 뒤 final stack tip의 fresh context에서 `journey_deferred`가 아닌 자동 journey를 먼저 1회 실행 · 첫 실행 PASS → 즉시 review · 실패 → 실행→관찰→배관 수정→재실행 · production gap → 재현 테스트 RED→GREEN + 의미 단위 commit · 설계·AC 충돌 → `SPEC_GAP_FOUND`로 중단 · device 유실은 자동 재준비 1회 · 무진행/총 iteration 상한 초과 → 커밋 보존 후 사용자 처분 3택 |
-| **impl-validator:CODEBASE_SANITY** | Epic close final candidate에서만 실행. 작은 repo는 전체 repo, 큰 repo는 affected module과 affected dependency cone + cheap global signals · `PASS` → local receipt 보존 후 일반 merge review · `FAIL [quality-gap]` → build-worker rework 후 새 code revision에서 Sanity 재감사(≤3) · `ESCALATE` → 사용자 |
-| **impl-validator** | stack tip vs main diff와 journey `target_ac` ↔ flow assertion 고정 대조 `PASS` → close 발동 여부 확인 · `FAIL`(`[spec-gap]` 또는 `[quality-gap]`) → 메인 root-cause 수정. 단일 story는 해당 branch commit, story PR 이 2개 이상인 topology면 story-local FAIL은 해당 story PR 브랜치 commit + downstream restack, cross-cutting FAIL은 QA branch 흡수 + 재리뷰(≤3). 아직 PR은 cut하지 않음 · `ESCALATE` → 사용자 |
-| **Cartography freshness** | build-worker Cartography impact + merge candidate diff + affected Root Cartography + 관련 epic/decision이 `영향 없음 또는 Root와 일치` → 기존 경로 · route/state/as-built edge stale → `module-architect:CARTOGRAPHY_REFRESH` bounded refresh + impl-validator 재검증 · system boundary/global decision 변경 → `/design --revise` 또는 system checkpoint backpressure |
-| **product-acceptance** | 수렴과 review가 끝난 최종 tip에서 close candidate story×N + epic을 sealed 실행으로 판정하며 수렴 receipt를 재사용하지 않는다. `journey_deferred`는 실행·PASS·close 증거에서 제외하고 human verification/follow-up으로 보고하며 나머지 journey만 새 receipt를 만든다. `PASS` → target GitHub issue AC close audit. 1-story fix는 PR cut 전 해당 branch commit, N-story tracked cross-cutting fix/flow 보정은 QA branch 흡수 · Epic code 변경은 수렴/Sanity/impl-validator 증거를 stale 처리하고 수렴부터 재진입, Story-only는 수렴/impl-validator 재리뷰 + acceptance 재검수(≤3) · capability 상태 drift가 route-only stale → `CARTOGRAPHY_REFRESH` + 같은 diff+갱신 Root impl-validator 재검증 + acceptance 재검수 · system boundary/global decision gap → `/design --revise`/checkpoint · `FAIL` 비자동 gap / round 초과 / `ESCALATE` → 사용자 |
-| **target GitHub issue AC close audit** | 메인이 acceptance verdict로 자동/`(JOURNEY)` typed AC만 체크한다. `check_issue_body.mjs --acceptance-only --require-complete`의 정확한 `PASS` → commit consolidate · checklist 밖 사람 확인 항목은 미체크 상태의 별도 merge gate로 보존 · typed AC 미충족·미체크 → clean 마감 금지, 구현 보강 (`blocked` 아님) |
-| **commit consolidate → PR cut** | 수렴 iteration 노이즈가 있을 때만 의미 단위 commit으로 재구성하고 전후 tree identity가 같아야 함. 이미 의미 단위면 no-op · 그 뒤 단일 story와 다중 story/조건부 QA stack 모두 clean 상태에서 최초 PR을 cut · 사람 확인 항목이 남으면 PR cut 뒤 human verification 대기, 없으면 사용자 merge 승인 대기 · CI rerun/인프라 복구로 tree 불변이면 기존 verdict 유효, tracked tree 변경이면 수렴부터 stale 재검증 |
+| **headless execution recovery** | mutation 뒤 `timeout` / `idle_timeout` / `empty_output` / `boundary_violation` / `tdd_guard` / canonical phase prose `phase_evidence` → 같은 provider + 같은 workspace bounded continuation, 기존 diff 보존, mutation-time guard 재검사(기본 ≤2) · hard boundary 자동 확대 / `tdd-exempt` 자동 삽입 / dirty cross-provider fallback 금지 · 한도 소진 또는 제품 의미·새 권한 필요 → 사용자 |
+| **dcness-story-runner `next-action`** | `task` → 다음 task build-worker · `story-pr` → 응답의 `pr_base`와 직전 story tip만 봉인하고 PR 없이 `next_branch_base`의 직전 story 브랜치에서 재분기 · `done` → `final_story` tip과 `stack_tip`을 확정하고 [`impl-loop-finish.md`](impl-loop-finish.md)를 lazy-load · `blocked` / `error` → task note를 근거로 retry 한도 내 재시도 또는 사용자 위임 |
 
-loop의 자동 merge 금지: 사용자가 유일한 merge gate다. 승인 뒤에만 대상 PR을 base=`main`으로 리타겟·리베이스하고 merge helper를 호출한다.
-
-task 구현 호출에서 `(JOURNEY)` REQ는 PASS 블로커가 아니다. build-worker가 flow 대본, `.dcness/` 밖 journey 매니페스트, 필요한 setup/teardown/상태전이 스크립트, `acceptance_environment`, `harness_paths`를 작성하고 수렴·acceptance 인계를 보고하면 task `PASS`로 진행한다. 그러나 모든 task 뒤 `journey_deferred`가 아닌 자동 journey의 `JOURNEY_CONVERGENCE PASS`는 integrated review의 선행 Must다. 이 경로는 메인 게이트 대행용 `VALIDATION_BLOCKED`와 다르다.
+task 구현 호출에서 `(JOURNEY)` REQ는 PASS 블로커가 아니다. build-worker가 flow 대본, `.dcness/` 밖 journey 매니페스트, 필요한 setup/teardown/상태전이 스크립트, `acceptance_environment`, `harness_paths`를 작성하고 마감 인계를 보고하면 task `PASS`로 진행한다. 메인 게이트 대행용 `VALIDATION_BLOCKED`와는 다른 경로다.
 
 ## retry 한도
 
@@ -113,58 +62,21 @@ task 구현 호출에서 `(JOURNEY)` REQ는 PASS 블로커가 아니다. build-w
 | build-worker `TESTS_FAIL` 또는 메인 게이트 대행 실패 | 3 | 사용자 위임 |
 | headless mutation 뒤 recoverable 실행/guard 실패 | 2 | diff 보존 + 사용자 위임 |
 | Codex `permission_required` 사용자 승인 재시도 | 1 | 추가 확대 없이 사용자 위임 |
-| `JOURNEY_CONVERGENCE` 같은 실패 서명이 수정 시도 후 반복되는 무진행 라운드 | 3 | 커밋 보존 후 사용자 처분 3택 |
-| `JOURNEY_CONVERGENCE` 총 iteration | 12 | 실패 서명 변화와 무관하게 커밋 보존 후 사용자 처분 3택 |
-| journey 실행 중 device 유실·재부팅 자동 재준비 | 1 | 무진행/총 iteration을 소비하지 않고 재실행, 다시 유실되면 사용자 처분 3택 |
-| Codebase Sanity `FAIL` → build-worker rework → Sanity 재감사 | 3 | 사용자 위임 |
-| impl-validator `FAIL` → 메인 root-cause 수정 → 재리뷰 | 3 | 사용자 위임 |
-| product-acceptance `FAIL` auto-fixable gap → rework → 재검수 | 3 | 사용자 위임 |
 | `SPEC_GAP_FOUND` design-doc 보강 | 1 | 사용자 위임 또는 `/design` 회수 |
 
 finding 수용 원칙: 같은 파일·주제·위험 클래스 finding 이 반복되면 점 패치가 아니라 root cause 를 재검토한다. 설계가 부족하면 `/design` 으로 회수한다.
 
-journey 무진행은 실패 단계 + exit code + 정규화한 핵심 오류의 같은 서명이 수정 시도 후 다시 나타날 때만 센다. 서로 다른 실패가 앞 실패 해소 뒤 순차 노출되고 이전 서명이 재발하지 않으면 한도를 소비하지 않는다. 실패 서명은 자초 회귀와 잠재 노출을 완전히 구분하지 못하므로 **총 iteration 12회가 실질 runaway 가드**다.
-
-두 수렴 상한 중 하나를 소진하면 작업 커밋을 보존하고 사용자가 다음 셋 중 하나를 고른다: **수렴 재개 / production 만 착지하고 journey를 human verification 대기 또는 follow-up으로 분리 / run 폐기**. production 만 착지를 고르면 env preflight의 분리 선택과 같은 run-local `journey_deferred` 처분을 적용해 story issue를 닫지 않고 PR body에 `Closes`를 붙이지 않는다. 이 선택은 env preflight의 구현 전 2택과 별개이며, happy path에서 추가 질문을 만들지 않는다.
-
-## 마감 acceptance 분기
-
-Epic close의 Codebase Sanity는 acceptance보다 먼저 수행한다. 모든 Story/PR마다 full-repo audit을 반복하지 않고 최종 stack tip(QA PR이 있으면 QA branch) vs main candidate 1회가 기본이다. 메인이 code revision과 실제 test/lint/build/typecheck/coverage 명령·exit/warning을 수집하며, coverage 도구가 없으면 `UNKNOWN`이다. 결과는 `dcness-helper sanity-receipt-dir --project-root "$PROJECT_ROOT"`가 반환한 persistent primary-worktree `.dcness-work/codebase-sanity/`에 local receipt로 보존해 linked `ExitWorktree` 뒤에도 재사용한다. 코드 변경은 Sanity와 일반 impl-validator 증거를 모두 stale로 만들어 Sanity부터 재진입한다. receipt는 canonical Root `CARTOGRAPHY_REFRESH` 또는 다음 design의 현재 코드 대조를 대신하지 않는다.
-
-story/epic close 를 실제 발동할 candidate의 impl-validator `PASS` 후 · 최초 PR cut 전 product-acceptance 검수를 끼운다. 기본 ON, `--no-acceptance` 명시 run 만 비대상이다. product-acceptance 를 생략해도 target GitHub issue AC close audit 은 생략되지 않는다.
-
-impl-validator 는 계획 대비 구현 정합과 merge candidate diff 위험을 검토한다. 여러 PR 이 합쳐진 story 동작과 여러 story 가 합쳐진 epic 동작의 사용자 관찰 가능 동작은 마감 product-acceptance 가 맡는다.
-
-여러 task commit이 합쳐진 story 동작은 봉인된 story branch tip과 acceptance 증거를 함께 보고 판정한다. 여러 story branch가 stack tip에서 합쳐진 epic 동작도 같은 원칙으로 product-acceptance가 맡는다. product-acceptance는 개별 task green이 아니라 story/epic close 시점의 사용자 동작 전체를 검수한다.
-
-STORY/EPIC_ACCEPTANCE는 build-worker 수렴 결과와 별도로 최종 tip에서 `journey_deferred`가 아닌 flow를 다시 실행해 sealed receipt를 생성·판정한다. deferred journey는 human verification/follow-up으로만 보고하며 그 target AC가 속한 story/epic close에는 사용하지 않는다. 수렴 대상 매니페스트/e2e가 없으면 실행 불가 gap과 도입 제안을 보고하며 특정 e2e 도구를 강제하지 않는다.
-
-Cartography freshness도 같은 close 경계의 Must다. capability 상태 drift, 미해소 route/state/as-built edge, system backpressure가 남으면 최종 clean과 merge로 진행하지 않는다. `CARTOGRAPHY_REFRESH`는 기존 module-architect의 bounded producer mode이며, local-only/ignored private docs는 code PR에 강제 포함하지 않고 canonical local refresh 또는 durable impact handoff를 보존한다. durable impact handoff만으로 freshness가 해소되지는 않으며 canonical local Root refresh 확인 전에는 최종 clean이 아니다. build-worker와 읽기 전용 validator가 docs를 직접 수정하지 않는다.
-
-- story close: `STORY_ACCEPTANCE`
-- 여러 story close: `STORY_ACCEPTANCE` 를 story × N
-- epic close: 모든 story PASS 뒤 `EPIC_ACCEPTANCE`
-
-gap 수정 commit 이 생겼으면 마지막 acceptance gap 수정 commit 이후의 PASS 만 clean 증거다. 이전 PASS 는 stale 이므로 STORY_ACCEPTANCE 부터 다시 돌린다.
-
-auto-fixable gap: PRD 유저 시나리오 / Story AC 미충족, 검수 증거 부족, 스모크 실패, mock-only green / 동작 증거 부족, 화면 증거 부재, 사용자 동선 부적합 / 내부 계약 노출, 구현 보강으로 닫히는 목업 불일치, 명확한 사용자 동선 보강. 비자동 gap: 설계 결함, 범위 재정의, 사용자/UX 선택 필요, 보안/권한/데이터 리스크.
-
-## clean / blocked 판정
+## task clean / blocked
 
 - task clean = build-worker PASS + phase prose 3개 + local commit sha + clean status + story-runner mark.
 - story boundary clean = 해당 story의 모든 task completed + story branch tip/base 봉인 + PR 없이 다음 branch를 직전 story branch에서 재분기.
-- integrated review clean = 모든 target task completed + stack tip 확정 + `journey_deferred`가 아닌 자동 journey면 env preflight 증거와 `JOURNEY_CONVERGENCE PASS` + Epic close이면 현재 code revision의 `impl-validator:CODEBASE_SANITY` PASS와 receipt + 일반 impl-validator PASS.
-- close 발동 candidate clean = integrated review clean + 필요한 product-acceptance PASS + typed target GitHub issue AC 전항목 충족·체크 + `require-complete`의 정확한 `PASS`. checklist 밖 사람 확인 항목은 delivery를 막지 않고 merge 전 별도 human verification gate로 남긴다.
-- deferred production candidate clean = integrated review clean + `journey_deferred`의 human verification/follow-up handoff + close/acceptance/AC audit 비발동 근거. 이는 해당 story/epic의 clean close가 아니다.
-- delivery clean = (close 발동 candidate clean 또는 deferred production candidate clean) + tree identity 불변 commit consolidate 또는 no-op 근거 + 그 뒤 최초 story/조건부 QA PR 생성. deferred candidate는 `Closes` 없이 `Document-Exception-PR-Close` 사유를 둔다. loop의 자동 merge는 여전히 0회다.
-- verify-only clean = 검증 명령 exit 0 + 변경 0 + validator PASS.
-
-false-clean 의심 시 blocked. 예: phase prose 부재, commit sha 부재, `journey_deferred`가 아닌 자동 journey 수렴 미실행, close candidate의 impl-validator/acceptance/target issue AC 감사 미충족, deferred production candidate의 handoff·PR 예외 사유 부재, consolidate tree identity 또는 최종 PR 흔적 부재. 단, PR cut 전 정상 중간 단계와 자동 항목은 모두 끝났고 사람 판정만 남은 `human verification 대기`는 blocked 로 뭉뚱그리지 않는다.
+- phase prose, commit sha, clean status, state mark 중 하나라도 없으면 false-clean blocked로 판정하고 다음 task로 넘기지 않는다.
+- 모든 target task가 completed 되면 이 문서를 더 읽지 않고 [`impl-loop-finish.md`](impl-loop-finish.md)로 이동한다.
 
 ## escalate 처리
 
-`IMPLEMENTATION_ESCALATE`, `ESCALATE`, retry 한도 초과, 비자동 acceptance gap 은 즉시 사용자 보고 후 대기한다. journey 수렴 한도는 위 3택을 사용하고, 그 밖의 자동 복구 / 우회 / 재시도는 금지한다.
+`IMPLEMENTATION_ESCALATE`, retry 한도 초과, 제품 의미·권한 변경 필요는 즉시 사용자 보고 후 대기한다. 그 밖의 자동 복구 / 우회 / 재시도는 금지한다.
 
 ## 후속
 
-clean → 5줄 요약 + 전체 완료 보고. 전체 완료 뒤 자율 작업(이슈 등록 / cleanup / 분석)으로 이어가면 진입 전 `post-task-begin` marker 를 호출해 task ROI 측정을 분리한다 (#472). error/blocked → 남은 finding, 실패 명령, 다음 판단 지점을 보고한다.
+task clean → mark + next-action. error/blocked → 남은 finding, 실패 명령, 다음 판단 지점을 보고한다. 전체 완료 보고와 후속 marker는 마감 진본이 소유한다.

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -1,186 +1,94 @@
 ---
 name: impl
-description: 구현 요청을 받아 메인이 직접 구현하고 격리 impl-validator 리뷰까지 거쳐 PR 로 끝내는 기본 구현 진입점. 사용자가 "구현해줘", "수정해줘", "고쳐줘", "버그픽스", "한 줄 수정", "리뷰까지 돌려", "/impl" 등을 말할 때 사용한다. 이슈번호/링크/파일/테스트처럼 concrete signal 이 있으면 읽고 바로 구현한다. 자연어 요청도 의도와 repo 범위가 충분하면 관련 코드를 찾아 바로 구현하며, 제품 의미나 새 권한이 실제로 필요한 경우에만 묻는다. high-risk 신호는 설계 선행 권장으로 경고하되, 사용자가 `/impl` 을 지시했다면 구현한다. 일반 구현을 별도 구현 worker 로 넘기지 않는다.
+description: 구현 요청을 받아 메인이 즉시 격리·focused read·RED/첫 edit로 진행하고, GREEN 뒤 격리 impl-validator와 PR 마감을 수행하는 기본 구현 진입점. 이슈번호/링크/파일/테스트처럼 concrete signal이 있으면 다시 설계하지 않고 구현한다. 제품 의미나 새 권한이 실제로 필요한 경우에만 묻는다. 일반 구현을 별도 worker로 넘기지 않는다.
 ---
 
-# Impl Skill — 기본 구현 진입점
+# Impl — main-direct action-first
 
-> `/impl` 은 사용자-facing 기본 구현 진입점이다. 공개 command 는 하나이고, 메인이 직접 구현한다. 격리되는 것은 `impl-validator` review step 이다. 공개 진입점 계약은 [`docs/plugin/positioning.md`](../../docs/plugin/positioning.md), 자유 요청의 진입점 선택은 [`docs/plugin/workflow-router.md`](../../docs/plugin/workflow-router.md), 용어는 [`docs/plugin/terms.md`](../../docs/plugin/terms.md) 를 따른다.
-
-> 🔴 **분기 규칙 SSOT** — `/impl` 내부의 direct / design-doc, retry, review provider 설명은 [`impl-routing.md`](impl-routing.md) 가 소유한다. 본 파일은 실행 절차를 담는다.
-
-## 구현 모델 — 메인 구현 + 격리 리뷰
-
-일반 `/impl` 구현 주체는 **항상 메인**이다. 일반 `/impl` 은 별도 구현 agent 를 구현자로 호출하지 않는다. `dcness-implementation-chain` 과 `build-worker` 는 story/epic impl task 파일을 처리하는 [`/impl-loop`](../impl-loop/SKILL.md) 영역이다.
-
-격리되는 것은 review step 이며, `impl-validator` 는 read-only provider 분기 대상이다. 기본 review provider 는 구현자와 반대 진영이다.
-
-- `/impl` 메인 구현(Claude) → Codex CLI 가 있으면 Codex `impl-validator`, 없으면 Claude `impl-validator` 폴백.
-- `/impl-loop` build-worker 구현 → 구현 provider 의 반대 진영. codex-headless 구현이면 Claude 리뷰, claude-headless 구현이면 Codex 리뷰(불가 시 Claude).
-- `routing.json` 에 명시 provider 가 있으면 override 를 존중한다.
-- Codex wrapper 가 실행 중 비정상 종료해도 같은 provider 로 밀어붙이지 말고 Claude `impl-validator` 로 재시도한 뒤, 폴백 사실을 한 줄로 보고한다.
-
-## 입력 처리
-
-- **이슈번호/링크/파일/symbol/테스트 명령**: 실존을 확인하고 바로 구현한다.
-- **설계 문서 경로**: `begin-run impl --design-doc <경로>` 로 기록하고 받은 설계도대로 구현한다. design-doc 기반 구현 — 설계도 기반 구현에서도 구현은 여전히 메인이 직접 수행하고, review 만 격리 provider 로 보낸다. 이 기록은 mutation-time task scope 와 review 근거다.
-- **자연어뿐인 구현 요청**: 대화에서 원하는 동작과 repo 범위가 충분하면 `rg`로 관련 entrypoint/test를 찾아 direct로 진행한다. 이슈 등록 여부만 묻는 질문은 하지 않는다. 제품 의미가 둘 이상으로 갈려 결과가 달라질 때만 한 번 묻는다. 사용자가 이슈 추적도 요청하면 `/to-issue`를 사용한다.
-- **high-risk 신호**: 새 product feature/epic, 외부 dependency/API/SDK/model 선택, auth/security/PII/compliance, migration/destructive change, public API breakage, cross-module/cross-story interface 등은 "설계 선행을 권장"한다고 한 줄 경고한다. 사용자가 그대로 진행을 택하면 `/impl` 안에서 구현한다. LLM 판단만으로 `/spec`·`/design` 으로 되돌리지 않는다.
-- **신규 시각 구조 UI 작업**: UI 기준 확보 분기에서 목업부터 만드는 것을 권장한다고 한 줄 안내한다. 내부 `canvas-design` wrapper 로 확정 목업을 만들 수 있지만, 사용자가 "그냥 가" 또는 "목업 없이"라고 하면 기존 `ux-flow` / 확정본이 있으면 참고하고, 없으면 메인이 구현한다.
-
-UI 기준 확보 분기 echo:
+`/impl`의 기본 구현자는 메인이다. 별도 구현 sub-agent나 headless worker를 먼저 만들지 않는다. 격리되는 것은 GREEN 이후 review뿐이다.
 
 ```text
-UI 기준: 기준 있음 — 사용자 제공 이미지·스케치·HTML 또는 기존 확정본을 구현 입력으로 사용
-UI 기준: 신규 시각 구조 + 기준 없음 — 목업 선행 권장, 동의 시 canvas-design 으로 확정본 승격
-UI 기준: 시각 구조 불변 — 목업 없이 구현
+target 확인 → 격리 → focused read → RED/첫 edit
 ```
 
-## Step 0 — 최소 실존 검증 후 즉시 착수
+후기 절차를 미리 정합하려고 멈추지 않는다. validator provider, Cartography freshness, target issue close audit, commit/PR/CI/merge 상세는 GREEN 뒤에만 [`impl-finish.md`](impl-finish.md)를 읽어 수행한다. direct/design-doc·위험 분기가 실제로 필요할 때만 [`impl-routing.md`](impl-routing.md)를 읽는다.
 
-추측으로 시작하지 않는다.
+## 질문 경계
 
-- GitHub issue/PR 이 입력이면 `gh issue view <N> --comments` 또는 `gh pr view <N>` 로 본문과 댓글을 확인한다.
-- 파일/symbol 입력이면 `rg` / 부분 read 로 현재 상태를 확인한다.
-- 선행 조건/의존 PR 이 있으면 merge 여부를 확인한다.
-- GitHub issue 번호가 대상이면 구현 실행 전 [`issue-lifecycle.md`](../../docs/plugin/issue-lifecycle.md#issuelabel-status-lifecycle)에 따라 `in-progress` label 을 붙인다. Project 좌표가 설정된 repo 에서는 Project `Status=In progress` 도 best-effort 로 미러한다.
-- repo 전체 탐색, boundary 후보 scan, generated TDD 설치 확인, 경로 preview를 착수 앞에 두지 않는다. 실제 lint/build/test 명령과 PR helper는 각각 필요한 실행 경계에서 찾는다.
+묻지 않고 진행한다:
 
-GitHub issue 가 대상이면 이 진입 preflight 에서 한 번 읽은 본문을 run 전체의 **target GitHub issue AC** snapshot 으로 재사용한다. 각 AC 에 구현 범위와 검증 증거를 대응시키고, task/commit/validator 단계마다 issue 를 반복 조회하지 않는다. `[command]` 는 명령과 종료코드, `[agent-read]` 는 읽은 산출물·diff·계약과 관찰 사실로 판정한다. AC가 없거나 검증 주체가 미기재됐으면 close 전에 현행 typed AC로 갱신하고, agent가 의미를 임의 추론해 체크·재분류하지 않는다. `구현이 완료된다`나 `정상 동작한다` 같은 일반론은 snapshot 에서 구체적인 관측 조건으로 교체해 구현 계약으로 쓰되 사용자 판단 없이는 구체화하지 않는다.
+- concrete issue/handoff/design-doc에 target·scope·검증이 이미 확정된 경우
+- 관련 파일과 test seam 탐색, 구현 방식 선택, 기계적 경로 오타 교정
+- 미래 story·out-of-scope 대안·후기 review/close 요구
+- 일반 test/lint 실패와 같은 범위의 재시도
 
-첫 진행 이정표는 위 최소 확인 직후 바로 남긴다.
+한 번 질문하는 경우는 제품 의미가 실제 결과를 둘 이상으로 가르거나, repo 밖 접근·새 dependency/secret·보안·데이터 파괴·hard boundary 변경처럼 새 권한이 필요한 때뿐이다. merge 승인은 사용자가 소유한다. 확정된 handoff나 사용자 선택을 다시 열어 wiki/web 조사나 설계 선택지로 되돌리지 않는다.
+
+fresh executor는 기본값도 자동 복구값도 아니다. decision-heavy A/B 실측이 main-direct보다 시간과 정확성에서 우세하다고 증명되기 전에는 같은 메인이 계속 구현한다.
+
+## 즉시 착수
+
+### 1. target 최소 확인
+
+- GitHub issue/PR이면 본문과 댓글을 한 번 읽고 target GitHub issue AC snapshot을 보관한다. AC가 없거나 검증 주체가 없으면 close 때 현행 typed AC로 갱신하며 의미를 임의 추론하지 않는다.
+- 파일/symbol이면 `rg`와 관련 부분만 읽는다.
+- 명시된 선행 PR이 있으면 merge 여부만 확인한다.
+- repo 전체 scan, branch naming 문서, 전체 SSOT, wiki/web, validator/provider, generated TDD 설치 상태는 읽지 않는다.
+- issue lifecycle state 변경은 기존 helper가 있으면 격리와 같은 첫 실행 묶음에서 처리한다. 그 helper 구현을 조사하지 않는다.
+
+첫 메시지는 다음 한 줄이면 충분하다.
 
 ```text
 착수: <target> 확인 · worktree 준비 · RED/첫 edit 진행
 ```
 
-## 질문 budget과 자율 복구
+### 2. 격리와 run 시작
 
-다음은 묻지 않고 처리한다: 관련 파일/테스트 탐색, 구현 방식 선택, task scope의 기계적 경로 오타 교정, 이미 설계 문서 `### 수정 허용`에 든 비표준 경로, recoverable timeout/empty prose, 일반 test/lint 실패, 같은 범위의 재시도.
+- 사용자가 “워크트리 없이”라고 하지 않았으면 즉시 `EnterWorktree`를 사용한다.
+- worktree 진입 뒤 모든 read/edit/test 경로를 새 cwd 기준으로 다시 잡는다.
+- 그 worktree에서 `dcness-helper begin-run impl --lane lite` 또는 design-doc 입력이면 `begin-run impl --design-doc <path>`를 한 번 실행한다.
+- 브랜치·커밋 네이밍은 commit 경계의 기존 hook을 우선한다. RED 전에 naming SSOT를 읽지 않는다.
 
-질문은 제품 의미가 실제로 둘 이상일 때, repo 밖 접근·새 dependency/secret/보안·데이터 파괴처럼 새 권한이나 위험 수용이 필요할 때, 자동 복구 한도를 소진했을 때, merge 승인처럼 사용자가 소유한 결정일 때만 한다. hard boundary를 자동으로 넓히거나 `tdd-exempt`를 자동 삽입하지 않는다.
+### 3. focused read
 
-같은 기계적 명령·판정·복구가 run 안에서 반복되면 메인이 같은 절차를 다시 타이핑하지 않는다. 기존 프로젝트 script/helper에 입력과 종료 조건을 묶어 재실행 가능하게 만들고, 대체된 일회성 helper·분기·문서는 같은 변경에서 삭제한다.
+- issue/handoff가 지정한 pointer와 test seam만 읽는다.
+- 파일을 통째로 읽기 전에 `rg`로 symbol과 기존 테스트를 찾는다.
+- 구현에 필요한 signature·인접 코드까지만 확장한다.
+- 사용자 선택이 이미 확정된 run은 선택 확정 뒤 blocking assistant turn 2회 안에 RED 또는 첫 edit를 만든다.
+- concrete pointer path가 주어졌으면 다음 순서를 바꾸거나 쪼개지 않는다.
+  1. 첫 tool call은 pointer만 읽어 exact source·test path를 얻는다. repo 탐색을 섞지 않는다.
+  2. 둘째 tool call 하나에서 그 exact source와 matching test를 함께 읽는다. 별도 `Read`, `find`, `ls`, 디렉터리별 `grep`/`cat`을 추가하지 않는다.
+  3. 다음 tool-bearing turn은 RED test 또는 첫 edit다.
+- source·test exact path까지 처음부터 주어졌으면 1·2를 한 tool call로 합친다.
 
-## Step 1 — 구현 완료조건
+### 4. RED → 구현 → GREEN
 
-메인 직접 구현도 [`build-worker` 완료 기준](../../docs/plugin/agents/build-worker/build-worker-agent.md)과 같은 수준의 완료조건을 만족해야 종료한다.
+- 테스트 가능한 변경은 실패 테스트를 먼저 작성하고 실제 RED를 확인한다.
+- docs-only·단순 설정처럼 테스트할 수 없으면 skip 사유를 한 줄 남긴다.
+- 메인이 직접 구현한다. 구현 중 routine 선택을 질문으로 올리지 않는다.
+- 관련 lint/build/test/typecheck/compile을 실제 실행한다.
+- 첫 edit 뒤 `진행: RED/첫 edit 확인`, green 뒤 `진행: 구현·검증 green · review 시작`만 알린다.
 
-- **TDD 신뢰성**: 테스트 가능한 코드 변경은 테스트를 먼저 RED 로 확인하고, 구현 후 GREEN 을 실제 실행으로 확인한다. docs-only / 단순 설정 변경은 TDD skip 사유를 남긴다.
-- **자체 검증 실제 실행**: lint/build/test/typecheck/compile 게이트를 명령 실제 실행 + 종료코드로 판정한다. 코드 읽기만으로 PASS 처리하지 않는다. 실행 불가 시 `VALIDATION_BLOCKED` 로 남기고 가능한 환경에서 복원한다.
-- **동작 증거**: 핵심 AC 를 mock-only green 으로 닫지 않는다. AC 성격에 맞게 정적 타입검사/compile, 실데이터 통합테스트, UI 자동화, API/CLI smoke, 실제 앱 진입점 실행 중 적절한 증거를 확보한다.
-- **경계**: 변경 파일이 impl scope / 권한 경계 안에 있어야 한다.
-- **커밋**: green 변경은 독립 검토 가능한 단위 commit 으로 닫는다.
-- **UI**: 확정 목업이 있으면 레이아웃·상태·`design:required` 토큰 정합을 대조하고 보고한다.
-- **Cartography impact**: 구현 결과에서 runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after와 증거, 관련 epic/decision의 변화 여부를 자유 prose로 남긴다. 영향이 없으면 `영향 없음`과 대조한 Root 좌표를 명시한다.
-- **target issue AC**: 대상 GitHub issue 가 있으면 typed target GitHub issue AC 전항목 충족과 자동 판정 가능한 체크박스 전부 check가 공통 자동 종료 조건이다. 하나라도 미충족·미체크면 `require-complete` 감사가 실패하므로 clean 마감, `Closes` PR 머지, 완료 보고를 금지한다. checklist와 분리된 사람 확인 항목은 human verification 대기이며 이 계약은 계획 파일 유무와 무관하다.
+## GREEN 이후
 
-### Cartography freshness boundary
+관련 검증이 GREEN이 된 뒤에만 [`impl-finish.md`](impl-finish.md)를 읽고 다음을 마친다.
 
-direct와 design-doc 구현 모두 메인이 작성한 Cartography impact, merge candidate diff, affected Root Cartography 좌표, 관련 epic/decision을 `impl-validator` 입력에 전달한다. `impl-validator`는 읽기 전용이므로 직접 문서를 수정하지 않으며, 메인이 prose를 읽어 다음 세 결과로 분기한다.
+1. 동작·경계·Cartography impact 증거 수집
+2. 격리 `impl-validator`와 최대 3회 root-cause 수정
+3. 의미 단위 commit, PR, CI
+4. target GitHub issue AC close audit와 최종 보고
 
-- **영향 없음 또는 Root와 일치**: 기존 review/PR 경로를 계속한다.
-- **system boundary는 유지되지만 route/state/as-built edge가 stale**: 기존 `module-architect`를 workflow 내부 `CARTOGRAPHY_REFRESH` producer로 호출한다. affected Root 좌표만 bounded하게 갱신하고 system boundary나 impl task를 재설계하지 않는다. tracked docs는 현재 branch/PR 정책으로 반영하고, local-only/ignored 문서는 code PR에 강제 포함하지 않은 채 canonical local Root를 갱신하거나 exact affected 좌표·상태 증거를 durable impact handoff로 보존한다. durable impact handoff만으로 freshness가 해소되지는 않으며, 그 뒤 같은 merge candidate diff와 갱신된 Root를 `impl-validator`가 재검증해야 한다.
-- **system boundary·global decision 변경**: route-only patch로 흡수하지 않는다. clean 진행을 멈추고 `/design --revise` 또는 system checkpoint backpressure와 영향 범위를 사용자에게 제시한다. 사용자의 구현 지시를 무시한 자동 재설계는 하지 않는다.
+GREEN 전에는 이 후기 진본이나 그 포인터가 가리키는 문서를 선행 read하지 않는다.
 
-standalone acceptance가 생략 가능한 direct `/impl`에서는 이 `impl-validator` 종료 경계가 최소 freshness 책임이다. 미해소 route-only stale이나 system backpressure가 있으면 commit/PR clean 판정으로 진행하지 않는다.
+## 안전 불변식
 
-## Step 2 — 실행 절차
-
-1. branch/worktree 격리
-   - git-spec 이 있으면 [`git-spec.md`](../../docs/plugin/git-spec.md) 패턴을 따른다.
-   - 사용자가 "워크트리 없이"라고 하지 않으면 worktree 격리를 기본으로 한다.
-   - worktree 진입 후 Read/Edit/Write 대상은 worktree 절대경로 또는 worktree cwd 상대경로로 다시 잡는다.
-   - 종료 시 `ExitWorktree` 정리 판단은 [`loop-procedure` worktree 분기](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정)를 따른다. 커밋 diff 흡수와 clean worktree 가 모두 확인될 때만 remove/discard 하고, dirty 상태는 keep 한다.
-2. 테스트 선작성
-   - 테스트 가능한 코드 변경은 구현 전에 실패 테스트를 먼저 쓴다.
-   - docs-only / 단순 설정 변경은 TDD skip 사유를 명시한다.
-   - RED 확인 또는 skip 사유 확정 시 `진행: RED 확인 · 구현 시작` 이정표를 남긴다.
-3. 구현
-   - 메인이 직접 Edit/Write 한다. 별도 구현 agent 를 호출하지 않는다.
-4. lint/build/test green
-   - 프로젝트에 실제 존재하는 명령만 실행한다.
-   - 하나라도 red 면 commit/PR 로 가지 않는다.
-   - green 확보 시 `진행: 구현 완료 · 검증 green · review 시작` 이정표를 남긴다.
-5. `impl-validator` review
-   - `begin-run impl` 또는 `begin-run impl --design-doc <경로>` → mode 없는 foreground Claude `impl-validator`는 lifecycle hook으로 merge candidate를 리뷰한다. Codex/headless wrapper 또는 modeful 호출만 명시적 `begin-step`을 연다.
-   - 검토 대상이 커밋으로 존재하면 커밋 id와 변경 파일 목록을 1급 입력으로 선행 전달하고, validator가 `git show` / `git diff` / `git log`로 커밋 진본을 직접 펼치게 한다. 호출자는 별도 diff 파일을 덤프하지 않는다. 커밋이 없는 uncommitted local diff일 때만 diff 파일 전달을 폴백으로 사용한다.
-   - prompt에 위 리뷰 대상, 메인의 Cartography impact 자유 prose, affected Root Cartography 좌표, 관련 epic/decision을 필요한 만큼 넣는다.
-   - provider 가 `codex` 이면 `dcness-codex-validator impl-validator` wrapper 를 사용한다.
-   - Codex CLI 부재나 wrapper 비정상 종료 시 Claude `impl-validator` 로 폴백하고 폴백 사실을 보고한다.
-   - review-only 다. 코드 수정은 메인이 한다. PASS 전 commit/PR 로 가지 않는다.
-6. finding 및 Cartography freshness 수정 루프
-   - 최대 3회. finding 의 줄만 고치지 말고 root cause 와 같은 계열 결함을 함께 확인한다.
-   - route/state/as-built edge stale은 `module-architect:CARTOGRAPHY_REFRESH` 후 impl-validator 재검증하고, system boundary/global decision 변경은 `/design --revise` 또는 system checkpoint 사용자 backpressure에서 멈춘다.
-   - producer 실행은 `begin-step module-architect CARTOGRAPHY_REFRESH`로 열고, 결과 prose를 `end-step module-architect CARTOGRAPHY_REFRESH --prose-file <cartography-refresh-prose>`로 기록한다. `PASS`이면 같은 merge candidate diff와 갱신 Root로 mode 없는 foreground `impl-validator` lifecycle hook 재검증을 열며, `SYSTEM_CHECKPOINT_REQUIRED`이면 Root patch를 적용하지 않고 backpressure에서 멈춘다.
-   - 각 round 마다 lint/build/test 재통과 후 `impl-validator` 재호출.
-7. 단위 commit + PR 생성
-   - 의미 단위 커밋 분할은 [`git-spec.md#의미-단위-커밋-분할`](../../docs/plugin/git-spec.md#의미-단위-커밋-분할)이 SSOT 다. hook 우회 금지.
-   - 독립 검토 가능한 의미 단위로 commit 을 나누고, 각 커밋은 hook 을 통과해야 한다.
-   - PR body 는 template, 관련 issue trailer, 배경/문제, 근본원인, 작업내용, 결정근거, Test Plan 을 포함한다.
-   - dcNess plugin 배포물 변경이면 PR body 에 배포 경로 검증을 적는다.
-8. CI / merge policy
-   - PR 생성 후 CI 를 확인한다.
-   - CI green 과 최종 review 증거가 확정된 뒤, target issue 를 `Closes` 하는 PR 경계에서 메인이 보관한 AC 증거를 전수 대조한다. `Closes` 대상이 여러 개면 issue 별로 모두 수행한다. 자동 판정 가능한 typed 항목을 모두 충족한 뒤 이슈 본문 체크박스 write 를 issue 별 close 경계에서 한 번 수행하고, 같은 body 를 `node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" --body-file <issue-body.md> --acceptance-only --require-complete` 로 감사한다. 정확한 `PASS`만 자동 close 경로를 열며, 사람 확인 항목은 checklist 밖에서 완료될 때까지 merge를 멈춘다. 진행 중에는 issue mutation 을 하지 않는다.
-   - 머지는 host repo 정책을 따른다. 사용자 승인 대기 정책 repo 에서는 임의 머지하지 않는다.
-
-최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, 격리 `impl-validator`, 단위 commit/PR, CI, false-clean 방지다. TDD 게이트는 삭제하지 않는다.
-
-사람이 직접 판정해야 하는 항목은 `Human verification / 사람 확인 안내`에 체크박스 없이 있어야 한다. 기존 이슈의 AC 체크박스에 사람 판정 항목이 남아 있으면 agent 가 체크하지 않는다. 자동 항목을 모두 충족·체크한 뒤 잔여 human verification 목록을 보고하고 merge 전에 정지한다. 이 상태는 구현·자동 검증 실패를 뜻하는 `blocked` 가 아니라 `human verification 대기`다.
-
-## Sub-agent prompt 작성 checkpoint (#780)
-
-`impl-validator` review를 격리 provider로 호출하기 전에 [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md)를 직접 읽고 3슬롯을 점검한다. 이 정적 checkpoint는 `begin-step` stdout relay가 아니다. foreground Claude Agent의 worktree 절대경로는 SubagentStart lifecycle context가 첫 prompt 전에 전달하고, headless wrapper는 자기 prompt에 직접 합성한다.
-
-- **대상 + 읽을 진본**: 이슈·설계도·task 파일·merge candidate diff·Cartography impact·affected Root Cartography 좌표·관련 epic/decision 등 agent 가 자체 read 할 SSOT 포인터만 둔다.
-- **리뷰 대상 전달 우선순위**: 커밋이 있으면 커밋 id와 변경 파일 목록을 선행 전달한다. diff 파일은 커밋이 없는 uncommitted local diff의 폴백으로만 전달한다.
-- **worktree**: foreground Claude Agent는 SubagentStart hook, headless는 wrapper가 동적으로 넣는다. 메인은 Bash stdout을 prompt로 재전달하지 않는다.
-- **이 호출 특유**: 진본에 없는 제약·신호만 둔다.
-- **방법 처방 금지**: 구현 방식, 테스트 assert 방식, 알고리즘 같은 방법 처방은 넣지 않는다.
-
-## Review Provider
-
-`impl-validator` provider resolve 예시:
-
-```bash
-PLUGIN_ROOT=""
-if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
-  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
-else
-  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
-fi
-[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
-HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
-PROVIDER=$("$HELPER" routing resolve impl-validator)
-if [ "$PROVIDER" = "codex" ]; then
-  if command -v codex >/dev/null 2>&1; then
-    "$PLUGIN_ROOT/scripts/dcness-codex-validator" impl-validator --prompt-file "$PROMPT_FILE" \
-      || Agent(subagent_type="impl-validator", ...)
-  else
-    echo "[dcness] Codex unavailable; falling back to Claude impl-validator"
-    Agent(subagent_type="impl-validator", ...)
-  fi
-else
-  Agent(subagent_type="impl-validator", ...)
-fi
-```
-
-최초 resolve한 `PLUGIN_ROOT`/`HELPER` 절대경로는 이후 독립 Bash 호출에 literal로 넣는다. 서로 다른 Bash tool 호출 사이에서 shell 변수가 지속된다고 가정하지 않는다.
-
-Codex 분기는 review provider 구현일 뿐 별도 public workflow 가 아니다. Codex wrapper receipt 는 실제 provider 를 `codex-headless` 로 기록한다.
-
-## 종료 보고
-
-최종 보고에는 구현 경로, review provider, 변경 요약, 검증 명령 결과, review round 수, PR URL 을 포함한다. 실패 시에는 남은 finding 과 다음 판단 지점을 명확히 쓴다.
-
-helper 기반 `begin-run impl` 이 열린 경로에서는 대표 workflow 종료 시 `"$HELPER" end-run` 으로 review.md 를 만들며, review.md 안에 CLAUDE.md/AGENTS.md 현행화 후보 read-only 섹션이 포함된다. 이 섹션은 제안만 출력하고 CLAUDE.md/AGENTS.md 를 자동 수정하지 않는다.
-
-대표 구현 workflow 완료 후 메인이 이슈 등록, cleanup, 측정 같은 자율 작업으로 이어갈 때는 진입 전 `dcness-helper post-task-begin --reason "<사유>"` 를 호출한다. 이 marker 는 task ROI 측정 분리를 위한 #472 계약이다.
+- TDD, lint/build/test, hard boundary, branch→PR, 격리 review, CI를 제거하지 않는다.
+- `tdd-exempt`나 boundary 확대를 자동 삽입하지 않는다.
+- 대체한 helper·분기·문서·테스트는 같은 변경에서 삭제하고 옛 이름·호출 예시가 남지 않았는지 `rg`로 확인한다.
+- 새 공개 command/skill/agent를 추가하지 않는다.
 
 ## 참조
 
-- 용어 사전: [`docs/plugin/terms.md`](../../docs/plugin/terms.md)
-- 공개 진입점: [`docs/plugin/positioning.md`](../../docs/plugin/positioning.md)
-- 진입점 분기 규칙: [`docs/plugin/workflow-router.md`](../../docs/plugin/workflow-router.md)
-- 구현 분기 규칙: [`impl-routing.md`](impl-routing.md)
-- branch / commit / PR: [`docs/plugin/git-spec.md`](../../docs/plugin/git-spec.md)
+- 초기 위험 분기(필요할 때만): [`impl-routing.md`](impl-routing.md)
+- GREEN 이후 마감(필요할 때만): [`impl-finish.md`](impl-finish.md)
+- 기본/고급 공개 진입점: [`positioning.md`](../../docs/plugin/positioning.md)

--- a/skills/impl/impl-finish.md
+++ b/skills/impl/impl-finish.md
@@ -1,0 +1,66 @@
+# `/impl` GREEN 이후 마감
+
+이 문서는 관련 lint/build/test/typecheck/compile이 GREEN이 된 뒤에만 읽는다. 구현 착수 전에 읽는 preflight가 아니다.
+
+## 완료 증거
+
+- 테스트 가능한 변경은 RED→GREEN 실행 기록을 남긴다. docs-only·단순 설정은 TDD skip 사유를 남긴다.
+- 핵심 AC는 성격에 맞는 compile, 통합테스트, API/CLI smoke, 실제 앱 진입점 또는 UI 증거로 확인한다. mock-only green만으로 닫지 않는다.
+- 변경 파일이 scope와 hard boundary 안인지 확인한다.
+- runtime entrypoint, capability/state owner, dependency edge, public surface, 상태 before/after, 관련 epic/decision 변화 여부를 Cartography impact 자유 prose로 정리한다. 영향이 없으면 대조한 Root 좌표와 함께 `영향 없음`을 적는다.
+- 대상 GitHub issue가 있으면 진입 때 보관한 typed AC snapshot을 구현·명령·agent-read 증거와 대응시킨다.
+
+## 격리 `impl-validator`
+
+1. 검토 대상이 commit이면 commit id와 변경 파일 목록을 전달한다. uncommitted diff일 때만 diff 파일을 사용한다.
+2. [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md)를 이 호출 직전에 읽는다.
+3. prompt에는 target/읽을 진본, review 대상, Cartography impact, affected Root 좌표, 관련 epic/decision, 진본에 없는 현재 finding만 넣는다. 구현 방법을 처방하거나 과거 대화 전체를 넣지 않는다.
+4. review provider는 [`impl-routing.md`](impl-routing.md)의 현행 규칙으로 한 번 resolve한다. Codex면 `dcness-codex-validator impl-validator`, 그 밖에는 mode 없는 foreground `impl-validator`를 사용한다.
+5. validator는 read-only다. 수정은 메인이 한다.
+
+MUST FIX가 있으면 최대 3회 root-cause 수정 루프를 돈다. 같은 계열 결함과 삭제된 로직의 잔여 호출·문서·테스트도 함께 찾고, 매 round마다 관련 gate를 다시 실행한 뒤 새 diff를 재검증한다. MUST FIX가 없으면 NICE TO HAVE를 merge blocker로 승격하지 않는다.
+
+## Cartography freshness
+
+validator가 merge candidate diff, Cartography impact, affected Root Cartography, 관련 epic/decision을 대조한다.
+
+- 영향 없음 또는 Root와 일치: 계속 진행한다.
+- system boundary는 유지되지만 route/state/as-built edge가 stale: `begin-step module-architect CARTOGRAPHY_REFRESH`로 bounded producer를 열고 affected Root만 refresh한다. 완료 prose는 `end-step module-architect CARTOGRAPHY_REFRESH --prose-file <path>`로 기록하고 같은 diff+갱신 Root를 validator가 다시 검증한다.
+- system boundary/global decision 변경: route-only patch로 흡수하지 않고 `/design --revise` 또는 system checkpoint를 사용자에게 제시한다.
+
+읽기 전용 validator와 build worker는 Cartography 문서를 직접 수정하지 않는다. route-only stale이나 system backpressure가 남은 상태를 clean으로 보고하지 않는다.
+local-only/ignored Root는 code PR에 강제 포함하지 않되 canonical local Root를 갱신한다. durable impact handoff만으로 freshness가 해소되지는 않으며 canonical Root refresh와 재검증이 필요하다.
+
+## commit·PR·CI
+
+- [`git-spec.md`](../../docs/plugin/git-spec.md)를 이 commit 경계에서 처음 읽고 branch/commit/PR 이름과 의미 단위 분할을 맞춘다.
+- hook을 우회하지 않는다. 각 commit은 독립적으로 green이어야 한다.
+- PR body는 저장소 template, 관련 issue trailer, 배경/문제, 원인, 작업내용, 결정 근거, Test Plan을 채운다.
+- dcNess 배포물 변경이면 외부 활성 프로젝트에 도달하는 배포 경로를 적는다.
+- PR 생성 후 CI를 확인하고 red면 원인을 수정해 다시 검증한다.
+
+## target GitHub issue AC close audit
+
+PR이 target issue close를 발동하기 직전에만 다음을 수행한다.
+
+1. 진입 때 보관한 AC snapshot과 최종 구현·명령·validator 증거를 전수 대조한다.
+2. 자동 판정 가능한 `[command]`/`[agent-read]` 항목만 충족 증거가 있을 때 체크한다.
+3. issue body write는 이 close 경계에서 한 번만 수행한다.
+4. `scripts/check_issue_body.mjs`가 있으면 같은 body를 다음처럼 감사한다.
+
+```bash
+node "$PLUGIN_ROOT/scripts/check_issue_body.mjs" \
+  --body-file <issue-body.md> \
+  --acceptance-only \
+  --require-complete
+```
+
+미충족·미체크 typed AC가 하나라도 있으면 clean 마감이나 `Closes` merge를 금지한다. 사람 판정 항목은 agent가 체크하지 않고 `human verification 대기`로 보고하며, 이 대기 자체는 `blocked`로 분류하지 않는다.
+
+## 종료
+
+helper 기반 run이면 대표 workflow 종료 시 `dcness-helper end-run`을 호출한다. 최종 보고에는 구현 경로, review provider, 변경 요약, 검증 명령과 종료코드, review round 수, PR URL, AC close audit 결과, 남은 위험 또는 사람 확인을 포함한다.
+
+PR/merge handoff가 끝나기 전에는 worktree를 유지한다. 종료 시점에만 [`loop-procedure.md` worktree 분기](../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정)를 읽고, 커밋 흡수와 clean 상태가 모두 증명되면 remove를 검토하며 dirty/unmerged 상태는 keep한다.
+
+완료 뒤 별도 자율 작업으로 이어갈 때만 `dcness-helper post-task-begin --reason <사유>`를 호출해 task ROI와 분리한다. 이 #472 marker는 구현 착수 preflight가 아니다.

--- a/skills/impl/impl-routing.md
+++ b/skills/impl/impl-routing.md
@@ -52,7 +52,7 @@ UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 �
 
 | 경로 | 다음 |
 |---|---|
-| direct · 메인 직접 | concrete signal 또는 충분한 자연어 의도에서 관련 파일을 찾고 메인 직접 `test -> impl -> test pass` 후 `begin-run impl` → `impl-validator` local diff |
+| direct · 메인 직접 | 격리 뒤 `begin-run impl`을 기록하고 concrete signal 또는 충분한 자연어 의도에서 관련 파일을 찾아 메인 직접 `test -> impl -> test pass` → `impl-validator` local diff |
 | design-doc · 메인 직접 | `begin-run impl --design-doc <경로>` 기록 후 받은 설계도로 메인 직접 `test -> impl -> test pass` → `impl-validator` local diff |
 
 일반 `/impl` 도 `impl-validator` 를 호출한다. direct 에 대상 issue 가 있으면 계획 파일이 없어도 spec 렌즈를 켜고 **target GitHub issue AC** 를 대조한다. design-doc 경로의 spec 기준은 plan ∪ target GitHub issue AC 이며, 대상 issue 가 없는 direct 만 quality 렌즈로 검토한다. 최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, 격리 `impl-validator`, 단위 commit/PR, CI, false-clean 방지다.

--- a/tests/test_acceptance_skill.py
+++ b/tests/test_acceptance_skill.py
@@ -13,7 +13,7 @@ class AcceptanceSkillContractTests(unittest.TestCase):
     def setUp(self) -> None:
         self.skill = ROOT / "skills" / "acceptance" / "SKILL.md"
         self.routing = ROOT / "skills" / "acceptance" / "acceptance-routing.md"
-        self.impl_loop = ROOT / "skills" / "impl-loop" / "impl-loop-routing.md"
+        self.impl_loop = ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
 
     def test_acceptance_skill_exists_as_story_epic_mvp(self) -> None:
         text = self.skill.read_text(encoding="utf-8")
@@ -96,16 +96,16 @@ class AcceptanceSkillContractTests(unittest.TestCase):
 
     def test_inline_acceptance_owns_cross_pr_story_behavior(self) -> None:
         text = self.impl_loop.read_text(encoding="utf-8")
-        self.assertIn("여러 PR 이 합쳐진 story 동작", text)
-        self.assertIn("여러 story 가 합쳐진 epic 동작", text)
-        self.assertIn("product-acceptance 가 맡는다", text)
-        self.assertIn("mock-only green / 동작 증거 부족", text)
-        self.assertIn("사용자 동선 부적합 / 내부 계약 노출", text)
+        self.assertIn("여러 PR이 합쳐진 story 동작", text)
+        self.assertIn("여러 story가 합쳐진 epic 동작", text)
+        self.assertIn("product-acceptance가 맡는다", text)
+        self.assertIn("mock-only green/동작 증거 부족", text)
+        self.assertIn("사용자 동선 부적합/내부 계약 노출", text)
 
     def test_inline_acceptance_injects_ui_mock_and_screen_evidence(self) -> None:
-        text = (ROOT / "skills" / "impl-loop" / "SKILL.md").read_text(
-            encoding="utf-8"
-        )
+        text = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+        ).read_text(encoding="utf-8")
         for needle in (
             "확정 목업 경로",
             "구현 화면 스크린샷",

--- a/tests/test_canvas_design_workflow.py
+++ b/tests/test_canvas_design_workflow.py
@@ -17,12 +17,22 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
         self.impl_routing = (
             ROOT / "skills" / "impl" / "impl-routing.md"
         ).read_text(encoding="utf-8")
+        self.impl_finish = (
+            ROOT / "skills" / "impl" / "impl-finish.md"
+        ).read_text(encoding="utf-8")
+        self.impl_contract = self.impl + self.impl_routing + self.impl_finish
         self.impl_loop = (
             ROOT / "skills" / "impl-loop" / "SKILL.md"
         ).read_text(encoding="utf-8")
         self.impl_loop_routing = (
             ROOT / "skills" / "impl-loop" / "impl-loop-routing.md"
         ).read_text(encoding="utf-8")
+        self.impl_loop_finish = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+        ).read_text(encoding="utf-8")
+        self.impl_loop_contract = (
+            self.impl_loop + self.impl_loop_routing + self.impl_loop_finish
+        )
         self.ux = (ROOT / "skills" / "ux" / "SKILL.md").read_text(encoding="utf-8")
         self.ux_routing = (
             ROOT / "skills" / "ux" / "ux-routing.md"
@@ -100,8 +110,8 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, skill)
 
-        self.assertIn("canvas-design", self.impl)
-        self.assertIn("canvas-design", self.impl_loop)
+        self.assertIn("canvas-design", self.impl_contract)
+        self.assertIn("canvas-design", self.impl_loop_contract)
         self.assertNotIn("/canvas-design", self.positioning)
 
         defaults = self._array(self.public_surface, "defaultSkills")
@@ -169,7 +179,6 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
             "`/impl` · `/impl-loop` · `/design` · `/ux`",
             "EnterWorktree(name=\"<skill>-{ts_short}\")",
             "impl / impl-loop / design / ux",
-            "`/impl`·`/impl-loop`·`/design`·`/ux` action loop",
             "`/spec` / `/tech-review` / `/to-issue` (commit 없음)",
             "ux = epic `ux-flow.md`, `docs/design.md`, "
             "`docs/design-variants/<screen-id>.html`, "
@@ -226,26 +235,35 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
         self.assertIn("사용자 PICK 대기 중에는 routed conclusion", skill)
 
     def test_canvas_design_is_main_owned_not_strict_agent_step(self) -> None:
-        for text in (self.impl_loop, self.impl_loop_routing):
-            with self.subTest(doc=text[:30]):
-                self.assertIn("main-owned", text)
-                self.assertIn("helper begin/end-step 비대상", text)
-                self.assertIn("mode 없는 foreground designer Agent", text)
-                self.assertIn("lifecycle hook", text)
-                self.assertNotIn("begin-step designer", text)
-                self.assertNotIn("begin-step canvas-design", text)
+        text = self.impl_loop
+        self.assertIn("main-owned", text)
+        self.assertIn("helper begin/end-step 비대상", text)
+        self.assertIn("mode 없는 foreground designer Agent", text)
+        self.assertIn("lifecycle hook", text)
+        self.assertNotIn("begin-step designer", text)
+        self.assertNotIn("begin-step canvas-design", text)
+
+    def test_impl_loop_enters_worktree_before_canvas_design_mutation(self) -> None:
+        worktree = self.impl_loop.index("### 2. worktree가 첫 mutation보다 먼저")
+        canvas = self.impl_loop.index("main-owned `canvas-design`", worktree)
+
+        self.assertLess(worktree, canvas)
+        self.assertIn(
+            "canvas-design의 seed·draft·확정본 mutation도 worktree 안에서만",
+            self.impl_loop,
+        )
 
     def test_impl_has_three_way_visual_baseline_branch_and_echo(self) -> None:
-        for text in (self.impl, self.impl_routing):
-            with self.subTest(file=text[:20]):
-                self.assertIn("UI 기준 확보 분기", text)
-                self.assertIn("기준 있음", text)
-                self.assertIn("신규 시각 구조 + 기준 없음", text)
-                self.assertIn("시각 구조 불변", text)
-                self.assertIn("목업 없이", text)
-                self.assertIn("UI 기준:", text)
-                self.assertIn("사용자 제공 이미지", text)
-                self.assertIn("기존 확정본", text)
+        text = self.impl_routing
+        self.assertIn("UI 기준 확보 분기", text)
+        self.assertIn("기준 있음", text)
+        self.assertIn("신규 시각 구조 + 기준 없음", text)
+        self.assertIn("시각 구조 불변", text)
+        self.assertIn("목업 없이", text)
+        self.assertIn("UI 기준:", text)
+        self.assertIn("사용자 제공 이미지", text)
+        self.assertIn("기존 확정본", text)
+        self.assertIn("impl-routing.md", self.impl)
 
     def test_impl_loop_uses_canvas_design_with_build_worker(self) -> None:
         for needle in (
@@ -256,7 +274,7 @@ class CanvasDesignWorkflowTests(unittest.TestCase):
             "단일 구현 엔진",
         ):
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.impl_loop)
+                self.assertIn(needle, self.impl_loop_contract)
         self.assertNotIn("test-engineer", self.impl_loop)
         self.assertNotIn("engineer:IMPL", self.impl_loop)
 

--- a/tests/test_cartography_workflow_integration.py
+++ b/tests/test_cartography_workflow_integration.py
@@ -30,7 +30,7 @@ class CartographyWorkflowIntegrationTests(unittest.TestCase):
         self.assertNotIn("전역 Cartography의 단일 write owner", skill)
 
     def test_direct_impl_hands_impact_and_root_coordinates_to_validator(self) -> None:
-        skill = read("skills/impl/SKILL.md")
+        skill = read("skills/impl/SKILL.md") + read("skills/impl/impl-finish.md")
         routing = read("skills/impl/impl-routing.md")
 
         for text in (skill, routing):
@@ -49,7 +49,7 @@ class CartographyWorkflowIntegrationTests(unittest.TestCase):
             self.assertIn(meaning, skill)
 
     def test_direct_impl_routes_three_freshness_results(self) -> None:
-        skill = read("skills/impl/SKILL.md")
+        skill = read("skills/impl/SKILL.md") + read("skills/impl/impl-finish.md")
         routing = read("skills/impl/impl-routing.md")
 
         for text in (skill, routing):
@@ -67,10 +67,11 @@ class CartographyWorkflowIntegrationTests(unittest.TestCase):
         self.assertIn("읽기 전용", skill)
 
     def test_impl_loop_preserves_impact_through_review_and_acceptance(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
-        routing = read("skills/impl-loop/impl-loop-routing.md")
+        skill = read("skills/impl-loop/SKILL.md") + read(
+            "skills/impl-loop/impl-loop-finish.md"
+        )
 
-        for text in (skill, routing):
+        for text in (skill,):
             self.assertIn("build-worker Cartography impact", text)
             self.assertIn("affected Root Cartography", text)
             self.assertIn("CARTOGRAPHY_REFRESH", text)
@@ -80,8 +81,8 @@ class CartographyWorkflowIntegrationTests(unittest.TestCase):
             self.assertIn("/design --revise", text)
             self.assertIn("durable impact handoff만으로 freshness가 해소되지는 않", text)
 
-        self.assertIn("acceptance 재검수", routing)
-        self.assertIn("CR -->|SYSTEM_CHECKPOINT_REQUIRED| DESIGN", routing)
+        self.assertIn("acceptance 재검수", skill)
+        self.assertIn("system boundary/global decision", skill)
 
     def test_validator_does_not_treat_durable_handoff_as_refresh_completion(self) -> None:
         validators = (
@@ -114,8 +115,8 @@ class CartographyWorkflowIntegrationTests(unittest.TestCase):
             self.assertIn(needle, producer)
 
         for workflow in (
-            read("skills/impl/SKILL.md"),
-            read("skills/impl-loop/SKILL.md"),
+            read("skills/impl/impl-finish.md"),
+            read("skills/impl-loop/impl-loop-finish.md"),
         ):
             self.assertIn(
                 "begin-step module-architect CARTOGRAPHY_REFRESH", workflow

--- a/tests/test_codebase_sanity_workflow.py
+++ b/tests/test_codebase_sanity_workflow.py
@@ -101,10 +101,9 @@ class CodebaseSanityWorkflowTests(unittest.TestCase):
         self.assertNotIn("merge review", reason)
 
     def test_impl_loop_defines_epic_only_sanity_lifecycle(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
-        routing = read("skills/impl-loop/impl-loop-routing.md")
+        skill = read("skills/impl-loop/impl-loop-finish.md")
 
-        for text in (skill, routing):
+        for text in (skill,):
             self.assertIn("impl-validator:CODEBASE_SANITY", text)
             self.assertIn("Epic", text)
             self.assertIn("affected dependency cone", text)
@@ -227,7 +226,7 @@ class CodebaseSanityWorkflowTests(unittest.TestCase):
         )
 
         for path in (
-            "skills/impl-loop/SKILL.md",
+            "skills/impl-loop/impl-loop-finish.md",
             "skills/design/SKILL.md",
             "skills/design-system/SKILL.md",
         ):

--- a/tests/test_codex_sandbox_permission.py
+++ b/tests/test_codex_sandbox_permission.py
@@ -694,9 +694,9 @@ class CodexSandboxPermissionRetryTests(unittest.TestCase):
 
 class CodexSandboxPermissionSurfaceTests(unittest.TestCase):
     def test_impl_loop_and_user_docs_describe_the_approval_journey(self) -> None:
-        impl_loop = (ROOT / "skills" / "impl-loop" / "SKILL.md").read_text(
-            encoding="utf-8"
-        )
+        impl_loop = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-routing.md"
+        ).read_text(encoding="utf-8")
         hooks = (ROOT / "docs" / "plugin" / "hooks.md").read_text(encoding="utf-8")
 
         for text in (impl_loop, hooks):

--- a/tests/test_codex_validator_wrapper.py
+++ b/tests/test_codex_validator_wrapper.py
@@ -719,18 +719,30 @@ class CodexWorkerWrapperTests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stderr)
         return args, project
 
-    def test_worker_default_sandbox_args_remain_workspace_write_only(self) -> None:
+    def test_worker_default_sandbox_adds_only_canonical_run_writable_root(self) -> None:
         for network_access in (None, "0", "false", "off"):
             with self.subTest(network_access=network_access):
                 args, project = self._capture_worker_args(
                     network_access=network_access,
                 )
+                canonical_run_dir = str(
+                    Path(project).resolve()
+                    / ".claude"
+                    / "harness-state"
+                    / ".sessions"
+                    / "sid-worker-sandbox"
+                    / "runs"
+                    / "run-sandbox1"
+                )
 
                 self.assertEqual(
-                    args[:7],
+                    args[:9],
                     [
                         "-a",
                         "never",
+                        "-c",
+                        "sandbox_workspace_write.writable_roots="
+                        + json.dumps([canonical_run_dir], ensure_ascii=False),
                         "exec",
                         "-C",
                         project,
@@ -738,10 +750,10 @@ class CodexWorkerWrapperTests(unittest.TestCase):
                         "workspace-write",
                     ],
                 )
-                self.assertEqual(args[7], "--output-last-message")
-                self.assertTrue(args[8])
-                self.assertEqual(args[9:], ["-"])
-                self.assertNotIn("-c", args)
+                self.assertEqual(args[9], "--output-last-message")
+                self.assertTrue(args[10])
+                self.assertEqual(args[11:], ["-"])
+                self.assertEqual(args.count("-c"), 1)
 
     def test_worker_adds_only_opted_in_sandbox_config_with_toml_escaping(self) -> None:
         writable_roots = [
@@ -754,6 +766,15 @@ class CodexWorkerWrapperTests(unittest.TestCase):
             network_access="true",
             writable_roots=writable_roots,
         )
+        canonical_run_dir = str(
+            Path(project).resolve()
+            / ".claude"
+            / "harness-state"
+            / ".sessions"
+            / "sid-worker-sandbox"
+            / "runs"
+            / "run-sandbox1"
+        )
 
         self.assertEqual(
             args[:11],
@@ -764,7 +785,10 @@ class CodexWorkerWrapperTests(unittest.TestCase):
                 "sandbox_workspace_write.network_access=true",
                 "-c",
                 "sandbox_workspace_write.writable_roots="
-                + json.dumps(writable_roots, ensure_ascii=False),
+                + json.dumps(
+                    [*writable_roots, canonical_run_dir],
+                    ensure_ascii=False,
+                ),
                 "exec",
                 "-C",
                 project,
@@ -789,18 +813,31 @@ class CodexWorkerWrapperTests(unittest.TestCase):
                 "roots-only",
                 None,
                 writable_roots,
-                [
-                    "sandbox_workspace_write.writable_roots="
-                    + json.dumps(writable_roots, ensure_ascii=False)
-                ],
+                [],
             ),
         )
 
         for name, network_access, roots, expected_configs in cases:
             with self.subTest(name=name):
-                args, _project = self._capture_worker_args(
+                args, project = self._capture_worker_args(
                     network_access=network_access,
                     writable_roots=roots,
+                )
+                canonical_run_dir = str(
+                    Path(project).resolve()
+                    / ".claude"
+                    / "harness-state"
+                    / ".sessions"
+                    / "sid-worker-sandbox"
+                    / "runs"
+                    / "run-sandbox1"
+                )
+                expected_configs.append(
+                    "sandbox_workspace_write.writable_roots="
+                    + json.dumps(
+                        [*(roots or []), canonical_run_dir],
+                        ensure_ascii=False,
+                    )
                 )
                 actual_configs = [
                     args[index + 1]
@@ -808,7 +845,7 @@ class CodexWorkerWrapperTests(unittest.TestCase):
                     if arg == "-c"
                 ]
                 self.assertEqual(actual_configs, expected_configs)
-                self.assertEqual(args.count("-c"), 1)
+                self.assertEqual(args.count("-c"), len(expected_configs))
                 self.assertIn("workspace-write", args)
 
     def test_worker_rejects_invalid_network_access_before_codex(self) -> None:
@@ -930,8 +967,10 @@ class CodexWorkerWrapperTests(unittest.TestCase):
             self.assertIn("dcNess implementation agent: build-worker", prompt)
             self.assertIn("build-worker 지침", prompt)
             self.assertIn("Implement the task from docs/impl.md.", prompt)
-            self.assertIn("-a\nnever\nexec", args_capture.read_text(encoding="utf-8"))
-            self.assertIn("workspace-write", args_capture.read_text(encoding="utf-8"))
+            captured_args = args_capture.read_text(encoding="utf-8")
+            self.assertIn("-a\nnever", captured_args)
+            self.assertIn("exec", captured_args)
+            self.assertIn("workspace-write", captured_args)
             self.assertTrue((project / "src" / "generated.py").exists())
             self.assertTrue(
                 helper_args.read_text(encoding="utf-8")

--- a/tests/test_generated_tdd_hooks.py
+++ b/tests/test_generated_tdd_hooks.py
@@ -9,7 +9,7 @@ import textwrap
 import unittest
 from pathlib import Path
 
-from harness.tdd_hooks import inspect_installation
+from harness.tdd_hooks import format_prompt_guidance, inspect_installation
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -89,6 +89,38 @@ def _run_central_guard(
 
 
 class GeneratedTddHookContractTests(unittest.TestCase):
+    def test_prompt_guidance_exposes_matching_test_contract_without_repo_scan(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            project = Path(td)
+            config = project / ".dcness" / "tdd-hooks.json"
+            config.parent.mkdir(parents=True)
+            config.write_text(
+                json.dumps(
+                    {
+                        "version": 1,
+                        "platform": "android",
+                        "impl_exts": [".kt", ".java"],
+                        "source_roots": ["app/src/main"],
+                        "test_candidate_templates": [
+                            "app/src/test/java/{stem}Test{ext}",
+                        ],
+                        "test_file_globs": ["**/*Test.kt", "**/*Test.java"],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            guidance = format_prompt_guidance(project)
+
+        self.assertIn("Project-local generated TDD guard is active", guidance)
+        self.assertIn("app/src/main", guidance)
+        self.assertIn(".kt, .java", guidance)
+        self.assertIn("app/src/test/java/{stem}Test{ext}", guidance)
+        self.assertIn("matching test", guidance)
+        self.assertIn("before writing the implementation file", guidance)
+
     def test_self_test_rejects_allow_all_hook_before_generation(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             project = Path(td) / "project"
@@ -759,7 +791,8 @@ class GeneratedTddHookDocsTests(unittest.TestCase):
                 self.assertIn("self-test", text)
                 self.assertIn("test_candidate_templates", text)
         self.assertNotIn("test_candidate_templates", impl_skill)
-        self.assertIn("TDD 게이트는 삭제하지 않는다", impl_skill)
+        self.assertIn("TDD", impl_skill)
+        self.assertIn("제거하지 않는다", impl_skill)
 
         ordered = [
             "TDD 계약",

--- a/tests/test_impl_cost_aware.py
+++ b/tests/test_impl_cost_aware.py
@@ -1,12 +1,4 @@
-"""skills/impl-loop/SKILL.md §사전 read 의무가 cost-aware 룰 (#436) 박혀있는지 검증.
-
-이슈 #436 — `/impl-loop` skill 의 통째 read 강제가 CLAUDE.md (글로벌) cost-aware 행동
-(#402) 과 충돌. 본 fix 가 다음 룰 박음:
-- 200 line 초과 doc → 부분 read (grep + offset/limit)
-- 수정 X 모듈 → grep + 시그니처만
-- PR body → --jq '.body' | head -20
-- 메인 직접 read = 최소 (진입 분기 판단만)
-"""
+"""Cost-aware fast-start and single build-worker contract tests."""
 
 import unittest
 from pathlib import Path
@@ -20,6 +12,12 @@ def read_impl_skill() -> str:
 
 def read_impl_routing() -> str:
     return (ROOT / "skills" / "impl-loop" / "impl-loop-routing.md").read_text(encoding="utf-8")
+
+
+def read_impl_finish() -> str:
+    return (
+        ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+    ).read_text(encoding="utf-8")
 
 
 def read_impl_skill_default() -> str:
@@ -47,84 +45,49 @@ def read_build_worker() -> str:
 
 
 class TestPreReadCostAware(unittest.TestCase):
-    """#436 — 사전 read 의무가 cost-aware 룰 명시."""
+    """The front door stays focused without restoring the old read matrix."""
 
-    def test_section_renamed_with_cost_aware_marker(self):
+    def test_front_door_keeps_task_local_focused_read(self):
         body = read_impl_skill()
-        self.assertIn(
-            "## impl 파일 사전 read 의무 (MUST — module-architect 7 원칙 + cost-aware #436)",
-            body,
-        )
-
-    def test_full_read_prohibition_marker(self):
-        """통째 read 금지 + 200 line 초과 시 부분 read 룰."""
-        body = read_impl_skill()
-        self.assertIn("통째 read 금지", body)
+        self.assertIn("focused read", body)
         self.assertIn("200 line 초과", body)
-        self.assertIn("grep + offset", body)
+        self.assertIn("메인은 worker 대신 문서를 통째로 읽지 않는다", body)
 
-    def test_per_file_read_scope_table_present(self):
-        """파일별 read 범위 표 박힘 — architecture.md / decisions / prd.md / PR body / 형제 PR / 의존 모듈."""
+    def test_front_door_does_not_restore_the_old_pre_read_matrix(self):
         body = read_impl_skill()
-        # 표 헤더
-        self.assertIn("| 항목 | read 범위 |", body)
-        # 핵심 항목 6개 매핑
-        self.assertIn("`docs/architecture.md`", body)
-        self.assertIn("`docs/decisions/`", body)
-        self.assertIn("`docs/prd.md`", body)
-        self.assertIn("의존 task 머지 PR", body)
-        self.assertIn("형제 PR 환기", body)
-        self.assertIn("의존 모듈", body)
-
-    def test_signature_only_read_for_unmodified_module(self):
-        """수정 X 영역 = grep + 시그니처만 read."""
-        body = read_impl_skill()
-        self.assertIn("grep + 시그니처만", body)
-        self.assertIn('grep "^export"', body)
-
-    def test_pr_body_jq_head_pattern(self):
-        """PR body 통째 json 폐기 — --jq '.body' | head -20 패턴."""
-        body = read_impl_skill()
-        self.assertIn("--jq '.body'", body)
-        self.assertIn("head -20", body)
-
-    def test_main_direct_read_is_minimum(self):
-        """메인 직접 read 의무 = 진입 분기 판단 최소만."""
-        body = read_impl_skill()
-        self.assertIn("진입 분기 판단", body)
-        self.assertIn("최소", body)
-        self.assertIn("메인이 통째 read 하지 말 것", body)
-
-    def test_402_cost_aware_reference(self):
-        """CLAUDE.md §cost-aware 행동 (#402) 정합 명시."""
-        body = read_impl_skill()
-        self.assertIn("#402", body)
-        self.assertIn("cost-aware", body)
+        self.assertNotIn("| 항목 | read 범위 |", body)
+        self.assertNotIn("--jq '.body' | head -20", body)
+        self.assertNotIn("docs/architecture.md", body)
+        self.assertNotIn("docs/decisions/", body)
 
 
 class TestImplLoopSingleEngine(unittest.TestCase):
     """#1023/#1041 — one build-worker, story PRs, one integrated review."""
 
     def test_impl_loop_declares_single_build_worker_engine(self):
-        skill = read_impl_skill()
+        skill = read_impl_skill() + "\n" + read_impl_finish()
         routing = read_impl_routing()
+        self.assertIn("build-worker", skill)
+        self.assertIn("impl-validator", skill)
+        self.assertIn("product-acceptance", skill)
+        self.assertIn("build-worker", routing)
+        self.assertIn("impl-loop-finish lazy-load", routing)
+        self.assertNotIn("impl-validator", routing)
+        self.assertNotIn("product-acceptance story", routing)
         for body in (skill, routing):
             with self.subTest(body=body[:60]):
-                self.assertIn("build-worker", body)
-                self.assertIn("impl-validator", body)
-                self.assertIn("product-acceptance", body)
                 self.assertNotIn("test-engineer", body)
                 self.assertNotIn("engineer:IMPL", body)
                 self.assertNotIn("2agent", body)
                 self.assertNotIn("4agent", body)
 
     def test_story_pr_boundary_keeps_one_integrated_review(self):
-        skill = read_impl_skill()
+        skill = read_impl_skill() + "\n" + read_impl_finish()
         for needle in (
             "action=story-pr",
             "story PR",
             "직전 story 브랜치에서 재분기",
-            "스택 tip vs main",
+            "stack tip vs main",
             "impl-validator review 출력은 merge candidate 경계에서 1회",
         ):
             with self.subTest(needle=needle):

--- a/tests/test_impl_fast_start_contract.py
+++ b/tests/test_impl_fast_start_contract.py
@@ -1,6 +1,7 @@
 """Fast-start and autonomous recovery contracts for /impl and /impl-loop."""
 from __future__ import annotations
 
+import json
 import tempfile
 import unittest
 from pathlib import Path
@@ -18,18 +19,42 @@ class ImplFastStartContractTests(unittest.TestCase):
     def test_impl_reaches_red_without_advisory_preflight_helpers(self) -> None:
         skill = self.read("skills/impl/SKILL.md")
 
-        self.assertIn("첫 진행 이정표", skill)
+        self.assertIn("착수: <target>", skill)
         self.assertIn("RED", skill)
+        self.assertIn("첫 tool call은 pointer만", skill)
+        self.assertIn("둘째 tool call 하나에서", skill)
+        self.assertIn("다음 tool-bearing turn은 RED test 또는 첫 edit", skill)
         self.assertNotIn("impl-preview", skill)
         self.assertNotIn("boundary-suggestions", skill)
         self.assertNotIn("dcness-tdd-hooks\" status", skill)
+
+    def test_impl_front_door_lazy_loads_finish_contract_after_green(self) -> None:
+        skill = self.read("skills/impl/SKILL.md")
+        finish = self.read("skills/impl/impl-finish.md")
+
+        self.assertLess(len(skill.encode("utf-8")), 12_000)
+        self.assertIn("target 확인 → 격리 → focused read → RED/첫 edit", skill)
+        self.assertIn("GREEN 뒤에만", skill)
+        self.assertNotIn("## Review Provider", skill)
+        self.assertNotIn("### Cartography freshness boundary", skill)
+        self.assertNotIn("Sub-agent prompt 작성 checkpoint", skill)
+        self.assertIn("Cartography freshness", finish)
+        self.assertIn("impl-validator", finish)
+        self.assertIn("target GitHub issue AC close audit", finish)
+        self.assertIn("PR", finish)
 
     def test_impl_loop_launches_worker_in_background_without_repeat_preflight(self) -> None:
         skill = self.read("skills/impl-loop/SKILL.md")
 
         self.assertIn("run_in_background", skill)
-        self.assertIn("같은 provider", skill)
-        self.assertIn("같은 workspace", skill)
+        self.assertIn("one-shot launch가 첫 tool call", skill)
+        self.assertIn("`nohup`, `&`, `disown`", skill)
+        self.assertIn("`.dcness-work`를 미리 만들지 않는다", skill)
+        self.assertIn("same-workspace recovery", skill)
+        self.assertIn("--init-path", skill)
+        self.assertNotIn('routing resolve build-worker', skill)
+        self.assertNotIn('prev-tasks-reset" 은', skill)
+        self.assertNotIn("begin-step build-worker`로 열고", skill)
         self.assertNotIn("boundary-suggestions --impl-plan", skill)
         self.assertNotIn("generated TDD hook 상태를 확인", skill)
 
@@ -100,6 +125,53 @@ class ImplFastStartContractTests(unittest.TestCase):
             "추가 시도 한도 | `2` | X |",
             common,
         )
+
+    def test_external_fast_start_evidence_meets_replay_and_ab_gates(self) -> None:
+        evidence = json.loads(
+            (ROOT / "evals" / "impl-fast-start-metadata.json").read_text(
+                encoding="utf-8"
+            )
+        )
+
+        main = evidence["impl_main_direct"]
+        fresh = evidence["impl_fresh_executor"]["trials"]
+        loops = evidence["impl_loop_real_forks"]
+        self.assertEqual((len(main), len(fresh), len(loops)), (3, 3, 3))
+        self.assertTrue(
+            all(
+                row["time_to_first_edit_seconds"] < 60
+                and row["blocking_assistant_requests"] <= 2
+                and row["product_ac_passed"]
+                for row in main
+            )
+        )
+        self.assertTrue(
+            all(
+                row["time_to_first_edit_seconds"] < 60
+                and row["product_ac_passed"]
+                for row in fresh
+            )
+        )
+        self.assertTrue(all(row["seconds_to_fork"] < 60 for row in loops))
+        self.assertEqual(
+            evidence["ab_decision"]["default"],
+            "main-direct",
+        )
+        self.assertFalse(
+            evidence["ab_decision"]["conditional_fresh_executor"]
+        )
+
+    def test_headless_workers_receive_canonical_phase_and_tdd_contracts(self) -> None:
+        for wrapper in (
+            self.read("scripts/dcness-codex-worker"),
+            self.read("scripts/dcness-claude-worker"),
+        ):
+            with self.subTest(wrapper=wrapper[:40]):
+                self.assertIn("CANONICAL_RUN_DIR", wrapper)
+                self.assertIn("TDD_PROMPT_GUIDANCE", wrapper)
+                self.assertIn("PROJECT TDD CONTRACT", wrapper)
+                self.assertIn("build-test.md", wrapper)
+                self.assertIn("phase_evidence", wrapper)
 
 
 if __name__ == "__main__":

--- a/tests/test_impl_loop_launch.py
+++ b/tests/test_impl_loop_launch.py
@@ -1,0 +1,525 @@
+"""One-shot /impl-loop launch ordering and lifecycle contracts."""
+from __future__ import annotations
+
+from datetime import datetime
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAIN = ROOT / "scripts" / "dcness-implementation-chain"
+
+
+def _run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class ImplLoopLaunchTests(unittest.TestCase):
+    def _fixture(self, base: Path, *, task_count: int = 1) -> tuple[Path, Path]:
+        primary = base / "primary"
+        worktree = base / "worktree"
+        primary.mkdir()
+        _run_git(primary, "init", "-q", "-b", "main")
+        _run_git(primary, "config", "user.name", "dcNess Test")
+        _run_git(primary, "config", "user.email", "dcness-test@example.invalid")
+        impl_dir = primary / "docs" / "epics" / "epic-1" / "impl"
+        impl_dir.mkdir(parents=True)
+        for index in range(1, task_count + 1):
+            task = impl_dir / f"{index:02d}-fast.md"
+            task.write_text(
+                "---\n"
+                "story: 1\n"
+                f"task_index: {index}/{task_count}\n"
+                f"title: Fast start {index}\n"
+                "---\n\n"
+                "## 수정 허용\n- src/**\n",
+                encoding="utf-8",
+            )
+        tdd_config = primary / ".dcness" / "tdd-hooks.json"
+        tdd_config.parent.mkdir(parents=True)
+        tdd_config.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "platform": "android",
+                    "impl_exts": [".kt", ".java"],
+                    "source_roots": ["app/src/main"],
+                    "test_candidate_templates": [
+                        "app/src/test/java/{stem}Test{ext}",
+                    ],
+                    "test_file_globs": ["**/*Test.kt", "**/*Test.java"],
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        (primary / "README.md").write_text("fixture\n", encoding="utf-8")
+        _run_git(primary, "add", ".")
+        _run_git(primary, "commit", "-qm", "fixture")
+        _run_git(
+            primary,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "fix/issue1190_fixture",
+            str(worktree),
+            "main",
+        )
+        return primary, worktree
+
+    def _launch(
+        self,
+        *,
+        primary: Path,
+        project: Path,
+        base: Path,
+        omit_phase_first_attempt: bool = False,
+        use_claude_session_env: bool = False,
+        acceptance_required: bool = True,
+        provider_conclusion: str = "PASS",
+        init_paths: tuple[str, ...] = (
+            "docs/epics/epic-1/impl/01-fast.md",
+        ),
+    ) -> subprocess.CompletedProcess[str]:
+        prompt = base / "prompt.md"
+        prompt.write_text(
+            "Read the task pointer, write RED first, implement, and validate.\n",
+            encoding="utf-8",
+        )
+        provider_started = base / "provider-started.json"
+        prompt_capture = base / "provider-prompt.md"
+        bin_dir = base / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        _write_executable(
+            bin_dir / "claude",
+            """\
+            #!/bin/sh
+            count="$(cat "$PROVIDER_COUNT" 2>/dev/null || printf 0)"
+            count=$((count + 1))
+            printf '%s' "$count" > "$PROVIDER_COUNT"
+            python3 - "$PROVIDER_STARTED" <<'PY'
+            import datetime
+            import json
+            import pathlib
+            import sys
+            pathlib.Path(sys.argv[1]).write_text(
+                json.dumps({"at": datetime.datetime.now(datetime.timezone.utc).isoformat()}),
+                encoding="utf-8",
+            )
+            PY
+            cat > "$PROMPT_CAPTURE"
+            if [ "$PROVIDER_CONCLUSION" != "PASS" ]; then
+              :
+            elif [ "$OMIT_PHASE_FIRST" = "1" ] && [ "$count" -eq 1 ]; then
+              mkdir -p src
+              printf 'partial work preserved for recovery\\n' > src/phase-recovery.txt
+            else
+              python3 - "$PROMPT_CAPTURE" <<'PY'
+            import pathlib
+            import re
+            import sys
+
+            prompt = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+            match = re.search(r"^canonical run directory: (.+)$", prompt, re.MULTILINE)
+            if not match:
+                raise SystemExit("canonical run directory missing")
+            run_dir = pathlib.Path(match.group(1))
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                (run_dir / phase).write_text(f"{phase} fixture evidence\\n", encoding="utf-8")
+            PY
+            fi
+            printf 'Worker completed without fixture mutation.\\n\\n%s\\n' "$PROVIDER_CONCLUSION"
+            """,
+        )
+        env = os.environ.copy()
+        env.update(
+            {
+                "DCNESS_FORCE_ENABLE": "1",
+                "OMIT_PHASE_FIRST": "1" if omit_phase_first_attempt else "0",
+                "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                "PROVIDER_CONCLUSION": provider_conclusion,
+                "PROMPT_CAPTURE": str(prompt_capture),
+                "PROVIDER_COUNT": str(base / "provider-count.txt"),
+                "PROVIDER_STARTED": str(provider_started),
+            }
+        )
+        if use_claude_session_env:
+            env.pop("DCNESS_SESSION_ID", None)
+            env["CLAUDE_CODE_SESSION_ID"] = "sid-fast-launch"
+        else:
+            env["DCNESS_SESSION_ID"] = "sid-fast-launch"
+        command = [
+                str(CHAIN),
+                "build-worker",
+                "--provider",
+                "claude-headless",
+                "--provider-provenance",
+                "explicit",
+                "--chain-state",
+                ".dcness-work/story-run.json",
+                "--prompt-file",
+                str(prompt),
+                "--project-root",
+                str(project),
+                "--helper",
+                str(ROOT / "scripts" / "dcness-helper"),
+            ]
+        if acceptance_required:
+            command.append("--acceptance-required")
+        for init_path in init_paths:
+            command[8:8] = ["--init-path", init_path]
+        result = subprocess.run(
+            command,
+            cwd=project,
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=30,
+        )
+        self.provider_started = provider_started
+        self.prompt_capture = prompt_capture
+        self.provider_count = base / "provider-count.txt"
+        return result
+
+    def test_one_call_initializes_in_worktree_and_starts_step_before_provider(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(primary=primary, project=worktree, base=base)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            state_path = worktree / ".dcness-work" / "story-run.json"
+            self.assertTrue(state_path.is_file())
+            self.assertFalse((primary / ".dcness-work" / "story-run.json").exists())
+            state = json.loads(state_path.read_text(encoding="utf-8"))
+            self.assertEqual(state["project_root"], str(worktree.resolve()))
+
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            events = [
+                json.loads(line)
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                [event["event"] for event in events],
+                ["run_started", "step_started", "step_completed"],
+            )
+            self.assertEqual(events[1]["agent"], "build-worker")
+            self.assertIs(events[0]["acceptance_required"], True)
+            self.assertTrue(
+                events[0]["design_doc"].startswith(str(worktree.resolve()))
+            )
+            provider_at = datetime.fromisoformat(
+                json.loads(self.provider_started.read_text(encoding="utf-8"))["at"]
+            )
+            step_at = datetime.fromisoformat(events[1]["ts"])
+            self.assertLessEqual(step_at, provider_at)
+            prompt = self.prompt_capture.read_text(encoding="utf-8")
+            self.assertIn("----- BEGIN PROJECT TDD CONTRACT -----", prompt)
+            self.assertIn("app/src/main", prompt)
+            self.assertIn("matching test", prompt)
+            self.assertIn(
+                f"canonical run directory: {run_dirs[0].resolve()}",
+                prompt,
+            )
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                self.assertIn(str((run_dirs[0] / phase).resolve()), prompt)
+                self.assertTrue((run_dirs[0] / phase).is_file())
+
+    def test_background_claude_session_id_bootstraps_first_run(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                use_claude_session_env=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            events = [
+                json.loads(line)["event"]
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                events,
+                ["run_started", "step_started", "step_completed"],
+            )
+
+    def test_completed_current_run_is_idempotent_without_second_provider_fork(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            first = self._launch(primary=primary, project=worktree, base=base)
+            self.assertEqual(first.returncode, 0, first.stderr)
+            second = self._launch(primary=primary, project=worktree, base=base)
+
+            self.assertEqual(second.returncode, 0, second.stderr)
+            self.assertIn("ALREADY_COMPLETED", second.stderr)
+            self.assertEqual(self.provider_count.read_text(encoding="utf-8"), "1")
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            events = [
+                json.loads(line)["event"]
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                events,
+                ["run_started", "step_started", "step_completed"],
+            )
+
+    def test_main_branch_rejection_happens_before_run_or_story_state_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, _ = self._fixture(base)
+
+            result = self._launch(primary=primary, project=primary, base=base)
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("refusing default branch", result.stderr)
+            self.assertFalse((primary / ".dcness-work" / "story-run.json").exists())
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            self.assertFalse(run_root.exists())
+
+    def test_second_task_reuses_state_but_gets_one_new_run_and_step(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base, task_count=2)
+            init_paths = (
+                "docs/epics/epic-1/impl/01-fast.md",
+                "docs/epics/epic-1/impl/02-fast.md",
+            )
+
+            first = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                init_paths=init_paths,
+            )
+            self.assertEqual(first.returncode, 0, first.stderr)
+            state_path = worktree / ".dcness-work" / "story-run.json"
+            head = _run_git(worktree, "rev-parse", "HEAD").stdout.strip()
+            marked = subprocess.run(
+                [
+                    str(ROOT / "scripts" / "dcness-story-runner"),
+                    "mark",
+                    "--state",
+                    str(state_path),
+                    "--task",
+                    "1",
+                    "--status",
+                    "completed",
+                    "--commit",
+                    head,
+                ],
+                cwd=worktree,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(marked.returncode, 0, marked.stderr)
+
+            second = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                init_paths=(),
+            )
+            self.assertEqual(second.returncode, 0, second.stderr)
+
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            run_dirs = sorted(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 2)
+            event_sets = [
+                [
+                    json.loads(line)
+                    for line in (run_dir / "ledger.jsonl")
+                    .read_text(encoding="utf-8")
+                    .splitlines()
+                ]
+                for run_dir in run_dirs
+            ]
+            ledgers = [
+                [event["event"] for event in events]
+                for events in event_sets
+            ]
+            self.assertCountEqual(
+                ledgers,
+                [
+                    [
+                        "run_started",
+                        "step_started",
+                        "step_completed",
+                        "run_finished",
+                    ],
+                    ["run_started", "step_started", "step_completed"],
+                ],
+            )
+            run_started = [
+                events[0]
+                for events in event_sets
+                if events and events[0]["event"] == "run_started"
+            ]
+            self.assertCountEqual(
+                [
+                    event.get("acceptance_required", False)
+                    for event in run_started
+                ],
+                [False, True],
+            )
+
+    def test_missing_canonical_phase_prose_recovers_without_duplicate_step(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                omit_phase_first_attempt=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(self.provider_count.read_text(encoding="utf-8"), "2")
+            self.assertIn("category=phase_evidence", result.stderr)
+            self.assertTrue((worktree / "src" / "phase-recovery.txt").is_file())
+
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            events = [
+                json.loads(line)["event"]
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                events,
+                ["run_started", "step_started", "step_completed"],
+            )
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                self.assertTrue((run_dirs[0] / phase).is_file())
+
+    def test_preflight_escalation_records_terminal_prose_without_phase_retry(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                provider_conclusion="IMPLEMENTATION_ESCALATE",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(self.provider_count.read_text(encoding="utf-8"), "1")
+            self.assertNotIn("category=phase_evidence", result.stderr)
+
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-fast-launch"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            events = [
+                json.loads(line)
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                [event["event"] for event in events],
+                ["run_started", "step_started", "step_completed"],
+            )
+            terminal_prose = Path(events[-1]["prose_file"]).read_text(
+                encoding="utf-8"
+            )
+            self.assertIn("IMPLEMENTATION_ESCALATE", terminal_prose)
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                self.assertFalse((run_dirs[0] / phase).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_impl_validator_commit_input.py
+++ b/tests/test_impl_validator_commit_input.py
@@ -48,18 +48,17 @@ class ImplValidatorCommitInputContractTests(unittest.TestCase):
         self,
     ) -> None:
         callers = (
-            self.read("skills/impl/SKILL.md"),
-            self.read("skills/impl-loop/SKILL.md"),
+            self.read("skills/impl/impl-finish.md"),
+            self.read("skills/impl-loop/impl-loop-finish.md"),
         )
 
         for caller in callers:
             with self.subTest(caller=caller[:40]):
                 for needle in (
-                    "커밋 id",
+                    "commit id",
                     "변경 파일 목록",
                     "diff 파일",
-                    "uncommitted local diff",
-                    "폴백",
+                    "uncommitted diff",
                 ):
                     self.assertIn(needle, caller)
 

--- a/tests/test_issue_acceptance_close_contract.py
+++ b/tests/test_issue_acceptance_close_contract.py
@@ -13,21 +13,24 @@ class IssueAcceptanceCloseContractTests(unittest.TestCase):
         return (ROOT / relative_path).read_text(encoding="utf-8")
 
     def test_impl_reads_target_issue_once_and_blocks_clean_close_on_unchecked_ac(self) -> None:
-        skill = self.read("skills/impl/SKILL.md")
+        skill = self.read("skills/impl/SKILL.md") + self.read(
+            "skills/impl/impl-finish.md"
+        )
         routing = self.read("skills/impl/impl-routing.md")
 
         for text in (skill, routing):
             self.assertIn("target GitHub issue AC", text)
             self.assertIn("require-complete", text)
             self.assertIn("미체크", text)
-        self.assertIn("진입 preflight 에서 한 번", skill)
+        self.assertIn("본문과 댓글을 한 번", skill)
         self.assertIn("close 경계에서 한 번", skill)
 
     def test_impl_loop_clean_contract_includes_target_issue_ac(self) -> None:
-        skill = self.read("skills/impl-loop/SKILL.md")
-        routing = self.read("skills/impl-loop/impl-loop-routing.md")
+        skill = self.read("skills/impl-loop/SKILL.md") + self.read(
+            "skills/impl-loop/impl-loop-finish.md"
+        )
 
-        for text in (skill, routing):
+        for text in (skill,):
             self.assertIn("target GitHub issue AC", text)
             self.assertIn("require-complete", text)
             self.assertIn("미체크", text)
@@ -52,8 +55,8 @@ class IssueAcceptanceCloseContractTests(unittest.TestCase):
 
     def test_human_verification_wait_is_not_blocked(self) -> None:
         surfaces = (
-            self.read("skills/impl/SKILL.md"),
-            self.read("skills/impl-loop/impl-loop-routing.md"),
+            self.read("skills/impl/impl-finish.md"),
+            self.read("skills/impl-loop/impl-loop-finish.md"),
             self.read("docs/plugin/issue-lifecycle.md"),
         )
 

--- a/tests/test_issue_body_validation.py
+++ b/tests/test_issue_body_validation.py
@@ -362,10 +362,22 @@ class IssueBodyValidationDocsTests(unittest.TestCase):
         self.assertIn("hard gate", text)
         self.assertIn("AC 또는 Acceptance criteria가 없는 body는 실패", text)
 
-        for relative in ("CLAUDE.md", "skills/impl/SKILL.md", "skills/impl-loop/SKILL.md"):
-            skill = (ROOT / relative).read_text(encoding="utf-8")
-            self.assertIn("현행 typed AC로 갱신", skill, relative)
-            self.assertIn("임의 추론", skill, relative)
+        surfaces = {
+            "CLAUDE.md": (ROOT / "CLAUDE.md").read_text(encoding="utf-8"),
+            "impl": (
+                (ROOT / "skills/impl/SKILL.md").read_text(encoding="utf-8")
+                + (ROOT / "skills/impl/impl-finish.md").read_text(encoding="utf-8")
+            ),
+            "impl-loop": (
+                (ROOT / "skills/impl-loop/SKILL.md").read_text(encoding="utf-8")
+                + (ROOT / "skills/impl-loop/impl-loop-finish.md").read_text(
+                    encoding="utf-8"
+                )
+            ),
+        }
+        for label, skill in surfaces.items():
+            self.assertIn("현행 typed AC로 갱신", skill, label)
+            self.assertIn("임의 추론", skill, label)
 
     def test_workflow_router_mentions_non_to_issue_agent_creation_still_validates(self) -> None:
         text = (ROOT / "docs" / "plugin" / "workflow-router.md").read_text(

--- a/tests/test_journey_convergence_contract.py
+++ b/tests/test_journey_convergence_contract.py
@@ -61,27 +61,26 @@ class JourneyConvergenceContractTests(unittest.TestCase):
         self.assertIn("self-verify", validator)
         self.assertIn("유일 관문", validator)
 
-    def test_routing_has_bounded_convergence_and_three_way_escalation(self) -> None:
-        routing = read("skills/impl-loop/impl-loop-routing.md")
+    def test_finish_has_bounded_convergence_and_three_way_escalation(self) -> None:
+        finish = read("skills/impl-loop/impl-loop-finish.md")
 
         for needle in (
-            "무진행 라운드",
+            "무진행은 3회",
             "3",
             "서로 다른 실패",
-            "총 iteration",
+            "전체 iteration",
             "12",
             "실질 runaway 가드",
             "수렴 재개",
-            "production 만 착지",
+            "production만 착지",
             "run 폐기",
-            "커밋 보존",
+            "커밋을 보존",
         ):
             with self.subTest(needle=needle):
-                self.assertIn(needle, routing)
+                self.assertIn(needle, finish)
 
     def test_clean_sequence_consolidates_after_acceptance_before_first_pr(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
-        section = skill.split("## Story PR / integrated review / merge", 1)[1]
+        section = read("skills/impl-loop/impl-loop-finish.md")
 
         sequence = (
             "JOURNEY_CONVERGENCE",
@@ -99,18 +98,19 @@ class JourneyConvergenceContractTests(unittest.TestCase):
         self.assertIn("최초 PR", section)
 
     def test_human_verification_remains_a_post_pr_merge_gate(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
-        routing = read("skills/impl-loop/impl-loop-routing.md")
+        finish = read("skills/impl-loop/impl-loop-finish.md")
 
-        self.assertIn("AC -->|typed require-complete PASS| CONSOLIDATE", routing)
-        self.assertIn("CONSOLIDATE --> PRCUT", routing)
-        self.assertIn("PRCUT --> HUMAN", routing)
-        self.assertIn("human verification 대기", routing)
-        self.assertNotIn("미충족·미체크 또는 사람 확인 대기", routing)
-        self.assertIn("별도 merge gate", skill)
+        self.assertIn(
+            "최초 PR 생성 뒤 `human verification 대기`",
+            finish,
+        )
+        self.assertIn("별도 merge gate", finish)
+        self.assertIn("사용자가 유일한 merge gate", finish)
 
     def test_env_split_is_a_durable_per_journey_deferred_disposition(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
+        skill = read("skills/impl-loop/SKILL.md") + read(
+            "skills/impl-loop/impl-loop-finish.md"
+        )
         routing = read("skills/impl-loop/impl-loop-routing.md")
         acceptance = read(
             "docs/plugin/agents/product-acceptance/product-acceptance-agent.md"
@@ -130,7 +130,7 @@ class JourneyConvergenceContractTests(unittest.TestCase):
         self.assertIn("매니페스트를 다시 쓰지 않는다", journey)
 
     def test_n_story_convergence_fix_ownership_is_unambiguous(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
+        skill = read("skills/impl-loop/impl-loop-finish.md")
 
         self.assertIn("story-local production 수정", skill)
         self.assertIn("해당 story branch", skill)
@@ -138,14 +138,13 @@ class JourneyConvergenceContractTests(unittest.TestCase):
         self.assertIn("flow/manifest 보정은 QA branch", skill)
 
     def test_write_zero_and_user_merge_gate_remain_unchanged(self) -> None:
-        skill = read("skills/impl-loop/SKILL.md")
-        routing = read("skills/impl-loop/impl-loop-routing.md")
+        skill = read("skills/impl-loop/SKILL.md") + read(
+            "skills/impl-loop/impl-loop-finish.md"
+        )
 
         self.assertEqual((), ALLOW_MATRIX["product-acceptance"])
         self.assertIn("사용자가 유일한 merge gate", skill)
-        self.assertIn("사용자가 유일한 merge gate", routing)
         self.assertIn("자동 merge 금지", skill)
-        self.assertIn("자동 merge 금지", routing)
 
 
 if __name__ == "__main__":

--- a/tests/test_measure_main_turns.py
+++ b/tests/test_measure_main_turns.py
@@ -5,7 +5,11 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
 
-from scripts.measure_main_turns import build_paired_screening, parse_session
+from scripts.measure_main_turns import (
+    build_paired_screening,
+    build_repeated_screening,
+    parse_session,
+)
 
 
 class MeasureMainTurnsTests(unittest.TestCase):
@@ -83,6 +87,86 @@ class MeasureMainTurnsTests(unittest.TestCase):
         ]
         path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
 
+    def _action_trace(
+        self,
+        path: Path,
+        *,
+        edit_second: int,
+        fresh: bool,
+        input_tokens: int,
+    ) -> None:
+        parent = "agent-launch" if fresh else None
+        rows = [
+            {
+                "type": "user",
+                "timestamp": "2026-07-20T00:00:00Z",
+                "parent_tool_use_id": None,
+                "message": {"role": "user", "content": "implement fixture"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-20T00:00:01Z",
+                "request_id": "main-read",
+                "parent_tool_use_id": None,
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": 10,
+                    },
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "read",
+                            "name": "Read",
+                            "input": {"file_path": "src/fixture.py"},
+                        }
+                    ],
+                },
+            },
+            {
+                "type": "assistant",
+                "timestamp": f"2026-07-20T00:00:{edit_second - 1:02d}Z",
+                "request_id": "executor-edit",
+                "parent_tool_use_id": parent,
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": input_tokens // 2,
+                        "output_tokens": 7,
+                    },
+                    "content": [
+                        {"type": "thinking", "thinking": "prepare edit"},
+                    ],
+                },
+            },
+            {
+                "type": "assistant",
+                "timestamp": f"2026-07-20T00:00:{edit_second:02d}Z",
+                "request_id": "executor-edit",
+                "parent_tool_use_id": parent,
+                "message": {
+                    "role": "assistant",
+                    "usage": {
+                        "input_tokens": input_tokens // 2,
+                        "output_tokens": 7,
+                    },
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "edit",
+                            "name": "Edit",
+                            "input": {"file_path": "src/fixture.py"},
+                        }
+                    ],
+                },
+            },
+        ]
+        path.write_text(
+            "\n".join(json.dumps(row) for row in rows) + "\n",
+            encoding="utf-8",
+        )
+
     def test_parse_session_collects_requests_tools_time_tokens_and_runtime(self) -> None:
         with TemporaryDirectory() as td:
             trace = Path(td) / "baseline.jsonl"
@@ -98,6 +182,8 @@ class MeasureMainTurnsTests(unittest.TestCase):
         self.assertEqual(result["models"], ["claude-sonnet-4-6"])
         self.assertEqual(result["effort_levels"], ["high"])
         self.assertEqual(result["providers"], ["claude-main"])
+        self.assertEqual(result["all_total_input_tokens"], 1109)
+        self.assertEqual(result["all_output_tokens"], 1029)
 
     def test_paired_screening_requires_same_fixture_and_quality_axes(self) -> None:
         with TemporaryDirectory() as td:
@@ -151,6 +237,163 @@ class MeasureMainTurnsTests(unittest.TestCase):
         del broken["trials"]["variant"]["human_intervention_count"]
         with self.assertRaisesRegex(ValueError, "human_intervention_count"):
             build_paired_screening({}, {}, broken)
+
+    def test_parse_session_measures_first_edit_across_fresh_executor(self) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "fresh.jsonl"
+            self._action_trace(
+                trace,
+                edit_second=7,
+                fresh=True,
+                input_tokens=100,
+            )
+
+            result = parse_session(trace)
+
+        self.assertEqual(result["time_to_first_edit_seconds"], 7.0)
+        self.assertEqual(
+            result["blocking_assistant_requests_before_first_edit"],
+            1,
+        )
+        self.assertEqual(result["first_edit_evidence"]["executor"], "fresh")
+        self.assertEqual(
+            result["first_edit_evidence"]["path"],
+            "src/fixture.py",
+        )
+        self.assertEqual(result["all_total_input_tokens"], 150)
+        self.assertEqual(result["all_output_tokens"], 17)
+
+    def test_process_start_falls_back_before_fresh_edit_when_root_duration_is_short(self) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "fresh-no-user.jsonl"
+            rows = [
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-20T00:00:01Z",
+                    "request_id": "launch",
+                    "parent_tool_use_id": None,
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "thinking", "thinking": "launch"}],
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-20T00:00:09Z",
+                    "request_id": "fresh-edit",
+                    "parent_tool_use_id": "agent",
+                    "message": {
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "name": "Write",
+                                "input": {"file_path": "fixture.py"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-20T00:00:12Z",
+                    "request_id": "done",
+                    "parent_tool_use_id": None,
+                    "message": {
+                        "role": "assistant",
+                        "content": [{"type": "text", "text": "done"}],
+                    },
+                },
+                {
+                    "type": "result",
+                    "duration_ms": 2_000,
+                    "usage": {},
+                },
+            ]
+            trace.write_text(
+                "\n".join(json.dumps(row) for row in rows) + "\n",
+                encoding="utf-8",
+            )
+
+            result = parse_session(trace)
+
+        self.assertEqual(result["time_to_first_edit_seconds"], 8.0)
+        self.assertEqual(result["start_evidence"]["kind"], "earliest_timed_event")
+
+    def test_repeated_screening_compares_same_runtime_and_keeps_main_default(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            baselines = []
+            variants = []
+            for index, seconds in enumerate((10, 12, 11), start=1):
+                path = base / f"baseline-{index}.jsonl"
+                self._action_trace(
+                    path,
+                    edit_second=seconds,
+                    fresh=False,
+                    input_tokens=120,
+                )
+                baselines.append(parse_session(path))
+            for index, seconds in enumerate((5, 6, 4), start=1):
+                path = base / f"variant-{index}.jsonl"
+                self._action_trace(
+                    path,
+                    edit_second=seconds,
+                    fresh=True,
+                    input_tokens=80,
+                )
+                variants.append(parse_session(path))
+
+            outcome = {
+                "runtime": {
+                    "model": "claude-sonnet-5",
+                    "effort": "medium",
+                    "provider": "claude-main",
+                },
+                "product_ac": {"passed": 2, "total": 2},
+                "must_fix_count": 0,
+                "regression_count": 0,
+                "human_intervention_count": 0,
+            }
+            outcomes = {
+                "fixture": {"id": "decision-heavy", "sha256": "b" * 64},
+                "trials": {
+                    "baseline": [
+                        json.loads(json.dumps(outcome)) for _ in range(3)
+                    ],
+                    "variant": [
+                        json.loads(json.dumps(outcome)) for _ in range(3)
+                    ],
+                },
+            }
+
+            screening = build_repeated_screening(
+                baselines,
+                variants,
+                outcomes,
+            )
+
+        self.assertEqual(screening["trial_count_per_variant"], 3)
+        self.assertEqual(
+            screening["summary"]["baseline"]["time_to_first_edit_seconds"][
+                "median"
+            ],
+            11.0,
+        )
+        self.assertEqual(
+            screening["summary"]["variant"]["time_to_first_edit_seconds"][
+                "median"
+            ],
+            5.0,
+        )
+        self.assertEqual(screening["adoption"]["default"], "main-direct")
+        self.assertTrue(
+            screening["adoption"]["conditional_fresh_executor"]
+        )
+
+        broken = json.loads(json.dumps(outcomes))
+        broken["trials"]["variant"][1]["runtime"]["effort"] = "high"
+        with self.assertRaisesRegex(ValueError, "same model/effort/provider"):
+            build_repeated_screening(baselines, variants, broken)
 
 
 if __name__ == "__main__":

--- a/tests/test_pr_finalize_non_default_base.py
+++ b/tests/test_pr_finalize_non_default_base.py
@@ -169,7 +169,7 @@ class PrFinalizeBaseGuardTests(unittest.TestCase):
 
     def test_user_facing_finalize_paths_use_plugin_root_for_active_projects(self) -> None:
         surfaces = [
-            REPO_ROOT / "skills" / "impl-loop" / "SKILL.md",
+            REPO_ROOT / "skills" / "impl-loop" / "impl-loop-finish.md",
             REPO_ROOT / "skills" / "design" / "SKILL.md",
             REPO_ROOT / "skills" / "spec" / "spec-delivery-reference.md",
             REPO_ROOT / "docs" / "plugin" / "git-spec.md",

--- a/tests/test_product_acceptance_agent.py
+++ b/tests/test_product_acceptance_agent.py
@@ -32,6 +32,9 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         self.impl_loop_routing = (
             ROOT / "skills" / "impl-loop" / "impl-loop-routing.md"
         )
+        self.impl_loop_finish = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+        )
         self.acceptance_skill = ROOT / "skills" / "acceptance" / "SKILL.md"
         self.impl_loop_skill = ROOT / "skills" / "impl-loop" / "SKILL.md"
         self.module_architect_prompt = (
@@ -160,12 +163,12 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
             self.assertIn(needle, text)
 
     def test_pipeline_assigns_cross_pr_story_behavior_to_product_acceptance(self) -> None:
-        text = self.impl_loop_routing.read_text(encoding="utf-8")
-        self.assertIn("impl-validator 는 계획 대비 구현 정합", text)
-        self.assertIn("impl-validator 는 계획 대비 구현 정합과 merge candidate diff 위험", text)
-        self.assertIn("여러 PR 이 합쳐진 story 동작", text)
-        self.assertIn("여러 story 가 합쳐진 epic 동작", text)
-        self.assertIn("마감 product-acceptance 가 맡는다", text)
+        text = self.impl_loop_finish.read_text(encoding="utf-8")
+        self.assertIn("impl-validator는 계획 대비 구현 정합", text)
+        self.assertIn("merge candidate diff 위험", text)
+        self.assertIn("여러 PR이 합쳐진 story 동작", text)
+        self.assertIn("여러 story가 합쳐진 epic 동작", text)
+        self.assertIn("마감 product-acceptance가 맡는다", text)
 
     def test_write_zero_boundary_and_no_codex_route(self) -> None:
         self.assertEqual(ALLOW_MATRIX["product-acceptance"], ())
@@ -190,7 +193,9 @@ class ProductAcceptanceAgentContractTests(unittest.TestCase):
         init_dcness = self.init_dcness.read_text(encoding="utf-8")
         acceptance_skill = self.acceptance_skill.read_text(encoding="utf-8")
         acceptance_routing = self.acceptance_routing.read_text(encoding="utf-8")
-        impl_loop_skill = self.impl_loop_skill.read_text(encoding="utf-8")
+        impl_loop_skill = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+        ).read_text(encoding="utf-8")
         impl_loop_routing = self.impl_loop_routing.read_text(encoding="utf-8")
 
         self.assertIn("(JOURNEY) <flow/매니페스트 경로>", template)

--- a/tests/test_product_journey.py
+++ b/tests/test_product_journey.py
@@ -565,7 +565,13 @@ class ProductJourneyContractDocumentTests(unittest.TestCase):
     ) -> None:
         contract = (ROOT / "docs/plugin/product-journey.md").read_text(encoding="utf-8")
         acceptance = (ROOT / "skills/acceptance/SKILL.md").read_text(encoding="utf-8")
-        impl_loop = (ROOT / "skills/impl-loop/SKILL.md").read_text(encoding="utf-8")
+        impl_loop = (
+            (ROOT / "skills/impl-loop/SKILL.md").read_text(encoding="utf-8")
+            + "\n"
+            + (ROOT / "skills/impl-loop/impl-loop-finish.md").read_text(
+                encoding="utf-8"
+            )
+        )
         product_acceptance = (
             ROOT
             / "docs/plugin/agents/product-acceptance/product-acceptance-agent.md"

--- a/tests/test_provider_chain.py
+++ b/tests/test_provider_chain.py
@@ -238,6 +238,10 @@ class ClaudeHeadlessWrapperTests(unittest.TestCase):
             self.assertEqual(len(logs), 1)
             raw_log = logs[0].read_text(encoding="utf-8")
             self.assertIn("UNATTRIBUTED", raw_log)
+            self.assertRegex(
+                raw_log,
+                r"PROCESS_FORK: pid=[1-9][0-9]* started_at=.+\+00:00",
+            )
             self.assertIn("Claude worker degraded prose", raw_log)
 
     def test_codex_worker_degraded_context_runs_provider(self) -> None:
@@ -339,6 +343,10 @@ class ClaudeHeadlessWrapperTests(unittest.TestCase):
             self.assertEqual(len(logs), 1)
             raw_log = logs[0].read_text(encoding="utf-8")
             self.assertIn("UNATTRIBUTED", raw_log)
+            self.assertRegex(
+                raw_log,
+                r"PROCESS_FORK: pid=[1-9][0-9]* started_at=.+\+00:00",
+            )
             self.assertIn("Codex worker degraded prose", raw_log)
 
     def test_claude_validator_degraded_context_runs_provider(self) -> None:

--- a/tests/test_provider_failure_cache.py
+++ b/tests/test_provider_failure_cache.py
@@ -37,7 +37,13 @@ def _write_chain_state(path: Path, project: Path, chain_id: str = "chain-a") -> 
                 "kind": "dcness-story-run",
                 "chain_id": chain_id,
                 "project_root": str(project.resolve()),
-                "tasks": [{"id": 1, "status": "pending"}],
+                "tasks": [
+                    {
+                        "id": 1,
+                        "path": "docs/epics/fixture/impl/01-cache.md",
+                        "status": "pending",
+                    }
+                ],
             }
         ),
         encoding="utf-8",
@@ -418,10 +424,8 @@ class ImplementationChainMemoizationTests(unittest.TestCase):
 
 class ProviderFailureCacheDocsTests(unittest.TestCase):
     def test_impl_loop_docs_publish_scope_categories_bypass_and_diagnostics(self) -> None:
-        paths = (
-            ROOT / "docs" / "plugin" / "loop-procedure.md",
-            ROOT / "skills" / "impl-loop" / "SKILL.md",
-        )
+        procedure_path = ROOT / "docs" / "plugin" / "loop-procedure.md"
+        skill_path = ROOT / "skills" / "impl-loop" / "SKILL.md"
         required = (
             "--chain-state",
             "--provider-provenance routing",
@@ -437,15 +441,16 @@ class ProviderFailureCacheDocsTests(unittest.TestCase):
             "first_raw_log",
             "chain_id",
         )
-        for path in paths:
-            text = path.read_text(encoding="utf-8")
-            for needle in required:
-                with self.subTest(path=path.name, needle=needle):
-                    self.assertIn(needle, text)
-        skill_text = paths[1].read_text(encoding="utf-8")
-        procedure_text = paths[0].read_text(encoding="utf-8")
-        self.assertIn("task 1개 single `/impl-loop`도", skill_text)
-        self.assertIn("single/chain 모드 모두 `--chain-state`", procedure_text)
+        procedure_text = procedure_path.read_text(encoding="utf-8")
+        for needle in required:
+            with self.subTest(path=procedure_path.name, needle=needle):
+                self.assertIn(needle, procedure_text)
+
+        skill_text = skill_path.read_text(encoding="utf-8")
+        self.assertIn("--chain-state", skill_text)
+        self.assertIn("task 1개 또는 story/epic chain", skill_text)
+        self.assertIn("impl-loop-routing.md", skill_text)
+        self.assertIn("single/chain 모두 implementation chain에 `--chain-state`", procedure_text)
 
 
 if __name__ == "__main__":

--- a/tests/test_provider_snippet_docs.py
+++ b/tests/test_provider_snippet_docs.py
@@ -56,7 +56,6 @@ class ProviderSnippetDocsTests(unittest.TestCase):
         expected = {
             Path("docs/plugin/loop-procedure.md"),
             Path("skills/design/SKILL.md"),
-            Path("skills/impl/SKILL.md"),
             Path("skills/impl-loop/SKILL.md"),
         }
         self.assertTrue(

--- a/tests/test_skill_scenarios.py
+++ b/tests/test_skill_scenarios.py
@@ -30,12 +30,22 @@ class SkillScenarioRegressionTests(unittest.TestCase):
         self.impl_skill = (ROOT / "skills" / "impl" / "SKILL.md").read_text(
             encoding="utf-8"
         )
+        self.impl_finish = (
+            ROOT / "skills" / "impl" / "impl-finish.md"
+        ).read_text(encoding="utf-8")
+        self.impl_contract = self.impl_skill + "\n" + self.impl_finish
         self.impl_routing = (ROOT / "skills" / "impl" / "impl-routing.md").read_text(
             encoding="utf-8"
         )
         self.impl_loop_skill = (
             ROOT / "skills" / "impl-loop" / "SKILL.md"
         ).read_text(encoding="utf-8")
+        self.impl_loop_finish = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+        ).read_text(encoding="utf-8")
+        self.impl_loop_contract = (
+            self.impl_loop_skill + "\n" + self.impl_loop_finish
+        )
         self.impl_loop_routing = (
             ROOT / "skills" / "impl-loop" / "impl-loop-routing.md"
         ).read_text(encoding="utf-8")
@@ -53,14 +63,13 @@ class SkillScenarioRegressionTests(unittest.TestCase):
     def test_impl_uses_main_implementation_and_isolated_review(self) -> None:
         """/impl keeps implementation on main and isolates only impl-validator."""
         for needle in (
-            "일반 `/impl` 구현 주체는 **항상 메인**",
-            "격리되는 것은 review step",
-            "일반 `/impl` 은 별도 구현 agent 를 구현자로 호출하지 않는다",
-            "review provider",
+            "`/impl`의 기본 구현자는 메인",
+            "별도 구현 sub-agent나 headless worker를 먼저 만들지 않는다",
+            "격리되는 것은 GREEN 이후 review",
             "impl-validator",
         ):
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.impl_skill)
+                self.assertIn(needle, self.impl_contract)
 
         for needle in (
             "일반 `/impl` 의 구현 주체는 항상 메인",
@@ -77,9 +86,9 @@ class SkillScenarioRegressionTests(unittest.TestCase):
 
         구현 또는 merged validation 이 빠지거나 순서가 바뀌면 false-clean 회귀(#431)로 직결된다.
         """
-        self.assertRegex(
-            self.impl_loop_skill,
-            r"build-worker.*impl-validator",
+        self.assertLess(
+            self.impl_loop_contract.index("build-worker"),
+            self.impl_loop_contract.index("impl-validator"),
         )
         self.assertIn("단일 구현 엔진 `build-worker`", self.impl_loop_skill)
         self.assertIn("action=story-pr", self.impl_loop_skill)
@@ -96,7 +105,7 @@ class SkillScenarioRegressionTests(unittest.TestCase):
         self.assertIn("phase prose", self.build_worker)
         self.assertIn("3개 실존", self.build_worker)
         # impl-loop 안티패턴 — phase prose 부재 시 blocked 강등.
-        self.assertIn("build-{test,impl,validate}.md", self.impl_loop_skill)
+        self.assertIn("phase prose 3개", self.impl_loop_contract)
 
     # ----- 시나리오 2a-2 — build-worker 결론 enum 노출 정합 -----
     def test_build_worker_conclusion_enums_consistent_with_template(self):
@@ -117,35 +126,27 @@ class SkillScenarioRegressionTests(unittest.TestCase):
         for needle in ("동작 증거", "mock-only", "핵심 AC"):
             self.assertIn(needle, self.build_worker)
 
-    # ----- 시나리오 2b — /impl-loop chain review 5줄 echo -----
-    def test_impl_loop_chain_review_echo_is_five_line(self) -> None:
-        """chain review echo = 5줄 요약, 자유 형식 단축 금지 (#446, F8 실측 #507)."""
-        self.assertIn("5줄 요약", self.impl_loop_skill)
-        self.assertIn("자유 형식 단축 금지", self.impl_loop_skill)
-        # 5줄 템플릿의 핵심 줄 키 보존 (구조가 무너지면 FAIL).
-        for key in ("finding:", "PR <#NNN> open", "next:"):
-            self.assertIn(key, self.impl_loop_skill)
-
     # ----- 시나리오 3 — false-clean 차단 -----
     def test_false_clean_downgrades_to_blocked(self) -> None:
         """worker/validator 흔적 없이 clean 표기 금지 — false-clean → blocked 강등 (#431)."""
         # impl-loop SKILL: false-clean 의심 → blocked 강등 (한 문장 안에 인과).
-        self.assertRegex(self.impl_loop_skill, r"false-clean.*blocked")
+        self.assertIn("phase prose", self.impl_loop_finish)
+        self.assertIn("clean으로 보고하지 않는다", self.impl_loop_finish)
         # impl-loop routing: clean 판정 게이트에서도 false-clean → blocked.
         self.assertRegex(self.impl_loop_routing, r"false-clean.*blocked")
         # impl 직접 구현 최소 gate 에도 false-clean 방지 명시.
-        self.assertIn("false-clean", self.impl_skill)
+        self.assertIn("clean으로 보고하지 않는다", self.impl_finish)
 
     def test_impl_design_doc_main_path_keeps_pr_reviewer_gate(self) -> None:
         """#851/#1019 — design-doc main-owned path keeps the impl-validator gate."""
         for needle in (
-            "design-doc 기반 구현 — 설계도 기반 구현",
-            "구현은 여전히 메인이 직접 수행",
-            "review 만 격리 provider",
-            "PASS 전 commit/PR 로 가지 않는다",
+            "design-doc 입력",
+            "메인이 직접 구현",
+            "격리 `impl-validator`",
+            "MUST FIX",
         ):
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.impl_skill)
+                self.assertIn(needle, self.impl_contract)
 
         self.assertIn(
             "design-doc · 메인 직접",
@@ -174,23 +175,22 @@ class SkillScenarioRegressionTests(unittest.TestCase):
                 self.assertIn(needle, self.git_spec)
 
         for needle in (
-            "git-spec.md#의미-단위-커밋-분할",
-            "독립 검토 가능한 의미 단위",
-            "각 커밋은 hook 을 통과",
+            "git-spec.md",
+            "의미 단위",
+            "hook을 우회하지 않는다",
         ):
             with self.subTest(doc="impl", needle=needle):
-                self.assertIn(needle, self.impl_skill)
+                self.assertIn(needle, self.impl_finish)
             with self.subTest(doc="impl-loop", needle=needle):
-                self.assertIn(needle, self.impl_loop_skill)
+                self.assertIn(needle, self.impl_loop_contract)
 
         self.assertIn("git-spec.md#의미-단위-커밋-분할", self.build_worker)
 
     def test_impl_paths_preserve_post_task_begin_marker(self) -> None:
         """#472 — after-task autonomous work must be separated from task ROI."""
         for doc_name, doc in (
-            ("impl", self.impl_skill),
-            ("impl-loop", self.impl_loop_skill),
-            ("impl-loop-routing", self.impl_loop_routing),
+            ("impl", self.impl_finish),
+            ("impl-loop", self.impl_loop_finish),
         ):
             for needle in (
                 "post-task-begin",
@@ -203,73 +203,27 @@ class SkillScenarioRegressionTests(unittest.TestCase):
 
     def test_impl_loop_documents_multi_story_qa_pr_policy(self) -> None:
         """#1108 — cross-cutting review/acceptance fixes belong to the QA PR."""
-        for doc_name, doc in (
-            ("impl-loop", self.impl_loop_skill),
-            ("impl-loop-routing", self.impl_loop_routing),
-        ):
-            for needle in (
-                "story PR 이 2개 이상",
-                "cross-cutting FAIL",
-                "QA PR",
-                "story-local FAIL",
-                "해당 story PR 브랜치",
-            ):
-                with self.subTest(doc=doc_name, needle=needle):
-                    self.assertIn(needle, doc)
-
-    def test_impl_loop_documents_qa_artifact_and_ac_write_contract(self) -> None:
         for needle in (
-            "1-story",
-            "N-story",
-            "tracked 변경",
-            ".dcness-work/product-journey/",
-            "빈 QA PR",
-            "acceptance verdict",
-            "`(JOURNEY)`",
-            "`사람 확인 안내`",
-            "--acceptance-only",
-            "--require-complete",
-            "human verification 대기",
-            "마지막 merge 대상 PR",
-            "`Closes #epic`",
+            "story-local production 수정",
+            "cross-cutting production 수정",
+            "QA branch",
+            "story PR stack",
         ):
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.impl_loop_skill)
+                self.assertIn(needle, self.impl_loop_finish)
 
     def test_impl_loop_makes_user_the_only_merge_gate(self) -> None:
         for doc_name, doc in (
             ("impl-loop", self.impl_loop_skill),
-            ("impl-loop-routing", self.impl_loop_routing),
+            ("impl-loop-finish", self.impl_loop_finish),
         ):
             with self.subTest(doc=doc_name):
                 self.assertIn("사용자가 유일한 merge gate", doc)
                 self.assertIn("자동 merge 금지", doc)
                 self.assertNotIn("즉시 머지", doc)
 
-        self.assertIn("downstream branch", self.impl_loop_skill)
-        self.assertIn("review/acceptance 증거", self.impl_loop_skill)
-
-    def test_impl_loop_chain_confirms_when_issue_close_will_fire(self) -> None:
-        """#851/#1019 — issue close 발동 story PR chain 은 1회 확인한다."""
-        for needle in (
-            "issue close 가 실제 발동되는 story PR",
-            "task 수와 무관하게",
-            "1회 확인",
-            "yolo 모드에서는 생략",
-            "확인 응답 전에는 task1 또는 story PR merge 준비로 진입하지 않는다",
-            "각 story PR 의 main 리타겟 직전에 1회 확인한다",
-        ):
-            with self.subTest(needle=needle):
-                self.assertIn(needle, self.impl_loop_skill)
-
-    # ----- 시나리오 4 — TaskCreate / TaskUpdate 의무 -----
-    def test_task_create_update_is_mandatory(self) -> None:
-        """impl-loop 모든 step 은 TaskCreate / TaskUpdate 와 한 묶음 — 자율 skip 금지 (사용자 가시성)."""
-        self.assertIn("TaskCreate", self.impl_loop_skill)
-        self.assertIn("TaskUpdate", self.impl_loop_skill)
-        self.assertIn("자율 skip 금지", self.impl_loop_skill)
-        # skip 은 중대 차단 안티패턴으로 명시돼야 한다.
-        self.assertIn("중대 차단 안티패턴", self.impl_loop_skill)
+        self.assertIn("downstream branch", self.impl_loop_finish)
+        self.assertIn("review/acceptance/AC audit", self.impl_loop_finish)
 
     # ----- 시나리오 5 — /init-dcness deploy path -----
     def test_init_dcness_deploy_sources_exist(self) -> None:

--- a/tests/test_story_runner.py
+++ b/tests/test_story_runner.py
@@ -13,6 +13,7 @@ from harness.story_runner import (
     next_action,
     next_task,
     prepare_init_state,
+    task_requires_acceptance,
 )
 
 
@@ -270,6 +271,8 @@ class StoryRunnerTests(unittest.TestCase):
 
         first = next_task(state)
         self.assertEqual(first["id"], 1)
+        self.assertFalse(task_requires_acceptance(state, "1"))
+        self.assertTrue(task_requires_acceptance(state, "2"))
         mark_task(state, "1", "running", provider="codex-headless")
         self.assertEqual(next_task(state)["id"], 1)
         mark_task(state, "1", "completed", commit="abc123")

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -62,12 +62,22 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.impl_skill = (ROOT / "skills" / "impl" / "SKILL.md").read_text(
             encoding="utf-8"
         )
+        self.impl_finish = (
+            ROOT / "skills" / "impl" / "impl-finish.md"
+        ).read_text(encoding="utf-8")
+        self.impl_contract = self.impl_skill + "\n" + self.impl_finish
         self.impl_routing = (
             ROOT / "skills" / "impl" / "impl-routing.md"
         ).read_text(encoding="utf-8")
         self.impl_loop_skill = (
             ROOT / "skills" / "impl-loop" / "SKILL.md"
         ).read_text(encoding="utf-8")
+        self.impl_loop_finish = (
+            ROOT / "skills" / "impl-loop" / "impl-loop-finish.md"
+        ).read_text(encoding="utf-8")
+        self.impl_loop_contract = (
+            self.impl_loop_skill + "\n" + self.impl_loop_finish
+        )
         self.tech_review_skill = (
             ROOT / "skills" / "tech-review" / "SKILL.md"
         ).read_text(encoding="utf-8")
@@ -432,7 +442,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertNotIn("impl 밖 — 설계 선행", self.impl_routing)
         self.assertNotIn("없으면 `/spec` / `/tech-review` / `/design` 선행", self.impl_routing)
         self.assertIn(
-            "spec / design 단계 → `/spec` (PRD) 또는 `/design` (설계)",
+            "일반 버그픽스·한 줄 수정·설계 문서 없는 구현",
             self.impl_loop_skill,
         )
 
@@ -579,11 +589,9 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.loop_procedure)
 
-        self.assertIn(
-            "../../docs/plugin/loop-procedure.md#worktree-분기-action-루프-한정",
-            self.impl_skill,
-        )
-        self.assertIn("ExitWorktree", self.impl_skill)
+        self.assertNotIn("loop-procedure.md#worktree", self.impl_skill)
+        self.assertIn("loop-procedure.md#worktree", self.impl_finish)
+        self.assertIn("dirty/unmerged", self.impl_finish)
 
     def test_issue_832_design_runs_mechanical_artifact_audit(self) -> None:
         """#832 — design loop runs the artifact audit before final validator/PR."""
@@ -789,7 +797,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         """#1185 — /impl reaches RED/first edit without preview/preflight helpers."""
         self.assertNotIn("impl-preview", self.impl_skill)
         self.assertNotIn("boundary-suggestions", self.impl_skill)
-        self.assertIn("첫 진행 이정표", self.impl_skill)
+        self.assertIn("착수: <target>", self.impl_skill)
         self.assertIn("RED", self.impl_skill)
 
     def test_issue_1019_impl_external_copy_uses_current_naming(self) -> None:
@@ -819,16 +827,12 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             "task commit",
             "story PR",
             "action=story-pr",
-            "final_story",
-            "task 단일 상태",
             "직전 story 브랜치에서 재분기",
-            "스택 tip vs main",
-            "story-run.completed-<UTC>.json",
-            "직렬 chain driver 전용",
+            "stack tip vs main",
             "impl-validator review 출력은 merge candidate 경계에서 1회",
         ):
             with self.subTest(needle=needle):
-                self.assertIn(needle, self.impl_loop_skill)
+                self.assertIn(needle, self.impl_loop_contract)
         for stale in (
             "PR 1개 = task 1개",
             "N task = N run = N review.md",
@@ -838,7 +842,7 @@ class SurfaceDocsSyncTests(unittest.TestCase):
             "mark-story",
         ):
             with self.subTest(stale=stale):
-                self.assertNotIn(stale, self.impl_loop_skill)
+                self.assertNotIn(stale, self.impl_loop_contract)
 
     def test_issue_885_claude_md_seed_and_audit_stays_inside_existing_surfaces(self) -> None:
         """#885 — CLAUDE.md seed/migration and audit wire into init/run-review only."""
@@ -946,8 +950,8 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("단계 내부 되돌림", self.router)
 
         # impl records design-doc when supplied, but does not auto-return to design.
-        self.assertIn("LLM 판단만으로 `/spec`·`/design` 으로 되돌리지 않는다", self.impl_skill)
-        self.assertIn("/design", self.impl_skill)
+        self.assertIn("확정된 handoff", self.impl_skill)
+        self.assertIn("다시 열", self.impl_skill)
         self.assertIn("--design-doc", self.impl_skill)
         self.assertNotIn("compact-design", self.impl_routing)
 
@@ -1000,16 +1004,17 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         )
         self.assertNotIn("[INSIGHTS]", self.loop_procedure)
 
-        for label, text in (
-            ("impl", self.impl_skill),
-            ("impl-loop", self.impl_loop_skill),
-            ("design", self.design_skill),
+        for label, front, finish in (
+            ("impl", self.impl_skill, self.impl_finish),
+            ("impl-loop", self.impl_loop_skill, self.impl_loop_finish),
         ):
             with self.subTest(label=label):
-                self.assertIn("Sub-agent prompt 작성 checkpoint (#780)", text)
-                self.assertIn("agent-prompt-slots.md", text)
-                self.assertIn("worktree 절대경로", text)
-                self.assertIn("방법 처방", text)
+                self.assertNotIn("agent-prompt-slots.md", front)
+                self.assertIn("agent-prompt-slots.md", finish)
+        self.assertIn("Sub-agent prompt 작성 checkpoint (#780)", self.design_skill)
+        self.assertIn("agent-prompt-slots.md", self.design_skill)
+        self.assertIn("worktree 절대경로", self.design_skill)
+        self.assertIn("방법 처방", self.design_skill)
 
     def _section(self, text: str, start: str, end: str) -> str:
         match = re.search(start + r"(?P<body>.*?)" + end, text, flags=re.S)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1190

## 배경 및 문제

`/impl`과 `/impl-loop`가 실제 파일 작업보다 규칙 재확인과 main-context 추론에 시간을 쓰면서, 확정된 요청 뒤에도 첫 RED/edit 또는 worker fork까지 수분이 걸렸습니다. 실측상 명령 실행은 전체 지연의 극히 일부였고, 반복 판단·설명·context 재처리가 주된 병목이었습니다.

## 원인 (해당 시)

- 구현 전 지침에 review, Cartography, acceptance, close/PR 규칙까지 한꺼번에 노출됐습니다.
- `/impl-loop`의 deterministic setup을 메인이 여러 tool turn으로 수동 조립했습니다.
- worker별 TDD/phase/lifecycle 계약이 서로 다른 문서와 wrapper에 흩어져 반복 확인과 false-clean을 만들었습니다.
- fast-start 회귀 검증이 문자열 존재만 확인하고 실제 fork 순서·시간·중복 state·A/B 정확성을 검증하지 않았습니다.

## 작업내용

- `/impl`을 target 확인 → 격리 → focused read → RED/첫 edit의 main-direct action-first 경로로 축소하고, GREEN 이후 절차를 `impl-finish.md`로 지연 로드합니다.
- `/impl-loop`는 worktree 이후 story state, run/step lifecycle, provider resolve, prompt 합성, same-workspace recovery를 `dcness-implementation-chain` 한 호출이 소유합니다.
- canonical phase prose와 프로젝트별 TDD 계약을 Claude/Codex worker에 동일하게 주입·검증합니다. PASS만 phase clean gate를 통과시키고, 환경 preflight의 `IMPLEMENTATION_ESCALATE` 같은 non-PASS receipt는 원형대로 보존합니다.
- UI canvas mutation을 worktree 이후로 고정하고, acceptance marker는 chain의 마지막 task에만 기록합니다.
- 기존 late-stage 중복 prose와 수동 setup 분기를 삭제하고, 완료 단계 진본을 `impl-finish.md` / `impl-loop-finish.md`로 분리했습니다.
- 동일 frozen fixture의 main-direct/fresh executor A/B와 외부 프로젝트의 실제 worker fork를 각 3회 측정했습니다. main-direct 중앙값 9.964초, fresh executor 18.272초라 기본 경로는 main-direct를 유지합니다. `/impl-loop` 실제 fork는 11.054~17.960초였습니다.

## 결정 근거

fresh executor는 정확했지만 세 번 모두 main-direct보다 느렸고 전체 executor 입력도 더 컸습니다. 따라서 모든 `/impl`을 headless/sub-agent로 전환하지 않고, 작은 front context의 main-direct를 기본으로 유지했습니다. `/impl-loop`만 이미 분리된 worker 경계 앞의 deterministic setup을 코드로 일괄화했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- 기존 공개 entrypoint `/impl`, `/impl-loop`만 갱신했으며 신규 public skill/command/agent는 없습니다.
- repository의 `skills/**`, `scripts/**`, `docs/plugin/**` 직접 패키징 경로와 public-surface/doc-sync 회귀 테스트를 함께 갱신했습니다.
- 전체 unittest와 surface/docs 계약 테스트가 배포 산출물 참조 일치를 검증했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 신규 public surface 없음. `impl-finish.md`와 `impl-loop-finish.md`는 기존 skill의 지연 로드용 내부 문서입니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests` — 1,179/1,179 PASS
- [x] `PYTHON_BIN=/tmp/dcness1190-mypy-venv/bin/python sh scripts/check_static_quality.sh` — ruff, mypy(36 files), Bandit PASS
- [x] `python3.11 evals/guard_efficacy.py` — 50/50 PASS
- [x] 실제 external `/impl` main-direct/fresh A/B 각 3회와 `/impl-loop` provider fork 3회, 전 실행 60초 미만
- [x] 독립 impl-validator 3라운드, 최종 MUST/SHOULD blocker 없음
- [x] `node scripts/check_issue_body.mjs --stdin --acceptance-only --require-complete` — 11개 AC PASS

## 참고

- fast-start 실측 metadata: `evals/impl-fast-start-metadata.json`
- 독립 검증의 비차단 후속 제안: A/B runtime의 effort/provider까지 future trace에서 직접 교차 검증
