### PR TITLE
[issue-1192] impl 소유자 선택과 교차 리뷰 자동화

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1186,"total":1186},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1187,"total":1187},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 공개 snapshot은 **v0.27.0, 2026-07-24 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,186/1,186 PASS, 결정적 guard 50/50 PASS | test 1,186, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,187/1,187 PASS, 결정적 guard 50/50 PASS | test 1,187, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1173,"total":1173},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1186,"total":1186},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 공개 snapshot은 **v0.27.0, 2026-07-24 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,173/1,173 PASS, 결정적 guard 50/50 PASS | test 1,173, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,186/1,186 PASS, 결정적 guard 50/50 PASS | test 1,186, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |
@@ -156,7 +156,7 @@ claude plugin install dcness@dcness
 
 `/impl` 은 설계도를 직접 그리지 않고, 들어온 요청을 보고 **가장 작은 안전한 경로** 를 스스로 고른다. 파일·이슈·테스트 같은 concrete signal 이 있거나 자연어 구현 의도가 충분하면 관련 코드를 찾아 바로 `테스트 → 구현 → 리뷰 → PR` 로 끝내고(direct), 설계도 경로가 있으면 그 설계도대로 구현한다(design-doc). 새 기능이나 위험이 큰 작업은 설계 선행을 권장하지만, 사용자가 그대로 진행을 택하면 구현한다.
 
-`/impl` 은 direct/design-doc 경로와 review provider 를 내부에서 고른다. 시작 전 전역 진단을 반복하지 않고 RED 또는 첫 수정으로 진행하며, 일상적인 파일·테스트 선택과 복구 가능한 실패는 사용자에게 되묻지 않는다. 일반 `/impl` 구현은 메인이 맡고, 격리되는 것은 `impl-validator` 검토다.
+`/impl` 은 direct/design-doc 경로와 구현 소유자를 내부에서 고른다. 이미 보이는 task shape가 단순하거나 애매하면 메인이 바로 구현하고, 여러 module·runtime seam·넓은 검증이 명확한 복잡 작업이면 첫 source edit 전에 headless one-shot으로 시작한다. 중간 handoff 없이 실제 구현 성공 provider가 review finding까지 고치며, `impl-validator`는 그 반대 진영이 맡는다.
 
 보조 진입점 — `/to-issue`(자연어를 GitHub 이슈로), `/next-work`(issue/label 에서 다음 할 일 조회), `/tech-review`(위험한 설계의 사전 기술 검증), `/impl-loop`(deep task 파일 단위 구현 러너), `/ux`(구현 없이 시안·흐름·디자인 시스템/토큰 베이스라인 먼저).
 
@@ -168,7 +168,7 @@ claude plugin install dcness@dcness
 
 ## Provider와 기록
 
-검증·리뷰 단계를 어느 provider 로 돌릴지는 프로젝트별로 고를 수 있다(Claude 서브에이전트 / Codex headless / Claude headless). provider 를 바꿔도 순서·파일 경계 규칙은 그대로 걸린다. 일반 `/impl` 구현은 메인이 맡고, story/epic deep task runner 인 `/impl-loop` 만 구현 worker provider 를 사용한다. provider 구성을 새로 켜거나 바꿀 때만 `/init-dcness` 를 다시 실행한다.
+구현·검증 단계를 어느 provider로 돌릴지는 프로젝트별로 고를 수 있다(Claude / Codex headless / Claude headless). provider를 바꿔도 순서·파일 경계 규칙은 그대로 걸린다. `/impl`은 단순 작업을 main-direct로, 명확한 복잡 작업을 headless one-shot으로 실행한다. `/impl-loop`는 story/epic deep task를 항상 headless worker로 처리한다. 최종 review는 설정값이 아니라 실제 구현 성공 provider의 반대 진영으로 정한다.
 
 `/impl-loop` deep task 는 `build-worker → impl-validator` 흐름을 사용한다. build-worker 는 task 별 로컬 커밋까지 만들고, 모든 대상 task 구현 뒤 merge candidate diff 를 impl-validator 가 1회 통합 리뷰한다. 각 run의 단계 완료는 `ledger.jsonl`에 기록되며, prose 파일과 sha256 receipt로 검증 가능한 작업 기록을 남긴다.
 
@@ -180,7 +180,7 @@ claude plugin install dcness@dcness
 | 형식 강제 | 없음 — 형식·flag·schema 는 agent 자율. 강제는 작업 순서 + 접근 영역 |
 | 컨텍스트 구조 | 2 layer (`CLAUDE.md` + agent 지침) |
 | 게이트 | 거버넌스 + 10개 CI (cross-ref · doc-sync · git-naming · plugin-manifest · pr-body · public-surface · python-tests · static-quality · release-sync · github-project-lifecycle) |
-| provider 선택 | 검증·리뷰 단계를 Claude 서브에이전트 또는 Codex 로 돌릴 수 있고, provider 가 바뀌어도 규칙은 동일. 일반 `/impl` 구현은 메인이 맡음 |
+| provider 선택 | `/impl`은 task shape로 main-direct/headless owner를 한 번 고르고, `/impl-loop`는 headless. review는 실제 구현 성공 provider의 반대 진영 |
 
 ## 공개 진입점
 
@@ -190,7 +190,7 @@ claude plugin install dcness@dcness
 |---|---|---|
 | 기본 workflow | `/spec` | 새 기능 spec + 검수 체크포인트 |
 | 기본 workflow | `/design` | 화면·시스템·모듈 설계 |
-| 기본 workflow | `/impl` | 구현 진입 — direct/design-doc 경로와 review provider 를 내부 판정 |
+| 기본 workflow | `/impl` | 구현 진입 — direct/design-doc 경로, 구현 owner, 반대 진영 review를 내부 판정 |
 | 기본 workflow | `/acceptance` | story/epic 제품 검수 |
 | support | `/to-issue` | 자연어 → Issue Brief → 승인 대기 없이 GitHub 선등록 (web 에서 확인·수정) |
 | 고급 | `/tech-review` | 위험한 설계의 사전 기술 검증 |

--- a/docs/plugin/agents/build-worker/build-worker-agent.md
+++ b/docs/plugin/agents/build-worker/build-worker-agent.md
@@ -2,7 +2,7 @@
 
 ## 목적
 
-`/impl-loop` 단일 구현 엔진으로 한 impl task의 조건부 `JOURNEY_ENV_PREFLIGHT`, 테스트 작성, 구현, 자체 검증, 로컬 커밋을 한 호출 안에서 끝낸다. 같은 agent를 completed 이후 `JOURNEY_CONVERGENCE` mode로 재사용해 자동 `(JOURNEY)`의 final tip 하네스도 수렴시킨다. 신규 agent나 공개 진입점을 만들지 않으며, 비용을 줄이되 검증 증거와 커밋 가능 상태를 생략하지 않는다.
+`/impl-loop`와 복잡 `/impl`의 headless 구현 엔진으로 한 task의 조건부 `JOURNEY_ENV_PREFLIGHT`, 테스트 작성, 구현, 자체 검증, 로컬 커밋을 한 호출 안에서 끝낸다. `/impl-loop`에서는 같은 agent를 completed 이후 `JOURNEY_CONVERGENCE` mode로 재사용해 자동 `(JOURNEY)`의 final tip 하네스도 수렴시킨다. 신규 agent나 공개 진입점을 만들지 않으며, 비용을 줄이되 검증 증거와 커밋 가능 상태를 생략하지 않는다.
 
 ## 입력
 
@@ -54,7 +54,7 @@
 
 ### `JOURNEY_ENV_PREFLIGHT`
 
-- `/impl-loop` 기본 one-shot worker가 impl task를 읽은 직후, source read/edit 전에 자동 `(JOURNEY)`가 하나라도 있을 때만 내부 phase로 1회 수행한다. 별도 main turn, provider fork, outer lifecycle step을 만들지 않는다. journey 미선언 run과 `acceptance_environment.automation=human_verification`만 있는 run은 비발동이다.
+- `/impl-loop` 기본 one-shot worker 또는 복잡 `/impl` headless worker가 task를 읽은 직후, source read/edit 전에 자동 `(JOURNEY)`가 하나라도 있을 때만 내부 phase로 1회 수행한다. 별도 main turn, provider fork, outer lifecycle step을 만들지 않는다. journey 미선언 run과 `acceptance_environment.automation=human_verification`만 있는 run은 비발동이다.
 - main 컨텍스트가 아니라 build-worker가 실제 실행될 동일 provider·sandbox의 worker 실행 컨텍스트에서 `requirements[].probe`를 수행한다. mobile은 device/emulator+`adb` socket, web은 browser/driver, CLI는 기동 service+writable fixture, API는 provisioned tenant처럼 해당 runtime 의존에 실제로 도달하는지 본다.
 - 확실한 미충족이라도 `requirements[].prepare`로 emulator boot, container/service 기동, socket 노출 같은 자동 준비가 가능하면 질문 없이 먼저 준비하고 다시 probe한다. 검출이 불확실하면 차단하지 않고 그 불확실성을 보고한 `PASS`로 task 구현에 진행해 수렴 호출이 흡수하게 한다.
 - 확실한 미충족이고 자동 준비가 불가능할 때만 근거와 함께 `IMPLEMENTATION_ESCALATE`를 보고한다. main이 host에서 대신 probe하거나 journey를 실행해 worker substrate 부재를 숨기지 않는다. 이 phase는 tracked file을 수정하거나 commit하지 않는다.
@@ -71,7 +71,7 @@
 ## phase prose 경로
 
 - headless wrapper가 prompt에 넣은 `canonical run directory` 절대경로가 phase prose의 유일한 기록 위치다. linked worktree 안의 상대 `.claude/harness-state`를 다시 계산하지 않는다.
-- phase prose는 worker 내부 test/impl/validate 증거다. outer Agent 호출의 `step_started`/`step_completed` receipt가 아니며, phase마다 outer `begin-step`/`end-step`을 호출하거나 phase 파일을 outer completion으로 append하지 않는다. foreground Claude outer lifecycle은 hook이 소유한다. `/impl-loop` headless outer lifecycle은 implementation chain이 provider fork 전 `step_started`, worker wrapper가 최종 prose의 `step_completed`를 각각 정확히 한 번 소유한다.
+- phase prose는 worker 내부 test/impl/validate 증거다. outer Agent 호출의 `step_started`/`step_completed` receipt가 아니며, phase마다 outer `begin-step`/`end-step`을 호출하거나 phase 파일을 outer completion으로 append하지 않는다. foreground Claude outer lifecycle은 hook이 소유한다. `/impl-loop`와 복잡 `/impl`의 headless outer lifecycle은 implementation chain이 provider fork 전 `step_started`, worker wrapper가 최종 prose의 `step_completed`를 각각 정확히 한 번 소유한다.
 - `phases/<RUN_ID>/` 같은 별도 worktree 경로를 만들거나 보고하지 않는다.
 - `build-test.md`, `build-impl.md`, `build-validate.md`를 쓴 뒤 `ls <run_dir>/build-test.md <run_dir>/build-impl.md <run_dir>/build-validate.md`로 3개 실존을 확인한다.
 - impl-validator finding 대응 등 별도 polish 기록이 필요하면 `build-polish.md`도 같은 `<run_dir>`에만 쓴다. 이 파일은 선택 기록이며 clean 게이트의 필수 3개에는 포함하지 않는다.

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -4,13 +4,13 @@
 
 ## 현재 공개 evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1173,"total":1173},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1186,"total":1186},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 plugin version은 **v0.27.0**, 측정일은 **2026-07-24**이다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
 
 | evidence | 관측값 | 재현 명령 | 한계 |
 |---|---:|---|---|
-| 전체 unit 계약 | 1,173/1,173 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
+| 전체 unit 계약 | 1,186/1,186 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
 | guard fixture | 50/50 PASS | `python3.11 evals/guard_efficacy.py --json` | deterministic payload의 allow/block/exit/stdout 계약 |
 | 공개 snapshot drift | README/benchmark 일치 | `node scripts/check_public_evidence.mjs` | 위 두 명령 결과와 문서 marker만 대조 |
 

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -4,13 +4,13 @@
 
 ## 현재 공개 evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1186,"total":1186},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.27.0","measured_at":"2026-07-24","unit_tests":{"passed":1187,"total":1187},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 plugin version은 **v0.27.0**, 측정일은 **2026-07-24**이다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
 
 | evidence | 관측값 | 재현 명령 | 한계 |
 |---|---:|---|---|
-| 전체 unit 계약 | 1,186/1,186 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
+| 전체 unit 계약 | 1,187/1,187 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
 | guard fixture | 50/50 PASS | `python3.11 evals/guard_efficacy.py --json` | deterministic payload의 allow/block/exit/stdout 계약 |
 | 공개 snapshot drift | README/benchmark 일치 | `node scripts/check_public_evidence.mjs` | 위 두 명령 결과와 문서 marker만 대조 |
 

--- a/docs/plugin/git-spec.md
+++ b/docs/plugin/git-spec.md
@@ -57,7 +57,7 @@
 
 ## 의미 단위 커밋 분할
 
-모든 구현 흐름은 독립 검토 가능한 의미 단위로 commit 을 쪼갠다. 적용 대상은 `/impl` 메인 직접 구현, `/impl-loop` build-worker task local commit, review finding 대응 commit, fix PR commit 을 모두 포함한다.
+모든 구현 흐름은 독립 검토 가능한 의미 단위로 commit 을 쪼갠다. 적용 대상은 `/impl` main-direct·headless 구현, `/impl-loop` build-worker task local commit, review finding 대응 commit, fix PR commit 을 모두 포함한다.
 
 - 각 commit 은 hook 을 통과할 수 있는 일관된 상태여야 한다. 테스트가 깨진 중간 저장용 commit 은 금지한다.
 - 변경량이 크면 테스트/결정적 helper/문서 surface/후속 cleanup 처럼 리뷰어가 단계별로 따라갈 수 있는 단위로 나눈다.

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -171,7 +171,7 @@ worker가 `DCNESS_PROVIDER_FAILURE_FILE` 내부 JSON으로 전달하는 failure 
 - 슬롯 1 ↔ 4요소 (1)(2)(4), 슬롯 2 ↔ worktree MUST(아래), 슬롯 3 ↔ 4요소 (3) + 미기록 결정 예외. 4요소를 줄인 게 아니라 *담는 칸* 을 고정한 것이다.
 - `이 호출 특유` 칸이 방법 처방을 막는 가드다 — 채울 게 없으면 비우고, 채워도 "무엇" 까지만 적는다.
 - **진본 충실 시 수렴**: module-architect 산출물(impl task 파일)이 인터페이스·수용기준 통과조건·테스트 스켈레톤·Scope 까지 담으면, 호출은 포인터+worktree(+미기록 사실 한 줄)로 수렴한다. agent 본업(RED·lint·결론 형식)이나 진본 사본(AC 통과조건·Scope·인터페이스 시그니처)을 prompt 에 다시 적으면 슬림 포인터 규약 위반이다 — 진본이 진본임을 prompt 가 명시하면서 그 사본을 욱여넣는 자기모순.
-- direct 기본 경로(메인 직접 구현)는 sub-agent 호출 자체가 없어 본 슬롯 대상이 아니다. 슬롯이 적용되는 곳은 *sub-agent 에 prompt 가 나가는* 경로다. `/impl-loop` build-worker 시작은 별도 slim prompt 계약이고, 본 슬롯은 GREEN 이후 validator/acceptance 호출에 적용된다.
+- direct의 main-direct 구현은 sub-agent 호출 자체가 없어 본 슬롯 대상이 아니다. 복잡 `/impl`과 `/impl-loop`의 build-worker 시작은 별도 slim prompt 계약이고, 본 슬롯은 GREEN 이후 validator/acceptance 호출에 적용된다.
 
 **worktree 활성 시 worktree 절대 경로 전달 — MUST**: foreground Claude Agent는 SubagentStart hook, headless worker는 wrapper가 worktree 절대경로를 첫 prompt에 직접 넣는다. main repo abs path 사용 금지 — 머지 전 옛 코드 read 로 false positive가 난다. hook/wrapper가 동적 경로를 전달하므로 메인이 Bash stdout을 다시 prompt로 relay하지 않는다.
 

--- a/docs/plugin/positioning.md
+++ b/docs/plugin/positioning.md
@@ -10,10 +10,10 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 |---|---|---|
 | `/spec` | 새 제품 기능, 큰 기획, PRD 변경처럼 의도 합의가 먼저 필요할 때 | PRD 초안/최종화 / stories / 필요한 tech-review preflight + `SPEC_ACCEPTANCE` |
 | `/design` | PRD 이후 구현 전 product/technical design, 즉 설계 전체가 필요할 때 | UX / 시스템 / 모듈 / 기술 선택 설계. 구현 없이 visual design 만 먼저 탐색하려면 `/ux` |
-| `/impl` | 구현, 수정, 버그픽스, 작은 리팩터링을 실제 PR 로 끝낼 때 | direct/design-doc 경로 + review provider 를 내부 판정 |
+| `/impl` | 구현, 수정, 버그픽스, 작은 리팩터링을 실제 PR 로 끝낼 때 | direct/design-doc 경로 + 구현 소유자 + 반대 진영 review를 내부 판정 |
 | `/acceptance` | PRD / Epic / Story 기준 제품 검수와 gap 후속 연결이 필요할 때 | story/epic acceptance. 핵심 AC별 동작 증거와 mock-only gap 을 구분한다. 사람 full E2E 는 MVP 범위 밖 |
 
-사용자는 구현 경로 이름을 외울 필요가 없다. `/impl` 은 설계를 하지 않고 파일·이슈·테스트 같은 concrete signal 이 있거나 자연어 구현 의도가 충분하면 관련 코드를 찾아 바로 구현한다. 설계도 경로가 있으면 design-doc 으로 받은 설계도를 구현한다. issue 등록은 사용자가 요청했을 때만 `/to-issue` 로 분기하고, 제품 의미가 실제로 둘 이상일 때만 짧게 묻는다. 일반 `/impl` 의 구현 주체는 메인이고, 격리되는 단계는 `impl-validator` 검토다. high-risk trigger 나 새 epic/product feature 는 설계 선행을 권장하는 신호지만, 사용자가 그대로 진행을 택하면 `/impl` 이 구현한다. 조건과 권고 기준은 [`workflow-router.md#구현-경로-표`](workflow-router.md#구현-경로-표) 가 소유한다. 본 문서는 공개 진입점과 사용자-facing 노출 범위만 소유한다.
+사용자는 구현 경로나 엔진 이름을 외울 필요가 없다. `/impl` 은 설계를 하지 않고 파일·이슈·테스트 같은 concrete signal 이 있거나 자연어 구현 의도가 충분하면 바로 구현한다. 설계도 경로가 있으면 design-doc 으로 받은 설계도를 구현한다. 이미 명확한 복잡 신호가 있으면 첫 source edit 전에 headless owner를 선택하고, 단순하거나 애매하면 main-direct로 진행한다. 구현 도중 owner를 바꾸지 않으며 review는 실제 구현 성공 provider의 반대 진영이다. issue 등록은 사용자가 요청했을 때만 `/to-issue` 로 분기하고, 제품 의미가 실제로 둘 이상일 때만 짧게 묻는다. high-risk trigger 나 새 epic/product feature 는 설계 선행을 권장하는 신호지만, 사용자가 그대로 진행을 택하면 `/impl` 이 구현한다. 조건과 권고 기준은 [`workflow-router.md#구현-경로-표`](workflow-router.md#구현-경로-표) 가 소유한다. 본 문서는 공개 진입점과 사용자-facing 노출 범위만 소유한다.
 
 ## Support Entrypoints
 
@@ -65,7 +65,7 @@ dcNess 의 기본 공개 workflow 는 제품 생명주기 기준으로 계획 / 
 
 agent 는 사용자가 외워야 하는 command 가 아니다. `architecture-validator`, `build-worker`, `impl-validator`, `designer`, `module-architect`, `product-acceptance`, `system-architect`, `tech-reviewer`, `ux-architect` 는 workflow 내부에서 호출되는 gate/worker/reviewer 로 분류한다.
 
-특히 `impl-validator`, `architecture-validator` 는 read-only validation provider 분기 대상이다. `build-worker` 는 `/impl-loop` 같은 deep task runner 의 implementation provider 분기 대상이지 일반 `/impl` 구현자가 아니다. provider 가 Claude 든 Codex 든 사용자-facing 단계 이름은 `impl-validator` / `build-worker` 같은 agent 이름으로 유지한다.
+특히 `impl-validator`, `architecture-validator` 는 read-only validation provider 분기 대상이다. `build-worker` 는 `/impl-loop`와 복잡 `/impl`의 내부 headless implementation provider이며 새 공개 구현 경로가 아니다. provider가 Claude든 Codex든 사용자-facing 단계 이름은 `impl-validator` / `build-worker` 같은 agent 이름으로 유지한다.
 
 ## Contract Gate
 

--- a/docs/plugin/workflow-router.md
+++ b/docs/plugin/workflow-router.md
@@ -9,7 +9,7 @@
 
 분기 규칙은 **권고**다. 코드가 강제하는 것은 작업 순서와 접근 영역이고, 진입점 선택은 메인/사용자의 판단이다. 사용자가 명시적으로 `/impl` 또는 "구현해줘"를 지시했고 concrete signal 이 있으면 구현을 우선한다. high-risk 신호는 설계 선행 권장 근거이지 자동 차단 근거가 아니다.
 
-기본 공개 진입점은 `/spec -> /design -> /impl -> /acceptance` 다. direct / design-doc 은 `/impl` 내부 echo 이름이고 공개 command 가 아니다. 기본 공개 진입점 계약은 [`positioning.md`](positioning.md) 가 진본이다.
+기본 공개 진입점은 `/spec -> /design -> /impl -> /acceptance` 다. direct / design-doc 은 `/impl` 내부 echo 이름이고 공개 command 가 아니다. main-direct / headless는 첫 source edit 전에 한 번 고르는 내부 구현 소유자이며 공개 command가 아니다. 기본 공개 진입점 계약은 [`positioning.md`](positioning.md) 가 진본이다.
 
 ## gate 축 — 어떤 공개 진입점으로 갈까
 
@@ -64,8 +64,8 @@ flowchart TB
 
 | 구현 경로 | 트리거 | 진입점 | 왜 이 경로 |
 |---|---|---|---|
-| **direct** | 파일 path · 함수/클래스/symbol · issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only/refactor 또는 충분한 자연어 구현 의도 | `/impl` — 관련 파일과 테스트를 찾아 메인 직접 `test -> impl -> test pass -> impl-validator -> PR` | 일상적인 파일·테스트 선택과 탐색은 메인이 해결한다. high-risk 신호는 권고로 표시하되 차단하지 않음 |
-| **design-doc** | 설계 문서 경로가 입력됨 | `/impl` — `--design-doc` 기록 후 받은 설계도로 메인이 구현 + 격리 `impl-validator` | impl 은 설계 생성 X. 받은 설계도 충실 구현과 review gate 유지 |
+| **direct** | 파일 path · 함수/클래스/symbol · issue/PR 번호 · 명시 테스트 명령 · 작은 docs-only/refactor 또는 충분한 자연어 구현 의도 | `/impl` — 단순·애매하면 main-direct, 여러 module/runtime seam/넓은 검증이 명확하면 첫 source edit 전 headless one-shot → 반대 진영 `impl-validator` → PR | 구현 소유자 판정을 위해 추가 scan·질문하지 않고 중간 handoff도 하지 않음 |
+| **design-doc** | 설계 문서 경로가 입력됨 | `/impl` — 같은 task-shape 기준으로 owner를 한 번 정하고 받은 설계도로 구현 + 반대 진영 `impl-validator` | impl은 설계 생성 X. 받은 설계도 충실 구현과 review gate 유지 |
 | **shape: chain** | story/epic deep task 파일 목록을 처리 | `/impl-loop` — build-worker task commit 누적 후 merge candidate `impl-validator` 1회 | 실행 형태. 일반 구현 진입점이 아니라 SDD 설계도 기반 headless runner |
 
 ## tech-review / architecture-validator 조건
@@ -99,7 +99,7 @@ flowchart TB
 |---|---|---|---|
 | **design → spec** | design 중 PRD/요구사항 부족 발견 → 메인 `/spec` 재진입 권고 | 설계 agent가 PRD 충돌/누락(`ESCALATE`) 또는 미검증 새 외부 의존(`NEW_DEP_ESCALATE`) 보고 | 진본 = [`design-routing.md` escalate 처리](../../skills/design/design-routing.md#escalate-처리) |
 | **impl → 사용자 결정** | 구현 중 되돌리기 어려운 영향 발견 → 사용자에게 설계 선행/계속 진행 선택지 보고 | high-risk 영향이 실제 코드 변경 지점에서 구체화 | 자동 `/spec`·`/design` 되돌림 금지 |
-| **review → 구현** | impl-validator FAIL → finding-class 에 따라 메인 root-cause 수정 | finding 발생 | 단계 내부 되돌림. retry 한도는 [`impl-routing.md`](../../skills/impl/impl-routing.md) |
+| **review → 구현** | impl-validator FAIL → finding-class에 따라 최초 구현 owner가 root-cause 수정 | finding 발생 | 단계 내부 되돌림. retry 한도는 [`impl-routing.md`](../../skills/impl/impl-routing.md) |
 
 단계 내부 되돌림과 단계 간 되돌림은 같은 원리의 다른 반경이다. 같은 영역 부족이 반복되면 점 패치 retry 로 한도를 소진하지 말고 근본 원인을 본다.
 

--- a/evals/cases/impl-fast-start-recovery/expected.md
+++ b/evals/cases/impl-fast-start-recovery/expected.md
@@ -1,6 +1,6 @@
 - [IFR-1][MUST] 제품 의미가 하나인 자연어 구현 요청은 관련 코드와 테스트를 스스로 찾아 RED 또는 첫 수정으로 바로 진행해야 한다.
 - [IFR-2][MUST_NOT] 첫 수정 전에 전역 구조 진단, 설치 상태 점검, 구현 preview, issue 등록 여부 확인을 의무적으로 반복하면 안 된다.
-- [IFR-3][MUST] 같은 계획과 설정의 다음 task는 run에서 이미 확인한 정보를 재사용하고 task별 preflight를 반복하지 않으며, headless 실행은 background에서 workspace/raw-log 진행을 관찰해야 한다.
+- [IFR-3][MUST] 같은 계획과 설정의 다음 task는 run에서 이미 확인한 정보를 재사용하고 task별 preflight를 반복하지 않으며, headless 실행은 runner가 workspace/raw-log를 보존하는 background one-shot으로 맡긴 뒤 메인이 `ps`/`tail`/수동 polling을 재조립하지 않아야 한다.
 - [IFR-4][MUST] 변경 뒤 timeout·idle timeout·빈 응답·boundary finding·post-run test guard 실패는 diff와 raw log를 보존한 같은 provider와 workspace에서 bounded continuation하고 관련 guard를 다시 확인해야 한다.
 - [IFR-5][MUST_NOT] 복구 가능한 timeout·빈 응답·일상적인 테스트 실패나 파일 선택을 곧바로 사용자 질문 또는 다른 provider fallback으로 넘기면 안 된다.
 - [IFR-6][MUST] 계획 밖 hard boundary 수정이나 test 면제는 자동 승인하지 않고 새 권한이 필요하다고 분리해 사용자 결정을 받아야 한다.

--- a/evals/impl-fast-start-metadata.json
+++ b/evals/impl-fast-start-metadata.json
@@ -96,6 +96,69 @@
     "conditional_fresh_executor": false,
     "reason": "Fresh execution was accurate but slower and used more median all-executor input."
   },
+  "complex_impl_owner_analysis": {
+    "issue": 1192,
+    "decision": "shape-conditional",
+    "owner_selection_before_first_source_edit": true,
+    "ambiguous_default": "main-direct",
+    "midstream_handoff": false,
+    "historical_complex_main_observation": {
+      "source_project": "Daeguk-Sun/NexusMessenger",
+      "session_id": "4cc35c28-f840-4bf7-9698-d1417d529f35",
+      "trace_sha256": "4d049fe6ebc50ba60f2fb6078f9b180d77e2c585c4141a38274c3aca26ce745b",
+      "decision_timestamp": "2026-07-24T02:07:12.806000+00:00",
+      "first_source_edit_timestamp": "2026-07-24T02:18:08.674000+00:00",
+      "decision_to_first_source_edit_seconds": 655.868,
+      "blocking_assistant_requests": 8,
+      "tool_calls": 12,
+      "tool_histogram": {
+        "Bash": 6,
+        "Read": 5,
+        "Write": 1
+      },
+      "model": "claude-opus-4-8",
+      "effort": "xhigh"
+    },
+    "historical_impl_loop_observation": {
+      "source_project": "Daeguk-Sun/alrimjang",
+      "session_id": "fb92a490-70da-4af8-adfc-0694b0b4b8f8",
+      "trace_sha256": "41d5582696c438e2e55bc1d7519c2604046400493c795bfbff52d880d5d89181",
+      "approval_timestamp": "2026-07-24T01:23:16.126000+00:00",
+      "headless_provider_start_timestamp": "2026-07-24T01:29:47+00:00",
+      "approval_to_provider_start_seconds": 390.874,
+      "root_cause": "main assembled run, step, routing, prompt, and launch serially before the provider fork"
+    },
+    "direct_chain_integration_replays": [
+      {
+        "trial": 1,
+        "elapsed_seconds": 4.68,
+        "lifecycle": "run_started -> step_started -> step_completed",
+        "provider_receipt": true,
+        "under_60_seconds": true
+      },
+      {
+        "trial": 2,
+        "elapsed_seconds": 4.72,
+        "lifecycle": "run_started -> step_started -> step_completed",
+        "provider_receipt": true,
+        "under_60_seconds": true
+      },
+      {
+        "trial": 3,
+        "elapsed_seconds": 4.57,
+        "lifecycle": "run_started -> step_started -> step_completed",
+        "provider_receipt": true,
+        "under_60_seconds": true
+      }
+    ],
+    "replay_command": "/usr/bin/time -p python3.11 -m unittest tests.test_impl_direct_headless.DirectHeadlessImplTests.test_direct_one_shot_creates_lite_run_and_opposite_review_receipt",
+    "interpretation": "The three existing simple-fixture trials keep main-direct because fresh execution was slower. The complex incident and the direct-chain integration replays justify selecting headless before mutation only when complexity is already clear.",
+    "limitations": [
+      "The historical complex observation and deterministic chain replay are not a same-fixture model-speed comparison.",
+      "The chain replay measures orchestration and lifecycle completion with a fake provider, not provider inference latency.",
+      "The result supports a scoped ownership policy, not provider or model superiority."
+    ]
+  },
   "impl_loop_real_forks": [
     {
       "session_id": "1eded949-7d58-4d2a-bd23-c0c6d7229514",

--- a/harness/agent_routing.py
+++ b/harness/agent_routing.py
@@ -25,11 +25,13 @@ __all__ = [
     "ROUTABLE_VALIDATION_AGENTS",
     "VALID_IMPLEMENTATION_PROVIDERS",
     "VALID_VALIDATION_PROVIDERS",
+    "ACTUAL_IMPLEMENTATION_PROVIDERS",
     "IMPLEMENTATION_PROVIDER_CHAINS",
     "routing_path",
     "load_routing",
     "save_routing",
     "resolve_provider",
+    "review_route_for_actual_provider",
     "implementation_provider_chain",
     "set_provider",
     "set_implementation_provider",
@@ -55,6 +57,11 @@ VALID_IMPLEMENTATION_PROVIDERS = (
     "claude",
     "claude-headless",
     "headless-chain",
+)
+ACTUAL_IMPLEMENTATION_PROVIDERS = (
+    "codex-headless",
+    "claude-headless",
+    "claude-main",
 )
 IMPLEMENTATION_PROVIDER_CHAINS = {
     "headless-chain": ("codex-headless", "claude-headless", "claude-main"),
@@ -130,6 +137,47 @@ def _default_validation_provider(
     if camp == "codex":
         return "claude"
     return "codex" if _codex_cli_available(codex_available) else "claude"
+
+
+def review_route_for_actual_provider(
+    actual_implementation_provider: str,
+    *,
+    codex_available: Optional[bool] = None,
+) -> Dict[str, Optional[str]]:
+    """Resolve impl-validator from the provider that actually finished.
+
+    This intentionally ignores a same-camp local validator override. A headless
+    chain is only a preference before execution; after fallback, the terminal
+    provider receipt is the source of truth for independent review.
+    """
+    if actual_implementation_provider not in ACTUAL_IMPLEMENTATION_PROVIDERS:
+        allowed = "|".join(ACTUAL_IMPLEMENTATION_PROVIDERS)
+        raise ValueError(
+            "unsupported actual implementation provider: "
+            f"{actual_implementation_provider} (allowed: {allowed})"
+        )
+    implementation_camp = (
+        "codex"
+        if actual_implementation_provider == "codex-headless"
+        else "claude"
+    )
+    preferred_review_provider = (
+        "claude" if implementation_camp == "codex" else "codex"
+    )
+    review_provider = preferred_review_provider
+    fallback_reason: Optional[str] = None
+    if preferred_review_provider == "codex" and not _codex_cli_available(
+        codex_available
+    ):
+        review_provider = "claude"
+        fallback_reason = "codex-cli-unavailable"
+    return {
+        "actual_implementation_provider": actual_implementation_provider,
+        "implementation_camp": implementation_camp,
+        "preferred_review_provider": preferred_review_provider,
+        "review_provider": review_provider,
+        "fallback_reason": fallback_reason,
+    }
 
 
 def _atomic_write_json(target: Path, payload: Dict[str, Any]) -> None:

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -710,6 +710,23 @@ def _cli_routing(args: Any) -> int:
         return 0
     if action == "resolve":
         try:
+            actual_provider = getattr(
+                args, "actual_implementation_provider", None
+            )
+            if actual_provider:
+                if args.agent != "impl-validator":
+                    raise ValueError(
+                        "--actual-implementation-provider is only valid for "
+                        "impl-validator"
+                    )
+                route = agent_routing.review_route_for_actual_provider(
+                    actual_provider
+                )
+                if getattr(args, "explain", False):
+                    print(json.dumps(route, ensure_ascii=False, sort_keys=True))
+                else:
+                    print(route["review_provider"])
+                return 0
             provider = agent_routing.resolve_provider(
                 args.agent,
                 implementation_provider=getattr(args, "implementation_provider", None),
@@ -1153,10 +1170,21 @@ def _build_arg_parser() -> Any:
         help="impl-validator 기본값을 계산할 때 구현 provider camp 를 반영",
     )
     rt_resolve.add_argument(
+        "--actual-implementation-provider",
+        choices=("codex-headless", "claude-headless", "claude-main"),
+        default=None,
+        help="실제 구현 완료 receipt provider로 반대 진영 impl-validator를 계산",
+    )
+    rt_resolve.add_argument(
         "--main-provider",
         choices=("claude", "codex"),
         default="claude",
         help="implementation provider 가 없을 때 main 구현 provider camp",
+    )
+    rt_resolve.add_argument(
+        "--explain",
+        action="store_true",
+        help="actual implementation provider review route를 JSON provenance로 출력",
     )
     rt_resolve.set_defaults(func=_cli_routing)
 

--- a/scripts/dcness-implementation-chain
+++ b/scripts/dcness-implementation-chain
@@ -11,7 +11,7 @@ set -uo pipefail
 usage() {
   cat <<'USAGE'
 Usage:
-  dcness-implementation-chain <agent> [MODE] --prompt-file <file> [--provider <provider>] [--provider-provenance <routing|explicit>] [--chain-state <file>] [--init-path <impl-path>]... [--project-root <dir>]
+  dcness-implementation-chain <agent> [MODE] --prompt-file <file> [--provider <provider>] [--provider-provenance <routing|explicit>] [--chain-state <file>] [--init-path <impl-path>]... [--direct-run] [--design-doc <path>] [--rework --resume-provider <actual-provider>] [--project-root <dir>]
 
 Agents:
   build-worker
@@ -28,6 +28,11 @@ Options:
   --chain-state       Story-runner state. Enables lifecycle setup and chain cache.
   --init-path         Impl task path used to initialize a missing chain state.
                       Repeat for a multi-task chain. Existing matching state is reused.
+  --direct-run        Create/reuse one lite /impl run without story state.
+                      Requires an isolated feature worktree.
+  --design-doc        Optional merged design document for --direct-run.
+  --rework            Open a new build-worker step for validator finding repair.
+  --resume-provider   Reuse the exact terminal implementation provider for rework.
   --issue-num         Target GitHub issue number recorded on an auto-created run.
   --acceptance-required  Enable acceptance on the final chain task only.
                          Requires --chain-state.
@@ -85,6 +90,10 @@ PROVIDER_ARG_SEEN=0
 PROVIDER_PROVENANCE=""
 CHAIN_STATE=""
 INIT_PATHS=()
+DIRECT_RUN=0
+DIRECT_DESIGN_DOC=""
+REWORK=0
+RESUME_PROVIDER=""
 ISSUE_NUM=""
 ACCEPTANCE_REQUIRED=0
 RECOVERY_LIMIT="${DCNESS_IMPLEMENTATION_RECOVERY_LIMIT:-2}"
@@ -124,6 +133,22 @@ while [ $# -gt 0 ]; do
       ;;
     --init-path)
       INIT_PATHS+=("${2:-}")
+      shift 2
+      ;;
+    --direct-run)
+      DIRECT_RUN=1
+      shift
+      ;;
+    --design-doc)
+      DIRECT_DESIGN_DOC="${2:-}"
+      shift 2
+      ;;
+    --rework)
+      REWORK=1
+      shift
+      ;;
+    --resume-provider)
+      RESUME_PROVIDER="${2:-}"
       shift 2
       ;;
     --issue-num)
@@ -180,6 +205,37 @@ if [ "${#INIT_PATHS[@]}" -gt 0 ] && [ -z "$CHAIN_STATE" ]; then
   echo "[dcness-implementation-chain] --init-path requires --chain-state" >&2
   exit 2
 fi
+if [ "$DIRECT_RUN" -eq 1 ] && [ -n "$CHAIN_STATE" ]; then
+  echo "[dcness-implementation-chain] --direct-run and --chain-state are mutually exclusive" >&2
+  exit 2
+fi
+if [ -n "$DIRECT_DESIGN_DOC" ] && [ "$DIRECT_RUN" -ne 1 ]; then
+  echo "[dcness-implementation-chain] --design-doc requires --direct-run" >&2
+  exit 2
+fi
+if [ "$REWORK" -eq 1 ] && [ "$DIRECT_RUN" -ne 1 ]; then
+  echo "[dcness-implementation-chain] --rework requires --direct-run" >&2
+  exit 2
+fi
+if [ "$REWORK" -eq 1 ] && [ -z "$RESUME_PROVIDER" ]; then
+  echo "[dcness-implementation-chain] --rework requires --resume-provider" >&2
+  exit 2
+fi
+if [ -n "$RESUME_PROVIDER" ] && [ "$REWORK" -ne 1 ]; then
+  echo "[dcness-implementation-chain] --resume-provider requires --rework" >&2
+  exit 2
+fi
+case "$RESUME_PROVIDER" in
+  ""|codex-headless|claude-headless|claude-main) ;;
+  *)
+    echo "[dcness-implementation-chain] unsupported --resume-provider: $RESUME_PROVIDER" >&2
+    exit 2
+    ;;
+esac
+if [ -n "$RESUME_PROVIDER" ] && [ "$PROVIDER_ARG_SEEN" -eq 1 ]; then
+  echo "[dcness-implementation-chain] --resume-provider and --provider are mutually exclusive" >&2
+  exit 2
+fi
 if [ "$ACCEPTANCE_REQUIRED" -eq 1 ] && [ -z "$CHAIN_STATE" ]; then
   echo "[dcness-implementation-chain] --acceptance-required requires --chain-state" >&2
   exit 2
@@ -189,7 +245,9 @@ if [ -n "$ISSUE_NUM" ] && [[ ! "$ISSUE_NUM" =~ ^[1-9][0-9]*$ ]]; then
   exit 2
 fi
 
-if [ -z "$PROVIDER_PROVENANCE" ]; then
+if [ -n "$RESUME_PROVIDER" ]; then
+  PROVIDER_PROVENANCE="explicit"
+elif [ -z "$PROVIDER_PROVENANCE" ]; then
   if [ "$PROVIDER_ARG_SEEN" -eq 1 ]; then
     PROVIDER_PROVENANCE="explicit"
   else
@@ -223,40 +281,44 @@ esac
 
 cd "$PROJECT_ROOT"
 
-prepare_chain_state() {
+verify_isolated_project_root() {
   local git_root=""
   local current_branch=""
   local default_branch=""
-  local plan_rc=0
-  local setup_required=""
-
-  [ -n "$CHAIN_STATE" ] || return 0
 
   git_root="$(git -C "$PROJECT_ROOT" rev-parse --show-toplevel 2>/dev/null || true)"
   if [ -z "$git_root" ] || [ "$(cd "$git_root" && pwd -P)" != "$PROJECT_ROOT" ]; then
     echo "[dcness-implementation-chain] project root is not a git worktree root: $PROJECT_ROOT" >&2
     return 2
   fi
+  if [ "$(pwd -P)" != "$PROJECT_ROOT" ]; then
+    echo "[dcness-implementation-chain] initial launch must run from its project/worktree root: $PROJECT_ROOT" >&2
+    return 2
+  fi
+  current_branch="$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)"
+  default_branch="$(
+    git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
+      | sed 's#^[^/]*/##' || true
+  )"
+  if [ -z "$default_branch" ]; then
+    case "$current_branch" in
+      main|master) default_branch="$current_branch" ;;
+    esac
+  fi
+  if [ -n "$default_branch" ] && [ "$current_branch" = "$default_branch" ]; then
+    echo "[dcness-implementation-chain] refusing default branch initial launch: $current_branch; enter an isolated feature worktree first." >&2
+    return 2
+  fi
+}
+
+prepare_chain_state() {
+  local plan_rc=0
+  local setup_required=""
+
+  [ -n "$CHAIN_STATE" ] || return 0
 
   if [ "${#INIT_PATHS[@]}" -gt 0 ]; then
-    if [ "$(pwd -P)" != "$PROJECT_ROOT" ]; then
-      echo "[dcness-implementation-chain] initial launch must run from its project/worktree root: $PROJECT_ROOT" >&2
-      return 2
-    fi
-    current_branch="$(git -C "$PROJECT_ROOT" branch --show-current 2>/dev/null || true)"
-    default_branch="$(
-      git -C "$PROJECT_ROOT" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
-        | sed 's#^[^/]*/##' || true
-    )"
-    if [ -z "$default_branch" ]; then
-      case "$current_branch" in
-        main|master) default_branch="$current_branch" ;;
-      esac
-    fi
-    if [ -n "$default_branch" ] && [ "$current_branch" = "$default_branch" ]; then
-      echo "[dcness-implementation-chain] refusing default branch initial launch: $current_branch; enter an isolated feature worktree first." >&2
-      return 2
-    fi
+    verify_isolated_project_root || return $?
 
     PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
       python3 - "$PROJECT_ROOT" "$CHAIN_STATE" "${INIT_PATHS[@]}" <<'PY'
@@ -462,10 +524,74 @@ PY
   export DCNESS_RUN_ID="$rid"
 }
 
+ensure_direct_run() {
+  local sid=""
+  local rid=""
+  local run_action=""
+  local begin_args=()
+
+  [ "$DIRECT_RUN" -eq 1 ] || return 0
+  verify_isolated_project_root || return $?
+  sid="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 -c 'from harness.session_state import auto_detect_session_id; print(auto_detect_session_id())'
+  )"
+  if [ -z "$sid" ]; then
+    echo "[dcness-implementation-chain] --direct-run could not resolve session id" >&2
+    return 2
+  fi
+  rid="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 -c 'from harness.session_state import auto_detect_run_id; print(auto_detect_run_id())'
+  )"
+  run_action="$(
+    PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+      python3 - "$sid" "$rid" "$PROJECT_ROOT" "$DIRECT_DESIGN_DOC" <<'PY'
+import sys
+from pathlib import Path
+
+from harness.session_state import read_live
+
+sid, rid, root_text, design_text = sys.argv[1:5]
+if not rid:
+    print("new")
+    raise SystemExit(0)
+slot = (read_live(sid) or {}).get("active_runs", {}).get(rid)
+if not isinstance(slot, dict) or slot.get("entry_point") != "impl":
+    print("new")
+    raise SystemExit(0)
+if design_text:
+    expected = (Path(root_text).resolve() / design_text).resolve()
+    actual_text = str(slot.get("design_doc") or "")
+    actual = Path(actual_text).resolve() if actual_text else None
+    print("reuse" if actual == expected else "new")
+else:
+    print("reuse" if slot.get("lane") == "lite" else "new")
+PY
+  )" || return $?
+  if [ "$run_action" = "new" ]; then
+    begin_args=(begin-run impl)
+    if [ -n "$DIRECT_DESIGN_DOC" ]; then
+      begin_args+=(--design-doc "$DIRECT_DESIGN_DOC")
+    else
+      begin_args+=(--lane lite)
+    fi
+    if [ -n "$ISSUE_NUM" ]; then
+      begin_args+=(--issue-num "$ISSUE_NUM")
+    fi
+    rid="$("$HELPER" "${begin_args[@]}")" || return $?
+  elif [ "$run_action" != "reuse" ]; then
+    echo "[dcness-implementation-chain] invalid direct run preparation action: $run_action" >&2
+    return 1
+  fi
+  export DCNESS_SESSION_ID="$sid"
+  export DCNESS_RUN_ID="$rid"
+}
+
 ensure_chain_step() {
   local state=""
 
-  [ -n "$CHAIN_STATE" ] || return 0
+  [ -n "$CHAIN_STATE" ] || [ "$DIRECT_RUN" -eq 1 ] || return 0
   [ -n "$RESOLVED_SID" ] && [ -n "$RESOLVED_RID" ] || return 0
   state="$(
     PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
@@ -525,7 +651,15 @@ PY
       return $?
       ;;
     completed)
-      echo "[dcness-implementation-chain] ALREADY_COMPLETED: current run already has a terminal build-worker receipt; mark the story task before launching the next task." >&2
+      if [ "$REWORK" -eq 1 ]; then
+        if [ -n "$MODE" ]; then
+          "$HELPER" begin-step "$AGENT" "$MODE" >/dev/null
+        else
+          "$HELPER" begin-step "$AGENT" >/dev/null
+        fi
+        return $?
+      fi
+      echo "[dcness-implementation-chain] ALREADY_COMPLETED: current run already has a terminal build-worker receipt; use --rework with the actual provider for finding repair, or advance the story task." >&2
       return 10
       ;;
     conflict:*)
@@ -542,6 +676,7 @@ PY
 prepare_chain_state || exit $?
 CURRENT_CHAIN_TASK="$(current_chain_task_path)" || exit $?
 ensure_chain_run || exit $?
+ensure_direct_run || exit $?
 dcness_resolve_headless_context "dcness-implementation-chain" "$PROJECT_ROOT" "$SCRIPT_DIR"
 ensure_chain_step
 STEP_RC=$?
@@ -629,8 +764,13 @@ provider_cache_clear() {
       --provider "$stage" >/dev/null 2>&1 || true
 }
 
-ROUTING_INFO="$(
-  PYTHONPATH="$SCRIPT_DIR/.." python3 - "$AGENT" "$PROVIDER" <<'PY'
+STAGES=()
+if [ -n "$RESUME_PROVIDER" ]; then
+  PROVIDER="resume:$RESUME_PROVIDER"
+  STAGES=("$RESUME_PROVIDER")
+else
+  ROUTING_INFO="$(
+    PYTHONPATH="$SCRIPT_DIR/.." python3 - "$AGENT" "$PROVIDER" <<'PY'
 import sys
 
 from harness.agent_routing import (
@@ -661,21 +801,21 @@ print(provider)
 for stage in implementation_provider_chain(provider):
     print(stage)
 PY
-)"
-ROUTING_RC=$?
-if [ "$ROUTING_RC" -ne 0 ]; then
-  exit "$ROUTING_RC"
-fi
+  )"
+  ROUTING_RC=$?
+  if [ "$ROUTING_RC" -ne 0 ]; then
+    exit "$ROUTING_RC"
+  fi
 
-PROVIDER="$(printf '%s\n' "$ROUTING_INFO" | sed -n '1p')"
-STAGES_RAW="$(printf '%s\n' "$ROUTING_INFO" | sed '1d')"
-STAGES=()
-while IFS= read -r STAGE_LINE; do
-  [ -n "$STAGE_LINE" ] || continue
-  STAGES+=("$STAGE_LINE")
-done <<EOF
+  PROVIDER="$(printf '%s\n' "$ROUTING_INFO" | sed -n '1p')"
+  STAGES_RAW="$(printf '%s\n' "$ROUTING_INFO" | sed '1d')"
+  while IFS= read -r STAGE_LINE; do
+    [ -n "$STAGE_LINE" ] || continue
+    STAGES+=("$STAGE_LINE")
+  done <<EOF
 $STAGES_RAW
 EOF
+fi
 
 if [ "${#STAGES[@]}" -eq 0 ]; then
   echo "[dcness-implementation-chain] provider resolved to empty chain: $PROVIDER" >&2
@@ -757,6 +897,7 @@ run_headless_stage() {
   local attempt=0
   local prompt_path="$PROMPT_FILE"
   local recovery_prompt=""
+  local phase_evidence_required=0
   local cmd=()
 
   case "$stage" in
@@ -774,6 +915,9 @@ run_headless_stage() {
 
   stage_initial_status="$(git_status_without_harness_state)"
   stage_initial_head="$(git -C "$PROJECT_ROOT" rev-parse --verify HEAD 2>/dev/null || true)"
+  if [ -n "$CHAIN_STATE" ] || [ "$DIRECT_RUN" -eq 1 ]; then
+    phase_evidence_required=1
+  fi
 
   while true; do
     log="$RAW_LOG_DIR/chain-${stage}-${AGENT}${MODE:+-$MODE}-attempt-$((attempt + 1))-$$.log"
@@ -796,7 +940,7 @@ run_headless_stage() {
 
     DCNESS_MUTATION_BASE_HEAD="$stage_initial_head" \
       DCNESS_RECOVERY_OWNER=implementation-chain \
-      DCNESS_PHASE_EVIDENCE_REQUIRED="$([ -n "$CHAIN_STATE" ] && printf 1 || printf 0)" \
+      DCNESS_PHASE_EVIDENCE_REQUIRED="$phase_evidence_required" \
       DCNESS_PROVIDER_FAILURE_FILE="$failure_file" \
       "${cmd[@]}" >> "$log" 2>&1
     rc=$?
@@ -896,6 +1040,26 @@ print(failure.get("permission_receipt", ""))
   done
 }
 
+emit_completion_route() {
+  local actual_provider="$1"
+  PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
+    python3 - "$actual_provider" <<'PY'
+import sys
+
+from harness.agent_routing import review_route_for_actual_provider
+
+route = review_route_for_actual_provider(sys.argv[1])
+fallback = route["fallback_reason"] or "none"
+print(
+    "[dcness-implementation-chain] IMPLEMENTATION_COMPLETED "
+    f"provider={route['actual_implementation_provider']} "
+    f"review_provider={route['review_provider']} "
+    f"fallback={fallback}",
+    file=sys.stderr,
+)
+PY
+}
+
 for STAGE in "${STAGES[@]}"; do
   case "$STAGE" in
     codex-headless|claude-headless)
@@ -914,6 +1078,7 @@ for STAGE in "${STAGES[@]}"; do
       run_headless_stage "$STAGE"
       STAGE_RC=$?
       if [ "$STAGE_RC" -eq 0 ]; then
+        emit_completion_route "$STAGE"
         exit 0
       fi
       ;;

--- a/scripts/dcness-implementation-chain
+++ b/scripts/dcness-implementation-chain
@@ -28,7 +28,7 @@ Options:
   --chain-state       Story-runner state. Enables lifecycle setup and chain cache.
   --init-path         Impl task path used to initialize a missing chain state.
                       Repeat for a multi-task chain. Existing matching state is reused.
-  --direct-run        Create/reuse one lite /impl run without story state.
+  --direct-run        Create/reuse one lite or design-doc /impl run without story state.
                       Requires an isolated feature worktree.
   --design-doc        Optional merged design document for --direct-run.
   --rework            Open a new build-worker step for validator finding repair.
@@ -546,19 +546,23 @@ ensure_direct_run() {
   )"
   run_action="$(
     PYTHONPATH="$SCRIPT_DIR/..${PYTHONPATH:+:$PYTHONPATH}" \
-      python3 - "$sid" "$rid" "$PROJECT_ROOT" "$DIRECT_DESIGN_DOC" <<'PY'
+      python3 - "$sid" "$rid" "$PROJECT_ROOT" "$DIRECT_DESIGN_DOC" "$REWORK" <<'PY'
 import sys
 from pathlib import Path
 
 from harness.session_state import read_live
 
-sid, rid, root_text, design_text = sys.argv[1:5]
+sid, rid, root_text, design_text, rework_text = sys.argv[1:6]
+rework = rework_text == "1"
 if not rid:
-    print("new")
+    print("missing" if rework else "new")
     raise SystemExit(0)
 slot = (read_live(sid) or {}).get("active_runs", {}).get(rid)
 if not isinstance(slot, dict) or slot.get("entry_point") != "impl":
-    print("new")
+    print("missing" if rework else "new")
+    raise SystemExit(0)
+if rework:
+    print("reuse")
     raise SystemExit(0)
 if design_text:
     expected = (Path(root_text).resolve() / design_text).resolve()
@@ -580,6 +584,9 @@ PY
       begin_args+=(--issue-num "$ISSUE_NUM")
     fi
     rid="$("$HELPER" "${begin_args[@]}")" || return $?
+  elif [ "$run_action" = "missing" ]; then
+    echo "[dcness-implementation-chain] --rework requires an active direct /impl run to resume" >&2
+    return 2
   elif [ "$run_action" != "reuse" ]; then
     echo "[dcness-implementation-chain] invalid direct run preparation action: $run_action" >&2
     return 1

--- a/skills/impl-loop/impl-loop-finish.md
+++ b/skills/impl-loop/impl-loop-finish.md
@@ -51,7 +51,7 @@ Epic당 최종 clean candidate 1회만 affected dependency cone을 `impl-validat
 
 ### 격리 review
 
-구현 provider의 반대 진영을 기본 review provider로 resolve한다. validator는 read-only다. MUST FIX가 있으면 최대 3회 root-cause 수정하고 관련 gate를 재실행한다. build-worker rework가 코드나 harness를 바꾸면 필요한 earlier evidence부터 다시 수집한다.
+설정된 chain이 아니라 terminal receipt의 실제 구현 성공 provider의 반대 진영을 기본 review provider로 resolve한다. Codex 구현이면 Claude review, Claude 구현이면 Codex review다. Codex reviewer가 불가하면 Claude로 폴백하고 이유를 기록한다. validator는 read-only다. MUST FIX가 있으면 실제 구현 provider와 동일한 build-worker가 최대 3회 root-cause 수정하고 관련 gate를 재실행한다. build-worker rework가 코드나 harness를 바꾸면 필요한 earlier evidence부터 다시 수집한다.
 
 `impl-validator review 출력은 merge candidate 경계에서 1회`가 기본이다. 모든 task마다 full review를 반복하지 않는다.
 

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -1,17 +1,27 @@
 ---
 name: impl
-description: 구현 요청을 받아 메인이 즉시 격리·focused read·RED/첫 edit로 진행하고, GREEN 뒤 격리 impl-validator와 PR 마감을 수행하는 기본 구현 진입점. 이슈번호/링크/파일/테스트처럼 concrete signal이 있으면 다시 설계하지 않고 구현한다. 제품 의미나 새 권한이 실제로 필요한 경우에만 묻는다. 일반 구현을 별도 worker로 넘기지 않는다.
+description: 구현 요청을 받아 이미 보이는 task shape로 구현 소유자를 한 번 정한 뒤 즉시 격리·RED/첫 edit로 진행하고, GREEN 뒤 반대 진영 impl-validator와 PR 마감을 수행하는 기본 구현 진입점. 단순 작업은 main-direct, 명확한 복잡 작업은 첫 source edit 전에 headless one-shot으로 시작한다. 제품 의미나 새 권한이 실제로 필요한 경우에만 묻는다.
 ---
 
-# Impl — main-direct action-first
+# Impl — action-first owner selection
 
-`/impl`의 기본 구현자는 메인이다. 별도 구현 sub-agent나 headless worker를 먼저 만들지 않는다. 격리되는 것은 GREEN 이후 review뿐이다.
+`/impl`은 구현 소유자를 첫 source edit 전에 한 번만 고른다. 단순 작업은 메인이 바로 구현하고, 명확한 복잡 작업은 격리 worktree에서 headless build-worker가 끝까지 구현한다. 중간 handoff, 즉 메인이 조금 구현한 뒤 worker로 넘기거나 review finding마다 구현 진영을 바꾸는 흐름을 금지한다.
 
 ```text
-target 확인 → 격리 → focused read → RED/첫 edit
+target 확인 → owner 1회 선택 → 격리 → RED/첫 edit
 ```
 
-후기 절차를 미리 정합하려고 멈추지 않는다. validator provider, Cartography freshness, target issue close audit, commit/PR/CI/merge 상세는 GREEN 뒤에만 [`impl-finish.md`](impl-finish.md)를 읽어 수행한다. direct/design-doc·위험 분기가 실제로 필요할 때만 [`impl-routing.md`](impl-routing.md)를 읽는다.
+owner 선택을 위한 별도 repo scan·SSOT read·질문은 하지 않는다. validator provider, Cartography freshness, target issue close audit, commit/PR/CI/merge 상세는 GREEN 뒤에만 [`impl-finish.md`](impl-finish.md)를 읽어 수행한다. 위험 분기가 실제로 필요할 때만 [`impl-routing.md`](impl-routing.md)를 읽는다.
+
+## 구현 소유자 선택
+
+요청·issue·handoff에 이미 드러난 신호만 사용한다.
+
+- **main-direct**: 한두 module의 국소 수정, exact source/test pointer가 있는 작업, docs/config, 기존 seam의 작은 버그
+- **headless one-shot**: 여러 module/계층을 함께 바꿈, 새 runtime seam·migration·DI/manifest 연동, 넓은 테스트·빌드와 반복 검증, 예상 source 범위가 큰 작업
+- **애매하면 main-direct**: 복잡도 판정을 위해 파일을 더 읽거나 사용자에게 선택을 묻지 않는다.
+
+선택 뒤에는 같은 구현 소유자가 GREEN과 review finding 수정을 모두 맡는다. headless가 workspace를 바꾼 뒤에는 다른 provider로 넘기지 않고 same-workspace recovery 또는 BLOCKED만 허용한다. 메인은 제품 결정, 진행 보고, 외부 issue/PR mutation을 계속 소유한다.
 
 ## 질문 경계
 
@@ -23,8 +33,6 @@ target 확인 → 격리 → focused read → RED/첫 edit
 - 일반 test/lint 실패와 같은 범위의 재시도
 
 한 번 질문하는 경우는 제품 의미가 실제 결과를 둘 이상으로 가르거나, repo 밖 접근·새 dependency/secret·보안·데이터 파괴·hard boundary 변경처럼 새 권한이 필요한 때뿐이다. merge 승인은 사용자가 소유한다. 확정된 handoff나 사용자 선택을 다시 열어 wiki/web 조사나 설계 선택지로 되돌리지 않는다.
-
-fresh executor는 기본값도 자동 복구값도 아니다. decision-heavy A/B 실측이 main-direct보다 시간과 정확성에서 우세하다고 증명되기 전에는 같은 메인이 계속 구현한다.
 
 ## 즉시 착수
 
@@ -42,15 +50,39 @@ fresh executor는 기본값도 자동 복구값도 아니다. decision-heavy A/B
 착수: <target> 확인 · worktree 준비 · RED/첫 edit 진행
 ```
 
-### 2. 격리와 run 시작
+### 2. 격리와 실행
 
 - 사용자가 “워크트리 없이”라고 하지 않았으면 즉시 `EnterWorktree`를 사용한다.
 - worktree 진입 뒤 모든 read/edit/test 경로를 새 cwd 기준으로 다시 잡는다.
-- 그 worktree에서 `dcness-helper begin-run impl --lane lite` 또는 design-doc 입력이면 `begin-run impl --design-doc <path>`를 한 번 실행한다.
+- main-direct면 그 worktree에서 `dcness-helper begin-run impl --lane lite` 또는 design-doc 입력이면 `begin-run impl --design-doc <path>`를 한 번 실행한다.
 - 브랜치·커밋 네이밍은 commit 경계의 기존 hook을 우선한다. RED 전에 naming SSOT를 읽지 않는다.
+
+headless one-shot이면 worktree 진입 직후 target, 보존할 결정, AC snapshot, exact pointer 또는 허용 scope, 검증 명령만 담은 slim prompt를 만들고 기존 chain을 첫 실행으로 호출한다. provider resolve, `begin-run`, `begin-step`, prompt-slot 문서 확인을 따로 하지 않는다.
+
+```bash
+PLUGIN_ROOT=""
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ] && [ -d "$CLAUDE_PLUGIN_ROOT/scripts" ]; then
+  PLUGIN_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+  PLUGIN_ROOT="$(ls -d "$HOME/.claude/plugins/cache/dcness/dcness/"* 2>/dev/null | sort -V | tail -1)"
+fi
+[ -n "$PLUGIN_ROOT" ] || { echo "[dcness] plugin root not found" >&2; exit 1; }
+HELPER="$PLUGIN_ROOT/scripts/dcness-helper"
+PROJECT_ROOT="$(git rev-parse --show-toplevel)"
+"$PLUGIN_ROOT/scripts/dcness-implementation-chain" build-worker \
+  --direct-run \
+  --issue-num <issue-number> \
+  --prompt-file <slim-prompt> \
+  --project-root "$PROJECT_ROOT"
+```
+
+design-doc 입력이면 `--design-doc <path>`만 추가한다. 대화형 호스트에서는 이 one-shot을 background tool 실행으로 시작하고 메인이 `ps`, `tail`, 수동 polling loop를 만들지 않는다. chain이 run/step lifecycle, provider chain, phase evidence, same-workspace recovery를 소유한다.
+
+종료 receipt의 `provider=<actual>`이 실제 구현 소유자다. `exit 75` 전에는 workspace mutation이 없으므로 메인이 `claude-main` 소유자로 구현할 수 있다. 그 밖의 실패는 [`impl-routing.md`](impl-routing.md)에서 처리한다.
 
 ### 3. focused read
 
+- 이 절은 main-direct에 적용한다. headless는 slim prompt 뒤 worker가 같은 규율로 읽고 구현한다.
 - issue/handoff가 지정한 pointer와 test seam만 읽는다.
 - 파일을 통째로 읽기 전에 `rg`로 symbol과 기존 테스트를 찾는다.
 - 구현에 필요한 signature·인접 코드까지만 확장한다.
@@ -65,7 +97,7 @@ fresh executor는 기본값도 자동 복구값도 아니다. decision-heavy A/B
 
 - 테스트 가능한 변경은 실패 테스트를 먼저 작성하고 실제 RED를 확인한다.
 - docs-only·단순 설정처럼 테스트할 수 없으면 skip 사유를 한 줄 남긴다.
-- 메인이 직접 구현한다. 구현 중 routine 선택을 질문으로 올리지 않는다.
+- 선택한 소유자가 직접 구현한다. 구현 중 routine 선택을 질문으로 올리지 않는다.
 - 관련 lint/build/test/typecheck/compile을 실제 실행한다.
 - 첫 edit 뒤 `진행: RED/첫 edit 확인`, green 뒤 `진행: 구현·검증 green · review 시작`만 알린다.
 
@@ -74,7 +106,7 @@ fresh executor는 기본값도 자동 복구값도 아니다. decision-heavy A/B
 관련 검증이 GREEN이 된 뒤에만 [`impl-finish.md`](impl-finish.md)를 읽고 다음을 마친다.
 
 1. 동작·경계·Cartography impact 증거 수집
-2. 격리 `impl-validator`와 최대 3회 root-cause 수정
+2. 실제 구현자의 반대 진영 `impl-validator`와 같은 구현 소유자의 최대 3회 root-cause 수정
 3. 의미 단위 commit, PR, CI
 4. target GitHub issue AC close audit와 최종 보고
 

--- a/skills/impl/impl-finish.md
+++ b/skills/impl/impl-finish.md
@@ -15,10 +15,10 @@
 1. 검토 대상이 commit이면 commit id와 변경 파일 목록을 전달한다. uncommitted diff일 때만 diff 파일을 사용한다.
 2. [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md)를 이 호출 직전에 읽는다.
 3. prompt에는 target/읽을 진본, review 대상, Cartography impact, affected Root 좌표, 관련 epic/decision, 진본에 없는 현재 finding만 넣는다. 구현 방법을 처방하거나 과거 대화 전체를 넣지 않는다.
-4. review provider는 [`impl-routing.md`](impl-routing.md)의 현행 규칙으로 한 번 resolve한다. Codex면 `dcness-codex-validator impl-validator`, 그 밖에는 mode 없는 foreground `impl-validator`를 사용한다.
-5. validator는 read-only다. 수정은 메인이 한다.
+4. terminal receipt의 실제 구현 provider로 `dcness-helper routing resolve impl-validator --actual-implementation-provider <provider> --explain`을 한 번 호출한다. Codex면 `dcness-codex-validator impl-validator`, 그 밖에는 mode 없는 foreground `impl-validator`를 사용한다.
+5. validator는 read-only다. 수정은 최초에 선택한 구현 owner가 한다. headless owner라면 새 slim rework prompt로 implementation chain에 `--direct-run --rework --resume-provider <actual-provider>`를 주어 동일 provider·동일 workspace에서 고친다.
 
-MUST FIX가 있으면 최대 3회 root-cause 수정 루프를 돈다. 같은 계열 결함과 삭제된 로직의 잔여 호출·문서·테스트도 함께 찾고, 매 round마다 관련 gate를 다시 실행한 뒤 새 diff를 재검증한다. MUST FIX가 없으면 NICE TO HAVE를 merge blocker로 승격하지 않는다.
+MUST FIX가 있으면 최대 3회 root-cause 수정 루프를 돈다. 같은 계열 결함과 삭제된 로직의 잔여 호출·문서·테스트도 함께 찾고, 매 round마다 관련 gate를 다시 실행한 뒤 새 diff를 재검증한다. 구현 owner를 중간에 바꾸지 않는다. MUST FIX가 없으면 NICE TO HAVE를 merge blocker로 승격하지 않는다.
 
 ## Cartography freshness
 

--- a/skills/impl/impl-routing.md
+++ b/skills/impl/impl-routing.md
@@ -1,13 +1,13 @@
 # impl 분기 규칙 SSOT
 
 > **Status**: ACTIVE
-> **Scope**: `/impl` skill 전용. 자유 구현 요청을 direct / design-doc 으로 판정하고, high-risk 권고, review provider, retry 를 정한다. 진행 절차는 [`SKILL.md`](SKILL.md). 용어·공개 진입점·분기 표현을 수정하거나 리뷰할 때는 [`terms.md`](../../docs/plugin/terms.md) 를 확인한다.
+> **Scope**: `/impl` skill 전용. 자유 구현 요청을 direct / design-doc 으로 판정하고, 내부 구현 소유자, high-risk 권고, review provider, retry 를 정한다. 진행 절차는 [`SKILL.md`](SKILL.md). 용어·공개 진입점·분기 표현을 수정하거나 리뷰할 때는 [`terms.md`](../../docs/plugin/terms.md) 를 확인한다.
 
 ## 읽는 법
 
 분기 규칙은 권고다. hard safety gate 는 branch/PR/test/review/CI 와 순서 차단 훅이 보존한다. 사용자는 구현 경로 이름을 외우지 않고 `/impl <작업>`만 말하면 된다.
 
-일반 `/impl` 의 구현 주체는 항상 메인이다. 별도 구현 agent 는 일반 `/impl` 구현자로 호출하지 않는다. 격리되는 것은 review step 이며, `impl-validator` provider 만 local routing 으로 Claude sub-agent 또는 Codex headless wrapper 중 하나를 쓴다. deep task 파일을 headless story/epic runner 로 돌리는 흐름은 [`/impl-loop`](../impl-loop/SKILL.md) 의 영역이다.
+`/impl`의 공개 경로는 그대로 direct/design-doc 두 개다. 구현 엔진은 공개 축이 아니라 첫 source edit 전에 이미 보이는 task shape로 한 번 선택하는 내부 소유권이다. 단순·애매한 작업은 main-direct, 명확한 복잡 작업은 headless one-shot이다. 선택을 위해 추가 scan이나 질문을 하지 않으며 중간 handoff를 금지한다. deep task 파일 목록을 story/epic runner로 돌리는 흐름은 계속 [`/impl-loop`](../impl-loop/SKILL.md)의 영역이다.
 
 구현 후에는 메인의 자유 prose Cartography impact와 merge candidate diff, affected Root Cartography 좌표, 관련 epic/decision을 읽기 전용 `impl-validator`에 함께 전달한다. 이 freshness boundary는 direct와 design-doc 모두 동일하다.
 
@@ -35,15 +35,21 @@ flowchart TB
   HR -->|예| WARN["warn-don't-block: 설계 선행 권장"]
   HR -->|아니오| DOC
   WARN --> DOC{"설계 문서 경로가 입력됐나?"}
-  DOC -->|예| DD["design-doc: begin-run --design-doc<br/>메인 구현 + impl-validator"]
-  DOC -->|아니오| DR["direct: 메인 구현 + impl-validator"]
+  DOC -->|예| DD["design-doc"]
+  DOC -->|아니오| DR["direct"]
+  DD --> OWNER{"이미 명확한 복잡 신호?"}
+  DR --> OWNER
+  OWNER -->|예| HW["headless one-shot 구현"]
+  OWNER -->|아니오/애매| MD["main-direct 구현"]
+  HW --> RV["실제 구현자의 반대 진영 review"]
+  MD --> RV
 ```
 
 필요한 경우의 짧은 경로 echo:
 
 ```text
-구현 경로: direct — concrete signal = <파일/이슈/테스트>, 구현 = 메인 직접, review_provider = <claude|codex>
-구현 경로: design-doc — 설계도 = <경로>, 구현 = 메인 직접, review_provider = <claude|codex>
+구현 경로: direct — concrete signal = <파일/이슈/테스트>, owner = <main-direct|headless>
+구현 경로: design-doc — 설계도 = <경로>, owner = <main-direct|headless>
 권고: high-risk 신호 감지 — 설계 선행을 권장하지만 사용자가 진행하면 구현
 UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 지시하면 ux-flow 참고 후 구현
 ```
@@ -52,8 +58,8 @@ UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 �
 
 | 경로 | 다음 |
 |---|---|
-| direct · 메인 직접 | 격리 뒤 `begin-run impl`을 기록하고 concrete signal 또는 충분한 자연어 의도에서 관련 파일을 찾아 메인 직접 `test -> impl -> test pass` → `impl-validator` local diff |
-| design-doc · 메인 직접 | `begin-run impl --design-doc <경로>` 기록 후 받은 설계도로 메인 직접 `test -> impl -> test pass` → `impl-validator` local diff |
+| direct | main-direct면 격리 뒤 `begin-run impl`; 명확한 복잡 작업이면 격리 뒤 implementation chain `--direct-run` one-shot. 선택한 owner가 `test -> impl -> test pass` → `impl-validator` |
+| design-doc | main-direct면 `begin-run impl --design-doc`; 명확한 복잡 작업이면 chain `--direct-run --design-doc <경로>`. 선택한 owner가 설계도로 `test -> impl -> test pass` → `impl-validator` |
 
 일반 `/impl` 도 `impl-validator` 를 호출한다. direct 에 대상 issue 가 있으면 계획 파일이 없어도 spec 렌즈를 켜고 **target GitHub issue AC** 를 대조한다. design-doc 경로의 spec 기준은 plan ∪ target GitHub issue AC 이며, 대상 issue 가 없는 direct 만 quality 렌즈로 검토한다. 최소 gate 는 테스트 선작성 또는 skip 사유, lint/build/test green, 격리 `impl-validator`, 단위 commit/PR, CI, false-clean 방지다.
 
@@ -75,22 +81,21 @@ UI 기준: 신규 시각 구조 — 목업 선행 권장, 사용자가 생략 �
 
 ## Review Provider
 
-`impl-validator` 기본 provider 는 구현자의 상대 진영이다.
+`impl-validator` 기본 provider는 설정된 chain이 아니라 **terminal receipt의 실제 구현 성공 provider**의 상대 진영이다.
 
 | 구현자 | 기본 review provider |
 |---|---|
-| `/impl` 메인 Claude | Codex 가능 시 Codex, 불가 시 Claude |
-| `/impl-loop` codex-headless build-worker | Claude |
-| `/impl-loop` claude-headless build-worker | Codex 가능 시 Codex, 불가 시 Claude |
+| `codex-headless` | Claude |
+| `claude-headless` 또는 `claude-main` | Codex 가능 시 Codex, 불가 시 Claude |
 
-`routing.json` 명시 provider 는 계속 존중한다. Codex CLI 가 없거나 `dcness-codex-validator` wrapper 가 비정상 종료하면 Claude `impl-validator` 로 폴백하고 폴백 사실을 한 줄로 고지한다.
+성공한 provider가 Codex→Claude로 폴백했다면 review는 Codex다. local routing의 same-camp validator override로 이 교차 검토를 무력화하지 않는다. Codex CLI가 없거나 `dcness-codex-validator` wrapper가 비정상 종료하면 Claude `impl-validator`로 폴백하고 `fallback_reason`을 기록·고지한다.
 
 ## 결론 → 다음 호출
 
 | 단계 | 결론 → 다음 |
 |---|---|
-| direct `impl-validator` | `PASS` → commit/PR/CI · target issue 가 있으면 AC close audit · `FAIL`(`[spec-gap]` 또는 `[quality-gap]`) → 메인 root-cause 수정 + test 재통과 + impl-validator 재호출(≤3) |
-| design-doc `impl-validator` | `PASS` → commit/PR/CI · `FAIL`(`[spec-gap]` 포함) → 메인 로직 수정 · `FAIL`(`[quality-gap]`만) → 메인 polish 수정 · 이후 test 재통과 + impl-validator 재호출(≤3) |
+| direct `impl-validator` | `PASS` → commit/PR/CI · target issue가 있으면 AC close audit · `FAIL`(`[spec-gap]` 또는 `[quality-gap]`) → 같은 구현 owner가 root-cause 수정 + test 재통과 + impl-validator 재호출(≤3) |
+| design-doc `impl-validator` | `PASS` → commit/PR/CI · `FAIL`(`[spec-gap]` 포함) → 같은 구현 owner가 로직 수정 · `FAIL`(`[quality-gap]`만) → 같은 owner가 polish 수정 · 이후 test 재통과 + impl-validator 재호출(≤3) |
 
 Cartography freshness 결과는 위 PASS/FAIL 의미 안에서 다음처럼 결정적으로 연결한다.
 
@@ -106,8 +111,8 @@ Cartography freshness 결과는 위 PASS/FAIL 의미 안에서 다음처럼 결�
 
 | 경로 | 한도 | 초과 시 |
 |---|---|---|
-| direct impl-validator FAIL(`[quality-gap]`) → 메인 root-cause 수정 | 3 | 사용자에게 남은 finding 보고 |
-| design-doc impl-validator FAIL(`[spec-gap]` 또는 `[quality-gap]`) → 메인 root-cause 수정 | 3 | 사용자에게 남은 finding 보고 |
+| direct impl-validator FAIL(`[quality-gap]`) → 같은 owner root-cause 수정 | 3 | 사용자에게 남은 finding 보고 |
+| design-doc impl-validator FAIL(`[spec-gap]` 또는 `[quality-gap]`) → 같은 owner root-cause 수정 | 3 | 사용자에게 남은 finding 보고 |
 
 finding 수용 원칙은 `/impl-loop` 와 같다. 같은 영역 finding 이 반복되면 줄 단위 점 패치가 아니라 root cause 를 재검토한다.
 

--- a/tests/test_agent_routing.py
+++ b/tests/test_agent_routing.py
@@ -59,6 +59,39 @@ class AgentRoutingTests(unittest.TestCase):
             "codex",
         )
 
+    def test_actual_implementation_provider_controls_opposite_review_camp(self) -> None:
+        agent_routing.set_provider("impl-validator", "codex")
+        codex_route = agent_routing.review_route_for_actual_provider(
+            "codex-headless",
+            codex_available=True,
+        )
+        self.assertEqual(codex_route["implementation_camp"], "codex")
+        self.assertEqual(codex_route["preferred_review_provider"], "claude")
+        self.assertEqual(codex_route["review_provider"], "claude")
+        self.assertIsNone(codex_route["fallback_reason"])
+
+        agent_routing.set_provider("impl-validator", "claude")
+        claude_route = agent_routing.review_route_for_actual_provider(
+            "claude-headless",
+            codex_available=True,
+        )
+        self.assertEqual(claude_route["implementation_camp"], "claude")
+        self.assertEqual(claude_route["preferred_review_provider"], "codex")
+        self.assertEqual(claude_route["review_provider"], "codex")
+        self.assertIsNone(claude_route["fallback_reason"])
+
+    def test_opposite_review_route_records_codex_unavailable_fallback(self) -> None:
+        route = agent_routing.review_route_for_actual_provider(
+            "claude-main",
+            codex_available=False,
+        )
+        self.assertEqual(route["preferred_review_provider"], "codex")
+        self.assertEqual(route["review_provider"], "claude")
+        self.assertEqual(route["fallback_reason"], "codex-cli-unavailable")
+
+        with self.assertRaisesRegex(ValueError, "actual implementation provider"):
+            agent_routing.review_route_for_actual_provider("headless-chain")
+
     def test_enable_codex_validation_routes_only_validators(self) -> None:
         agent_routing.enable_codex_validation()
         for agent in agent_routing.ROUTABLE_VALIDATION_AGENTS:
@@ -206,6 +239,19 @@ class AgentRoutingCliTests(unittest.TestCase):
         self.assertEqual(ns.implementation_provider, "headless-chain")
 
         ns = parser.parse_args(
+            [
+                "routing",
+                "resolve",
+                "impl-validator",
+                "--actual-implementation-provider",
+                "codex-headless",
+                "--explain",
+            ]
+        )
+        self.assertEqual(ns.actual_implementation_provider, "codex-headless")
+        self.assertTrue(ns.explain)
+
+        ns = parser.parse_args(
             ["routing", "set-implementation", "build-worker", "claude-headless"]
         )
         self.assertEqual(ns.routing_cmd, "set-implementation")
@@ -264,6 +310,26 @@ class AgentRoutingCliTests(unittest.TestCase):
             )
         self.assertEqual(rc, 0)
         self.assertEqual(out.getvalue().strip(), "claude")
+
+    def test_cli_resolve_impl_validator_from_actual_provider_with_provenance(self) -> None:
+        agent_routing.set_provider("impl-validator", "codex")
+        out = StringIO()
+        with redirect_stdout(out):
+            rc = _cli_routing(
+                SimpleNamespace(
+                    routing_cmd="resolve",
+                    agent="impl-validator",
+                    implementation_provider=None,
+                    actual_implementation_provider="codex-headless",
+                    main_provider="claude",
+                    explain=True,
+                )
+            )
+        self.assertEqual(rc, 0)
+        payload = json.loads(out.getvalue())
+        self.assertEqual(payload["actual_implementation_provider"], "codex-headless")
+        self.assertEqual(payload["review_provider"], "claude")
+        self.assertIsNone(payload["fallback_reason"])
 
     def test_cli_implementation_modes_and_resolve(self) -> None:
 

--- a/tests/test_impl_direct_headless.py
+++ b/tests/test_impl_direct_headless.py
@@ -1,0 +1,398 @@
+"""Direct /impl one-shot headless ownership and lifecycle contracts."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHAIN = ROOT / "scripts" / "dcness-implementation-chain"
+
+
+def _git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body), encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+class DirectHeadlessImplTests(unittest.TestCase):
+    def _fixture(self, base: Path) -> tuple[Path, Path]:
+        primary = base / "primary"
+        worktree = base / "worktree"
+        primary.mkdir()
+        _git(primary, "init", "-q", "-b", "main")
+        _git(primary, "config", "user.name", "dcNess Test")
+        _git(primary, "config", "user.email", "dcness-test@example.invalid")
+        (primary / "README.md").write_text("fixture\n", encoding="utf-8")
+        _git(primary, "add", ".")
+        _git(primary, "commit", "-qm", "fixture")
+        _git(
+            primary,
+            "worktree",
+            "add",
+            "-q",
+            "-b",
+            "fix/issue1192_fixture",
+            str(worktree),
+            "main",
+        )
+        return primary, worktree
+
+    def _provider_bin(self, base: Path) -> Path:
+        bin_dir = base / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        _write_executable(
+            bin_dir / "claude",
+            """\
+            #!/bin/sh
+            count="$(cat "$PROVIDER_COUNT" 2>/dev/null || printf 0)"
+            count=$((count + 1))
+            printf '%s' "$count" > "$PROVIDER_COUNT"
+            cat > "$PROMPT_CAPTURE"
+            python3 - "$PROMPT_CAPTURE" <<'PY'
+            import pathlib
+            import re
+            import sys
+
+            prompt = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+            match = re.search(r"^canonical run directory: (.+)$", prompt, re.MULTILINE)
+            if not match:
+                raise SystemExit("canonical run directory missing")
+            run_dir = pathlib.Path(match.group(1))
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                (run_dir / phase).write_text(f"{phase} direct evidence\\n", encoding="utf-8")
+            PY
+            printf 'Direct worker completed.\\n\\nPASS\\n'
+            """,
+        )
+        _write_executable(
+            bin_dir / "codex",
+            """\
+            #!/bin/sh
+            if [ "${1:-}" = "--help" ]; then
+              printf 'codex fixture\\n'
+              exit 0
+            fi
+            if [ "${CODEX_EXIT_CODE:-0}" -ne 0 ]; then
+              exit "$CODEX_EXIT_CODE"
+            fi
+            output=""
+            previous=""
+            for argument in "$@"; do
+              if [ "$previous" = "--output-last-message" ]; then
+                output="$argument"
+                break
+              fi
+              previous="$argument"
+            done
+            [ -n "$output" ] || exit 2
+            count="$(cat "$PROVIDER_COUNT" 2>/dev/null || printf 0)"
+            count=$((count + 1))
+            printf '%s' "$count" > "$PROVIDER_COUNT"
+            cat > "$PROMPT_CAPTURE"
+            python3 - "$PROMPT_CAPTURE" "$output" <<'PY'
+            import pathlib
+            import re
+            import sys
+
+            prompt = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+            match = re.search(r"^canonical run directory: (.+)$", prompt, re.MULTILINE)
+            if not match:
+                raise SystemExit("canonical run directory missing")
+            run_dir = pathlib.Path(match.group(1))
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                (run_dir / phase).write_text(f"{phase} direct evidence\\n", encoding="utf-8")
+            pathlib.Path(sys.argv[2]).write_text(
+                "Direct Codex worker completed.\\n\\nPASS\\n",
+                encoding="utf-8",
+            )
+            PY
+            """,
+        )
+        return bin_dir
+
+    def _launch(
+        self,
+        *,
+        primary: Path,
+        project: Path,
+        base: Path,
+        provider: str | None = "claude-headless",
+        codex_exit_code: int = 0,
+        extra_args: tuple[str, ...] = (),
+    ) -> subprocess.CompletedProcess[str]:
+        prompt = base / "prompt.md"
+        prompt.write_text(
+            "\n".join(
+                [
+                    "target: issue #1192 fixture",
+                    "confirmed_choice: complex upfront-headless",
+                    "scope: README.md",
+                    "test: no product mutation in fixture",
+                    "ssot_pointer: README.md",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        bin_dir = self._provider_bin(base)
+        env = os.environ.copy()
+        env.update(
+            {
+                "DCNESS_FORCE_ENABLE": "1",
+                "DCNESS_SESSION_ID": "sid-direct-impl",
+                "CODEX_EXIT_CODE": str(codex_exit_code),
+                "PATH": f"{bin_dir}{os.pathsep}/usr/bin:/bin:/usr/sbin:/sbin",
+                "PROMPT_CAPTURE": str(base / "provider-prompt.md"),
+                "PROVIDER_COUNT": str(base / "provider-count.txt"),
+            }
+        )
+        command = [
+            str(CHAIN),
+            "build-worker",
+            "--direct-run",
+            "--prompt-file",
+            str(prompt),
+            "--issue-num",
+            "1192",
+            "--project-root",
+            str(project),
+            "--helper",
+            str(ROOT / "scripts" / "dcness-helper"),
+            *extra_args,
+        ]
+        if provider is not None:
+            command[3:3] = [
+                "--provider",
+                provider,
+                "--provider-provenance",
+                "explicit",
+            ]
+        result = subprocess.run(
+            command,
+            cwd=project,
+            capture_output=True,
+            env=env,
+            text=True,
+            timeout=30,
+        )
+        self.provider_count = base / "provider-count.txt"
+        self.prompt_capture = base / "provider-prompt.md"
+        return result
+
+    def test_direct_one_shot_creates_lite_run_and_opposite_review_receipt(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-direct-impl"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            events = [
+                json.loads(line)
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                [event["event"] for event in events],
+                ["run_started", "step_started", "step_completed"],
+            )
+            self.assertEqual(events[0]["lane"], "lite")
+            self.assertEqual(events[0]["issue_num"], 1192)
+            self.assertEqual(events[2]["provider"], "claude-headless")
+            self.assertIn(
+                "IMPLEMENTATION_COMPLETED provider=claude-headless "
+                "review_provider=codex fallback=none",
+                result.stderr,
+            )
+            prompt = self.prompt_capture.read_text(encoding="utf-8")
+            self.assertIn("target: issue #1192 fixture", prompt)
+            self.assertIn("canonical run directory:", prompt)
+            for phase in ("build-test.md", "build-impl.md", "build-validate.md"):
+                self.assertTrue((run_dirs[0] / phase).is_file())
+
+            repeated = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+            )
+            self.assertEqual(repeated.returncode, 0, repeated.stderr)
+            self.assertEqual(self.provider_count.read_text(encoding="utf-8"), "1")
+
+            unsafe_rework = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                extra_args=("--rework",),
+            )
+            self.assertEqual(unsafe_rework.returncode, 2)
+            self.assertIn(
+                "--rework requires --resume-provider",
+                unsafe_rework.stderr,
+            )
+            self.assertEqual(self.provider_count.read_text(encoding="utf-8"), "1")
+
+            rework = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                provider=None,
+                extra_args=(
+                    "--rework",
+                    "--resume-provider",
+                    "claude-headless",
+                ),
+            )
+            self.assertEqual(rework.returncode, 0, rework.stderr)
+            self.assertEqual(self.provider_count.read_text(encoding="utf-8"), "2")
+            rework_events = [
+                json.loads(line)
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                [event["event"] for event in rework_events],
+                [
+                    "run_started",
+                    "step_started",
+                    "step_completed",
+                    "step_started",
+                    "step_completed",
+                ],
+            )
+            self.assertEqual(rework_events[-1]["provider"], "claude-headless")
+
+    def test_direct_pre_mutation_failure_falls_back_and_reports_actual_provider(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                provider="headless-chain",
+                codex_exit_code=1,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(
+                "provider codex-headless failed before workspace mutation",
+                result.stderr,
+            )
+            self.assertIn(
+                "IMPLEMENTATION_COMPLETED provider=claude-headless "
+                "review_provider=codex fallback=none",
+                result.stderr,
+            )
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-direct-impl"
+                / "runs"
+            )
+            run_dir = next(run_root.glob("run-*"))
+            events = [
+                json.loads(line)
+                for line in (run_dir / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(events[-1]["provider"], "claude-headless")
+
+    def test_direct_codex_success_routes_review_to_claude(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                provider="headless-chain",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn(
+                "IMPLEMENTATION_COMPLETED provider=codex-headless "
+                "review_provider=claude fallback=none",
+                result.stderr,
+            )
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-direct-impl"
+                / "runs"
+            )
+            run_dir = next(run_root.glob("run-*"))
+            events = [
+                json.loads(line)
+                for line in (run_dir / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(events[-1]["provider"], "codex-headless")
+
+    def test_direct_initial_launch_refuses_default_branch(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, _ = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=primary,
+                base=base,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("enter an isolated feature worktree first", result.stderr)
+            self.assertFalse(
+                (
+                    primary
+                    / ".claude"
+                    / "harness-state"
+                    / ".sessions"
+                    / "sid-direct-impl"
+                ).exists()
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_impl_direct_headless.py
+++ b/tests/test_impl_direct_headless.py
@@ -39,6 +39,11 @@ class DirectHeadlessImplTests(unittest.TestCase):
         _git(primary, "config", "user.name", "dcNess Test")
         _git(primary, "config", "user.email", "dcness-test@example.invalid")
         (primary / "README.md").write_text("fixture\n", encoding="utf-8")
+        (primary / "docs" / "epics").mkdir(parents=True)
+        (primary / "docs" / "epics" / "issue-1192.md").write_text(
+            "# fixture design\n",
+            encoding="utf-8",
+        )
         _git(primary, "add", ".")
         _git(primary, "commit", "-qm", "fixture")
         _git(
@@ -292,6 +297,71 @@ class DirectHeadlessImplTests(unittest.TestCase):
                 ],
             )
             self.assertEqual(rework_events[-1]["provider"], "claude-headless")
+
+    def test_design_doc_rework_reuses_completed_run_without_repassing_doc(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            primary, worktree = self._fixture(base)
+
+            result = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                extra_args=("--design-doc", "docs/epics/issue-1192.md"),
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            run_root = (
+                primary
+                / ".claude"
+                / "harness-state"
+                / ".sessions"
+                / "sid-direct-impl"
+                / "runs"
+            )
+            run_dirs = list(run_root.glob("run-*"))
+            self.assertEqual(len(run_dirs), 1)
+            initial_events = [
+                json.loads(line)
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                Path(initial_events[0]["design_doc"]).resolve(),
+                (worktree / "docs" / "epics" / "issue-1192.md").resolve(),
+            )
+            self.assertNotIn("lane", initial_events[0])
+
+            rework = self._launch(
+                primary=primary,
+                project=worktree,
+                base=base,
+                provider=None,
+                extra_args=(
+                    "--rework",
+                    "--resume-provider",
+                    "claude-headless",
+                ),
+            )
+            self.assertEqual(rework.returncode, 0, rework.stderr)
+            self.assertEqual(len(list(run_root.glob("run-*"))), 1)
+            events = [
+                json.loads(line)
+                for line in (run_dirs[0] / "ledger.jsonl")
+                .read_text(encoding="utf-8")
+                .splitlines()
+            ]
+            self.assertEqual(
+                [event["event"] for event in events],
+                [
+                    "run_started",
+                    "step_started",
+                    "step_completed",
+                    "step_started",
+                    "step_completed",
+                ],
+            )
+            self.assertEqual(events[-1]["provider"], "claude-headless")
 
     def test_direct_pre_mutation_failure_falls_back_and_reports_actual_provider(
         self,

--- a/tests/test_impl_fast_start_contract.py
+++ b/tests/test_impl_fast_start_contract.py
@@ -21,6 +21,9 @@ class ImplFastStartContractTests(unittest.TestCase):
 
         self.assertIn("착수: <target>", skill)
         self.assertIn("RED", skill)
+        self.assertIn("첫 source edit 전에", skill)
+        self.assertIn("애매하면 main-direct", skill)
+        self.assertIn("--direct-run", skill)
         self.assertIn("첫 tool call은 pointer만", skill)
         self.assertIn("둘째 tool call 하나에서", skill)
         self.assertIn("다음 tool-bearing turn은 RED test 또는 첫 edit", skill)
@@ -33,7 +36,7 @@ class ImplFastStartContractTests(unittest.TestCase):
         finish = self.read("skills/impl/impl-finish.md")
 
         self.assertLess(len(skill.encode("utf-8")), 12_000)
-        self.assertIn("target 확인 → 격리 → focused read → RED/첫 edit", skill)
+        self.assertIn("target 확인 → owner 1회 선택 → 격리 → RED/첫 edit", skill)
         self.assertIn("GREEN 뒤에만", skill)
         self.assertNotIn("## Review Provider", skill)
         self.assertNotIn("### Cartography freshness boundary", skill)
@@ -159,6 +162,32 @@ class ImplFastStartContractTests(unittest.TestCase):
         )
         self.assertFalse(
             evidence["ab_decision"]["conditional_fresh_executor"]
+        )
+        complex_analysis = evidence["complex_impl_owner_analysis"]
+        self.assertEqual(complex_analysis["decision"], "shape-conditional")
+        self.assertTrue(
+            complex_analysis["owner_selection_before_first_source_edit"]
+        )
+        self.assertEqual(
+            complex_analysis["ambiguous_default"],
+            "main-direct",
+        )
+        self.assertFalse(complex_analysis["midstream_handoff"])
+        self.assertGreater(
+            complex_analysis["historical_complex_main_observation"][
+                "decision_to_first_source_edit_seconds"
+            ],
+            60,
+        )
+        direct_replays = complex_analysis["direct_chain_integration_replays"]
+        self.assertEqual(len(direct_replays), 3)
+        self.assertTrue(
+            all(
+                row["under_60_seconds"]
+                and row["provider_receipt"]
+                and row["elapsed_seconds"] < 60
+                for row in direct_replays
+            )
         )
 
     def test_headless_workers_receive_canonical_phase_and_tdd_contracts(self) -> None:

--- a/tests/test_skill_scenarios.py
+++ b/tests/test_skill_scenarios.py
@@ -59,24 +59,25 @@ class SkillScenarioRegressionTests(unittest.TestCase):
             encoding="utf-8"
         )
 
-    # ----- 시나리오 1 — /impl 메인 구현 + 격리 리뷰 -----
-    def test_impl_uses_main_implementation_and_isolated_review(self) -> None:
-        """/impl keeps implementation on main and isolates only impl-validator."""
+    # ----- 시나리오 1 — /impl 소유자 1회 선택 + 반대 진영 리뷰 -----
+    def test_impl_selects_one_owner_and_opposite_review(self) -> None:
+        """/impl selects one owner before mutation and crosses camps for review."""
         for needle in (
-            "`/impl`의 기본 구현자는 메인",
-            "별도 구현 sub-agent나 headless worker를 먼저 만들지 않는다",
-            "격리되는 것은 GREEN 이후 review",
+            "구현 소유자를 첫 source edit 전에 한 번만",
+            "애매하면 main-direct",
+            "headless one-shot",
+            "중간 handoff",
             "impl-validator",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.impl_contract)
 
         for needle in (
-            "일반 `/impl` 의 구현 주체는 항상 메인",
-            "격리되는 것은 review step",
-            "direct · 메인 직접",
-            "design-doc · 메인 직접",
-            "review provider",
+            "내부 소유권",
+            "단순·애매한 작업은 main-direct",
+            "중간 handoff를 금지",
+            "terminal receipt",
+            "실제 구현 성공 provider",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.impl_routing)
@@ -137,19 +138,19 @@ class SkillScenarioRegressionTests(unittest.TestCase):
         # impl 직접 구현 최소 gate 에도 false-clean 방지 명시.
         self.assertIn("clean으로 보고하지 않는다", self.impl_finish)
 
-    def test_impl_design_doc_main_path_keeps_pr_reviewer_gate(self) -> None:
-        """#851/#1019 — design-doc main-owned path keeps the impl-validator gate."""
+    def test_impl_design_doc_keeps_owner_and_reviewer_gate(self) -> None:
+        """#851/#1192 — design-doc keeps one implementation owner and review gate."""
         for needle in (
             "design-doc 입력",
-            "메인이 직접 구현",
-            "격리 `impl-validator`",
+            "선택한 소유자",
+            "반대 진영 `impl-validator`",
             "MUST FIX",
         ):
             with self.subTest(needle=needle):
                 self.assertIn(needle, self.impl_contract)
 
         self.assertIn(
-            "design-doc · 메인 직접",
+            "design-doc",
             (ROOT / "skills" / "impl" / "impl-routing.md").read_text(encoding="utf-8"),
         )
         for relpath in (
@@ -166,7 +167,7 @@ class SkillScenarioRegressionTests(unittest.TestCase):
         for needle in (
             "## 의미 단위 커밋 분할",
             "모든 구현 흐름",
-            "`/impl` 메인 직접 구현",
+            "`/impl` main-direct·headless 구현",
             "`/impl-loop` build-worker task local commit",
             "각 commit 은 hook 을 통과",
             "push, PR 생성, merge, issue mutation",

--- a/tests/test_surface_docs_sync.py
+++ b/tests/test_surface_docs_sync.py
@@ -426,19 +426,20 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertNotIn("Deep: /spec 내부 tech-review", self.router)
         self.assertIn("설계 선행을 권장하는 신호", self.positioning)
         self.assertIn("`/impl` direct", self.router)
-        self.assertIn("high-risk 신호는 권고로 표시하되 차단하지 않음", self.router)
+        self.assertIn("high-risk 신호는 설계 선행 권장 근거이지 자동 차단 근거가 아니다", self.router)
         self.assertIn(
             "concrete signal 이라 곧장 `/impl`",
             self.router,
         )
-        self.assertIn("일반 `/impl` 의 구현 주체는 메인", self.positioning)
-        self.assertIn("격리되는 단계는 `impl-validator`", self.positioning)
+        self.assertIn("첫 source edit 전에 headless owner", self.positioning)
+        self.assertIn("review는 실제 구현 성공 provider의 반대 진영", self.positioning)
 
     def test_internal_routing_docs_prefer_lifecycle_names(self) -> None:
         # #1032 — /impl no longer auto-routes high-risk work back to spec/design.
         self.assertIn("warn-don't-block", self.impl_routing)
         self.assertIn("권고 → 강제 자동 승격 금지", self.impl_routing)
-        self.assertIn("일반 `/impl` 의 구현 주체는 항상 메인", self.impl_routing)
+        self.assertIn("단순·애매한 작업은 main-direct", self.impl_routing)
+        self.assertIn("중간 handoff를 금지", self.impl_routing)
         self.assertNotIn("impl 밖 — 설계 선행", self.impl_routing)
         self.assertNotIn("없으면 `/spec` / `/tech-review` / `/design` 선행", self.impl_routing)
         self.assertIn(
@@ -806,15 +807,16 @@ class SurfaceDocsSyncTests(unittest.TestCase):
         self.assertIn("design-doc", self.impl_skill)
         self.assertIn("제품 의미", self.impl_skill)
 
-    def test_issue_1019_general_impl_does_not_expose_headless_engine_axis(self) -> None:
-        """#1019 — general /impl is main-owned; headless worker engines belong to /impl-loop."""
+    def test_issue_1192_impl_keeps_owner_axis_internal(self) -> None:
+        """#1192 — conditional owner selection stays internal to /impl."""
         for text in (self.impl_skill, self.impl_routing, self.positioning, self.readme):
             with self.subTest(source=text[:40]):
                 self.assertIn("메인", text)
                 self.assertNotIn("Standard · 경량 build-worker", text)
                 self.assertNotIn("구현 경로(설계도 유무)와 엔진", text)
-        self.assertIn("story/epic deep task runner", self.readme)
-        self.assertIn("일반 `/impl` 구현은 메인이 맡고", self.readme)
+        self.assertIn("story/epic deep task를 항상 headless worker", self.readme)
+        self.assertIn("명확한 복잡 작업이면 첫 source edit 전에 headless", self.readme)
+        self.assertIn("terminal receipt의 실제 구현 성공 provider", self.impl_routing)
 
     def test_issue_1019_impl_loop_uses_story_runner_boundaries(self) -> None:
         """#1019/#1023/#1041 — task state, story PRs, and one integrated review."""


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1192

## 배경 및 문제

- `/impl`이 작업 모양과 무관하게 메인 대화에서 긴 SSOT 탐색·셋업을 수행해 실제 첫 수정까지 수 분이 걸리는 사례가 있었습니다.
- 반대로 모든 작업을 headless로 넘기면 단순 수정의 시작 비용과 context 전달 비용이 더 커질 수 있어, 단순/복잡 작업을 같은 경로로 처리하는 방식으로는 속도와 효율을 함께 만족시키기 어려웠습니다.
- provider chain fallback 뒤에도 설정상의 최초 provider를 기준으로 reviewer를 고르면 실제 구현자와 같은 진영이 리뷰할 수 있었습니다.

## 원인 (해당 시)

- `/impl`에 “첫 source edit 전 한 번만 구현 소유자를 선택”하는 계약과 direct headless 실행 진입점이 없었습니다.
- 실제 완료 provider를 durable receipt로 남겨 reviewer route의 입력으로 쓰는 경로가 없었습니다.
- 반복 실행·rework를 메인이 수동으로 조립할 여지가 있어 preflight와 polling이 누적됐습니다.

## 작업내용

- 이미 보이는 task shape만으로 단순/애매한 작업은 main-direct, 명확히 복잡한 작업은 upfront headless one-shot으로 소유자를 한 번 선택하도록 `/impl` 계약을 정리했습니다.
- 기존 `dcness-implementation-chain`에 `--direct-run`, 선택적 `--design-doc`, 동일 실제 provider rework를 위한 `--rework --resume-provider`를 추가했습니다.
- 실제 terminal provider와 반대 진영 reviewer/fallback provenance를 계산하는 routing API·CLI와 completion receipt를 추가했습니다.
- direct run의 lite lifecycle, default branch 차단, phase evidence, idempotent 재호출, pre-mutation fallback, 동일-provider rework를 격리 fixture로 검증했습니다.
- Alrim/Nexus 실세션 지연과 simple/complex replay 측정값을 증거에 반영하고, 낡은 수동 polling eval 기대를 runner-owned background one-shot 계약으로 갱신했습니다.

## 결정 근거

- 단순 작업은 기존 A/B 3+3 재생에서 main-direct median 9.964초가 fresh headless 18.272초보다 빨라 유지했습니다.
- Nexus 복잡 작업은 결정 후 첫 source write까지 655.868초가 걸려, 복잡 작업만 처음부터 headless가 소유하도록 분리했습니다.
- midstream handoff는 context 재구성과 책임 불일치를 만들므로 금지하고, review finding도 실제 구현 provider가 계속 수정하도록 했습니다.
- 구현자가 Codex면 Claude, 구현자가 Claude면 Codex를 우선 reviewer로 선택하며 Codex 사용 불가 시에만 사유를 남기고 Claude로 fallback합니다.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1: `skills/impl/**`, `skills/impl-loop/**`와 기존 bundled runtime인 `scripts/dcness-implementation-chain`, `harness/**`가 plug-in 업데이트에 함께 포함됩니다.
- 경로 3: `docs/plugin/workflow-router.md`, `positioning.md`, `git-spec.md`, `loop-procedure.md`, build-worker 문서를 같은 계약으로 갱신했습니다.
- 새 복사 대상·별도 설치 스크립트·기존 프로젝트 재배포 단계는 추가하지 않았습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

- N/A — 새 public skill/command/agent/gate 없이 기존 `/impl`, `/impl-loop`, implementation chain, routing helper 내부 옵션으로 흡수했습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
  - `python3.11 -m unittest discover -s tests -v`: 1,187/1,187 PASS
  - direct/routing/docs/fast-start 회귀 95건 PASS
  - `node scripts/check_public_evidence.mjs`: tests 1,187/1,187, guard 50/50 PASS
- [x] 회귀 검증
  - Python 3.11 ruff/mypy/bandit PASS
  - `bash -n scripts/dcness-implementation-chain`, `git diff --check` PASS
  - `impl-fast-start-recovery` behavior eval 1/1 PASS

## 참고

- Codex가 구현했으므로 PR 생성 뒤 Claude `impl-validator`로 반대 진영 리뷰를 수행합니다.