### PR TITLE
[docs] release 0.29.0 — 마감 검증 fail-fast 순차화

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
   },
   "metadata": {
     "description": "dcNess — Claude Code와 Codex를 제품 개발 루프에 묶고 순서 게이트, 역할 경계, TDD guard, 검증 가능한 작업 기록을 제공하는 agent workflow harness. release 브랜치의 경량 runtime artifact 배포.",
-    "version": "0.28.0"
+    "version": "0.29.0"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dcness",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Claude Code와 Codex를 Git/PR/CI 흐름 안에서 순서 게이트·역할 경계·TDD guard·검증 가능한 작업 기록으로 묶는 agent workflow harness. (한국어 사용자 대상)",
   "author": {
     "name": "alruminum",

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.28.0","measured_at":"2026-07-24","unit_tests":{"passed":1187,"total":1187},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-24","unit_tests":{"passed":1210,"total":1210},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
-현재 공개 snapshot은 **v0.28.0, 2026-07-24 측정**이다. 숫자마다 분모와 source 수를
+현재 공개 snapshot은 **v0.29.0, 2026-07-24 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,187/1,187 PASS, 결정적 guard 50/50 PASS | test 1,187, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,210/1,210 PASS, 결정적 guard 50/50 PASS | test 1,210, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/docs/internal/release-notes.md
+++ b/docs/internal/release-notes.md
@@ -10,6 +10,30 @@ _(다음 릴리즈 대기 항목 없음)_
 
 ---
 
+## v0.29.0 (2026-07-24)
+
+**커밋 범위**: `v0.28.0..v0.29.0` (머지 PR 1개, [#1196](https://github.com/Daeguk-Sun/dcNess/pull/1196))
+**핵심 변경**: **`/impl`·`/impl-loop` 의 구현 마감(close) 검증 경로를, validator 와 product-acceptance 를 동시에 돌리는 병렬 대신 값싼 read-only holistic review 를 먼저 통과시킨 뒤에만 비싼 sealed acceptance 를 여는 fail-fast 순차 검증으로 단순화한** minor 릴리즈. 실측상 어느 복잡 마감은 task 5/5 이후 PR 준비까지 55분 41초(3,341초)가 걸렸고, route-only as-built 문서 정합을 architecture 재설계로 되돌린 module-architect 왕복과 task/commit 별 reviewer fan-out 이 큰 비중을 차지했다. 처음 검토한 validator/acceptance 병렬화는 최근 복잡 마감 2건의 validator 초회 PASS 가 0/2 였다는 관찰상 happy path 는 짧아도 validator finding 이 흔한 실제 구현에서 device/Journey 검수 전체가 폐기될 위험이 커, 사용자 피드백에 따라 fail-fast 순차 검증으로 수정했다.
+
+### 무엇이 바뀌나
+
+1. **`/impl`·`/impl-loop` 마감 검증 fail-fast 순차화 + Cartography 1회 bounded sync + tree drift 차단** ([#1196](https://github.com/Daeguk-Sun/dcNess/pull/1196) Closes [#1194](https://github.com/Daeguk-Sun/dcNess/issues/1194)) — 마감에서 route-only as-built 문서 정합이 architecture 재설계 역할까지 회귀하고, 최종 merge candidate 를 한 번 보는 대신 validator 가 task/commit 별 하위 검토를 기본 생성하며, product-acceptance 가 같은 tree 의 unit/lint/build 를 반복 실행하고, close receipt 에 candidate HEAD/tree 가 없어 검증 사이 tracked tree drift 를 기계적으로 차단할 수 없던 문제를 해소. `JOURNEY_CONVERGENCE` 뒤 final mutation owner 가 Cartography 를 1회 bounded sync/no-op 하고 candidate 를 freeze 하도록 `/impl` 과 `/impl-loop` 계약을 통일하고, module-architect 의 폐기된 `CARTOGRAPHY_REFRESH` mode 와 전용 fixture 를 제거했다. 반대 진영 impl-validator 를 final diff 1회 holistic review 로 바꾸고 Epic Sanity 렌즈를 같은 호출에 합쳤으며, validator terminal PASS 뒤에만 같은 HEAD/tree 의 product-acceptance 를 열도록 provider-independent order gate 와 close join 을 추가했다. product-acceptance 는 same-tree terminal unit/lint/build evidence 를 소비하고 sealed Journey 만 독립 재실행한다. Alrim baseline(3,341초)과 Nexus 실제 finding 을 고정한 회귀 fixture, 순차 close 상태 테스트, 3개 deterministic replay 를 추가했다. 보수적인 순차 counterfactual 3개에서 task-complete→PR-ready median 감소 추정치는 38.6%(목표 30% 초과)이나, 이는 실측이 아니라 deterministic replay 기반 추정임을 명시한다.
+
+### 자기개선 점검
+
+- Sense/Diagnose: 이번 릴리즈 diff 가 `/impl`·`/impl-loop` 마감 경로·impl-validator·product-acceptance·provider-independent order gate·`session_state`/hooks 의 close join 인접 영역을 건드려 결정적 guard-efficacy 를 재실행 — **50/50 PASS**(v0.28.0 50/50 유지), 회귀 없음. 전체 unittest 도 재실행해 공개 수치를 실측 동기화 — **1,210/1,210 PASS**(v0.28.0 1,187 → close 순차 검증 회귀 fixture·상태 테스트·replay 확장 반영). 머지 PR 은 개별 CI(pytest·static-quality·public-surface·cross-ref·index-map·doc-sync·plugin-manifest·pr-body)를 통과했다.
+- Decide: 소멸 후보 없음. follow-up 없음. (module-architect 의 `CARTOGRAPHY_REFRESH` mode 와 전용 fixture, validator 의 task/commit 별 하위 검토 fan-out 을 제거해 하네스를 오히려 감량했다.)
+- Verify: fail-fast 순차 close(validator final-diff holistic review → provider-independent order gate → same HEAD/tree product-acceptance)·Cartography 1회 bounded sync·candidate freeze 와 tracked tree drift 차단·순차 close 상태·deterministic replay 신규/회귀 테스트 통과. 공개 evidence snapshot(README·`docs/plugin/benchmark.md`)을 v0.29.0 / 2026-07-24 실측(unit 1,210/1,210 · guard 50/50)으로 갱신했고 `node scripts/check_public_evidence.mjs` 로 문서 marker 와 실측 대조를 검증한다.
+
+### 사용자 영향
+
+- **`claude plugin update dcness@dcness` 로 자동 반영** — `skills/impl/**`·`skills/impl-loop/**`·`skills/acceptance/**`·`harness/**`·`docs/plugin/**`(agents·loop-procedure·parallel-policy)·`codex/skills/dcness-impl-validator/**` 변경.
+- **`/impl`·`/impl-loop` 로 마감하는 프로젝트** — validator 가 task/commit 별로 나눠 보지 않고 final merge candidate diff 1회를 Epic Sanity 렌즈까지 합쳐 holistic 하게 리뷰한다. validator 가 terminal PASS 를 낸 뒤에만 같은 HEAD/tree 의 product-acceptance 가 열리고(순차 fail-fast), acceptance 는 그 tree 의 unit/lint/build 를 다시 돌리지 않고 sealed Journey 만 독립 재실행한다. validator finding 이 나오면 비싼 device/Journey 검수 전체가 폐기되던 병렬 낭비가 사라진다.
+- **`/design` 으로 epic 을 설계하는 프로젝트** — module-architect 의 `CARTOGRAPHY_REFRESH` 작성 mode 가 제거되고, as-built Cartography 정합은 마감의 final mutation owner 가 1회 bounded sync/no-op 로 소유한다. 정상 route-only 문서 정합이 architecture 재설계로 회귀하지 않는다.
+- **구현/리뷰 진영을 나누는 프로젝트** — 반대 진영 리뷰 계약은 그대로 유지된다(#1196 구현 provider 는 Codex, merge review 는 반대 진영 Claude). close receipt 에 candidate HEAD/tree 가 기록돼 검증 사이 tracked tree drift 가 기계적으로 차단된다.
+
+---
+
 ## v0.28.0 (2026-07-24)
 
 **커밋 범위**: `v0.27.0..v0.28.0` (머지 PR 2개, [#1191](https://github.com/Daeguk-Sun/dcNess/pull/1191) · [#1193](https://github.com/Daeguk-Sun/dcNess/pull/1193))

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -4,13 +4,13 @@
 
 ## 현재 공개 evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.28.0","measured_at":"2026-07-24","unit_tests":{"passed":1187,"total":1187},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-24","unit_tests":{"passed":1210,"total":1210},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
-현재 plugin version은 **v0.28.0**, 측정일은 **2026-07-24**이다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
+현재 plugin version은 **v0.29.0**, 측정일은 **2026-07-24**이다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
 
 | evidence | 관측값 | 재현 명령 | 한계 |
 |---|---:|---|---|
-| 전체 unit 계약 | 1,187/1,187 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
+| 전체 unit 계약 | 1,210/1,210 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
 | guard fixture | 50/50 PASS | `python3.11 evals/guard_efficacy.py --json` | deterministic payload의 allow/block/exit/stdout 계약 |
 | 공개 snapshot drift | README/benchmark 일치 | `node scripts/check_public_evidence.mjs` | 위 두 명령 결과와 문서 marker만 대조 |
 


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: v0.29.0 릴리즈 version bump·릴리즈 노트 작성 PR. 기능 이슈 #1194 는 머지 PR #1196 에서 이미 close 됨.

## 배경 및 문제

- v0.28.0 이후 머지된 PR #1196(Closes #1194) 하나를 minor 릴리즈로 배포하기 위해 두 manifest version 을 0.29.0 으로 올리고 릴리즈 노트를 작성한다.
- #1196 은 `/impl`·`/impl-loop` 마감(close) 검증을 validator/acceptance 병렬에서 fail-fast 순차(holistic review → order gate → same-tree acceptance)로 단순화한다.

## 원인 (해당 시)

- (해당 없음 — 릴리즈 운영 PR)

## 작업내용

- `.claude-plugin/plugin.json`·`.claude-plugin/marketplace.json` version `0.28.0` → `0.29.0`.
- `docs/internal/release-notes.md` v0.29.0 섹션 작성 (무엇이 바뀌나 1항목 + 자기개선 점검 + 사용자 영향), Unreleased 비움.
- 공개 evidence snapshot(`README.md`·`docs/plugin/benchmark.md`) `plugin_version` `0.28.0` → `0.29.0`, unit `1,187` → `1,210` 으로 갱신. #1196 이 close 순차 검증 회귀 fixture·상태 테스트·replay 를 추가해 test 수가 1,187 → 1,210 으로 늘었고, 본 릴리즈에서 전체 unittest·guard 를 재실행해 실측 확인.

## 결정 근거

- 개별 기능은 머지 PR #1196 에서 CI PASS·반대 진영 격리 리뷰(round 1 FAIL 2건 근본 수정 → round 2 PASS) 완료됐으므로 본 PR 은 version bump + 노트 + snapshot 만 담는 표준 릴리즈 PR 로 최소화.
- `measured_at` 은 릴리즈 재측정일(2026-07-24)로 유지. unit 값은 직전 snapshot(1,187)과 달라져 1,210 으로 실측 갱신했고 guard 는 50/50 유지.

## 배포 경로 검증 (plug-in 영향 시)

- 경로 1 (plug-in 본체): #1196 의 `skills/impl/**`·`skills/impl-loop/**`·`skills/acceptance/**`·`harness/**`·`docs/plugin/agents/**`·`docs/plugin/loop-procedure.md`·`codex/skills/dcness-impl-validator/**` 배포 경로 검증은 머지 PR 에서 완료됨. 본 PR 은 version bump 로 그 배포물을 marketplace 에 공개 배포한다.
- 경로 3 (사용자 SSOT 문서): `README.md`·`docs/plugin/benchmark.md`·`docs/internal/release-notes.md` 는 dcness self 문서로, `v0.29.0` tag push 시 release artifact 로 반영된다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public surface 없음. #1196 은 기존 `/impl`·`/impl-loop`·impl-validator·product-acceptance 내부 계약만 단순화했고 본 PR 은 version bump + 릴리즈 노트 + evidence snapshot 만.

## Test Plan

- [x] \`node scripts/check_plugin_manifest.mjs\` — \`dcness@0.29.0\` PASS
- [x] \`node scripts/check_public_evidence.mjs\` — version=0.29.0, tests=1210/1210, guard=50/50, measured_at=2026-07-24 PASS
- [x] \`node scripts/check_cross_refs.mjs\` — dead link/anchor/옛 명칭/고아 0건 PASS
- [x] \`python3.11 -m unittest discover -s tests < /dev/null\` — 1,210/1,210 PASS (Ran 1210 tests, OK)
- [x] \`python3.11 evals/guard_efficacy.py\` — 50/50 PASS

## 참고

- v0.29.0 배포는 본 PR 머지 후 \`main\` 에서 \`scripts/release_preflight.py\` PASS 확인 → \`v0.29.0\` immutable tag push → \`release-sync.yml\` workflow 의 4단 정합(main version·tag·release parent SHA·bundle digest) 확인 순으로 완료한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)