### PR TITLE
[feature] Flow Health 감사를 실세션 측정에 연결

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-24","unit_tests":{"passed":1210,"total":1210},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-25","unit_tests":{"passed":1215,"total":1215},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 공개 snapshot은 **v0.29.0, 2026-07-24 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,210/1,210 PASS, 결정적 guard 50/50 PASS | test 1,210, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,215/1,215 PASS, 결정적 guard 50/50 PASS | test 1,215, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -4,13 +4,13 @@
 
 ## 현재 공개 evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-24","unit_tests":{"passed":1210,"total":1210},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-25","unit_tests":{"passed":1215,"total":1215},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 plugin version은 **v0.29.0**, 측정일은 **2026-07-24**이다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
 
 | evidence | 관측값 | 재현 명령 | 한계 |
 |---|---:|---|---|
-| 전체 unit 계약 | 1,210/1,210 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
+| 전체 unit 계약 | 1,215/1,215 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
 | guard fixture | 50/50 PASS | `python3.11 evals/guard_efficacy.py --json` | deterministic payload의 allow/block/exit/stdout 계약 |
 | 공개 snapshot drift | README/benchmark 일치 | `node scripts/check_public_evidence.mjs` | 위 두 명령 결과와 문서 marker만 대조 |
 
@@ -48,6 +48,15 @@ scripts/dcness-efficiency summary --repo "$(pwd)"
 ```
 
 `/efficiency`는 Claude Code session JSONL의 usage를 합산한다. dashboard와 heuristic pattern 판정은 만들지 않는다.
+
+### maintainer Flow Health
+
+```bash
+python3.11 scripts/measure_main_turns.py <session-jsonl-or-project-session-directory> \
+  --flow-health --plugin-version <audited-plugin-version> --json
+```
+
+dcNess source checkout의 이 모드는 활성 프로젝트 세션 안 `/impl`·`/impl-loop` 호출마다 첫 구현 action(메인 직접 구현 edit 또는 headless worker launch)까지의 시간, blocking main request, 실제 tool 시간, 비도구 대기 비율, 최장 tool 후 무응답을 다시 계산한다. 첫 action `<60초`·blocking request `≤2회`가 fast-start 계약이며, 위반 실측이 하나라도 있으면 `DEGRADED`, 위반 없이 현행 버전 표본 3개 이상이면 `HEALTHY`, 그 전에는 `UNVERIFIED`다. 이 판정은 maturity audit의 Workflow·Legibility·Observability 근거로 쓰되 release artifact `GO`/`HOLD`와 합치지 않는다. 사용자 prompt·session ID·절대경로는 감사 보고서에 노출하지 않는다.
 
 ### guard 공개 계약
 

--- a/scripts/measure_main_turns.py
+++ b/scripts/measure_main_turns.py
@@ -33,6 +33,8 @@ Tool histogram 은 tool_use block 의 `name` 빈도. Agent 호출은 `name=Task`
       --paired-with variant.jsonl --outcomes outcomes.json --json
     python3 scripts/measure_main_turns.py baseline-trials/ \
       --paired-with fresh-trials/ --outcomes repeated-outcomes.json --json
+    python3 scripts/measure_main_turns.py <project-session-directory> \
+      --flow-health --plugin-version 0.29.0 --json
 
 예시 (jajang impl 1-task 세션 측정):
     python3 scripts/measure_main_turns.py \\
@@ -59,6 +61,29 @@ _TOKEN_FIELDS = (
     "cache_read_input_tokens",
     "output_tokens",
 )
+_FLOW_COMMAND_PATTERN = re.compile(
+    r"<command-name>\s*/?(?P<name>[^<\s]+)\s*</command-name>"
+)
+_FLOW_PLUGIN_VERSION_PATTERN = re.compile(
+    r"/dcness/dcness/(?P<version>[^/]+)/skills/(?:impl|impl-loop)(?:/|\s|$)"
+)
+_FLOW_WORKER_LAUNCH_PATTERN = re.compile(
+    r"""(?mx)
+    ^\s*
+    (?:
+        ["']?\$(?:\{?[A-Z_][A-Z0-9_]*\}?)["']?
+        |
+        ["']?[^\s\n]*dcness-implementation-chain["']?
+    )
+    \s+build-worker(?:\s|\\|$)
+    """
+)
+_FLOW_DEFAULT_COMMANDS = ("dcness:impl", "dcness:impl-loop")
+_FLOW_EDIT_TOOLS = {"Edit", "Write", "NotebookEdit"}
+_FLOW_MAX_FIRST_ACTION_SECONDS = 60.0
+_FLOW_MAX_BLOCKING_REQUESTS = 2
+_FLOW_HEALTHY_MINIMUM_SAMPLES = 3
+_FLOW_OPERATIONAL_PATHS = {".claude", ".dcness-work", ".git", ".metrics"}
 
 
 def _parse_timestamp(value: Any) -> datetime | None:
@@ -140,6 +165,539 @@ def _first_edit_observation(
                 ),
             }
     return None
+
+
+def _event_text(event: dict[str, Any]) -> str:
+    content = (event.get("message") or {}).get("content")
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+    return "\n".join(
+        str(block.get("text") or "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    )
+
+
+def _normalize_flow_command(value: str) -> str:
+    command = value.strip().lstrip("/")
+    if command in {"impl", "impl-loop"}:
+        return f"dcness:{command}"
+    return command
+
+
+def _flow_command(event: dict[str, Any]) -> str | None:
+    if event.get("type") != "user":
+        return None
+    match = _FLOW_COMMAND_PATTERN.search(_event_text(event))
+    if match is None:
+        return None
+    return _normalize_flow_command(match.group("name"))
+
+
+def _load_timed_events(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    with path.open() as source:
+        for line_number, line in enumerate(source, start=1):
+            try:
+                raw = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(raw, dict):
+                continue
+            event = dict(raw)
+            event["_line"] = line_number
+            event["_at"] = _parse_timestamp(raw.get("timestamp"))
+            events.append(event)
+    return events
+
+
+def _assistant_content(event: dict[str, Any]) -> list[Any]:
+    if event.get("type") != "assistant":
+        return []
+    message = event.get("message") or {}
+    if message.get("role") != "assistant":
+        return []
+    content = message.get("content")
+    return content if isinstance(content, list) else []
+
+
+def _is_root_assistant_event(event: dict[str, Any]) -> bool:
+    return (
+        bool(_assistant_content(event))
+        and event.get("parent_tool_use_id") in (None, "")
+    )
+
+
+def _assistant_request_key(event: dict[str, Any]) -> str:
+    message = event.get("message") or {}
+    return str(
+        event.get("request_id")
+        or message.get("id")
+        or event.get("uuid")
+        or f"line-{event['_line']}"
+    )
+
+
+def _is_implementation_path(path_value: Any, cwd_value: Any) -> bool:
+    if not isinstance(path_value, str) or not path_value:
+        return True
+    path = Path(path_value)
+    if not path.is_absolute():
+        relative = path
+    elif isinstance(cwd_value, str) and cwd_value:
+        try:
+            relative = path.relative_to(Path(cwd_value))
+        except ValueError:
+            return False
+    else:
+        return False
+    return not relative.parts or relative.parts[0] not in _FLOW_OPERATIONAL_PATHS
+
+
+def _flow_edit_observation(
+    event: dict[str, Any],
+    project_root: Any = None,
+) -> dict[str, Any] | None:
+    timestamp = event.get("_at")
+    if not isinstance(timestamp, datetime):
+        return None
+    for block in _assistant_content(event):
+        if not isinstance(block, dict) or block.get("type") != "tool_use":
+            continue
+        if block.get("name") not in _FLOW_EDIT_TOOLS:
+            continue
+        tool_input = block.get("input") or {}
+        path = tool_input.get("file_path") or tool_input.get("path") or ""
+        if not _is_implementation_path(
+            path,
+            event.get("cwd") or project_root,
+        ):
+            continue
+        return {
+            "timestamp": timestamp.isoformat(),
+            "line": event["_line"],
+            "tool": block.get("name"),
+            "path": path,
+            "executor": (
+                "main"
+                if event.get("parent_tool_use_id") in (None, "")
+                else "fresh"
+            ),
+        }
+    return None
+
+
+def _flow_worker_observation(
+    event: dict[str, Any],
+) -> dict[str, Any] | None:
+    timestamp = event.get("_at")
+    if not isinstance(timestamp, datetime):
+        return None
+    for block in _assistant_content(event):
+        if (
+            not isinstance(block, dict)
+            or block.get("type") != "tool_use"
+            or block.get("name") != "Bash"
+        ):
+            continue
+        command = str((block.get("input") or {}).get("command") or "")
+        if (
+            "dcness-implementation-chain" not in command
+            or _FLOW_WORKER_LAUNCH_PATTERN.search(command) is None
+        ):
+            continue
+        return {
+            "timestamp": timestamp.isoformat(),
+            "line": event["_line"],
+            "tool": "WorkerLaunch",
+            "path": "",
+            "executor": "headless",
+        }
+    return None
+
+
+def _tool_result_ids(event: dict[str, Any]) -> list[str]:
+    if event.get("type") != "user":
+        return []
+    content = (event.get("message") or {}).get("content")
+    if not isinstance(content, list):
+        return []
+    return [
+        str(block["tool_use_id"])
+        for block in content
+        if (
+            isinstance(block, dict)
+            and block.get("type") == "tool_result"
+            and block.get("tool_use_id")
+        )
+    ]
+
+
+def _merged_interval_seconds(
+    intervals: list[tuple[datetime, datetime]],
+) -> float:
+    if not intervals:
+        return 0.0
+    merged: list[list[datetime]] = []
+    for start, end in sorted(intervals):
+        if end < start:
+            continue
+        if not merged or start > merged[-1][1]:
+            merged.append([start, end])
+        else:
+            merged[-1][1] = max(merged[-1][1], end)
+    return sum((end - start).total_seconds() for start, end in merged)
+
+
+def _pre_action_tool_observations(
+    events: list[dict[str, Any]],
+    start_at: datetime,
+    stop_at: datetime,
+) -> tuple[float, list[dict[str, Any]]]:
+    calls: dict[str, tuple[datetime, int]] = {}
+    intervals: list[tuple[datetime, datetime]] = []
+    results: list[dict[str, Any]] = []
+    for event in events:
+        timestamp = event.get("_at")
+        if not isinstance(timestamp, datetime):
+            continue
+        for block in _assistant_content(event):
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            tool_id = block.get("id")
+            if tool_id and start_at <= timestamp < stop_at:
+                calls[str(tool_id)] = (timestamp, int(event["_line"]))
+        if not start_at <= timestamp < stop_at:
+            continue
+        for tool_id in _tool_result_ids(event):
+            call = calls.get(tool_id)
+            if call is None:
+                continue
+            call_at, call_line = call
+            intervals.append((call_at, timestamp))
+            results.append(
+                {
+                    "timestamp": timestamp,
+                    "line": event["_line"],
+                    "tool_use_line": call_line,
+                }
+            )
+    return _merged_interval_seconds(intervals), results
+
+
+def _has_visible_progress(event: dict[str, Any]) -> bool:
+    if not _is_root_assistant_event(event):
+        return False
+    for block in _assistant_content(event):
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "tool_use":
+            return True
+        if block.get("type") == "text" and str(block.get("text") or "").strip():
+            return True
+    return False
+
+
+def _next_visible_progress(
+    events: list[dict[str, Any]],
+    after: datetime,
+    stop_at: datetime,
+) -> dict[str, Any] | None:
+    for event in events:
+        timestamp = event.get("_at")
+        if (
+            isinstance(timestamp, datetime)
+            and after < timestamp <= stop_at
+            and _has_visible_progress(event)
+        ):
+            return event
+    return None
+
+
+def _flow_silence_observations(
+    events: list[dict[str, Any]],
+    start_at: datetime,
+    stop_at: datetime,
+    tool_results: list[dict[str, Any]],
+) -> tuple[float | None, dict[str, Any] | None, float | None]:
+    first_progress = _next_visible_progress(events, start_at, stop_at)
+    time_to_first_progress = None
+    if first_progress is not None:
+        time_to_first_progress = (
+            first_progress["_at"] - start_at
+        ).total_seconds()
+
+    longest_seconds: float | None = None
+    longest_evidence: dict[str, Any] | None = None
+    for result in tool_results:
+        progress = _next_visible_progress(events, result["timestamp"], stop_at)
+        if progress is None:
+            continue
+        seconds = (progress["_at"] - result["timestamp"]).total_seconds()
+        if longest_seconds is None or seconds > longest_seconds:
+            longest_seconds = seconds
+            longest_evidence = {
+                "tool_result_line": result["line"],
+                "tool_result_timestamp": result["timestamp"].isoformat(),
+                "next_progress_line": progress["_line"],
+                "next_progress_timestamp": progress["_at"].isoformat(),
+            }
+    return time_to_first_progress, longest_evidence, longest_seconds
+
+
+def _flow_plugin_version(events: list[dict[str, Any]]) -> str | None:
+    for event in events:
+        match = _FLOW_PLUGIN_VERSION_PATTERN.search(_event_text(event))
+        if match is not None:
+            return match.group("version")
+    return None
+
+
+def _flow_invocation(
+    path: Path,
+    command: str,
+    events: list[dict[str, Any]],
+) -> dict[str, Any]:
+    start_event = events[0]
+    start_at = start_event.get("_at")
+    if not isinstance(start_at, datetime):
+        raise ValueError("flow command timestamp is required")
+    timed_events = [
+        event for event in events if isinstance(event.get("_at"), datetime)
+    ]
+    observed_end_at = max(
+        (event["_at"] for event in timed_events),
+        default=start_at,
+    )
+    first_action: dict[str, Any] | None = None
+    first_action_event: dict[str, Any] | None = None
+    for event in events[1:]:
+        first_action = _flow_edit_observation(event, start_event.get("cwd"))
+        if first_action is None:
+            first_action = _flow_worker_observation(event)
+        if first_action is not None:
+            first_action_event = event
+            break
+    stop_at = (
+        first_action_event["_at"]
+        if first_action_event is not None
+        else observed_end_at
+    )
+    elapsed_seconds = max((stop_at - start_at).total_seconds(), 0.0)
+    last_user_input_at = max(
+        (
+            event["_at"]
+            for event in events[1:]
+            if (
+                isinstance(event.get("_at"), datetime)
+                and event["_at"] < stop_at
+                and event.get("type") == "user"
+                and event.get("parent_tool_use_id") in (None, "")
+                and event.get("isMeta") is not True
+                and event.get("isSynthetic") is not True
+                and _flow_command(event) is None
+                and _is_direct_user_request(
+                    (event.get("message") or {}).get("content")
+                )
+            )
+        ),
+        default=None,
+    )
+    first_action_request_key = (
+        _assistant_request_key(first_action_event)
+        if first_action_event is not None
+        and _is_root_assistant_event(first_action_event)
+        else None
+    )
+    request_first_seen: dict[str, datetime] = {}
+    for event in events:
+        timestamp = event.get("_at")
+        if (
+            not isinstance(timestamp, datetime)
+            or timestamp < start_at
+            or timestamp >= stop_at
+            or not _is_root_assistant_event(event)
+        ):
+            continue
+        request_first_seen.setdefault(_assistant_request_key(event), timestamp)
+    blocking_requests = sum(
+        request_key != first_action_request_key
+        for request_key in request_first_seen
+    )
+    tool_seconds, tool_results = _pre_action_tool_observations(
+        events,
+        start_at,
+        stop_at,
+    )
+    (
+        time_to_first_progress,
+        longest_silence_evidence,
+        longest_silence_seconds,
+    ) = _flow_silence_observations(
+        events,
+        start_at,
+        stop_at,
+        tool_results,
+    )
+    non_tool_ratio = (
+        max(elapsed_seconds - tool_seconds, 0.0) / elapsed_seconds
+        if elapsed_seconds
+        else None
+    )
+    failure_reasons: list[str] = []
+    if elapsed_seconds >= _FLOW_MAX_FIRST_ACTION_SECONDS:
+        failure_reasons.append("time_to_first_action")
+    if blocking_requests > _FLOW_MAX_BLOCKING_REQUESTS:
+        failure_reasons.append("blocking_assistant_requests")
+    if first_action is not None:
+        result = "FAIL" if failure_reasons else "PASS"
+    else:
+        result = "FAIL" if failure_reasons else "INCOMPLETE"
+    return {
+        "session": path.name,
+        "command": command,
+        "plugin_version": _flow_plugin_version(events),
+        "result": result,
+        "failure_reasons": failure_reasons,
+        "startup_target": (
+            "headless_worker_launch"
+            if first_action is not None
+            and first_action["tool"] == "WorkerLaunch"
+            else "implementation_edit"
+        ),
+        "time_to_first_action_seconds": (
+            round(elapsed_seconds, 3) if first_action is not None else None
+        ),
+        "last_user_input_to_first_action_seconds": (
+            round((stop_at - last_user_input_at).total_seconds(), 3)
+            if first_action is not None and last_user_input_at is not None
+            else None
+        ),
+        "time_to_first_edit_seconds": (
+            round(elapsed_seconds, 3)
+            if first_action is not None
+            and first_action["tool"] != "WorkerLaunch"
+            else None
+        ),
+        "observed_without_action_seconds": (
+            round(elapsed_seconds, 3) if first_action is None else None
+        ),
+        "blocking_assistant_requests_before_first_action": blocking_requests,
+        "pre_action_tool_execution_seconds": round(tool_seconds, 3),
+        "pre_action_non_tool_wait_ratio": (
+            round(non_tool_ratio, 6) if non_tool_ratio is not None else None
+        ),
+        "time_to_first_progress_seconds": (
+            round(time_to_first_progress, 3)
+            if time_to_first_progress is not None
+            else None
+        ),
+        "max_post_tool_silence_seconds": (
+            round(longest_silence_seconds, 3)
+            if longest_silence_seconds is not None
+            else None
+        ),
+        "max_post_tool_silence_evidence": longest_silence_evidence,
+        "start_evidence": {
+            "timestamp": start_at.isoformat(),
+            "line": start_event["_line"],
+            "kind": "command_invocation",
+        },
+        "first_action_evidence": first_action,
+        "first_edit_evidence": (
+            first_action
+            if first_action is not None
+            and first_action["tool"] != "WorkerLaunch"
+            else None
+        ),
+    }
+
+
+def parse_flow_invocations(
+    path: Path,
+    command_names: tuple[str, ...] | list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Measure each selected /impl command inside a session independently."""
+    selected = {
+        _normalize_flow_command(value)
+        for value in (command_names or _FLOW_DEFAULT_COMMANDS)
+    }
+    events = _load_timed_events(path)
+    command_indexes = [
+        (index, command)
+        for index, event in enumerate(events)
+        if (command := _flow_command(event)) is not None
+    ]
+    rows: list[dict[str, Any]] = []
+    for position, (start_index, command) in enumerate(command_indexes):
+        if command not in selected:
+            continue
+        end_index = (
+            command_indexes[position + 1][0]
+            if position + 1 < len(command_indexes)
+            else len(events)
+        )
+        window = events[start_index:end_index]
+        if isinstance(window[0].get("_at"), datetime):
+            rows.append(_flow_invocation(path, command, window))
+    return rows
+
+
+def build_flow_health(
+    paths: list[Path],
+    *,
+    command_names: tuple[str, ...] | list[str] | None = None,
+    plugin_version: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate command-scoped observations into a non-compensating status."""
+    observed = [
+        row
+        for path in paths
+        for row in parse_flow_invocations(path, command_names)
+    ]
+    if plugin_version is None:
+        invocations = observed
+        excluded_version_count = 0
+    else:
+        invocations = [
+            row for row in observed if row["plugin_version"] == plugin_version
+        ]
+        excluded_version_count = len(observed) - len(invocations)
+    evaluated = [
+        row for row in invocations if row["result"] in {"PASS", "FAIL"}
+    ]
+    pass_count = sum(row["result"] == "PASS" for row in evaluated)
+    fail_count = sum(row["result"] == "FAIL" for row in evaluated)
+    if fail_count:
+        status = "DEGRADED"
+    elif pass_count >= _FLOW_HEALTHY_MINIMUM_SAMPLES:
+        status = "HEALTHY"
+    else:
+        status = "UNVERIFIED"
+    return {
+        "status": status,
+        "plugin_version": plugin_version,
+        "sample_count": len(evaluated),
+        "pass_count": pass_count,
+        "fail_count": fail_count,
+        "incomplete_count": sum(
+            row["result"] == "INCOMPLETE" for row in invocations
+        ),
+        "excluded_version_count": excluded_version_count,
+        "thresholds": {
+            "time_to_first_action_seconds": "<60",
+            "blocking_assistant_requests_before_first_action": "<=2",
+            "healthy_minimum_samples": _FLOW_HEALTHY_MINIMUM_SAMPLES,
+        },
+        "invocations": invocations,
+        "claim_boundary": (
+            "Current-version external command traces only. DEGRADED is a "
+            "measured breach; HEALTHY requires at least three passing samples; "
+            "otherwise the status is UNVERIFIED."
+        ),
+    }
 
 
 def parse_session(path: Path) -> dict:
@@ -724,6 +1282,37 @@ def format_text(r: dict) -> str:
     return "\n".join(lines)
 
 
+def format_flow_health_text(report: dict[str, Any]) -> str:
+    lines = [
+        f"Flow Health: {report['status']}",
+        (
+            "  samples (pass/fail/incomplete): "
+            f"{report['sample_count']} "
+            f"({report['pass_count']}/{report['fail_count']}/"
+            f"{report['incomplete_count']})"
+        ),
+        (
+            "  contract: first edit or headless worker launch <60s, "
+            "blocking assistant requests <=2; "
+            "HEALTHY requires >=3 passing current-version samples"
+        ),
+    ]
+    if report["plugin_version"]:
+        lines.append(f"  plugin version: {report['plugin_version']}")
+    for row in report["invocations"]:
+        lines.append(
+            "  - "
+            f"{row['session']} {row['command']} {row['result']}: "
+            f"first_action={row['time_to_first_action_seconds']}s "
+            f"({row['startup_target']}), "
+            "blocking="
+            f"{row['blocking_assistant_requests_before_first_action']}, "
+            f"tool_time={row['pre_action_tool_execution_seconds']}s, "
+            f"non_tool_wait={row['pre_action_non_tool_wait_ratio']}"
+        )
+    return "\n".join(lines)
+
+
 def _session_files(path: Path) -> list[Path]:
     if path.is_dir():
         return sorted(path.glob("*.jsonl"))
@@ -751,9 +1340,41 @@ def main(argv: list[str] | None = None) -> int:
         "--outcomes",
         help="JSON with frozen fixture identity and product AC/MUST-FIX/regression/human-intervention axes",
     )
+    ap.add_argument(
+        "--flow-health",
+        action="store_true",
+        help="Measure command-scoped /impl and /impl-loop startup flow",
+    )
+    ap.add_argument(
+        "--command-name",
+        action="append",
+        help="Command to include in Flow Health (repeatable; default: dcness:impl and dcness:impl-loop)",
+    )
+    ap.add_argument(
+        "--plugin-version",
+        help="Only include Flow Health invocations expanded from this dcNess version",
+    )
     args = ap.parse_args(argv)
 
     p = Path(args.path).expanduser()
+    if args.flow_health and args.paired_with:
+        print(
+            "ERROR: --flow-health cannot be combined with --paired-with",
+            file=sys.stderr,
+        )
+        return 2
+    if args.plugin_version and not args.flow_health:
+        print(
+            "ERROR: --plugin-version requires --flow-health",
+            file=sys.stderr,
+        )
+        return 2
+    if args.command_name and not args.flow_health:
+        print(
+            "ERROR: --command-name requires --flow-health",
+            file=sys.stderr,
+        )
+        return 2
     if args.paired_with:
         baseline_files = _session_files(p)
         if not baseline_files:
@@ -790,6 +1411,18 @@ def main(argv: list[str] | None = None) -> int:
     if not files:
         print(f"ERROR: not found: {p}", file=sys.stderr)
         return 2
+
+    if args.flow_health:
+        report = build_flow_health(
+            files,
+            command_names=args.command_name,
+            plugin_version=args.plugin_version,
+        )
+        if args.json:
+            print(json.dumps(report, ensure_ascii=False, indent=2))
+        else:
+            print(format_flow_health_text(report))
+        return 0
 
     results = [parse_session(f) for f in files]
 

--- a/tests/test_measure_main_turns.py
+++ b/tests/test_measure_main_turns.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 import unittest
 
 from scripts.measure_main_turns import (
+    build_flow_health,
     build_paired_screening,
     build_repeated_screening,
+    parse_flow_invocations,
     parse_session,
 )
 
@@ -167,6 +170,148 @@ class MeasureMainTurnsTests(unittest.TestCase):
             encoding="utf-8",
         )
 
+    def _flow_trace(
+        self,
+        path: Path,
+        *,
+        edit_second: int,
+        plugin_version: str = "0.29.0",
+        blocking_requests: int = 1,
+        include_prior_edit: bool = False,
+    ) -> None:
+        command_at = datetime(2026, 7, 20, 0, 10, tzinfo=timezone.utc)
+
+        def timestamp(offset_seconds: int) -> str:
+            return (
+                (command_at + timedelta(seconds=offset_seconds))
+                .isoformat()
+                .replace("+00:00", "Z")
+            )
+
+        rows: list[dict[str, object]] = []
+        if include_prior_edit:
+            rows.extend(
+                [
+                    {
+                        "type": "user",
+                        "timestamp": "2026-07-20T00:00:00Z",
+                        "message": {"role": "user", "content": "unrelated task"},
+                    },
+                    {
+                        "type": "assistant",
+                        "timestamp": "2026-07-20T00:00:01Z",
+                        "message": {
+                            "id": "prior-edit",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": "prior-write",
+                                    "name": "Write",
+                                    "input": {"file_path": "unrelated.txt"},
+                                }
+                            ],
+                        },
+                    },
+                ]
+            )
+        rows.extend(
+            [
+                {
+                    "type": "user",
+                    "timestamp": timestamp(0),
+                    "cwd": "/tmp/project",
+                    "message": {
+                        "role": "user",
+                        "content": (
+                            "<command-message>dcness:impl</command-message>\n"
+                            "<command-name>/dcness:impl</command-name>\n"
+                            "<command-args>issue 80</command-args>"
+                        ),
+                    },
+                },
+                {
+                    "type": "user",
+                    "timestamp": timestamp(0),
+                    "isMeta": True,
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Base directory for this skill: "
+                                    f"/tmp/dcness/dcness/{plugin_version}/skills/impl"
+                                    "\n\n# Impl"
+                                ),
+                            }
+                        ],
+                    },
+                },
+            ]
+        )
+        for index in range(blocking_requests):
+            second = 5 + index * 10
+            tool_id = f"read-{index}"
+            rows.extend(
+                [
+                    {
+                        "type": "assistant",
+                        "timestamp": timestamp(second),
+                        "message": {
+                            "id": f"blocking-{index}",
+                            "role": "assistant",
+                            "content": [
+                                {
+                                    "type": "tool_use",
+                                    "id": tool_id,
+                                    "name": "Read",
+                                    "input": {"file_path": "src/fixture.py"},
+                                }
+                            ],
+                        },
+                    },
+                    {
+                        "type": "user",
+                        "timestamp": timestamp(second + 2),
+                        "message": {
+                            "role": "user",
+                            "content": [
+                                {
+                                    "type": "tool_result",
+                                    "tool_use_id": tool_id,
+                                    "content": "ok",
+                                }
+                            ],
+                        },
+                    },
+                ]
+            )
+        rows.append(
+            {
+                "type": "assistant",
+                "timestamp": timestamp(edit_second),
+                "message": {
+                    "id": "implementation-edit",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "source-write",
+                            "name": "Write",
+                            "input": {
+                                "file_path": "/tmp/project/src/fixture_test.py",
+                            },
+                        }
+                    ],
+                },
+            }
+        )
+        path.write_text(
+            "\n".join(json.dumps(row) for row in rows) + "\n",
+            encoding="utf-8",
+        )
+
     def test_parse_session_collects_requests_tools_time_tokens_and_runtime(self) -> None:
         with TemporaryDirectory() as td:
             trace = Path(td) / "baseline.jsonl"
@@ -262,6 +407,179 @@ class MeasureMainTurnsTests(unittest.TestCase):
         )
         self.assertEqual(result["all_total_input_tokens"], 150)
         self.assertEqual(result["all_output_tokens"], 17)
+
+    def test_flow_health_scopes_measurement_to_impl_command(self) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "session.jsonl"
+            self._flow_trace(
+                trace,
+                edit_second=45,
+                blocking_requests=2,
+                include_prior_edit=True,
+            )
+
+            rows = parse_flow_invocations(trace)
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["command"], "dcness:impl")
+        self.assertEqual(rows[0]["plugin_version"], "0.29.0")
+        self.assertEqual(rows[0]["time_to_first_edit_seconds"], 45.0)
+        self.assertEqual(
+            rows[0]["blocking_assistant_requests_before_first_action"],
+            2,
+        )
+        self.assertEqual(rows[0]["first_edit_evidence"]["line"], 9)
+        self.assertEqual(rows[0]["result"], "PASS")
+
+    def test_flow_health_separates_tool_time_and_marks_slow_flow_degraded(self) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "session.jsonl"
+            self._flow_trace(
+                trace,
+                edit_second=75,
+                blocking_requests=3,
+            )
+
+            report = build_flow_health([trace], plugin_version="0.29.0")
+
+        self.assertEqual(report["status"], "DEGRADED")
+        self.assertEqual(report["sample_count"], 1)
+        row = report["invocations"][0]
+        self.assertEqual(row["pre_action_tool_execution_seconds"], 6.0)
+        self.assertEqual(row["pre_action_non_tool_wait_ratio"], 0.92)
+        self.assertEqual(row["max_post_tool_silence_seconds"], 48.0)
+        self.assertEqual(row["result"], "FAIL")
+
+    def test_flow_health_uses_headless_worker_launch_as_impl_loop_start(self) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "session.jsonl"
+            rows = [
+                {
+                    "type": "user",
+                    "timestamp": "2026-07-20T00:00:00Z",
+                    "cwd": "/tmp/project",
+                    "message": {
+                        "role": "user",
+                        "content": (
+                            "<command-name>/dcness:impl-loop</command-name>"
+                        ),
+                    },
+                },
+                {
+                    "type": "user",
+                    "timestamp": "2026-07-20T00:00:00Z",
+                    "isMeta": True,
+                    "message": {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": (
+                                    "Base directory for this skill: "
+                                    "/tmp/dcness/dcness/0.29.0/skills/impl-loop"
+                                ),
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-20T00:00:10Z",
+                    "cwd": "/tmp/project",
+                    "message": {
+                        "id": "prompt-file",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "scratch",
+                                "name": "Write",
+                                "input": {"file_path": "/tmp/slim-prompt.md"},
+                            }
+                        ],
+                    },
+                },
+                {
+                    "type": "user",
+                    "timestamp": "2026-07-20T00:00:40Z",
+                    "message": {
+                        "role": "user",
+                        "content": "확정했으니 진행",
+                    },
+                },
+                {
+                    "type": "assistant",
+                    "timestamp": "2026-07-20T00:01:10Z",
+                    "cwd": "/tmp/project/.claude/worktrees/feature",
+                    "message": {
+                        "id": "worker-launch",
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "chain",
+                                "name": "Bash",
+                                "input": {
+                                    "command": (
+                                        "CHAIN=/tmp/dcness-implementation-chain\n"
+                                        '"$CHAIN" build-worker \\\n'
+                                        "  --direct-run"
+                                    ),
+                                },
+                            }
+                        ],
+                    },
+                },
+            ]
+            trace.write_text(
+                "\n".join(json.dumps(row) for row in rows) + "\n",
+                encoding="utf-8",
+            )
+
+            report = build_flow_health([trace], plugin_version="0.29.0")
+
+        row = report["invocations"][0]
+        self.assertEqual(report["status"], "DEGRADED")
+        self.assertEqual(row["startup_target"], "headless_worker_launch")
+        self.assertEqual(row["time_to_first_action_seconds"], 70.0)
+        self.assertEqual(
+            row["last_user_input_to_first_action_seconds"],
+            30.0,
+        )
+        self.assertIsNone(row["time_to_first_edit_seconds"])
+        self.assertEqual(row["first_action_evidence"]["tool"], "WorkerLaunch")
+
+    def test_flow_health_requires_three_current_version_passes_for_healthy(self) -> None:
+        with TemporaryDirectory() as td:
+            base = Path(td)
+            traces = []
+            for index, seconds in enumerate((20, 30, 40), start=1):
+                trace = base / f"session-{index}.jsonl"
+                self._flow_trace(trace, edit_second=seconds)
+                traces.append(trace)
+            old_trace = base / "old.jsonl"
+            self._flow_trace(
+                old_trace,
+                edit_second=75,
+                plugin_version="0.28.0",
+            )
+            traces.append(old_trace)
+
+            report = build_flow_health(traces, plugin_version="0.29.0")
+
+        self.assertEqual(report["status"], "HEALTHY")
+        self.assertEqual(report["sample_count"], 3)
+        self.assertEqual(report["excluded_version_count"], 1)
+
+    def test_flow_health_is_unverified_with_too_few_passing_samples(self) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "session.jsonl"
+            self._flow_trace(trace, edit_second=20)
+
+            report = build_flow_health([trace], plugin_version="0.29.0")
+
+        self.assertEqual(report["status"], "UNVERIFIED")
+        self.assertEqual(report["sample_count"], 1)
 
     def test_process_start_falls_back_before_fresh_edit_when_root_duration_is_short(self) -> None:
         with TemporaryDirectory() as td:


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: issue 없는 감사 측정 인프라 후속 작업

## 배경 및 문제

기존 maturity audit은 문서·결정적 테스트·release integrity를 잘 평가했지만, 실제 활성 프로젝트에서 `/impl`·`/impl-loop`가 첫 구현 action까지 수 분 지연되는 현상을 점수와 함께 표면화하지 못했습니다. 기존 `measure_main_turns.py`도 세션 전체의 첫 요청만 보아 같은 세션의 이전 작업을 잘못 기준으로 삼았습니다.

## 원인 (해당 시)

명령 호출별 window, headless worker launch, 실제 tool 실행 시간과 비도구 대기 시간을 한 계약으로 묶는 측정 경로가 없었습니다.

## 작업내용

- `/impl`·`/impl-loop` 명령 window별 첫 action을 측정합니다. main-direct는 첫 구현 edit, headless는 실제 `build-worker` launch가 기준입니다.
- 현행 plugin version 필터와 `HEALTHY`/`DEGRADED`/`UNVERIFIED` 판정을 추가했습니다.
- blocking main request, tool 실행 시간, 비도구 대기 비율, 최장 tool 후 무응답, 후속 결정→action 시간을 함께 출력합니다.
- 운영 scratch write는 첫 구현 edit에서 제외하고, 이전 세션 작업이 현재 명령 측정에 섞이지 않도록 회귀 테스트를 추가했습니다.
- README와 benchmark 공개 evidence를 실제 1,215 tests / guard 50건 결과로 동기화했습니다.

## 결정 근거

새 agent·hook·state·dashboard·CI gate·runtime telemetry를 만들지 않고 기존 repo-only 측정기를 확장했습니다. Flow Health는 고정 100점의 새 축이 아니라 Workflow·Legibility·Observability의 실사용 근거이자 별도 non-compensating qualifier입니다. artifact release `GO/HOLD`와도 분리합니다.

## 배포 경로 검증 (plug-in 영향 시)

- `scripts/measure_main_turns.py`는 maintainer source-checkout 분석 도구이며 release artifact에서 의도적으로 제외됩니다. plugin runtime과 사용자 surface 증가는 없습니다.
- 재현 계약은 `docs/plugin/benchmark.md`에 기록했습니다.
- 개인 `dcness-harness-audit` skill은 이 source-checkout 명령을 호출하도록 별도 갱신·검증했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 측정기 옵션과 기존 감사 skill만 확장했으며 새 public surface가 없습니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,215/1,215 PASS
- [x] `python3.11 evals/guard_efficacy.py --json` — 50/50 PASS
- [x] `PYTHON_BIN=<quality-venv>/bin/python bash scripts/check_static_quality.sh` — PASS
- [x] 깨끗한 임시 clone에서 Flow Health·fast-start 19 tests, static quality, public evidence PASS
- [x] `node scripts/check_public_evidence.mjs` — PASS

## 참고

실측 재생 결과: v0.29 `/impl`은 command→첫 edit 493.859초, blocking request 7회, 비도구 대기 99.2453%, 최장 무응답 161.033초로 `DEGRADED`; 이전 `/impl-loop`는 command→worker launch 1,081.535초, 마지막 사용자 결정→launch 390.080초로 재현됩니다.
