### PR TITLE
[feature] Flow Health 판정 축 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ fail-open은 hook이 정책 판단을 못 해서 차단 대신 통과한 의심 
 
 [![guard-efficacy](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml/badge.svg)](https://github.com/Daeguk-Sun/dcNess/actions/workflows/guard-efficacy.yml)
 
-<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-25","unit_tests":{"passed":1215,"total":1215},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-25","unit_tests":{"passed":1216,"total":1216},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 공개 snapshot은 **v0.29.0, 2026-07-24 측정**이다. 숫자마다 분모와 source 수를
 붙이고, 서로 다른 evidence 영역을 합산하거나 대신 쓰지 않는다.
 
 | evidence 영역 | 관측 결과 | denominator / source | 재현 명령 | 이 수치가 말하지 않는 것 |
 |---|---|---|---|---|
-| 하네스·기계적 guard | unittest 1,215/1,215 PASS, 결정적 guard 50/50 PASS | test 1,215, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
+| 하네스·기계적 guard | unittest 1,216/1,216 PASS, 결정적 guard 50/50 PASS | test 1,216, guard case 50 / dcNess checkout 1 | `node scripts/check_public_evidence.mjs` | 보안 증명이나 제품 성공률이 아니다 |
 | Agent effectiveness | 실측 개선 관측 — 오경로 `1→0`, 영향 과다 포함 `2→0`, 전체 탐색 tool `15→13`; fixture task AC `7/8→8/8` | task×variant run 4, task 2 / 실측 fixture 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-13-agent-effectiveness-실측-paired-screening)의 trace→record 재현 명령 | model `claude-sonnet-4-6` 단일 frozen fixture 1회 paired 실측(1+1). downstream MUST-FIX·회귀·사람 복구·context 재작업·cross-session은 실행하지 않아 측정 불가다. 1차 거부와 2차 채택 trace는 host metadata를 비식별화했고 세션 ID·SHA-256·capture/rebuild 명령이 provenance에 있다. 공개 우위 주장이 아니다 |
 | PR·validator 운영 | finished run 26/28, measurable PR merge 7/7, validator verdict 33건 | candidate run 28 / 외부 활성 프로젝트 2 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#재현-명령)의 source-ref 고정 명령 | merge와 validator FAIL은 과정 evidence이지 제품 outcome이 아니다 |
 | 실제 제품 outcome | non-UI journey 1/1 PASS, 제품 AC 1/1 | journey 1, AC 1 / 외부 활성 프로젝트 1 | [`docs/internal/outcome-baseline.md`](https://github.com/Daeguk-Sun/dcNess/blob/main/docs/internal/outcome-baseline.md#2026-07-12-non-ui-제품-journey-pilot)의 receipt 집계 명령 | 단일 pilot이며 일반 제품 성공률이나 공개 우위가 아니다 |

--- a/docs/plugin/benchmark.md
+++ b/docs/plugin/benchmark.md
@@ -4,13 +4,13 @@
 
 ## 현재 공개 evidence snapshot
 
-<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-25","unit_tests":{"passed":1215,"total":1215},"guard":{"passed":50,"total":50},"source_project_count":2} -->
+<!-- public-evidence-snapshot {"plugin_version":"0.29.0","measured_at":"2026-07-25","unit_tests":{"passed":1216,"total":1216},"guard":{"passed":50,"total":50},"source_project_count":2} -->
 
 현재 plugin version은 **v0.29.0**, 측정일은 **2026-07-24**이다. unit과 guard 수치는 dcNess source checkout의 기계적 계약 evidence이며 보안 증명이나 제품 성공률이 아니다.
 
 | evidence | 관측값 | 재현 명령 | 한계 |
 |---|---:|---|---|
-| 전체 unit 계약 | 1,215/1,215 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
+| 전체 unit 계약 | 1,216/1,216 PASS | `python3.11 -m unittest discover -s tests -v` | source checkout 1개의 코드·문서 계약 |
 | guard fixture | 50/50 PASS | `python3.11 evals/guard_efficacy.py --json` | deterministic payload의 allow/block/exit/stdout 계약 |
 | 공개 snapshot drift | README/benchmark 일치 | `node scripts/check_public_evidence.mjs` | 위 두 명령 결과와 문서 marker만 대조 |
 
@@ -56,7 +56,18 @@ python3.11 scripts/measure_main_turns.py <session-jsonl-or-project-session-direc
   --flow-health --plugin-version <audited-plugin-version> --json
 ```
 
-dcNess source checkout의 이 모드는 활성 프로젝트 세션 안 `/impl`·`/impl-loop` 호출마다 첫 구현 action(메인 직접 구현 edit 또는 headless worker launch)까지의 시간, blocking main request, 실제 tool 시간, 비도구 대기 비율, 최장 tool 후 무응답을 다시 계산한다. 첫 action `<60초`·blocking request `≤2회`가 fast-start 계약이며, 위반 실측이 하나라도 있으면 `DEGRADED`, 위반 없이 현행 버전 표본 3개 이상이면 `HEALTHY`, 그 전에는 `UNVERIFIED`다. 이 판정은 maturity audit의 Workflow·Legibility·Observability 근거로 쓰되 release artifact `GO`/`HOLD`와 합치지 않는다. 사용자 prompt·session ID·절대경로는 감사 보고서에 노출하지 않는다.
+dcNess source checkout의 이 모드는 활성 프로젝트 세션 안 `/impl`·`/impl-loop` 호출마다 첫 구현 action(메인 직접 구현 edit 또는 headless worker launch)까지의 시간, blocking main request, 실제 tool 시간, 비도구 경과 비율, 첫 progress와 tool 후 최장 무응답을 다시 계산한다. 비도구 경과에는 모델 생성·오케스트레이션·사용자 판단 시간이 함께 들어갈 수 있으므로 낭비나 idle 시간으로 해석하지 않는다.
+
+단일 `Flow Health` 등급으로 서로 다른 사실을 합치지 않고 네 축을 따로 보고한다.
+
+| 축 | 판정 |
+|---|---|
+| Startup SLO | 첫 action `<60초`·blocking request `≤2회`. 위반 표본이 있으면 `MISS`, 위반 없이 현행 버전 표본 3개 이상이면 `PASS`, 그 전에는 `UNVERIFIED` |
+| Flow Visibility | 첫 progress와 tool 후 다음 progress가 각각 `<60초`. 위반 표본이 있으면 `DEGRADED`, 위반 없이 표본 3개 이상이면 `CLEAR`, 그 전에는 `UNVERIFIED` |
+| Agent Activity | 60초 이상 무응답 뒤 같은 assistant request에 thinking block이 관측되면 `ACTIVE_REASONING_OBSERVED`; thinking 근거가 없는 구간이 있으면 `UNATTRIBUTED_WAIT_OBSERVED`. 이는 활동 증거이지 reasoning의 생산성 증명이 아니다 |
+| Relative Speed | 이 command-only 측정에서는 항상 `UNPROVEN`. 같은 fixture·model·effort·provider의 반복 paired trial과 품질 비회귀가 있어야 상대 속도를 주장한다 |
+
+Startup SLO는 Workflow, Flow Visibility는 Legibility, 이 네 축을 자동 산출하는 능력은 Observability 근거로 쓴다. release artifact `GO`/`HOLD`와는 합치지 않으며 사용자 prompt·session ID·절대경로는 감사 보고서에 노출하지 않는다.
 
 ### guard 공개 계약
 

--- a/scripts/measure_main_turns.py
+++ b/scripts/measure_main_turns.py
@@ -82,7 +82,8 @@ _FLOW_DEFAULT_COMMANDS = ("dcness:impl", "dcness:impl-loop")
 _FLOW_EDIT_TOOLS = {"Edit", "Write", "NotebookEdit"}
 _FLOW_MAX_FIRST_ACTION_SECONDS = 60.0
 _FLOW_MAX_BLOCKING_REQUESTS = 2
-_FLOW_HEALTHY_MINIMUM_SAMPLES = 3
+_FLOW_MAX_PROGRESS_SILENCE_SECONDS = 60.0
+_FLOW_MINIMUM_CONFIDENT_SAMPLES = 3
 _FLOW_OPERATIONAL_PATHS = {".claude", ".dcness-work", ".git", ".metrics"}
 
 
@@ -416,18 +417,67 @@ def _next_visible_progress(
     return None
 
 
+def _progress_activity_evidence(
+    events: list[dict[str, Any]],
+    progress: dict[str, Any],
+) -> dict[str, Any]:
+    request_key = _assistant_request_key(progress)
+    has_thinking = False
+    output_tokens = 0
+    for event in events:
+        event_at = event.get("_at")
+        if (
+            not _is_root_assistant_event(event)
+            or _assistant_request_key(event) != request_key
+            or not isinstance(event_at, datetime)
+            or event_at > progress["_at"]
+        ):
+            continue
+        has_thinking = has_thinking or any(
+            isinstance(block, dict) and block.get("type") == "thinking"
+            for block in _assistant_content(event)
+        )
+        message = event.get("message") or {}
+        usage = message.get("usage") or event.get("usage") or {}
+        if isinstance(usage, dict):
+            output_tokens = max(
+                output_tokens,
+                int(usage.get("output_tokens") or 0),
+            )
+    return {
+        "next_progress_has_thinking": has_thinking,
+        "next_progress_output_tokens": output_tokens,
+    }
+
+
 def _flow_silence_observations(
     events: list[dict[str, Any]],
     start_at: datetime,
     stop_at: datetime,
     tool_results: list[dict[str, Any]],
-) -> tuple[float | None, dict[str, Any] | None, float | None]:
+) -> tuple[
+    float | None,
+    dict[str, Any] | None,
+    float | None,
+    list[dict[str, Any]],
+]:
     first_progress = _next_visible_progress(events, start_at, stop_at)
     time_to_first_progress = None
+    long_silences: list[dict[str, Any]] = []
     if first_progress is not None:
         time_to_first_progress = (
             first_progress["_at"] - start_at
         ).total_seconds()
+        if time_to_first_progress >= _FLOW_MAX_PROGRESS_SILENCE_SECONDS:
+            long_silences.append(
+                {
+                    "source": "command_start",
+                    "seconds": time_to_first_progress,
+                    "next_progress_line": first_progress["_line"],
+                    "next_progress_timestamp": first_progress["_at"].isoformat(),
+                    **_progress_activity_evidence(events, first_progress),
+                }
+            )
 
     longest_seconds: float | None = None
     longest_evidence: dict[str, Any] | None = None
@@ -436,15 +486,26 @@ def _flow_silence_observations(
         if progress is None:
             continue
         seconds = (progress["_at"] - result["timestamp"]).total_seconds()
+        evidence = {
+            "source": "tool_result",
+            "seconds": seconds,
+            "tool_result_line": result["line"],
+            "tool_result_timestamp": result["timestamp"].isoformat(),
+            "next_progress_line": progress["_line"],
+            "next_progress_timestamp": progress["_at"].isoformat(),
+            **_progress_activity_evidence(events, progress),
+        }
         if longest_seconds is None or seconds > longest_seconds:
             longest_seconds = seconds
-            longest_evidence = {
-                "tool_result_line": result["line"],
-                "tool_result_timestamp": result["timestamp"].isoformat(),
-                "next_progress_line": progress["_line"],
-                "next_progress_timestamp": progress["_at"].isoformat(),
-            }
-    return time_to_first_progress, longest_evidence, longest_seconds
+            longest_evidence = evidence
+        if seconds >= _FLOW_MAX_PROGRESS_SILENCE_SECONDS:
+            long_silences.append(evidence)
+    return (
+        time_to_first_progress,
+        longest_evidence,
+        longest_seconds,
+        long_silences,
+    )
 
 
 def _flow_plugin_version(events: list[dict[str, Any]]) -> str | None:
@@ -535,13 +596,14 @@ def _flow_invocation(
         time_to_first_progress,
         longest_silence_evidence,
         longest_silence_seconds,
+        long_silence_evidence,
     ) = _flow_silence_observations(
         events,
         start_at,
         stop_at,
         tool_results,
     )
-    non_tool_ratio = (
+    non_tool_elapsed_ratio = (
         max(elapsed_seconds - tool_seconds, 0.0) / elapsed_seconds
         if elapsed_seconds
         else None
@@ -586,8 +648,10 @@ def _flow_invocation(
         ),
         "blocking_assistant_requests_before_first_action": blocking_requests,
         "pre_action_tool_execution_seconds": round(tool_seconds, 3),
-        "pre_action_non_tool_wait_ratio": (
-            round(non_tool_ratio, 6) if non_tool_ratio is not None else None
+        "pre_action_non_tool_elapsed_ratio": (
+            round(non_tool_elapsed_ratio, 6)
+            if non_tool_elapsed_ratio is not None
+            else None
         ),
         "time_to_first_progress_seconds": (
             round(time_to_first_progress, 3)
@@ -600,6 +664,12 @@ def _flow_invocation(
             else None
         ),
         "max_post_tool_silence_evidence": longest_silence_evidence,
+        "long_silence_count": len(long_silence_evidence),
+        "reasoning_observed_long_silence_count": sum(
+            bool(evidence["next_progress_has_thinking"])
+            for evidence in long_silence_evidence
+        ),
+        "long_silence_evidence": long_silence_evidence,
         "start_evidence": {
             "timestamp": start_at.isoformat(),
             "line": start_event["_line"],
@@ -651,7 +721,7 @@ def build_flow_health(
     command_names: tuple[str, ...] | list[str] | None = None,
     plugin_version: str | None = None,
 ) -> dict[str, Any]:
-    """Aggregate command-scoped observations into a non-compensating status."""
+    """Aggregate command traces without conflating speed, visibility, and activity."""
     observed = [
         row
         for path in paths
@@ -671,13 +741,56 @@ def build_flow_health(
     pass_count = sum(row["result"] == "PASS" for row in evaluated)
     fail_count = sum(row["result"] == "FAIL" for row in evaluated)
     if fail_count:
-        status = "DEGRADED"
-    elif pass_count >= _FLOW_HEALTHY_MINIMUM_SAMPLES:
-        status = "HEALTHY"
+        startup_status = "MISS"
+    elif pass_count >= _FLOW_MINIMUM_CONFIDENT_SAMPLES:
+        startup_status = "PASS"
     else:
-        status = "UNVERIFIED"
+        startup_status = "UNVERIFIED"
+
+    visibility_evaluated = [
+        row
+        for row in evaluated
+        if row["time_to_first_progress_seconds"] is not None
+    ]
+    visibility_degraded_count = sum(
+        (
+            row["time_to_first_progress_seconds"]
+            >= _FLOW_MAX_PROGRESS_SILENCE_SECONDS
+            or (
+                row["max_post_tool_silence_seconds"] is not None
+                and row["max_post_tool_silence_seconds"]
+                >= _FLOW_MAX_PROGRESS_SILENCE_SECONDS
+            )
+        )
+        for row in visibility_evaluated
+    )
+    if visibility_degraded_count:
+        visibility_status = "DEGRADED"
+    elif len(visibility_evaluated) >= _FLOW_MINIMUM_CONFIDENT_SAMPLES:
+        visibility_status = "CLEAR"
+    else:
+        visibility_status = "UNVERIFIED"
+
+    long_silences = [
+        evidence
+        for row in visibility_evaluated
+        for evidence in row["long_silence_evidence"]
+    ]
+    reasoning_observed_count = sum(
+        bool(evidence["next_progress_has_thinking"])
+        for evidence in long_silences
+    )
+    unattributed_count = len(long_silences) - reasoning_observed_count
+    if not visibility_evaluated:
+        activity_status = "UNVERIFIED"
+    elif not long_silences:
+        activity_status = "NO_LONG_SILENCE_OBSERVED"
+    elif unattributed_count:
+        activity_status = "UNATTRIBUTED_WAIT_OBSERVED"
+    else:
+        activity_status = "ACTIVE_REASONING_OBSERVED"
+
     return {
-        "status": status,
         "plugin_version": plugin_version,
         "sample_count": len(evaluated),
         "pass_count": pass_count,
@@ -686,16 +799,47 @@ def build_flow_health(
             row["result"] == "INCOMPLETE" for row in invocations
         ),
         "excluded_version_count": excluded_version_count,
+        "startup_slo": {
+            "status": startup_status,
+            "sample_count": len(evaluated),
+            "pass_count": pass_count,
+            "miss_count": fail_count,
+        },
+        "flow_visibility": {
+            "status": visibility_status,
+            "sample_count": len(visibility_evaluated),
+            "clear_count": (
+                len(visibility_evaluated) - visibility_degraded_count
+            ),
+            "degraded_count": visibility_degraded_count,
+        },
+        "agent_activity": {
+            "status": activity_status,
+            "long_silence_count": len(long_silences),
+            "reasoning_observed_count": reasoning_observed_count,
+            "unattributed_count": unattributed_count,
+        },
+        "relative_speed": {
+            "status": "UNPROVEN",
+            "basis": (
+                "Command-scoped Flow Health has no matched baseline. Relative "
+                "speed requires repeated same-fixture, same-runtime paired "
+                "trials with non-regressed quality."
+            ),
+        },
         "thresholds": {
             "time_to_first_action_seconds": "<60",
             "blocking_assistant_requests_before_first_action": "<=2",
-            "healthy_minimum_samples": _FLOW_HEALTHY_MINIMUM_SAMPLES,
+            "time_to_first_progress_seconds": "<60",
+            "max_post_tool_silence_seconds": "<60",
+            "minimum_confident_samples": _FLOW_MINIMUM_CONFIDENT_SAMPLES,
         },
         "invocations": invocations,
         "claim_boundary": (
-            "Current-version external command traces only. DEGRADED is a "
-            "measured breach; HEALTHY requires at least three passing samples; "
-            "otherwise the status is UNVERIFIED."
+            "Current-version external command traces only. Startup SLO and "
+            "visibility are separate absolute observations. Thinking blocks "
+            "prove model activity, not productivity. Relative speed remains "
+            "UNPROVEN without matched repeated trials."
         ),
     }
 
@@ -1284,7 +1428,10 @@ def format_text(r: dict) -> str:
 
 def format_flow_health_text(report: dict[str, Any]) -> str:
     lines = [
-        f"Flow Health: {report['status']}",
+        f"Startup SLO: {report['startup_slo']['status']}",
+        f"Flow Visibility: {report['flow_visibility']['status']}",
+        f"Agent Activity: {report['agent_activity']['status']}",
+        f"Relative Speed: {report['relative_speed']['status']}",
         (
             "  samples (pass/fail/incomplete): "
             f"{report['sample_count']} "
@@ -1294,7 +1441,7 @@ def format_flow_health_text(report: dict[str, Any]) -> str:
         (
             "  contract: first edit or headless worker launch <60s, "
             "blocking assistant requests <=2; "
-            "HEALTHY requires >=3 passing current-version samples"
+            "PASS/CLEAR require >=3 current-version samples"
         ),
     ]
     if report["plugin_version"]:
@@ -1308,7 +1455,9 @@ def format_flow_health_text(report: dict[str, Any]) -> str:
             "blocking="
             f"{row['blocking_assistant_requests_before_first_action']}, "
             f"tool_time={row['pre_action_tool_execution_seconds']}s, "
-            f"non_tool_wait={row['pre_action_non_tool_wait_ratio']}"
+            "non_tool_elapsed="
+            f"{row['pre_action_non_tool_elapsed_ratio']}, "
+            f"max_silence={row['max_post_tool_silence_seconds']}s"
         )
     return "\n".join(lines)
 

--- a/tests/test_measure_main_turns.py
+++ b/tests/test_measure_main_turns.py
@@ -178,6 +178,7 @@ class MeasureMainTurnsTests(unittest.TestCase):
         plugin_version: str = "0.29.0",
         blocking_requests: int = 1,
         include_prior_edit: bool = False,
+        reasoning_before_edit: bool = False,
     ) -> None:
         command_at = datetime(2026, 7, 20, 0, 10, tzinfo=timezone.utc)
 
@@ -286,6 +287,24 @@ class MeasureMainTurnsTests(unittest.TestCase):
                         },
                     },
                 ]
+            )
+        if reasoning_before_edit:
+            rows.append(
+                {
+                    "type": "assistant",
+                    "timestamp": timestamp(edit_second - 1),
+                    "message": {
+                        "id": "implementation-edit",
+                        "role": "assistant",
+                        "usage": {"output_tokens": 6000},
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": "compare contracts before edit",
+                            }
+                        ],
+                    },
+                }
             )
         rows.append(
             {
@@ -431,24 +450,61 @@ class MeasureMainTurnsTests(unittest.TestCase):
         self.assertEqual(rows[0]["first_edit_evidence"]["line"], 9)
         self.assertEqual(rows[0]["result"], "PASS")
 
-    def test_flow_health_separates_tool_time_and_marks_slow_flow_degraded(self) -> None:
+    def test_flow_health_separates_startup_visibility_and_observed_reasoning(self) -> None:
         with TemporaryDirectory() as td:
             trace = Path(td) / "session.jsonl"
             self._flow_trace(
                 trace,
-                edit_second=75,
+                edit_second=100,
                 blocking_requests=3,
+                reasoning_before_edit=True,
             )
 
             report = build_flow_health([trace], plugin_version="0.29.0")
 
-        self.assertEqual(report["status"], "DEGRADED")
+        self.assertEqual(report["startup_slo"]["status"], "MISS")
+        self.assertEqual(report["flow_visibility"]["status"], "DEGRADED")
+        self.assertEqual(
+            report["agent_activity"]["status"],
+            "ACTIVE_REASONING_OBSERVED",
+        )
+        self.assertEqual(report["relative_speed"]["status"], "UNPROVEN")
         self.assertEqual(report["sample_count"], 1)
         row = report["invocations"][0]
         self.assertEqual(row["pre_action_tool_execution_seconds"], 6.0)
-        self.assertEqual(row["pre_action_non_tool_wait_ratio"], 0.92)
-        self.assertEqual(row["max_post_tool_silence_seconds"], 48.0)
+        self.assertEqual(row["pre_action_non_tool_elapsed_ratio"], 0.94)
+        self.assertEqual(row["max_post_tool_silence_seconds"], 73.0)
+        self.assertEqual(row["long_silence_count"], 1)
+        self.assertEqual(row["reasoning_observed_long_silence_count"], 1)
+        self.assertEqual(
+            row["max_post_tool_silence_evidence"][
+                "next_progress_has_thinking"
+            ],
+            True,
+        )
+        self.assertEqual(
+            row["max_post_tool_silence_evidence"][
+                "next_progress_output_tokens"
+            ],
+            6000,
+        )
         self.assertEqual(row["result"], "FAIL")
+
+    def test_flow_health_labels_long_silence_without_thinking_as_unattributed(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as td:
+            trace = Path(td) / "session.jsonl"
+            self._flow_trace(trace, edit_second=75)
+
+            report = build_flow_health([trace], plugin_version="0.29.0")
+
+        self.assertEqual(report["startup_slo"]["status"], "MISS")
+        self.assertEqual(report["flow_visibility"]["status"], "DEGRADED")
+        self.assertEqual(
+            report["agent_activity"]["status"],
+            "UNATTRIBUTED_WAIT_OBSERVED",
+        )
 
     def test_flow_health_uses_headless_worker_launch_as_impl_loop_start(self) -> None:
         with TemporaryDirectory() as td:
@@ -539,7 +595,13 @@ class MeasureMainTurnsTests(unittest.TestCase):
             report = build_flow_health([trace], plugin_version="0.29.0")
 
         row = report["invocations"][0]
-        self.assertEqual(report["status"], "DEGRADED")
+        self.assertEqual(report["startup_slo"]["status"], "MISS")
+        self.assertEqual(report["flow_visibility"]["status"], "UNVERIFIED")
+        self.assertEqual(
+            report["agent_activity"]["status"],
+            "NO_LONG_SILENCE_OBSERVED",
+        )
+        self.assertEqual(report["relative_speed"]["status"], "UNPROVEN")
         self.assertEqual(row["startup_target"], "headless_worker_launch")
         self.assertEqual(row["time_to_first_action_seconds"], 70.0)
         self.assertEqual(
@@ -549,7 +611,7 @@ class MeasureMainTurnsTests(unittest.TestCase):
         self.assertIsNone(row["time_to_first_edit_seconds"])
         self.assertEqual(row["first_action_evidence"]["tool"], "WorkerLaunch")
 
-    def test_flow_health_requires_three_current_version_passes_for_healthy(self) -> None:
+    def test_flow_health_requires_three_current_version_passes(self) -> None:
         with TemporaryDirectory() as td:
             base = Path(td)
             traces = []
@@ -567,7 +629,13 @@ class MeasureMainTurnsTests(unittest.TestCase):
 
             report = build_flow_health(traces, plugin_version="0.29.0")
 
-        self.assertEqual(report["status"], "HEALTHY")
+        self.assertEqual(report["startup_slo"]["status"], "PASS")
+        self.assertEqual(report["flow_visibility"]["status"], "CLEAR")
+        self.assertEqual(
+            report["agent_activity"]["status"],
+            "NO_LONG_SILENCE_OBSERVED",
+        )
+        self.assertEqual(report["relative_speed"]["status"], "UNPROVEN")
         self.assertEqual(report["sample_count"], 3)
         self.assertEqual(report["excluded_version_count"], 1)
 
@@ -578,7 +646,13 @@ class MeasureMainTurnsTests(unittest.TestCase):
 
             report = build_flow_health([trace], plugin_version="0.29.0")
 
-        self.assertEqual(report["status"], "UNVERIFIED")
+        self.assertEqual(report["startup_slo"]["status"], "UNVERIFIED")
+        self.assertEqual(report["flow_visibility"]["status"], "UNVERIFIED")
+        self.assertEqual(
+            report["agent_activity"]["status"],
+            "NO_LONG_SILENCE_OBSERVED",
+        )
+        self.assertEqual(report["relative_speed"]["status"], "UNPROVEN")
         self.assertEqual(report["sample_count"], 1)
 
     def test_process_start_falls_back_before_fresh_edit_when_root_duration_is_short(self) -> None:


### PR DESCRIPTION
## 관련 이슈 번호

Document-Exception-PR-Close: 실세션 Flow Health 판정의 의미 혼합을 바로잡는 후속 개선이며 별도 이슈 없이 사용자 요청으로 진행

## 배경 및 문제

- 단일 DEGRADED 등급이 착수 SLO 위반, 화면 무응답, 실제 모델 활동, 다른 workflow 대비 상대 속도를 한 사실처럼 보이게 했습니다.
- NexusMessenger 실세션에서는 첫 구현까지 493.859초였지만 60초 이상 침묵 4건 모두 같은 assistant request의 thinking block과 연결됐습니다.

## 원인 (해당 시)

- 기존 측정기가 startup 계약 위반 하나를 전체 Flow Health 상태로 승격했고 비도구 경과를 wait로 명명했습니다.
- 비교군 조건이 다른 과거 세션만으로 상대 속도를 해석할 여지가 있었습니다.

## 작업내용

- Startup SLO, Flow Visibility, Agent Activity, Relative Speed를 독립 판정합니다.
- thinking block이 확인된 장기 침묵은 ACTIVE_REASONING_OBSERVED로 기록하되 생산성 증거로 취급하지 않습니다.
- 비도구 wait를 non-tool elapsed로 정정하고 실제 의미 경계를 문서화했습니다.
- 측정기 회귀 테스트와 공개 evidence 수치를 1,216건으로 갱신했습니다.

## 결정 근거

- 절대 계약 위반과 비교 성능은 서로 다른 주장입니다. 같은 fixture와 runtime의 반복 paired trial이 없으면 상대 속도는 UNPROVEN으로 남깁니다.
- 한 번의 위반은 MISS 또는 DEGRADED를 확정할 수 있지만 PASS 또는 CLEAR는 현행 버전 표본 3개를 요구합니다.

## 배포 경로 검증 (plug-in 영향 시)

- N/A — source checkout 전용 maintainer 측정기와 감사 기준 변경이며 release artifact runtime surface는 변하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

- N/A — 기존 measure_main_turns.py --flow-health 출력만 정정하며 새 public surface를 추가하지 않습니다.

## Test Plan

- [x] python3.11 -m unittest discover -s tests -v: 1,216/1,216 PASS
- [x] python3.11 evals/guard_efficacy.py --json: 50/50 PASS
- [x] Python 3.11 static-quality PASS
- [x] 실제 NexusMessenger 세션 재측정과 격리 clone 검증 PASS
- [x] public evidence, cross-ref, public-surface 검사 PASS

## 참고

- 개인 dcness-harness-audit 스킬도 동일한 4축 기준으로 갱신하고 skill validator를 통과했습니다.
