### PR TITLE
[issue-1205] impl-loop 진행 뷰를 복원합니다.

### DIFF
--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -82,6 +82,8 @@ Task 진행 표시는 [`impl-loop` 진행 뷰](../../skills/impl-loop/SKILL.md#�
 유지하면서 `dcness-helper chain-view`의 operations를 TaskCreate/TaskUpdate로
 적용한다. chain-view와 background implementation-chain은 같은 assistant turn의
 독립 tool batch이며, Task UI 적용을 기다리느라 worker 시작을 늦추지 않는다.
+batch 미지원 환경에서는 chain-view를 별도 호출하지 않고 기존 진행 메시지의
+수동 완료/현재/예정 view로 폴백해 helper 전용 tool turn을 만들지 않는다.
 
 ```
 TaskCreate("<agent>: <mode 또는 짧은 설명>")

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -69,7 +69,12 @@ echo "[<entry>] run started: $RUN_ID"
 
 ## Step 1 — TaskCreate
 
-해당 skill 의 `## Loop` 의 `task_list` 필드대로 일괄 등록한다. **단 `/impl-loop`는 이 절을 적용하지 않는다.** story runner state와 implementation chain의 lifecycle receipt가 진행 진본이므로 worker 시작 전에 `TaskCreate`/`TaskUpdate`를 만들지 않는다.
+해당 skill 의 `## Loop` 의 `task_list` 필드대로 일괄 등록한다. `/impl-loop`의
+Task 진행 표시는 [`impl-loop` 진행 뷰](../../skills/impl-loop/SKILL.md#진행-뷰-task-리스트)가
+소유한다. story runner state와 implementation chain receipt를 실행 진본으로
+유지하면서 `dcness-helper chain-view`의 operations를 TaskCreate/TaskUpdate로
+적용한다. chain-view와 background implementation-chain은 같은 assistant turn의
+독립 tool batch이며, Task UI 적용을 기다리느라 worker 시작을 늦추지 않는다.
 
 ```
 TaskCreate("<agent>: <mode 또는 짧은 설명>")

--- a/docs/plugin/loop-procedure.md
+++ b/docs/plugin/loop-procedure.md
@@ -69,7 +69,14 @@ echo "[<entry>] run started: $RUN_ID"
 
 ## Step 1 — TaskCreate
 
-해당 skill 의 `## Loop` 의 `task_list` 필드대로 일괄 등록한다. `/impl-loop`의
+해당 skill 이 정의한 task list를 일괄 등록한다. `/impl`은
+[`/impl` 진행 뷰](../../skills/impl/SKILL.md#진행-뷰-task-리스트)의 고정 3개
+task를 TaskCreate/TaskUpdate로 적용한다. Task 호출은 EnterWorktree·첫 work
+action·validator·마감 호출과 같은 assistant turn의 독립 tool batch다.
+TaskCreate가 반환한 id를 쓰는 첫 TaskUpdate도 다음의 이미 필요한 work action에
+붙여 main-direct 첫 edit나 background implementation-chain을 기다리게 하지 않는다.
+
+`/impl-loop`의
 Task 진행 표시는 [`impl-loop` 진행 뷰](../../skills/impl-loop/SKILL.md#진행-뷰-task-리스트)가
 소유한다. story runner state와 implementation chain receipt를 실행 진본으로
 유지하면서 `dcness-helper chain-view`의 operations를 TaskCreate/TaskUpdate로

--- a/harness/chain_view.py
+++ b/harness/chain_view.py
@@ -473,10 +473,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         prog="chain-view",
         description="impl-loop chain 진행 뷰 자동 렌더 (#755) — 도구이지 게이트 아님",
     )
-    parser.add_argument(
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument(
         "--tasks",
-        required=True,
         help="task list JSON 경로 ('-' = stdin). {tasks:[{name,engine,closes?}], current?}",
+    )
+    source.add_argument(
+        "--tasks-json",
+        help="task list inline JSON. 별도 파일 없이 first tool batch에서 사용.",
     )
     parser.add_argument(
         "--current",
@@ -496,12 +500,26 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         action="store_true",
         help="전체 task list 최초 생성/재생성 operation 산출 (임의 current 점프 포함).",
     )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Task tool batch 전달용 단일 줄 JSON 출력.",
+    )
     args = parser.parse_args(argv)
 
     try:
-        data = _load_input(args.tasks)
+        if args.tasks_json:
+            data = json.loads(args.tasks_json)
+            if not isinstance(data, dict):
+                raise ValueError("입력 JSON 은 {tasks, current} 객체여야 한다")
+        else:
+            data = _load_input(args.tasks)
         tasks = parse_tasks(data.get("tasks", []))
-        current = args.current if args.current is not None else int(data.get("current", 0))
+        current = (
+            args.current
+            if args.current is not None
+            else int(data.get("current", 0))
+        )
         payload = build_chain_view(
             tasks, current, prev=args.prev, initial=args.initial
         )
@@ -509,7 +527,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         print(f"[chain-view] 입력 오류: {exc}", file=sys.stderr)
         return 1
 
-    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    print(
+        json.dumps(
+            payload,
+            ensure_ascii=False,
+            indent=None if args.compact else 2,
+            separators=(",", ":") if args.compact else None,
+        )
+    )
     return 0
 
 

--- a/harness/chain_view.py
+++ b/harness/chain_view.py
@@ -508,7 +508,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     try:
-        if args.tasks_json:
+        if args.tasks_json is not None:
             data = json.loads(args.tasks_json)
             if not isinstance(data, dict):
                 raise ValueError("입력 JSON 은 {tasks, current} 객체여야 한다")

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -578,7 +578,7 @@ def _cli_chain_view(args: Any) -> int:
     return chain_view.main(
         (
             ["--tasks", args.tasks]
-            if getattr(args, "tasks", None)
+            if getattr(args, "tasks", None) is not None
             else ["--tasks-json", args.tasks_json]
         )
         + (["--current", str(args.current)] if args.current is not None else [])

--- a/harness/session_state_cli.py
+++ b/harness/session_state_cli.py
@@ -576,13 +576,15 @@ def _cli_chain_view(args: Any) -> int:
     from harness import chain_view
 
     return chain_view.main(
-        [
-            "--tasks",
-            args.tasks,
-        ]
+        (
+            ["--tasks", args.tasks]
+            if getattr(args, "tasks", None)
+            else ["--tasks-json", args.tasks_json]
+        )
         + (["--current", str(args.current)] if args.current is not None else [])
         + (["--prev", str(args.prev)] if args.prev is not None else [])
         + (["--initial"] if getattr(args, "initial", False) else [])
+        + (["--compact"] if getattr(args, "compact", False) else [])
     )
 
 
@@ -989,10 +991,15 @@ def _build_arg_parser() -> Any:
         "chain-view",
         help="impl-loop chain 진행 뷰 자동 렌더 JSON (task list + current → view/operations/strategy — #755)",
     )
-    p_cv.add_argument(
+    p_cv_source = p_cv.add_mutually_exclusive_group(required=True)
+    p_cv_source.add_argument(
         "--tasks",
-        required=True,
         help="task list JSON 경로 ('-' = stdin). {tasks:[{name,engine,closes?}], current?}",
+    )
+    p_cv_source.add_argument(
+        "--tasks-json",
+        dest="tasks_json",
+        help="task list inline JSON. 별도 파일 없이 first tool batch에서 사용.",
     )
     p_cv.add_argument(
         "--current",
@@ -1010,6 +1017,11 @@ def _build_arg_parser() -> Any:
         "--initial",
         action="store_true",
         help="전체 task list 최초 생성 operation 산출 (transition 대신).",
+    )
+    p_cv.add_argument(
+        "--compact",
+        action="store_true",
+        help="Task tool batch 전달용 단일 줄 JSON 출력.",
     )
     p_cv.set_defaults(func=_cli_chain_view)
 

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -25,14 +25,65 @@ target/AC snapshot → worktree → implementation-chain 한 호출 → worker
 
 같은 story 값은 path 정렬 결과에서 한 연속 block이어야 한다. 다중 story는 `story1(base=main) → story2(base=story1)` branch stack이며, 다음 story는 직전 story 브랜치에서 재분기한다.
 
+## 진행 뷰 (task 리스트)
+
+메인은 impl-loop의 실제 진행을 사용자에게 보이도록 `dcness-helper chain-view`
+출력을 적용한다. story runner state와 implementation chain receipt는 실행
+진본이고, 진행 뷰는 그 상태를 사용자 UI에 투영하는 표시다. 둘은 대체 관계가
+아니다.
+
+확정된 순서의 전체 target task는
+`{"tasks":[{"name":"<task>","engine":"build-worker","closes":"story"}]}`
+형태로 한 번 만들고 run 동안 재사용한다. 별도 파일은 만들지 않고
+`chain-view --tasks-json '<json>' --compact`로 넘긴다. UI checkpoint가 있는 task만
+`engine: "ui-build-worker"`를 쓴다. `closes`는 마감 task에만 지정한다.
+epic 마감이면 값은 `"epic"`이다.
+메인이 완료·현재·예정 글리프, 들여쓰기, sub-step 또는 task 수별 다시 그리기
+전략을 다시 계산하지 않는다.
+
+정상 fast-start에서는 `chain-view`와 background `dcness-implementation-chain`을
+같은 assistant turn의 독립 tool batch로 발행한다. 두 호출은 서로 결과를 입력으로
+쓰지 않는다. implementation-chain은 chain-view 결과나 TaskCreate/TaskUpdate
+완료를 기다리지 않는다. batch 발행이 불가능한 환경이면 implementation-chain을
+먼저 launch하고 바로 chain-view를 호출한다. 진행 뷰 때문에 별도 직렬 tool call을
+추가하지 않는다. helper 결과가 돌아오면 worker가 실행되는 동안 `operations`를
+순서 그대로 Task 시스템에 적용하고 `view`를 사용자에게 진행 메시지로 표시한다.
+
+호출 경계는 다음 세 곳이다.
+
+1. **chain 진입**: worktree 진입 뒤
+   `chain-view --tasks-json '<json>' --current 0 --initial --compact`와 one-shot
+   implementation-chain을 같은 첫 tool-bearing turn에 발행한다. worker launch가
+   진행 뷰 렌더를 기다리지 않는다.
+2. **task 완료마다**: task `i`를 completed로 mark하고 `next-action`을 받은 뒤
+   다음 task가 있으면 `chain-view --prev <i> --current <i+1>`과 다음
+   implementation-chain을 같은 assistant turn에 발행한다. story branch 전환이
+   필요하면 branch를 만든 직후 이 batch를 발행한다. resume처럼 사용자 Task
+   목록이 비어 있으면 `--initial`로 현재 index 전체를 다시 그린다.
+3. **마감 시퀀스 진입**: 마지막 build-worker가 끝나 `action=done`이면 이미
+   펼쳐진 마감 task에서 `build-worker` sub-step을 completed,
+   `validation-sequence:STORY|EPIC`을 in_progress로 TaskUpdate하고 그 `view`를
+   다시 표시한 뒤 `impl-loop-finish.md`로 이동한다. `--initial`을 기존
+   Task 목록 위에 다시 적용해 중복 생성하지 않는다. 마감 시퀀스까지 PASS한
+   뒤에만 `--prev <last-index> --current <task-total>` payload를 적용해 전체
+   완료를 표시한다.
+
+각 payload의 `create_header`·`create_substep`은 TaskCreate, 상태 변경과 삭제는
+TaskUpdate로 적용한다. Task tool이 없거나 helper가 실패하면 같은 완료/현재/예정
+표현을 수동으로 다시 만들고 run은 계속한다. helper는 도구이지 gate가 아니며
+run state를 변경하지 않는다. 현재 run에 `journey_deferred`가 있으면 렌더된
+`view` 바로 아래에 해당 journey id 목록을 유지하고 이후 worker prompt에도
+같은 목록을 전달한다.
+
 ## Fast start
 
 ### 1. 최소 snapshot
 
 warm handoff나 사용자 입력이 exact task path·AC snapshot pointer·slim prompt와
 feature worktree 상태를 이미 확정했으면 이 snapshot을 다시 `ls`/`find`/`cat`하지
-않는다. one-shot launch가 첫 tool call이다. worktree/default-branch 정합은 chain이
-mutation 전에 검증한다.
+않는다. one-shot launch가 첫 tool-bearing turn의 독립 batch에 포함된다. 같은
+turn의 chain-view는 launch를 기다리게 하는 선행 호출이 아니다.
+worktree/default-branch 정합은 chain이 mutation 전에 검증한다.
 
 1. `stories.md`의 parent epic/story issue pointer를 확인한다.
 2. 대상 issue 본문을 한 번 읽어 target GitHub issue AC snapshot을 보관한다. 진행 중 재조회하지 않는다.
@@ -145,7 +196,7 @@ prose를 기록한 것이므로 재호출하지 않는다. 최신 prose가 `PASS
 
 - `action=task`: 다음 task용 slim prompt로 chain을 다시 호출한다. 기존 state이므로 `--init-path`는 생략하며, chain이 이전 run 종료와 새 run 시작을 같은 호출 안에서 처리한다.
 - `action=story-pr`: 직전 story tip/base를 봉인하고 PR 없이 다음 story branch를 만든다.
-- `action=done`: worker loop를 끝내고 GREEN 이후 진본으로 이동한다.
+- `action=done`: 진행 뷰를 마감 시퀀스 상태로 갱신하고 worker loop를 끝낸 뒤 GREEN 이후 진본으로 이동한다.
 - `action=error|blocked`: 그때만 routing 문서를 읽어 bounded recovery 또는 사용자 결정을 수행한다.
 
 진행 메시지는 `진행: RED/첫 edit 확인`, `진행: 구현·검증 green`, `진행: 통합 review 시작`처럼 사용자에게 의미 있는 변화만 남긴다. helper PASS/no-op과 polling 자체를 성과처럼 반복 출력하지 않는다.

--- a/skills/impl-loop/SKILL.md
+++ b/skills/impl-loop/SKILL.md
@@ -44,9 +44,11 @@ epic 마감이면 값은 `"epic"`이다.
 정상 fast-start에서는 `chain-view`와 background `dcness-implementation-chain`을
 같은 assistant turn의 독립 tool batch로 발행한다. 두 호출은 서로 결과를 입력으로
 쓰지 않는다. implementation-chain은 chain-view 결과나 TaskCreate/TaskUpdate
-완료를 기다리지 않는다. batch 발행이 불가능한 환경이면 implementation-chain을
-먼저 launch하고 바로 chain-view를 호출한다. 진행 뷰 때문에 별도 직렬 tool call을
-추가하지 않는다. helper 결과가 돌아오면 worker가 실행되는 동안 `operations`를
+완료를 기다리지 않는다. batch를 지원하지 않으면 chain-view를 독립 호출하지 않는다.
+implementation-chain을 먼저 launch하고 같은 진행 메시지에
+수동 완료/현재/예정 view를 붙인다. 이후 경계도 진행 뷰 때문에
+별도 직렬 tool call을 추가하지 않는다.
+helper 결과가 돌아오면 worker가 실행되는 동안 `operations`를
 순서 그대로 Task 시스템에 적용하고 `view`를 사용자에게 진행 메시지로 표시한다.
 
 호출 경계는 다음 세 곳이다.

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -23,6 +23,53 @@ owner 선택을 위한 별도 repo scan·SSOT read·질문은 하지 않는다. 
 
 선택 뒤에는 같은 구현 소유자가 GREEN과 review finding 수정을 모두 맡는다. headless가 workspace를 바꾼 뒤에는 다른 provider로 넘기지 않고 same-workspace recovery 또는 BLOCKED만 허용한다. 메인은 제품 결정, 진행 보고, 외부 issue/PR mutation을 계속 소유한다.
 
+## 진행 뷰 (task 리스트)
+
+메인은 owner와 target을 확정하면 다음 고정 3개 task를 만들고 run 동안 반환된
+task id를 재사용한다.
+
+1. `구현 · <target> (<main-direct|headless>)`
+2. `검증 · impl-validator`
+3. `마감 · commit/PR/CI`
+
+첫 task는 실행 시작과 함께 `in_progress`, 나머지는 `pending`으로 표시한다.
+lifecycle state와 implementation-chain receipt가 실행 진본이고 Task 목록은
+사용자 UI에 진행을 투영하는 표시다. 고정 3개이므로 이 `/impl` 진행 뷰는
+추가 helper subprocess를 호출하지 않는다.
+
+정상 fast-start에서는 세 `TaskCreate`와 `EnterWorktree 또는 첫 work action`을
+같은 첫 tool-bearing turn의 독립 tool batch로 발행한다. `TaskCreate`가 기본
+`pending`으로 만들어 반환한 id는 바로 다음의 **이미 필요했던** work action에서
+첫 task를 `in_progress`로 바꾸는 `TaskUpdate`에 쓴다. 예를 들어 격리 결과를
+받은 뒤 main-direct는 `TaskUpdate`와 `begin-run`·exact pointer read·RED/첫 edit
+중 그 시점의 호출을, headless는 `TaskUpdate`와 background
+implementation-chain launch를 같은 독립 batch로 발행한다. headless
+implementation-chain은 TaskCreate나 TaskUpdate 결과를 기다리지 않는다.
+
+이미 격리된 상태에서는 `TaskCreate`를 target 확인·exact pointer read·slim
+prompt 준비처럼 원래 필요한 호출에 붙이고, 다음 원래 work action에
+`TaskUpdate`를 붙인다. batch 발행이 불가능하면 work action을 먼저 실행하고
+Task 호출은 다음의 이미 필요한 tool-bearing turn에 붙인다. Task만 처리하는
+사이 turn이나 진행 뷰만을 위한 추가 assistant turn을 만들지 않는다. 아래
+focused read의 `첫 tool call은 pointer만`은 work action의 read 경계를 뜻한다.
+같은 batch의 Task sidecar는 추가 repo read나 blocking assistant turn이 아니다.
+
+상태 변경은 기존 필수 작업과 같은 tool-bearing turn에 `TaskUpdate`로 묶는다.
+
+1. 구현과 관련 gate가 GREEN이면 구현 task를 `completed`, 검증 task를
+   `in_progress`로 바꾸고 candidate freeze/impl-validator 경로를 계속한다.
+2. validator가 MUST FIX를 내면 같은 task를 새로 만들지 않고 구현 task를
+   `in_progress`, 검증 task를 `pending`으로 되돌려 같은 owner의 rework를 표시한다.
+3. validator PASS면 검증 task를 `completed`, 마감 task를 `in_progress`로 바꾸고
+   commit·PR·CI·target AC audit을 진행한다.
+4. 자동 마감이 끝나면 마감 task를 `completed`로 바꾼다. 사람 확인이 남으면
+   Task를 늘리지 않고 `human verification 대기`를 별도 메시지로 유지한다.
+
+resume 시 같은 제목의 기존 `/impl` task가 있으면 id와 상태를 재사용하고
+`TaskCreate`를 중복 생성하지 않는다. Task tool이 없거나 호출이 실패하면 같은
+3줄 완료/현재/예정 ASCII 뷰를 진행 메시지에 표시하고 구현은 계속한다. 진행
+표시는 도구이지 gate가 아니다.
+
 ## 질문 경계
 
 묻지 않고 진행한다:

--- a/skills/impl/SKILL.md
+++ b/skills/impl/SKILL.md
@@ -30,7 +30,7 @@ task id를 재사용한다.
 
 1. `구현 · <target> (<main-direct|headless>)`
 2. `검증 · impl-validator`
-3. `마감 · commit/PR/CI`
+3. `마감 · PR/CI/AC audit`
 
 첫 task는 실행 시작과 함께 `in_progress`, 나머지는 `pending`으로 표시한다.
 lifecycle state와 implementation-chain receipt가 실행 진본이고 Task 목록은
@@ -56,12 +56,13 @@ focused read의 `첫 tool call은 pointer만`은 work action의 read 경계를 �
 
 상태 변경은 기존 필수 작업과 같은 tool-bearing turn에 `TaskUpdate`로 묶는다.
 
-1. 구현과 관련 gate가 GREEN이면 구현 task를 `completed`, 검증 task를
-   `in_progress`로 바꾸고 candidate freeze/impl-validator 경로를 계속한다.
+1. 구현 관련 gate, Cartography sync와 candidate commit까지 끝나면 구현 task를
+   `completed`, 검증 task를 `in_progress`로 바꾸고 candidate
+   freeze/impl-validator 경로를 계속한다.
 2. validator가 MUST FIX를 내면 같은 task를 새로 만들지 않고 구현 task를
    `in_progress`, 검증 task를 `pending`으로 되돌려 같은 owner의 rework를 표시한다.
 3. validator PASS면 검증 task를 `completed`, 마감 task를 `in_progress`로 바꾸고
-   commit·PR·CI·target AC audit을 진행한다.
+   PR·CI·target AC audit을 진행한다.
 4. 자동 마감이 끝나면 마감 task를 `completed`로 바꾼다. 사람 확인이 남으면
    Task를 늘리지 않고 `human verification 대기`를 별도 메시지로 유지한다.
 

--- a/tests/test_chain_view.py
+++ b/tests/test_chain_view.py
@@ -28,6 +28,11 @@
         - JSON-ish 입력 파싱 → payload
         - 순수 변환(run state mutation 없음 — 도구이지 게이트 아님)
 """
+from contextlib import redirect_stdout
+from io import StringIO
+import json
+from pathlib import Path
+import subprocess
 import unittest
 
 from harness.chain_view import (
@@ -35,6 +40,7 @@ from harness.chain_view import (
     MAIN_OWNED_SUBSTEPS,
     build_chain_view,
     initial_operations,
+    main as chain_view_main,
     normalize_engine,
     parse_tasks,
     redraw_strategy,
@@ -42,6 +48,8 @@ from harness.chain_view import (
     substeps_for,
     transition_operations,
 )
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _task(name, engine="build-worker", closes=None):
@@ -448,6 +456,97 @@ class TestBuildChainViewAndParse(unittest.TestCase):
         self.assertIn("   ㄴ canvas-design", payload["view"])
         self.assertNotIn("   ㄴ 사용자 PICK", payload["view"])
         self.assertIn("canvas-design", payload["current_substeps"])
+
+    def test_inline_cli_emits_compact_payload_without_task_list_file(self):
+        data = {
+            "tasks": [
+                {
+                    "name": "alpha",
+                    "engine": "build-worker",
+                    "closes": "epic",
+                },
+            ],
+        }
+        stdout = StringIO()
+        with redirect_stdout(stdout):
+            rc = chain_view_main(
+                [
+                    "--tasks-json",
+                    json.dumps(data, ensure_ascii=False),
+                    "--initial",
+                    "--compact",
+                ]
+            )
+
+        self.assertEqual(rc, 0)
+        rendered = stdout.getvalue().strip()
+        self.assertEqual(len(rendered.splitlines()), 1)
+        payload = json.loads(rendered)
+        self.assertIn("▾ task1 · alpha", payload["view"])
+        self.assertEqual(
+            payload["current_substeps"],
+            ["build-worker", "validation-sequence:EPIC"],
+        )
+
+    def test_helper_cli_renders_initial_and_task_completion_transition(self):
+        data = json.dumps(
+            {
+                "tasks": [
+                    {"name": "alpha", "engine": "build-worker"},
+                    {
+                        "name": "beta",
+                        "engine": "build-worker",
+                        "closes": "story",
+                    },
+                ]
+            },
+            ensure_ascii=False,
+        )
+
+        initial = subprocess.run(
+            [
+                str(ROOT / "scripts" / "dcness-helper"),
+                "chain-view",
+                "--tasks-json",
+                data,
+                "--current",
+                "0",
+                "--initial",
+                "--compact",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        transition = subprocess.run(
+            [
+                str(ROOT / "scripts" / "dcness-helper"),
+                "chain-view",
+                "--tasks-json",
+                data,
+                "--prev",
+                "0",
+                "--current",
+                "1",
+                "--compact",
+            ],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(initial.returncode, 0, initial.stderr)
+        self.assertEqual(transition.returncode, 0, transition.stderr)
+        self.assertIn("▾ task1 · alpha", json.loads(initial.stdout)["view"])
+        updated = json.loads(transition.stdout)
+        self.assertIn("✓ task1 · alpha", updated["view"])
+        self.assertIn("▾ task2 · beta", updated["view"])
+        self.assertIn(
+            "validation-sequence:STORY",
+            updated["current_substeps"],
+        )
 
 
 class TestViewOperationsConsistency(unittest.TestCase):

--- a/tests/test_chain_view.py
+++ b/tests/test_chain_view.py
@@ -28,7 +28,7 @@
         - JSON-ish 입력 파싱 → payload
         - 순수 변환(run state mutation 없음 — 도구이지 게이트 아님)
 """
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 import json
 from pathlib import Path
@@ -487,6 +487,15 @@ class TestBuildChainViewAndParse(unittest.TestCase):
             payload["current_substeps"],
             ["build-worker", "validation-sequence:EPIC"],
         )
+
+    def test_empty_inline_json_reports_input_error_without_traceback(self):
+        stderr = StringIO()
+        with redirect_stderr(stderr):
+            rc = chain_view_main(["--tasks-json", ""])
+
+        self.assertEqual(rc, 1)
+        self.assertIn("[chain-view] 입력 오류:", stderr.getvalue())
+        self.assertNotIn("Traceback", stderr.getvalue())
 
     def test_helper_cli_renders_initial_and_task_completion_transition(self):
         data = json.dumps(

--- a/tests/test_impl_fast_start_contract.py
+++ b/tests/test_impl_fast_start_contract.py
@@ -53,7 +53,8 @@ class ImplFastStartContractTests(unittest.TestCase):
         self.assertIn("## 진행 뷰 (task 리스트)", skill)
         self.assertIn("구현 · <target> (<main-direct|headless>)", skill)
         self.assertIn("검증 · impl-validator", skill)
-        self.assertIn("마감 · commit/PR/CI", skill)
+        self.assertIn("마감 · PR/CI/AC audit", skill)
+        self.assertIn("Cartography sync와 candidate commit까지 끝나면", skill)
         self.assertIn("TaskCreate", skill)
         self.assertIn("TaskUpdate", skill)
         self.assertIn("첫 tool-bearing turn의 독립 tool batch", skill)
@@ -102,6 +103,12 @@ class ImplFastStartContractTests(unittest.TestCase):
         self.assertIn("같은 assistant turn의 독립 tool batch", skill)
         self.assertIn("implementation-chain은 chain-view", skill)
         self.assertIn("완료를 기다리지 않는다", skill)
+        self.assertIn(
+            "batch를 지원하지 않으면 chain-view를 독립 호출하지 않는다",
+            skill,
+        )
+        self.assertIn("수동 완료/현재/예정 view", skill)
+        self.assertNotIn("먼저 launch하고 바로 chain-view를 호출", skill)
         self.assertIn("`nohup`, `&`, `disown`", skill)
         self.assertIn("`.dcness-work`를 미리 만들지 않는다", skill)
         self.assertIn("same-workspace recovery", skill)

--- a/tests/test_impl_fast_start_contract.py
+++ b/tests/test_impl_fast_start_contract.py
@@ -46,6 +46,52 @@ class ImplFastStartContractTests(unittest.TestCase):
         self.assertIn("target GitHub issue AC close audit", finish)
         self.assertIn("PR", finish)
 
+    def test_impl_progress_tasks_do_not_delay_main_or_headless_start(self) -> None:
+        skill = self.read("skills/impl/SKILL.md")
+        procedure = self.read("docs/plugin/loop-procedure.md")
+
+        self.assertIn("## 진행 뷰 (task 리스트)", skill)
+        self.assertIn("구현 · <target> (<main-direct|headless>)", skill)
+        self.assertIn("검증 · impl-validator", skill)
+        self.assertIn("마감 · commit/PR/CI", skill)
+        self.assertIn("TaskCreate", skill)
+        self.assertIn("TaskUpdate", skill)
+        self.assertIn("첫 tool-bearing turn의 독립 tool batch", skill)
+        self.assertIn("EnterWorktree 또는 첫 work action", skill)
+        self.assertIn(
+            "`TaskCreate`가 기본\n`pending`으로 만들어 반환한 id",
+            skill,
+        )
+        self.assertIn(
+            "다음의 **이미 필요했던** work action",
+            skill,
+        )
+        self.assertIn(
+            "implementation-chain은 TaskCreate나 TaskUpdate 결과를 기다리지 않는다",
+            skill,
+        )
+        self.assertIn("batch 발행이 불가능하면 work action을 먼저", skill)
+        self.assertIn("다음의 이미 필요한 tool-bearing turn에 붙인다", skill)
+        self.assertIn(
+            "진행 뷰만을 위한 추가 assistant turn을 만들지 않는다",
+            skill,
+        )
+        self.assertIn(
+            "같은 batch의 Task sidecar는 추가 repo read나 blocking assistant turn이 아니다",
+            skill,
+        )
+        self.assertIn("추가 helper subprocess를 호출하지 않는다", skill)
+        self.assertIn("중복 생성하지 않는다", skill)
+        self.assertIn("Task tool이 없거나 호출이 실패하면", skill)
+        self.assertIn("도구이지 gate가 아니다", skill)
+        self.assertIn(
+            "[`/impl` 진행 뷰](../../skills/impl/SKILL.md#진행-뷰-task-리스트)",
+            procedure,
+        )
+        self.assertNotIn("TaskCreate 완료 후 EnterWorktree", skill)
+        self.assertNotIn("TaskCreate 완료 후 implementation-chain", skill)
+        self.assertNotIn("dcness-helper chain-view", skill)
+
     def test_impl_loop_launches_worker_in_background_without_repeat_preflight(self) -> None:
         skill = self.read("skills/impl-loop/SKILL.md")
 

--- a/tests/test_impl_fast_start_contract.py
+++ b/tests/test_impl_fast_start_contract.py
@@ -50,7 +50,12 @@ class ImplFastStartContractTests(unittest.TestCase):
         skill = self.read("skills/impl-loop/SKILL.md")
 
         self.assertIn("run_in_background", skill)
-        self.assertIn("one-shot launch가 첫 tool call", skill)
+        self.assertIn("one-shot launch가 첫 tool-bearing turn", skill)
+        self.assertIn("별도 직렬 tool call을", skill)
+        self.assertIn("추가하지 않는다", skill)
+        self.assertIn("같은 assistant turn의 독립 tool batch", skill)
+        self.assertIn("implementation-chain은 chain-view", skill)
+        self.assertIn("완료를 기다리지 않는다", skill)
         self.assertIn("`nohup`, `&`, `disown`", skill)
         self.assertIn("`.dcness-work`를 미리 만들지 않는다", skill)
         self.assertIn("same-workspace recovery", skill)
@@ -60,6 +65,34 @@ class ImplFastStartContractTests(unittest.TestCase):
         self.assertNotIn("begin-step build-worker`로 열고", skill)
         self.assertNotIn("boundary-suggestions --impl-plan", skill)
         self.assertNotIn("generated TDD hook 상태를 확인", skill)
+
+    def test_impl_loop_chain_view_is_rendered_at_each_lifecycle_boundary(self) -> None:
+        skill = self.read("skills/impl-loop/SKILL.md")
+        procedure = self.read("docs/plugin/loop-procedure.md")
+
+        self.assertIn("## 진행 뷰 (task 리스트)", skill)
+        self.assertIn("dcness-helper chain-view", skill)
+        self.assertIn("chain 진입", skill)
+        self.assertIn("task 완료마다", skill)
+        self.assertIn("마감 시퀀스 진입", skill)
+        self.assertIn("--tasks-json", skill)
+        self.assertIn("`operations`를", skill)
+        self.assertIn("순서 그대로 Task 시스템에 적용", skill)
+        self.assertIn("`view`를", skill)
+        self.assertIn("사용자에게 진행", skill)
+        self.assertIn("메시지로 표시한다", skill)
+        self.assertIn("`--initial`을 기존", skill)
+        self.assertIn("중복 생성하지 않는다", skill)
+        self.assertIn("journey_deferred", skill)
+        self.assertIn("`/impl-loop`의", procedure)
+        self.assertIn(
+            "[`impl-loop` 진행 뷰](../../skills/impl-loop/SKILL.md#진행-뷰-task-리스트)",
+            procedure,
+        )
+        self.assertNotIn(
+            "worker 시작 전에 `TaskCreate`/`TaskUpdate`를 만들지 않는다",
+            procedure,
+        )
 
     def test_build_worker_order_gate_does_not_run_advisory_preflights(self) -> None:
         source = self.read("harness/session_state.py")


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1205

## 배경 및 문제

- PR #1186, #1191에서 `/impl-loop`의 cold-start 선행 작업을 줄이고 implementation-chain을 첫 tool-bearing turn에 바로 시작하도록 개선했습니다.
- 그 과정에서 예전 TaskCreate/TaskUpdate 절차와 함께 `chain-view` 호출 지시까지 제거됐지만 helper와 CLI는 남아, 긴 구현에서 사용자가 현재/완료/예정 task를 볼 수 없었습니다.
- 같은 fast-start 정리 이후 일반 `/impl`도 main-direct와 headless one-shot 모두 Task 진행 목록을 만들거나 갱신하는 계약이 없어졌습니다.

## 원인 (해당 시)

- fast-start 경로를 단순화할 때 수동 preflight와 진행 표시가 같은 선행 비용으로 취급돼 호출 계약이 함께 삭제됐습니다.
- 진행 표시는 worker의 입력이나 사전 조건이 아닌데도 독립 sidecar로 분리되지 않아, 구현만 남은 고아 상태가 됐습니다.
- `/impl-loop`는 가변 task chain을 렌더링할 helper가 남아 있었지만 `/impl`의 고정 구현·검증·마감 단계에는 별도 진행 뷰 소유자가 없었습니다.

## 작업내용

- `chain-view`가 task JSON을 파일 없이 직접 받고 한 줄 payload를 반환하도록 `--tasks-json`, `--compact`를 추가했습니다.
- `/impl-loop`가 chain 진입, 각 task 완료, 마감 시퀀스 진입에서 view/operations를 Task 시스템과 사용자 메시지에 적용하도록 복원했습니다.
- `chain-view`와 background implementation-chain을 같은 assistant turn의 독립 tool batch로 발행하며, worker가 view/Task 적용을 기다리지 않는 fast-start 계약을 명시했습니다.
- 실제 `dcness-helper chain-view` 초기/전이 실행과 fast-start 비직렬 계약을 회귀 테스트로 고정했습니다.
- 빈 inline JSON도 traceback 없이 입력 오류로 정리하도록 source 선택 경계를 보강했습니다.
- `/impl`은 main-direct/headless 공통으로 `구현 → 검증 → 마감` 고정 3-task 진행 UI를 복원했습니다.
- `/impl`의 TaskCreate는 EnterWorktree·필수 준비 호출과, TaskUpdate는 다음의 이미 필요한 work action·validator·마감 호출과 독립 batch로 묶어 Task 전용 assistant turn을 만들지 않도록 고정했습니다.
- resume 시 task ID 재사용, Task 도구 실패 시 비차단 ASCII fallback, 구현 재작업 시 기존 task 상태 재사용을 명시하고 fast-start 회귀 테스트를 추가했습니다.
- `/impl`의 candidate commit은 실제 순서대로 구현 task 완료 조건에 포함하고, 마지막 task는 `PR/CI/AC audit`으로 맞췄습니다.
- batch 미지원 `/impl-loop`는 chain-view를 독립 호출하지 않고 기존 진행 메시지의 수동 view로 폴백해 helper 전용 tool turn도 만들지 않습니다.

## 결정 근거

- 구현/CLI를 제거하는 대신 진행 뷰를 유지했습니다. 4시간대 run처럼 긴 작업에서 진행 가시성이 필요하기 때문입니다.
- implementation-chain 스크립트나 provider fork 경로에는 코드를 추가하지 않았습니다. 정상 환경의 진행 표시는 worker와 독립 batch이고, batch가 불가능하면 worker를 먼저 launch한 뒤 helper를 생략하고 수동 view를 사용합니다.
- inline JSON으로 임시 task 파일 생성과 추가 파일 I/O를 없앴습니다. 로컬 helper 단독 실행은 약 0.06초였으며 worker launch의 직렬 선행 단계가 아닙니다.
- `/impl`은 단계가 고정 3개라 `chain-view`나 다른 helper subprocess를 추가하지 않았습니다. Task 생성·갱신은 원래 필요했던 tool-bearing turn에 붙여 main-direct 첫 edit와 headless implementation-chain 시작을 기다리게 하지 않습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `skills/impl/SKILL.md`, `skills/impl-loop/SKILL.md`, `docs/plugin/loop-procedure.md`, `harness/chain_view.py`, `harness/session_state_cli.py`는 기존 release artifact allowlist 경로로 plug-in bundle에 포함됩니다.
- `python3.11 scripts/release_artifact.py smoke --repo-root . --ref HEAD --contract scripts/release_artifact.json` 결과 PASS이며 최종 source SHA는 아래 Test Plan에 기록합니다.
- 별도 `/init-dcness` 복사 경로는 없고, plug-in 업데이트로 반영됩니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 내부 `chain-view` 명령에 입력 형식을 추가하고 기존 `/impl`·`/impl-loop` 진행 표시 계약을 복원했으며, 새 공개 skill/command/agent/gate는 없습니다.

## Test Plan

- [x] `python3.11 -m unittest tests.test_chain_view tests.test_impl_fast_start_contract tests.test_skill_scenarios tests.test_close_validation_sequence tests.test_surface_docs_sync tests.test_impl_cost_aware -v < /dev/null` — 150 PASS
- [x] 진행 UI 전체 focused 계약 회귀 테스트 — 152 PASS
- [x] `python3.11 -m unittest discover -s tests -v < /dev/null` — 1,221 PASS
- [x] 최종 commit pre-commit hook 전체 테스트 — 1,221 PASS
- [x] `PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality.sh`
- [x] public surface, plug-in manifest, index/design doc, cross-ref 게이트
- [x] `python3.11 evals/guard_efficacy.py --json` — 50/50 PASS
- [x] release artifact smoke

## 참고

- 실제 `/impl` main-direct/headless와 `/impl-loop` run에서 진행 뷰 가독성 및 시작 main turn 수를 확인하는 human verification은 PR 리뷰 이후 사용자 확인 대기로 남깁니다.
- 최종 release artifact source SHA: `6b5eaefcf36be07b4d9a60557fa4fb42009ea87c`
