### PR TITLE
[feature] impl-validator 재리뷰 delta 모드

### DIFF
--- a/codex/skills/dcness-impl-validator/SKILL.md
+++ b/codex/skills/dcness-impl-validator/SKILL.md
@@ -27,7 +27,7 @@ Epic close에서는 같은 holistic merge-review invocation에 `CODEBASE_SANITY`
 - `CODEBASE_SANITY`이면 code revision/tree identity, 적용 scope, 메인이 발견·실행한 test/lint/build/typecheck/coverage 명령별 exit code와 warning
 - 구현자가 자유 prose로 남긴 build-worker impact 보고. direct 구현이면 같은 의미 축의 Cartography impact 보고
 - impact가 가리키는 affected Root Cartography 좌표와 tracked/local-only 문서 정책
-- 필요하면 retry count, scope note, known constraint
+- 재리뷰이면 retry round, 직전 `step_completed` receipt 식별자인 `prose_file` + `sha256`, receipt 전문, 직전 candidate HEAD/tree/workspace root, 현재 candidate HEAD/tree/workspace root, 직전 candidate HEAD..현재 candidate HEAD의 commit·변경 파일 목록
 - 다중 story/epic invocation이면 포함된 story PR/조건부 QA PR 목록과 최종 stack tip
 
 ## 먼저 볼 기준
@@ -40,6 +40,22 @@ Epic close에서는 같은 holistic merge-review invocation에 `CODEBASE_SANITY`
 - 호출자가 제공한 test evidence
 - implementation Cartography impact가 있으면 구현 diff, build-worker impact 보고, affected Root Cartography 좌표, 상태 증거, 관련 epic/decision
 - 이전 impl-validator 결과가 있으면 재검증 delta
+
+## 재리뷰 delta mode
+
+첫 라운드는 base..candidate 전체 holistic 리뷰다. 첫 라운드 `FAIL` 뒤 root-cause 수정으로 새 candidate가 생긴 같은 close 재리뷰만 delta mode 후보다. 직전 receipt는 최종 판정 재사용이 아니라 직전 라운드의 검토 범위와 finding을 보존한 이력이다.
+
+delta mode에서는 직전 receipt의 모든 `MUST FIX` finding이 현재 tip에서 근본 원인으로 해소됐는지 다시 추적하고, 직전 candidate HEAD..현재 candidate HEAD의 commit·변경 파일과 직접 영향 표면에서 신규 spec/quality/Cartography 위험을 찾는다. Epic close면 활성 `CODEBASE_SANITY` 렌즈의 신규 위험도 같은 delta에서 판정한다. 직전 holistic 리뷰가 확인했고 candidate delta가 건드리지 않은 영역은 검토 이력으로 재사용할 수 있지만, 이는 안 본 영역을 새로 통과 처리하는 것이 아니다. 이전에 읽지 않은 영역, transitive 영향, finding 판정에 필요한 owner·registration·test·contract는 선택적으로 더 읽는다.
+
+다음 신호가 있으면 좁힌 범위를 고집하지 않고 전체 재독으로 승격한다. 이는 자동 threshold가 아니라 reviewer 판단 기준이다.
+
+- `prose_file`/`sha256` 부재 또는 digest 불일치
+- 직전 candidate HEAD/tree/workspace root나 현재 candidate HEAD/tree/workspace root 부재, history rewrite·base/workspace 변경으로 계보와 delta 증명 불가
+- public contract, module owner, dependency/registration, schema, security boundary, Cartography system boundary의 넓은 변경 또는 Epic close `CODEBASE_SANITY` cheap global signal이 가리키는 delta 밖 신규 위험
+- 직전 finding의 근본 원인 해소를 delta와 직접 영향만으로 판정할 수 없거나 반복 finding이 구조 결함을 시사함
+- changed files/영향 범위가 merge candidate 대부분과 겹쳐 delta mode 이점이 없음
+
+결과 prose에는 delta인지 전체 재독인지, 직전 receipt 식별자와 직전/현재 candidate identity, 실제로 읽은 finding·delta·추가 영향 표면, 판정 범위와 그 근거를 남긴다. delta mode에서도 전체 재독으로 승격할 조건을 어떤 근거로 검토했고 이번에는 왜 해당하지 않았는지 밝히며, 승격했다면 그 이유를 남긴다. 이전 holistic 검토 이력 중 재사용한 범위와 새로 읽은 범위를 밝혀 좁힘이 안 본 영역을 새로 통과 처리한 것으로 읽히지 않게 한다. 고정 heading이나 schema가 아닌 자유 prose 의미 요구다.
 
 ## 판단 축
 
@@ -97,7 +113,7 @@ Epic close holistic invocation 또는 mode가 명시됐을 때 적용한다. 작
 
 ## 작업 흐름
 
-1. mode와 close 단위를 확인한다. 기본 merge-review mode는 changed code를 본다. 검토 대상 커밋 id가 있으면 그 커밋을 직접 조회하고, 커밋이 없는 uncommitted local diff에서만 전달된 diff 파일을 폴백으로 읽는다. 다중 story/epic이면 stack tip vs main diff를 우선하고 Epic close이면 같은 호출에서 `CODEBASE_SANITY` scope도 확정한다.
+1. mode와 close 단위를 확인한다. 첫 라운드는 changed code와 base..candidate 전체 diff를 holistic하게 읽는다. 재리뷰이면 receipt·candidate identity·candidate delta를 검증해 delta mode 또는 전체 재독을 스스로 고른다. 검토 대상 커밋 id가 있으면 그 커밋을 직접 조회하고, 커밋이 없는 uncommitted local diff에서만 전달된 diff 파일을 폴백으로 읽는다. 다중 story/epic이면 stack tip vs main diff를 우선하고 Epic close이면 같은 호출에서 `CODEBASE_SANITY` scope도 확정한다.
 2. plan ∪ target GitHub issue AC 가 있으면 spec 렌즈를 먼저 적용한다. plan 없는 direct 도 target issue 가 있으면 spec 렌즈를 켜고, 둘 다 없을 때만 건너뛴다.
 3. quality 렌즈로 merge blocker를 찾는다. `CODEBASE_SANITY`이면 warning·coverage·dead-code·replacement 분류를 함께 수행한다.
 4. Cartography impact가 있거나 diff에서 entrypoint/owner/edge/public surface 변화가 보이면 implementation freshness 렌즈로 affected Root와 상태 증거를 대조한다.
@@ -128,6 +144,7 @@ UI/API/CLI entrypoint 를 만지는 diff 는 새 flow append 인지, owner modul
 - 다중 story/epic invocation에서 stack tip vs main diff가 제공되지 않았고 개별 PR 단편만으로는 cross-story 결함을 판단할 수 없으면 ESCALATE할 수 있다.
 - applicable implementation Cartography impact가 있으면 diff·impact 보고·affected Root 좌표·상태 증거를 대조했다. as-built drift, 증거 없는 `landed`, route-only drift가 남아 있으면 PASS하지 않는다. local-only/ignored 정책에서도 canonical local Root refresh가 확인되지 않고 durable impact handoff만 있으면 같은 미해소 상태다. system backpressure가 남아 있어도 PASS하지 않는다.
 - `CODEBASE_SANITY` PASS이면 revision/scope와 기계적 증거가 명확하고 모든 후보가 근거로 분류됐으며 rework finding이 없다. merge 판단을 막는 unknown은 ESCALATE한다.
+- 재리뷰이면 직전 finding 전항목과 candidate delta 신규 위험을 판정했고 prose에 판정 범위와 그 근거가 있다. delta mode가 불충분한 신호가 있으면 전체 재독으로 승격했다.
 
 ## 권한 경계
 

--- a/docs/plugin/agents/impl-validator/impl-validator-agent.md
+++ b/docs/plugin/agents/impl-validator/impl-validator-agent.md
@@ -18,7 +18,7 @@ Epic close에서는 같은 holistic merge-review invocation에 `CODEBASE_SANITY`
 - `CODEBASE_SANITY` mode이면 호출자가 제공한 code revision 또는 tree identity, 적용 scope, 발견·실행한 test/lint/build/typecheck/coverage 명령별 exit code와 warning 원문·요약
 - 구현자가 자유 prose로 남긴 build-worker impact 보고. direct 구현이면 메인이 같은 의미 축으로 남긴 Cartography impact 보고
 - impact가 가리키는 affected Root Cartography 좌표와 프로젝트의 tracked/local-only 문서 정책
-- 필요하면 이전 impl-validator 결과와 retry round
+- 재리뷰이면 retry round, 직전 `step_completed` receipt 식별자인 `prose_file` + `sha256`, receipt 전문, 직전 candidate HEAD/tree/workspace root, 현재 candidate HEAD/tree/workspace root, 직전 candidate HEAD..현재 candidate HEAD의 commit·변경 파일 목록
 - 다중 story/epic invocation이면 봉인된 story branch/base와 조건부 QA branch 목록, 최종 stack tip. review 뒤 PR을 cut한 재검증이면 PR 목록도 보조 맥락으로 받을 수 있다.
 - 직전 Codebase Sanity receipt가 있으면 그 receipt와 현재 code tree 일치 여부. receipt는 `.dcness-work/codebase-sanity/` 같은 local-only/ignored 경로일 수 있다.
 - merge candidate에 `(JOURNEY)`가 있으면 Story별 `target_ac`, project-local 매니페스트, flow/assertion, `harness_paths`, build-worker 수렴 실행·수정 증거
@@ -34,6 +34,27 @@ Epic close에서는 같은 holistic merge-review invocation에 `CODEBASE_SANITY`
 - design:required UI 작업 상황별 필수: impl 계획의 `## 디자인 참조`, `docs/design.md`, 확정 목업 경로, 구현 diff 의 theme/component/style 상수
 - 상황별: 용어·공개 진입점·분기 표현을 검증할 때만 [`docs/plugin/terms.md`](../../terms.md)
 - 참고: [`references/finding-classes.md`](references/finding-classes.md)
+
+## 재리뷰 delta mode
+
+첫 라운드는 base..candidate 전체 holistic 리뷰다. 첫 라운드가 `FAIL`이고 root-cause 수정으로 새 candidate가 생긴 뒤의 같은 close 재리뷰만 delta mode 후보가 된다. 이때 직전 receipt는 최종 판정을 재사용하는 통과표가 아니라, 직전 라운드가 실제로 읽은 범위와 finding을 보존한 검토 이력이다.
+
+delta mode에서는 다음 두 축을 우선 읽는다.
+
+1. 직전 receipt의 모든 `MUST FIX` finding을 현재 tip에서 다시 추적해 증상만 사라진 것이 아니라 근본 원인이 닫혔는지 판정한다.
+2. 직전 candidate HEAD..현재 candidate HEAD의 commit·변경 파일과 그 직접 영향 표면을 읽어 rework가 만든 신규 spec/quality/Cartography 위험과, Epic close면 활성 `CODEBASE_SANITY` 렌즈의 신규 위험을 판정한다.
+
+직전 receipt가 무결하고 직전/현재 candidate가 같은 base와 workspace 계보로 연결되면, 직전 holistic 리뷰가 이미 확인했고 candidate delta가 건드리지 않은 영역의 검토 이력을 재사용할 수 있다. 이는 안 본 영역을 새로 통과 처리하는 것이 아니다. 이전에 읽지 않은 영역, delta의 transitive 영향 표면, finding 해소 판정에 필요한 owner·registration·test·contract는 선택적으로 더 읽는다.
+
+다음과 같이 좁힌 범위가 신뢰할 수 없거나 사실상 전체가 된 경우에는 전체 재독으로 승격한다. 예시는 자동 threshold가 아니라 reviewer 판단 신호다.
+
+- `prose_file` 또는 `sha256`가 없거나 receipt 전문과 digest가 맞지 않아 직전 검토 이력을 신뢰할 수 없다.
+- 직전 candidate HEAD/tree/workspace root 또는 현재 candidate HEAD/tree/workspace root가 누락됐거나, history rewrite·base/workspace 변경 때문에 두 candidate의 계보와 delta를 증명할 수 없다.
+- rework가 public contract, module owner, dependency/registration, schema, security boundary, Cartography system boundary처럼 넓은 영향 표면을 바꿨거나, Epic close `CODEBASE_SANITY`의 cheap global signal이 delta 밖 신규 위험을 가리킨다.
+- 직전 finding의 근본 원인 해소를 delta와 직접 영향 표면만으로 판정할 수 없거나, 반복 finding이 더 넓은 구조 결함을 시사한다.
+- changed files/영향 범위가 merge candidate 대부분과 겹쳐 delta mode의 절감 이점이 없다.
+
+결과 prose에는 이번 판정 범위가 delta인지 전체 재독인지, 직전 receipt 식별자와 직전/현재 candidate identity, 실제로 읽은 finding·delta·추가 영향 표면, 판정 범위와 그 근거를 남긴다. delta mode에서도 전체 재독으로 승격할 조건을 어떤 근거로 검토했고 이번에는 왜 해당하지 않았는지 밝히며, 승격했으면 그 이유를 남긴다. 좁힌 범위라면 이전 holistic 검토 이력 중 무엇을 재사용했고 무엇을 새로 읽었는지 밝혀, 좁힘이 안 본 영역을 새로 통과 처리한 것으로 읽히지 않게 한다. 이는 자유 prose의 의미 요구이며 고정 heading이나 schema가 아니다.
 
 ## 판단 축
 
@@ -99,7 +120,7 @@ Epic close에서는 같은 holistic merge-review invocation에 `CODEBASE_SANITY`
 
 ## 작업 흐름
 
-1. mode와 close 단위를 확인한다. 기본 merge-review mode는 변경 파일과 diff 중심으로 실제 검증 범위를 확정한다. 검토 대상 커밋 id가 있으면 그 커밋을 직접 조회하고, 커밋이 없는 uncommitted local diff에서만 전달된 diff 파일을 폴백으로 읽는다. 다중 story/epic invocation에서는 stack tip vs main diff를 우선하고 Epic close이면 같은 호출에서 `CODEBASE_SANITY` scope도 확정한다.
+1. mode와 close 단위를 확인한다. 첫 라운드는 변경 파일과 base..candidate 전체 diff로 holistic 범위를 확정한다. 재리뷰이면 receipt·candidate identity·candidate delta를 검증해 delta mode 또는 전체 재독을 스스로 고른다. 검토 대상 커밋 id가 있으면 그 커밋을 직접 조회하고, 커밋이 없는 uncommitted local diff에서만 전달된 diff 파일을 폴백으로 읽는다. 다중 story/epic invocation에서는 stack tip vs main diff를 우선하고 Epic close이면 같은 호출에서 `CODEBASE_SANITY` scope도 확정한다.
 2. plan ∪ target GitHub issue AC 가 있으면 spec 렌즈를 먼저 적용한다. 계획 없는 direct 도 target issue 가 있으면 spec 렌즈를 켜고, 둘 다 없을 때만 건너뛴다. `(JOURNEY)` diff가 있으면 재량으로 생략하지 않고 선언된 각 `target_ac` ↔ flow의 실제 assertion 대조를 같은 spec 렌즈의 체크리스트 고정 항목으로 수행한다.
 3. quality 렌즈로 유지보수성, merge risk, 보안·운영 risk, 테스트 신뢰도를 본다. `CODEBASE_SANITY`이면 semantic 렌즈의 warning·coverage·dead-code·replacement 분류도 함께 수행한다.
 4. Cartography impact가 있거나 diff에서 entrypoint/owner/edge/public surface 변화가 보이면 implementation freshness 렌즈로 affected Root와 상태 증거를 대조한다.
@@ -122,6 +143,7 @@ UI/API/CLI entrypoint 를 만지는 diff 는 새 flow append 인지, owner modul
 - applicable implementation Cartography impact가 있으면 diff·impact 보고·affected Root 좌표·상태 증거를 대조했다. route-only drift가 남아 있으면 PASS하지 않는다. local-only/ignored 정책에서도 canonical local Root refresh가 확인되지 않고 durable impact handoff만 존재하면 같은 미해소 상태다. system backpressure가 남아 있어도 PASS하지 않는다.
 - `CODEBASE_SANITY` PASS이면 code revision/tree identity와 scope가 명확하고, warning·coverage·dead-code·replacement 후보가 근거와 함께 분류됐으며 rework가 필요한 finding이 없다. unknown이 merge 판단을 막으면 PASS하지 않고 ESCALATE한다.
 - `(JOURNEY)` merge candidate이면 각 `target_ac`와 flow의 실제 assertion 대조 근거가 있고, manifest 선언·build-worker self-verify·sealed exit code 중 하나만으로 대응을 추정하지 않았다.
+- 재리뷰이면 직전 finding 전항목과 candidate delta 신규 위험을 판정했고, prose에 판정 범위와 그 근거가 있다. delta mode가 불충분한 신호가 있으면 전체 재독으로 승격했다.
 
 ## 권한 경계
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -171,6 +171,7 @@ instruction snapshot을 작업 디렉터리로 사용하며, 별도 fixture sand
 
 | 케이스 | 입력 | 기대 |
 |---|---|---|
+| `impl-validator-delta-rereview` | (합성) 110파일 전체 holistic FAIL receipt 뒤 4파일 root-cause rework와 신규 authorization bypass가 들어온 2라운드 candidate delta | 직전 finding 전항목의 근본 해소와 신규 delta 위험을 판정하고, 이전 검토 이력 재사용 범위·전체 재독 승격 경계를 보고해야 한다 |
 | `impl-fast-start-recovery` | (실사고 #1185/#1181) 자연어 direct 구현, 반복 loop task, 변경 후 timeout·빈 prose·TDD guard 실패, 권한 확대 제안이 이어지는 trace | 사전 ceremony·routine 질문 없이 개발을 시작하고 같은 provider/workspace에서 bounded 복구하되 hard boundary·test 면제는 자동 승인하지 않아야 한다 |
 | `story-slice-partfirst` | (합성) 기능 영역(인테이크/템플릿/오디오/렌더/업로드) 부품 단위로 잘려 마지막 story 까지 동작이 안 나오는 backlog | 분할·순서 결함이 지적돼야 한다 |
 | `story-slice-skeleton` | (합성) 첫 story 가 얇은 end-to-end 골격이고 매 story 가 확인 가능한 증분인 backlog | 분할·순서를 이유로 퇴짜 놓으면 안 된다 |

--- a/evals/cases/impl-validator-delta-rereview/candidate-delta.md
+++ b/evals/cases/impl-validator-delta-rereview/candidate-delta.md
@@ -1,0 +1,25 @@
+# Candidate delta
+
+Previous HEAD/tree: `2222222` / `aaaaaaaa`
+Current HEAD/tree: `3333333` / `bbbbbbbb`
+
+## module-018/service.py
+
+- stored recipient와 canonical recipient를 항상 비교하고 mismatch면 persist한다.
+- unchanged-message-row self-heal regression test가 추가됐다.
+
+## module-059/service.py
+
+- selected-message address fallback을 제거했다.
+- canonical recipient가 없으면 retransmit을 중단한다.
+- outgoing MMS/self-number regression test가 추가됐다.
+
+## module-103/service.py
+
+- notification deep link에 `?simple=true`를 붙인다.
+- notification tap routing test가 추가됐다.
+
+## module-104/retry_controller.py
+
+- 신규 코드: `authorized = request.retry or policy.authorize(request.actor)`
+- `request.retry`는 호출자가 직접 설정할 수 있다.

--- a/evals/cases/impl-validator-delta-rereview/expected.md
+++ b/evals/cases/impl-validator-delta-rereview/expected.md
@@ -1,0 +1,5 @@
+- [E1][MUST] 직전 세 finding이 현재 candidate에서 근본 원인으로 해소됐는지 각각 판정한다.
+- [E2][MUST] 신규 delta의 caller-controlled retry authorization bypass를 새 merge blocker로 지적한다.
+- [E3][MUST] 이번 판정이 delta 범위인 이유와 이전 holistic 검토 이력 중 재사용한 범위를 밝힌다.
+- [E4][MUST] receipt/candidate 연결 불능 또는 광범위 영향에서는 전체 재독으로 승격한다는 경계를 남긴다.
+- [E5][MUST_NOT] 이전에 보지 않은 영역을 새로 통과 처리했다고 주장하지 않는다.

--- a/evals/cases/impl-validator-delta-rereview/prior-receipt.md
+++ b/evals/cases/impl-validator-delta-rereview/prior-receipt.md
@@ -1,0 +1,13 @@
+# Previous impl-validator receipt
+
+검토 범위는 base `1111111`부터 candidate `2222222`까지의 110개 변경 파일 전체였다.
+
+MUST FIX:
+
+1. `[quality-gap]` `module-018/service.py:41` — unchanged thread row가 canonical recipient로 self-heal되지 않는다.
+2. `[quality-gap]` `module-059/service.py:88` — retransmit이 outgoing MMS의 self-number address로 fallback한다.
+3. `[spec-gap]` `module-103/service.py:27` — notification deep link에 `simple=true`가 없다.
+
+그 밖의 전체 diff와 직접 영향 표면에서는 blocker를 찾지 못했다.
+
+FAIL

--- a/evals/cases/impl-validator-delta-rereview/prompt.md
+++ b/evals/cases/impl-validator-delta-rereview/prompt.md
@@ -1,0 +1,14 @@
+너는 같은 close의 2라운드 impl-validator 재리뷰를 수행한다. 먼저 다음 지침을 Read 한다.
+
+- `{{REPO_ROOT}}/docs/plugin/agents/impl-validator/impl-validator-agent.md`
+
+그 다음 아래 재리뷰 입력을 읽는다.
+
+- 직전 receipt: `{{CASE_DIR}}/prior-receipt.md`
+- receipt sha256: `c516ce8fe719c2d81b69353bc2cc178da7dfdcdfea28c99195f87645d400d53d`
+- 직전 candidate HEAD/tree/workspace root: `2222222` / `aaaaaaaa` / 현재 fixture root
+- 현재 candidate HEAD/tree/workspace root: `3333333` / `bbbbbbbb` / 현재 fixture root
+- 직전 candidate HEAD..현재 candidate HEAD delta: `{{CASE_DIR}}/candidate-delta.md`
+
+지침에 따라 판정 범위를 스스로 정하고, 직전 finding 해소 여부와 신규 delta 위험을 검토한다.
+근거와 영향 범위를 자유 prose로 쓰고 마지막 단락에 PASS, FAIL, ESCALATE 중 하나를 명시한다.

--- a/evals/impl-validator-delta-replay-metadata.json
+++ b/evals/impl-validator-delta-replay-metadata.json
@@ -74,7 +74,7 @@
   "verification_command": "python3.11 -m unittest tests.test_impl_validator_delta_review_contract.ImplValidatorDeltaReviewContractTests.test_two_round_replay_records_material_speedup_without_quality_loss -v",
   "limitations": [
     "Provider latency varies; this paired replay is evidence for the scoped contract, not a model-speed guarantee.",
-    "The fixture preserves the observed 110-file and roughly 5816-line shape but uses synthetic module summaries rather than product source.",
+    "The fixture preserves the observed 110-file and 5500-line shape but uses synthetic module summaries rather than product source.",
     "A separate human verification remains required on one real story close."
   ]
 }

--- a/evals/impl-validator-delta-replay-metadata.json
+++ b/evals/impl-validator-delta-replay-metadata.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": 1,
+  "issue": 1201,
+  "measured_at": "2026-07-26",
+  "runtime": {
+    "provider": "claude-cli",
+    "claude_code": "2.1.220",
+    "model": "sonnet"
+  },
+  "fixture": {
+    "first_candidate_files": 110,
+    "first_candidate_lines": 5500,
+    "first_candidate_bytes": 486965,
+    "delta_files": 4,
+    "delta_bytes": 707
+  },
+  "material_reduction_contract": {
+    "minimum_relative_percent": 15,
+    "minimum_absolute_seconds": 30,
+    "quality_contract_must_be_preserved": true,
+    "rationale": "The issue did not prescribe a numeric threshold. A reduction must clear both a relative and an absolute floor so provider jitter or a tiny fast case cannot satisfy the claim."
+  },
+  "rounds": [
+    {
+      "round": 1,
+      "review_scope": "full",
+      "elapsed_seconds": 181.173,
+      "quality_contract_preserved": true,
+      "report_sha256": "f47be061466f2e94ff57b306cca5f8de7327a52fa48f469b2068065218d6ef35"
+    },
+    {
+      "round": 2,
+      "review_scope": "delta",
+      "elapsed_seconds": 148.274,
+      "quality_contract_preserved": true,
+      "report_sha256": "38d1d519060e02d0cc8dc164c31fe95f6d72fcc74db399d49a6120ffea0cc241"
+    }
+  ],
+  "observed_reduction": {
+    "seconds": 32.899,
+    "percent": 18.2
+  },
+  "judge": {
+    "result": "PASS",
+    "report_sha256": "9ae1aacafcc3b2b2b7d3730c9a114e07bbc43c9184af4972b47f9b58a8d6879f",
+    "assertions": [
+      "round 1 found all three seeded merge blockers after reading all 110 files",
+      "round 2 confirmed root-cause resolution of every prior finding",
+      "round 2 found the new authorization bypass in the four-file delta",
+      "round 2 explained scope, receipt and candidate identity, reused coverage, and full-read escalation"
+    ]
+  },
+  "invalid_attempts": [
+    {
+      "attempt": 1,
+      "first_candidate_shape": "one synthetic file, 36293 bytes",
+      "round_1_seconds": 152.796,
+      "round_2_seconds": 141.921,
+      "observed_reduction_percent": 7.1,
+      "quality_contract_preserved": false,
+      "invalid_reason": "The undersized one-file fixture did not reproduce the issue's 110-file read cost, and temporary reports were not preserved for diagnosis."
+    },
+    {
+      "attempt": 2,
+      "first_candidate_shape": "one synthetic file, 5507 lines and 487293 bytes",
+      "round_1_seconds": 152.572,
+      "round_2_seconds": 173.096,
+      "observed_reduction_percent": -13.5,
+      "quality_contract_preserved": false,
+      "invalid_reason": "The combined file still required only one Read while delta mode required several Reads. The judge also ran from the repository cwd and attempted an unrelated tool call instead of grading the inline reports."
+    }
+  ],
+  "replay_command": "python3.11 evals/replay_impl_validator_delta.py --model sonnet --modules 110 --minimum-reduction-percent 15 --minimum-reduction-seconds 30 --output-dir <empty-dir>",
+  "verification_command": "python3.11 -m unittest tests.test_impl_validator_delta_review_contract.ImplValidatorDeltaReviewContractTests.test_two_round_replay_records_material_speedup_without_quality_loss -v",
+  "limitations": [
+    "Provider latency varies; this paired replay is evidence for the scoped contract, not a model-speed guarantee.",
+    "The fixture preserves the observed 110-file and roughly 5816-line shape but uses synthetic module summaries rather than product source.",
+    "A separate human verification remains required on one real story close."
+  ]
+}

--- a/evals/replay_impl_validator_delta.py
+++ b/evals/replay_impl_validator_delta.py
@@ -293,11 +293,12 @@ HEAD `2222222222222222222222222222222222222222`, tree
     rendered = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
     metadata_path.write_text(rendered, encoding="utf-8")
     print(rendered, end="")
-    return not (
+    succeeded = (
         quality
         and reduction >= args.minimum_reduction_percent
         and reduction_seconds >= args.minimum_reduction_seconds
     )
+    return 0 if succeeded else 1
 
 
 if __name__ == "__main__":

--- a/evals/replay_impl_validator_delta.py
+++ b/evals/replay_impl_validator_delta.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Run a two-round live replay for the impl-validator delta contract.
+
+This is a manual, provider-backed performance check. It is not a CI gate.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR = ROOT / "docs/plugin/agents/impl-validator/impl-validator-agent.md"
+
+
+def _module_text(index: int) -> str:
+    lines = [
+        f"# module-{index:03d}/service.py",
+        "",
+        f"- owner: module_{index:03d}",
+        "- public contract: unchanged",
+        "- tests: unit and integration PASS",
+        "- registration: unchanged",
+    ]
+    if index == 18:
+        lines.extend(
+            [
+                "- changed code: `if messages_changed: persist(canonical_recipient)`",
+                "- behavior: an unchanged existing row keeps its stored recipient.",
+                "- contract: list and detail must show the same canonical recipient.",
+            ]
+        )
+    elif index == 59:
+        lines.extend(
+            [
+                "- changed code: `target = canonical or selected_message.address`",
+                "- behavior: an outgoing MMS message address can be the account self-number.",
+                "- contract: retransmit must never target the account self-number.",
+            ]
+        )
+    elif index == 103:
+        lines.extend(
+            [
+                "- changed code: `nexus://messages/thread/{id}`",
+                "- router contract: a single-thread route requires `simple=true`.",
+                "- tests: notification tap route has no assertion.",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "- changed code: local naming/branch simplification only.",
+                "- behavior: no entrypoint, state-owner, or dependency-edge change.",
+                "- evidence: focused regression assertion covers the changed branch.",
+            ]
+        )
+    for fact in range(1, 42):
+        lines.append(
+            f"- review fact {fact:02d}: module-{index:03d} keeps invariant "
+            f"`owner_{index:03d}_state_{fact:02d}` unchanged with matching evidence."
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _delta_modules() -> dict[str, str]:
+    return {
+        "module-018.md": """# module-018/service.py
+- Always compare the stored recipient with the canonical recipient and persist on mismatch.
+- Added an unchanged-message-row self-heal regression assertion.
+""",
+        "module-059.md": """# module-059/service.py
+- Removed the selected-message fallback.
+- Abort retransmit when the canonical thread recipient is unavailable.
+- Added outgoing-MMS/self-number regression assertions.
+""",
+        "module-103.md": """# module-103/service.py
+- Notification deep links now append `?simple=true`.
+- Added a notification-tap single-thread routing assertion.
+""",
+        "module-104.md": """# module-104/retry_controller.py
+- New code: `authorized = request.retry or policy.authorize(request.actor)`.
+- A caller-controlled retry flag therefore bypasses the existing authorization policy.
+""",
+    }
+
+
+def _run_claude(prompt: str, model: str, case_dir: Path) -> tuple[str, float]:
+    started = time.monotonic()
+    result = subprocess.run(
+        [
+            "claude",
+            "-p",
+            prompt,
+            "--model",
+            model,
+            "--safe-mode",
+            "--tools",
+            "Read",
+            "Glob",
+            "--add-dir",
+            str(ROOT),
+            "--add-dir",
+            str(case_dir),
+        ],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"claude invocation failed ({result.returncode}): {result.stderr.strip()}"
+        )
+    return result.stdout.strip(), round(elapsed, 3)
+
+
+def _judge(
+    round_one: str, round_two: str, model: str, judge_cwd: Path
+) -> tuple[bool, str]:
+    prompt = f"""도구를 호출하지 말고 제공된 두 보고만 읽어 아래 품질 계약을 채점하라.
+
+- 1라운드는 전체 candidate에서 세 결함(목록 canonical self-heal, retransmit self-number fallback,
+  notification deep link simple=true 누락)을 모두 finding으로 잡아야 한다.
+- 2라운드는 세 finding의 근본 해소를 확인하고 신규 authorization bypass를 finding으로 잡아야 한다.
+- 2라운드는 delta 판정 범위, 이전 holistic 검토 이력 재사용 근거, 이전/현재 candidate와 receipt,
+  전체 재독 승격 조건을 설명해야 한다.
+- 자유 prose 형식은 채점하지 않는다.
+
+[1라운드]
+{round_one}
+
+[2라운드]
+{round_two}
+
+모두 충족하면 마지막 줄에 RESULT: PASS, 아니면 RESULT: FAIL만 쓴다."""
+    result = subprocess.run(
+        [
+            "claude",
+            "-p",
+            prompt,
+            "--model",
+            model,
+            "--safe-mode",
+            "--tools",
+            "",
+        ],
+        cwd=judge_cwd,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"judge invocation failed ({result.returncode}): {result.stderr.strip()}"
+        )
+    report = result.stdout.strip()
+    return report.splitlines()[-1:] == ["RESULT: PASS"], report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--model", default="sonnet")
+    parser.add_argument("--modules", type=int, default=110)
+    parser.add_argument("--minimum-reduction-percent", type=float, default=15.0)
+    parser.add_argument("--minimum-reduction-seconds", type=float, default=30.0)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    if shutil.which("claude") is None:
+        parser.error("claude CLI is required")
+    if args.modules < 103:
+        parser.error("--modules must be at least 103")
+
+    case_dir = args.output_dir.resolve()
+    case_dir.mkdir(parents=True, exist_ok=True)
+    if any(case_dir.iterdir()):
+        parser.error(f"--output-dir must be empty: {case_dir}")
+
+    candidate_dir = case_dir / "candidate-round1"
+    delta_dir = case_dir / "candidate-delta"
+    receipt = case_dir / "round1-receipt.md"
+    round_two_report = case_dir / "round2-report.md"
+    judge_report = case_dir / "judge.md"
+    metadata_path = case_dir / "metadata.json"
+    candidate_dir.mkdir()
+    for index in range(1, args.modules + 1):
+        candidate_dir.joinpath(f"module-{index:03d}.md").write_text(
+            _module_text(index), encoding="utf-8"
+        )
+
+    round_one_prompt = f"""너는 final merge candidate를 검증하는 impl-validator다.
+먼저 `{VALIDATOR}`를 Read한다. base `1111111111111111111111111111111111111111`,
+HEAD `2222222222222222222222222222222222222222`, tree
+`aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`인 첫 candidate의 변경 파일 {args.modules}개가
+`{candidate_dir}`에 각각 있다. Glob으로 목록을 확정하고 모든 파일을 Read해 첫 라운드
+전체 holistic 범위로 검토한다.
+근거와 영향 범위를 자유 prose로 쓰고 마지막 단락에 PASS, FAIL, ESCALATE 중 하나를 명시한다."""
+    round_one, round_one_seconds = _run_claude(
+        round_one_prompt, args.model, case_dir
+    )
+    receipt.write_text(round_one + "\n", encoding="utf-8")
+    receipt_sha = hashlib.sha256((round_one + "\n").encode()).hexdigest()
+    delta_dir.mkdir()
+    for name, text in _delta_modules().items():
+        delta_dir.joinpath(name).write_text(text, encoding="utf-8")
+
+    round_two_prompt = f"""너는 같은 close의 impl-validator 재리뷰를 수행한다.
+먼저 `{VALIDATOR}`를 Read한다. 다음 입력으로 판정 범위를 스스로 정한다.
+
+- retry round: 2
+- 직전 receipt: `{receipt}`
+- receipt sha256: `{receipt_sha}`
+- 직전 candidate HEAD/tree/workspace root:
+  2222222222222222222222222222222222222222 /
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa / {case_dir}
+- 현재 candidate HEAD/tree/workspace root:
+  3333333333333333333333333333333333333333 /
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb / {case_dir}
+- 직전 candidate HEAD..현재 candidate HEAD의 변경 파일 4개: `{delta_dir}`
+- 전체 첫 candidate는 필요하면 `{candidate_dir}`에서 읽을 수 있다.
+
+근거와 영향 범위를 자유 prose로 쓰고 마지막 단락에 PASS, FAIL, ESCALATE 중 하나를 명시한다."""
+    round_two, round_two_seconds = _run_claude(
+        round_two_prompt, args.model, case_dir
+    )
+    round_two_report.write_text(round_two + "\n", encoding="utf-8")
+
+    judge_cwd = case_dir / "judge-workspace"
+    judge_cwd.mkdir()
+    quality, judge = _judge(round_one, round_two, args.model, judge_cwd)
+    judge_report.write_text(judge + "\n", encoding="utf-8")
+    reduction = round(
+        100 * (round_one_seconds - round_two_seconds) / round_one_seconds,
+        1,
+    )
+    reduction_seconds = round(round_one_seconds - round_two_seconds, 3)
+    result = {
+        "schema_version": 1,
+        "fixture": {
+            "modules": args.modules,
+            "first_candidate_files": len(list(candidate_dir.glob("*.md"))),
+            "first_candidate_lines": sum(
+                len(path.read_text(encoding="utf-8").splitlines())
+                for path in candidate_dir.glob("*.md")
+            ),
+            "first_candidate_bytes": sum(
+                path.stat().st_size for path in candidate_dir.glob("*.md")
+            ),
+            "delta_files": len(list(delta_dir.glob("*.md"))),
+            "delta_bytes": sum(
+                path.stat().st_size for path in delta_dir.glob("*.md")
+            ),
+        },
+        "runtime": {"provider": "claude-cli", "model": args.model},
+        "rounds": [
+            {
+                "round": 1,
+                "review_scope": "full",
+                "elapsed_seconds": round_one_seconds,
+                "quality_contract_preserved": quality,
+            },
+            {
+                "round": 2,
+                "review_scope": "delta",
+                "elapsed_seconds": round_two_seconds,
+                "quality_contract_preserved": quality,
+            },
+        ],
+        "reduction_seconds": reduction_seconds,
+        "reduction_percent": reduction,
+        "quality_contract_preserved": quality,
+        "replay_command": (
+            "python3.11 evals/replay_impl_validator_delta.py "
+            "--model sonnet --modules 110 --minimum-reduction-percent 15 "
+            "--minimum-reduction-seconds 30 "
+            "--output-dir <empty-dir>"
+        ),
+        "limitations": [
+            "Provider latency varies; this paired replay is evidence for the scoped "
+            "contract, not a model-speed guarantee.",
+            "The fixture preserves the observed 110-file and roughly 5,816-line "
+            "shape but uses synthetic module summaries rather than product source.",
+            "A separate human verification remains required on one real story close.",
+        ],
+    }
+    rendered = json.dumps(result, ensure_ascii=False, indent=2) + "\n"
+    metadata_path.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+    return not (
+        quality
+        and reduction >= args.minimum_reduction_percent
+        and reduction_seconds >= args.minimum_reduction_seconds
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/replay_impl_validator_delta.py
+++ b/evals/replay_impl_validator_delta.py
@@ -285,7 +285,7 @@ HEAD `2222222222222222222222222222222222222222`, tree
         "limitations": [
             "Provider latency varies; this paired replay is evidence for the scoped "
             "contract, not a model-speed guarantee.",
-            "The fixture preserves the observed 110-file and roughly 5,816-line "
+            "The fixture preserves the observed 110-file and 5,500-line "
             "shape but uses synthetic module summaries rather than product source.",
             "A separate human verification remains required on one real story close.",
         ],

--- a/skills/impl-loop/impl-loop-finish.md
+++ b/skills/impl-loop/impl-loop-finish.md
@@ -7,6 +7,7 @@
 - 단일 story는 story branch vs main, 다중 story는 최종 stack tip vs main을 merge candidate로 고정한다.
 - task별 commit, 검증 명령, phase prose, build-worker Cartography impact, affected Root Cartography, 관련 epic/decision, target GitHub issue AC snapshot을 수집한다.
 - review 대상이 commit이면 commit id와 변경 파일 목록을 선행한다. uncommitted diff일 때만 diff 파일을 쓴다.
+- 첫 라운드는 base..candidate 전체 holistic 입력을 준다. validator `FAIL` 뒤 재리뷰에서는 직전 `step_completed` receipt 식별자인 `prose_file` + `sha256`, receipt 전문, 직전 candidate HEAD/tree/workspace root, 현재 candidate HEAD/tree/workspace root, 직전 candidate HEAD..현재 candidate HEAD의 commit·변경 파일 목록을 함께 준다. history rewrite 등으로 두 candidate 사이 delta를 증명할 수 없으면 그 사실을 적고 전체 holistic 입력으로 되돌린다.
 - [`agent-prompt-slots.md`](../../docs/plugin/templates/agent-prompt-slots.md)는 validator/acceptance 호출 직전에만 읽는다.
 
 ## Story PR / integrated review / merge
@@ -40,7 +41,9 @@
 
 설정된 chain이 아니라 terminal receipt의 실제 구현 성공 provider의 반대 진영을 기본 review provider로 resolve한다. Codex 구현이면 Claude review, Claude 구현이면 Codex review다. Codex reviewer가 불가하면 Claude로 폴백하고 이유를 기록한다. validator는 read-only다. MUST FIX가 있으면 실제 구현 provider와 동일한 build-worker가 최대 3회 root-cause 수정하고 관련 gate를 재실행한다. build-worker rework가 코드나 harness를 바꾸면 필요한 earlier evidence부터 다시 수집한다.
 
-`impl-validator`는 base부터 final stack tip까지를 한 번에 보는 반대 진영 holistic reviewer다. task/commit 목록은 추적 근거이지 fixed task/commit fan-out 계획이 아니다. task별·commit별 child reviewer를 자동 생성하지 않고, 실제 unresolved high-risk 또는 넓은 context가 발견된 경우에만 같은 reviewer가 selective extra investigation을 수행한다.
+`impl-validator`의 첫 라운드는 base부터 final stack tip까지를 한 번에 보는 반대 진영 전체 holistic reviewer다. task/commit 목록은 추적 근거이지 fixed task/commit fan-out 계획이 아니다. task별·commit별 child reviewer를 자동 생성하지 않고, 실제 unresolved high-risk 또는 넓은 context가 발견된 경우에만 같은 reviewer가 selective extra investigation을 수행한다.
+
+`FAIL → root-cause 수정 → 재리뷰`는 직전 receipt와 candidate delta를 1급 입력으로 쓰는 delta mode다. validator는 직전 finding의 최종 tip 해소 여부와 rework delta가 만든 신규 위험을 우선 판정하고, 변경 영향이 넓거나 receipt/candidate 연결을 신뢰할 수 없으면 스스로 전체 재독으로 승격한다. 호출자는 좁힌 범위를 처방하거나 전체 재독을 막지 않는다. 재리뷰 한도는 현행 3회이며 provider 선택·첫 라운드 범위·제품 acceptance 순서는 바꾸지 않는다.
 
 Epic close의 dead code, stale registration, duplicate/example/scaffold, suppression/deprecation, convention drift와 replacement 잔존 감사도 이 holistic invocation의 `CODEBASE_SANITY` 렌즈에 합친다. 별도 Sanity reviewer를 선행 호출하지 않는다. code revision/tree identity와 같은-tree lint/build/test/typecheck/coverage terminal evidence를 소비하고, coverage 도구가 없으면 `UNKNOWN`으로 기록한다.
 
@@ -70,7 +73,7 @@ auto-fixable gap은 PRD/Story AC 미충족, 검수 증거 부족, smoke 실패, 
 
 ## 마감 복구와 증거 invalidation
 
-- code/harness finding은 same implementation owner가 root-cause 수정한다. tracked tree가 바뀌면 이전 validation sequence 결과는 stale이며, 영향받은 lint/build/test, journey convergence, Cartography sync를 다시 모은 뒤 새 candidate를 freeze하고 validator부터 다시 시작한다.
+- code/harness finding은 same implementation owner가 root-cause 수정한다. tracked tree가 바뀌면 이전 validation sequence의 terminal 판정은 stale이며, 영향받은 lint/build/test, journey convergence, Cartography sync를 다시 모은 뒤 새 candidate를 freeze하고 validator부터 다시 시작한다. 다만 직전 validator receipt는 폐기하지 않고 finding과 검토 이력을 증명하는 재리뷰 입력으로만 사용한다.
 - device/external transient가 발생했지만 tracked HEAD/tree가 그대로면 validator PASS를 유지하고 acceptance만 재실행한다.
 - validator provider/tool transient에서 tracked HEAD/tree가 그대로면 acceptance PASS를 유지하고 validator만 재실행한다.
 - validator PASS 뒤 tracked tree가 바뀌거나 두 receipt의 candidate identity가 다르면 acceptance 결과와 close를 거부한다.

--- a/tests/test_impl_validator_delta_review_contract.py
+++ b/tests/test_impl_validator_delta_review_contract.py
@@ -1,9 +1,10 @@
 """Contracts for issue #1201 impl-validator delta re-review."""
 from __future__ import annotations
 
+import hashlib
 import json
 import statistics
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 import sys
 from tempfile import TemporaryDirectory
@@ -22,6 +23,16 @@ def read(path: str) -> str:
 
 
 class ImplValidatorDeltaReviewContractTests(unittest.TestCase):
+    def test_behavior_fixture_receipt_digest_matches_prompt(self) -> None:
+        receipt = (
+            ROOT
+            / "evals/cases/impl-validator-delta-rereview/prior-receipt.md"
+        ).read_bytes()
+        digest = hashlib.sha256(receipt).hexdigest()
+        prompt = read("evals/cases/impl-validator-delta-rereview/prompt.md")
+
+        self.assertIn(f"receipt sha256: `{digest}`", prompt)
+
     def test_impl_loop_reentry_supplies_receipt_identity_and_candidate_delta(
         self,
     ) -> None:
@@ -130,7 +141,9 @@ class ImplValidatorDeltaReviewContractTests(unittest.TestCase):
                 patch.object(replay, "_judge", return_value=(True, "RESULT: PASS")),
                 redirect_stdout(StringIO()),
             ):
-                self.assertEqual(replay.main(), 0)
+                result = replay.main()
+                self.assertEqual(result, 0)
+                self.assertIs(type(result), int)
 
             self.assertEqual(calls, 2)
             metadata = json.loads(
@@ -152,13 +165,16 @@ class ImplValidatorDeltaReviewContractTests(unittest.TestCase):
             "--output-dir",
             "/tmp/not-created-by-replay-test",
         ]
+        stderr = StringIO()
         with (
             patch.object(sys, "argv", argv),
             patch.object(replay.shutil, "which", return_value="/bin/claude"),
             redirect_stdout(StringIO()),
+            redirect_stderr(stderr),
             self.assertRaises(SystemExit),
         ):
             replay.main()
+        self.assertIn("--modules must be at least 103", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/tests/test_impl_validator_delta_review_contract.py
+++ b/tests/test_impl_validator_delta_review_contract.py
@@ -1,0 +1,164 @@
+"""Contracts for issue #1201 impl-validator delta re-review."""
+from __future__ import annotations
+
+import json
+import statistics
+from contextlib import redirect_stdout
+from io import StringIO
+import sys
+from tempfile import TemporaryDirectory
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from evals import replay_impl_validator_delta as replay
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+class ImplValidatorDeltaReviewContractTests(unittest.TestCase):
+    def test_impl_loop_reentry_supplies_receipt_identity_and_candidate_delta(
+        self,
+    ) -> None:
+        finish = read("skills/impl-loop/impl-loop-finish.md")
+
+        for needle in (
+            "첫 라운드",
+            "전체 holistic",
+            "`prose_file` + `sha256`",
+            "직전 candidate HEAD/tree/workspace root",
+            "현재 candidate HEAD/tree/workspace root",
+            "직전 candidate HEAD..현재 candidate HEAD",
+            "재리뷰 한도는 현행 3회",
+        ):
+            with self.subTest(needle=needle):
+                self.assertIn(needle, finish)
+
+    def test_claude_and_codex_reviewers_define_bounded_delta_mode(self) -> None:
+        prompts = (
+            read("docs/plugin/agents/impl-validator/impl-validator-agent.md"),
+            read("codex/skills/dcness-impl-validator/SKILL.md"),
+        )
+
+        for prompt in prompts:
+            with self.subTest(prompt=prompt[:40]):
+                for needle in (
+                    "재리뷰 delta mode",
+                    "`prose_file` + `sha256`",
+                    "직전 candidate HEAD/tree/workspace root",
+                    "현재 candidate HEAD/tree/workspace root",
+                    "직전 candidate HEAD..현재 candidate HEAD",
+                    "전체 재독으로 승격",
+                    "판정 범위와 그 근거",
+                    "안 본 영역을 새로 통과 처리",
+                ):
+                    self.assertIn(needle, prompt)
+
+    def test_two_round_replay_records_material_speedup_without_quality_loss(
+        self,
+    ) -> None:
+        evidence = json.loads(
+            read("evals/impl-validator-delta-replay-metadata.json")
+        )
+        rounds = evidence["rounds"]
+
+        self.assertGreaterEqual(len(rounds), 2)
+        self.assertEqual(rounds[0]["review_scope"], "full")
+        baseline = rounds[0]["elapsed_seconds"]
+        reductions = []
+        for replay_round in rounds[1:]:
+            with self.subTest(round=replay_round["round"]):
+                self.assertEqual(replay_round["review_scope"], "delta")
+                self.assertTrue(replay_round["quality_contract_preserved"])
+                self.assertLess(replay_round["elapsed_seconds"], baseline)
+                reductions.append(
+                    100
+                    * (baseline - replay_round["elapsed_seconds"])
+                    / baseline
+                )
+
+        self.assertGreaterEqual(statistics.median(reductions), 15)
+        self.assertGreaterEqual(
+            baseline
+            - statistics.median(
+                replay_round["elapsed_seconds"]
+                for replay_round in rounds[1:]
+            ),
+            30,
+        )
+        self.assertIn("replay_command", evidence)
+        self.assertTrue(evidence["limitations"])
+
+    def test_live_replay_hides_future_delta_until_round_one_finishes(self) -> None:
+        with TemporaryDirectory() as tmp:
+            output = Path(tmp) / "replay"
+            calls = 0
+
+            def fake_run(
+                prompt: str, model: str, case_dir: Path
+            ) -> tuple[str, float]:
+                nonlocal calls
+                calls += 1
+                self.assertEqual(model, "sonnet")
+                candidate_files = list(
+                    case_dir.joinpath("candidate-round1").glob("*.md")
+                )
+                self.assertEqual(len(candidate_files), 110)
+                if calls == 1:
+                    self.assertFalse(case_dir.joinpath("candidate-delta").exists())
+                    return "three findings\n\nFAIL", 200.0
+                self.assertEqual(
+                    len(list(case_dir.joinpath("candidate-delta").glob("*.md"))),
+                    4,
+                )
+                return "resolved and one new finding\n\nFAIL", 100.0
+
+            argv = [
+                "replay_impl_validator_delta.py",
+                "--output-dir",
+                str(output),
+            ]
+            with (
+                patch.object(sys, "argv", argv),
+                patch.object(replay.shutil, "which", return_value="/bin/claude"),
+                patch.object(replay, "_run_claude", side_effect=fake_run),
+                patch.object(replay, "_judge", return_value=(True, "RESULT: PASS")),
+                redirect_stdout(StringIO()),
+            ):
+                self.assertEqual(replay.main(), 0)
+
+            self.assertEqual(calls, 2)
+            metadata = json.loads(
+                output.joinpath("metadata.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(metadata["fixture"]["first_candidate_files"], 110)
+            self.assertEqual(metadata["fixture"]["delta_files"], 4)
+            self.assertEqual(metadata["reduction_seconds"], 100.0)
+            self.assertEqual(metadata["reduction_percent"], 50.0)
+
+    def test_live_replay_rejects_fixture_too_small_for_seeded_findings(
+        self,
+    ) -> None:
+        argv = [
+            "replay_impl_validator_delta.py",
+            "--modules",
+            "102",
+            "--output-dir",
+            "/tmp/not-created-by-replay-test",
+        ]
+        with (
+            patch.object(sys, "argv", argv),
+            patch.object(replay.shutil, "which", return_value="/bin/claude"),
+            redirect_stdout(StringIO()),
+            self.assertRaises(SystemExit),
+        ):
+            replay.main()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_impl_validator_delta_review_contract.py
+++ b/tests/test_impl_validator_delta_review_contract.py
@@ -137,6 +137,7 @@ class ImplValidatorDeltaReviewContractTests(unittest.TestCase):
                 output.joinpath("metadata.json").read_text(encoding="utf-8")
             )
             self.assertEqual(metadata["fixture"]["first_candidate_files"], 110)
+            self.assertEqual(metadata["fixture"]["first_candidate_lines"], 5500)
             self.assertEqual(metadata["fixture"]["delta_files"], 4)
             self.assertEqual(metadata["reduction_seconds"], 100.0)
             self.assertEqual(metadata["reduction_percent"], 50.0)


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1201

## 배경 및 문제

- `/impl-loop`의 첫 구현 검증 뒤 재리뷰도 전체 candidate를 다시 읽어, 라운드가 누적될수록 검증 시간이 커졌습니다.
- 기존 caller는 이전 findings를 전달했지만, 이전 receipt와 candidate identity 및 실제 변경 delta를 식별하는 계약이 없었습니다.

## 원인 (해당 시)

- 기존 delta-first 규칙은 보고서의 변경 요약 범위만 좁혔고 validator의 읽기 범위는 계속 holistic이었습니다.
- 이전 검증이 어느 tree를 대상으로 했는지 증명할 identity가 없어 안전하게 기존 coverage를 재사용할 수 없었습니다.

## 작업내용

- 첫 라운드는 종전처럼 전체 holistic 검증을 유지하고, 재리뷰에는 이전 receipt identity와 이전/현재 candidate identity 및 commit/file delta를 전달하도록 caller 계약을 추가했습니다.
- Claude/Codex impl-validator 문서에 이전 findings의 root-cause 해소, 새 delta risk, 영향 범위 확인, full reread 자율 escalation 조건과 prose 기록 의무를 명시했습니다.
- retry 최대 3회, provider 선택, acceptance 순서는 변경하지 않았습니다.
- behavior eval case와 계약 테스트를 추가하고, 110개 파일 candidate의 2라운드 provider-backed replay로 품질 유지 및 속도 개선을 검증했습니다.

## 결정 근거

- 기존 helper가 생성하는 `prose_file + sha256` receipt와 workspace root/HEAD/tree identity를 재사용해 별도 상태 포맷이나 public surface를 추가하지 않았습니다.
- 좁은 delta는 기존 holistic coverage를 제한적으로 재사용하되, lineage 불명·광범위 변경·전역 신호·미해결 root cause에서는 validator가 전체 재독하도록 해 자율성과 안전성을 유지했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- plugin agent 문서와 impl-loop finish 문서는 기존 plugin artifact 경로에 포함됩니다.
- Codex mirror `codex/skills/dcness-impl-validator`는 `scripts/release_artifact.json`에 이미 포함되어 있고 `/init-dcness` Core Step 5의 always-overwrite 배포 대상입니다.
- 기존 배포 대상 파일만 갱신했으므로 새 wiring은 필요하지 않습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 impl-validator 내부 재리뷰 단계와 수동 eval 도구만 확장했으며 새 public skill/command/agent/gate를 추가하지 않았습니다.

## Test Plan

- [x] `python3.11 -m unittest discover -s tests` — #1206 반영 최신 main 기준 1227 passed
- [x] `uvx --from ruff==0.15.17 ruff check .`
- [x] `uvx --from mypy==2.1.0 mypy`
- [x] `uvx --from bandit==1.9.4 bandit -c pyproject.toml -r harness scripts -l -i`
- [x] `node scripts/aggregate_index_map.mjs --check`
- [x] `node scripts/check_design_artifact_structure.mjs`
- [x] `node scripts/check_doc_path_integrity.mjs`
- [x] `EVAL_CASES=impl-validator-delta-rereview EVAL_OUTPUT_DIR=/tmp/dcness-1201-delta-eval EVAL_PARALLEL=1 bash evals/run.sh` — 1/1 PASS
- [x] `uv run python evals/replay_impl_validator_delta.py --output-dir /tmp/dcness-1201-live-replay-3` — findings 품질 유지, 181.173초 → 148.274초(32.899초, 18.2% 감소), judge PASS

## 참고

- #1206 merge 후 최신 main(`08357d9`)으로 rebase했습니다. 변경 파일 교집합과 3-way 충돌은 없고, rebase 전후 combined patch-id가 동일함을 확인했습니다.
- review 후속으로 behavior fixture receipt SHA-256 계약, argparse stderr 캡처, replay의 명시적 integer exit code를 보강했습니다.
- issue의 사람 검증 가이드인 실제 story 종료 1회 이상 비교는 draft PR에서 별도로 수행해야 합니다.
- 이 PR은 해당 사람 검증과 명시적 merge 지시 전에는 머지하지 않습니다.
