### PR TITLE
[issue-1202] validator timeout과 idle guard 정렬

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,12 +189,12 @@ PYTHON_BIN=/tmp/dcness-quality-venv/bin/python bash scripts/check_static_quality
 | `EVAL_RUNS` / `EVAL_MODEL` / `EVAL_OUTPUT_DIR` / `EVAL_RELEASE_CHECK` / `EVAL_STRICT_CASES` | `evals/run.sh` 행동 eval — 반복 수 / 모델 / 산출물 위치 / 릴리즈 N/N 모드 / 핵심 케이스 목록 | `1` / `sonnet` / `.metrics/evals/run-*` / `0` / 핵심 2케이스 | X |
 | `EVAL_PARALLEL` | `evals/run.sh` 행동 eval 의 동시 실행 `(case, run)` 셀 상한. `1` = 직렬(회귀 안전판). headless `claude -p` quota 는 메인 세션과 공유하므로 보수적 값 유지 | `4` | X |
 | `DCNESS_FORCE_ENABLE` | is-active 게이트 임시 활성 (디버깅) | 미설정 | X |
-| `DCNESS_CODEX_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt timeout | validator `600`, worker `3000` | X |
-| `DCNESS_CODEX_IDLE_TIMEOUT` | `dcness-codex-worker` Codex attempt 의 stdout/prose/workspace 무진행 조기 kill timeout | `900` | X |
+| `DCNESS_CODEX_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt timeout | `3000` | X |
+| `DCNESS_CODEX_IDLE_TIMEOUT` | `dcness-codex-validator` / `dcness-codex-worker` Codex attempt 의 stdout/prose 무진행 조기 kill timeout (worker는 workspace 진행도 포함) | `900` | X |
 | `DCNESS_CODEX_NETWORK_ACCESS` | `dcness-codex-worker` 의 `workspace-write` network opt-in (`1` / `true` / `on`; `0` / `false` / `off` 는 비활성) | 미설정 | X |
 | `DCNESS_CODEX_WRITABLE_ROOTS` | `dcness-codex-worker` 의 추가 writable roots. 플랫폼 path separator(macOS/Linux `:`)로 여러 절대경로 구분 | 미설정 | X |
-| `DCNESS_CLAUDE_TIMEOUT` | `dcness-claude-worker` Claude headless attempt timeout | `3000` | X |
-| `DCNESS_CLAUDE_IDLE_TIMEOUT` | `dcness-claude-worker` Claude attempt 의 stdout/stderr/workspace 무진행 조기 kill timeout (codex worker 와 패리티) | `900` | X |
+| `DCNESS_CLAUDE_TIMEOUT` | `dcness-claude-validator` / `dcness-claude-worker` Claude headless attempt timeout | `3000` | X |
+| `DCNESS_CLAUDE_IDLE_TIMEOUT` | `dcness-claude-validator` / `dcness-claude-worker` Claude attempt 의 stdout/stderr 무진행 조기 kill timeout (worker는 workspace 진행도 포함) | `900` | X |
 | `DCNESS_IMPLEMENTATION_RECOVERY_LIMIT` | `dcness-implementation-chain` 의 동일 provider·동일 workspace 자동 복구 추가 시도 한도 | `2` | X |
 | `DCNESS_CODEX_MODEL` / `DCNESS_CODEX_EFFORT` | Codex headless wrapper model / reasoning effort opt-in override. 미설정 시 사용자 Codex config 상속 | 미설정 | X |
 | `DCNESS_PROJECTS_FILE` | `scripts/loop_diagnose.py` 의 활성 프로젝트 whitelist 경로 override (테스트용) | `~/.claude/plugins/data/dcness-dcness/projects.json` | X |

--- a/scripts/dcness-claude-validator
+++ b/scripts/dcness-claude-validator
@@ -21,7 +21,8 @@ Options:
   --help, -h          Show this help.
 
 Environment:
-  DCNESS_CLAUDE_TIMEOUT  Seconds per Claude attempt. Default: 600.
+  DCNESS_CLAUDE_TIMEOUT  Seconds per Claude attempt. Default: 3000.
+  DCNESS_CLAUDE_IDLE_TIMEOUT  Seconds without stdout/stderr progress. Default: 900.
 
 The wrapper runs Claude Code in print mode with hooks/plugins enabled:
   claude -p --permission-mode dontAsk --allowedTools Read,Grep,Glob --output-format text
@@ -63,7 +64,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT=""
 PROMPT_FILE=""
 HELPER="$SCRIPT_DIR/dcness-helper"
-CLAUDE_TIMEOUT="${DCNESS_CLAUDE_TIMEOUT:-600}"
+CLAUDE_TIMEOUT="${DCNESS_CLAUDE_TIMEOUT:-3000}"
+CLAUDE_IDLE_TIMEOUT="${DCNESS_CLAUDE_IDLE_TIMEOUT:-900}"
 
 abs_path() {
   case "$1" in
@@ -129,6 +131,16 @@ if [ "$CLAUDE_TIMEOUT" -lt 1 ]; then
   echo "[dcness-claude-validator] DCNESS_CLAUDE_TIMEOUT must be >= 1" >&2
   exit 2
 fi
+case "$CLAUDE_IDLE_TIMEOUT" in
+  ''|*[!0-9]*)
+    echo "[dcness-claude-validator] DCNESS_CLAUDE_IDLE_TIMEOUT must be a positive integer: $CLAUDE_IDLE_TIMEOUT" >&2
+    exit 2
+    ;;
+esac
+if [ "$CLAUDE_IDLE_TIMEOUT" -lt 1 ]; then
+  echo "[dcness-claude-validator] DCNESS_CLAUDE_IDLE_TIMEOUT must be >= 1" >&2
+  exit 2
+fi
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "[dcness-claude-validator] python3 not found; required for timeout and context resolution" >&2
@@ -159,9 +171,10 @@ fi
 
 TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-validator-${AGENT}.XXXXXX")"
 TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-validator-prompt-${AGENT}.XXXXXX")"
+TMP_FAILURE_CAUSE="$(mktemp "${TMPDIR:-/tmp}/dcness-claude-validator-cause-${AGENT}.XXXXXX")"
 RAW_LOG="$RAW_LOG_DIR/claude-headless-${AGENT}${MODE:+-$MODE}-$$.log"
 dcness_write_headless_context_header "dcness-claude-validator" "$RAW_LOG"
-trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
+trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT" "$TMP_FAILURE_CAUSE"' EXIT
 
 AGENT_DOC="$SCRIPT_DIR/../agents/$AGENT.md"
 AGENT_DETAIL="$SCRIPT_DIR/../docs/plugin/agents/$AGENT/$AGENT-agent.md"
@@ -212,12 +225,16 @@ import os
 import signal
 import subprocess
 import sys
+import time
+from datetime import datetime, timezone
 
 timeout = int(sys.argv[1])
-prompt = sys.argv[2]
-output = sys.argv[3]
-log = sys.argv[4]
-cmd = sys.argv[5:]
+idle_timeout = int(sys.argv[2])
+prompt = sys.argv[3]
+output = sys.argv[4]
+log = sys.argv[5]
+failure_cause = sys.argv[6]
+cmd = sys.argv[7:]
 
 def child_env_without_nested_session_markers():
     env = os.environ.copy()
@@ -252,6 +269,27 @@ def child_env_without_nested_session_markers():
             env.pop(key, None)
     return env, sorted(removed)
 
+def file_size(path):
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+def terminate(exit_code):
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+    sys.exit(exit_code)
+
 with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") as raw:
     raw.write(("COMMAND: " + " ".join(cmd) + "\n").encode("utf-8", "replace"))
     child_env, removed_env = child_env_without_nested_session_markers()
@@ -265,24 +303,54 @@ with open(prompt, "rb") as stdin, open(output, "wb") as stdout, open(log, "ab") 
         env=child_env,
         start_new_session=True,
     )
-    try:
-        proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(proc.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        try:
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            proc.wait()
-        sys.exit(124)
-    sys.exit(proc.returncode)
-' "$CLAUDE_TIMEOUT" "$TMP_PROMPT" "$TMP_PROSE" "$RAW_LOG" "${CLAUDE_CMD[@]}"
+    raw.write(
+        (
+            f"PROCESS_FORK: pid={proc.pid} "
+            f"started_at={datetime.now(timezone.utc).isoformat()}\n"
+        ).encode("utf-8", "replace")
+    )
+    raw.flush()
+    started = time.monotonic()
+    deadline = started + timeout
+    last_progress = started
+    last_output_size = file_size(output)
+    last_log_size = file_size(log)
+
+    while True:
+        rc = proc.poll()
+        if rc is not None:
+            sys.exit(rc)
+
+        now = time.monotonic()
+        output_size = file_size(output)
+        log_size = file_size(log)
+        if output_size != last_output_size or log_size != last_log_size:
+            last_progress = now
+            last_output_size = output_size
+            last_log_size = log_size
+
+        if now >= deadline:
+            raw.write(f"\n[dcness-claude-validator] total timeout after {timeout}s\n".encode())
+            raw.flush()
+            with open(failure_cause, "w", encoding="utf-8") as marker:
+                marker.write("timeout")
+            terminate(124)
+        if now - last_progress >= idle_timeout:
+            raw.write(
+                f"\n[dcness-claude-validator] idle timeout after {idle_timeout}s "
+                "(no stdout/stderr progress)\n".encode()
+            )
+            raw.flush()
+            with open(failure_cause, "w", encoding="utf-8") as marker:
+                marker.write("idle_timeout")
+            terminate(124)
+        sleep_for = min(
+            1.0,
+            max(0.05, deadline - now),
+            max(0.05, idle_timeout - (now - last_progress)),
+        )
+        time.sleep(sleep_for)
+' "$CLAUDE_TIMEOUT" "$CLAUDE_IDLE_TIMEOUT" "$TMP_PROMPT" "$TMP_PROSE" "$RAW_LOG" "$TMP_FAILURE_CAUSE" "${CLAUDE_CMD[@]}"
 }
 
 CLAUDE_RC=0
@@ -303,6 +371,15 @@ if [ "$CLAUDE_RC" -ne 0 ]; then
     echo "[dcness-claude-validator] raw log: $RAW_LOG" >&2
     git -C "$PROJECT_ROOT" status --short >&2 || true
     exit 1
+  fi
+  if [ "$CLAUDE_RC" -eq 124 ]; then
+    TIMEOUT_CAUSE="$(cat "$TMP_FAILURE_CAUSE" 2>/dev/null || true)"
+    if [ "$TIMEOUT_CAUSE" = "idle_timeout" ]; then
+      echo "[dcness-claude-validator] claude -p idle timeout after ${CLAUDE_IDLE_TIMEOUT}s; raw log: $RAW_LOG" >&2
+    else
+      echo "[dcness-claude-validator] claude -p total timeout after ${CLAUDE_TIMEOUT}s; raw log: $RAW_LOG" >&2
+    fi
+    exit 124
   fi
   echo "[dcness-claude-validator] claude -p failed before workspace mutation (exit $CLAUDE_RC); raw log: $RAW_LOG" >&2
   exit "$CLAUDE_RC"

--- a/scripts/dcness-codex-validator
+++ b/scripts/dcness-codex-validator
@@ -20,7 +20,8 @@ Options:
   --help, -h          Show this help.
 
 Environment:
-  DCNESS_CODEX_TIMEOUT  Seconds per Codex attempt. Default: 600.
+  DCNESS_CODEX_TIMEOUT  Seconds per Codex attempt. Default: 3000.
+  DCNESS_CODEX_IDLE_TIMEOUT  Seconds without stdout/prose progress. Default: 900.
   DCNESS_CODEX_MODEL    Optional Codex model override. Default: inherit user config.
   DCNESS_CODEX_EFFORT   Optional reasoning effort override. Default: inherit user config.
   CLAUDE_PLUGIN_ROOT    Optional plugin root fallback. Default: wrapper parent.
@@ -75,7 +76,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT=""
 PROMPT_FILE=""
 HELPER="$SCRIPT_DIR/dcness-helper"
-CODEX_TIMEOUT="${DCNESS_CODEX_TIMEOUT:-600}"
+CODEX_TIMEOUT="${DCNESS_CODEX_TIMEOUT:-3000}"
+CODEX_IDLE_TIMEOUT="${DCNESS_CODEX_IDLE_TIMEOUT:-900}"
 CODEX_MODEL="${DCNESS_CODEX_MODEL:-}"
 CODEX_EFFORT="${DCNESS_CODEX_EFFORT:-}"
 
@@ -143,6 +145,16 @@ if [ "$CODEX_TIMEOUT" -lt 1 ]; then
   echo "[dcness-codex-validator] DCNESS_CODEX_TIMEOUT must be >= 1" >&2
   exit 2
 fi
+case "$CODEX_IDLE_TIMEOUT" in
+  ''|*[!0-9]*)
+    echo "[dcness-codex-validator] DCNESS_CODEX_IDLE_TIMEOUT must be a positive integer: $CODEX_IDLE_TIMEOUT" >&2
+    exit 2
+    ;;
+esac
+if [ "$CODEX_IDLE_TIMEOUT" -lt 1 ]; then
+  echo "[dcness-codex-validator] DCNESS_CODEX_IDLE_TIMEOUT must be >= 1" >&2
+  exit 2
+fi
 
 if ! command -v python3 >/dev/null 2>&1; then
   echo "[dcness-codex-validator] python3 not found; required for timeout and context resolution" >&2
@@ -177,9 +189,10 @@ fi
 # 끝나야 한다 (GNU mktemp 는 embedded X 도 처리하므로 Linux CI 에선 안 드러남).
 TMP_PROSE="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-${AGENT}.XXXXXX")"
 TMP_PROMPT="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-prompt-${AGENT}.XXXXXX")"
+TMP_FAILURE_CAUSE="$(mktemp "${TMPDIR:-/tmp}/dcness-codex-validator-cause-${AGENT}.XXXXXX")"
 RAW_LOG="$RAW_LOG_DIR/codex-headless-${AGENT}${MODE:+-$MODE}-$$.log"
 dcness_write_headless_context_header "dcness-codex-validator" "$RAW_LOG"
-trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT"' EXIT
+trap 'rm -f "$TMP_PROSE" "$TMP_PROMPT" "$TMP_FAILURE_CAUSE"' EXIT
 
 SKILL_NAME="dcness-${AGENT}"
 CODEX_HOME_DIR="${CODEX_HOME:-${HOME:-}/.codex}"
@@ -249,13 +262,41 @@ import os
 import signal
 import subprocess
 import sys
+import time
+from datetime import datetime, timezone
 
 timeout = int(sys.argv[1])
-prompt = sys.argv[2]
-log = sys.argv[3]
-cmd = sys.argv[4:]
+idle_timeout = int(sys.argv[2])
+prompt = sys.argv[3]
+log = sys.argv[4]
+prose = sys.argv[5]
+failure_cause = sys.argv[6]
+cmd = sys.argv[7:]
+
+def file_size(path):
+    try:
+        return os.path.getsize(path)
+    except OSError:
+        return 0
+
+def terminate(exit_code):
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except ProcessLookupError:
+        pass
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        proc.wait()
+    sys.exit(exit_code)
+
 with open(prompt, "rb") as stdin, open(log, "ab") as raw:
     raw.write(("COMMAND: " + " ".join(cmd) + "\n").encode("utf-8", "replace"))
+    raw.flush()
     proc = subprocess.Popen(
         cmd,
         stdin=stdin,
@@ -263,31 +304,69 @@ with open(prompt, "rb") as stdin, open(log, "ab") as raw:
         stderr=subprocess.STDOUT,
         start_new_session=True,
     )
-    try:
-        proc.wait(timeout=timeout)
-    except subprocess.TimeoutExpired:
-        try:
-            os.killpg(proc.pid, signal.SIGTERM)
-        except ProcessLookupError:
-            pass
-        try:
-            proc.wait(timeout=1)
-        except subprocess.TimeoutExpired:
-            try:
-                os.killpg(proc.pid, signal.SIGKILL)
-            except ProcessLookupError:
-                pass
-            proc.wait()
-        sys.exit(124)
-    sys.exit(proc.returncode)
-' "$CODEX_TIMEOUT" "$TMP_PROMPT" "$RAW_LOG" "${CODEX_CMD[@]}" "${CODEX_ARGS[@]}"
+    raw.write(
+        (
+            f"PROCESS_FORK: pid={proc.pid} "
+            f"started_at={datetime.now(timezone.utc).isoformat()}\n"
+        ).encode("utf-8", "replace")
+    )
+    raw.flush()
+    started = time.monotonic()
+    deadline = started + timeout
+    last_progress = started
+    last_log_size = file_size(log)
+    last_prose_size = file_size(prose)
+
+    while True:
+        rc = proc.poll()
+        if rc is not None:
+            sys.exit(rc)
+
+        now = time.monotonic()
+        log_size = file_size(log)
+        prose_size = file_size(prose)
+        if log_size != last_log_size or prose_size != last_prose_size:
+            last_progress = now
+            last_log_size = log_size
+            last_prose_size = prose_size
+
+        if now >= deadline:
+            raw.write(f"\n[dcness-codex-validator] total timeout after {timeout}s\n".encode())
+            raw.flush()
+            with open(failure_cause, "w", encoding="utf-8") as marker:
+                marker.write("timeout")
+            terminate(124)
+        if now - last_progress >= idle_timeout:
+            raw.write(
+                f"\n[dcness-codex-validator] idle timeout after {idle_timeout}s "
+                "(no stdout/prose progress)\n".encode()
+            )
+            raw.flush()
+            with open(failure_cause, "w", encoding="utf-8") as marker:
+                marker.write("idle_timeout")
+            terminate(124)
+        sleep_for = min(
+            1.0,
+            max(0.05, deadline - now),
+            max(0.05, idle_timeout - (now - last_progress)),
+        )
+        time.sleep(sleep_for)
+' "$CODEX_TIMEOUT" "$CODEX_IDLE_TIMEOUT" "$TMP_PROMPT" "$RAW_LOG" "$TMP_PROSE" "$TMP_FAILURE_CAUSE" "${CODEX_CMD[@]}" "${CODEX_ARGS[@]}"
 }
 
 write_timeout_prose() {
+  FAILURE_CAUSE="$1"
+  if [ "$FAILURE_CAUSE" = "idle_timeout" ]; then
+    TIMEOUT_TITLE="idle timeout"
+    TIMEOUT_DETAIL="produced no stdout/prose progress for ${CODEX_IDLE_TIMEOUT}s"
+  else
+    TIMEOUT_TITLE="total timeout"
+    TIMEOUT_DETAIL="did not finish within ${CODEX_TIMEOUT}s"
+  fi
   cat > "$TMP_PROSE" <<EOF
-# Codex validation timeout
+# Codex validation ${TIMEOUT_TITLE}
 
-dcNess Codex validation did not finish within ${CODEX_TIMEOUT}s. The wrapper killed the hung codex exec process, retried once, and the retry timed out as well.
+dcNess Codex validation ${TIMEOUT_DETAIL}. The wrapper killed the codex exec process, retried once, and the retry also reached a timeout guard.
 
 검증이 완료되지 않았으므로 이 결과를 PASS 또는 FAIL로 간주하면 안 된다. 호출 측은 이 task를 수동 검증하거나 사용자에게 에스컬레이트해야 한다.
 
@@ -299,15 +378,23 @@ ATTEMPT=1
 MAX_ATTEMPTS=2
 CODEX_RC=0
 TIMED_OUT=0
+TIMEOUT_CAUSE=""
 while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
   : > "$TMP_PROSE"
+  : > "$TMP_FAILURE_CAUSE"
   run_codex_once
   CODEX_RC=$?
   if [ "$CODEX_RC" -eq 0 ]; then
     break
   fi
   if [ "$CODEX_RC" -eq 124 ]; then
-    echo "[dcness-codex-validator] codex exec timed out after ${CODEX_TIMEOUT}s (attempt ${ATTEMPT}/${MAX_ATTEMPTS}); raw log: $RAW_LOG" >&2
+    TIMEOUT_CAUSE="$(cat "$TMP_FAILURE_CAUSE" 2>/dev/null || true)"
+    if [ "$TIMEOUT_CAUSE" = "idle_timeout" ]; then
+      echo "[dcness-codex-validator] codex exec idle timeout after ${CODEX_IDLE_TIMEOUT}s (attempt ${ATTEMPT}/${MAX_ATTEMPTS}); raw log: $RAW_LOG" >&2
+    else
+      TIMEOUT_CAUSE="timeout"
+      echo "[dcness-codex-validator] codex exec total timeout after ${CODEX_TIMEOUT}s; timed out after ${CODEX_TIMEOUT}s (attempt ${ATTEMPT}/${MAX_ATTEMPTS}); raw log: $RAW_LOG" >&2
+    fi
     if [ "$ATTEMPT" -lt "$MAX_ATTEMPTS" ]; then
       ATTEMPT=$((ATTEMPT + 1))
       continue
@@ -320,7 +407,7 @@ while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
 done
 
 if [ "$TIMED_OUT" = "1" ]; then
-  write_timeout_prose
+  write_timeout_prose "$TIMEOUT_CAUSE"
   dcness_append_final_prose_to_raw_log "CODEX TIMEOUT" "$TMP_PROSE" "$RAW_LOG"
   if [ -n "$MODE" ]; then
     "$HELPER" end-step "$AGENT" "$MODE" --provider codex-headless --prose-file "$TMP_PROSE" || true

--- a/tests/test_impl_fast_start_contract.py
+++ b/tests/test_impl_fast_start_contract.py
@@ -198,15 +198,20 @@ class ImplFastStartContractTests(unittest.TestCase):
         self.assertIn("task-scope", source)
 
     def test_timeout_defaults_cover_long_headless_work(self) -> None:
-        codex = self.read("scripts/dcness-codex-worker")
-        claude = self.read("scripts/dcness-claude-worker")
+        codex_worker = self.read("scripts/dcness-codex-worker")
+        codex_validator = self.read("scripts/dcness-codex-validator")
+        claude_worker = self.read("scripts/dcness-claude-worker")
+        claude_validator = self.read("scripts/dcness-claude-validator")
         common = self.read("CLAUDE.md")
 
-        self.assertIn('DCNESS_CODEX_TIMEOUT:-3000', codex)
-        self.assertIn('DCNESS_CODEX_IDLE_TIMEOUT:-900', codex)
-        self.assertIn('DCNESS_CLAUDE_TIMEOUT:-3000', claude)
-        self.assertIn('DCNESS_CLAUDE_IDLE_TIMEOUT:-900', claude)
-        self.assertIn("validator `600`, worker `3000`", common)
+        for source in (codex_worker, codex_validator):
+            self.assertIn('DCNESS_CODEX_TIMEOUT:-3000', source)
+            self.assertIn('DCNESS_CODEX_IDLE_TIMEOUT:-900', source)
+        for source in (claude_worker, claude_validator):
+            self.assertIn('DCNESS_CLAUDE_TIMEOUT:-3000', source)
+            self.assertIn('DCNESS_CLAUDE_IDLE_TIMEOUT:-900', source)
+        self.assertNotIn("validator `600`, worker `3000`", common)
+        self.assertGreaterEqual(common.count("| `3000` | X |"), 2)
         self.assertGreaterEqual(common.count("| `900` | X |"), 2)
         self.assertIn(
             "| `DCNESS_IMPLEMENTATION_RECOVERY_LIMIT` "

--- a/tests/test_validator_timeout_contract.py
+++ b/tests/test_validator_timeout_contract.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLAUDE_VALIDATOR = ROOT / "scripts" / "dcness-claude-validator"
+CODEX_VALIDATOR = ROOT / "scripts" / "dcness-codex-validator"
+
+
+class ValidatorTimeoutContractTests(unittest.TestCase):
+    def test_usage_documents_worker_aligned_timeout_defaults(self) -> None:
+        for wrapper, hard_name, idle_name in (
+            (
+                CLAUDE_VALIDATOR,
+                "DCNESS_CLAUDE_TIMEOUT",
+                "DCNESS_CLAUDE_IDLE_TIMEOUT",
+            ),
+            (
+                CODEX_VALIDATOR,
+                "DCNESS_CODEX_TIMEOUT",
+                "DCNESS_CODEX_IDLE_TIMEOUT",
+            ),
+        ):
+            with self.subTest(wrapper=wrapper.name):
+                result = subprocess.run(
+                    [str(wrapper), "--help"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                self.assertIn(f"{hard_name}", result.stdout)
+                self.assertIn("Default: 3000.", result.stdout)
+                self.assertIn(f"{idle_name}", result.stdout)
+                self.assertIn("Default: 900.", result.stdout)
+
+    def test_progress_beyond_idle_window_completes_for_both_validators(self) -> None:
+        for provider in ("claude", "codex"):
+            with self.subTest(provider=provider):
+                result = self._run_wrapper(
+                    provider,
+                    command_body=self._progressing_command(provider),
+                    hard_timeout=5,
+                    idle_timeout=1,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_zero_progress_process_stops_at_idle_timeout_with_distinct_reason(self) -> None:
+        for provider in ("claude", "codex"):
+            with self.subTest(provider=provider):
+                result = self._run_wrapper(
+                    provider,
+                    command_body="sleep 30\n",
+                    hard_timeout=10,
+                    idle_timeout=1,
+                )
+                self.assertEqual(result.returncode, 124, result.stderr)
+                self.assertIn("idle timeout after 1s", result.stderr)
+                self.assertNotIn("total timeout after 10s", result.stderr)
+
+    def test_hard_timeout_reports_total_timeout_reason(self) -> None:
+        for provider in ("claude", "codex"):
+            with self.subTest(provider=provider):
+                result = self._run_wrapper(
+                    provider,
+                    command_body=self._progressing_forever_command(provider),
+                    hard_timeout=1,
+                    idle_timeout=10,
+                )
+                self.assertEqual(result.returncode, 124, result.stderr)
+                self.assertIn("total timeout after 1s", result.stderr)
+                self.assertNotIn("idle timeout after 10s", result.stderr)
+
+    def _run_wrapper(
+        self,
+        provider: str,
+        *,
+        command_body: str,
+        hard_timeout: int,
+        idle_timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as td:
+            tmp = Path(td)
+            project = tmp / "project"
+            project.mkdir()
+            subprocess.run(["git", "init", "-q"], cwd=project, check=True)
+
+            prompt = tmp / "prompt.md"
+            prompt.write_text("Review the candidate.\n", encoding="utf-8")
+
+            helper = tmp / "dcness-helper"
+            helper.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            helper.chmod(0o755)
+
+            bin_dir = tmp / "bin"
+            bin_dir.mkdir()
+            executable = bin_dir / provider
+            executable.write_text(
+                self._command_script(provider, command_body),
+                encoding="utf-8",
+            )
+            executable.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "PATH": f"{bin_dir}{os.pathsep}{env.get('PATH', '')}",
+                    f"DCNESS_{provider.upper()}_TIMEOUT": str(hard_timeout),
+                    f"DCNESS_{provider.upper()}_IDLE_TIMEOUT": str(idle_timeout),
+                }
+            )
+            wrapper = CLAUDE_VALIDATOR if provider == "claude" else CODEX_VALIDATOR
+            return subprocess.run(
+                [
+                    str(wrapper),
+                    "impl-validator",
+                    "--prompt-file",
+                    str(prompt),
+                    "--project-root",
+                    str(project),
+                    "--helper",
+                    str(helper),
+                ],
+                capture_output=True,
+                env=env,
+                text=True,
+                timeout=12,
+            )
+
+    @staticmethod
+    def _command_script(provider: str, command_body: str) -> str:
+        codex_prelude = ""
+        if provider == "codex":
+            codex_prelude = textwrap.dedent(
+                """\
+                if [ "${1:-}" = "--help" ]; then
+                  echo "Usage: codex"
+                  exit 0
+                fi
+                out=""
+                while [ "$#" -gt 0 ]; do
+                  case "$1" in
+                    --output-last-message)
+                      out="$2"
+                      shift 2
+                      ;;
+                    *)
+                      shift
+                      ;;
+                  esac
+                done
+                """
+            )
+        return "#!/bin/sh\n" + codex_prelude + command_body
+
+    @staticmethod
+    def _progressing_command(provider: str) -> str:
+        final_output = (
+            "printf 'Validator prose\\n\\nPASS\\n' > \"$out\"\n"
+            if provider == "codex"
+            else "printf 'Validator prose\\n\\nPASS\\n'\n"
+        )
+        return (
+            "i=0\n"
+            "while [ \"$i\" -lt 6 ]; do\n"
+            "  printf 'progress %s\\n' \"$i\"\n"
+            "  sleep 0.25\n"
+            "  i=$((i + 1))\n"
+            "done\n"
+            + final_output
+        )
+
+    @staticmethod
+    def _progressing_forever_command(provider: str) -> str:
+        del provider
+        return (
+            "while :; do\n"
+            "  printf 'progress\\n'\n"
+            "  sleep 0.2\n"
+            "done\n"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1202

## 배경 및 문제

validator wrapper의 600초 hard timeout이 실제 holistic review 시간보다 짧고 idle guard도 없어, 정상 장기 실행과 무진행 hang을 구분하지 못했습니다.

## 원인 (해당 시)

Claude/Codex validator가 worker wrapper에 이미 적용된 `hard timeout + idle timeout` 2-knob 실행 감시를 공유하지 않고, 단일 600초 wall-clock 제한만 사용했습니다.

## 작업내용

- 두 validator의 hard timeout 기본값을 worker와 동일한 3000초로 정렬했습니다.
- `DCNESS_CLAUDE_IDLE_TIMEOUT` / `DCNESS_CODEX_IDLE_TIMEOUT` 900초 기본값과 양의 정수 검증을 추가했습니다.
- stdout/stderr/prose 파일 크기 변화를 진행 신호로 추적하고, hard timeout과 idle timeout을 서로 다른 raw log·stderr 사유로 보고합니다.
- Codex의 기존 timeout 1회 재시도와 ESCALATE prose 계약은 보존하면서 사유를 구분했습니다.
- 축소 시간 fixture로 장시간 진행 완주, 무진행 idle 종료, hard cap 종료를 두 provider 모두 검증했습니다.

## 결정 근거

worker에서 검증된 polling/프로세스 그룹 종료 패턴을 validator에 동일하게 적용했습니다. 실제 600초를 기다리는 테스트 대신 동일한 상태 전이를 1~10초 범위로 축소해 결정적으로 검증했습니다.

## 배포 경로 검증 (plug-in 영향 시)

- `scripts/dcness-claude-validator`와 `scripts/dcness-codex-validator`는 release artifact의 plug-in 본체에 포함되므로 plug-in update 시 외부 활성 프로젝트에 직접 도달합니다.
- `/init-dcness`가 프로젝트로 복사하는 파일 계약은 변경하지 않아 별도 재-init 배포 단계가 필요하지 않습니다.
- `tests/test_release_artifact.py`를 포함한 전체 1,231 tests와 plugin manifest gate가 통과했습니다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 내부 validator wrapper의 실행 감시 계약만 보강했으며 새 public surface를 추가하지 않았습니다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `bash -n scripts/dcness-claude-validator scripts/dcness-codex-validator`
- [x] `python3.11 -m unittest discover -s tests < /dev/null` — 1,231 tests PASS
- [x] plugin manifest / public surface / cross-ref / doc-sync gate PASS
- [x] static quality (ruff / mypy / Bandit) PASS

## 참고

- 자동 merge는 수행하지 않습니다.
