### PR TITLE
[issue-1213] eval 후보 판정 테스트의 날짜 시한폭탄 제거

### DIFF
--- a/tests/test_loop_diagnose.py
+++ b/tests/test_loop_diagnose.py
@@ -112,13 +112,13 @@ def _write_eval_events(repo_root: Path) -> None:
                 "kind": "eval_case_result",
                 "case": "headless-prose-quality",
                 "passed": True,
-                "ts": "2026-07-01T00:00:00Z",
+                "ts": _iso_days_ago(2),
             },
             {
                 "kind": "eval_case_result",
                 "case": "headless-prose-quality",
                 "passed": True,
-                "ts": "2026-07-02T00:00:00Z",
+                "ts": _iso_days_ago(1),
             },
         ],
     )
@@ -408,13 +408,13 @@ class LoopDiagnoseTests(unittest.TestCase):
                         "kind": "eval_case_result",
                         "case": "flow-ownership-entrypoint-bad",
                         "passed": True,
-                        "ts": "2026-07-05T00:00:00Z",
+                        "ts": _iso_days_ago(2),
                     },
                     {
                         "kind": "eval_case_result",
                         "case": "flow-ownership-entrypoint-bad",
                         "passed": False,
-                        "ts": "2026-07-05T01:00:00Z",
+                        "ts": _iso_days_ago(1),
                     },
                 ],
             )


### PR DESCRIPTION
## 관련 이슈 번호

Closes #1213

## 배경 및 문제

기본 브랜치의 단위 테스트 CI 가 코드 변경 없이 실패 상태로 바뀌었다. 마지막으로 성공한 실행은 2026-07-26 이고, 2026-08-11 실행에서 자기개선 sweep 도구의 eval 후보 판정 테스트 두 건이 실패했다. 릴리즈 publish 는 태그가 가리키는 소스의 전체 단위 테스트 통과를 요구하므로 플러그인 릴리즈가 이 실패로 막혀 있었다.

## 원인 (해당 시)

sweep 도구는 eval 결과 이벤트를 최근 30일 창으로만 집계해 포화 후보와 flaky 후보를 뽑는다. 그런데 두 테스트의 fixture 가 이벤트 타임스탬프를 2026-07-01 / 2026-07-02 / 2026-07-05 절대 날짜로 고정해 두었다. 2026-08-01 과 2026-08-04 를 지나면서 fixture 이벤트가 집계 창 밖으로 밀려 후보가 하나도 잡히지 않게 됐고, 두 테스트가 달력 경과만으로 결정적으로 실패했다.

## 작업내용

- `tests/test_loop_diagnose.py` 의 eval 포화 후보 fixture 와 flaky 후보 fixture 가 같은 파일에 이미 있던 `_iso_days_ago` 상대 시간 헬퍼로 타임스탬프를 만들도록 교체했다. 실행 시점이 언제든 집계 창 안에 들어온다.
- 판정 로직(집계 창 길이, 최소 시도 횟수, 포화·flaky 조건)과 공개 옵션 기본값은 변경하지 않았다.

## 결정 근거

집계 창 안의 최근 이벤트를 재현하는 것이 두 테스트의 원래 의도이므로, 판정 로직이나 창 길이를 손대는 대신 fixture 를 상대 시간으로 되돌리는 것이 최소 수정이다. 시간을 고정하는 mock 을 새로 도입하는 방법도 있으나, 같은 파일의 다른 fixture 가 이미 상대 시간 헬퍼를 쓰고 있어 기존 관례를 따랐다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — dcness self 테스트 fixture 수정이며 plug-in 배포물과 사용자 surface 변경이 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 새 public 발화를 추가하지 않는다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest tests.test_loop_diagnose -v < /dev/null` — 11/11 PASS
- [x] 로컬 pre-commit pytest 게이트 PASS (전체 suite)

## 참고

- 같은 CI 실행에서 리눅스 CI 전용으로 함께 실패한 제품 journey 서비스 실행 테스트는 원인이 다르므로 본 PR 범위에 넣지 않았다. 본 PR 의 CI 결과로 재현 여부를 확인한다.
