### PR TITLE
[feature] release bundle 소비 스모크 3축 완성

### DIFF
--- a/docs/internal/plugin-release.md
+++ b/docs/internal/plugin-release.md
@@ -74,6 +74,14 @@ python3 scripts/release_artifact.py snapshot --root <artifact-root>
 python3 scripts/release_artifact.py compare --expected <candidate-root> --actual <cache-root>
 ```
 
+`smoke`는 candidate bundle을 임시 경로에 구성한 뒤 세 축을 결정적으로 검사한다. **agent 등록 표면** —
+`agents/`를 재귀 탐색해 중첩 진입점을 거부하고, 진입점마다 상세 지침과 그 지침이 직접 참조하는
+문서가 bundle 안에 실존하는지 확인하며, 공개 surface SSOT 대조까지 실행한다. **지침 도달** — 격리된
+외부 프로젝트 cwd에서 각 agent가 자기 지침을 실제로 read 할 수 있는지 확인한다. **활성화와 경계** —
+활성화 전 SessionStart가 아무것도 주입하지 않는 no-op을 확인하고, 활성화 후 hook 진입과 write-zero
+agent의 파일 경계 차단을 candidate 코드로 재현한다. 세 축의 관측값은 `inactive_session_start_bytes`,
+`agent_instruction_reads`, `init_core_deployed_files`, `write_boundary_blocks`로 출력된다.
+
 baseline clean-install manifest는
 [`marketplace-artifact-baseline.json`](marketplace-artifact-baseline.json)에 저장한다. 릴리즈 PR에서는
 태그·공개 전에 위 smoke를 통과시킨다. FAIL이면 릴리즈를 중단하고, 현재 PR 범위에서 근본원인을

--- a/scripts/release_artifact.py
+++ b/scripts/release_artifact.py
@@ -478,6 +478,38 @@ def _run_checked(command: list[str], *, cwd: Path, env: dict[str, str] | None = 
     return result.stdout
 
 
+_MARKDOWN_LINK = re.compile(r"(?<!!)\[[^]]*\]\(([^)]+)\)")
+
+
+def _verify_instruction_references(bundle: Path, instruction: Path) -> None:
+    """지침이 직접 참조하는 상대 링크 대상이 bundle 안에 실존하는지 확인한다."""
+    root = bundle.resolve()
+    in_fence = False
+    for line in instruction.read_text(encoding="utf-8").splitlines():
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            continue
+        prose = re.sub(r"`[^`]*`", "", line)
+        for raw_target in _MARKDOWN_LINK.findall(prose):
+            target = raw_target.split("#", 1)[0].strip().strip("<>")
+            if not target or "://" in target or target.startswith(("/", "mailto:")):
+                continue
+            resolved = (instruction.parent / target).resolve()
+            source = instruction.relative_to(bundle).as_posix()
+            try:
+                resolved.relative_to(root)
+            except ValueError:
+                raise ArtifactError(
+                    f"agent instruction reference escapes the bundle: {source} -> {target}"
+                ) from None
+            if not resolved.exists():
+                raise ArtifactError(
+                    f"agent instruction reference missing: {source} -> {target}"
+                )
+
+
 def _verify_agent_surface(bundle: Path, public_surface_checker: Path) -> None:
     agents_root = bundle / "agents"
     recursive = sorted(path for path in agents_root.rglob("*.md") if path.is_file())
@@ -490,6 +522,7 @@ def _verify_agent_surface(bundle: Path, public_surface_checker: Path) -> None:
         instruction = bundle / "docs" / "plugin" / "agents" / name / f"{name}-agent.md"
         if not instruction.is_file():
             raise ArtifactError(f"agent instruction missing: {instruction.relative_to(bundle)}")
+        _verify_instruction_references(bundle, instruction)
     _run_checked([_executable("node"), str(public_surface_checker)], cwd=bundle)
 
 
@@ -643,6 +676,54 @@ print(count)
     return int(output.strip())
 
 
+def _session_start(
+    bundle: Path, project: Path, env: dict[str, str]
+) -> subprocess.CompletedProcess[str]:
+    payload = json.dumps({"session_id": "release-artifact-smoke", "cwd": str(project)})
+    return subprocess.run(  # nosec B603
+        [_executable("bash"), str(bundle / "hooks" / "session-start.sh")],
+        cwd=project,
+        env=env,
+        input=payload,
+        check=False,
+        text=True,
+        capture_output=True,
+        timeout=30,
+    )
+
+
+def _verify_inactive_noop(bundle: Path, project: Path, env: dict[str, str]) -> int:
+    """활성화 전 프로젝트는 hook 이 아무것도 주입하지 않아야 한다."""
+    result = _session_start(bundle, project, env)
+    if result.returncode != 0:
+        raise ArtifactError(f"inactive SessionStart failed: {result.stderr.strip()}")
+    if result.stdout.strip():
+        raise ArtifactError(
+            "inactive project received SessionStart output: " + result.stdout.strip()[:200]
+        )
+    return len(result.stdout.encode("utf-8"))
+
+
+def _verify_write_boundary(project: Path, env: dict[str, str]) -> int:
+    """활성 프로젝트에서 candidate 코드가 실제로 write 경계를 차단하는지 재현한다."""
+    code = """
+import sys
+from pathlib import Path
+from harness.agent_boundary import check_write_allowed
+
+project = Path(sys.argv[1])
+blocked = 0
+for agent in ('impl-validator', 'architecture-validator'):
+    reason = check_write_allowed(agent, str(project / 'src' / 'main.py'), cwd=project)
+    if not reason:
+        raise SystemExit(f'{agent}: write-zero boundary did not block')
+    blocked += 1
+print(blocked)
+"""
+    output = _run_checked([sys.executable, "-c", code, str(project)], cwd=project, env=env)
+    return int(output.strip())
+
+
 def _verify_external_runtime(bundle: Path, temp_root: Path) -> dict[str, int]:
     project = temp_root / "external-project"
     home = temp_root / "home"
@@ -670,19 +751,11 @@ def _verify_external_runtime(bundle: Path, temp_root: Path) -> dict[str, int]:
             "PYTHONDONTWRITEBYTECODE": "1",
         }
     )
+    inactive_bytes = _verify_inactive_noop(bundle, project, env)
     deployed_count = _deploy_init_core(bundle, project, home, env)
     agent_read_count = _verify_agent_reads(bundle, project, env)
-    payload = json.dumps({"session_id": "release-artifact-smoke", "cwd": str(project)})
-    result = subprocess.run(  # nosec B603
-        [_executable("bash"), str(bundle / "hooks" / "session-start.sh")],
-        cwd=project,
-        env=env,
-        input=payload,
-        check=False,
-        text=True,
-        capture_output=True,
-        timeout=30,
-    )
+    boundary_blocks = _verify_write_boundary(project, env)
+    result = _session_start(bundle, project, env)
     if result.returncode != 0:
         raise ArtifactError(f"SessionStart failed: {result.stderr.strip()}")
     try:
@@ -696,6 +769,8 @@ def _verify_external_runtime(bundle: Path, temp_root: Path) -> dict[str, int]:
         "init_core_deployed_files": deployed_count,
         "agent_instruction_reads": agent_read_count,
         "session_start_additional_context_bytes": len(context.encode("utf-8")),
+        "inactive_session_start_bytes": inactive_bytes,
+        "write_boundary_blocks": boundary_blocks,
     }
 
 
@@ -728,6 +803,8 @@ def smoke(
             "session_start_token_approx": (context_bytes + 3) // 4,
             "agent_instruction_reads": runtime["agent_instruction_reads"],
             "init_core_deployed_files": runtime["init_core_deployed_files"],
+            "inactive_session_start_bytes": runtime["inactive_session_start_bytes"],
+            "write_boundary_blocks": runtime["write_boundary_blocks"],
         }
 
 

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
 import os
 from pathlib import Path
@@ -11,11 +12,41 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "release_artifact.py"
 CONTRACT = ROOT / "scripts" / "release_artifact.json"
+PUBLIC_SURFACE_CHECKER = ROOT / "scripts" / "check_public_surface.mjs"
+
+
+def _load_release_artifact() -> Any:
+    spec = importlib.util.spec_from_file_location("release_artifact", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    # dataclass 처리가 sys.modules 조회에 의존하므로 exec 전에 등록한다.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_minimal_agent_surface(bundle: Path) -> Path:
+    """Build the smallest bundle shape the agent surface check reads."""
+    entrypoint = bundle / "agents" / "impl-validator.md"
+    entrypoint.parent.mkdir(parents=True, exist_ok=True)
+    entrypoint.write_text("---\nname: impl-validator\n---\n", encoding="utf-8")
+    instruction = (
+        bundle / "docs" / "plugin" / "agents" / "impl-validator" / "impl-validator-agent.md"
+    )
+    instruction.parent.mkdir(parents=True, exist_ok=True)
+    instruction.write_text(
+        "# impl-validator\n\n판정 계약은 [product journey](../../product-journey.md) 를 따른다.\n",
+        encoding="utf-8",
+    )
+    reference = bundle / "docs" / "plugin" / "product-journey.md"
+    reference.write_text("# product journey\n", encoding="utf-8")
+    return bundle
 
 
 def _run(*args: str, cwd: Path | None = None, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -1158,6 +1189,54 @@ class ReleaseArtifactContractTests(unittest.TestCase):
             },
         )
         self.assertIsNone(smoke_metrics["previous_version_update"])
+        self.assertEqual(smoke_metrics["inactive_session_start_bytes"], 0)
+        self.assertGreaterEqual(smoke_metrics["write_boundary_blocks"], 1)
+
+    def test_nested_agent_entrypoint_fails_the_bundle_surface_check(self) -> None:
+        """v0.13.0 은 중첩 agent `.md` 42개를 배포했다. 같은 결함이 다시 통과하면 안 된다."""
+        module = _load_release_artifact()
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = _write_minimal_agent_surface(Path(tmp) / "bundle")
+            nested = bundle / "agents" / "impl-validator" / "references.md"
+            nested.parent.mkdir(parents=True, exist_ok=True)
+            nested.write_text("nested entrypoint\n", encoding="utf-8")
+
+            with self.assertRaises(module.ArtifactError) as caught:
+                module._verify_agent_surface(bundle, PUBLIC_SURFACE_CHECKER)
+
+        self.assertIn("agents/impl-validator/references.md", str(caught.exception))
+
+    def test_missing_agent_instruction_fails_the_bundle_surface_check(self) -> None:
+        """설치본에서 상세 지침이 빠지면 서브에이전트가 지침 없이 실행된다."""
+        module = _load_release_artifact()
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = _write_minimal_agent_surface(Path(tmp) / "bundle")
+            instruction = (
+                bundle
+                / "docs"
+                / "plugin"
+                / "agents"
+                / "impl-validator"
+                / "impl-validator-agent.md"
+            )
+            instruction.unlink()
+
+            with self.assertRaises(module.ArtifactError) as caught:
+                module._verify_agent_surface(bundle, PUBLIC_SURFACE_CHECKER)
+
+        self.assertIn("impl-validator-agent.md", str(caught.exception))
+
+    def test_missing_instruction_reference_fails_the_bundle_surface_check(self) -> None:
+        """지침이 직접 참조하는 문서가 bundle 에서 빠지면 지침 도달이 끊긴다."""
+        module = _load_release_artifact()
+        with tempfile.TemporaryDirectory() as tmp:
+            bundle = _write_minimal_agent_surface(Path(tmp) / "bundle")
+            (bundle / "docs" / "plugin" / "product-journey.md").unlink()
+
+            with self.assertRaises(module.ArtifactError) as caught:
+                module._verify_agent_surface(bundle, PUBLIC_SURFACE_CHECKER)
+
+        self.assertIn("product-journey.md", str(caught.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 관련 이슈 번호

Closes #966

## 배경 및 문제

서브에이전트가 설치본의 전체 지침을 읽지 못한 결함과 중첩 agent 문서가 가짜 agent 타입으로 등록된 결함은 여러 버전에 걸쳐 self 테스트를 통과한 채 배포됐다. 두 결함은 수정됐지만, 같은 조합이 다시 새어 나가는 것을 막는 release bundle 소비 검사는 축이 일부만 구현돼 있었다.

기존 `release_artifact.py smoke` 는 candidate bundle 을 비파괴로 구성해 agent 등록 표면과 지침 read 가능 여부, 활성 SessionStart 진입까지는 확인했으나 세 가지가 비어 있었다. 지침이 직접 참조하는 문서가 bundle 에 실존하는지 따라가지 않았고, 활성화 전 미활성 no-op 을 확인하지 않았으며, 파일 경계 차단을 candidate 코드로 재현하지 않았다. 결함 fixture 가 실제로 FAIL 하는지 고정한 회귀 테스트도 없어 검출력이 증명되지 않은 상태였다.

## 원인 (해당 시)

검사 대상이 "파일이 있는가" 수준에 머물러, 지침 도달을 링크 한 단계 뒤까지 따라가지 않았고 활성화 계약은 활성 경로만 관측했다. 검출력은 구현 존재로 갈음됐고 결함을 심은 fixture 로 확인하지 않았다.

## 작업내용

- agent 지침이 직접 참조하는 상대 링크 대상이 candidate bundle 안에 실존하는지 확인하는 검사를 추가했다. 코드펜스와 인라인 코드, 외부 URL, 절대 경로는 제외하고, bundle 밖으로 이탈하는 참조도 거부한다.
- 활성화 전 SessionStart 가 아무것도 주입하지 않는 no-op 을 확인하는 검사를 추가했다. 기존 활성 경로 확인은 그대로 두고 순서만 앞에 붙였다.
- 격리된 외부 프로젝트에서 write-zero agent 2종의 파일 경계 차단을 candidate 코드로 재현하는 검사를 추가했다.
- smoke 출력에 `inactive_session_start_bytes` 와 `write_boundary_blocks` 를 노출해 세 축의 관측값을 밖에서 읽을 수 있게 했다.
- 검출력 회귀 3종을 추가했다. 중첩 agent 진입점, 지침 파일 누락, 지침 참조 대상 누락 fixture 가 각각 bundle 표면 검사를 FAIL 시킨다.
- `docs/internal/plugin-release.md` 에 smoke 의 세 축과 관측 지표를 서술했다.

## 결정 근거

새 명령이나 public surface 를 만들지 않고 기존 `smoke` 한 명령 안에서 축을 채웠다. 검출력 증거는 역사 버전 전체를 재현하는 대신 같은 결함 클래스를 보존한 최소 fixture 로 고정했다. 이슈가 허용한 방식이며 실행 시간이 짧아 매 릴리즈마다 반복 가능하다.

경계 차단 재현 대상으로는 write-zero validator 를 골랐다. 프로젝트 boundary 설정이나 task scope 로도 열 수 없는 계약이라 fixture 환경 차이에 흔들리지 않는다.

## 배포 경로 검증 (plug-in 영향 시)

N/A — `scripts/release_artifact.py` 는 릴리즈 검증 도구이고 `scripts/release_artifact.json` 의 positive allowlist 에 포함되지 않아 사용자 bundle 로 배포되지 않는다. `docs/internal/**` 도 배포 대상이 아니다. plug-in runtime 과 사용자 surface 변경이 없다.

## 신규 surface justification (새 public skill/command/agent/gate 추가 시만)

N/A — 기존 `release_artifact.py smoke` 의 검사 축만 채웠고 새 command·agent·gate 를 추가하지 않았다.

## Test Plan

- [x] 관련 테스트 추가/갱신/전체 통과
- [x] 회귀 검증
- [x] `python3.11 -m unittest discover -s tests < /dev/null` — 전체 PASS
- [x] `python3.11 -m unittest tests.test_release_artifact -v < /dev/null` — 20/20 PASS (17 → 20)
- [x] `python3.11 scripts/release_artifact.py smoke --repo-root . --ref HEAD --contract scripts/release_artifact.json` — PASS · `inactive_session_start_bytes=0` · `write_boundary_blocks=2` · `agent_instruction_reads=9` · `init_core_deployed_files=7`
- [x] `node scripts/check_public_surface.mjs` — PASS
- [x] `node scripts/check_cross_refs.mjs` — PASS (105 파일, 0건)
- [x] `python3.11 evals/guard_efficacy.py --json` — 50/50 PASS
- [x] `uvx --from ruff==0.15.17 ruff check .` — All checks passed
- [x] `uvx --from mypy==2.1.0 mypy` — no issues in 36 source files
- [x] `uvx --from bandit==1.9.4 bandit -c pyproject.toml -r harness scripts -l -i` — 0 issues

## 참고

검출력 증거는 다음 세 fixture 다. 각각 결함을 심은 최소 bundle 을 만들어 표면 검사가 실패하는지 확인한다.

- 중첩 agent 진입점 — `agents/impl-validator/references.md` 를 추가하면 `nested agent entrypoints are not allowed` 로 실패한다
- 지침 파일 누락 — `docs/plugin/agents/impl-validator/impl-validator-agent.md` 를 지우면 `agent instruction missing` 으로 실패한다
- 지침 참조 대상 누락 — 지침이 링크한 문서를 지우면 `agent instruction reference missing` 으로 실패한다
